### PR TITLE
Upgrade select2: Scheduled reports

### DIFF
--- a/corehq/apps/hqwebapp/fields.py
+++ b/corehq/apps/hqwebapp/fields.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from django import forms
 from django.forms import fields
 from django.core.validators import validate_email
-from .widgets import AutocompleteTextarea
 
 
 class CSVListField(fields.CharField):
@@ -25,20 +24,14 @@ class CSVListField(fields.CharField):
 class MultiCharField(forms.Field):
     """
     A text field that expects a comma-separated list of inputs, and by default
-    uses the AutocompleteTextarea widget, which uses a jQuery plugin to provide
-    autocompletion (depends on Bootstrap) based on the 'choices' constructor
-    argument.
-
+    uses select2 widget that allows for multiple selections and accepts free text.
     """
-    widget = AutocompleteTextarea
+    widget = forms.SelectMultiple(attrs={'class': 'hqwebapp-autocomplete form-control'})
 
     def __init__(self, initial=None, choices=(), *args, **kwargs):
         """
         choices - a list of choices to use as a source for autocompletion
-
         """
-        if initial:
-            initial = ', '.join(initial)
         super(MultiCharField, self).__init__(initial=initial, *args, **kwargs)
 
         self.choices = choices
@@ -47,15 +40,16 @@ class MultiCharField(forms.Field):
         return self._choices
 
     def _set_choices(self, value):
-        self._choices = self.widget.choices = value
-    
+        self._choices = value
+        self.widget.choices = value
+
     choices = property(_get_choices, _set_choices)
 
     def to_python(self, value):
         if not value:
             return []
 
-        return [val.strip() for val in value.split(',') if val.strip()]
+        return value
 
     def run_validators(self, value):
         for val in value:

--- a/corehq/apps/hqwebapp/fields.py
+++ b/corehq/apps/hqwebapp/fields.py
@@ -45,12 +45,6 @@ class MultiCharField(forms.Field):
 
     choices = property(_get_choices, _set_choices)
 
-    def to_python(self, value):
-        if not value:
-            return []
-
-        return value
-
     def run_validators(self, value):
         for val in value:
             if val not in self.choices:

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
@@ -12,7 +12,7 @@ hqDefine("hqwebapp/js/widgets", [
             var $input = $(input);
             $input.select2(_.extend({
                 multiple: true,
-                tags: $input.data("choices"),
+                tags: true,
             }, additionalConfig));
         });
 

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -43,24 +43,6 @@ class BootstrapCheckboxInput(CheckboxInput):
                          (flatatt(final_attrs), self.inline_label))
 
 
-class AutocompleteTextarea(forms.Textarea):
-    """
-    Textarea with auto-complete.  Uses a custom extension on top of Twitter
-    Bootstrap's typeahead plugin.
-    """
-
-    def render(self, name, value, attrs=None):
-        if hasattr(self, 'choices') and self.choices:
-            if not attrs:
-                attrs = {}
-            attrs.update({
-                'class': 'hqwebapp-autocomplete form-control',
-                'data-choices': json.dumps([{'text': c, 'id': c} for c in self.choices]),
-            })
-
-        return super(AutocompleteTextarea, self).render(name, value, attrs=attrs)
-
-
 class _Select2Mixin(object):
 
     class Media(object):

--- a/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
+++ b/corehq/apps/reports/static/reports/js/edit_scheduled_report.js
@@ -4,7 +4,7 @@ hqDefine("reports/js/edit_scheduled_report", [
     "analytix/js/google",
     "hqwebapp/js/initial_page_data",
     "hqwebapp/js/multiselect_utils",
-    "hqwebapp/js/widgets_v3",  // autocomplete widget for email recipient list
+    "hqwebapp/js/widgets_v4",  // autocomplete widget for email recipient list
 ], function (
     $,
     _,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -194,7 +194,7 @@ from corehq.form_processor.utils.xform import resave_form
 from corehq.apps.hqcase.utils import resave_case
 from corehq.apps.hqwebapp.decorators import (
     use_jquery_ui,
-    use_select2,
+    use_select2_v4,
     use_datatables,
     use_multiselect,
 )
@@ -890,7 +890,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     template_name = 'reports/edit_scheduled_report.html'
 
     @use_multiselect
-    @use_select2
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(ScheduledReportsView, self).dispatch(request, *args, **kwargs)
 
@@ -985,14 +985,13 @@ class ScheduledReportsView(BaseProjectReportSectionView):
                                key=self.domain, include_docs=True).all()
         web_user_emails = [u.get_email() for u in web_users]
         initial = self.report_notification.to_json()
-        initial['recipient_emails'] = ', '.join(initial['recipient_emails'])
         kwargs = {'initial': initial}
         args = ((self.request.POST, ) if self.request.method == "POST" else ())
 
         from corehq.apps.reports.forms import ScheduledReportForm
         form = ScheduledReportForm(*args, **kwargs)
         form.fields['config_ids'].choices = self.config_choices
-        form.fields['recipient_emails'].choices = web_user_emails
+        form.fields['recipient_emails'].choices = [(e, e) for e in web_user_emails]
 
         form.fields['hour'].help_text = "This scheduled report's timezone is %s (%s GMT)" % \
                                         (Domain.get_by_name(self.domain)['default_timezone'],

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -983,10 +983,19 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     def scheduled_report_form(self):
         web_users = WebUser.view('users/web_users_by_domain', reduce=False,
                                key=self.domain, include_docs=True).all()
-        web_user_emails = [u.get_email() for u in web_users]
         initial = self.report_notification.to_json()
         kwargs = {'initial': initial}
-        args = ((self.request.POST, ) if self.request.method == "POST" else ())
+        if self.request.method == "POST":
+            args = (self.request.POST, )
+            selected_emails = self.request.POST.getlist('recipient_emails', {})
+        else:
+            args = ()
+            selected_emails = kwargs.get('initial', {}).get('recipient_emails', [])
+
+        web_user_emails = [u.get_email() for u in web_users]
+        for email in selected_emails:
+            if email not in web_user_emails:
+                web_user_emails = [email] + web_user_emails
 
         from corehq.apps.reports.forms import ScheduledReportForm
         form = ScheduledReportForm(*args, **kwargs)


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/22024 isn't working because it uses v4 but scheduled reports, which use the same optimized javascript bundle, are still on v3. So let's upgrade scheduled reports.

Most of the code is in updating `MultiCharField` to use a select element, which is what select2 v4 needs, instead of a textarea with a comma-separated value.

Product: this makes minor changes to the appearance of the input for "Other recipients" when editing a scheduled report.

@dannyroberts / @Rohit25negi 