### PR TITLE
Find the number of registered deaths on icds

### DIFF
--- a/custom/icds_reports/management/commands/nos_of_deaths.py
+++ b/custom/icds_reports/management/commands/nos_of_deaths.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, print_function
+
+from __future__ import unicode_literals
+import csv342 as csv
+import codecs
+import os
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.userreports.models import StaticDataSourceConfiguration
+from corehq.apps.userreports.util import get_indicator_adapter, get_table_name
+
+from corehq.sql_db.connections import connection_manager
+from io import open
+
+PERSON_TABLE_ID = 'static-person_cases_v2'
+AWC_LOCATION_TABLE_ID = 'static-awc_location'
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'file_path'
+        )
+
+    def handle(self, file_path, *args, **options):
+        domain = 'icds-cas'
+
+        data_source_id = StaticDataSourceConfiguration.get_doc_id(domain, PERSON_TABLE_ID)
+        config = StaticDataSourceConfiguration.by_id(data_source_id)
+        adapter = get_indicator_adapter(config)
+        session_helper = connection_manager.get_session_helper(adapter.engine_id)
+        person_table_name = get_table_name(domain, PERSON_TABLE_ID)
+        awc_location_table_name = get_table_name(domain, AWC_LOCATION_TABLE_ID)
+        session = session_helper.Session
+
+        with open(
+            os.path.join(os.path.dirname(__file__), 'sql_scripts', 'nos_of_deaths.sql'),
+            encoding='utf-8'
+        ) as f:
+            sql_script = f.read()
+            rows = session.execute(
+                sql_script % {
+                    'person_table_name': person_table_name,
+                    'awc_location_table_name': awc_location_table_name
+                }
+            )
+
+            utf_decoded_rows = []
+            for row in rows:
+                temp_row = []
+                for elem in row:
+                    temp_row.append(str(elem).decode("utf-8"))
+                utf_decoded_rows.append(temp_row)
+
+            with codecs.open(file_path, 'w', encoding='utf-8') as file_object:
+                writer = csv.writer(file_object)
+                writer.writerow([
+                    'State',
+                    'District',
+                    'AWC',
+                    'Month',
+                    'Deaths',
+                ])
+                writer.writerows(utf_decoded_rows)

--- a/custom/icds_reports/management/commands/nos_of_deaths.py
+++ b/custom/icds_reports/management/commands/nos_of_deaths.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, print_function
 
 from __future__ import unicode_literals
 import csv342 as csv
-import codecs
 import os
 
 from django.core.management.base import BaseCommand
@@ -47,14 +46,7 @@ class Command(BaseCommand):
                 }
             )
 
-            utf_decoded_rows = []
-            for row in rows:
-                temp_row = []
-                for elem in row:
-                    temp_row.append(str(elem).decode("utf-8"))
-                utf_decoded_rows.append(temp_row)
-
-            with codecs.open(file_path, 'w', encoding='utf-8') as file_object:
+            with open(file_path, 'w', encoding='utf-8') as file_object:
                 writer = csv.writer(file_object)
                 writer.writerow([
                     'State',
@@ -63,4 +55,4 @@ class Command(BaseCommand):
                     'Month',
                     'Deaths',
                 ])
-                writer.writerows(utf_decoded_rows)
+                writer.writerows(rows)

--- a/custom/icds_reports/management/commands/sql_scripts/nos_of_deaths.sql
+++ b/custom/icds_reports/management/commands/sql_scripts/nos_of_deaths.sql
@@ -1,0 +1,17 @@
+
+SELECT
+  convert_to(state, 'UTF8') AS state,
+  convert_to(district, 'UTF8') AS district,
+  convert_to(awc, 'UTF8') AS AWC,
+  death_month,
+  count(*) as no_of_deaths
+FROM (
+      SELECT awc_location.state_name AS state,
+             awc_location.district_name AS district,
+             awc_location.awc_name AS awc,
+             date_trunc('month',person_case.date_death) as death_month
+      FROM "%(person_table_name)s" AS person_case
+      INNER JOIN "%(awc_location_table_name)s" AS awc_location
+      ON person_case.awc_id = awc_location.doc_id
+      WHERE date_death IS NOT NULL) AS joined_result
+GROUP BY state,district,awc, death_month;

--- a/custom/icds_reports/management/commands/sql_scripts/nos_of_deaths.sql
+++ b/custom/icds_reports/management/commands/sql_scripts/nos_of_deaths.sql
@@ -1,10 +1,10 @@
 
 SELECT
-  convert_to(state, 'UTF8') AS state,
-  convert_to(district, 'UTF8') AS district,
-  convert_to(awc, 'UTF8') AS AWC,
+  state,
+  district,
+  awc,
   death_month,
-  count(*) as no_of_deaths
+  count(*)
 FROM (
       SELECT awc_location.state_name AS state,
              awc_location.district_name AS district,
@@ -14,4 +14,4 @@ FROM (
       INNER JOIN "%(awc_location_table_name)s" AS awc_location
       ON person_case.awc_id = awc_location.doc_id
       WHERE date_death IS NOT NULL) AS joined_result
-GROUP BY state,district,awc, death_month;
+GROUP BY state, district, awc, death_month;


### PR DESCRIPTION
Code adds a management command to find all the registered deaths on icds till not group by month, awc, district ,state. 
This is specific to case 'person case'. the death is identified by the attribute called date_death which is a compulsory field in case of death.
Result is exported in a csv file
http://manage.dimagi.com/default.asp?284058#1535710