### PR TITLE
Test optimized ICDS UCR report

### DIFF
--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -417,7 +417,7 @@ class ConditionalAggregationColumn(_CaseExpressionColumn):
 
 class SumWhenColumn(_CaseExpressionColumn):
     type = TypeProperty("sum_when")
-    else_ = IntegerProperty()
+    else_ = IntegerProperty(default=0)
     _agg_column_type = SumWhen
 
 

--- a/custom/icds_reports/ucr/reports/testing/mpr_10a_children_referred.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10a_children_referred.json
@@ -101,7 +101,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ypremature\y'": 1
+          "referral_health_problem ~ '\\ypremature\\y'": 1
         }
       },
       {
@@ -111,7 +111,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ysepsis\y'": 1
+          "referral_health_problem ~ '\\ysepsis\\y'": 1
         }
       },
       {
@@ -121,7 +121,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ydiarrhoea\y'": 1
+          "referral_health_problem ~ '\\ydiarrhoea\\y'": 1
         }
       },
       {
@@ -131,7 +131,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ypneumonia\y'": 1
+          "referral_health_problem ~ '\\ypneumonia\\y'": 1
         }
       },
       {
@@ -141,7 +141,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yfever_child\y'": 1
+          "referral_health_problem ~ '\\yfever_child\\y'": 1
         }
       },
       {
@@ -151,7 +151,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yseverely_underweight\y'": 1
+          "referral_health_problem ~ '\\yseverely_underweight\\y'": 1
         }
       },
       {
@@ -161,7 +161,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yother_child\y'": 1
+          "referral_health_problem ~ '\\yother_child\\y'": 1
         }
       },
       {
@@ -171,7 +171,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypremature\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypremature\\y'": 1
         }
       },
       {
@@ -181,7 +181,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ysepsis\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ysepsis\\y'": 1
         }
       },
       {
@@ -191,7 +191,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ydiarrhoea\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ydiarrhoea\\y'": 1
         }
       },
       {
@@ -201,7 +201,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypneumonia\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypneumonia\\y'": 1
         }
       },
       {
@@ -211,7 +211,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yfever_child\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yfever_child\\y'": 1
         }
       },
       {
@@ -221,7 +221,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yseverely_underweight\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yseverely_underweight\\y'": 1
         }
       },
       {
@@ -231,7 +231,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yother_child\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yother_child\\y'": 1
         }
       }
     ],

