### PR TITLE
dont do any checks in case of no obfuscation

### DIFF
--- a/custom/nic_compliance/tests/test_utils.py
+++ b/custom/nic_compliance/tests/test_utils.py
@@ -129,10 +129,10 @@ class TestExtractPassword(TestCase):
 
     def test_invalid_regex_format(self):
         obfuscated_password = "sha255$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="
-        self.assertEqual(extract_password(obfuscated_password), obfuscated_password)
+        self.assertFalse(extract_password(obfuscated_password))
 
         obfuscated_password = "sha255$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ=="
-        self.assertEqual(extract_password(obfuscated_password), obfuscated_password)
+        self.assertFalse(extract_password(obfuscated_password))
 
     def test_invalid_padding(self):
         obfuscated_password = "sha256$1e456bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="

--- a/custom/nic_compliance/tests/test_utils.py
+++ b/custom/nic_compliance/tests/test_utils.py
@@ -129,10 +129,10 @@ class TestExtractPassword(TestCase):
 
     def test_invalid_regex_format(self):
         obfuscated_password = "sha255$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="
-        self.assertFalse(extract_password(obfuscated_password))
+        self.assertEqual(extract_password(obfuscated_password), None)
 
         obfuscated_password = "sha255$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ=="
-        self.assertFalse(extract_password(obfuscated_password))
+        self.assertEqual(extract_password(obfuscated_password), None)
 
     def test_invalid_padding(self):
         obfuscated_password = "sha256$1e456bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="

--- a/custom/nic_compliance/utils.py
+++ b/custom/nic_compliance/utils.py
@@ -61,8 +61,7 @@ def extract_password(obfuscated_password):
             # completely
             return ''
     else:
-        # return the password received AS-IS
-        return obfuscated_password
+        return False
 
 
 def hash_password(password):
@@ -102,13 +101,18 @@ def get_raw_password(obfuscated_password, username=None):
     def _decode_password():
         # In case of 2-step authentication for web skip by checking for auth-username which is
         # present in first step
+        raw_password = extract_password(obfuscated_password)
+        if raw_password is False:
+            # if there was no obfuscation done, just return the raw password
+            # and skip any further checks
+            return obfuscated_password
         if username and (
                 (request and request.POST.get('auth-username')) or
                 _mobile_request_to_track(username)):
             if replay_attack():
                 return ''
             record_login_attempt()
-        return extract_password(obfuscated_password)
+        return raw_password
 
     if settings.OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE:
         request = get_request()

--- a/custom/nic_compliance/utils.py
+++ b/custom/nic_compliance/utils.py
@@ -61,7 +61,7 @@ def extract_password(obfuscated_password):
             # completely
             return ''
     else:
-        return False
+        return None
 
 
 def hash_password(password):
@@ -100,7 +100,7 @@ def get_raw_password(obfuscated_password, username=None):
 
     def _decode_password():
         raw_password = extract_password(obfuscated_password)
-        if raw_password is False:
+        if raw_password is None:
             # if there was no obfuscation done, just return the raw password
             # and skip any further checks
             return obfuscated_password

--- a/custom/nic_compliance/utils.py
+++ b/custom/nic_compliance/utils.py
@@ -99,13 +99,13 @@ def get_raw_password(obfuscated_password, username=None):
         return resolve(request.path).url_name in MOBILE_REQUESTS_TO_TRACK_FOR_REPLAY_ATTACK
 
     def _decode_password():
-        # In case of 2-step authentication for web skip by checking for auth-username which is
-        # present in first step
         raw_password = extract_password(obfuscated_password)
         if raw_password is False:
             # if there was no obfuscation done, just return the raw password
             # and skip any further checks
             return obfuscated_password
+        # In case of 2-step authentication for web skip by checking for auth-username which is
+        # present in first step
         if username and (
                 (request and request.POST.get('auth-username')) or
                 _mobile_request_to_track(username)):


### PR DESCRIPTION
Follow up from https://github.com/dimagi/commcare-hq/pull/22195

In case the HQ environment has obfuscation enabled but the mobile application does not, the current logic would lock out the mobile user permanently because the user would always submit with the same password and HQ would consider that a re-attempt instead.
This PR addresses that by skipping any check if the mobile app does not submit obfuscated password