### PR TITLE
Specify database for the transaction in ICDS aggregation

### DIFF
--- a/custom/icds_reports/models/aggregate.py
+++ b/custom/icds_reports/models/aggregate.py
@@ -141,7 +141,7 @@ class CcsRecordMonthly(models.Model):
         index_queries = helper.indexes()
 
         with get_cursor(cls) as cursor:
-            with transaction.atomic():
+            with transaction.atomic(using=db_for_read_write(cls)):
                 cursor.execute(helper.drop_table_query())
                 cursor.execute(agg_query, agg_params)
                 for query in index_queries:
@@ -477,7 +477,7 @@ class AggCcsRecord(models.Model):
         index_queries = [query for index_list in index_queries for query in index_list]
 
         with get_cursor(cls) as cursor:
-            with transaction.atomic():
+            with transaction.atomic(using=db_for_read_write(cls)):
                 cursor.execute(helper.drop_table_query())
                 cursor.execute(agg_query, agg_params)
                 for query in rollup_queries:
@@ -570,7 +570,7 @@ class AggChildHealth(models.Model):
         index_queries = [query for index_list in index_queries for query in index_list]
 
         with get_cursor(cls) as cursor:
-            with transaction.atomic():
+            with transaction.atomic(using=db_for_read_write(cls)):
                 cursor.execute(helper.drop_table_query())
                 cursor.execute(agg_query, agg_params)
                 for query in rollup_queries:

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -401,15 +401,15 @@ def _aggregate_bp_forms(state_id, day):
     AggregateBirthPreparednesForms.aggregate(state_id, day)
 
 
-@transaction.atomic
 def _run_custom_sql_script(commands, day=None):
     db_alias = get_icds_ucr_db_alias()
     if not db_alias:
         return
 
-    with connections[db_alias].cursor() as cursor:
-        for command in commands:
-            cursor.execute(command, [day])
+    with transaction.atomic(using=db_alias):
+        with connections[db_alias].cursor() as cursor:
+            for command in commands:
+                cursor.execute(command, [day])
 
 
 def aggregate_awc_daily(day):
@@ -442,7 +442,7 @@ def _child_health_monthly_table(state_ids, day):
     sub_aggregations.get()
 
     celery_task_logger.info("Inserting into child_health_monthly_table")
-    with transaction.atomic():
+    with transaction.atomic(using=db_for_read_write(ChildHealthMonthly)):
         _run_custom_sql_script([
             "SELECT create_new_table_for_month('child_health_monthly', %s)",
         ], day)
@@ -463,7 +463,7 @@ def _child_health_helper(query, params):
 
 @track_time
 def _ccs_record_monthly_table(day):
-    with transaction.atomic():
+    with transaction.atomic(using=db_for_read_write(CcsRecordMonthly)):
         _run_custom_sql_script([
             "SELECT create_new_table_for_month('ccs_record_monthly', %s)",
         ], day)
@@ -480,7 +480,7 @@ def _daily_attendance_table(day):
 
 @track_time
 def _agg_child_health_table(day):
-    with transaction.atomic():
+    with transaction.atomic(using=db_for_read_write(AggChildHealth)):
         _run_custom_sql_script([
             "SELECT create_new_aggregate_table_for_month('agg_child_health', %s)",
         ], day)
@@ -489,7 +489,7 @@ def _agg_child_health_table(day):
 
 @track_time
 def _agg_ccs_record_table(day):
-    with transaction.atomic():
+    with transaction.atomic(using=db_for_read_write(AggCcsRecord)):
         _run_custom_sql_script([
             "SELECT create_new_aggregate_table_for_month('agg_ccs_record', %s)",
         ], day)


### PR DESCRIPTION
:man_facepalming: 

> atomic takes a using argument which should be the name of a database. If this argument isn’t provided, Django uses the "default" database.

https://docs.djangoproject.com/en/2.1/topics/db/transactions/#controlling-transactions-