### PR TITLE
Hide implicit data types

### DIFF
--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -25,8 +25,8 @@ def recurse_subclasses(cls):
 
 
 class ValueSource(DocumentSchema):
-    external_data_type = StringProperty(required=False, default=DATA_TYPE_UNKNOWN)
-    commcare_data_type = StringProperty(required=False, default=DATA_TYPE_UNKNOWN,
+    external_data_type = StringProperty(required=False, default=DATA_TYPE_UNKNOWN, exclude_if_none=True)
+    commcare_data_type = StringProperty(required=False, default=DATA_TYPE_UNKNOWN, exclude_if_none=True,
                                         choices=COMMCARE_DATA_TYPES + (DATA_TYPE_UNKNOWN,))
 
     @classmethod


### PR DESCRIPTION
A small change to unclutter MOTECH configuration if a data type is set to `None`. (`DATA_TYPE_UNKNOWN` = `None`.)

(The `exclude_if_none` parameter actually hides all falsey values, not just `None`, but all other possible values of `external_data_type` and `commcare_data_type` are truthy.)

Feature flag: `openmrs_integration` / "Enable OpenMRS integration"

buddy @mkangia 
