### PR TITLE
Adjust to the fact that requests 2.11+ requires header values to be strings

### DIFF
--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -283,7 +283,7 @@ def post_data_helper(d, auth, content_type, url, log=False):
     up = urlparse(url)
     headers = {}
     headers["content-type"] = content_type
-    headers["content-length"] = len(data)
+    headers["content-length"] = str(len(data))
     conn = six.moves.http_client.HTTPConnection(up.netloc)
     conn.request('POST', up.path, data, headers)
     resp = conn.getresponse()
@@ -296,7 +296,7 @@ def formplayer_post_data_helper(d, content_type, url):
     up = urlparse(url)
     headers = {}
     headers["Content-Type"] = content_type
-    headers["content-length"] = len(data)
+    headers["content-length"] = str(len(data))
     headers["X-MAC-DIGEST"] = get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, data)
     response = requests.post(
         url,

--- a/corehq/ex-submodules/dimagi/utils/post.py
+++ b/corehq/ex-submodules/dimagi/utils/post.py
@@ -25,7 +25,7 @@ def simple_post(data, url, content_type="text/xml", timeout=60, headers=None, au
         data = data.encode('utf-8')  # can't pass unicode to http request posts
     default_headers = requests.structures.CaseInsensitiveDict({
         "content-type": content_type,
-        "content-length": len(data),
+        "content-length": str(len(data)),
     })
     if headers:
         default_headers.update(headers)


### PR DESCRIPTION
previously it converted ints to strings

Related to recent update to requests 2.20

Fixes https://sentry.io/dimagi/commcarehq/issues/748890370/?environment=production.
See https://github.com/requests/requests/issues/3477.