### PR TITLE
Cache form updates

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1442,6 +1442,7 @@ class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
                 "%s is not a valid question" % question_path
             )
 
+    @quickcache(['self.unique_id', 'self.version'], timeout=24 * 60 * 60)
     def get_all_case_updates(self):
         """
         Collate contributed case updates from all sources within the form

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1442,7 +1442,8 @@ class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
                 "%s is not a valid question" % question_path
             )
 
-    @quickcache(['self.unique_id', 'self.version'], timeout=24 * 60 * 60)
+    @quickcache(['self.unique_id', 'self.version'], timeout=24 * 60 * 60,
+                skip_arg=lambda *args: settings.UNIT_TESTING)
     def get_all_case_updates(self):
         """
         Collate contributed case updates from all sources within the form


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?283896

This is easy to cache, and doesn't need invalidation (assuming form.unique_id is unique, which it isn't in some tests).  In my ideal world, this would actually be stored on the form doc, though I'm not sure of a good way to go about that.