### PR TITLE
migration dry run

### DIFF
--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -98,7 +98,7 @@ class Command(BaseCommand):
 
         if options['COMMIT']:
             self.require_only_option('COMMIT', options)
-            assert couch_sql_migration_in_progress(domain, any_run=False)
+            assert couch_sql_migration_in_progress(domain, include_dry_runs=False)
             if not self.no_input:
                 _confirm(
                     "This will allow convert the domain to use the SQL backend and"

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -75,11 +75,12 @@ class Command(BaseCommand):
 
         if options['MIGRATE']:
             self.require_only_option('MIGRATE', options)
-            set_couch_sql_migration_started(domain)
+            set_couch_sql_migration_started(domain, self.dry_run)
             do_couch_to_sql_migration(domain, with_progress=not self.no_input, debug=self.debug)
             has_diffs = self.print_stats(domain, short=True, diffs_only=True)
             if has_diffs:
                 print("\nUse '--stats-short', '--stats-long', '--show-diffs' to see more info.\n")
+
         if options['blow_away']:
             self.require_only_option('blow_away', options)
             if not self.no_input:
@@ -89,13 +90,15 @@ class Command(BaseCommand):
                 )
             set_couch_sql_migration_not_started(domain)
             _blow_away_migration(domain)
+
         if options['stats_short'] or options['stats_long']:
             self.print_stats(domain, short=options['stats_short'])
         if options['show_diffs']:
             self.show_diffs(domain)
+
         if options['COMMIT']:
             self.require_only_option('COMMIT', options)
-            assert couch_sql_migration_in_progress(domain)
+            assert couch_sql_migration_in_progress(domain, any_run=False)
             if not self.no_input:
                 _confirm(
                     "This will allow convert the domain to use the SQL backend and"

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -59,8 +59,9 @@ class Command(BaseCommand):
             'debug',
             'dry_run',
         }
-        assert all(not value for key, value in options.items()
-                   if key in this_command_opts and key != sole_option)
+        for key, value in options.items():
+            if value and key in this_command_opts and key != sole_option:
+                raise CommandError("%s must be the sole option used" % key)
 
     def handle(self, domain, **options):
         if should_use_sql_backend(domain):
@@ -98,7 +99,8 @@ class Command(BaseCommand):
 
         if options['COMMIT']:
             self.require_only_option('COMMIT', options)
-            assert couch_sql_migration_in_progress(domain, include_dry_runs=False)
+            if not couch_sql_migration_in_progress(domain, include_dry_runs=False):
+                raise CommandError("cannot commit a migration that is not in state in_progress")
             if not self.no_input:
                 _confirm(
                     "This will allow convert the domain to use the SQL backend and"

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -45,10 +45,20 @@ class Command(BaseCommand):
         parser.add_argument('--show-diffs', action='store_true', default=False)
         parser.add_argument('--no-input', action='store_true', default=False)
         parser.add_argument('--debug', action='store_true', default=False)
+        parser.add_argument('--dry-run', action='store_true', default=False)
 
     @staticmethod
     def require_only_option(sole_option, options):
-        this_command_opts = {'MIGRATE', 'COMMIT', 'blow_away', 'stats', 'show_diffs', 'no_input', 'debug'}
+        this_command_opts = {
+            'MIGRATE',
+            'COMMIT',
+            'blow_away',
+            'stats',
+            'show_diffs',
+            'no_input',
+            'debug',
+            'dry_run',
+        }
         assert all(not value for key, value in options.items()
                    if key in this_command_opts and key != sole_option)
 
@@ -58,6 +68,8 @@ class Command(BaseCommand):
 
         self.no_input = options.pop('no_input', False)
         self.debug = options.pop('debug', False)
+        self.dry_run = options.pop('dry_run', False)
+
         if self.no_input and not settings.UNIT_TESTING:
             raise CommandError('no-input only allowed for unit testing')
 

--- a/corehq/apps/couch_sql_migration/progress.py
+++ b/corehq/apps/couch_sql_migration/progress.py
@@ -22,8 +22,8 @@ def set_couch_sql_migration_not_started(domain):
     set_migration_not_started(domain, COUCH_TO_SQL_SLUG)
 
 
-def couch_sql_migration_in_progress(domain, any_run=True):
-    return migration_in_progress(domain, COUCH_TO_SQL_SLUG, any_run)
+def couch_sql_migration_in_progress(domain, include_dry_runs=True):
+    return migration_in_progress(domain, COUCH_TO_SQL_SLUG, include_dry_runs)
 
 
 def _notify_dimagi_users_on_domain(domain):

--- a/corehq/apps/couch_sql_migration/progress.py
+++ b/corehq/apps/couch_sql_migration/progress.py
@@ -4,24 +4,26 @@ from __future__ import unicode_literals
 from django.conf import settings
 
 from corehq.apps.domain_migration_flags.api import (
-    set_migration_started, set_migration_not_started,
-    get_migration_status)
+    set_migration_started,
+    set_migration_not_started,
+    migration_in_progress
+)
 from corehq.apps.domain_migration_flags.models import MigrationStatus, DomainMigrationProgress
 from corehq.apps.tzmigration.api import set_tz_migration_complete
 
 COUCH_TO_SQL_SLUG = 'couch_to_sql'
 
 
