### PR TITLE
Add account service type to toggles page

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/edit-flag.js
@@ -33,7 +33,8 @@ hqDefine('toggle_ui/js/edit-flag', [
 
         self.init_items = function (config) {
             var items = config.items,
-                last_used = config.last_used || {};
+                last_used = config.last_used || {},
+                service_type = config.service_type || {};
             self.items.removeAll();
             _(items).each(function (item) {
                 var fields = item.split(':'),
@@ -43,6 +44,7 @@ hqDefine('toggle_ui/js/edit-flag', [
                     namespace: ko.observable(self.padded_ns[namespace]),
                     value: ko.observable(value),
                     last_used: ko.observable(last_used[value]),
+                    service_type: ko.observable(service_type[value]),
                 });
             });
         };
@@ -52,6 +54,7 @@ hqDefine('toggle_ui/js/edit-flag', [
                 namespace: ko.observable(self.padded_ns[namespace]),
                 value: ko.observable(),
                 last_used: ko.observable(),
+                service_type: ko.observable(),
             });
             self.change();
         };
@@ -112,6 +115,7 @@ hqDefine('toggle_ui/js/edit-flag', [
             last_used: initialPageData.get('last_used'),
             is_random_editable: initialPageData.get('is_random_editable'),
             randomness: initialPageData.get('randomness'),
+            service_type: initialPageData.get('service_type'),
         });
         $home.koApplyBindings(view);
         $home.on('change', 'input', view.change);

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -29,16 +29,23 @@
     {% initial_page_data 'items' toggle.enabled_users %}
     {% initial_page_data 'namespaces' namespaces %}
     {% initial_page_data 'last_used' last_used %}
+    {% initial_page_data 'service_type' service_type %}
     {% initial_page_data 'is_random_editable' is_random_editable %}
     {% initial_page_data 'randomness' toggle_meta.randomness %}
     <div class="row" style="margin-bottom: 50px;">
         <div class="col-sm-12">
+            <span class="pull-right">
             {% if not usage_info %}
-                <a href="{{ page_url }}?usage_info=true" class="pull-right">
+                <a href="{{ page_url }}?usage_info=true">
                     <i class="icon-white icon-info-sign"></i>
                     {% trans "Show usage" %}
-                </a>
+                </a> |
             {% endif %}
+            <a href="{{ page_url }}?show_service_type=true">
+                <i class="icon-white icon-info-sign"></i>
+                {% trans "Show account service type" %}
+            </a>
+            </span>
             {% if toggle_meta.description %}
                 <p>{{ toggle_meta.description|safe }}</p>
             {% endif %}
@@ -98,6 +105,7 @@
                                   data-bind="html: $parent.getNamespaceHtml(namespace(), value())"
                                   style="font-family:monospace;"></span>
                             <span data-bind="text: last_used, visible: last_used" class="input-group-addon"></span>
+                            <span data-bind="text: service_type" class="input-group-addon"></span>
                         </div>
                     </div>
                 </div>

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -12,6 +12,7 @@ from django.utils.decorators import method_decorator
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster, \
     toggle_js_user_cachebuster
 from couchforms.analytics import get_last_form_submission_received
+from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import require_superuser_or_contractor
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.toggle_ui.utils import find_static_toggle
@@ -125,6 +126,10 @@ class ToggleEditView(ToggleBaseView):
         return self.request.GET.get('usage_info') == 'true'
 
     @property
+    def show_service_type(self):
+        return self.request.GET.get('show_service_type') == 'true'
+
+    @property
     def toggle_slug(self):
         return self.args[0] if len(self.args) > 0 else self.kwargs.get('toggle', "")
 
@@ -174,6 +179,10 @@ class ToggleEditView(ToggleBaseView):
         }
         if self.usage_info:
             context['last_used'] = _get_usage_info(toggle)
+
+        if self.show_service_type:
+            context['service_type'] = _get_service_type(toggle)
+
         return context
 
     def post(self, request, *args, **kwargs):
@@ -212,6 +221,8 @@ class ToggleEditView(ToggleBaseView):
         }
         if self.usage_info:
             data['last_used'] = _get_usage_info(toggle)
+        if self.show_service_type:
+            data['service_type'] = _get_service_type(toggle)
         return HttpResponse(json.dumps(data), content_type="application/json")
 
     def _notify_on_change(self, added_entries):
@@ -302,6 +313,19 @@ def _get_usage_info(toggle):
     last_used["_latest"] = _get_most_recently_used(last_used)
     last_used["_active_domains"] = active_domains
     return last_used
+
+
+def _get_service_type(toggle):
+    """Returns subscription service type for each toggle
+    """
+    service_type = {}
+    for enabled in toggle.enabled_users:
+        name = _enabled_item_name(enabled)
+        if _namespace_domain(enabled):
+            subscription = Subscription.get_active_subscription_by_domain(name)
+            if subscription:
+                service_type[name] = subscription.service_type
+    return service_type
 
 
 def _namespace_domain(enabled_item):


### PR DESCRIPTION
Shows whether a domain has an internal or product type account on the feature flag page.

I was trying to figure out how many domains with a specific flag were "real" (i.e. not internal people testing). This seems like a good way to get that information. 

@djmore9 

![screenshot from 2018-10-12 21-50-11](https://user-images.githubusercontent.com/146896/46899970-ed6c0480-ce68-11e8-8387-c2283f428ed8.png)
