### PR TITLE
Revert "Upgrade gevent to 1.3.7"

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -87,10 +87,10 @@ fixture==1.5.11
 freezegun==0.3.10
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.3.7
+gevent==1.2.2
 ghdiff==0.4
 graphviz==0.7
-greenlet==0.4.15
+greenlet==0.4.12
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -71,9 +71,9 @@ eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.3.7
+gevent==1.2.2
 ghdiff==0.4
-greenlet==0.4.15
+greenlet==0.4.12
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -76,9 +76,9 @@ faker==0.8.15
 flower==0.9.2
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.3.7
+gevent==1.2.2
 ghdiff==0.4
-greenlet==0.4.15
+greenlet==0.4.12
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
 attrs==18.1.0
-# needed to build jsonobject, and possibly other libraries?
+# needed to build gevent from source
 cython==0.27.3
 iso8601==0.1.12
 jsonobject==0.9.4
@@ -45,8 +45,8 @@ Unidecode==0.04.20
 xlrd==1.0.0
 simplejson==3.11.1
 sh==1.09
-gevent==1.3.7
-greenlet==0.4.15
+gevent==1.2.2
+greenlet==0.4.12
 numpy==1.7.1
 six==1.11.0
 socketpool==0.5.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -69,9 +69,9 @@ eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2           # via mock
 futures==3.2.0            # via s3transfer, tinys3
-gevent==1.3.7
+gevent==1.2.2
 ghdiff==0.4
-greenlet==0.4.15
+greenlet==0.4.12
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -75,9 +75,9 @@ faker==0.8.15
 freezegun==0.3.10
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.3.7
+gevent==1.2.2
 ghdiff==0.4
-greenlet==0.4.15
+greenlet==0.4.12
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0b8


### PR DESCRIPTION
Reverts dimagi/commcare-hq#22159

This is showing a bad interaction with our version of celery e.g. https://sentry.io/dimagi/commcarehq/issues/743273636/?environment=production