### PR TITLE
diff within fudge factor

### DIFF
--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -404,4 +404,7 @@ def _type_sort(action_type):
     """
     Consistent ordering for action types
     """
-    return const.CASE_ACTIONS.index(action_type)
+    for idx, type_action in enumerate(CaseTransaction.TYPE_ACTIONS_ENUM):
+        if action_type & type_action == action_type:
+            return idx
+    return len(CaseTransaction.TYPE_ACTIONS_ENUM)

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -404,7 +404,7 @@ def _type_sort(action_type):
     """
     Consistent ordering for action types
     """
-    for idx, type_action in enumerate(CaseTransaction.TYPE_ACTIONS_ENUM):
+    for idx, type_action in enumerate(CaseTransaction.FORM_TYPE_ACTIONS_ORDER):
         if action_type & type_action == action_type:
             return idx
-    return len(CaseTransaction.TYPE_ACTIONS_ENUM)
+    return len(CaseTransaction.FORM_TYPE_ACTIONS_ORDER)

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1132,7 +1132,6 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
     )
     TYPE_ACTIONS_ENUM = (
         TYPE_CASE_CREATE,
-        TYPE_FORM,
         TYPE_CASE_INDEX,
         TYPE_CASE_CLOSE,
         TYPE_CASE_ATTACHMENT,

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1130,6 +1130,20 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
     TYPES_TO_PROCESS = (
         TYPE_FORM,
     )
+    TYPE_ACTIONS_ENUM = (
+        TYPE_CASE_CREATE,
+        TYPE_FORM,
+        TYPE_CASE_INDEX,
+        TYPE_CASE_CLOSE,
+        TYPE_CASE_ATTACHMENT,
+        TYPE_LEDGER,
+        TYPE_REBUILD_WITH_REASON,
+        TYPE_REBUILD_USER_REQUESTED,
+        TYPE_REBUILD_USER_ARCHIVED,
+        TYPE_REBUILD_FORM_ARCHIVED,
+        TYPE_REBUILD_FORM_EDIT,
+        TYPE_REBUILD_FORM_REPROCESS,
+    )
     case = models.ForeignKey(
         'CommCareCaseSQL', to_field='case_id', db_index=False,
         related_name="transaction_set", related_query_name="transaction",

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1136,12 +1136,6 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
         TYPE_CASE_CLOSE,
         TYPE_CASE_ATTACHMENT,
         TYPE_LEDGER,
-        TYPE_REBUILD_WITH_REASON,
-        TYPE_REBUILD_USER_REQUESTED,
-        TYPE_REBUILD_USER_ARCHIVED,
-        TYPE_REBUILD_FORM_ARCHIVED,
-        TYPE_REBUILD_FORM_EDIT,
-        TYPE_REBUILD_FORM_REPROCESS,
     )
     case = models.ForeignKey(
         'CommCareCaseSQL', to_field='case_id', db_index=False,

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1130,7 +1130,7 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
     TYPES_TO_PROCESS = (
         TYPE_FORM,
     )
-    TYPE_ACTIONS_ENUM = (
+    FORM_TYPE_ACTIONS_ORDER = (
         TYPE_CASE_CREATE,
         TYPE_CASE_INDEX,
         TYPE_CASE_CLOSE,


### PR DESCRIPTION
Turns out my test coverage wasn't quite thorough enough. Here is a bit more, covering the case where the time diff is within the fudge factor (I thought I had covered that, but I had towards the last minute made the fudge factor only 12 hours instead of a day)

The enum basically mirrors [const.CASE_ACTIONS](https://github.com/dimagi/commcare-hq/blob/0740ba59e4c820699d16d742ab2e67795b5e988f/corehq/ex-submodules/casexml/apps/case/const.py#L14)

The `_type_sort` function is slightly more complex than just the original index call, because of the fairly common case that an action has multiple types

@millerdev @snopoke buddy: @Rohit25negi 