### PR TITLE
Profile app builds

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5268,7 +5268,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     def timing_context(self):
         return TimingContext(self.name)
 
-    @time_method()
     def validate_app(self):
         errors = []
 
@@ -6282,6 +6281,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             })
         return errors
 
+    @time_method()
     def validate_app(self):
         xmlns_count = defaultdict(int)
         errors = []

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6283,31 +6283,33 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
 
     @time_method()
     def _check_modules(self):
+        errors = []
         if not self.modules:
-            yield {'type': "no modules"}
+            errors.append({'type': "no modules"})
         for module in self.get_modules():
             try:
-                for error in module.validate_for_build():
-                    yield error
+                errors.extend(module.validate_for_build())
             except ModuleNotFoundException as ex:
-                yield {
+                errors.append({
                     "type": "missing module",
                     "message": six.text_type(ex)
-                }
+                })
+        return errors
 
     @time_method()
     def _check_forms(self):
+        errors = []
         xmlns_count = defaultdict(int)
         for form in self.get_forms():
-            for error in form.validate_for_build(validate_module=False):
-                yield error
+            errors.extend(form.validate_for_build(validate_module=False))
 
             # make sure that there aren't duplicate xmlns's
             if not isinstance(form, ShadowForm):
                 xmlns_count[form.xmlns] += 1
             for xmlns in xmlns_count:
                 if xmlns_count[xmlns] > 1:
-                    yield {'type': "duplicate xmlns", "xmlns": xmlns}
+                    errors.append({'type': "duplicate xmlns", "xmlns": xmlns})
+        return errors
 
     @time_method()
     def validate_app(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -6281,6 +6281,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             })
         return errors
 
+    @time_method()
     def _check_modules(self):
         if not self.modules:
             yield {'type': "no modules"}
@@ -6294,6 +6295,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                     "message": six.text_type(ex)
                 }
 
+    @time_method()
     def _check_forms(self):
         xmlns_count = defaultdict(int)
         for form in self.get_forms():

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -520,13 +520,12 @@ class AppBuildTimingsView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(AppBuildTimingsView, self).get_context_data(**kwargs)
         app_id = self.request.GET.get('app_id')
-        request_user_id = self.request.couch_user._id
         if app_id:
             try:
                 app = Application.get(app_id)
             except ResourceNotFound:
                 raise Http404()
-            timing_context = self.get_timing_context(app, request_user_id)
+            timing_context = self.get_timing_context(app)
             context.update({
                 'app': app,
                 'timing_data': timing_context.to_list(),
@@ -534,7 +533,7 @@ class AppBuildTimingsView(TemplateView):
         return context
 
     @staticmethod
-    def get_timing_context(app, request_user_id):
+    def get_timing_context(app):
         with app.timing_context:
             errors = app.validate_app()
             assert not errors, errors


### PR DESCRIPTION
Currently we only capture timing information on the superclass's version of `validate_app` - this change will expand that scope a bit and see if parsing modules and forms is a big part of the slowness we're seeing.