### PR TITLE
Put the case importer in its own queue

### DIFF
--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -33,7 +33,7 @@ CASEBLOCK_CHUNKSIZE = 100
 RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
 
 
-@task(serializer='pickle')
+@task(serializer='pickle', queue='case_import_queue')
 def bulk_import_async(config, domain, excel_id):
     case_upload = CaseUpload.get(excel_id)
     try:
@@ -58,7 +58,7 @@ def bulk_import_async(config, domain, excel_id):
         store_task_result.delay(excel_id)
 
 
-@task(serializer='pickle')
+@task(serializer='pickle', queue='case_import_queue')
 def store_task_result(upload_id):
     case_upload = CaseUpload.get(upload_id)
     case_upload.store_task_result()


### PR DESCRIPTION
Sister PR of https://github.com/dimagi/commcare-cloud/pull/2341, triggered by https://manage.dimagi.com/default.asp?283896
Hopefully this should make it a little more obvious whether case imports are being blocked by random other stuff in the queue, and we may soon want to shuffle resources around so these are higher priority.

Waiting on deployment of https://github.com/dimagi/commcare-cloud/pull/2341