### PR TITLE
adds "has diffs" as a reported outcome

### DIFF
--- a/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
@@ -49,8 +49,9 @@ class Command(BaseCommand):
         self.stdout.write("Processing {} domains".format(len(domains)))
         for domain in with_progress_bar(domains, oneline=False):
             try:
-                if not self.migrate_domain(domain):
-                    failed.append((domain, "has diffs"))
+                success, reason = self.migrate_domain(domain)
+                if not success:
+                    failed.append((domain, reason))
             except Exception as e:
                 if with_traceback:
                     traceback.print_exc()
@@ -69,7 +70,11 @@ class Command(BaseCommand):
     def migrate_domain(self, domain):
         if should_use_sql_backend(domain):
             self.stderr.write("{} already on the SQL backend".format(domain))
-            return
+            return True, None
+
+        if couch_sql_migration_in_progress(domain, include_dry_runs=True):
+            self.stderr.write("{} migration is already in progress".format(domain))
+            return False, "in progress"
 
         set_couch_sql_migration_started(domain)
 
@@ -83,12 +88,12 @@ class Command(BaseCommand):
             writer.write_table(['Doc Type', '# Couch', '# SQL', '# Diffs', '# Docs with Diffs'], [
                 (doc_type,) + stat for doc_type, stat in stats.items()
             ])
-            return False
+            return False, "has diffs"
 
         assert couch_sql_migration_in_progress(domain)
         set_couch_sql_migration_complete(domain)
         self.stdout.write(shell_green("Domain migrated: {}".format(domain)))
-        return True
+        return True, None
 
     def get_diff_stats(self, domain):
         db = get_diff_db(domain)


### PR DESCRIPTION
both commits are niceties

first commit: i don't like that i have to watch the migrate_multiple to see what i have to followup on for diffs, so this prints out the "has diffs" outcome, as well as exceptions in the migration

second commit: i've occasionally run two different migration_multiple processes side by side to go through a bunch of migrations at once. this would be even more efficient if they could use the same doc, but if i tried that currently, they would blow away each others migrations. this makes it so that `in_progress` and `dry_run` are handled more gently. this is also safer if i accidentally include a running migration in a txt file by accident

@millerdev @snopoke buddy: @orangejenny 