### PR TITLE
add USD cost along with other currencies

### DIFF
--- a/corehq/apps/smsbillables/tasks.py
+++ b/corehq/apps/smsbillables/tasks.py
@@ -49,13 +49,30 @@ def send_gateway_fee_report_out():
 
     subject = "[{}] Cost per SMS Gateway Monthly Summary".format(settings.SERVER_ENVIRONMENT)
 
+    def _get_cost_string(cost, currency_code):
+        cost_template = '%.2f %s'
+        cost_string_in_original_currency = cost_template % (cost, currency_code)
+        default_code = Currency.get_default().code
+        if currency_code == default_code:
+            return cost_string_in_original_currency
+        else:
+            cost_string_in_default_currency = cost_template % (
+                cost / Currency.objects.get(code=currency_code).rate_to_default,
+                default_code
+            )
+            return '%s (%s)' % (
+                cost_string_in_original_currency,
+                cost_string_in_default_currency
+            )
+
+
     send_HTML_email(
         subject,
         settings.ACCOUNTS_EMAIL,
         ''.join(
             '<p>{}: {}</p>'.format(
                 backend_api_id, '; '.join(
-                    '%.2f %s' % (cost, currency) for (cost, currency) in cost_by_backend
+                    _get_cost_string(cost, currency_code) for (cost, currency_code) in cost_by_backend
                 )
             )
             for (backend_api_id, cost_by_backend) in costs_by_backend.items()

--- a/corehq/apps/smsbillables/tasks.py
+++ b/corehq/apps/smsbillables/tasks.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 from collections import defaultdict


### PR DESCRIPTION
Makes the Gateway Fee Monthly Summary email easier to comprehend by adding the cost per gateway in USD whenever the original cost is in another currency.