--- a/custom/icds_reports/ucr/reports/testing/mpr_10a_children_referred.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10a_children_referred.json
@@ -1,0 +1,241 @@
+{
+  "domains": [
+    "icds-cas",
+    "icds-dashboard-qa",
+    "reach-test"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_10a_children_referred-optimized",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR 10a - Children Referred (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Last Referral Date",
+        "slug": "last_referral_date",
+        "type": "date",
+        "field": "last_referral_date",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "last_referral_date",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "referred_premature",
+        "column_id": "referred_premature",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ypremature\y'": 1
+        }
+      },
+      {
+        "display": "referred_sepsis",
+        "column_id": "referred_sepsis",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ysepsis\y'": 1
+        }
+      },
+      {
+        "display": "referred_diarrhoea",
+        "column_id": "referred_diarrhoea",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ydiarrhoea\y'": 1
+        }
+      },
+      {
+        "display": "referred_pneumonia",
+        "column_id": "referred_pneumonia",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ypneumonia\y'": 1
+        }
+      },
+      {
+        "display": "referred_fever_child",
+        "column_id": "referred_fever_child",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yfever_child\y'": 1
+        }
+      },
+      {
+        "display": "referred_severely_underweight",
+        "column_id": "referred_severely_underweight",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yseverely_underweight\y'": 1
+        }
+      },
+      {
+        "display": "referred_other_child",
+        "column_id": "referred_other_child",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yother_child\y'": 1
+        }
+      },
+      {
+        "display": "premature_reached_count",
+        "column_id": "premature_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypremature\y'": 1
+        }
+      },
+      {
+        "display": "sepsis_reached_count",
+        "column_id": "sepsis_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ysepsis\y'": 1
+        }
+      },
+      {
+        "display": "diarrhoea_reached_count",
+        "column_id": "diarrhoea_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ydiarrhoea\y'": 1
+        }
+      },
+      {
+        "display": "pneumonia_reached_count",
+        "column_id": "pneumonia_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypneumonia\y'": 1
+        }
+      },
+      {
+        "display": "fever_child_reached_count",
+        "column_id": "fever_child_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yfever_child\y'": 1
+        }
+      },
+      {
+        "display": "sev_underweight_reached_count",
+        "column_id": "sev_underweight_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yseverely_underweight\y'": 1
+        }
+      },
+      {
+        "display": "other_child_reached_count",
+        "column_id": "other_child_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yother_child\y'": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_10a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10a_person_cases.json
@@ -93,7 +93,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ypremature\y'": 1
+          "referral_health_problem ~ '\\ypremature\\y'": 1
         }
       },
       {
@@ -103,7 +103,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ysepsis\y'": 1
+          "referral_health_problem ~ '\\ysepsis\\y'": 1
         }
       },
       {
@@ -113,7 +113,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ydiarrhoea\y'": 1
+          "referral_health_problem ~ '\\ydiarrhoea\\y'": 1
         }
       },
       {
@@ -123,7 +123,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ypneumonia\y'": 1
+          "referral_health_problem ~ '\\ypneumonia\\y'": 1
         }
       },
       {
@@ -133,7 +133,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yfever_child\y'": 1
+          "referral_health_problem ~ '\\yfever_child\\y'": 1
         }
       },
       {
@@ -143,7 +143,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yseverely_underweight\y'": 1
+          "referral_health_problem ~ '\\yseverely_underweight\\y'": 1
         }
       },
       {
@@ -153,7 +153,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yother_child\y'": 1
+          "referral_health_problem ~ '\\yother_child\\y'": 1
         }
       },
       {
@@ -163,7 +163,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypremature\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypremature\\y'": 1
         }
       },
       {
@@ -173,7 +173,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ysepsis\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ysepsis\\y'": 1
         }
       },
       {
@@ -183,7 +183,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ydiarrhoea\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ydiarrhoea\\y'": 1
         }
       },
       {
@@ -193,7 +193,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypneumonia\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypneumonia\\y'": 1
         }
       },
       {
@@ -203,7 +203,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yfever_child\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yfever_child\\y'": 1
         }
       },
       {
@@ -213,7 +213,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yseverely_underweight\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yseverely_underweight\\y'": 1
         }
       },
       {
@@ -223,7 +223,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yother_child\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yother_child\\y'": 1
         }
       }
     ],

