### PR TITLE
Make invoicing_plan field optional part of form

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -111,7 +111,10 @@ class BillingAccountBasicForm(forms.Form):
         required=False,
         help_text='ex: dimagi.com, commcarehq.org',
     )
-    invoicing_plan = forms.ChoiceField(label="Invoicing Plan")
+    invoicing_plan = forms.ChoiceField(
+        label="Invoicing Plan",
+        required=False
+    )
     active_accounts = forms.IntegerField(
         label=ugettext_lazy("Transfer Subscriptions To"),
         help_text=ugettext_lazy(


### PR DESCRIPTION
FB: https://manage.dimagi.com/default.asp?284832

Julie noted that accounting admins are currently unable to create new accounts from the Billing Accounts admin page. The `BillingAccountBasicForm`, which normally allows users to create or modify an account was not valid because
> {'invoicing_plan': [u'This field is required.']}

This PR makes the invoicing_plan field an optional part of the account form, so new accounts may be created.