### PR TITLE
Upgrade gevent to 1.3.7

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -86,10 +86,10 @@ first==2.0.1              # via pip-tools
 fixture==1.5.11
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.2.2
+gevent==1.3.7
 ghdiff==0.4
 graphviz==0.7
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -71,9 +71,9 @@ eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.2.2
+gevent==1.3.7
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -76,9 +76,9 @@ faker==0.8.15
 flower==0.9.2
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.2.2
+gevent==1.3.7
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -45,8 +45,8 @@ Unidecode==0.04.20
 xlrd==1.0.0
 simplejson==3.11.1
 sh==1.09
-gevent==1.2.2
-greenlet==0.4.12
+gevent==1.3.7
+greenlet==0.4.15
 numpy==1.7.1
 six==1.11.0
 socketpool==0.5.3

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
 attrs==18.1.0
-# needed to build gevent from source
+# needed to build jsonobject, and possibly other libraries?
 cython==0.27.3
 iso8601==0.1.12
 jsonobject==0.9.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -69,9 +69,9 @@ eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2           # via mock
 futures==3.2.0            # via s3transfer, tinys3
-gevent==1.2.2
+gevent==1.3.7
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -74,9 +74,9 @@ fakecouch==0.0.15
 faker==0.8.15
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.2.2
+gevent==1.3.7
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8


### PR DESCRIPTION
One small part of work being done to mitigate general slowness seen on production env. May improve gevent performance a bit. [Ad-hoc benchmark](https://github.com/millerdev/gtime) showed small improvement over gevent 1.2.2. The plan is to deploy to staging first for a bit, and then to production if nothing comes up on staging.