--- a/custom/icds_reports/ucr/reports/testing/mpr_10a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10a_person_cases.json
@@ -1,0 +1,233 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-test",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_10a_person_cases-optimized",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR - 10a - Person cases (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "display": "Last Referral Date",
+        "slug": "last_referral_date",
+        "type": "date",
+        "field": "last_referral_date",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "referred_premature",
+        "column_id": "referred_premature",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ypremature\y'": 1
+        }
+      },
+      {
+        "display": "referred_sepsis",
+        "column_id": "referred_sepsis",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ysepsis\y'": 1
+        }
+      },
+      {
+        "display": "referred_diarrhoea",
+        "column_id": "referred_diarrhoea",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ydiarrhoea\y'": 1
+        }
+      },
+      {
+        "display": "referred_pneumonia",
+        "column_id": "referred_pneumonia",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ypneumonia\y'": 1
+        }
+      },
+      {
+        "display": "referred_fever_child",
+        "column_id": "referred_fever_child",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yfever_child\y'": 1
+        }
+      },
+      {
+        "display": "referred_severely_underweight",
+        "column_id": "referred_severely_underweight",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yseverely_underweight\y'": 1
+        }
+      },
+      {
+        "display": "referred_other_child",
+        "column_id": "referred_other_child",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yother_child\y'": 1
+        }
+      },
+      {
+        "display": "premature_reached_count",
+        "column_id": "premature_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypremature\y'": 1
+        }
+      },
+      {
+        "display": "sepsis_reached_count",
+        "column_id": "sepsis_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ysepsis\y'": 1
+        }
+      },
+      {
+        "display": "diarrhoea_reached_count",
+        "column_id": "diarrhoea_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ydiarrhoea\y'": 1
+        }
+      },
+      {
+        "display": "pneumonia_reached_count",
+        "column_id": "pneumonia_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ypneumonia\y'": 1
+        }
+      },
+      {
+        "display": "fever_child_reached_count",
+        "column_id": "fever_child_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yfever_child\y'": 1
+        }
+      },
+      {
+        "display": "sev_underweight_reached_count",
+        "column_id": "sev_underweight_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yseverely_underweight\y'": 1
+        }
+      },
+      {
+        "display": "other_child_reached_count",
+        "column_id": "other_child_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yother_child\y'": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_10b_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10b_person_cases.json
@@ -1,0 +1,213 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-test",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_10b_person_cases-optimized",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR - 10b - Person cases (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "display": "Last Referral Date",
+        "slug": "last_referral_date",
+        "type": "date",
+        "field": "last_referral_date",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "referred_bleeding",
+        "column_id": "referred_bleeding",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ybleeding\y'": 1
+        }
+      },
+      {
+        "display": "referred_convulsions",
+        "column_id": "referred_convulsions",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yconvulsions\y'": 1
+        }
+      },
+      {
+        "display": "referred_prolonged_labor",
+        "column_id": "referred_prolonged_labor",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yprolonged_labor\y'": 1
+        }
+      },
+      {
+        "display": "referred_abortion_complications",
+        "column_id": "referred_abortion_complications",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yabortion_complications\y'": 1
+        }
+      },
+      {
+        "display": "referred_fever_discharge",
+        "column_id": "referred_fever_discharge",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y'": 1
+        }
+      },
+      {
+        "display": "referred_other",
+        "column_id": "referred_other",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y' OR referral_health_problem ~ '\yother\y'": 1
+        }
+      },
+      {
+        "display": "bleeding_reached_count",
+        "column_id": "bleeding_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ybleeding\y'": 1
+        }
+      },
+      {
+        "display": "convulsions_reached_count",
+        "column_id": "convulsions_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yconvulsions\y'": 1
+        }
+      },
+      {
+        "display": "prolonged_labor_reached_count",
+        "column_id": "prolonged_labor_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yprolonged_labor\y'": 1
+        }
+      },
+      {
+        "display": "abort_comp_reached_count",
+        "column_id": "abort_comp_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yabortion_complications\y'": 1
+        }
+      },
+      {
+        "display": "fever_discharge_reached_count",
+        "column_id": "fever_discharge_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y')": 1
+        }
+      },
+      {
+        "display": "other_reached_count",
+        "column_id": "other_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yother\y' OR referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y')": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_10b_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10b_person_cases.json
@@ -93,7 +93,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ybleeding\y'": 1
+          "referral_health_problem ~ '\\ybleeding\\y'": 1
         }
       },
       {
@@ -103,7 +103,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yconvulsions\y'": 1
+          "referral_health_problem ~ '\\yconvulsions\\y'": 1
         }
       },
       {
@@ -113,7 +113,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yprolonged_labor\y'": 1
+          "referral_health_problem ~ '\\yprolonged_labor\\y'": 1
         }
       },
       {
@@ -123,7 +123,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yabortion_complications\y'": 1
+          "referral_health_problem ~ '\\yabortion_complications\\y'": 1
         }
       },
       {
@@ -133,7 +133,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y'": 1
+          "referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'": 1
         }
       },
       {
@@ -143,7 +143,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y' OR referral_health_problem ~ '\yother\y'": 1
+          "referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'": 1
         }
       },
       {
@@ -153,7 +153,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ybleeding\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ybleeding\\y'": 1
         }
       },
       {
@@ -163,7 +163,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yconvulsions\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yconvulsions\\y'": 1
         }
       },
       {
@@ -173,7 +173,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yprolonged_labor\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yprolonged_labor\\y'": 1
         }
       },
       {
@@ -183,7 +183,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yabortion_complications\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yabortion_complications\\y'": 1
         }
       },
       {
@@ -193,7 +193,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y')": 1
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')": 1
         }
       },
       {
@@ -203,7 +203,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yother\y' OR referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y')": 1
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')": 1
         }
       }
     ],

--- a/custom/icds_reports/ucr/reports/testing/mpr_10b_pregnancies_referred.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10b_pregnancies_referred.json
@@ -1,0 +1,221 @@
+{
+  "domains": [
+    "icds-cas",
+    "icds-dashboard-qa",
+    "reach-test"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_10b_pregnancies_referred-optimized",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR 10b - Pregnancies Referred (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Last Referral Date",
+        "slug": "last_referral_date",
+        "type": "date",
+        "field": "last_referral_date",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "last_referral_date",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "referred_bleeding",
+        "column_id": "referred_bleeding",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\ybleeding\y'": 1
+        }
+      },
+      {
+        "display": "referred_convulsions",
+        "column_id": "referred_convulsions",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yconvulsions\y'": 1
+        }
+      },
+      {
+        "display": "referred_prolonged_labor",
+        "column_id": "referred_prolonged_labor",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yprolonged_labor\y'": 1
+        }
+      },
+      {
+        "display": "referred_abortion_complications",
+        "column_id": "referred_abortion_complications",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yabortion_complications\y'": 1
+        }
+      },
+      {
+        "display": "referred_fever_discharge",
+        "column_id": "referred_fever_discharge",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y'": 1
+        }
+      },
+      {
+        "display": "referred_other",
+        "column_id": "referred_other",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y' OR referral_health_problem ~ '\yother\y'": 1
+        }
+      },
+      {
+        "display": "bleeding_reached_count",
+        "column_id": "bleeding_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ybleeding\y'": 1
+        }
+      },
+      {
+        "display": "convulsions_reached_count",
+        "column_id": "convulsions_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yconvulsions\y'": 1
+        }
+      },
+      {
+        "display": "prolonged_labor_reached_count",
+        "column_id": "prolonged_labor_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yprolonged_labor\y'": 1
+        }
+      },
+      {
+        "display": "abort_comp_reached_count",
+        "column_id": "abort_comp_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yabortion_complications\y'": 1
+        }
+      },
+      {
+        "display": "fever_discharge_reached_count",
+        "column_id": "fever_discharge_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y')": 1
+        }
+      },
+      {
+        "display": "other_reached_count",
+        "column_id": "other_reached_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yother\y' OR referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y')": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_10b_pregnancies_referred.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_10b_pregnancies_referred.json
@@ -101,7 +101,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\ybleeding\y'": 1
+          "referral_health_problem ~ '\\ybleeding\\y'": 1
         }
       },
       {
@@ -111,7 +111,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yconvulsions\y'": 1
+          "referral_health_problem ~ '\\yconvulsions\\y'": 1
         }
       },
       {
@@ -121,7 +121,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yprolonged_labor\y'": 1
+          "referral_health_problem ~ '\\yprolonged_labor\\y'": 1
         }
       },
       {
@@ -131,7 +131,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yabortion_complications\y'": 1
+          "referral_health_problem ~ '\\yabortion_complications\\y'": 1
         }
       },
       {
@@ -141,7 +141,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y'": 1
+          "referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'": 1
         }
       },
       {
@@ -151,7 +151,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y' OR referral_health_problem ~ '\yother\y'": 1
+          "referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'": 1
         }
       },
       {
@@ -161,7 +161,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\ybleeding\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ybleeding\\y'": 1
         }
       },
       {
@@ -171,7 +171,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yconvulsions\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yconvulsions\\y'": 1
         }
       },
       {
@@ -181,7 +181,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yprolonged_labor\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yprolonged_labor\\y'": 1
         }
       },
       {
@@ -191,7 +191,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\yabortion_complications\y'": 1
+          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yabortion_complications\\y'": 1
         }
       },
       {
@@ -201,7 +201,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yfever\y' OR referral_health_problem ~ '\yoffensive_discharge\y')": 1
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')": 1
         }
       },
       {
@@ -211,7 +211,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\yother\y' OR referral_health_problem ~ '\yswelling\y' OR referral_health_problem ~ '\yblurred_vision\y')": 1
+          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')": 1
         }
       }
     ],

--- a/custom/icds_reports/ucr/reports/testing/mpr_1_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_1_person_cases.json
@@ -1,0 +1,96 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-test",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_1_person_cases-optimized",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR - 1 - Person cases (Static)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "open_count",
+        "column_id": "open_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_3_children_registered.json
@@ -1,0 +1,159 @@
+{
+  "domains": [
+    "icds-cas",
+    "icds-dashboard-qa",
+    "reach-test"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_3_children_registered-optimized",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR 3 - Children Registered (Static) (Optimized)",
+    "description": "New children registered during month.  Displays person cases grouped by month opened, owner ID, and age group at time of registration",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id",
+      "month",
+      "age_group"
+    ],
+    "filters": [
+      {
+        "display": "Date Case Opened",
+        "slug": "opened_on",
+        "type": "date",
+        "field": "opened_on",
+        "datatype": "date"
+      },
+      {
+        "slug": "age_at_registration_in_bounds",
+        "type": "pre",
+        "field": "age_at_reg",
+        "pre_operator": "between",
+        "pre_value": [0, 6],
+        "datatype": "integer"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "opened_on",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "Age Group",
+        "column_id": "age_group",
+        "type": "conditional_aggregation",
+        "whens": {
+            "age_at_reg BETWEEN 0 AND 2": "0_to_2",
+            "age_at_reg BETWEEN 3 AND 6": "3_to_6"
+        }
+      },
+      {
+        "display": "F_resident_count",
+        "column_id": "F_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' AND resident = 'yes'": 1
+        }
+      },
+      {
+        "display": "M_resident_count",
+        "column_id": "M_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') AND resident = 'yes'": 1
+        }
+      },
+      {
+        "display": "F_migrant_count",
+        "column_id": "F_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' AND resident IS DISTINCT FROM 'yes'": 1
+        }
+      },
+      {
+        "display": "M_migrant_count",
+        "column_id": "M_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') AND resident IS DISTINCT FROM 'yes'": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_3ii_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_3ii_person_cases.json
@@ -1,0 +1,147 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-test",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_3ii_person_cases-optimized",
+  "data_source_table": "static-person_cases_v2",
+  "config": {
+    "title": "MPR - 3ii - Person cases (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "display": "Date Case Opened",
+        "slug": "opened_on",
+        "type": "date",
+        "field": "opened_on",
+        "datatype": "date"
+      },
+      {
+        "display": "Age at Registration Low Bound",
+        "slug": "age_at_reg",
+        "type": "numeric",
+        "field": "age_at_reg",
+        "datatype": "integer"
+      },
+      {
+        "display": "Age at Registration High Bound",
+        "slug": "age_at_reg1",
+        "type": "numeric",
+        "field": "age_at_reg",
+        "datatype": "integer"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "F_resident_count",
+        "column_id": "F_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' AND resident = 'yes'": 1
+        }
+      },
+      {
+        "display": "M_resident_count",
+        "column_id": "M_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') AND resident = 'yes'": 1
+        }
+      },
+      {
+        "display": "F_migrant_count",
+        "column_id": "F_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' AND resident IS DISTINCT FROM 'yes'": 1
+        }
+      },
+      {
+        "display": "M_migrant_count",
+        "column_id": "M_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') AND resident IS DISTINCT FROM 'yes'": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/settings.py
+++ b/settings.py
@@ -1910,9 +1910,9 @@ STATIC_UCR_REPORTS = [
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'ls_thr_forms.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'ls_timely_home_visits.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'ls_ccs_record_cases.json'),
+    os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'testing', '*.json'),
 
     os.path.join('custom', 'echis_reports', 'ucr', 'reports', '*.json'),
-
 ]
 
 


### PR DESCRIPTION
I'm working on reducing the size of the person cases table. This PR is the first part of that. My workflow (currently between step 2 and 3):

1. Copy all reports that depend on the person case data source to a new directory
2. For each report in the new directory:
    1. Change the name of the report so it doesn't clash
    2. Go through each column to be returned and find instances where columns can be changed to use a general use column instead of a single purpose column (e.g. changing column `referred_other` to `referral_health_problem = 'other'`)
3. Use laboratory to test that the old and new reports return the same information (will separate cc-cloud PR)
4. Iterate on reports if differences are found
5. Once verified they return the same information, move calculation to the "official" report.

`referral_health_problem ~ '\ypremature\y'` - regex expression that <word boundary>premature<word boundary> exists in referral_health_problem

There are some other reports based on person cases that won't be tested in this PR because its not possible to optimize them fully. I've begun that work (along with creating a new data source) [here](https://github.com/dimagi/commcare-hq/compare/je/new-person-cases)