### PR TITLE
create transaction if necessary

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -14,11 +14,13 @@ from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2, V1
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
     use_sql_backend,
 )
-from corehq.util.test_utils import TestFileMixin
+from corehq.util.test_utils import TestFileMixin, softer_assert
 
 
 class SimpleCaseBugTests(SimpleTestCase):
@@ -329,6 +331,35 @@ class TestCaseHierarchy(TestCase):
             )[0]
         hierarchy = get_case_hierarchy(cases['bungo'], {})
         self.assertEqual(4, len(hierarchy['case_list']))
+
+    @softer_assert()
+    def test_missing_transactions(self):
+        # this could happen if a form was edited and resulted in a new case transaction
+        # e.g. a condition on a case transaction changed
+        case_id1 = uuid.uuid4().hex
+        case_id2 = uuid.uuid4().hex
+        form_id = uuid.uuid4().hex
+        case_block = CaseBlock(
+            case_id=case_id1,
+            create=True,
+        ).as_string()
+        submit_case_blocks(case_block, 'test-transactions', form_id=form_id)
+        try:
+            CaseAccessors().get_case(case_id2)
+            self.fail('Case should not exist')
+        except CaseNotFound:
+            pass
+
+        # form with same ID submitted but now has a new case transaction
+        new_case_block = CaseBlock(
+            case_id=case_id2,
+            create=True,
+            case_type='t1',
+        ).as_string()
+        submit_case_blocks([case_block, new_case_block], 'test-transactions', form_id=form_id)
+        case2 = CaseAccessors().get_case(case_id2)
+        self.assertEqual([form_id], case2.xform_ids)
+        self.assertEqual('t1', case2.type)
 
 
 @use_sql_backend

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -344,11 +344,8 @@ class TestCaseHierarchy(TestCase):
             create=True,
         ).as_string()
         submit_case_blocks(case_block, 'test-transactions', form_id=form_id)
-        try:
+        with self.assertRaises(CaseNotFound):
             CaseAccessors().get_case(case_id2)
-            self.fail('Case should not exist')
-        except CaseNotFound:
-            pass
 
         # form with same ID submitted but now has a new case transaction
         new_case_block = CaseBlock(

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -60,6 +60,7 @@ from corehq.sql_db.config import get_sql_db_aliases_in_use, partition_config
 from corehq.sql_db.routers import db_for_read_write, get_cursor
 from corehq.sql_db.util import split_list_by_db_partition
 from corehq.util.queries import fast_distinct_in_domain
+from corehq.util.soft_assert import soft_assert
 from dimagi.utils.chunked import chunked
 
 doc_type_to_state = {
@@ -1287,6 +1288,10 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         forms_missing_transactions = list(updated_xform_ids - form_ids)
         for form_id in forms_missing_transactions:
             # Add in any transactions that aren't already present
+            soft_assert('{}@dimagi.com'.format('skelly'))(False, 'Missing form transaction during rebuild', {
+                'form_id': form_id,
+                'case_id': case.case_id
+            })
             form = updated_xforms_map[form_id]
             case_updates = [update for update in get_case_updates(form) if update.id == case.case_id]
             types = [

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -23,6 +23,7 @@ from django.db.models import Q, F
 from django.db.models.functions import Greatest, Concat
 from django.db.models.expressions import Value
 
+from casexml.apps.case.xform import get_case_updates
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.blobs import get_blob_db
 from corehq.form_processor.exceptions import (
@@ -1245,7 +1246,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
                 yield trans
 
     @staticmethod
-    def get_case_transactions_by_case_id(case_id, updated_xforms=None):
+    def get_case_transactions_by_case_id(case, updated_xforms=None):
         """
         This fetches all the transactions required to rebuild the case along
         with all the forms for those transactions.
@@ -1258,12 +1259,12 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         :return: list of ``CaseTransaction`` objects with their associated forms attached.
         """
 
-        transactions = CaseAccessorSQL.get_transactions_for_case_rebuild(case_id)
-        CaseAccessorSQL.fetch_case_transaction_forms(transactions, updated_xforms)
+        transactions = CaseAccessorSQL.get_transactions_for_case_rebuild(case.case_id)
+        CaseAccessorSQL.fetch_case_transaction_forms(case, transactions, updated_xforms)
         return transactions
 
     @staticmethod
-    def fetch_case_transaction_forms(transactions, updated_xforms=None):
+    def fetch_case_transaction_forms(case, transactions, updated_xforms=None):
         """
         Fetches the forms for a list of transactions, caching them onto each transaction
 
@@ -1276,11 +1277,26 @@ class CaseAccessorSQL(AbstractCaseAccessor):
             xform.form_id: xform for xform in updated_xforms if not xform.is_deprecated
         } if updated_xforms else {}
 
-        form_ids_to_fetch = list(form_ids - set(updated_xforms_map))
+        updated_xform_ids = set(updated_xforms_map)
+        form_ids_to_fetch = list(form_ids - updated_xform_ids)
         xform_map = {
             form.form_id: form
             for form in FormAccessorSQL.get_forms_with_attachments_meta(form_ids_to_fetch)
         }
+
+        forms_missing_transactions = list(updated_xform_ids - form_ids)
+        for form_id in forms_missing_transactions:
+            # Add in any transactions that aren't already present
+            form = updated_xforms_map[form_id]
+            case_updates = [update for update in get_case_updates(form) if update.id == case.case_id]
+            types = [
+                CaseTransaction.type_from_action_type_slug(a.action_type_slug)
+                for case_update in case_updates
+                for a in case_update.actions
+            ]
+            modified_on = case_updates[0].guess_modified_on()
+            new_transaction = CaseTransaction.form_transaction(case, form, modified_on, types)
+            transactions.append(new_transaction)
 
         def get_form(form_id):
             if form_id in updated_xforms_map:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -305,7 +305,7 @@ class FormProcessorSQL(object):
     @staticmethod
     def _rebuild_case_from_transactions(case, detail, updated_xforms=None):
         transactions = CaseAccessorSQL.get_case_transactions_by_case_id(
-            case.case_id,
+            case,
             updated_xforms=updated_xforms)
         strategy = SqlCaseUpdateStrategy(case)
 

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -288,6 +288,8 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
             if transaction.is_form_transaction and transaction.is_relevant:
                 self._apply_form_transaction(transaction)
                 real_transactions.append(transaction)
+                if not transaction.is_saved():
+                    self.case.track_create(transaction)
 
         self._delete_old_related_models(
             original_indices,
@@ -329,7 +331,7 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
                     error.format(self.case.case_id, sorted_transactions[0])
                 )
 
-        CaseAccessorSQL.fetch_case_transaction_forms(sorted_transactions)
+        CaseAccessorSQL.fetch_case_transaction_forms(self.case, sorted_transactions)
         rebuild_detail = RebuildWithReason(reason="client_date_reconciliation")
         rebuild_transaction = CaseTransaction.rebuild_transaction(self.case, rebuild_detail)
         self.rebuild_from_transactions(sorted_transactions, rebuild_transaction)


### PR DESCRIPTION
I realized this while working on https://github.com/dimagi/commcare-hq/pull/22209. Once that PR is merged this will only be possible for edited forms (which should be removed soon anyway).