### PR TITLE
Roll back showing full ancestry on case list page

### DIFF
--- a/corehq/apps/case_migrations/views.py
+++ b/corehq/apps/case_migrations/views.py
@@ -51,9 +51,9 @@ class MigrationView(BaseMigrationView, FormView):
 
 
 def get_case_hierarchy_for_restore(case):
-    from corehq.apps.reports.view_helpers import get_children
+    from corehq.apps.reports.view_helpers import get_case_hierarchy
     return [
-        c for c in get_children(case)['case_list']
+        c for c in get_case_hierarchy(case, {})['case_list']
         if not c.closed
     ]
 

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -201,7 +201,7 @@ def get_case_hierarchy(case, type_info):
     accessor = CaseAccessors(case.domain)
     new_indices = {case.case_id}
     seen_indices = {case.case_id}
-    last_index = case.case_id
+    last_index = None
     while True:
         new_indices = accessor.get_indexed_case_ids(new_indices)
         if not set(new_indices) - seen_indices:

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -1,17 +1,17 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from functools import partial
 import datetime
 import numbers
-from functools import partial
-
 import pytz
+
+from couchdbkit import ResourceNotFound
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from casexml.apps.case.views import get_wrapped_case
 from corehq.apps.hqwebapp.templatetags.proptable_tags import get_display_data
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=None):
@@ -21,9 +21,34 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
     columns = wrapped_case.related_cases_columns
     type_info = wrapped_case.related_type_info
 
-    case_list = get_flat_descendant_case_list(
+    descendent_case_list = get_flat_descendant_case_list(
         case, get_case_url, type_info=type_info
     )
+
+    parent_cases = []
+    if case.indices:
+        # has parent case(s)
+        # todo: handle duplicates in ancestor path (bubbling up of parent-child
+        # relationships)
+        for idx in case.indices:
+            try:
+                parent_cases.append(idx.referenced_case)
+            except ResourceNotFound:
+                parent_cases.append(None)
+        for parent_case in parent_cases:
+            if parent_case:
+                parent_case.edit_data = {
+                    'view_url': get_case_url(parent_case.case_id)
+                }
+                last_parent_id = parent_case.case_id
+            else:
+                last_parent_id = None
+
+        for c in descendent_case_list:
+            if not getattr(c, 'treetable_parent_node_id', None) and last_parent_id:
+                c.treetable_parent_node_id = last_parent_id
+
+    case_list = parent_cases + descendent_case_list
 
     for c in case_list:
         if not c:
@@ -154,18 +179,17 @@ def process_case_hierarchy(case_output, get_case_url, type_info):
     process_output(case_output)
 
 
-def get_children(case, type_info=None):
-    def _get_children(case, referenced_type=None, seen=None):
+def get_case_hierarchy(case, type_info):
+    def get_children(case, referenced_type=None, seen=None):
         seen = seen or set()
 
-        # only relevant for `pact`
-        ignore_types = type_info.get(case.type, {}).get("ignore_relationship_types", []) if type_info else []
+        ignore_types = type_info.get(case.type, {}).get("ignore_relationship_types", [])
         if referenced_type and referenced_type in ignore_types:
             return None
 
         seen.add(case.case_id)
         children = [
-            _get_children(i.referenced_case, i.referenced_type, seen) for i in case.reverse_indices
+            get_children(i.referenced_case, i.referenced_type, seen) for i in case.reverse_indices
             if i.referenced_id not in seen
         ]
 
@@ -194,22 +218,8 @@ def get_children(case, type_info=None):
             'descendant_types': list(set(descendant_types + [c['case'].type for c in children])),
             'case_list': [case] + child_cases
         }
-    return _get_children(case)
 
-
-def get_case_hierarchy(case, type_info):
-    accessor = CaseAccessors(case.domain)
-    new_indices = {case.case_id}
-    seen_indices = {case.case_id}
-    last_index = None
-    while True:
-        new_indices = accessor.get_indexed_case_ids(new_indices)
-        if not set(new_indices) - seen_indices:
-            break
-        last_index = new_indices[0]
-        seen_indices |= set(new_indices)
-
-    return get_children(CaseAccessors(case.domain).get_case(last_index), type_info)
+    return get_children(case)
 
 
 def get_flat_descendant_case_list(case, get_case_url, type_info=None):

--- a/corehq/apps/reports/view_helpers.py
+++ b/corehq/apps/reports/view_helpers.py
@@ -13,8 +13,6 @@ from casexml.apps.case.views import get_wrapped_case
 from corehq.apps.hqwebapp.templatetags.proptable_tags import get_display_data
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
-MAX_CHILD_CASES = 100
-
 
 def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=None):
     wrapped_case = get_wrapped_case(case)
