### PR TITLE
[VectorLink] fix for username and phone number

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -146,8 +146,13 @@
         "is_nullable": true,
         "column_id": "phone_number",
         "expression": {
-          "type": "property_name",
-          "property_name": "phone_number"
+          "type": "reduce_items",
+          "items_expression": {
+            "datatype": "array",
+            "type": "property_name",
+            "property_name": "phone_numbers"
+          },
+          "aggregation_fn": "first_item"
         }
       }
     ],

--- a/custom/abt/reports/late_pmt.py
+++ b/custom/abt/reports/late_pmt.py
@@ -177,7 +177,7 @@ class LatePmtReport(GenericTabularReport, CustomProjectReport, DatespanMixin):
         def _to_report_format(date, user, group):
             return [
                 date.strftime("%Y-%m-%d"),
-                user['username'],
+                user['username'].split('@')[0],
                 user['phone_number'],
                 user['country'],
                 user['level_1'],


### PR DESCRIPTION
Hi @nickpell 

I added small fixes for Late PMT report.
#1 we want only the first part of the username in the report so I split by '@' character.
#2 the phone number is missing in the report so I take first one from the phone numbers list.

CASE: https://manage.dimagi.com/default.asp?283512#1541721

Please let me know if you have any questions.

Regards,
Łukasz