### PR TITLE
Clarify that UCR ID is a ReportConfig ID

### DIFF
--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -42,7 +42,7 @@ class DataValueMap(DocumentSchema):
 class DataSetMap(Document):
     # domain and UCR uniquely identify a DataSetMap
     domain = StringProperty()
-    ucr_id = StringProperty()
+    ucr_id = StringProperty()  # UCR ReportConfig id
 
     description = StringProperty()
     frequency = StringProperty(choices=SEND_FREQUENCIES, default=SEND_FREQUENCY_MONTHLY)

--- a/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
+++ b/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
@@ -85,7 +85,7 @@
 
         <div class="form-group">
             <label class="control-label col-sm-3 col-md-2 requiredField">
-                {% trans "UCR ID" %}<span class="asteriskField">*</span>
+                {% trans "UCR Report ID" %}<span class="asteriskField">*</span>
             </label>
             <div class="controls col-sm-9 col-md-8 col-lg-6">
                 <input class="textinput textInput form-control"


### PR DESCRIPTION
Minor clarification from https://manage.dimagi.com/default.asp?284549
It'd be nice to add in validation that what the user enters is a valid report ID, but there's not currently any validation built in to that page and I didn't want to spend too much time on this.