### PR TITLE
fix deprecation warning

### DIFF
--- a/corehq/apps/reports/v2/formatters/cases.py
+++ b/corehq/apps/reports/v2/formatters/cases.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from couchdbkit import ResourceNotFound
 
-from django.core.urlresolvers import NoReverseMatch
+from django.urls import NoReverseMatch
 from django.utils import html
 from django.utils.translation import ugettext as _
 


### PR DESCRIPTION
Fixes

```
corehq/apps/reports/v2/formatters/cases.py:6: RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.
  from django.core.urlresolvers import NoReverseMatch
```

Avoiding introducing deprecation warnings will help the poor soul who ends up upgrading django to 2.0