### PR TITLE
Make useful form metadata available

### DIFF
--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -231,6 +231,37 @@ class GetFormQuestionValuesTests(SimpleTestCase):
             value = get_form_question_values({'form': {'foo': {b'b\xc4\x85r': 'baz'}}})
         self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
 
+    def test_received_on(self):
+        value = get_form_question_values({
+            'form': {
+                'foo': {'bar': 'baz'},
+            },
+            'received_on': '2018-11-06T18:30:00.000000Z',
+        })
+        self.assertDictEqual(value, {
+            '/data/foo/bar': 'baz',
+            '/metadata/received_on': '2018-11-06T18:30:00.000000Z',
+        })
+
+    def test_metadata(self):
+        value = get_form_question_values({
+            'form': {
+                'foo': {'bar': 'baz'},
+                'meta': {
+                    'timeStart': '2018-11-06T18:00:00.000000Z',
+                    'timeEnd': '2018-11-06T18:15:00.000000Z',
+                    'spam': 'ham',
+                },
+            },
+            'received_on': '2018-11-06T18:30:00.000000Z',
+        })
+        self.assertDictEqual(value, {
+            '/data/foo/bar': 'baz',
+            '/metadata/timeStart': '2018-11-06T18:00:00.000000Z',
+            '/metadata/timeEnd': '2018-11-06T18:15:00.000000Z',
+            '/metadata/received_on': '2018-11-06T18:30:00.000000Z',
+        })
+
 
 class ExportOnlyTests(SimpleTestCase):
 

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -245,4 +245,11 @@ def get_form_question_values(form_json):
     _recurse_form_questions(form_json['form'], [b'/data'], result)  # "/data" is just convention, hopefully
     # familiar from form builder. The form's data will usually be immediately under "form_json['form']" but not
     # necessarily. If this causes problems we may need a more reliable way to get to it.
+
+    metadata = {
+        'timeStart': form_json['form']['meta']['timeStart'],
+        'timeEnd': form_json['form']['meta']['timeEnd'],
+        'received_on': form_json['received_on'],
+    }
+    _recurse_form_questions(metadata, [b'/metadata'], result)
     return result

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -247,11 +247,12 @@ def get_form_question_values(form_json):
     # necessarily. If this causes problems we may need a more reliable way to get to it.
 
     metadata = {}
-    if form_json['form'].get('meta', {}).get('timeStart'):
-        metadata['timeStart'] = form_json['form']['meta']['timeStart']
-    if form_json['form'].get('meta', {}).get('timeEnd'):
-        metadata['timeEnd'] = form_json['form']['meta']['timeEnd']
-    if form_json.get('received_on'):
+    if 'meta' in form_json['form']:
+        if 'timeStart' in form_json['form']['meta']:
+            metadata['timeStart'] = form_json['form']['meta']['timeStart']
+        if 'timeEnd' in form_json['form']['meta']:
+            metadata['timeEnd'] = form_json['form']['meta']['timeEnd']
+    if 'received_on' in form_json:
         metadata['received_on'] = form_json['received_on']
     if metadata:
         _recurse_form_questions(metadata, [b'/metadata'], result)

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -246,11 +246,13 @@ def get_form_question_values(form_json):
     # familiar from form builder. The form's data will usually be immediately under "form_json['form']" but not
     # necessarily. If this causes problems we may need a more reliable way to get to it.
 
-    if 'meta' in form_json['form'] and 'received_on' in form_json:
-        metadata = {
-            'timeStart': form_json['form']['meta']['timeStart'],
-            'timeEnd': form_json['form']['meta']['timeEnd'],
-            'received_on': form_json['received_on'],
-        }
+    metadata = {}
+    if form_json['form'].get('meta', {}).get('timeStart'):
+        metadata['timeStart'] = form_json['form']['meta']['timeStart']
+    if form_json['form'].get('meta', {}).get('timeEnd'):
+        metadata['timeEnd'] = form_json['form']['meta']['timeEnd']
+    if form_json.get('received_on'):
+        metadata['received_on'] = form_json['received_on']
+    if metadata:
         _recurse_form_questions(metadata, [b'/metadata'], result)
     return result

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -246,10 +246,11 @@ def get_form_question_values(form_json):
     # familiar from form builder. The form's data will usually be immediately under "form_json['form']" but not
     # necessarily. If this causes problems we may need a more reliable way to get to it.
 
-    metadata = {
-        'timeStart': form_json['form']['meta']['timeStart'],
-        'timeEnd': form_json['form']['meta']['timeEnd'],
-        'received_on': form_json['received_on'],
-    }
-    _recurse_form_questions(metadata, [b'/metadata'], result)
+    if 'meta' in form_json['form'] and 'received_on' in form_json:
+        metadata = {
+            'timeStart': form_json['form']['meta']['timeStart'],
+            'timeEnd': form_json['form']['meta']['timeEnd'],
+            'received_on': form_json['received_on'],
+        }
+        _recurse_form_questions(metadata, [b'/metadata'], result)
     return result


### PR DESCRIPTION
This change allows integrators to use `timeStart`, `timeEnd` and `received_on` form metadata in MOTECH configurations.

Documentation to follow in a separate PR.

Feature flag: "Enable OpenMRS integration"
