### PR TITLE
adding back pagination exception handler

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -664,7 +664,7 @@ def _save_migrated_models(sql_form, case_stock_result=None):
 
 
 class MigrationPaginationEventHandler(PaginationEventHandler):
-    RETRIES = 10
+    RETRIES = 5
 
     def __init__(self, domain):
         self.domain = domain
@@ -676,6 +676,14 @@ class MigrationPaginationEventHandler(PaginationEventHandler):
     def page_end(self, total_emitted, duration, *args, **kwargs):
         self.retries = self.RETRIES
         cache_utils.clear_limit(self._cache_key())
+
+    def page_exception(self, e):
+        if self.retries <= 0:
+            return False
+
+        self.retries -= 1
+        sleep(1)
+        return True
 
 
 def _get_main_form_iterator(domain):

--- a/corehq/util/pagination.py
+++ b/corehq/util/pagination.py
@@ -21,6 +21,15 @@ class PaginationEventHandler(object):
         """
         pass
 
+    def page_exception(self, exception):
+        """ Called on the load if it raises an exception
+
+        :param exception: the exception that was raised
+
+        returns a boolean of whether the exception was handled
+        """
+        return False
+
     def page_end(self, total_emitted, duration, *args, **kwargs):
         """Called at the end of each page of data
 
@@ -103,7 +112,13 @@ def paginate_function(data_function, args_provider, event_handler=None):
         event_handler.page_start(total_emitted, *args, **kwargs)
         results = data_function(*args, **kwargs)
         start_time = datetime.utcnow()
-        len_results = len(results)
+
+        try:
+            len_results = len(results)
+        except Exception as e:
+            if event_handler.page_exception(e):
+                continue
+            raise
 
         for item in results:
             yield item


### PR DESCRIPTION
This exception handler still seems useful to me, even if there aren't http errors. I had no idea it was [removed here](https://github.com/dimagi/commcare-hq/pull/21494/commits/410ebb5935ece1c0b5620a109b95364e1f5636de), so I'm adding it back.

@snopoke @millerdev buddy @orangejenny 