### PR TITLE
Send Customer Invoices to Enterprise Admins

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1965,7 +1965,8 @@ class TriggerCustomerInvoiceForm(forms.Form):
             invoice_factory = CustomerAccountInvoiceFactory(
                 date_start=invoice_start,
                 date_end=invoice_end,
-                account=account
+                account=account,
+                recipients=[settings.ACCOUNTS_EMAIL]
             )
             invoice_factory.create_invoice()
         except BillingAccount.DoesNotExist:

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -402,6 +402,9 @@ class CustomerAccountInvoiceFactory(object):
             if self.recipients:
                 for email in self.recipients:
                     record.send_email(contact_email=email)
+            elif self.account.enterprise_admin_emails:
+                for email in self.account.enterprise_admin_emails:
+                    record.send_email(contact_email=email)
             elif self.account.dimagi_contact:
                 record.send_email(contact_email=self.account.dimagi_contact,
                                   cc_emails=[settings.ACCOUNTS_EMAIL])


### PR DESCRIPTION
This PR ensures the customer invoice is sent to `enterprise_admin_emails` (when there are no recipients passed in) and to accounts@ when invoices are triggered manually