### PR TITLE
Speed up case importer 

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -9,7 +9,6 @@ from corehq import toggles
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.dbaccessors import get_case_sharing_apps_in_domain
 from corehq.apps.app_manager.util import is_usercase_in_use, all_apps_by_domain
-from corehq.apps.data_dictionary.util import get_data_dict_props_by_case_type
 from corehq.util.quickcache import quickcache
 from memoized import memoized
 import six
@@ -380,6 +379,7 @@ class ParentCasePropertyBuilder(object):
 
         :return: {<case_type>: set([<property>])} for all case types found
         """
+        from corehq.apps.data_dictionary.util import get_data_dict_props_by_case_type
         case_properties_by_case_type = defaultdict(set)
 
         _zip_update(case_properties_by_case_type, self._get_all_case_updates())

--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -519,7 +519,7 @@ def get_usercase_properties(app):
 
 
 def all_case_properties_by_domain(domain, case_types=None, include_parent_properties=True):
-    result = {}
+    result = defaultdict(set)
     get_case_types_from_apps = case_types is None
 
     for app in all_apps_by_domain(domain):
@@ -533,18 +533,12 @@ def all_case_properties_by_domain(domain, case_types=None, include_parent_proper
             defaults=('name',), include_parent_properties=include_parent_properties)
 
         for case_type, properties in six.iteritems(property_map):
-            if case_type in result:
-                result[case_type].extend(properties)
-            else:
-                result[case_type] = properties
+            result[case_type].update(properties)
 
-    cleaned_result = {}
-    for case_type, properties in six.iteritems(result):
-        properties = list(set(properties))
-        properties.sort()
-        cleaned_result[case_type] = properties
-
-    return cleaned_result
+    return {
+        case_type: sorted(properties)
+        for case_type, properties in result.items()
+    }
 
 
 def get_per_type_defaults(domain, case_types=None):

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -76,3 +76,8 @@ class CaseProperty(models.Model):
                 case_type_obj = CaseType.get_or_create(domain, case_type)
                 prop = CaseProperty.objects.create(case_type=case_type_obj, name=name)
             return prop
+
+    def save(self, *args, **kwargs):
+        from .util import get_data_dict_props_by_case_type
+        get_data_dict_props_by_case_type.clear(self.case_type.domain)
+        return super(CaseProperty, self).save(*args, **kwargs)

--- a/corehq/apps/data_dictionary/tests/test_util.py
+++ b/corehq/apps/data_dictionary/tests/test_util.py
@@ -9,7 +9,7 @@ from corehq.apps.data_dictionary.models import CaseType, CaseProperty
 from corehq.apps.data_dictionary.util import generate_data_dictionary
 
 
-@patch('corehq.apps.data_dictionary.util.get_all_case_properties')
+@patch('corehq.apps.data_dictionary.util._get_all_case_properties')
 class GenerateDictionaryTest(TestCase):
     domain = uuid.uuid4().hex
 

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+from itertools import groupby
+from operator import attrgetter
+
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext
 
@@ -149,3 +153,15 @@ def save_case_property(name, case_type, domain=None, data_type=None,
     except ValidationError as e:
         return six.text_type(e)
     prop.save()
+
+
+def get_data_dict_props_by_case_type(domain):
+    return {
+        case_type: {prop.name for prop in props} for case_type, props in groupby(
+            CaseProperty.objects
+            .filter(case_type__domain=domain, deprecated=False)
+            .select_related("case_type")
+            .order_by('case_type__name'),
+            key=attrgetter('case_type.name')
+        )
+    }

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext
 
 from corehq import toggles
+from corehq.util.quickcache import quickcache
 from corehq.apps.app_manager.app_schemas.case_properties import all_case_properties_by_domain
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.data_dictionary.models import CaseProperty, CaseType
@@ -155,6 +156,7 @@ def save_case_property(name, case_type, domain=None, data_type=None,
     prop.save()
 
 
+@quickcache(vary_on=['domain'], timeout=24 * 60 * 60)
 def get_data_dict_props_by_case_type(domain):
     return {
         case_type: {prop.name for prop in props} for case_type, props in groupby(

--- a/corehq/apps/data_dictionary/util.py
+++ b/corehq/apps/data_dictionary/util.py
@@ -15,13 +15,13 @@ class OldExportsEnabledException(Exception):
 
 
 def generate_data_dictionary(domain):
-    properties = get_all_case_properties(domain)
+    properties = _get_all_case_properties(domain)
     _create_properties_for_case_types(domain, properties)
     CaseType.objects.filter(domain=domain, name__in=list(properties)).update(fully_generated=True)
     return True
 
 
-def get_all_case_properties(domain, case_types=None):
+def _get_all_case_properties(domain, case_types=None):
     # moved here to avoid circular import
     from corehq.apps.export.models.new import CaseExportDataSchema
 


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?283896

Product: This PR should speed up the case importer.  It has no other user-facing aspects.

There's a lot that's bad about this function.  I'm working on splitting apart some of these sources so they can be put on longer caches.  This PR splits out the data dictionary lookup and caches that.

The biggest improvement will probably come from the `traverse_apps` flag.  As currently implemented, this code scales exponentially with the number of apps on the domain:
* `all_case_properties_by_domain` iterates over all apps
* for each app, it fetches a list of relevant case types
* then it calls [`get_case_properties`](https://github.com/dimagi/commcare-hq/blob/693f5f4e86a5359a4df0fa0f627113bff0397695/corehq/apps/app_manager/app_schemas/case_properties.py#L532-L533)
* That instantiates `ParentCasePropertyBuilder` and calls `get_case_property_map(case_types)`
* For every case type, that calls `self.get_properties(case_type)`
* That implementation is just `return self.get_properties_by_case_type()[case_type]`
* (Luckily `get_case_properties_by_case_type` is memoized, so we don't actually do that n^2 times)
* That calls `_get_all_case_updates`, which calls `_get_relevant_forms`
* ...and THAT calls `_get_relevant_apps`, which calls **_get_other_case_sharing_apps_in_domain**

Put another way - for every app, it looks over all forms **for every app**.

The code needs some cleanup, but this fix is fairly urgent, so I'm PRing a bandaid fix to that issue for now and will work on improving the structure a bit.  The `ParentCasePropertyBuilder` class is used in a few different contexts and it's hard to isolate components of that to optimize - I'd like to see if I can split that into a set of utils or something.

:shark: :x: :tropical_fish: