### PR TITLE
consolidate module translations for same context

### DIFF
--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -181,7 +181,7 @@ class AppTranslationsGenerator:
     def _get_translation_for_sheet(self, app, sheet_name, rows):
         occurrence = None
         # a dict mapping of a context to a Translation object with
-        # clubbed occurrences
+        # multiple occurrences
         translations = OrderedDict()
         type_and_id = None
         key_lang_index = self._get_header_index(sheet_name, self.lang_prefix + self.key_lang)

--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -212,8 +212,7 @@ class AppTranslationsGenerator:
                 def occurrence(_row):
                     return _row[label_index]
         is_module = type_and_id and type_and_id.type == "Module"
-        for i, row in enumerate(rows):
-            index = i + 1
+        for index, row in enumerate(rows, 1):
             source = row[key_lang_index]
             translation = row[source_lang_index]
             if self.exclude_if_default:

--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -220,15 +220,17 @@ class AppTranslationsGenerator:
                 if translation == row[default_lang_index]:
                     translation = ''
             occurrence_row = occurrence(row)
+            occurrence_row_and_source = "%s %s" % (occurrence_row, source)
             if is_module:
-                # if there is already a translation with the same context, just add this occurrence
-                if occurrence_row in translations:
-                    translations[occurrence_row].occurrences.append(
+                # if there is already a translation with the same context and source,
+                # just add this occurrence
+                if occurrence_row_and_source in translations:
+                    translations[occurrence_row_and_source].occurrences.append(
                         (occurrence_row, index)
                     )
                     continue
 
-            translations[occurrence_row] = Translation(
+            translations[occurrence_row_and_source] = Translation(
                 source,
                 translation,
                 [(occurrence_row, index)],

--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -235,7 +235,7 @@ class AppTranslationsGenerator:
                 translation,
                 [(occurrence_row, index)],
                 occurrence_row)
-        return translations.values()
+        return list(translations.values())
 
     @property
     @memoized

--- a/corehq/apps/app_manager/app_translations/parser.py
+++ b/corehq/apps/app_manager/app_translations/parser.py
@@ -67,7 +67,6 @@ class TranslationsParser(object):
         by using occurrences
         """
         rows = {}
-        po_entries = []
         # align entries in a dict with their index as the key
         for po_entry in consolidated_po_entries:
             occurrences = po_entry.occurrences
@@ -78,7 +77,7 @@ class TranslationsParser(object):
         if rows:
             assert len(rows) == int(max(rows.keys()))
         # sort by index to have the expected order
-        return [po_entry for index, po_entry in sorted(rows.items())]
+        return [po_entry for i, po_entry in sorted(rows.items())]
 
     def _add_module_sheet(self, ws, po_entries):
         context_regex = CONTEXT_REGEXS['module_sheet']

--- a/corehq/apps/app_manager/app_translations/parser.py
+++ b/corehq/apps/app_manager/app_translations/parser.py
@@ -78,9 +78,7 @@ class TranslationsParser(object):
         if rows:
             assert len(rows) == int(max(rows.keys()))
         # sort by index to have the expected order
-        for index in sorted(rows.keys()):
-            po_entries.append(rows[index])
-        return po_entries
+        return [po_entry for index, po_entry in sorted(rows.items())]
 
     def _add_module_sheet(self, ws, po_entries):
         context_regex = CONTEXT_REGEXS['module_sheet']


### PR DESCRIPTION
Modules tend to have repetitions with same case property or same ID Mapping text used at multiple places.
This was expected to cause failures when pushing to transifex since duplicates are not allowed.
But seems like we would need to handle this.

This PR, consolidates translations with same context and source before sending them to transifex and then unfolds them back once pulled.