### PR TITLE
Fix unreleased form locks

### DIFF
--- a/corehq/ex-submodules/couchforms/exceptions.py
+++ b/corehq/ex-submodules/couchforms/exceptions.py
@@ -14,11 +14,5 @@ class MissingXMLNSError(CouchFormException):
     pass
 
 
-class DuplicateError(CouchFormException):
-
-    def __init__(self, xform):
-        self.xform = xform
-
-
 class UnexpectedDeletedXForm(Exception):
     pass


### PR DESCRIPTION
Duplicate processing has been moved into `FormProcessingResult.get_locked_forms()` to avoid acquiring any form locks before ~that method is called~ the returned context manager is entered. There is now only one lock on the (possibly duplicate) submitted form ID. All other form IDs involved in the processing are newly generated UUIDs and therefore should not have contention unless there is a collision (and that should be suitably rare to not be a concern).

This should resolve the following:

Consider [this code block](https://github.com/dimagi/commcare-hq/blob/0c65b8424f39f3a9ea8c7e324db06acb05674987/corehq/form_processor/submission_post.py#L219-L237). The lock is acquired on line 219 (previously I had thought it was acquired on line 237). The two return statements after line 219 but before line 237 happen before the lock is released. In other words, the lock is acquired but never released (until timeout).

@snopoke @dannyroberts @ctsims 