### PR TITLE
Ignore software plan's domain limit when user modifies version

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1294,7 +1294,7 @@ class Subscription(models.Model):
         assert self.is_active
         assert date_end is None or date_end >= today
 
-        if new_plan_version.plan.at_max_domains():
+        if new_plan_version.plan.at_max_domains() and self.plan_version.plan != new_plan_version.plan:
             raise SubscriptionAdjustmentError(
                 'The maximum number of project spaces has been reached for %(new_plan_version)s. ' % {
                     'new_plan_version': new_plan_version,


### PR DESCRIPTION
This PR allows admins to upgrade/downgrade the software plan _version_ when the plan is already at its max number of domains. If a domain is already subscribed to a plan, updating the subscription's plan version won't change the number of domains.