### PR TITLE
Revert "Cache form updates"

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1442,8 +1442,6 @@ class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
                 "%s is not a valid question" % question_path
             )
 
-    @quickcache(['self.unique_id', 'self.version'], timeout=24 * 60 * 60,
-                skip_arg=lambda *args: settings.UNIT_TESTING)
     def get_all_case_updates(self):
         """
         Collate contributed case updates from all sources within the form


### PR DESCRIPTION
Reverts dimagi/commcare-hq#22136
This was causing new case properties to not appear.

https://manage.dimagi.com/default.asp?284950
Looks like `form.version` is `None` for current forms, guessing only saved forms have versions.  I think this can still be cached, but it'll need invalidation.