### PR TITLE
gracefully handle turning an Exception with a non-ascii bytes message…

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -275,7 +275,7 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Bul
                 notify_exception(
                     None,
                     "Error in saving changes chunk {ids}: {ex}".format(
-                        ids=[c.id for c in to_update], ex=ex))
+                        ids=[c.id for c in to_update], ex=repr(ex)))
                 retry_changes.update(to_update)
         if async_configs_by_doc_id:
             doc_type_by_id = {


### PR DESCRIPTION
… into a readable format

https://sentry.io/dimagi/commcarehq/issues/745707625/

This changes the text a bit such that it will have "Exception(<message>)" but is more future-proof than using ```ex.message``` which is removed in python 3.