### PR TITLE
[Vector-Link] fix wrong engine_id in late pmt datasource

### DIFF
--- a/custom/abt/reports/late_pmt.py
+++ b/custom/abt/reports/late_pmt.py
@@ -22,7 +22,7 @@ from custom.abt.reports.filters import UsernameFilter, CountryFilter, LevelOneFi
 
 
 class LatePMTUsers(SqlData):
-    engine_id = 'ucr'
+    engine_id = 'default'
 
     @property
     def table_name(self):


### PR DESCRIPTION
Hi @nickpell 

Regarding this issue: http://manage.dimagi.com/default.asp?284764 I changed the engine_id in ```LatePMTUsers```

Please let me know if you have any questions.

Regards,
Łukasz