### PR TITLE
Log couchdb timing metrics

### DIFF
--- a/corehq/ex-submodules/dimagi/ext/couchdbkit.py
+++ b/corehq/ex-submodules/dimagi/ext/couchdbkit.py
@@ -68,3 +68,10 @@ class SafeSaveDocument(OldSafeSaveDocument):
     def delete_attachment(self, *args, **kwargs):
         _couch_attachment_soft_assert(False, 'SafeSaveDocument.delete_attachment was called')
         super(SafeSaveDocument, self).delete_attachment(*args, **kwargs)
+
+
+# A formatter configured in HQ settings (`couch-request-formatter`) logs
+# extra metrics provided by this logger to a file that can be consumed
+# for couch request timing analysis.
+from couchdbkit.logging import install_request_logger as _install_logger
+_install_logger()

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -108,7 +108,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.9
+jsonobject-couchdbkit==0.9.10
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -88,7 +88,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.9
+jsonobject-couchdbkit==0.9.10
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -93,7 +93,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.9
+jsonobject-couchdbkit==0.9.10
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@ attrs==18.1.0
 cython==0.27.3
 iso8601==0.1.12
 jsonobject==0.9.4
-jsonobject-couchdbkit==0.9.9
+jsonobject-couchdbkit==0.9.10
 celery==3.1.25
 # required by django-digest
 decorator==4.0.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,7 +85,7 @@ jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.9
+jsonobject-couchdbkit==0.9.10
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -90,7 +90,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.9
+jsonobject-couchdbkit==0.9.10
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3


### PR DESCRIPTION
Depends on https://github.com/dimagi/couchdbkit/pull/60 (and a new version of jsonobject-couchdbkit being pushed to PyPI, which has already been done).

@pr33thi @snopoke 