### PR TITLE
Ignore SSL if necessary when polling Atom feed

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -99,7 +99,8 @@ def get_updated_patients(repeater):
         repeater.domain,
         repeater.url,
         repeater.username,
-        repeater.password
+        repeater.password,
+        verify=repeater.verify
     )
     # The OpenMRS Atom Feed's timestamps are timezone-aware. So when we
     # compare timestamps in has_new_entries_since(), this timestamp
@@ -214,7 +215,8 @@ def update_patient(repeater, patient_uuid, updated_at):
         repeater.domain,
         repeater.url,
         repeater.username,
-        repeater.password
+        repeater.password,
+        verify=repeater.verify
     )
     patient = get_patient_by_uuid(requests, patient_uuid)
     case, error = importer_util.lookup_case(


### PR DESCRIPTION
Importing patient updates from the OpenMRS Atom feed must respect if the repeater has "Skip SSL certificate verification" enabled.

Feature flag: "Enable OpenMRS integration"
