### PR TITLE
Bump form timeout to 15 minutes

### DIFF
--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -95,7 +95,7 @@ class FormProcessorInterface(object):
             return LedgerDBCouch()
 
     def acquire_lock_for_xform(self, xform_id):
-        lock = self.xform_model.get_obj_lock_by_id(xform_id, timeout_seconds=5 * 60)
+        lock = self.xform_model.get_obj_lock_by_id(xform_id, timeout_seconds=15 * 60)
         try:
             lock.acquire()
         except RedisError:


### PR DESCRIPTION
Hoping this will alleviate this:
https://manage.dimagi.com/default.asp?269112

Some supply updates are being applied twice.  The suspicion is that they take so long to process that they are hitting a timeout and being  submitted/processed a second time.  More context in that ticket.

This isn't the fix we want, but it's the fix we have.

Here's a branch which attempts to reproduce the issue: https://github.com/dimagi/commcare-hq/compare/es/duplicate-ledgers
(commit 9b4eadf if that's gone)