### PR TITLE
Fix syntax error in find_by_id.js

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
@@ -3,13 +3,13 @@ hqDefine("data_interfaces/js/find_by_id", [
     'knockout',
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
-    'analytix/js/kissmetrix'
+    'analytix/js/kissmetrix',
 ], function (
     $,
     ko,
     assertProperties,
     initialPageData,
-    kissmetrics,
+    kissmetrics
 ) {
     var findModel = function (options) {
         assertProperties.assert(options, ['errorMessage', 'eventName', 'header', 'help', 'placeholder', 'successMessage']);

--- a/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/find_by_id.js
@@ -3,7 +3,7 @@ hqDefine("data_interfaces/js/find_by_id", [
     'knockout',
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
-    'analytix/js/kissmetrix',
+    'analytix/js/kissmetrix'
 ], function (
     $,
     ko,


### PR DESCRIPTION
Error in https://github.com/dimagi/commcare-hq/pull/22046

This doesn't cause a user-facing problem, but it prevents uglifyjs from being able to minify the file in prod. Not sure why it didn't show up as a lint error when it was introduced; running `eslint` on the `master` version of this file does throw an error.

@dannyroberts / @jmtroth0 