### PR TITLE
Support partial bulk translations for ID mappings

### DIFF
--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -908,6 +908,7 @@ def _update_case_list_translations(sheet, rows, app):
                     word
                 )
             ))
+
     if msgs:
         return msgs
 
@@ -974,12 +975,8 @@ def _update_case_list_translations(sheet, rows, app):
             _update_detail(row, detail)
 
     if partial_upload:
-        case_list_rows = {
-            row['case_property']: row for row in condensed_rows if row['list_or_detail'] == 'list'
-        }
-        case_detail_rows = {
-            row['case_property']: row for row in condensed_rows if row['list_or_detail'] == 'detail'
-        }
+        case_list_rows = {row['case_property']: row for row in list_rows}
+        case_detail_rows = {row['case_property']: row for row in detail_rows}
 
         for detail in short_details:
             if case_list_rows.get(detail.field):

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -974,16 +974,15 @@ def _update_case_list_translations(sheet, rows, app):
                 continue
             _update_detail(row, detail)
 
-    if partial_upload:
-        case_list_rows = {row['case_property']: row for row in list_rows}
-        case_detail_rows = {row['case_property']: row for row in detail_rows}
+    def _partial_upload(rows, details):
+        rows_by_property = {row['case_property']: row for row in rows}
+        for detail in details:
+            if rows_by_property.get(detail.field):
+                _update_detail(rows_by_property.get(detail.field), detail)
 
-        for detail in short_details:
-            if case_list_rows.get(detail.field):
-                _update_detail(case_list_rows.get(detail.field), detail)
-        for detail in long_details:
-            if case_detail_rows.get(detail.field):
-                _update_detail(case_detail_rows.get(detail.field), detail)
+    if partial_upload:
+        _partial_upload(list_rows, short_details)
+        _partial_upload(detail_rows, long_details)
     else:
         _update_details_based_on_position(list_rows, short_details, detail_rows, long_details)
 

--- a/corehq/apps/app_manager/app_translations/app_translations.py
+++ b/corehq/apps/app_manager/app_translations/app_translations.py
@@ -13,6 +13,7 @@ import re
 from lxml.etree import XMLSyntaxError, Element
 from celery.task import task
 
+from corehq import toggles
 from corehq.apps.app_manager.app_translations.const import MODULES_AND_FORMS_SHEET_NAME
 from corehq.apps.app_manager.const import APP_TRANSLATION_UPLOAD_FAIL_MESSAGE
 from corehq.apps.app_manager.exceptions import (
@@ -896,7 +897,7 @@ def _update_case_list_translations(sheet, rows, app):
             # then we can perform a partial upload using field (case property)
             # as a key
             number_fields = len({detail.field for detail in expected_list})
-            if number_fields == len(expected_list):
+            if number_fields == len(expected_list) and toggles.ICDS.enabled(app.domain):
                 partial_upload = True
                 continue
             msgs.append((
@@ -930,7 +931,7 @@ def _update_case_list_translations(sheet, rows, app):
             ))
 
     def _update_id_mappings(rows, detail):
-        if len(rows) == len(detail.enum):
+        if len(rows) == len(detail.enum) or not toggles.ICDS.enabled(app.domain):
             for row, mapping in zip(rows, detail.enum):
                 _update_translation(row, mapping.value)
         else:

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -14,6 +14,7 @@ from corehq.util.workbook_json.excel import WorkbookJSONReader
 
 from couchexport.export import export_raw
 from couchexport.models import Format
+from corehq.util.test_utils import flag_enabled
 from corehq.apps.app_manager.models import Application, Module
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.app_translations import (
@@ -408,6 +409,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
             ]
         )
 
+    @flag_enabled('ICDS')
     def test_partial_case_list_translation_upload(self):
         # note this isn't a "partial" upload because this app only has one case list property
         module = self.app.get_module(0)
@@ -433,6 +435,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
             module.case_details.short.columns[0].header, {'en': 'Name'}
         )
 
+    @flag_enabled('ICDS')
     def test_partial_case_detail_translation_upload(self):
         module = self.app.get_module(0)
         self.assertEqual(
@@ -468,6 +471,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
             module.case_details.long.columns[1].header, {'en': 'Other Prop', 'fra': 'Autre Prop'}
         )
 
+    @flag_enabled('ICDS')
     def test_partial_upload_id_mapping(self):
         module = self.app.get_module(0)
         self.assertEqual(


### PR DESCRIPTION
Continuation of https://github.com/dimagi/commcare-hq/pull/22072

REACH needs to be able to delete rows from bulk translations - this extends that capability to ID mappings.

[Rant] This code is really messy and difficult to follow - I don't like editing it in this state, but a full refactor is wildly out of scope for what I'm doing.  The existing framework (before @emord's change) is brittle and inflexible, and I don't think we can reliably stretch it much.