### PR TITLE
Provide document_id as key for kafka partitioning

### DIFF
--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -24,7 +24,7 @@ class ChangeProducer(object):
             client_id="cchq-producer",
             retries=3,
             acks=1,
-            key_serializer=lambda key: key.encode()
+            key_serializer=lambda key: str(key).encode()
         )
         return self._producer
 

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -23,7 +23,8 @@ class ChangeProducer(object):
             api_version=settings.KAFKA_API_VERSION,
             client_id="cchq-producer",
             retries=3,
-            acks=1
+            acks=1,
+            key_serializer=lambda key: key.encode()
         )
         return self._producer
 

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -30,7 +30,7 @@ class ChangeProducer(object):
     def send_change(self, topic, change_meta):
         message = change_meta.to_json()
         try:
-            self.producer.send(topic, bytes(json.dumps(message)))
+            self.producer.send(topic, bytes(json.dumps(message)), key=change_meta.document_id)
             self.producer.flush()
         except Exception as e:
             _assert = soft_assert(notify_admins=True)


### PR DESCRIPTION
This will ensure that forms and cases reliably go to the same partition
when saved.

It provides a potential speedup in the event that the same document is
saved multiple times rapidly and we can de-duplicate its processing
(such as a pillow that processes changes in bulk). It also reduces the
likelihood that multiple processes will process the same document at the
same time.

The document will not be guaranteed to be in the same partition when we
add partitions to kafka.

@snopoke I had mentioned this in an earlier PR