### PR TITLE
Add ability to upload part of the case list and case details in app translations

### DIFF
--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -918,24 +918,7 @@ def _update_case_list_translations(sheet, rows, app):
                 " of the case property '%s'" % row['case_property']
             ))
 
-    for row, detail in \
-            itertools.chain(zip(list_rows, short_details), zip(detail_rows, long_details)):
-
-        # Check that names match (user is not allowed to change property in the
-        # upload). Mismatched names indicate the user probably botched the sheet.
-        if row.get('id', None) != detail.field:
-            msgs.append((
-                messages.error,
-                'A row in sheet {sheet} has an unexpected value of "{field}" '
-                'in the case_property column. Case properties must appear in '
-                'the same order as they do in the bulk app translation '
-                'download. No translations updated for this row.'.format(
-                    sheet=sheet.worksheet.title,
-                    field=row.get('case_property', "")
-                )
-            ))
-            continue
-
+    def _update_detail(row, detail):
         # Update the translations for the row and all its child rows
         _update_translation(row, detail.header)
         for i, enum_value_row in enumerate(row.get('mappings', [])):
@@ -961,6 +944,26 @@ def _update_case_list_translations(sheet, rows, app):
                 detail['graph_configuration']['series'][series_index]['locale_specific_config'][config_key],
                 False
             )
+
+    for row, detail in \
+            itertools.chain(zip(list_rows, short_details), zip(detail_rows, long_details)):
+
+        # Check that names match (user is not allowed to change property in the
+        # upload). Mismatched names indicate the user probably botched the sheet.
+        if row.get('id', None) != detail.field:
+            msgs.append((
+                messages.error,
+                'A row in sheet {sheet} has an unexpected value of "{field}" '
+                'in the case_property column. Case properties must appear in '
+                'the same order as they do in the bulk app translation '
+                'download. No translations updated for this row.'.format(
+                    sheet=sheet.worksheet.title,
+                    field=row.get('case_property', "")
+                )
+            ))
+            continue
+        _update_detail(row, detail)
+
     for index, tab in enumerate(detail_tab_headers):
         if tab:
             _update_translation(tab, module.case_details.long.tabs[index].header)

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -945,24 +945,27 @@ def _update_case_list_translations(sheet, rows, app):
                 False
             )
 
-    for row, detail in \
-            itertools.chain(zip(list_rows, short_details), zip(detail_rows, long_details)):
+    def _update_details_based_on_position(list_rows, short_details, detail_rows, long_details):
+        for row, detail in \
+                itertools.chain(zip(list_rows, short_details), zip(detail_rows, long_details)):
 
-        # Check that names match (user is not allowed to change property in the
-        # upload). Mismatched names indicate the user probably botched the sheet.
-        if row.get('id', None) != detail.field:
-            msgs.append((
-                messages.error,
-                'A row in sheet {sheet} has an unexpected value of "{field}" '
-                'in the case_property column. Case properties must appear in '
-                'the same order as they do in the bulk app translation '
-                'download. No translations updated for this row.'.format(
-                    sheet=sheet.worksheet.title,
-                    field=row.get('case_property', "")
-                )
-            ))
-            continue
-        _update_detail(row, detail)
+            # Check that names match (user is not allowed to change property in the
+            # upload). Mismatched names indicate the user probably botched the sheet.
+            if row.get('id', None) != detail.field:
+                msgs.append((
+                    messages.error,
+                    'A row in sheet {sheet} has an unexpected value of "{field}" '
+                    'in the case_property column. Case properties must appear in '
+                    'the same order as they do in the bulk app translation '
+                    'download. No translations updated for this row.'.format(
+                        sheet=sheet.worksheet.title,
+                        field=row.get('case_property', "")
+                    )
+                ))
+                continue
+            _update_detail(row, detail)
+
+    _update_details_based_on_position(list_rows, short_details, detail_rows, long_details)
 
     for index, tab in enumerate(detail_tab_headers):
         if tab:

--- a/corehq/apps/app_manager/tests/test_repeater.py
+++ b/corehq/apps/app_manager/tests/test_repeater.py
@@ -27,7 +27,7 @@ class TestAppStructureRepeater(TestCase):
 
         repeat_records = RepeatRecord.all(domain=self.domain, due_before=datetime.utcnow())
         self.assertEqual(len(repeat_records), 0)
-        
+
         app_structure_repeater = AppStructureRepeater(domain=self.domain, url=self.forwarding_url)
         app_structure_repeater.save()
 
@@ -36,9 +36,9 @@ class TestAppStructureRepeater(TestCase):
 
         self.assertEqual(len(repeat_records), 1)
         for repeat_record in repeat_records:
-                self.assertEqual(repeat_record.url, self.forwarding_url)
+                self.assertEqual(repeat_record.repeater.get_url(repeat_record), self.forwarding_url)
                 self.assertEqual(repeat_record.get_payload(), application.get_id)
                 repeat_record.delete()
-        
+
         application.delete()
         app_structure_repeater.delete()


### PR DESCRIPTION
@esoergel https://app.asana.com/0/671300723874076/856537961273647

review commit by commit. First three commits are pre-factor

Sorry for throwing this over the wall on my last day, but I think it's all here. 

This was a little trickier than expected because it is possible to reference the same case property in the same case list/case detail configuration. Because of this I decided to go with the following workflow

1. Assume its a full upload
2. If the user supplied all details and lists, perform the full upload (existing behavior)
3. If the user did not supply all details or lists, check if the fields referenced are unique.
4. If the fields are unique, perform a partial upload using case_property and field to join the submitted XLS with the Application translations doc
5. If they are not unique, return with the same error message as we do currently