### PR TITLE
Skip auditing if domain is not present

### DIFF
--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -100,5 +100,7 @@ class DomainAuditMiddleware(MiddlewareMixin):
     def process_view(self, request, view_func, view_args, view_kwargs):
         if view_func.func_name in DOMAIN_AUDIT_VIEWS:
             domain = view_kwargs.get('domain', None)
-            DomainAuditRecordEntry.update_calculations(domain, view_func.func_name)
+            # skipping  audit if domain=None/''
+            if domain:
+                DomainAuditRecordEntry.update_calculations(domain, view_func.func_name)
         return None


### PR DESCRIPTION
Skipping the audit event if the domain is null.
looks being raised after this:https://github.com/dimagi/commcare-hq/commit/1678f33217013dbf30346c373468d2791701188b

FYI @snopoke 