### PR TITLE
Don't create_all_files twice in live preview

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5961,6 +5961,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         return files
 
     @time_method()
+    @memoized
     def create_all_files(self, build_profile_id=None):
         prefix = '' if not build_profile_id else build_profile_id + '/'
         files = {


### PR DESCRIPTION
This is called as part of validate_app, then again during build_application_zip when downloading cczs directly.  The same app instance is kept around, so we can just memoize it on the instance.

This change should knock off about 18s from the build time for L10K.

@orangejenny FYI as area owner.