### PR TITLE
Ignore python optimized files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.pyo
 *~
 *.swp
 *.swo


### PR DESCRIPTION
These are created for the celery queues where we use `python -O`