### PR TITLE
Account for undefined variables before calling split.(',')

### DIFF
--- a/corehq/apps/export/static/export/js/download_export.ng.js
+++ b/corehq/apps/export/static/export/js/download_export.ng.js
@@ -147,10 +147,10 @@
 
             var filterNamesAsString = $("#exportFiltersFormId").find("input[name="
                         + getFilterName($scope.exportList[0].export_type) + "]")
-                        .val()
+                .val();
 
             function getFilterNames() {
-              return (filterNamesAsString ? filterNamesAsString.split(',') : "");
+                return (filterNamesAsString ? filterNamesAsString.split(',') : "");
             }
 
             hqImport('analytix/js/kissmetrix').track.event("Clicked Prepare Export", {

--- a/corehq/apps/export/static/export/js/download_export.ng.js
+++ b/corehq/apps/export/static/export/js/download_export.ng.js
@@ -150,7 +150,7 @@
                 .val();
 
             function getFilterNames() {
-                return (filterNamesAsString ? filterNamesAsString.split(',') : "");
+                return (filterNamesAsString ? filterNamesAsString.split(',') : []);
             }
 
             hqImport('analytix/js/kissmetrix').track.event("Clicked Prepare Export", {

--- a/corehq/apps/export/static/export/js/download_export.ng.js
+++ b/corehq/apps/export/static/export/js/download_export.ng.js
@@ -144,12 +144,19 @@
             function getFilterName(exportType) {
                 return (exportType === "form" ? "emw" : "case_list_filter");
             }
+
+            var filterNamesAsString = $("#exportFiltersFormId").find("input[name="
+                        + getFilterName($scope.exportList[0].export_type) + "]")
+                        .val()
+
+            function getFilterNames() {
+              return (filterNamesAsString ? filterNamesAsString.split(',') : "");
+            }
+
             hqImport('analytix/js/kissmetrix').track.event("Clicked Prepare Export", {
                 "Export type": $scope.exportList[0].export_type,
                 "filters": _.map(
-                    $("#exportFiltersFormId").find("input[name="
-                        + getFilterName($scope.exportList[0].export_type) + "]")
-                        .val().split(','),
+                    getFilterNames(),
                     function (item) {
                         if (item.substring(0,3) === "t__") {
                             return userTypes[item.substring(3)];


### PR DESCRIPTION
This should fix the [broken travis tests](https://travis-ci.org/dimagi/commcare-hq/jobs/444925502).

@jmtroth0 
code buddy @sravfeyn 