-def set_couch_sql_migration_started(domain):
-    set_migration_started(domain, COUCH_TO_SQL_SLUG)
+def set_couch_sql_migration_started(domain, dry_run):
+    set_migration_started(domain, COUCH_TO_SQL_SLUG, dry_run)
 
 
 def set_couch_sql_migration_not_started(domain):
     set_migration_not_started(domain, COUCH_TO_SQL_SLUG)
 
 
-def couch_sql_migration_in_progress(domain):
-    return get_migration_status(domain, COUCH_TO_SQL_SLUG, strict=True) == MigrationStatus.IN_PROGRESS
+def couch_sql_migration_in_progress(domain, any_run=True):
+    return migration_in_progress(domain, COUCH_TO_SQL_SLUG, any_run)
 
 
 def _notify_dimagi_users_on_domain(domain):

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -10,6 +10,7 @@ from django.core.files.uploadedfile import UploadedFile
 from django.core.management import call_command
 from django.test import TestCase
 from django.test import override_settings
+from django.core.management.base import CommandError
 
 from casexml.apps.case.mock import CaseBlock
 from corehq.toggles import COUCH_SQL_MIGRATION_BLACKLIST, NAMESPACE_DOMAIN
@@ -575,7 +576,7 @@ class MigrationTestCase(BaseMigrationTestCase):
             dry_run=True
         )
         clear_local_domain_sql_backend_override(self.domain_name)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(CommandError):
             call_command('migrate_domain_from_couch_to_sql', self.domain_name, COMMIT=True, no_input=True)
         self.assertFalse(Domain.get_by_name(self.domain_name).use_sql_backend)
         call_command('migrate_domain_from_couch_to_sql', self.domain_name, blow_away=True, no_input=True)

--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -60,8 +60,12 @@ def migration_in_progress(domain, slug, include_dry_runs=False):
 
 @quickcache(['domain'], skip_arg='strict', timeout=60 * 60, memoize_timeout=60)
 def any_migrations_in_progress(domain, strict=False):
