### PR TITLE
Track restore times on large prod domains

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2161,8 +2161,12 @@ THROTTLE_SCHED_REPORTS_PATTERNS = (
 
 RESTORE_TIMING_DOMAINS = {
     # ("env", "domain"),
+    ("production", "born-on-time-2"),
+    ("production", "hki-nepal-suaahara-2"),
     ("production", "malawi-fp-study"),
+    ("production", "no-lean-season"),
     ("production", "rec"),
+    ("production", "sauti-1"),
 }
 
 #### Django Compressor Stuff after localsettings overrides ####


### PR DESCRIPTION
These are the top 5 domains according to [submissions by domain](https://app.datadoghq.com/dash/968242?live=true&page=0&is_auto=false&from_ts=1533395256489&to_ts=1541171256489&tile_size=xl&fullscreen=false)

@dannyroberts 