@@ -40,7 +38,6 @@ def case_hierarchy_context(case, get_case_url, show_view_buttons=True, timezone=
         'current_case': case,
         'domain': case.domain,
         'case_list': case_list,
-        'max_child_cases': MAX_CHILD_CASES,
         'columns': columns,
         'num_columns': len(columns) + 1,
         'show_view_buttons': show_view_buttons,
@@ -167,10 +164,8 @@ def get_children(case, type_info=None):
             return None
 
         seen.add(case.case_id)
-        case.num_children = len(case.reverse_indices)
         children = [
-            _get_children(i.referenced_case, i.referenced_type, seen)
-            for i in case.reverse_indices[:MAX_CHILD_CASES]
+            _get_children(i.referenced_case, i.referenced_type, seen) for i in case.reverse_indices
             if i.referenced_id not in seen
         ]
 
@@ -197,7 +192,7 @@ def get_children(case, type_info=None):
             'case': case,
             'child_cases': children,
             'descendant_types': list(set(descendant_types + [c['case'].type for c in children])),
-            'case_list': [case] + child_cases,
+            'case_list': [case] + child_cases
         }
     return _get_children(case)
 
@@ -214,7 +209,7 @@ def get_case_hierarchy(case, type_info):
         last_index = new_indices[0]
         seen_indices |= set(new_indices)
 
-    return get_children(accessor.get_case(last_index), type_info)
+    return get_children(CaseAccessors(case.domain).get_case(last_index), type_info)
 
 
 def get_flat_descendant_case_list(case, get_case_url, type_info=None):

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
@@ -84,7 +84,7 @@
                 </a>
                 {% endwith %}
                 {% endif %}
-
+                
                 <div class="pull-right btn-group">
                     {% if case.edit_data.edit_form_id != None and not case.closed %}
                     {% with case.edit_data as data %}
@@ -100,7 +100,7 @@
                     </a>
                     {% endwith %}
                     {% endif %}
-
+                    
                     {% if show_view_buttons and case.case_id != current_case.case_id %}
                     <a class="btn btn-sm btn-default" href="{{ case.edit_data.view_url }}">
                         <i class="fa fa-eye"></i> {% trans "View" %}
@@ -123,17 +123,6 @@
                     <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
                 </div>
                 {% endif %}
-
-                {% if case.num_children > max_child_cases %}
-                <br style="line-height:0">
-                <span class="indenter" style="line-height:0; padding: 0 {{ case.edit_data.indent_px }}px"></span>
-                <div style="display:inline-block">
-                    {% blocktrans with case.num_children as num_children %}
-                    Displaying {{ max_child_cases }} of {{ num_children }} children
-                    {% endblocktrans %}
-                </div>
-                {% endif %}
-
             </td>
 
             {% for column in case.columns %}

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -311,27 +311,6 @@ class TestCaseHierarchy(TestCase):
         self.assertEqual(2, len(hierarchy['child_cases'][0]['case_list']))
         self.assertEqual(1, len(hierarchy['child_cases'][0]['child_cases']))
 
-    def test_full_ancestry(self):
-        """get_case_hierarchy should return the full parentage tree for any case
-        """
-        factory = CaseFactory('baggins-of-hobbiton')
-        bagginses = ['balbo', 'mungo', 'bungo', 'bilbo']
-        cases = {}
-        for level, baggins in enumerate(bagginses):
-            cases[baggins] = factory.create_or_update_case(
-                CaseStructure(
-                    case_id=baggins,
-                    attrs={
-                        'case_type': 'baggins',
-                        'update': {'name': baggins},
-                        'create': True},
-                    indices=[CaseIndex(CaseStructure(case_id=bagginses[level - 1]))] if level != 0 else None,
-                    walk_related=False,
-                )
-            )[0]
-        hierarchy = get_case_hierarchy(cases['bungo'], {})
-        self.assertEqual(4, len(hierarchy['case_list']))
-
     @softer_assert()
     def test_missing_transactions(self):
         # this could happen if a form was edited and resulted in a new case transaction


### PR DESCRIPTION
https://trello.com/c/sQtqYcuL/65-case-list-issue-reported-in-fogbugz

Rolls back this change: https://github.com/dimagi/commcare-hq/pull/21461 (and this: https://github.com/dimagi/commcare-hq/pull/21716)

This feature was bricking the page for some people with strange case structures, so putting it back to its original state. Will add metrics in a followup PR to this page to see how much people are trying to see the full ancestry to see if we want to pursue adding a feature like this in a better way.

# Before
![image](https://user-images.githubusercontent.com/146896/47931978-b193f000-dea6-11e8-9517-423190d78308.png)

# After
![image](https://user-images.githubusercontent.com/146896/47931973-af319600-dea6-11e8-840a-e6ded8cdc37c.png)

