### PR TITLE
Show downgrade messages on confirm downgrade page

### DIFF
--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -78,6 +78,27 @@
         {% endif %}
     {% endif %}
 
+    {% if downgrade_messages %}
+    <hr />
+    <h4>
+        {% if show_community_notice %}
+        {% trans 'Note: If you do not upgrade from the Community Plan the following changes will take place.' %}
+        {% else %}
+        {% trans 'Note: Selecting this plan will result in the following changes to your project.' %}
+        {% endif %}
+    </h4>
+    {% endif %}
+    {% for message in downgrade_messages %}
+        <div class="alert alert-warning">
+            {{ message.message }}
+            <ul>
+            {% for detail in message.details %}
+                <li>{{ detail|safe }}</li>
+            {% endfor %}
+            </ul>
+        </div>
+    {% endfor %}
+
     {% if show_community_notice %}
     <div class="form-actions">
         <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>


### PR DESCRIPTION
This PR adds downgrading messages back into the confirm plan page, below the "We're sorry to see you downgrade" message

FB: https://manage.dimagi.com/default.asp?284765

<img width="1191" alt="screen shot 2018-10-25 at 2 05 21 pm" src="https://user-images.githubusercontent.com/15271571/47520920-8afb0700-d85f-11e8-8508-e2cebdd189a1.png">
