### PR TITLE
Don't ignore extra_fields

### DIFF
--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -240,7 +240,10 @@ class ExportOnlyTests(SimpleTestCase):
         should not be exported.
         """
         requests = mock.Mock()
-        info = mock.Mock(updates={'sex': 'M', 'dob': '1918-07-18'})
+        info = mock.Mock(
+            updates={'sex': 'M', 'dob': '1918-07-18'},
+            extra_fields={},
+        )
         case_config = copy.deepcopy(CASE_CONFIG)
         case_config['patient_identifiers'] = {}
         case_config['person_preferred_name'] = {}

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -126,7 +126,11 @@ class CaseProperty(ValueSource):
     case_property = StringProperty()
 
     def _get_commcare_value(self, case_trigger_info):
-        return case_trigger_info.updates.get(self.case_property)
+        case_property_values = dict(
+            list(case_trigger_info.extra_fields.items()) +
+            list(case_trigger_info.updates.items())
+        )
+        return case_property_values.get(self.case_property)
 
 
 class FormQuestion(ValueSource):


### PR DESCRIPTION
Fixes a bug where MOTECH sometimes tries to set patient properties to null.

`extra_fields` are case properties that have been included in the integration. This change fetches the current values of those properties from the case.

The bug was happening when patient properties were compared to case properties. If the case property value wasn't found, MOTECH would try to "update" the patient property to `null`.

Feature flag: "Enable OpenMRS integration"
