### PR TITLE
removing signal handler

### DIFF
--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -18,14 +18,11 @@ from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_type
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL, CaseAccessorSQL
 from corehq.form_processor.utils import should_use_sql_backend
-from corehq.form_processor.utils.general import clear_local_domain_sql_backend_override
 from corehq.util.markup import shell_green, shell_red
-from corehq.util.signals import SignalHandlerContext
 from couchforms.dbaccessors import get_form_ids_by_type
 from couchforms.models import doc_types, XFormInstance
 from six.moves import input, zip_longest
-import signal
-import sys
+
 import logging
 _logger = logging.getLogger('main_couch_sql_datamigration')
 
@@ -67,8 +64,7 @@ class Command(BaseCommand):
         if options['MIGRATE']:
             self.require_only_option('MIGRATE', options)
             set_couch_sql_migration_started(domain)
-            with SignalHandlerContext([signal.SIGTERM, signal.SIGINT], _get_sigterm_handler(domain)):
-                do_couch_to_sql_migration(domain, with_progress=not self.no_input, debug=self.debug)
+            do_couch_to_sql_migration(domain, with_progress=not self.no_input, debug=self.debug)
             has_diffs = self.print_stats(domain, short=True, diffs_only=True)
             if has_diffs:
                 print("\nUse '--stats-short', '--stats-long', '--show-diffs' to see more info.\n")
@@ -196,16 +192,6 @@ def _confirm(message):
         return
     else:
         raise CommandError('abort')
-
-
-def _get_sigterm_handler(domain):
-    def _sigterm_handler(signal, frame):
-        _logger.error("{} signal received".format(signal))
-        set_couch_sql_migration_not_started(domain)
-        clear_local_domain_sql_backend_override(domain)
-        _blow_away_migration(domain)
-        sys.exit(1)
-    return _sigterm_handler
 
 
 def _blow_away_migration(domain):

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
@@ -8,7 +8,7 @@ from django.core.management.base import CommandError, BaseCommand
 from corehq.apps.couch_sql_migration.couchsqlmigration import (
     do_couch_to_sql_migration, get_diff_db)
 from corehq.apps.couch_sql_migration.management.commands.migrate_domain_from_couch_to_sql import (
-    _blow_away_migration, _get_sigterm_handler
+    _blow_away_migration
 )
 from corehq.apps.couch_sql_migration.progress import (
     set_couch_sql_migration_started, couch_sql_migration_in_progress,
@@ -21,10 +21,8 @@ from corehq.form_processor.utils import should_use_sql_backend
 from corehq.form_processor.utils.general import clear_local_domain_sql_backend_override
 from corehq.util.log import with_progress_bar
 from corehq.util.markup import shell_green, SimpleTableWriter, TableRowFormatter
-from corehq.util.signals import SignalHandlerContext
 from couchforms.dbaccessors import get_form_ids_by_type
 from couchforms.models import doc_types, XFormInstance
-import signal
 from io import open
 
 
@@ -74,8 +72,7 @@ class Command(BaseCommand):
 
         set_couch_sql_migration_started(domain)
 
-        with SignalHandlerContext([signal.SIGTERM, signal.SIGINT], _get_sigterm_handler(domain)):
-            do_couch_to_sql_migration(domain, with_progress=False, debug=False)
+        do_couch_to_sql_migration(domain, with_progress=False, debug=False)
 
         stats = self.get_diff_stats(domain)
         if stats:


### PR DESCRIPTION
This has been a bit annoying at times where I've wanted to cancel a long running migration, but still be able to look at what data has been moved. In particular with the dry run and resumable migration prs coming up, this seems like it might do more harm than good

@snopoke @millerdev buddy: @Rohit25negi 