### PR TITLE
only pass bytes to hashlib.md5

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -239,7 +239,7 @@ def get_indicator_table(indicator_config, custom_metadata=None):
 
 def _custom_index_name(table_name, column_ids):
     base_name = "ix_{}_{}".format(table_name, ','.join(column_ids))
-    base_hash = hashlib.md5(base_name).hexdigest()
+    base_hash = hashlib.md5(base_name.encode('utf-8')).hexdigest()
     return "{}_{}".format(base_name[:50], base_hash[:5])
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
@@ -84,7 +84,7 @@ class _RestoreCache(_CacheAccessor):
             _get_domain_freshness_token(domain),
             _get_user_freshness_token(domain, user_id),
         ]])
-        return hashlib.md5(hashable_key).hexdigest()
+        return hashlib.md5(hashable_key.encode('utf-8')).hexdigest()
 
 
 class RestorePayloadPathCache(_RestoreCache):

--- a/corehq/ex-submodules/couchexport/models.py
+++ b/corehq/ex-submodules/couchexport/models.py
@@ -548,7 +548,7 @@ class DefaultExportSchema(BaseSavedExportSchema):
             def _human_readable_key(tag, prev_export_id, format, max_column_size):
                 return "couchexport_:%s:%s:%s:%s" % (tag, prev_export_id, format, max_column_size)
             return hashlib.md5(_human_readable_key(tag, prev_export_id,
-                format, max_column_size)).hexdigest()
+                format, max_column_size).encode('utf-8')).hexdigest()
 
         # check cache, only supported for filterless queries, currently
         cache_key = _build_cache_key(export_tag, previous_export_id, format, max_column_size)

--- a/corehq/ex-submodules/dimagi/utils/django/cache.py
+++ b/corehq/ex-submodules/dimagi/utils/django/cache.py
@@ -6,6 +6,6 @@ from django.utils.http import urlquote
 
 def make_template_fragment_key(fragment_name, vary_on):
     # Build a unicode key for this fragment and all vary-on's.
-    args = hashlib.md5(':'.join([urlquote(var) for var in vary_on]))
+    args = hashlib.md5(':'.join([urlquote(var) for var in vary_on]).encode('utf-8'))
     cache_key = 'template.cache.%s.%s' % (fragment_name, args.hexdigest())
     return cache_key


### PR DESCRIPTION
Right now, the encoding step is implicit.  These changes make it explicit.