### PR TITLE
track heartbeat, login and restores for mobile for replay attack

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -94,7 +94,7 @@ def get_username_and_password_from_request(request):
     elif auth[0].lower() == BASIC:
         username, password = base64.b64decode(auth[1]).split(b':', 1)
         # decode password submitted from mobile app login
-        password = decode_password(password)
+        password = decode_password(password, username)
         username, password = _decode(username), _decode(password)
     return username, password
 

--- a/custom/nic_compliance/const.py
+++ b/custom/nic_compliance/const.py
@@ -4,3 +4,8 @@ REDIS_LOGIN_ATTEMPTS_LIST_PREFIX = 'login_attempts_'
 RESTRICT_USED_PASSWORDS_NUM = 3  # passwords inclusive of current password
 EXPIRE_PASSWORD_ATTEMPTS_IN = 10  # days
 EXPIRE_LOGIN_ATTEMPTS_IN = 3  # days
+MOBILE_REQUESTS_TO_TRACK_FOR_REPLAY_ATTACK = [
+    'key_server_url',  # login
+    'app_aware_restore',  # restore
+    'phone_heartbeat',  # heartbeat
+]

--- a/custom/nic_compliance/const.py
+++ b/custom/nic_compliance/const.py
@@ -9,3 +9,10 @@ MOBILE_REQUESTS_TO_TRACK_FOR_REPLAY_ATTACK = [
     'app_aware_restore',  # restore
     'phone_heartbeat',  # heartbeat
 ]
+USERS_TO_TRACK_FOR_REPLAY_ATTACK = [
+    'audit.aww1@icds-cas.commcarehq.org',
+    'audit.aww2@icds-cas.commcarehq.org',
+    'audit.bhd1@icds-cas.commcarehq.org',
+    'audit.ls1@icds-cas.commcarehq.org',
+    'adhaar.test@icds-cas.commcarehq.org',
+]

--- a/custom/nic_compliance/const.py
+++ b/custom/nic_compliance/const.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 REDIS_USED_PASSWORDS_LIST_PREFIX = 'used_passwords_'
-REDIS_LOGIN_ATTEMPTS_LIST_PREFIX = 'login_attempts_'
+REDIS_LOGIN_ATTEMPTS_LIST_PREFIX = 'login_attempts'
 RESTRICT_USED_PASSWORDS_NUM = 3  # passwords inclusive of current password
 EXPIRE_PASSWORD_ATTEMPTS_IN = 10  # days
 EXPIRE_LOGIN_ATTEMPTS_IN = 3  # days

--- a/custom/nic_compliance/const.py
+++ b/custom/nic_compliance/const.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 REDIS_USED_PASSWORDS_LIST_PREFIX = 'used_passwords_'
-REDIS_LOGIN_ATTEMPTS_LIST_PREFIX = 'login_attempts'
+REDIS_LOGIN_ATTEMPTS_LIST_PREFIX = '$$la'
 RESTRICT_USED_PASSWORDS_NUM = 3  # passwords inclusive of current password
 EXPIRE_PASSWORD_ATTEMPTS_IN = 10  # days
 EXPIRE_LOGIN_ATTEMPTS_IN = 3  # days

--- a/custom/nic_compliance/tests/test_utils.py
+++ b/custom/nic_compliance/tests/test_utils.py
@@ -4,7 +4,11 @@ from __future__ import unicode_literals
 from django.test import TestCase, override_settings, Client
 from django.urls import reverse
 from dimagi.utils.couch.cache.cache_core import get_redis_client
-from custom.nic_compliance.utils import extract_password, verify_password, get_obfuscated_passwords
+
+from mock import patch
+
+from custom.nic_compliance.utils import extract_password, verify_password, get_obfuscated_passwords, \
+    obfuscated_password_redis_key_for_user
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser
 
