### PR TITLE
Change AWW incentive report name

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -116,7 +116,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         {id: 5, name: 'AWC Infrastructure'},
         {id: 6, name: 'Child Beneficiary List'},
         {id: 7, name: 'ICDS-CAS Monthly Register'},
-        {id: 8, name: 'AWW Performance Incentive Report'}
+        {id: 8, name: 'AWW Performance Report'}
     ];
 
     var ALL_OPTION = {name: 'All', location_id: 'all'};


### PR DESCRIPTION
On change request from Sarvesh. Change AWW incentive report name from 
'AWW Performance Incentive Report' to 'AWW Performance Report'

Sarvesh: 'for the name change I just need to remove incentive from the name so it should be "AWW Performance Report" instead of "AWW Performance Incentive Report" '