### PR TITLE
UAT feedback for Find by ID page

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
@@ -22,7 +22,7 @@ hqDefine("data_interfaces/js/find_by_id", [
 
         self.linkMessage = ko.computed(function () {
             if (self.link()) {
-                var redirectTemplate = _.template(gettext("<a href='<%= link %>'>Click here</a> if you are not redirected."));
+                var redirectTemplate = _.template(gettext("<a href='<%= link %>' target='_blank'>View <i class='fa fa-external-link'></i></a>"));
                 return self.successMessage + " " + redirectTemplate({link: self.link()});
             }
             return '';
@@ -47,9 +47,6 @@ hqDefine("data_interfaces/js/find_by_id", [
                 success: function (data) {
                     self.loading(false);
                     self.link(data.link);
-                    _.delay(function () {
-                        document.location = data.link;
-                    }, 2000);
                 },
                 error: function () {
                     self.loading(false);

--- a/corehq/apps/data_interfaces/templates/data_interfaces/find_by_id.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/find_by_id.html
@@ -1,5 +1,6 @@
 {% extends "hqwebapp/base_section.html" %}
 {% load hq_shared_tags %}
+{% load i18n %}
 
 {% requirejs_main "data_interfaces/js/find_by_id" %}
 
@@ -7,6 +8,14 @@
     {% registerurl 'global_quick_find' %}
     {% registerurl 'list_case_exports' domain %}
     {% registerurl 'list_form_exports' domain %}
+
+    {% blocktrans %}
+        <p class="lead">Find Data by ID</p>
+        <p>
+            This page allows you to directly access a specific form data or case data page.
+            Read more on our <a href='https://confluence.dimagi.com/display/commcarepublic/Find+Data+by+ID'>help site</a>.
+        </p>
+    {% endblocktrans %}
 
     {% if can_view_cases %}
         <fieldset id="find-case" class="ko-template">

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1071,7 +1071,7 @@ def quick_find(request):
         return HttpResponseBadRequest('GET param "q" must be provided')
 
     def deal_with_doc(doc, domain, doc_info_fn):
-        if request.couch_user.is_superuser or (domain and request.couch_user.is_domain_admin(domain)):
+        if request.couch_user.is_superuser or (domain and request.couch_user.is_member_of(domain)):
             doc_info = doc_info_fn(doc)
         else:
             raise Http404()

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -798,7 +798,7 @@ class ProjectDataTab(UITab):
             ))
         if self.can_view_form_exports or self.can_view_case_exports:
             items.append(dropdown_dict(
-                _('Find Data by ID (Beta)'),
+                _('Find Data by ID'),
                 url=reverse('data_find_by_id', args=[self.domain])
             ))
 


### PR DESCRIPTION
Show a link to open the case/form in a new tab instead of redirecting:
<img width="397" alt="screen shot 2018-10-11 at 11 21 26 am" src="https://user-images.githubusercontent.com/1486591/46817930-0207aa00-cd4e-11e8-8466-49d1b028eda7.png">

This also makes search accessible to all all domain members instead of just admins.

@dimagi/product fyi