@@ -19,12 +23,17 @@ OBFUSCATED_PASSWORD_MAPPING = {
 
 
 class TestDecodePassword(TestCase):
+    username = "username@test.com"
+
     @classmethod
     def setUpClass(cls):
         super(TestDecodePassword, cls).setUpClass()
         cls.domain = Domain(name="delhi", is_active=True)
         cls.domain.save()
         cls.username = "username@test.com"
+        cls.web_user = WebUser.get_by_username(cls.username)
+        if cls.web_user:
+            cls.web_user.delete()
         cls.web_user = WebUser.create(cls.domain.name, cls.username, "123456")
 
     @classmethod
@@ -33,8 +42,10 @@ class TestDecodePassword(TestCase):
         cls.web_user.delete()
         super(TestDecodePassword, cls).tearDownClass()
 
+    @patch("custom.nic_compliance.utils.USERS_TO_TRACK_FOR_REPLAY_ATTACK", [username])
     def test_login_attempt(self):
         get_redis_client().clear()
+        redis_client = get_redis_client()
         with override_settings(OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE=True):
             obfuscated_password = "sha256$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="
             client = Client(enforce_csrf_checks=False)
@@ -44,18 +55,11 @@ class TestDecodePassword(TestCase):
                 'hq_login_view-current_step': 'auth'
             }
             # ensure that login attempt gets stored
-            login_attempts = get_obfuscated_passwords(self.username)
-            self.assertEqual(login_attempts, [])
+            key_name = obfuscated_password_redis_key_for_user(self.username, obfuscated_password)
+            self.assertFalse(redis_client.get(key_name))
             response = client.post(reverse('login'), form_data, follow=True)
             self.assertRedirects(response, '/a/delhi/dashboard/project/')
-            login_attempts = get_obfuscated_passwords(self.username)
-
-            self.assertTrue(
-                verify_password(
-                    obfuscated_password,
-                    login_attempts[0]
-                )
-            )
+            self.assertTrue(redis_client.get(key_name))
             client.get(reverse('logout'))
 
             # test replay attack
@@ -63,6 +67,7 @@ class TestDecodePassword(TestCase):
             self.assertContains(response, "Please enter a password")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.request['PATH_INFO'], '/accounts/login/')
+            redis_client.expire(key_name, 0)
 
 
 class TestExtractPassword(TestCase):

--- a/custom/nic_compliance/tests/test_utils.py
+++ b/custom/nic_compliance/tests/test_utils.py
@@ -61,12 +61,14 @@ class TestDecodePassword(TestCase):
             # ensure that login attempt gets stored
             key_name = obfuscated_password_redis_key_for_user(self.username, obfuscated_password)
             self.assertFalse(redis_client.get(key_name))
-            response = client.get(reverse('phone_heartbeat'), **auth_headers)
-            self.assertEqual(response.status_code, 200)
+            response = client.get(reverse('phone_heartbeat', args=[self.domain.name, "bad_app_id"]),
+                                  **auth_headers)
+            self.assertEqual(response.status_code, 404)
             self.assertTrue(redis_client.get(key_name))
 
             # test replay attack
-            response = client.get(reverse('phone_heartbeat'), **auth_headers)
+            response = client.get(reverse('phone_heartbeat', args=[self.domain.name, "bad_app_id"]),
+                                  **auth_headers)
             self.assertEqual(response.status_code, 401)
             redis_client.expire(key_name, 0)
 

--- a/custom/nic_compliance/tests/test_utils.py
+++ b/custom/nic_compliance/tests/test_utils.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import base64
+
 from django.test import TestCase, override_settings, Client
 from django.urls import reverse
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 
 from mock import patch
 
-from custom.nic_compliance.utils import extract_password, verify_password, get_obfuscated_passwords, \
-    obfuscated_password_redis_key_for_user
+from custom.nic_compliance.utils import (
+    extract_password,
+    obfuscated_password_redis_key_for_user,
+)
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser
 
@@ -43,7 +47,30 @@ class TestDecodePassword(TestCase):
         super(TestDecodePassword, cls).tearDownClass()
 
     @patch("custom.nic_compliance.utils.USERS_TO_TRACK_FOR_REPLAY_ATTACK", [username])
