### PR TITLE
remove long request logging

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -96,21 +96,6 @@ class TimingMiddleware(object):
         return response
 
 
-class LogLongRequestMiddleware(MiddlewareMixin):
-
-    def process_request(self, request):
-        request._profile_starttime = datetime.datetime.utcnow()
-
-    def process_response(self, request, response):
-        if hasattr(request, '_profile_starttime'):
-            duration = datetime.datetime.utcnow() - request._profile_starttime
-            if duration > datetime.timedelta(minutes=10):
-                notify_exception(request, "Request took a very long time.", details={
-                    'duration': duration.total_seconds(),
-                })
-        return response
-
-
 class TimeoutMiddleware(MiddlewareMixin):
 
     @staticmethod

--- a/settings.py
+++ b/settings.py
@@ -151,7 +151,6 @@ MIDDLEWARE = [
     'corehq.middleware.SentryContextMiddleware',
     'corehq.apps.domain.middleware.DomainMigrationMiddleware',
     'corehq.middleware.TimeoutMiddleware',
-    'corehq.middleware.LogLongRequestMiddleware',
     'corehq.apps.domain.middleware.CCHQPRBACMiddleware',
     'corehq.apps.domain.middleware.DomainHistoryMiddleware',
     'corehq.apps.domain.project_access.middleware.ProjectAccessMiddleware',


### PR DESCRIPTION
@dannyroberts removing this unless you think it's still adding value. It's been triggered 151K times since being deployed on prod.