### PR TITLE
resumable iteration rebase

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -169,13 +169,10 @@ class CouchSqlDomainMigrator(object):
 
     def _try_to_process_form(self, wrapped_form, pool):
         case_ids = get_case_ids_from_form(wrapped_form)
-        if case_ids:  # if this form involves a case check if we can process it
-            if self.queues.try_obj(case_ids, wrapped_form):
-                pool.spawn(self._migrate_form_and_associated_models_async, wrapped_form)
-            elif self.queues.full:
-                sleep(0.01)  # swap greenlets
-        else:  # if not, just go ahead and process it
+        if self.queues.try_obj(case_ids, wrapped_form):
             pool.spawn(self._migrate_form_and_associated_models_async, wrapped_form)
+        elif self.queues.full:
+            sleep(0.01)  # swap greenlets
 
     def _try_to_process_queues(self, pool):
         # regularly check if we can empty the queues

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -837,6 +837,9 @@ class PartiallyLockingQueue(object):
 
         Returns :boolean: True if it acquired the lock, False if it was added to queue
         """
+        if not lock_ids:
+            self._add_item(lock_ids, queue_obj, to_queue=False)
+            return True
         if self._check_lock(lock_ids):  # if it's currently locked, it can't acquire the lock
             self._add_item(lock_ids, queue_obj)
             return False

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -63,9 +63,14 @@ CASE_DOC_TYPES = ['CommCareCase', 'CommCareCase-Deleted', ]
 UNPROCESSED_DOC_TYPES = list(all_known_formlike_doc_types() - {'XFormInstance'})
 
 
-def do_couch_to_sql_migration(domain, with_progress=True, debug=False):
+def do_couch_to_sql_migration(domain, with_progress=True, debug=False, run_timestamp=None):
     set_local_domain_sql_backend_override(domain)
-    CouchSqlDomainMigrator(domain, with_progress=with_progress, debug=debug).migrate()
+    CouchSqlDomainMigrator(
+        domain,
+        with_progress=with_progress,
+        debug=debug,
+        run_timestamp=run_timestamp
+    ).migrate()
 
 
 class CouchSqlDomainMigrator(object):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -813,6 +813,9 @@ class PartiallyLockingQueue(object):
         def get_cached_list_key():
             return "partial_queues.queued_or_processing.%s" % run_timestamp
         self.get_cached_list_key = get_cached_list_key
+        client = get_redis_connection()
+        client.rpush(get_cached_list_key(), '')  # hack to make key exist
+        client.expire(get_cached_list_key(), 60 * 60 * 24 * 30)  # 30 days
 
     def add_processing_doc_id(self, doc_id):
         client = get_redis_connection()

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -46,6 +46,12 @@ class Command(BaseCommand):
         parser.add_argument('--no-input', action='store_true', default=False)
         parser.add_argument('--debug', action='store_true', default=False)
         parser.add_argument('--dry-run', action='store_true', default=False)
+        parser.add_argument(
+            '--run-timestamp',
+            type=int,
+            default=None,
+            help='use this option to continue a previous run that was started at this timestamp'
+        )
 
     @staticmethod
     def require_only_option(sole_option, options):
@@ -77,7 +83,11 @@ class Command(BaseCommand):
         if options['MIGRATE']:
             self.require_only_option('MIGRATE', options)
             set_couch_sql_migration_started(domain, self.dry_run)
-            do_couch_to_sql_migration(domain, with_progress=not self.no_input, debug=self.debug)
+            do_couch_to_sql_migration(
+                domain,
+                with_progress=not self.no_input,
+                debug=self.debug,
+                run_timestamp=options.get('run_timestamp'))
             has_diffs = self.print_stats(domain, short=True, diffs_only=True)
             if has_diffs:
                 print("\nUse '--stats-short', '--stats-long', '--show-diffs' to see more info.\n")

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -82,12 +82,19 @@ class Command(BaseCommand):
 
         if options['MIGRATE']:
             self.require_only_option('MIGRATE', options)
-            set_couch_sql_migration_started(domain, self.dry_run)
+
+            if options.get('run_timestamp'):
+                if not couch_sql_migration_in_progress(domain):
+                    raise CommandError("Migration must be in progress if run_timestamp is passed in")
+            else:
+                set_couch_sql_migration_started(domain, self.dry_run)
+
             do_couch_to_sql_migration(
                 domain,
                 with_progress=not self.no_input,
                 debug=self.debug,
                 run_timestamp=options.get('run_timestamp'))
+
             has_diffs = self.print_stats(domain, short=True, diffs_only=True)
             if has_diffs:
                 print("\nUse '--stats-short', '--stats-long', '--show-diffs' to see more info.\n")


### PR DESCRIPTION
I decided to close and rebase from [this other branch/pr](https://github.com/dimagi/commcare-hq/pull/21007) to clean things up a bit. It's been long enough that I wanted to go through it again and get another review, even though it was approved.

Explanation from the previous pr:
> adds both parts of resumability: 
>
> (1) the main iterators use the ResumableIterators classes
>
> (2) the queues store a persistent list of ids in redis that are currently processing or are in the queues so that they can be rebuilt
>
> It uses a timestamp to key runs, which is printed out at the beginning of the migration


🐟 

@snopoke @millerdev buddy @orangejenny 