### PR TITLE
use view to provide active confs

### DIFF
--- a/corehq/apps/userreports/data_source_providers.py
+++ b/corehq/apps/userreports/data_source_providers.py
@@ -13,7 +13,10 @@ class DataSourceProvider(six.with_metaclass(ABCMeta, object)):
 class DynamicDataSourceProvider(DataSourceProvider):
 
     def get_data_sources(self):
-        return [config for config in DataSourceConfiguration.all() if not config.is_deactivated]
+        return [DataSourceConfiguration.wrap(r['doc'])
+                for r in
+                DataSourceConfiguration.get_db().view('userreports/active_data_sources',
+                                                      reduce=False, include_docs=True)]
 
 
 class StaticDataSourceProvider(DataSourceProvider):


### PR DESCRIPTION
follow up https://github.com/dimagi/commcare-hq/pull/22251/files

I checked the number of docs to confirm that the view has results as expected, but there was a difference in number of docs.

the old process
`[config for config in DataSourceConfiguration.all() if not config.is_deactivated]`
gives 1756 results but the new view has 1569.

I also checked 
1. all `DataSourceConfiguration` docs have values either True of False for `is_deactivated`, so we should have all with is_deactivated as False in the view.

^ this has been fixed. Resaved all active confs that didn't have `is_deactivated` set. Now both the ways give the same set of confs


Any thoughts why the difference?
@emord 