### PR TITLE
Correct date filter for configurable reports

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -106,7 +106,6 @@ class DateFilterValue(FilterValue):
 
     def _offset_enddate(self, enddate):
         # offset enddate for SQL query
-        
         if enddate:
             enddate = datetime.datetime.combine(enddate, datetime.datetime.max.time())
         return enddate

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -106,10 +106,9 @@ class DateFilterValue(FilterValue):
 
     def _offset_enddate(self, enddate):
         # offset enddate for SQL query
-        # if it is datetime.date object it should not be offset
-        # if it is datetime.datetime object it should be offset to last microsecond of the day
-        if enddate and type(enddate) is datetime.datetime:
-            enddate = enddate + datetime.timedelta(days=1) - datetime.timedelta.resolution
+        
+        if enddate:
+            enddate = datetime.datetime.combine(enddate, datetime.datetime.max.time())
         return enddate
 
 

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from datetime import datetime
 import json
 from io import BytesIO
 from contextlib import contextmanager, closing
@@ -232,7 +233,11 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def filter_values(self):
-        return get_filter_values(self.filters, self.request_dict, user=self.request_user)
+        filters = get_filter_values(self.filters, self.request_dict, user=self.request_user)
+        for key in filters:
+            if isinstance(filters[key], DateSpan) and filters[key].inclusive:
+                filters[key].enddate = datetime.combine(filters[key].enddate, datetime.max.time())
+        return filters
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -232,9 +232,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def filter_values(self):
-        filters = get_filter_values(self.filters, self.request_dict, user=self.request_user)
-
-        return filters
+        return get_filter_values(self.filters, self.request_dict, user=self.request_user)
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from datetime import datetime
 import json
 from io import BytesIO
 from contextlib import contextmanager, closing

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -234,9 +234,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     @memoized
     def filter_values(self):
         filters = get_filter_values(self.filters, self.request_dict, user=self.request_user)
-        for key in filters:
-            if isinstance(filters[key], DateSpan) and filters[key].inclusive:
-                filters[key].enddate = datetime.combine(filters[key].enddate, datetime.max.time())
+
         return filters
 
     @property

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -710,14 +710,14 @@ class DateFilterOffsetTest(SimpleTestCase):
         start, end = date(2015, 1, 1), date(2015, 1, 2)
         computed_start, computed_end = self._computed_dates(start, end)
         self.assertEqual(computed_start, start)
-        self.assertEqual(computed_end, end)
+        self.assertEqual(computed_end, datetime.combine(end,datetime.max.time()))
 
     def test_datetime_objects(self):
         # computed_enddate should be last minute of the enddate
         start, end = datetime(2015, 1, 1), datetime(2015, 1, 2)
         computed_start, computed_end = self._computed_dates(start, end)
         self.assertEqual(computed_start, start)
-        self.assertNotEqual(computed_end, end)
+        self.assertEqual(computed_end, datetime.combine(end,datetime.max.time()))
         self.assertEqual((computed_end - end).days, 0)
 
 

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -710,14 +710,14 @@ class DateFilterOffsetTest(SimpleTestCase):
         start, end = date(2015, 1, 1), date(2015, 1, 2)
         computed_start, computed_end = self._computed_dates(start, end)
         self.assertEqual(computed_start, start)
-        self.assertEqual(computed_end, datetime.combine(end,datetime.max.time()))
+        self.assertEqual(computed_end, datetime.combine(end, datetime.max.time()))
 
     def test_datetime_objects(self):
         # computed_enddate should be last minute of the enddate
         start, end = datetime(2015, 1, 1), datetime(2015, 1, 2)
         computed_start, computed_end = self._computed_dates(start, end)
         self.assertEqual(computed_start, start)
-        self.assertEqual(computed_end, datetime.combine(end,datetime.max.time()))
+        self.assertEqual(computed_end, datetime.combine(end, datetime.max.time()))
         self.assertEqual((computed_end - end).days, 0)
 
 


### PR DESCRIPTION
Correct the date filter for configurable report. 
It was having a problem that the enddate was not being included(even if the inclusive is true.) Explanation is in the ticket: http://manage.dimagi.com/default.asp?283413#1537218
Directly adding one day to the end date would resolve the bug in the ticket. But would produce a new 
 bug(filter for DOB 27/10/1995 - 27/10/1995 would include 28/10/1995 also).
Setting the enddate to max time for that date solves both the issues without much if-else complications.
