### PR TITLE
Fix ReindexAccessor.sql_db_aliases

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -56,7 +56,7 @@ from corehq.form_processor.utils.sql import (
     fetchall_as_namedtuple
 )
 from corehq.sql_db.config import get_sql_db_aliases_in_use, partition_config
-from corehq.sql_db.routers import get_cursor
+from corehq.sql_db.routers import db_for_read_write, get_cursor
 from corehq.sql_db.util import split_list_by_db_partition
 from corehq.util.queries import fast_distinct_in_domain
 from dimagi.utils.chunked import chunked
@@ -216,7 +216,8 @@ class ReindexAccessor(six.with_metaclass(ABCMeta)):
 
     @property
     def sql_db_aliases(self):
-        all_db_aliases = get_sql_db_aliases_in_use() if self.is_sharded() else ['default']
+        all_db_aliases = get_sql_db_aliases_in_use() if self.is_sharded() \
+            else [db_for_read_write(self.model_class)]
         if self.limit_db_aliases:
             db_aliases = list(set(all_db_aliases) & set(self.limit_db_aliases))
             assert db_aliases, 'Limited DBs not in expected list: {} {}'.format(


### PR DESCRIPTION
...for non-sharded models not living in the default database.

I encountered an error while migrating blob metadata on ICDS:
```
django.db.utils.ProgrammingError: relation "icds_reports_icdsfile" does not exist
LINE 1: ..._type", "icds_reports_icdsfile"."file_added" FROM "icds_repo...
```

I had seen the same error on other envs, but since it was an ICDS-specific table I figured the table did not exist and I skipped that (last) part of the migration by commenting out this line and re-running the migration to ensure it completed without errors:

https://github.com/dimagi/commcare-hq/blob/1aa0d29a3737ec8615a360bc2fbb00591882ca40/corehq/blobs/migrate_metadata.py#L361

However, on ICDS I figured the table should exist, and after digging a bit deeper I realized `ReindexAccessor.sql_db_aliases` was the problem.

I also went back and re-ran the migration with the fix on softlayer. The database where that table lives (`icds-ucr`) does not exist on prod.