### PR TITLE
Temporarily remove deactivated users from the case list filters

### DIFF
--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -22,7 +22,7 @@ class CaseListFilterUtils(EmwfUtils):
         return [
             ("all_data", _("[All Data]")),
             ('project_data', _("[Project Data]"))
-        ] + options[1:]
+        ] + options[2:]
 
     def _group_to_choice_tuple(self, group):
         if group.case_sharing:


### PR DESCRIPTION
Currently, the [Deactivated Mobile Workers] label does not work for the case list. [This is the real fix](https://github.com/dimagi/commcare-hq/pull/22179#pullrequestreview-168808447), but staging is currently down, and I want QA to take a look before I deploy that. So, in the meantime, I decided that just removing the label is the best short term action while staging is down (Dev is on board with this plan).
@esoergel code buddy @sravfeyn 