### PR TITLE
handle null ccs records

### DIFF
--- a/custom/icds_reports/utils/aggregation.py
+++ b/custom/icds_reports/utils/aggregation.py
@@ -257,7 +257,7 @@ class ComplementaryFormsCcsRecordAggregationHelper(BaseICDSAggregationHelper):
         LAST_VALUE(timeend) OVER w AS latest_time_end,
         SUM(CASE WHEN unscheduled_visit=0 AND days_visit_late < 8 THEN 1 ELSE 0 END) OVER w as valid_visits
         FROM "{ucr_tablename}"
-        WHERE timeend >= %(current_month_start)s AND timeend < %(next_month_start)s AND state_id = %(state_id)s
+        WHERE timeend >= %(current_month_start)s AND timeend < %(next_month_start)s AND state_id = %(state_id)s AND ccs_record_case_id IS NOT NULL
         WINDOW w AS (
             PARTITION BY ccs_record_case_id
             ORDER BY timeend RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING


### PR DESCRIPTION
`ccs_record_case_id` was recently added to the UCR so old records have a null value for it. This was breaking the rest of the aggregation.
@emord @esoergel @Rohit25negi 