### PR TITLE
Non-blocking case locks

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -252,6 +252,14 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
             lock.release()
         self.assertEqual(response.status_code, 423)
 
+    def test_case_locked(self):
+        from casexml.apps.case.models import CommCareCase
+        case_id = 'ad38211be256653bceac8e2156475667'
+        lock = CommCareCase.get_obj_lock_by_id(case_id, timeout_seconds=30)
+        with lock:
+            _, response = self._submit('form_with_case.xml')
+        self.assertEqual(response.status_code, 423)
+
 
 @use_sql_backend
 class SubmissionErrorTestSQL(SubmissionErrorTest):

--- a/corehq/ex-submodules/dimagi/utils/couch/__init__.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/__init__.py
@@ -224,16 +224,16 @@ class RedisLockableMixIn(object):
         except:
             release_lock(lock, degrade_gracefully)
             raise
-        else:
-            if _id:
-                return LockManager(obj, lock)
-            else:
-                obj_lock = cls.get_obj_lock(obj)
-                obj_lock = acquire_lock(obj_lock, degrade_gracefully)
-                # Refresh the object in case another thread has updated it
-                obj = cls.get_latest_obj(obj)
-                release_lock(lock, degrade_gracefully)
-                return LockManager(obj, obj_lock)
+        if _id:
+            return LockManager(obj, lock)
+        try:
+            obj_lock = cls.get_obj_lock(obj)
+            obj_lock = acquire_lock(obj_lock, degrade_gracefully)
+            # Refresh the object in case another thread has updated it
+            obj = cls.get_latest_obj(obj)
+            return LockManager(obj, obj_lock)
+        finally:
+            release_lock(lock, degrade_gracefully)
 
 
 class CouchDocLockableMixIn(RedisLockableMixIn):

--- a/corehq/ex-submodules/dimagi/utils/couch/__init__.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/__init__.py
@@ -222,8 +222,9 @@ class RedisLockableMixIn(object):
                     release_lock(lock, degrade_gracefully)
                     return LockManager(None, None)
         except:
+            exc = sys.exc_info()
             release_lock(lock, degrade_gracefully)
-            raise
+            six.reraise(*exc)
         if _id:
             return LockManager(obj, lock)
         try:

--- a/corehq/ex-submodules/dimagi/utils/couch/__init__.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/__init__.py
@@ -205,9 +205,14 @@ class RedisLockableMixIn(object):
         """
         create = kwargs.pop("create", False)
         _id = kwargs.get("_id", None)
-        degrade_gracefully = kwargs.pop('degrade_gracefully', False)
         block = kwargs.pop('block', True)
         timeout_seconds = kwargs.pop('timeout_seconds', 120)
+
+        assert 'degrade_gracefully' not in kwargs, (
+            "DO NOT USE THIS OPTION it's hard to reason "
+            "about outcomes when lock errors are ignored"
+        )
+        degrade_gracefully = False
 
         if _id:
             lock = cls.get_obj_lock_by_id(_id, timeout_seconds=timeout_seconds)

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -15,6 +15,7 @@ from casexml.apps.case.util import get_case_xform_ids
 from casexml.apps.case.xform import get_case_updates
 from corehq.blobs.mixin import bulk_atomic_blobs
 from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
+from corehq.form_processor.exceptions import CaseLockError
 from corehq.form_processor.interfaces.processor import XFormQuestionValueIterator
 from corehq.form_processor.utils import extract_meta_instance_id
 from couchforms.models import (
@@ -252,8 +253,8 @@ class FormProcessorCouch(object):
                     if case and not wrap:
                         case = case.to_json()
                     return case, lock
-                except LockNotAcquired:
-                    raise
+                except LockNotAcquired as err:
+                    six.raise_from(CaseLockError(case_id), err)
                 except redis.RedisError:
                     case_doc = _get_case()
             else:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -26,7 +26,7 @@ from corehq.form_processor.models import (
 from corehq.form_processor.utils import convert_xform_to_json, extract_meta_instance_id, extract_meta_user_id
 from corehq import toggles
 from couchforms.const import ATTACHMENT_NAME
-from dimagi.utils.couch import acquire_lock, release_lock
+from dimagi.utils.couch import acquire_lock, release_lock, LockNotAcquired
 import six
 
 
@@ -336,7 +336,9 @@ class FormProcessorSQL(object):
         try:
             if lock:
                 try:
-                    return CommCareCaseSQL.get_locked_obj(_id=case_id)
+                    return CommCareCaseSQL.get_locked_obj(_id=case_id, block=False)
+                except LockNotAcquired:
+                    raise
                 except redis.RedisError:
                     case = CaseAccessorSQL.get_case(case_id)
             else:

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from couchdbkit import ResourceNotFound
 from django.core.exceptions import ObjectDoesNotExist
 
+from corehq.util.datadog.metrics import CASE_LOCKED_COUNT, XFORM_LOCKED_COUNT
 from dimagi.utils.mixins import UnicodeMixIn
 
 
@@ -68,6 +69,7 @@ class XFormLockError(Exception):
 
     The error message should identify the locked form.
     """
