### PR TITLE
Fix human-readable mobile worker type names in export download analytics

### DIFF
--- a/corehq/apps/export/static/export/js/download_export.ng.js
+++ b/corehq/apps/export/static/export/js/download_export.ng.js
@@ -116,7 +116,7 @@
                     getFilterNames(),
                     function (item) {
                         var prefix = "t__";
-                        if (item.substring(prefix.length) === prefix) {
+                        if (item.substring(0, prefix.length) === prefix) {
                             return userTypes[item.substring(prefix.length)];
                         }
                         return item;


### PR DESCRIPTION
Introduced in https://github.com/dimagi/commcare-hq/pull/22140/

@pr33thi 