### PR TITLE
Return self in totalCostItem()

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/payment_method_handler.js
@@ -380,6 +380,8 @@ hqDefine('accounting/js/payment_method_handler', [
         self.reset =  function () {
             initData.paginatedListModel.refreshList();
         };
+
+        return self;
     };
 
     totalCostItem.prototype = Object.create(chargedCostItem.prototype);


### PR DESCRIPTION
`totalCostItem` in `payment_method_handlers.js` wasn't returning self, so the buttons to submit a bulk wire invoice request or a bulk credit card payment were not enabled, blocking all bulk invoice payments