-    """Returns True if there are any migrations in progress where modifications to
-    project forms and cases should be prevented
+    """ Checks if any migrations at all are in progress for the domain
+
+    Returns True if there are any migrations in progress where modifications to
+    project forms and cases should be prevented.
+
+    This does not include migrations that are marked as dry runs.
     """
     return DATA_MIGRATION.enabled(domain) or DomainMigrationProgress.objects.filter(
         domain=domain, migration_status=MigrationStatus.IN_PROGRESS

--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -53,10 +53,9 @@ def get_migration_status(domain, slug, strict=False):
         return MigrationStatus.NOT_STARTED
 
 
-def migration_in_progress(domain, slug, any_run=False):
-    """ any_run means a dry run should also be checked """
+def migration_in_progress(domain, slug, include_dry_runs=False):
     status = get_migration_status(domain, slug)
-    return status == MigrationStatus.IN_PROGRESS or (any_run and status == MigrationStatus.DRY_RUN)
+    return status == MigrationStatus.IN_PROGRESS or (include_dry_runs and status == MigrationStatus.DRY_RUN)
 
 
 @quickcache(['domain'], skip_arg='strict', timeout=60 * 60, memoize_timeout=60)

--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -34,6 +34,10 @@ def set_migration_not_started(domain, slug):
 
 def set_migration_complete(domain, slug):
     progress, _ = DomainMigrationProgress.objects.get_or_create(domain=domain, migration_slug=slug)
+
+    if progress.migration_status == MigrationStatus.DRY_RUN:
+        raise DomainMigrationProgressError("Cannot complete a migration that is in state dry run")
+
     if progress.migration_status != MigrationStatus.COMPLETE:
         progress.migration_status = MigrationStatus.COMPLETE
         progress.save()

--- a/corehq/apps/domain_migration_flags/models.py
+++ b/corehq/apps/domain_migration_flags/models.py
@@ -6,11 +6,13 @@ from django.db import models
 class MigrationStatus(object):
     NOT_STARTED = 'not_started'
     IN_PROGRESS = 'in_progress'
+    DRY_RUN = 'dry_run'
     COMPLETE = 'complete'
 
     choices = [
         (NOT_STARTED, 'Not Started'),
         (IN_PROGRESS, 'In Progress'),
+        (DRY_RUN, 'Dry Run'),
         (COMPLETE, 'Complete'),
     ]
 

--- a/corehq/apps/domain_migration_flags/tests/test_domain_migration_progress.py
+++ b/corehq/apps/domain_migration_flags/tests/test_domain_migration_progress.py
@@ -10,7 +10,8 @@ from corehq.apps.domain_migration_flags.api import (
     set_migration_complete,
     set_migration_not_started,
     set_migration_started,
-    any_migrations_in_progress)
+    any_migrations_in_progress,
+    migration_in_progress)
 from corehq.apps.domain_migration_flags.models import MigrationStatus
 
 
@@ -29,8 +30,20 @@ class DomainMigrationProgressTest(TestCase):
     def test_in_progress(self):
         set_migration_started('yellow', self.slug)
         self.assertFalse(get_migration_complete('yellow', self.slug))
+        self.assertTrue(migration_in_progress('yellow', self.slug))
+        self.assertTrue(migration_in_progress('yellow', self.slug, True))
         self.assertEqual(get_migration_status('yellow', self.slug),
                          MigrationStatus.IN_PROGRESS)
+        self.assertEqual(get_migration_status('yellow', 'otherslug'),
+                         MigrationStatus.NOT_STARTED)
+
+    def test_dry_run(self):
+        set_migration_started('yellow', self.slug, True)
+        self.assertFalse(get_migration_complete('yellow', self.slug))
+        self.assertFalse(migration_in_progress('yellow', self.slug))
+        self.assertTrue(migration_in_progress('yellow', self.slug, True))
+        self.assertEqual(get_migration_status('yellow', self.slug),
+                         MigrationStatus.DRY_RUN)
         self.assertEqual(get_migration_status('yellow', 'otherslug'),
                          MigrationStatus.NOT_STARTED)
 


### PR DESCRIPTION
Pretty straightforward: this allows a migration to be set as a dry run by adding a new status to the domain migrations `dry_run`. The idea is that in the api, there can be an option to check for that status or not, which the local processes will check, but the other ones will not.

In the case of couchsql, this means that the local process will use the sql backend, as it is set to using the threading.local object, while the main processor will still use the couch one and won't restrict form submissions or sms, etc.

The change is simple, but it also touches potentially a bunch of things, so please ask if I've considered different angles, since there is definitely a chance I missed something.

🐟 

@snopoke @millerdev buddy @orangejenny 