### PR TITLE
REACH UCR expressions

### DIFF
--- a/corehq/apps/userreports/reports/filters/specs.py
+++ b/corehq/apps/userreports/reports/filters/specs.py
@@ -61,7 +61,7 @@ class FilterSpec(JsonObject):
         choices=[
             'date', 'quarter', 'numeric', 'pre', 'choice_list', 'dynamic_choice_list',
             'multi_field_dynamic_choice_list', 'location_drilldown',
-            'enikshay_location_hierarchy'
+            'village_choice_list'
         ]
     )
     # this shows up as the ID in the filter HTML.

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -370,7 +370,7 @@ class AWCOwnerId(JsonObject):
     """
     type = TypeProperty('icds_awc_owner_id')
     case_id_expression = DefaultProperty(required=True)
-    index_identifier = 'awc'
+    index_identifier = 'owner_awc'
 
     def configure(self, case_id_expression):
         self._case_id_expression = case_id_expression
@@ -432,7 +432,7 @@ class AWCOwnerId(JsonObject):
 
 class VillageOwnerId(AWCOwnerId):
     type = TypeProperty('icds_village_owner_id')
-    index_identifier = 'village'
+    index_identifier = 'owner_village'
 
     def __str__(self):
         return "village owner_id"

--- a/custom/icds_reports/ucr/filter_spec.py
+++ b/custom/icds_reports/ucr/filter_spec.py
@@ -1,0 +1,36 @@
+from corehq.apps.reports_core.filters import DynamicChoiceListFilter
+from corehq.apps.userreports.reports.filters.factory import FilterChoiceProviderFactory
+from corehq.apps.userreports.reports.filters.values import dynamic_choice_list_url
+from corehq.apps.userreports.reports.filters.specs import DynamicChoiceListFilterSpec
+from corehq.apps.userreports.specs import TypeProperty
+
+
+class VillageChoiceListFilterSpec(DynamicChoiceListFilterSpec):
+    """Using this filter allows us to filter by village without introducing a
+    data source change to include the village in the data source.
+
+    It does this by finding the case ids that belong to the village and
+    filtering on the doc_id column instead of a location column
+
+    This would likely be very inefficient to do at scale, but should be ok for
+    a pilot
+    """
+    type = TypeProperty('village_choice_list')
+
+
+def build_village_choice_list_filter_spec(spec, report):
+    wrapped = VillageChoiceListFilterSpec.wrap(spec)
+    choice_provider_spec = {"type": "location"}
+    choice_provider = FilterChoiceProviderFactory.from_spec(choice_provider_spec)(report, wrapped.slug)
+    choice_provider.configure(choice_provider_spec)
+
+    return DynamicChoiceListFilter(
+        name=wrapped.slug,
+        datatype=wrapped.datatype,
+        field=wrapped.field,
+        label=wrapped.display,
+        show_all=wrapped.show_all,
+        url_generator=dynamic_choice_list_url,
+        choice_provider=choice_provider,
+        ancestor_expression=wrapped.ancestor_expression,
+    )

--- a/custom/icds_reports/ucr/filter_spec.py
+++ b/custom/icds_reports/ucr/filter_spec.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from corehq.apps.reports_core.filters import DynamicChoiceListFilter
 from corehq.apps.userreports.reports.filters.factory import FilterChoiceProviderFactory
 from corehq.apps.userreports.reports.filters.values import dynamic_choice_list_url

--- a/custom/icds_reports/ucr/filter_value.py
+++ b/custom/icds_reports/ucr/filter_value.py
@@ -1,0 +1,33 @@
+from corehq.apps.reports.util import get_INFilter_element_bindparam
+from corehq.apps.userreports.reports.filters.values import ChoiceListFilterValue
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+
+
+class VillageFilterValue(ChoiceListFilterValue):
+    ALLOWED_TYPES = ('village_choice_list', )
+
+    def __init__(self, filter, value):
+        super(VillageFilterValue, self).__init__(filter, value)
+
+    @property
+    def is_null(self):
+        if super(VillageFilterValue, self).is_null is True:
+            return True
+        # If there are no case ids that belong to the user, then nothing
+        # will be bound to the parameter in the future, and it would error
+        return len(self._get_case_ids()) == 0
+
+    def _get_case_ids(self):
+        asha_location_ids = [choice.value for choice in self.value]
+        accessor = CaseAccessors('icds-cas')  # figure out how to get the domain here
+        return accessor.get_case_ids_by_owners(asha_location_ids)
+
+    def to_sql_values(self):
+        if self.show_all or self.is_null:
+            return {}
+        case_ids = self._get_case_ids()
+        values = {
+            get_INFilter_element_bindparam(self.filter['slug'], i): val.value
+            for i, val in enumerate(case_ids)
+        }
+        return values

--- a/custom/icds_reports/ucr/filter_value.py
+++ b/custom/icds_reports/ucr/filter_value.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from corehq.apps.reports.util import get_INFilter_element_bindparam
 from corehq.apps.userreports.reports.filters.values import ChoiceListFilterValue
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors

--- a/custom/icds_reports/ucr/reports/mobile/mpr_3i_pregnancies.json
+++ b/custom/icds_reports/ucr/reports/mobile/mpr_3i_pregnancies.json
@@ -29,6 +29,12 @@
         "datatype": "date"
       },
       {
+        "display": "Filter by Village",
+        "slug": "asha_id",
+        "type": "village_choice_list",
+        "field": "doc_id"
+      },
+      {
         "display": "Filter by AWW",
         "slug": "awc_id",
         "type": "dynamic_choice_list",

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -458,7 +458,7 @@ def test_awc_owner_id(self, case):
     ('child_health_person_case',),
     ('child_health_case',),
 ], TestLegacyCaseStructureOwnerID)
-def test_reach_village_owner_id(self, case):
+def test_village_owner_id(self, case):
     expression = ExpressionFactory.from_spec({
         "type": "icds_village_owner_id",
         "case_id_expression": {

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -449,6 +449,27 @@ def test_awc_owner_id(self, case):
     self.assertEqual(self.awc_owner_id, expression(getattr(self, case).to_json()))
 
 
+@generate_cases([
+    ('household_case',),
+    # ('awc_ownership_case',), currently returns AWC. Should it return village?
+    ('father_person_case',),
+    ('mother_person_case',),
+    ('ccs_record_case',),
+    ('child_health_person_case',),
+    ('child_health_case',),
+], TestLegacyCaseStructureOwnerID)
+def test_reach_village_owner_id(self, case):
+    expression = ExpressionFactory.from_spec({
+        "type": "icds_village_owner_id",
+        "case_id_expression": {
+            "type": "property_name",
+            "property_name": "case_id",
+        },
+    })
+    context = EvaluationContext({"domain": self.domain_name}, 0)
+    self.assertEqual(None, expression(getattr(self, case).to_json(), context))
+
+
 class TestREACHCaseStructureOwnerID(_TestOwnerIDBase):
     awc_owner_id = uuid.uuid4().hex
     village_owner_id = uuid.uuid4().hex

--- a/custom/icds_reports/ucr/tests/test_expressions.py
+++ b/custom/icds_reports/ucr/tests/test_expressions.py
@@ -498,7 +498,7 @@ class TestREACHCaseStructureOwnerID(_TestOwnerIDBase):
             },
             indices=[CaseIndex(
                 household_case,
-                identifier='awc',
+                identifier='owner_awc',
                 relationship=CASE_INDEX_EXTENSION,
                 related_type='household',
             )],
@@ -515,7 +515,7 @@ class TestREACHCaseStructureOwnerID(_TestOwnerIDBase):
             },
             indices=[CaseIndex(
                 household_case,
-                identifier='village',
+                identifier='owner_village',
                 relationship=CASE_INDEX_EXTENSION,
                 related_type='household',
             )],

--- a/settings.py
+++ b/settings.py
@@ -2072,9 +2072,13 @@ CUSTOM_UCR_EXPRESSION_LISTS = [
     ('corehq.apps.userreports.expressions.extension_expressions.CUSTOM_UCR_EXPRESSIONS'),
 ]
 
-CUSTOM_UCR_REPORT_FILTERS = []
+CUSTOM_UCR_REPORT_FILTERS = [
+    ('village_choice_list', 'custom.icds_reports.ucr.filter_spec.build_village_choice_list_filter_spec')
+]
 
-CUSTOM_UCR_REPORT_FILTER_VALUES = []
+CUSTOM_UCR_REPORT_FILTER_VALUES = [
+    ('village_choice_list', 'custom.icds_reports.ucr.filter_value.VillageFilterValue')
+]
 
 CUSTOM_MODULES = [
     'custom.apps.crs_reports',


### PR DESCRIPTION
@esoergel this is mostly an FYI and a dumping ground until we get more concrete requirements for reporting. These first additions are to abstract owner_id away from using `property_name: owner_id` since that would return `-` or `None` in a world where new cases don't have a direct owner id