### PR TITLE
Upgrade to couchdbkit 0.9.11

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -110,7 +110,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.10
+jsonobject-couchdbkit==0.9.11
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -89,7 +89,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.10
+jsonobject-couchdbkit==0.9.11
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -94,7 +94,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.10
+jsonobject-couchdbkit==0.9.11
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@ attrs==18.1.0
 cython==0.27.3
 iso8601==0.1.12
 jsonobject==0.9.4
-jsonobject-couchdbkit==0.9.10
+jsonobject-couchdbkit==0.9.11
 celery==3.1.25
 # required by django-digest
 decorator==4.0.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -86,7 +86,7 @@ jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.10
+jsonobject-couchdbkit==0.9.11
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -92,7 +92,7 @@ jinja2==2.10
 jmespath==0.9.3
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.10
+jsonobject-couchdbkit==0.9.11
 jsonobject==0.9.4
 jsonpath-rw==1.4.0
 kafka-python==1.4.3


### PR DESCRIPTION
Subset of #22261, which incorporates https://github.com/dimagi/couchdbkit/pull/65 (mainly for https://github.com/dimagi/couchdbkit/pull/65/commits/739c347ae0f3467856e868cb32ef263bd926e3eb) to clean up couch logs. The rest of #22261 will have to wait for a more thorough solution.

@dannyroberts 