### PR TITLE
Don't use ajax to fetch export list

### DIFF
--- a/corehq/apps/export/static/export/js/list_exports.ng.js
+++ b/corehq/apps/export/static/export/js/list_exports.ng.js
@@ -30,11 +30,10 @@
          */
         var self = {};
         $scope._ = _;  // allow use of underscore.js within the template
-        $scope.exports = [];
+        $scope.exports = hqImport('hqwebapp/js/initial_page_data').get('exports');
         $scope.bulk_download_url = bulk_download_url;
         $scope.legacy_bulk_download_url = legacy_bulk_download_url;
 
-        $scope.exports = hqImport('hqwebapp/js/initial_page_data').get('exports');
         $scope.myExports = $scope.exports.filter(function (val) { return !!val.my_export; });
         $scope.notMyExports = $scope.exports.filter(function (val) { return !val.my_export; });
         _.each($scope.exports, function (exp) {

--- a/corehq/apps/export/static/export/js/list_exports.ng.js
+++ b/corehq/apps/export/static/export/js/list_exports.ng.js
@@ -20,8 +20,7 @@
 
     var exportsControllers = {};
     exportsControllers.ListExportsController = function (
-        $scope, djangoRMI, bulk_download_url, legacy_bulk_download_url, $rootScope, modelType,
-        $timeout
+        $scope, djangoRMI, bulk_download_url, legacy_bulk_download_url, $rootScope, modelType, $timeout
     ) {
         /**
          * This controller fetches a list of saved exports from
@@ -31,53 +30,18 @@
          */
         var self = {};
         $scope._ = _;  // allow use of underscore.js within the template
-        $scope.hasLoaded = false;
         $scope.exports = [];
-        $scope.exportsListError = null;
         $scope.bulk_download_url = bulk_download_url;
         $scope.legacy_bulk_download_url = legacy_bulk_download_url;
 
-        self._numTries = 0;
-        self._getExportsList = function () {
-            // The method below lives in the subclasses of
-            // BaseExportListView.
-
-            var filterMyExports = function (val) {
-                return !!val.my_export;
-            };
-
-            var filterNotMyExports = function (val) {
-                return !val.my_export;
-            };
-
-            djangoRMI.get_exports_list({})
-                .success(function (data) {
-                    if (data.success) {
-                        $scope.exports = data.exports;
-                        $scope.myExports = data.exports.filter(filterMyExports);
-                        $scope.notMyExports = data.exports.filter(filterNotMyExports);
-                        _.each($scope.exports, function (exp) {
-                            if (exp.emailedExport && exp.emailedExport.taskStatus.inProgress) {
-                                $rootScope.pollProgressBar(exp);
-                            }
-                        });
-                    } else {
-                        $scope.exportsListError = data.error;
-                    }
-                    $scope.hasLoaded = true;
-                })
-                .error(function () {
-                    // Retry in case the connection was flaky.
-                    if (self._numTries > 3) {
-                        $scope.hasLoaded = true;
-                        $scope.exportsListError = 'default';
-                        return;
-                    }
-                    self._numTries ++;
-                    self._getExportsList();
-                });
-        };
-        self._getExportsList();
+        $scope.exports = hqImport('hqwebapp/js/initial_page_data').get('exports');
+        $scope.myExports = $scope.exports.filter(function (val) { return !!val.my_export; });
+        $scope.notMyExports = $scope.exports.filter(function (val) { return !val.my_export; });
+        _.each($scope.exports, function (exp) {
+            if (exp.emailedExport && exp.emailedExport.taskStatus.inProgress) {
+                $rootScope.pollProgressBar(exp);
+            }
+        });
 
         // For Bulk Export
         $scope.showBulkExportDownload = false;

--- a/corehq/apps/export/static/export/js/list_exports.ng.js
+++ b/corehq/apps/export/static/export/js/list_exports.ng.js
@@ -52,7 +52,6 @@
             tick();
         };
 
-        var self = {};
         $scope._ = _;  // allow use of underscore.js within the template
         $scope.exports = hqImport('hqwebapp/js/initial_page_data').get('exports');
         $scope.bulk_download_url = bulk_download_url;

--- a/corehq/apps/export/static/export/spec/ListExportsController.spec.mo.js
+++ b/corehq/apps/export/static/export/spec/ListExportsController.spec.mo.js
@@ -2,23 +2,21 @@ describe('ListExportsController Unit Tests', function () {
     var $httpBackend, createController, $rootScope, currentScope;
 
     var mockBackendUrls = {
-        GET_EXPORTS_LIST: '/fake/exports/list',
         UPDATE_EMAILED_EXPORT_DATA: '/fake/exports/update/data',
         TOGGLE_SAVED_EXPORT_ENABLED_STATE: '/fake/exports/toggle_enabled',
         GET_SAVED_EXPORT_PROGRESS: '/fake/exports/get_progress',
     };
 
+    hqImport("hqwebapp/js/initial_page_data").register("exports", [
+        ListExportsTestData.exportWithFileData,
+        ListExportsTestData.exportDeId,
+        ListExportsTestData.exportSimple,
+    ]);
+
     beforeEach(function () {
         var listExportsTestApp = angular.module('ngtest.ListExportsApp', ['hq.list_exports']);
         listExportsTestApp.config(["djangoRMIProvider", function (djangoRMIProvider) {
             djangoRMIProvider.configure({
-                get_exports_list: {
-                    url: mockBackendUrls.GET_EXPORTS_LIST,
-                    headers: {
-                        'DjNg-Remote-Method': 'get_exports_list',
-                    },
-                    method: 'auto',
-                },
                 update_emailed_export_data: {
                     url: mockBackendUrls.UPDATE_EMAILED_EXPORT_DATA,
                     headers: {
@@ -64,16 +62,6 @@ describe('ListExportsController Unit Tests', function () {
 
         beforeEach(function () {
             $httpBackend
-                .when('POST', mockBackendUrls.GET_EXPORTS_LIST)
-                .respond({
-                    success: true,
-                    exports: [
-                        ListExportsTestData.exportWithFileData,
-                        ListExportsTestData.exportDeId,
-                        ListExportsTestData.exportSimple,
-                    ],
-                });
-            $httpBackend
                 .when('POST', mockBackendUrls.GET_SAVED_EXPORT_PROGRESS)
                 .respond({
                     success: true,
@@ -92,8 +80,6 @@ describe('ListExportsController Unit Tests', function () {
 
         it('selectAll()', function () {
             createController();
-            $httpBackend.expectPOST(mockBackendUrls.GET_EXPORTS_LIST);
-            $httpBackend.flush();
 
             assert.equal(currentScope.bulkExportList.length, 2);
             assert.isFalse(currentScope.showBulkExportDownload);
@@ -104,8 +90,6 @@ describe('ListExportsController Unit Tests', function () {
 
         it('selectNone()', function () {
             createController();
-            $httpBackend.expectPOST(mockBackendUrls.GET_EXPORTS_LIST);
-            $httpBackend.flush();
 
             assert.equal(currentScope.bulkExportList.length, 2);
             assert.isFalse(currentScope.showBulkExportDownload);
@@ -126,8 +110,6 @@ describe('ListExportsController Unit Tests', function () {
                         success: true,
                     });
                 createController();
-                $httpBackend.expectPOST(mockBackendUrls.GET_EXPORTS_LIST);
-                $httpBackend.flush();
                 $httpBackend.expectPOST(mockBackendUrls.UPDATE_EMAILED_EXPORT_DATA);
                 exportToUpdate = currentScope.exports[0];
                 component = exportToUpdate.emailedExport;
@@ -157,8 +139,6 @@ describe('ListExportsController Unit Tests', function () {
                         isAutoRebuildEnabled: false,
                     });
                 createController();
-                $httpBackend.expectPOST(mockBackendUrls.GET_EXPORTS_LIST);
-                $httpBackend.flush();
                 $httpBackend.expectPOST(mockBackendUrls.TOGGLE_SAVED_EXPORT_ENABLED_STATE);
                 exportToUpdate = currentScope.exports[0];
                 component = exportToUpdate.emailedExport;

--- a/corehq/apps/export/static/export/spec/ListExportsController.spec.mo.js
+++ b/corehq/apps/export/static/export/spec/ListExportsController.spec.mo.js
@@ -83,36 +83,6 @@ describe('ListExportsController Unit Tests', function () {
             assert.equal(currentScope.exports.length, 1);
             assert.isTrue(currentScope.hasLoaded);
         });
-
-        it('registers a server-side error', function () {
-            var serverErrorMsg = 'error initializing exports for test';
-            $httpBackend
-                .when('POST', mockBackendUrls.GET_EXPORTS_LIST)
-                .respond({
-                    error: serverErrorMsg,
-                });
-            createController();
-            assert.equal(currentScope.exports.length, 0);
-            assert.isFalse(currentScope.hasLoaded);
-            $httpBackend.expectPOST(mockBackendUrls.GET_EXPORTS_LIST);
-            $httpBackend.flush();
-            assert.equal(currentScope.exports.length, 0);
-            assert.isTrue(currentScope.hasLoaded);
-            assert.equal(serverErrorMsg, currentScope.exportsListError);
-        });
-
-        it('registers a connection error', function () {
-            $httpBackend
-                .when('POST', mockBackendUrls.GET_EXPORTS_LIST)
-                .respond(522, '');
-            createController();
-            $httpBackend.expectPOST(mockBackendUrls.GET_EXPORTS_LIST);
-            $httpBackend.flush();
-            assert.equal(currentScope.exports.length, 0);
-            assert.isTrue(currentScope.hasLoaded);
-            assert.equal('default', currentScope.exportsListError);
-        });
-
     });
 
     describe("Actions", function () {

--- a/corehq/apps/export/static/export/spec/ListExportsController.spec.mo.js
+++ b/corehq/apps/export/static/export/spec/ListExportsController.spec.mo.js
@@ -58,32 +58,7 @@ describe('ListExportsController Unit Tests', function () {
             currentScope = $rootScope.$new();
             return $controller('ListExportsController', {'$scope': currentScope});
         };
-
     }));
-
-    describe('Initialization', function () {
-
-        afterEach(function () {
-            $httpBackend.verifyNoOutstandingExpectation();
-            $httpBackend.verifyNoOutstandingRequest();
-        });
-
-        it('registers a non-blank list of exports', function () {
-            $httpBackend
-                .when('POST', mockBackendUrls.GET_EXPORTS_LIST)
-                .respond({
-                    success: true,
-                    exports: [ListExportsTestData.exportSimple],
-                });
-            createController();
-            assert.equal(currentScope.exports.length, 0);
-            assert.isFalse(currentScope.hasLoaded);
-            $httpBackend.expectPOST(mockBackendUrls.GET_EXPORTS_LIST);
-            $httpBackend.flush();
-            assert.equal(currentScope.exports.length, 1);
-            assert.isTrue(currentScope.hasLoaded);
-        });
-    });
 
     describe("Actions", function () {
 

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -24,8 +24,9 @@
 {% endblock %}
 
 {% block page_content %}
-    {% initial_page_data 'djng_current_rmi' djng_current_rmi %}
     {% initial_page_data 'bulk_download_url' bulk_download_url %}
+    {% initial_page_data 'djng_current_rmi' djng_current_rmi %}
+    {% initial_page_data 'exports' exports %}
     {% initial_page_data 'legacy_bulk_download_url' legacy_bulk_download_url %}
     {% initial_page_data 'model_type' model_type %}
     {% initial_page_data 'static_model_type' static_model_type %}

--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -23,7 +23,7 @@
     </p>
     {% endif %}
     {% if has_edit_permissions %}
-    <p ng-show="!_.isEmpty(exports) || !hasLoaded">
+    <p ng-show="!_.isEmpty(exports)">
         <a href="#createExportOptionsModal"
            data-toggle="modal"
            class="btn btn-success new-export-link">
@@ -33,8 +33,7 @@
             {% endblocktrans %}
         </a>
     </p>
-    <div class="alert alert-success"
-         ng-show="_.isEmpty(exports) && !!hasLoaded">
+    <div class="alert alert-success" ng-show="_.isEmpty(exports)">
         <p class="lead"><strong>{% blocktrans %}
             It seems you haven't created any {{ export_type_plural }} yet!
         {% endblocktrans %}</strong></p>

--- a/corehq/apps/export/templates/export/partials/loading_exports.html
+++ b/corehq/apps/export/templates/export/partials/loading_exports.html
@@ -4,15 +4,7 @@
 {% load djangular_tags %}
 {% load humanize %}
 
-<div class="alert alert-info"
-     ng-show="!hasLoaded">
-    <p>
-        <i class="fa fa-spinner fa-spin"></i>
-        <strong>{% blocktrans %}Fetching List of {{ export_type_caps_plural }}...{% endblocktrans %}</strong>
-    </p>
-</div>
-<div class="alert alert-info"
-     ng-show="_.isEmpty(exports) && !!hasLoaded && !exportsListError">
+<div class="alert alert-info" ng-show="_.isEmpty(exports)">
     <p>
         {% if is_deid %}
             {% blocktrans %}
@@ -24,20 +16,4 @@
             {% endblocktrans %}
         {% endif %}
     </p>
-</div>
-<div class="alert alert-warning"
-     ng-show="!!exportsListError">
-    <strong ng-if="exportsListError === 'default'">
-        {% blocktrans %}
-            Issue fetching list of {{ export_type_plural }}. Please check your Internet connection.
-        {% endblocktrans %}
-    </strong>
-    <strong ng-if="exportsListError !== 'default'">
-        {% angularjs %}{{ exportsListError }}{% endangularjs %}
-    </strong>
-    {% blocktrans %}
-        If this problem persists, please
-        <a href="#modalReportIssue"
-           data-toggle="modal">Report an Issue</a>.
-    {% endblocktrans %}
 </div>

--- a/corehq/apps/export/templates/export/partials/my_exports_table.html
+++ b/corehq/apps/export/templates/export/partials/my_exports_table.html
@@ -4,8 +4,7 @@
 {% load djangular_tags %}
 {% load humanize %}
 
-<table class="table table-striped"
-       ng-show="!!hasLoaded && !_.isEmpty(exports)">
+<table class="table table-striped" ng-show="!_.isEmpty(exports)">
     <thead>
         <tr>
             <th class="col-sm-4">{% trans 'Name' %}</th>

--- a/corehq/apps/export/templates/export/partials/original_exports_table.html
+++ b/corehq/apps/export/templates/export/partials/original_exports_table.html
@@ -4,8 +4,7 @@
 {% load djangular_tags %}
 {% load humanize %}
 
-<table class="table table-striped"
-       ng-show="!!hasLoaded && !_.isEmpty(exports)">
+<table class="table table-striped" ng-show="!_.isEmpty(exports)">
     <thead>
         <tr>
             <th class="col-sm-4">{% trans 'Name' %}</th>

--- a/corehq/apps/export/templates/export/partials/shared_exports_table.html
+++ b/corehq/apps/export/templates/export/partials/shared_exports_table.html
@@ -4,8 +4,7 @@
 {% load djangular_tags %}
 {% load humanize %}
 
-<table class="table table-striped"
-       ng-show="!!hasLoaded && !_.isEmpty(exports)">
+<table class="table table-striped" ng-show="!_.isEmpty(exports)">
     <thead>
         <tr>
             <th class="col-sm-4">{% trans 'Name' %}</th>


### PR DESCRIPTION
Load exports via initial page data instead of an ajax request. The bespoke loading and error logic adds complexity but little benefit - there's no non-ajax content on the page for a user to interact with while the list loads, this page doesn't need its own custom retry logic for slow connections, and the error message handling is just for generic exceptions, which aren't likely to be any more actionable than the generic 500 page.

Product: this makes trivial changes to the exports page (e.g., there's no longer a loading spinner shown).

@dannyroberts / @esoergel 

`w=1`