-    def test_login_attempt(self):
+    def test_mobile_heartbeat_attempt(self):
+        get_redis_client().clear()
+        redis_client = get_redis_client()
+        with override_settings(OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE=True):
+            obfuscated_password = "sha256$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="
+            client = Client(enforce_csrf_checks=False)
+            auth_headers = {
+                'HTTP_AUTHORIZATION': 'Basic ' + base64.b64encode('%s:%s' % (
+                    self.username, obfuscated_password
+                )),
+            }
+            # ensure that login attempt gets stored
+            key_name = obfuscated_password_redis_key_for_user(self.username, obfuscated_password)
+            self.assertFalse(redis_client.get(key_name))
+            response = client.get(reverse('phone_heartbeat'), **auth_headers)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(redis_client.get(key_name))
+
+            # test replay attack
+            response = client.get(reverse('phone_heartbeat'), **auth_headers)
+            self.assertEqual(response.status_code, 401)
+            redis_client.expire(key_name, 0)
+
+    def test_web_login_attempt(self):
         get_redis_client().clear()
         redis_client = get_redis_client()
         with override_settings(OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE=True):

--- a/custom/nic_compliance/utils.py
+++ b/custom/nic_compliance/utils.py
@@ -101,8 +101,9 @@ def get_raw_password(obfuscated_password, username=None):
     def _decode_password():
         # In case of 2-step authentication for web skip by checking for auth-username which is
         # present in first step
-        if username and (request and request.POST.get('auth-username') or
-                         _mobile_request_to_track()):
+        if username and (
+                (request and request.POST.get('auth-username')) or
+                _mobile_request_to_track()):
             if replay_attack():
                 return ''
             record_login_attempt()

--- a/custom/nic_compliance/utils.py
+++ b/custom/nic_compliance/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import re
 import base64
+import hashlib
 from datetime import timedelta
 from django.conf import settings
 from django.urls import resolve
@@ -73,7 +74,9 @@ def verify_password(password, encoded_password):
 
 
 def obfuscated_password_redis_key_for_user(username, obfuscated_password):
-    return '_'.join([REDIS_LOGIN_ATTEMPTS_LIST_PREFIX, username, obfuscated_password])
+    return REDIS_LOGIN_ATTEMPTS_LIST_PREFIX + hashlib.md5("%s%s" % (
+        username, obfuscated_password
+    )).hexdigest()
 
 
 def get_raw_password(obfuscated_password, username=None):

--- a/custom/nic_compliance/utils.py
+++ b/custom/nic_compliance/utils.py
@@ -76,11 +76,6 @@ def obfuscated_password_redis_key_for_user(username, obfuscated_password):
     return '_'.join([REDIS_LOGIN_ATTEMPTS_LIST_PREFIX, username, obfuscated_password])
 
 
-def get_obfuscated_passwords(username, obfuscated_password):
-    client = get_redis_client()
-    return client.get(obfuscated_password_redis_key_for_user(username, obfuscated_password), [])
-
-
 def get_raw_password(obfuscated_password, username=None):
     client = get_redis_client()
 


### PR DESCRIPTION
[Details](https://docs.google.com/document/d/1O4SD_vNBNzvnmy4YsrwsO1VVQA-9ur9LwB0RyG6yJSI/edit)

1. Check for replay attack for mobile requests for login, heartbeat and restore [done]
2. improve logic to expire obfuscated passwords older than 3 days [done]

Test:
1. behaviour in case of 401 requests. Are their username present in case of the initial 401's sent by phone?


QA:
Web
1. login in successfully by a mobile user
2. login in with 2-factor auth by a web user
3. on replay attack fails login by a web user

Mobile:
1. login in successfully
2. does not track for user not asked to track for
3. does not track request not to be tracked like form submission
4. test replay attack blocking/returning 401 for requests to be tracked
5. test replay attack not blocking for requests not to be tracked