### PR TITLE
correctly process forms after error

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -353,6 +353,7 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual('from the create form', case.get_case_property('pcreate'))
         self.assertEqual('this should get overridden', case.get_case_property('pboth'))
 
+        # submit a form and simulate an error
         couch_patch = patch(
             'corehq.form_processor.backends.couch.casedb.CaseDbCacheCouch.get_cases_for_saving',
             side_effect=CouchSaveAborted
@@ -372,7 +373,9 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual('this should get overridden', case.get_case_property('pboth'))
 
         form = FormAccessors(domain).get_form(update_form_id)
+        self.assertTrue(form.is_error)
 
+        # re-submit the same form and make sure it get's processed
         res = submit_form_locally(update_xml, domain)
         form = res.xform
         case = res.cases[0]

--- a/corehq/form_processor/backends/sql/casedb.py
+++ b/corehq/form_processor/backends/sql/casedb.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import redis
 from casexml.apps.case.exceptions import IllegalCaseId
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.backends.sql.update_strategy import SqlCaseUpdateStrategy
 from corehq.form_processor.casedb_base import AbstractCaseDbCache
-from corehq.form_processor.exceptions import CaseNotFound, CaseSaveError
+from corehq.form_processor.exceptions import CaseSaveError
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq import toggles
 

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -214,10 +214,15 @@ def _handle_duplicate(new_doc):
             )
             return FormProcessingResult(new_doc, existing_doc)
     else:
-        # follow standard dupe handling, which simply saves a copy of the form
-        # but a new doc_id, and a doc_type of XFormDuplicate
-        duplicate = interface.deduplicate_xform(new_doc)
-        return FormProcessingResult(duplicate, existing_doc)
+        if existing_doc.is_normal or existing_doc.is_archived or existing_doc.is_duplicate:
+            # follow standard dupe handling, which simply saves a copy of the form
+            # but a new doc_id, and a doc_type of XFormDuplicate
+            duplicate = interface.deduplicate_xform(new_doc)
+            return FormProcessingResult(duplicate, existing_doc)
+        else:
+            # in this case the existing form is an error form so we should try to reprocess the form
+            existing_doc, new_doc = apply_deprecation(existing_doc, new_doc, interface)
+            return FormProcessingResult(new_doc, existing_doc)
 
 
 def apply_deprecation(existing_xform, new_xform, interface=None):


### PR DESCRIPTION
Discovered this error from a soft assert:
```
Message: Case created without create block in CC version >= 2.44
Value: {u'xform_id': u'c38bc24e-73d2-479b-963f-9f44cdbef9e7', u'case_id': u'8c6fa1cc-e7fe-4189-b339-0fb6e8ac8a9d', u'domain': u'rec', u'version': '2.44.1'}
```

Turns out a lot of these forms fail because the case was saved while the form was being processed. Seems like the locking isn't quite working properly or it's timing out.

We'll also need to go back and re-process a lot of forms. Management command to do that still to come.