### PR TITLE
Updated .appnav-title in app manager menu to break words more often

### DIFF
--- a/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
@@ -379,6 +379,7 @@ nav.appmanager-content {
   background-color: @cc-brand-low;
   .appnav-title {
     border-color: darken(@cc-bg, 2);
+    word-break: break-word;
   }
   a {
     color: white;


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?285006

Before, the settings & reordering icons are difficult/impossible to access:
<img width="275" alt="screen shot 2018-10-26 at 9 52 49 am" src="https://user-images.githubusercontent.com/1486591/47570790-0236a680-d905-11e8-8e6d-1e7b31e8e1fc.png">

After, the word breaks in an awkward place but you can at least access everything:
<img width="272" alt="screen shot 2018-10-26 at 9 53 10 am" src="https://user-images.githubusercontent.com/1486591/47570816-111d5900-d905-11e8-91b4-563cc349cb67.png">


@nickpell @esoergel 