### PR TITLE
Always allow non customer billing accounts to change subscription

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1852,11 +1852,12 @@ class Subscription(models.Model):
             return False
 
     def user_can_change_subscription(self, user):
-        if self.account.is_customer_billing_account:
-            return False
         if user.is_superuser:
             return True
-        return self.account.has_enterprise_admin(user.email)
+        elif self.account.is_customer_billing_account:
+            return self.account.has_enterprise_admin(user.email)
+        else:
+            return True
 
 
 class InvoiceBaseManager(models.Manager):


### PR DESCRIPTION
My if statement was switched around in this PR: https://github.com/dimagi/commcare-hq/pull/22049, thus blocking everyone from changing subscriptions
This change allows all users that are on a regular (non-customer) account to change their subscription