### PR TITLE
Better standardization for form proportions

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -218,7 +218,7 @@ class SnapshotFixtureForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(SnapshotFixtureForm, self).__init__(*args, **kwargs)
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.helper.form_tag = False
         self.helper.layout = crispy.Layout(
             twbscrispy.PrependedText('publish', ''),
@@ -263,7 +263,7 @@ class SnapshotSettingsForm(forms.Form):
         self.is_superuser = kw.pop("is_superuser", None)
         super(SnapshotSettingsForm, self).__init__(*args, **kw)
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.helper.form_tag = False
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
@@ -436,7 +436,7 @@ class TransferDomainForm(forms.ModelForm):
         self.fields['domain'].label = _('Type the name of the project to confirm')
         self.fields['to_username'].label = _('New owner\'s CommCare username')
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.helper.layout = crispy.Layout(
             'domain',
             'to_username',
@@ -595,7 +595,7 @@ class DomainGlobalSettingsForm(forms.Form):
         self.domain = self.project.name
         self.can_use_custom_logo = kwargs.pop('can_use_custom_logo', False)
         super(DomainGlobalSettingsForm, self).__init__(*args, **kwargs)
-        self.helper = HQFormHelper(self)
+        self.helper = hqcrispy.HQFormHelper(self)
         self.helper[4] = twbscrispy.PrependedText('delete_logo', '')
         self.helper[5] = twbscrispy.PrependedText('call_center_enabled', '')
         self.helper.all().wrap_together(crispy.Fieldset, _('Edit Basic Information'))
@@ -1097,7 +1097,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
                 help_text='Set to "no" if this project opts out of data usage. Defaults to "yes".'
             )
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _("Basic Information"),
@@ -1474,7 +1474,7 @@ class EditBillingAccountInfoForm(forms.ModelForm):
 
         super(EditBillingAccountInfoForm, self).__init__(data, *args, **kwargs)
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         fields = [
             'company_name',
             'first_name',
@@ -1787,7 +1787,7 @@ class ProBonoForm(forms.Form):
         super(ProBonoForm, self).__init__(*args, **kwargs)
         if not use_domain_field:
             self.fields['domain'].required = False
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
             _('Pro-Bono Application'),
@@ -1949,7 +1949,7 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
     def __init__(self, domain, web_user, *args, **kwargs):
         super(DimagiOnlyEnterpriseForm, self).__init__(domain, web_user, *args, **kwargs)
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.HTML(ugettext_noop(
                 '<i class="fa fa-info-circle"></i> You will have access to all '
@@ -2017,7 +2017,7 @@ class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
         self.fields['organization_name'].initial = self.autocomplete_account_name
         self.fields['emails'].initial = self.current_contact_emails
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.Field('organization_name'),
             crispy.Field('emails', css_class='input-xxlarge'),
@@ -2132,7 +2132,7 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
     def __init__(self, domain, web_user, *args, **kwargs):
         super(ContractedPartnerForm, self).__init__(domain, web_user, *args, **kwargs)
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         self.fields['fogbugz_client_name'].initial = self.autocomplete_account_name
         self.fields['emails'].initial = self.current_contact_emails
 
@@ -2342,7 +2342,7 @@ class SelectSubscriptionTypeForm(forms.Form):
         defaults = defaults or {}
         super(SelectSubscriptionTypeForm, self).__init__(defaults, **kwargs)
 
-        self.helper = HQFormHelper()
+        self.helper = hqcrispy.HQFormHelper()
         if defaults and disable_input:
             self.helper.layout = crispy.Layout(
                 hqcrispy.B3TextField(

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -16,7 +16,6 @@ from corehq.apps.users.models import CouchUser
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import StrictButton
-from crispy_forms.helper import FormHelper
 from dateutil.relativedelta import relativedelta
 from django import forms
 from django.conf import settings
@@ -129,11 +128,8 @@ class ProjectSettingsForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(ProjectSettingsForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
+        self.helper = hqcrispy.HQFormHelper(self)
         self.helper.form_id = 'my-project-settings-form'
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
         self.helper.all().wrap_together(crispy.Fieldset, _('My Timezone'))
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
@@ -200,10 +196,8 @@ class SnapshotApplicationForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(SnapshotApplicationForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper()
+        self.helper = hqcrispy.HQFormHelper(self)
         self.helper.form_tag = False
-        self.helper.label_class = 'col-sm-3 col-md-4 col-lg-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
         self.helper.layout = crispy.Layout(
             twbscrispy.PrependedText('publish', ''),
             crispy.Div(
@@ -224,7 +218,7 @@ class SnapshotFixtureForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(SnapshotFixtureForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper()
+        self.helper = HQFormHelper()
         self.helper.form_tag = False
         self.helper.layout = crispy.Layout(
             twbscrispy.PrependedText('publish', ''),
@@ -269,9 +263,7 @@ class SnapshotSettingsForm(forms.Form):
         self.is_superuser = kw.pop("is_superuser", None)
         super(SnapshotSettingsForm, self).__init__(*args, **kw)
 
-        self.helper = FormHelper()
-        self.helper.label_class = 'col-sm-3 col-md-4 col-lg-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         self.helper.form_tag = False
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
@@ -444,7 +436,7 @@ class TransferDomainForm(forms.ModelForm):
         self.fields['domain'].label = _('Type the name of the project to confirm')
         self.fields['to_username'].label = _('New owner\'s CommCare username')
 
-        self.helper = FormHelper()
+        self.helper = HQFormHelper()
         self.helper.layout = crispy.Layout(
             'domain',
             'to_username',
@@ -603,10 +595,7 @@ class DomainGlobalSettingsForm(forms.Form):
         self.domain = self.project.name
         self.can_use_custom_logo = kwargs.pop('can_use_custom_logo', False)
         super(DomainGlobalSettingsForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper(self)
         self.helper[4] = twbscrispy.PrependedText('delete_logo', '')
         self.helper[5] = twbscrispy.PrependedText('call_center_enabled', '')
         self.helper.all().wrap_together(crispy.Fieldset, _('Edit Basic Information'))
@@ -820,10 +809,7 @@ class PrivacySecurityForm(forms.Form):
         user_name = kwargs.pop('user_name')
         domain = kwargs.pop('domain')
         super(PrivacySecurityForm, self).__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = hqcrispy.HQFormHelper(self)
         self.helper[0] = twbscrispy.PrependedText('restrict_superusers', '')
         self.helper[1] = twbscrispy.PrependedText('secure_submissions', '')
         self.helper[2] = twbscrispy.PrependedText('secure_sessions', '')
@@ -1111,10 +1097,7 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
                 help_text='Set to "no" if this project opts out of data usage. Defaults to "yes".'
             )
 
-        self.helper = FormHelper()
-        self.helper.form_class = 'form form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _("Basic Information"),
@@ -1491,10 +1474,7 @@ class EditBillingAccountInfoForm(forms.ModelForm):
 
         super(EditBillingAccountInfoForm, self).__init__(data, *args, **kwargs)
 
-        self.helper = FormHelper()
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         fields = [
             'company_name',
             'first_name',
@@ -1807,10 +1787,7 @@ class ProBonoForm(forms.Form):
         super(ProBonoForm, self).__init__(*args, **kwargs)
         if not use_domain_field:
             self.fields['domain'].required = False
-        self.helper = FormHelper()
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
             _('Pro-Bono Application'),
@@ -1972,10 +1949,7 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
     def __init__(self, domain, web_user, *args, **kwargs):
         super(DimagiOnlyEnterpriseForm, self).__init__(domain, web_user, *args, **kwargs)
 
-        self.helper = FormHelper()
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.HTML(ugettext_noop(
                 '<i class="fa fa-info-circle"></i> You will have access to all '
@@ -2043,10 +2017,7 @@ class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
         self.fields['organization_name'].initial = self.autocomplete_account_name
         self.fields['emails'].initial = self.current_contact_emails
 
-        self.helper = FormHelper()
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         self.helper.layout = crispy.Layout(
             crispy.Field('organization_name'),
             crispy.Field('emails', css_class='input-xxlarge'),
@@ -2161,10 +2132,7 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
     def __init__(self, domain, web_user, *args, **kwargs):
         super(ContractedPartnerForm, self).__init__(domain, web_user, *args, **kwargs)
 
-        self.helper = FormHelper()
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         self.fields['fogbugz_client_name'].initial = self.autocomplete_account_name
         self.fields['emails'].initial = self.current_contact_emails
 
@@ -2374,10 +2342,7 @@ class SelectSubscriptionTypeForm(forms.Form):
         defaults = defaults or {}
         super(SelectSubscriptionTypeForm, self).__init__(defaults, **kwargs)
 
-        self.helper = FormHelper()
-        self.helper.form_class = 'form-horizontal'
-        self.helper.label_class = 'col-sm-3 col-md-2'
-        self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper = HQFormHelper()
         if defaults and disable_input:
             self.helper.layout = crispy.Layout(
                 hqcrispy.B3TextField(

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -37,7 +37,7 @@ from corehq.apps.reports.util import (
     case_users_filter,
     datespan_from_beginning,
 )
-from corehq.apps.hqwebapp.crispy import B3MultiField, CrispyTemplate
+from corehq.apps.hqwebapp.crispy import B3MultiField, CrispyTemplate, HQFormHelper
 from corehq.apps.hqwebapp.widgets import DateRangePickerWidget, Select2AjaxV3
 from corehq.pillows import utils
 
@@ -100,6 +100,7 @@ class CreateExportTagForm(forms.Form):
             model_field.widget.attrs['readonly'] = True
             model_field.widget.attrs['disabled'] = True
 
+        # This form appears inside a modal, so it's differently proportioned than most forms
         self.helper = FormHelper()
         self.helper.form_tag = False
         self.helper.label_class = 'col-sm-2'
@@ -223,10 +224,8 @@ class BaseFilterExportDownloadForm(forms.Form):
         self.domain_object = domain_object
         super(BaseFilterExportDownloadForm, self).__init__(*args, **kwargs)
 
-        self.helper = FormHelper()
+        self.helper = HQFormHelper()
         self.helper.form_tag = False
-        self.helper.label_class = 'col-sm-3'
-        self.helper.field_class = 'col-sm-5'
 
         self.helper.layout = Layout(
             *self.extra_fields
@@ -328,6 +327,7 @@ class DashboardFeedFilterForm(forms.Form):
             reverse(SubmitHistoryFilter.options_url, args=(self.domain_object.name,))
         )
 
+        # This form appears inside a modal, so it's differently proportioned than most forms
         self.helper = FormHelper()
         self.helper.form_tag = False
         self.helper.label_class = 'col-sm-3 col-md-2 col-lg-2'

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -37,7 +37,7 @@ from corehq.apps.reports.util import (
     case_users_filter,
     datespan_from_beginning,
 )
-from corehq.apps.hqwebapp.crispy import B3MultiField, CrispyTemplate, HQFormHelper
+from corehq.apps.hqwebapp.crispy import HQFormHelper
 from corehq.apps.hqwebapp.widgets import DateRangePickerWidget, Select2AjaxV3
 from corehq.pillows import utils
 

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -15,7 +15,7 @@ from django.utils.translation import ugettext
 
 CSS_LABEL_CLASS = 'col-xs-12 col-sm-4 col-md-4 col-lg-2'
 CSS_FIELD_CLASS = 'col-xs-12 col-sm-8 col-md-8 col-lg-6'
-CSS_ACTION_CLASS = CSS_FIELD_CLASS  + ' col-sm-offset-4 col-md-offset-4 col-lg-offset-2'
+CSS_ACTION_CLASS = CSS_FIELD_CLASS + ' col-sm-offset-4 col-md-offset-4 col-lg-offset-2'
 
 
 class HQFormHelper(FormHelper):

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -4,12 +4,19 @@ import re
 from contextlib import contextmanager
 
 from crispy_forms.bootstrap import AccordionGroup, InlineField, FormActions as OriginalFormActions
+from crispy_forms.helper import FormHelper
 from crispy_forms.layout import LayoutObject, MultiField, Field as OldField
 from crispy_forms.utils import render_field, get_template_pack, flatatt
 from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
+
+
+class HQFormHelper(FormHelper):
+    form_class = 'form form-horizontal'
+    label_class = 'col-xs-12 col-sm-4 col-md-4 col-lg-2'
+    field_class = 'col-xs-12 col-sm-8 col-md-8 col-lg-6'
 
 
 class HiddenFieldWithErrors(OldField):

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -13,10 +13,15 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 
 
+CSS_LABEL_CLASS = 'col-xs-12 col-sm-4 col-md-4 col-lg-2'
+CSS_FIELD_CLASS = 'col-xs-12 col-sm-8 col-md-8 col-lg-6'
+CSS_ACTION_CLASS = CSS_FIELD_CLASS  + ' col-sm-offset-4 col-md-offset-4 col-lg-offset-2'
+
+
 class HQFormHelper(FormHelper):
     form_class = 'form form-horizontal'
-    label_class = 'col-xs-12 col-sm-4 col-md-4 col-lg-2'
-    field_class = 'col-xs-12 col-sm-8 col-md-8 col-lg-6'
+    label_class = CSS_LABEL_CLASS
+    field_class = CSS_FIELD_CLASS
 
 
 class HiddenFieldWithErrors(OldField):

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -305,6 +305,24 @@ def toggle_js_url(domain, username):
     )
 
 
+@register.simple_tag
+def css_label_class():
+    from corehq.apps.hqwebapp.crispy import CSS_LABEL_CLASS
+    return CSS_LABEL_CLASS
+
+
+@register.simple_tag
+def css_field_class():
+    from corehq.apps.hqwebapp.crispy import CSS_FIELD_CLASS
+    return CSS_FIELD_CLASS
+
+
+@register.simple_tag
+def css_action_class():
+    from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
+    return CSS_ACTION_CLASS
+
+
 @quickcache(['domain'], timeout=30 * 24 * 60 * 60)
 def toggle_js_domain_cachebuster(domain):
     # to get fresh cachebusters on the next deploy

--- a/corehq/apps/reports/dont_use/fields.py
+++ b/corehq/apps/reports/dont_use/fields.py
@@ -9,10 +9,7 @@ import pytz
 import warnings
 from django.utils.translation import ugettext_noop
 import uuid
-from corehq.apps.reports.util import (
-    DEFAULT_CSS_FIELD_CLASS_REPORT_FILTER,
-    DEFAULT_CSS_LABEL_CLASS_REPORT_FILTER,
-)
+from corehq.apps.hqwebapp.crispy import CSS_LABEL_CLASS, CSS_FIELD_CLASS
 
 
 class ReportField(object):
@@ -33,8 +30,8 @@ class ReportField(object):
         self.domain = domain
         self.timezone = timezone
         self.parent_report = parent_report
-        self.css_label = css_label or DEFAULT_CSS_LABEL_CLASS_REPORT_FILTER
-        self.css_field = css_field or DEFAULT_CSS_FIELD_CLASS_REPORT_FILTER
+        self.css_label = css_label or (CSS_LABEL_CLASS + ' control-label')
+        self.css_field = css_field or CSS_FIELD_CLASS
 
     def render(self):
         if not self.template: return ""

--- a/corehq/apps/reports/filters/base.py
+++ b/corehq/apps/reports/filters/base.py
@@ -5,10 +5,7 @@ from django.template.loader import render_to_string
 from memoized import memoized
 # For translations
 from django.utils.translation import ugettext_noop
-from corehq.apps.reports.util import (
-    DEFAULT_CSS_FIELD_CLASS_REPORT_FILTER,
-    DEFAULT_CSS_LABEL_CLASS_REPORT_FILTER,
-)
+from corehq.apps.hqwebapp.crispy import CSS_LABEL_CLASS, CSS_FIELD_CLASS
 
 
 class BaseReportFilter(object):
@@ -39,8 +36,8 @@ class BaseReportFilter(object):
         self.request = request
         self.timezone = timezone
         self.parent_report = parent_report
-        self.css_label = css_label or DEFAULT_CSS_LABEL_CLASS_REPORT_FILTER
-        self.css_field = css_field or DEFAULT_CSS_FIELD_CLASS_REPORT_FILTER
+        self.css_label = css_label or (CSS_LABEL_CLASS + ' control-label')
+        self.css_field = css_field or CSS_FIELD_CLASS
         self.context = {}
 
     @property

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -19,8 +19,8 @@ from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.reports.models import ReportConfig
 from corehq.apps.reports.datatables import DataTablesHeader
 from corehq.apps.reports.filters.dates import DatespanFilter
-from corehq.apps.reports.util import \
-    DEFAULT_CSS_FORM_ACTIONS_CLASS_REPORT_FILTER, DatatablesParams
+from corehq.apps.reports.util import DatatablesParams
+from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
     use_jquery_ui,
     use_datatables,
@@ -524,7 +524,7 @@ class GenericReportView(object):
         """
         self.context.update(rendered_as=self.rendered_as)
         self.context.update({
-            'report_filter_form_action_css_class': DEFAULT_CSS_FORM_ACTIONS_CLASS_REPORT_FILTER,
+            'report_filter_form_action_css_class': CSS_ACTION_CLASS,
         })
         self.context['report'].update(
             show_filters=self.fields or not self.hide_filters,

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -41,12 +41,6 @@ import six
 from six.moves import range
 from six.moves import map
 
-DEFAULT_CSS_LABEL_CLASS_REPORT_FILTER = 'col-xs-4 col-md-3 col-lg-2 control-label'
-DEFAULT_CSS_FIELD_CLASS_REPORT_FILTER = 'col-xs-8 col-md-8 col-lg-9'
-DEFAULT_CSS_FORM_ACTIONS_CLASS_REPORT_FILTER = (
-    'col-xs-8 col-md-8 col-lg-9 col-xs-offset-4 col-md-offset-3 col-lg-offset-2'
-)
-
 
 def make_form_couch_key(domain, user_id=Ellipsis):
     """

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -8,9 +8,9 @@ from django.http.response import HttpResponseServerError
 from django.shortcuts import redirect, render
 
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.reports.util import \
-    DEFAULT_CSS_FORM_ACTIONS_CLASS_REPORT_FILTER, DatatablesParams
+from corehq.apps.reports.util import DatatablesParams
 from corehq.apps.reports_core.filters import Choice, PreFilter
+from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
     use_select2,
     use_daterangepicker,
@@ -329,7 +329,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             'headers': self.headers,
             'can_edit_report': can_edit_report(self.request, self),
             'has_report_builder_trial': has_report_builder_trial(self.request),
-            'report_filter_form_action_css_class': DEFAULT_CSS_FORM_ACTIONS_CLASS_REPORT_FILTER,
+            'report_filter_form_action_css_class': CSS_ACTION_CLASS,
         }
         context.update(self.saved_report_context_data)
         context.update(self.pop_report_builder_context_data())


### PR DESCRIPTION
Being inconsistent about these classes leads to pages like this:
<img width="1084" alt="screen shot 2018-11-06 at 5 54 46 pm" src="https://user-images.githubusercontent.com/1486591/48099281-158f1f00-e1ed-11e8-99ec-10da57f2bb93.png">

This PR adds a subclass of `FormHelper` to use in server-generated forms and starts using that subclass. It also adds template tags for forms that are not server-generated, but I haven't started using those yet. Does this approach seem helpful/reasonable?

@jmtroth0 / @biyeun 
fyi @ohmegasquared 