### PR TITLE
move reconciliation to after form save before case save

### DIFF
--- a/corehq/form_processor/backends/sql/casedb.py
+++ b/corehq/form_processor/backends/sql/casedb.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import redis
 from casexml.apps.case.exceptions import IllegalCaseId
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.backends.sql.update_strategy import SqlCaseUpdateStrategy
 from corehq.form_processor.casedb_base import AbstractCaseDbCache
-from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.models import CommCareCaseSQL
-from corehq import toggles
+
 
 class CaseDbCacheSQL(AbstractCaseDbCache):
     case_model_classes = (CommCareCaseSQL,)
@@ -51,7 +49,3 @@ class CaseDbCacheSQL(AbstractCaseDbCache):
     def filter_closed_extensions(self, extensions_to_close):
         # noop for SQL since the filtering already happened when we fetched the IDs
         return extensions_to_close
-
-    def post_process_case(self, case, xform):
-        if toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL.enabled(case.domain, toggles.NAMESPACE_DOMAIN):
-            self.case_update_strategy(case).reconcile_transactions_if_necessary()


### PR DESCRIPTION
So, something went wrong with the last migration I tried that required this. I don't have a good explanation as to why it didn't happen earlier, except that maybe the reconciliation wasn't appropriately triggered.

The bug was that the form had not been saved by the time the reconciliation was happening, which meant that when the transaction went to fetch the form (which it doesn't know to use any kind of a cache for), it didn't yet exist in PG. I hadn't realized that some case transaction data that i was relying on ([`user_id`](https://github.com/dimagi/commcare-hq/blob/66d83d85def103bdc94795f15cd3e131dae42d4b/corehq/form_processor/models.py#L1184-L1188), [`relevance`](https://github.com/dimagi/commcare-hq/blob/66d83d85def103bdc94795f15cd3e131dae42d4b/corehq/form_processor/models.py#L1177-L1182)) requires this, which is not ideal performance-wise. It seems fine for now since they are only used on problematic cases, not in the original check for problems. 

Those values seemed reasonably important, so I didn't just remove them, but it might be worth eventually trying to figure out a way to use the already fetched version rather than fetching anew.

@millerdev @snopoke buddy: @orangejenny 