+    metric = XFORM_LOCKED_COUNT
 
 
 class CaseLockError(Exception):
@@ -75,3 +77,4 @@ class CaseLockError(Exception):
 
     The error message should identify the locked case.
     """
+    metric = CASE_LOCKED_COUNT

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -68,3 +68,10 @@ class XFormLockError(Exception):
 
     The error message should identify the locked form.
     """
+
+
+class CaseLockError(Exception):
+    """Exception raised when a case lock cannot be acquired
+
+    The error message should identify the locked case.
+    """

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -238,7 +238,7 @@ class FormProcessorInterface(object):
         :param strip_history: If False, don't include case actions. (Couch only)
         :param wrap: Return wrapped case if True. (Couch only)
         :return: tuple(case, lock). Either could be None
-        :raises: IllegalCaseId
+        :raises: IllegalCaseId, CaseLockError
         """
         # check across Couch & SQL to ensure global uniqueness
         # check this domains DB first to support existing bad data

--- a/corehq/util/datadog/metrics.py
+++ b/corehq/util/datadog/metrics.py
@@ -5,4 +5,6 @@ REPEATER_ERROR_COUNT = 'commcare.repeaters.error'
 REPEATER_SUCCESS_COUNT = 'commcare.repeaters.success'
 MULTIMEDIA_SUBMISSION_ERROR_COUNT = 'commcare.corrupt-multimedia-submission.error.count'
 DATE_OPENED_CASEBLOCK_ERROR_COUNT = 'commcare.date-opened-caseblock-bug.error.count'
+
+CASE_LOCKED_COUNT = 'commcare.caselocked.count'
 XFORM_LOCKED_COUNT = 'commcare.xformlocked.count'


### PR DESCRIPTION
Case locks acquired in the form processor's case db cache (and by a few management commands) are now non-blocking. This should remove the possibility of deadlock when multiple requests lock a set of cases with different lock acquisition ordering. Note that this deadlock scenario would result in the deadlocked requests waiting for lock expiration before continuing with form processing with expired locks, which may be worse than not using locks at all.

Example:
- request 1 locks case A
- request 2 locks case B
- request 1 locks case B (block)
- request 2 locks case A (block, deadlock until timeout)
- lock A expires
- lock B expires
- request 1 locks case B (request 2 thinks it still has a valid lock on case B)
- request 2 locks case A (request 1 thinks it still has a valid lock on case A)
- request 1 finishes form processing without lock on case A
- request 2 finishes form processing without lock on case B

This is just one possible, and probably worst case, scenario. Slight changes in timing of lock expiration and acquisition may result in one of the requests completing with valid locks. However, it is not possible (in the case of deadlock) for both requests to complete with valid locks.

Would it make sense to write form submissions to a queue rather than processing synchronously while the phone waits? That should allow a faster response and may reduce the number of times a phone needs to retry sending a submission.

Probably best reviewed by commit 🐠 

@snopoke @dannyroberts 