### PR TITLE
Add ability to skip uploading entire modules and forms from transifex

### DIFF
--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -19,6 +19,7 @@ Unique_ID = namedtuple('UniqueID', 'type id')
 HQ_MODULE_SHEET_NAME = re.compile('^module(\d+)$')
 HQ_FORM_SHEET_NAME = re.compile('^module(\d+)_form(\d+)$')
 POFileInfo = namedtuple("POFileInfo", "name path")
+SKIP_TRANSFEX_STRING = "SKIP TRANSIFEX"
 
 
 class AppTranslationsGenerator:
@@ -64,7 +65,7 @@ class AppTranslationsGenerator:
         for module in module_data:
             for form in module['forms']:
                 for question in form['questions']:
-                    if (question['comment'] and 'SKIP TRANSIFEX' in question['comment']
+                    if (question['comment'] and SKIP_TRANSFEX_STRING in question['comment']
                             and 'label_ref' in question):
                         labels_to_skip[form['id']].append(question['label_ref'])
         return labels_to_skip

--- a/corehq/apps/app_manager/app_translations/generators.py
+++ b/corehq/apps/app_manager/app_translations/generators.py
@@ -74,11 +74,20 @@ class AppTranslationsGenerator:
         # get the translations data
         from corehq.apps.app_manager.app_translations.app_translations import expected_bulk_app_sheet_rows
         # simply the rows of data per sheet name
-        rows = expected_bulk_app_sheet_rows(app)
+        rows = expected_bulk_app_sheet_rows(
+            app,
+            exclude_module=lambda module: SKIP_TRANSFEX_STRING in module.comment,
+            exclude_form=lambda form: SKIP_TRANSFEX_STRING in form.comment
+        )
 
         # get the translation data headers
         from corehq.apps.app_manager.app_translations.app_translations import expected_bulk_app_sheet_headers
-        for header_row in expected_bulk_app_sheet_headers(app):
+        headers = expected_bulk_app_sheet_headers(
+            app,
+            exclude_module=lambda module: SKIP_TRANSFEX_STRING in module.comment,
+            exclude_form=lambda form: SKIP_TRANSFEX_STRING in form.comment
+        )
+        for header_row in headers:
             self.headers[header_row[0]] = header_row[1]
         self._set_sheet_name_to_module_or_form_mapping(rows[MODULES_AND_FORMS_SHEET_NAME])
         return rows


### PR DESCRIPTION
@mkangia @orangejenny are probably interested and relevant

https://app.asana.com/0/884043562651823/900449731914966/f

This uses a string in the form and module comment in app builder to exclude entire forms and modules from transifex translations. They will still be accessible/translatable via the normal excel upload/download process.

Not pleased with this as it feels like some custom code is bleeding into non-custom areas, but the translation code is at the moment split into icds, app_manager and translations apps. I chose to do it this way because I was optimizing ease of implementation and not including more complex refactors or adding more attributes/checkboxes to applications. Happy to change it around if anyone else has better ideas on the tradeoff there