### PR TITLE
refuse early if not needed

### DIFF
--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dimagi.utils.couch.database import safe_delete
 from corehq.util.test_utils import unit_testing_only
-from dimagi.utils.parsing import string_to_utc_datetime
+from dimagi.utils.parsing import json_format_datetime
 
 
 def get_latest_case_export_schema(domain, case_type):
@@ -130,23 +130,37 @@ def _get_export_instance(cls, key):
 
 def get_all_daily_saved_export_instance_ids(accessed_after=None):
     """
-    get all saved exports accessed after the timestamp
-    :param accessed_after: reports that have been accessed after this time
+    get all saved exports or accessed after the timestamp
+    :param accessed_after: datetime to get reports that have been accessed after this timestamp
     """
     from .models import ExportInstance
-    results = ExportInstance.get_db().view(
-        "export_instances_by_is_daily_saved/view",
-        include_docs=False,
-        reduce=False,
-    ).all()
-    if accessed_after:
-        # return exports that have accessed_after set after the cutoff requested
-        # or don't have any value set for it yet
-        return [result['id'] for result in results
-                if not result['key'][0] or
-                string_to_utc_datetime(result['key'][0]) >= accessed_after]
+    if not accessed_after:
+        # just return all saved export ids
+        results = ExportInstance.get_db().view(
+            "export_instances_by_is_daily_saved/view",
+            include_docs=False,
+            reduce=False,
+        ).all()
+        export_ids = [result['id'] for result in results]
     else:
-        return [result['id'] for result in results]
+        # get exports that have not been accessed yet
+        new_exports = ExportInstance.get_db().view(
+            "export_instances_by_is_daily_saved/view",
+            include_docs=False,
+            key=[None],
+            reduce=False,
+        ).all()
+        export_ids = [export['id'] for export in new_exports]
+
+        # get exports that have accessed_after set after the cutoff requested
+        accessed_reports = ExportInstance.get_db().view(
+            "export_instances_by_is_daily_saved/view",
+            include_docs=False,
+            startkey=[json_format_datetime(accessed_after)],
+            reduce=False,
+        ).all()
+        export_ids.extend([result['id'] for result in accessed_reports])
+    return export_ids
 
 
 def get_properly_wrapped_export_instance(doc_id):

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dimagi.utils.couch.database import safe_delete
 from corehq.util.test_utils import unit_testing_only
+from dimagi.utils.parsing import json_format_datetime
 
 
 def get_latest_case_export_schema(domain, case_type):
@@ -127,12 +128,17 @@ def _get_export_instance(cls, key):
     return [cls.wrap(result['doc']) for result in results]
 
 
-def get_all_daily_saved_export_instance_ids():
+def get_all_daily_saved_export_instance_ids(accessed_after):
+    """
+    get all saved exports accessed after the timestamp
+    :param last_access_cutoff:
+    :return:
+    """
     from .models import ExportInstance
     results = ExportInstance.get_db().view(
         "export_instances_by_is_daily_saved/view",
-        startkey=[True],
-        endkey=[True, {}],
+        startkey=[True, True, json_format_datetime(accessed_after)],
+        endkey=[True, True, {}],
         include_docs=False,
         reduce=False,
     ).all()

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -128,7 +128,7 @@ def _get_export_instance(cls, key):
     return [cls.wrap(result['doc']) for result in results]
 
 
-def get_all_daily_saved_export_instance_ids(accessed_after=None):
+def get_daily_saved_export_ids_for_auto_rebuild(accessed_after=None):
     """
     get all saved exports or accessed after the timestamp
     :param accessed_after: datetime to get reports that have been accessed after this timestamp

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -132,7 +132,6 @@ def get_all_daily_saved_export_instance_ids(accessed_after=None):
     """
     get all saved exports accessed after the timestamp
     :param accessed_after: reports that have been accessed after this time
-    :return:
     """
     from .models import ExportInstance
     results = ExportInstance.get_db().view(

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -378,7 +378,7 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
             DownloadBase.set_progress(progress_tracker, row_number + 1, documents.count)
 
     end = _time_in_milliseconds()
-    tags = ['format:{}'.format(writer.format), 'export_id:{}'.format(export_instance.get_id)]
+    tags = ['format:{}'.format(writer.format)]
     _record_datadog_export_write_rows(write_total, total_bytes, total_rows, tags)
     _record_datadog_export_compute_rows(compute_total, total_bytes, total_rows, tags)
     _record_datadog_export_duration(end - start, total_bytes, total_rows, tags)

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -30,7 +30,6 @@ from corehq.apps.export.models.new import (
     SMSExportInstance,
 )
 from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
-from corehq.apps.export.dbaccessors import get_properly_wrapped_export_instance
 import six
 from io import open
 

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -379,7 +379,7 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
             DownloadBase.set_progress(progress_tracker, row_number + 1, documents.count)
 
     end = _time_in_milliseconds()
-    tags = ['format:{}'.format(writer.format)]
+    tags = ['format:{}'.format(writer.format), 'export_id:{}'.format(export_instance.get_id)]
     _record_datadog_export_write_rows(write_total, total_bytes, total_rows, tags)
     _record_datadog_export_compute_rows(compute_total, total_bytes, total_rows, tags)
     _record_datadog_export_duration(end - start, total_bytes, total_rows, tags)

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -461,14 +461,10 @@ def should_rebuild_export(export, last_access_cutoff):
     # Don't rebuild exports that haven't been accessed since last_access_cutoff or aren't enabled
     if isinstance(export, six.string_types):
         export = get_properly_wrapped_export_instance(export)
-    is_auto_rebuild = last_access_cutoff is not None
-    return not is_auto_rebuild or (
-        export.auto_rebuild_enabled
-        and (
-            export.last_accessed is None
-            or export.last_accessed > last_access_cutoff
-        )
-    )
+    return (export.auto_rebuild_enabled and
+            (export.last_accessed is None or
+             export.last_accessed > last_access_cutoff
+             ))
 
 
 def save_export_payload(export, payload):

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -420,12 +420,12 @@ def __record_datadog_export(duration, doc_bytes, n_rows, metric, tags):
 
 
 def _record_export_duration(duration, export):
-    export.last_duration = duration
+    export.last_build_duration = duration
     try:
         export.save()
     except ResourceConflict:
-        export = get_properly_wrapped_export_instance(export.export_id)
-        export.last_duration = duration
+        export = get_properly_wrapped_export_instance(export.get_id)
+        export.last_build_duration = duration
         export.save()
 
 

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -453,20 +453,6 @@ def rebuild_export(export_instance, progress_tracker):
             save_export_payload(export_instance, payload)
 
 
-def should_rebuild_export(export, last_access_cutoff):
-    """
-    :param last_access_cutoff: Any exports not accessed since this date will not be rebuilt.
-    :return: True if export should be rebuilt
-    """
-    # Don't rebuild exports that haven't been accessed since last_access_cutoff or aren't enabled
-    if isinstance(export, six.string_types):
-        export = get_properly_wrapped_export_instance(export)
-    return (export.auto_rebuild_enabled and
-            (export.last_accessed is None or
-             export.last_accessed > last_access_cutoff
-             ))
-
-
 def save_export_payload(export, payload):
     """
     Save the contents of an export file to disk for later retrieval.

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -30,6 +30,7 @@ from corehq.apps.export.models.new import (
     SMSExportInstance,
 )
 from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
+from corehq.apps.export.dbaccessors import get_properly_wrapped_export_instance
 import six
 from io import open
 
@@ -458,6 +459,8 @@ def should_rebuild_export(export, last_access_cutoff):
     :return: True if export should be rebuilt
     """
     # Don't rebuild exports that haven't been accessed since last_access_cutoff or aren't enabled
+    if isinstance(export, six.string_types):
+        export = get_properly_wrapped_export_instance(export)
     is_auto_rebuild = last_access_cutoff is not None
     return not is_auto_rebuild or (
         export.auto_rebuild_enabled

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -384,7 +384,7 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
     _record_datadog_export_write_rows(write_total, total_bytes, total_rows, tags)
     _record_datadog_export_compute_rows(compute_total, total_bytes, total_rows, tags)
     _record_datadog_export_duration(end - start, total_bytes, total_rows, tags)
-    _record_export_runtime(end - start, export_instance.get_id)
+    _record_export_duration(end - start, export_instance.get_id)
 
 
 def _time_in_milliseconds():
@@ -419,10 +419,10 @@ def __record_datadog_export(duration, doc_bytes, n_rows, metric, tags):
         )
 
 
-def _record_export_runtime(runtime, export_id):
+def _record_export_duration(duration, export_id):
     # reload the export again to avoid stale updates to pre-loaded export doc
     export = get_properly_wrapped_export_instance(export_id)
-    export.last_runtime = runtime
+    export.last_duration = duration
     export.save()
 
 

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -384,7 +384,7 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
     _record_datadog_export_write_rows(write_total, total_bytes, total_rows, tags)
     _record_datadog_export_compute_rows(compute_total, total_bytes, total_rows, tags)
     _record_datadog_export_duration(end - start, total_bytes, total_rows, tags)
-    _record_export_duration(end - start, export_instance.get_id)
+    _record_export_duration(end - start, export_instance)
 
 
 def _time_in_milliseconds():
@@ -419,11 +419,14 @@ def __record_datadog_export(duration, doc_bytes, n_rows, metric, tags):
         )
 
 
-def _record_export_duration(duration, export_id):
-    # reload the export again to avoid stale updates to pre-loaded export doc
-    export = get_properly_wrapped_export_instance(export_id)
+def _record_export_duration(duration, export):
     export.last_duration = duration
-    export.save()
+    try:
+        export.save()
+    except ResourceConflict:
+        export = get_properly_wrapped_export_instance(export.export_id)
+        export.last_duration = duration
+        export.save()
 
 
 def _get_base_query(export_instance):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -676,7 +676,7 @@ class ExportInstance(BlobMixin, Document):
     # daily saved export fields:
     last_updated = DateTimeProperty()
     last_accessed = DateTimeProperty()
-    last_runtime = IntegerProperty()
+    last_duration = IntegerProperty()
 
     description = StringProperty(default='')
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -36,7 +36,12 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.daterange import get_daterange_start_end_dates
 from corehq.util.timezones.utils import get_timezone_for_domain
 from memoized import memoized
-from couchdbkit import SchemaListProperty, SchemaProperty, BooleanProperty, DictProperty
+from couchdbkit import (
+    SchemaListProperty,
+    SchemaProperty,
+    BooleanProperty,
+    DictProperty,
+)
 
 from corehq import feature_previews
 from corehq.apps.userreports.expressions.getters import NestedDictGetter
@@ -671,6 +676,8 @@ class ExportInstance(BlobMixin, Document):
     # daily saved export fields:
     last_updated = DateTimeProperty()
     last_accessed = DateTimeProperty()
+
+    last_runtime = IntegerProperty()
 
     description = StringProperty(default='')
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -676,7 +676,6 @@ class ExportInstance(BlobMixin, Document):
     # daily saved export fields:
     last_updated = DateTimeProperty()
     last_accessed = DateTimeProperty()
-
     last_runtime = IntegerProperty()
 
     description = StringProperty(default='')

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -676,7 +676,7 @@ class ExportInstance(BlobMixin, Document):
     # daily saved export fields:
     last_updated = DateTimeProperty()
     last_accessed = DateTimeProperty()
-    last_duration = IntegerProperty()
+    last_build_duration = IntegerProperty()
 
     description = StringProperty(default='')
 

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -27,7 +27,7 @@ from .dbaccessors import (
     get_properly_wrapped_export_instance,
     get_all_daily_saved_export_instance_ids,
 )
-from .export import get_export_file, rebuild_export, should_rebuild_export
+from .export import get_export_file, rebuild_export
 from .models.new import EmailExportWhenDoneRequest
 from .system_properties import MAIN_CASE_TABLE_PROPERTIES
 

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -25,7 +25,7 @@ from .const import SAVED_EXPORTS_QUEUE, EXPORT_DOWNLOAD_QUEUE
 from .dbaccessors import (
     get_case_inferred_schema,
     get_properly_wrapped_export_instance,
-    get_all_daily_saved_export_instance_ids,
+    get_daily_saved_export_ids_for_auto_rebuild,
 )
 from .export import get_export_file, rebuild_export
 from .models.new import EmailExportWhenDoneRequest
@@ -162,7 +162,7 @@ def saved_exports():
         export_for_group_async.delay(group_config_id)
 
     last_access_cutoff = datetime.utcnow() - timedelta(days=settings.SAVED_EXPORT_ACCESS_CUTOFF)
-    for daily_saved_export_id in get_all_daily_saved_export_instance_ids(last_access_cutoff):
+    for daily_saved_export_id in get_daily_saved_export_ids_for_auto_rebuild(last_access_cutoff):
         rebuild_saved_export(daily_saved_export_id, manual=False)
 
 

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -161,10 +161,9 @@ def saved_exports():
     for group_config_id in get_doc_ids_by_class(HQGroupExportConfiguration):
         export_for_group_async.delay(group_config_id)
 
-    for daily_saved_export_id in get_all_daily_saved_export_instance_ids():
-        last_access_cutoff = datetime.utcnow() - timedelta(days=settings.SAVED_EXPORT_ACCESS_CUTOFF)
-        if should_rebuild_export(daily_saved_export_id, last_access_cutoff):
-            rebuild_saved_export(daily_saved_export_id, last_access_cutoff, manual=False)
+    last_access_cutoff = datetime.utcnow() - timedelta(days=settings.SAVED_EXPORT_ACCESS_CUTOFF)
+    for daily_saved_export_id in get_all_daily_saved_export_instance_ids(last_access_cutoff):
+        rebuild_saved_export(daily_saved_export_id, last_access_cutoff, manual=False)
 
 
 @quickcache(['sender', 'domain', 'case_type', 'properties'], timeout=60 * 60)

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -104,7 +104,7 @@ def _get_saved_export_download_data(export_instance_id):
     return download_data
 
 
-def rebuild_saved_export(export_instance_id, last_access_cutoff=None, manual=False):
+def rebuild_saved_export(export_instance_id, manual=False):
     """Kicks off a celery task to rebuild the export.
 
     If this is called while another one is already running for the same export
@@ -163,7 +163,7 @@ def saved_exports():
 
     last_access_cutoff = datetime.utcnow() - timedelta(days=settings.SAVED_EXPORT_ACCESS_CUTOFF)
     for daily_saved_export_id in get_all_daily_saved_export_instance_ids(last_access_cutoff):
-        rebuild_saved_export(daily_saved_export_id, last_access_cutoff, manual=False)
+        rebuild_saved_export(daily_saved_export_id, manual=False)
 
 
 @quickcache(['sender', 'domain', 'case_type', 'properties'], timeout=60 * 60)

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -90,10 +90,9 @@ def populate_export_download_task(export_instances, filters, download_id, filena
 
 
 @task(serializer='pickle', queue=SAVED_EXPORTS_QUEUE, ignore_result=True)
-def _start_export_task(export_instance_id, last_access_cutoff):
+def _start_export_task(export_instance_id):
     export_instance = get_properly_wrapped_export_instance(export_instance_id)
-    if should_rebuild_export(export_instance, last_access_cutoff):
-        rebuild_export(export_instance, progress_tracker=_start_export_task)
+    rebuild_export(export_instance, progress_tracker=_start_export_task)
 
 
 def _get_saved_export_download_data(export_instance_id):
@@ -127,9 +126,7 @@ def rebuild_saved_export(export_instance_id, last_access_cutoff=None, manual=Fal
     # associate task with the export instance
     download_data.set_task(
         _start_export_task.apply_async(
-            args=[
-                export_instance_id, last_access_cutoff
-            ],
+            args=[export_instance_id],
             queue=EXPORT_DOWNLOAD_QUEUE if manual else SAVED_EXPORTS_QUEUE,
         )
     )

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -166,7 +166,8 @@ def saved_exports():
 
     for daily_saved_export_id in get_all_daily_saved_export_instance_ids():
         last_access_cutoff = datetime.utcnow() - timedelta(days=settings.SAVED_EXPORT_ACCESS_CUTOFF)
-        rebuild_saved_export(daily_saved_export_id, last_access_cutoff, manual=False)
+        if should_rebuild_export(daily_saved_export_id, last_access_cutoff):
+            rebuild_saved_export(daily_saved_export_id, last_access_cutoff, manual=False)
 
 
 @quickcache(['sender', 'domain', 'case_type', 'properties'], timeout=60 * 60)

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -123,8 +123,8 @@
                             {% endangularjs %}
                             {% if request|toggle_enabled:"SUPPORT" %}
                                 {% angularjs %}
-                                <span ng-show="export.last_duration">
-                                   <strong>{% trans "Last Duration:" %}</strong> {{ export.last_duration }}
+                                <span ng-show="export.last_build_duration">
+                                   <strong>{% trans "Last Build Duration:" %}</strong> {{ export.last_build_duration }}
                                 </span>
                                 {% endangularjs %}
                             {% endif %}

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -120,6 +120,15 @@
                                 {% trans "Just now" %}&nbsp;&nbsp;&nbsp;
                             </span>
                             <strong>{% trans "Last Downloaded:" %}</strong> {{ export.emailedExport.fileData.lastAccessed }}
+                            {% endangularjs %}
+                            {% if request|toggle_enabled:"SUPPORT" %}
+                                {% angularjs %}
+                                <span ng-show="export.last_runtime">
+                                   <strong>{% trans "Last Runtime:" %}</strong> {{ export.last_runtime }}
+                                </span>
+                                {% endangularjs %}
+                            {% endif %}
+                            {% angularjs %}
                         </span>
                         &nbsp;&nbsp;
                         {% angularjs %}

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -123,8 +123,8 @@
                             {% endangularjs %}
                             {% if request|toggle_enabled:"SUPPORT" %}
                                 {% angularjs %}
-                                <span ng-show="export.last_runtime">
-                                   <strong>{% trans "Last Runtime:" %}</strong> {{ export.last_runtime }}
+                                <span ng-show="export.last_duration">
+                                   <strong>{% trans "Last Duration:" %}</strong> {{ export.last_duration }}
                                 </span>
                                 {% endangularjs %}
                             {% endif %}

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -18,7 +18,7 @@ from corehq.apps.export.dbaccessors import (
     get_case_export_instances,
     get_export_count_by_domain,
     get_deid_export_count,
-    get_all_daily_saved_export_instance_ids,
+    get_daily_saved_export_ids_for_auto_rebuild,
     get_properly_wrapped_export_instance,
     get_case_inferred_schema,
     get_form_inferred_schema,
@@ -130,6 +130,7 @@ class TestExportInstanceDBAccessors(TestCase):
         cls.form_instance_daily_saved = FormExportInstance(
             domain='wrong-domain',
             is_daily_saved_export=True,
+            auto_rebuild_enabled=True
         )
         cls.case_instance_deid = CaseExportInstance(
             domain=cls.domain,
@@ -144,6 +145,7 @@ class TestExportInstanceDBAccessors(TestCase):
         cls.case_instance_daily_saved = CaseExportInstance(
             domain='wrong-domain',
             is_daily_saved_export=True,
+            auto_rebuild_enabled=True
         )
 
         cls.instances = [
@@ -189,7 +191,7 @@ class TestExportInstanceDBAccessors(TestCase):
         self.assertEqual(len(instances), 0)
 
     def test_get_daily_saved_exports(self):
-        instance_ids = get_all_daily_saved_export_instance_ids()
+        instance_ids = get_daily_saved_export_ids_for_auto_rebuild()
         self.assertEqual(
             set(instance_ids),
             {self.form_instance_daily_saved._id, self.case_instance_daily_saved._id}

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -130,7 +130,8 @@ class TestExportInstanceDBAccessors(TestCase):
         cls.form_instance_daily_saved = FormExportInstance(
             domain='wrong-domain',
             is_daily_saved_export=True,
-            auto_rebuild_enabled=True
+            auto_rebuild_enabled=True,
+            last_accessed=datetime.utcnow()
         )
         cls.case_instance_deid = CaseExportInstance(
             domain=cls.domain,
@@ -145,7 +146,8 @@ class TestExportInstanceDBAccessors(TestCase):
         cls.case_instance_daily_saved = CaseExportInstance(
             domain='wrong-domain',
             is_daily_saved_export=True,
-            auto_rebuild_enabled=True
+            auto_rebuild_enabled=True,
+            last_accessed=(datetime.utcnow() - timedelta(days=4))
         )
 
         cls.instances = [
@@ -195,6 +197,12 @@ class TestExportInstanceDBAccessors(TestCase):
         self.assertEqual(
             set(instance_ids),
             {self.form_instance_daily_saved._id, self.case_instance_daily_saved._id}
+        )
+        recently_accessed_instance_ids = get_daily_saved_export_ids_for_auto_rebuild(
+            datetime.utcnow() - timedelta(days=2))
+        self.assertEqual(
+            set(recently_accessed_instance_ids),
+            {self.form_instance_daily_saved._id}
         )
 
     def test_get_properly_wrapped_export_instance(self):

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -97,7 +97,8 @@ class WriterTest(SimpleTestCase):
         },
     ]
 
-    def test_simple_table(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_simple_table(self, export_save):
         """
         Confirm that some simple documents and a simple FormExportInstance
         are writtern with _write_export_file() correctly
@@ -135,10 +136,12 @@ class WriterTest(SimpleTestCase):
                 'rows': [['baz', 'foo'], ['bop', 'bip']],
             }
         })
+        self.assertTrue(export_save.called)
 
+    @patch('corehq.apps.export.models.FormExportInstance.save')
     @patch('corehq.apps.export.export.MAX_EXPORTABLE_ROWS', 2)
     @flag_enabled('PAGINATED_EXPORTS')
-    def test_paginated_table(self):
+    def test_paginated_table(self, export_save):
         export_instance = FormExportInstance(
             export_format=Format.JSON,
             tables=[
@@ -175,8 +178,10 @@ class WriterTest(SimpleTestCase):
                 'rows': [['baz', 'foo'], ['bop', 'bip']],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_split_questions(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_split_questions(self, export_save):
         """Ensure columns are split when `split_multiselects` is set to True"""
         export_instance = FormExportInstance(
             export_format=Format.JSON,
@@ -209,8 +214,10 @@ class WriterTest(SimpleTestCase):
                 'rows': [[EMPTY_VALUE, 1, 'extra'], [1, 1, '']],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_array_data_in_scalar_question(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_array_data_in_scalar_question(self, export_save):
         '''
         This test ensures that when a question id has array data
         that we return still return a string for scalar data.
@@ -248,8 +255,10 @@ class WriterTest(SimpleTestCase):
                 'rows': [['one two']],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_form_stock_columns(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_form_stock_columns(self, export_save):
         """Ensure that we can export stock properties in a form export"""
         docs = [{
             '_id': 'simone-biles',
@@ -341,8 +350,10 @@ class WriterTest(SimpleTestCase):
                 ],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_transform_dates(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_transform_dates(self, export_save):
         """Ensure dates are transformed for excel when `transform_dates` is set to True"""
         export_instance = FormExportInstance(
             export_format=Format.JSON,
@@ -371,8 +382,10 @@ class WriterTest(SimpleTestCase):
                 'rows': [[MISSING_VALUE], [couch_to_excel_datetime('2015-07-22T14:16:49.584880Z', None)]],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_split_questions_false(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_split_questions_false(self, export_save):
         """Ensure multiselects are not split when `split_multiselects` is set to False"""
         export_instance = FormExportInstance(
             export_format=Format.JSON,
@@ -405,8 +418,10 @@ class WriterTest(SimpleTestCase):
                 'rows': [['two extra'], ['one two']],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_multi_table(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_multi_table(self, export_save):
         export_instance = FormExportInstance(
             export_format=Format.JSON,
             tables=[
@@ -451,8 +466,10 @@ class WriterTest(SimpleTestCase):
                 'rows': [['bar'], ['boop']],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_multi_table_order(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_multi_table_order(self, export_save):
         tables = [
             TableConfiguration(
                 label="My table {}".format(i),
@@ -492,8 +509,10 @@ class WriterTest(SimpleTestCase):
 
         expected_tables = [t.label for t in tables]
         self.assertEqual(len(expected_tables), len(exported_tables))
+        self.assertTrue(export_save.called)
 
-    def test_multiple_write_export_instance_calls(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_multiple_write_export_instance_calls(self, export_save):
         """
         Confirm that calling _write_export_instance() multiple times
         (as part of a bulk export) works as expected.
@@ -582,8 +601,10 @@ class WriterTest(SimpleTestCase):
                         },
                     }
                 )
+        self.assertTrue(export_save.called)
 
-    def test_empty_location(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_empty_location(self, export_save):
         export_instance = FormExportInstance(
             export_format=Format.JSON,
             tables=[
@@ -621,8 +642,10 @@ class WriterTest(SimpleTestCase):
                 'rows': [[EMPTY_VALUE]],
             }
         })
+        self.assertTrue(export_save.called)
 
-    def test_empty_table_label(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_empty_table_label(self, export_save):
         export_instance = FormExportInstance(
             export_format=Format.JSON,
             domain=DOMAIN,
@@ -650,6 +673,7 @@ class WriterTest(SimpleTestCase):
                 'rows': [['foo'], ['bip']],
             }
         })
+        self.assertTrue(export_save.called)
 
 
 class ExportTest(SimpleTestCase):
@@ -682,7 +706,8 @@ class ExportTest(SimpleTestCase):
         cache.clear()
         super(ExportTest, cls).tearDownClass()
 
-    def test_get_export_file(self):
+    @patch('corehq.apps.export.models.CaseExportInstance.save')
+    def test_get_export_file(self, export_save):
         export_json = get_export_json(
             CaseExportInstance(
                 export_format=Format.JSON,
@@ -727,8 +752,10 @@ class ExportTest(SimpleTestCase):
                 }
             }
         )
+        self.assertTrue(export_save.called)
 
-    def test_case_name_transform(self):
+    @patch('corehq.apps.export.models.FormExportInstance.save')
+    def test_case_name_transform(self, export_save):
         docs = [
             {
                 'domain': 'my-domain',
@@ -771,9 +798,11 @@ class ExportTest(SimpleTestCase):
                 'rows': [['batman'], [MISSING_VALUE]],
             }
         })
+        self.assertTrue(export_save.called)
 
     @patch('couchexport.deid.DeidGenerator.random_number', return_value=3)
-    def test_export_transforms(self, _):
+    @patch('corehq.apps.export.models.CaseExportInstance.save')
+    def test_export_transforms(self, export_save, _):
         export_json = get_export_json(
             CaseExportInstance(
                 export_format=Format.JSON,
@@ -813,8 +842,10 @@ class ExportTest(SimpleTestCase):
                 }
             }
         )
+        self.assertTrue(export_save.called)
 
-    def test_selected_false(self):
+    @patch('corehq.apps.export.models.CaseExportInstance.save')
+    def test_selected_false(self, export_save):
         export_json = get_export_json(
             CaseExportInstance(
                 export_format=Format.JSON,
@@ -829,8 +860,10 @@ class ExportTest(SimpleTestCase):
             )
         )
         self.assertEqual(export_json, {})
+        self.assertTrue(export_save.called)
 
-    def test_simple_bulk_export(self):
+    @patch('corehq.apps.export.models.CaseExportInstance.save')
+    def test_simple_bulk_export(self, export_save):
 
         with TransientTempfile() as temp_path:
             export_file = get_export_file(
@@ -906,6 +939,7 @@ class ExportTest(SimpleTestCase):
                                 sheet, cell, expected[sheet][cell], wb[sheet][cell].value
                             )
                         )
+        self.assertTrue(export_save.called)
 
 
 class TableHeaderTest(SimpleTestCase):

--- a/corehq/apps/export/tests/test_sms_export.py
+++ b/corehq/apps/export/tests/test_sms_export.py
@@ -69,14 +69,15 @@ class TestSmsExport(SimpleTestCase):
         cls.export_meta.export_format = Format.JSON
         cls.export_no_meta.export_format = Format.JSON
 
+    @patch('corehq.apps.export.models.SMSExportInstance.save')
     @patch('corehq.apps.export.transforms.cached_user_id_to_username')
     @patch('corehq.apps.export.export.get_export_documents')
-    def test_export(self, docs, owner_id_to_display):
+    def test_export(self, docs, owner_id_to_display, export_save):
         docs.return_value = self._message_docs()
         owner_id_to_display.return_value = None
 
         export_json = get_export_json(self.export_no_meta)
-
+        self.assertTrue(export_save.called)
         self.assertEqual(
             export_json,
             {
@@ -96,14 +97,15 @@ class TestSmsExport(SimpleTestCase):
             }
         )
 
+    @patch('corehq.apps.export.models.SMSExportInstance.save')
     @patch('corehq.apps.export.transforms.cached_user_id_to_username')
     @patch('corehq.apps.export.export.get_export_documents')
-    def test_export_meta(self, docs, owner_id_to_display):
+    def test_export_meta(self, docs, owner_id_to_display, export_save):
         docs.return_value = self._message_docs()
         owner_id_to_display.return_value = None
 
         export_json = get_export_json(self.export_meta)
-
+        self.assertTrue(export_save.called)
         self.assertEqual(
             export_json,
             {
@@ -124,10 +126,11 @@ class TestSmsExport(SimpleTestCase):
             }
         )
 
+    @patch('corehq.apps.export.models.SMSExportInstance.save')
     @patch('corehq.apps.export.transforms._cached_case_id_to_case_name')
     @patch('corehq.apps.export.transforms.cached_user_id_to_username')
     @patch('corehq.apps.export.export.get_export_documents')
-    def test_export_doc_type_transform(self, docs, owner_id_to_display, case_id_to_casename):
+    def test_export_doc_type_transform(self, docs, owner_id_to_display, case_id_to_casename, export_save):
         docs.return_value = [
             self._make_message(1234, couch_recipient_doc_type='WebUser'),
             self._make_message(1235, couch_recipient_doc_type='CommCareCase'),
@@ -141,7 +144,7 @@ class TestSmsExport(SimpleTestCase):
         rows_value[2][0] = 'Unknown'
 
         export_json = get_export_json(self.export_no_meta)
-
+        self.assertTrue(export_save.called)
         self.assertEqual(
             export_json,
             {
@@ -163,7 +166,8 @@ class TestSmsExport(SimpleTestCase):
 
     @patch('corehq.apps.export.transforms.cached_user_id_to_username')
     @patch('corehq.apps.export.export.get_export_documents')
-    def test_export_workflow_transform(self, docs, owner_id_to_display):
+    @patch('corehq.apps.export.models.SMSExportInstance.save')
+    def test_export_workflow_transform(self, obj_save, docs, owner_id_to_display):
         messages = [
             self._make_message(1234, workflow='blah'),
             self._make_message(1235, workflow=''),
@@ -176,7 +180,7 @@ class TestSmsExport(SimpleTestCase):
         rows_value[1][-1] = 'survey'
 
         export_json = get_export_json(self.export_no_meta)
-
+        self.assertTrue(obj_save.called)
         self.assertEqual(
             export_json,
             {
@@ -196,10 +200,11 @@ class TestSmsExport(SimpleTestCase):
             }
         )
 
+    @patch('corehq.apps.export.models.SMSExportInstance.save')
     @patch('corehq.apps.export.transforms._cached_case_id_to_case_name')
     @patch('corehq.apps.export.transforms.cached_user_id_to_username')
     @patch('corehq.apps.export.export.get_export_documents')
-    def test_export_recipient_id_transform(self, docs, owner_id_to_display, case_id_to_casename):
+    def test_export_recipient_id_transform(self, docs, owner_id_to_display, case_id_to_casename, export_save):
         docs.return_value = [
             self._make_message(1234, couch_recipient_doc_type='WebUser'),
             self._make_message(1235, couch_recipient_doc_type='CommCareCase'),
@@ -215,7 +220,7 @@ class TestSmsExport(SimpleTestCase):
         rows_value[2][0] = 'Unknown'
 
         export_json = get_export_json(self.export_no_meta)
-
+        self.assertTrue(export_save.called)
         self.assertEqual(
             export_json,
             {

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -428,7 +428,8 @@ class DailySavedExportListView(BaseExportListView):
             'isDeid': export.is_safe,
             'name': export.name,
             'description': export.description,
-            'last_duration': (str(timedelta(seconds=export.last_duration)) if export.last_duration else ''),
+            'last_build_duration': (str(timedelta(seconds=export.last_build_duration))
+                                    if export.last_build_duration else ''),
             'my_export': export.owner_id == self.request.couch_user.user_id,
             'sharing': export.sharing,
             'owner_username': (

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -187,7 +187,7 @@ class BaseExportListView(HQJSONResponseMixin, BaseProjectDataView):
                 reverse('download_daily_saved_export', args=[self.domain, export._id]))
             file_data = self._fmt_emailed_export_fileData(
                 export._id, export.file_size, export.last_updated,
-                export.last_accessed, download_url
+                export.last_accessed, export.last_runtime, download_url
             )
 
         location_restrictions = []
@@ -212,7 +212,7 @@ class BaseExportListView(HQJSONResponseMixin, BaseProjectDataView):
         }
 
     def _fmt_emailed_export_fileData(self, fileId, size, last_updated,
-                                     last_accessed, download_url):
+                                     last_accessed, last_runtime, download_url):
         """
         Return a dictionary containing details about an emailed export file.
         This will eventually be passed to an Angular controller.
@@ -428,6 +428,7 @@ class DailySavedExportListView(BaseExportListView):
             'isDeid': export.is_safe,
             'name': export.name,
             'description': export.description,
+            'last_runtime': (str(timedelta(seconds=export.last_runtime)) if export.last_runtime else ''),
             'my_export': export.owner_id == self.request.couch_user.user_id,
             'sharing': export.sharing,
             'owner_username': (

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -187,7 +187,7 @@ class BaseExportListView(HQJSONResponseMixin, BaseProjectDataView):
                 reverse('download_daily_saved_export', args=[self.domain, export._id]))
             file_data = self._fmt_emailed_export_fileData(
                 export._id, export.file_size, export.last_updated,
-                export.last_accessed, export.last_runtime, download_url
+                export.last_accessed, download_url
             )
 
         location_restrictions = []
@@ -212,7 +212,7 @@ class BaseExportListView(HQJSONResponseMixin, BaseProjectDataView):
         }
 
     def _fmt_emailed_export_fileData(self, fileId, size, last_updated,
-                                     last_accessed, last_runtime, download_url):
+                                     last_accessed, download_url):
         """
         Return a dictionary containing details about an emailed export file.
         This will eventually be passed to an Angular controller.
@@ -428,7 +428,7 @@ class DailySavedExportListView(BaseExportListView):
             'isDeid': export.is_safe,
             'name': export.name,
             'description': export.description,
-            'last_runtime': (str(timedelta(seconds=export.last_runtime)) if export.last_runtime else ''),
+            'last_duration': (str(timedelta(seconds=export.last_duration)) if export.last_duration else ''),
             'my_export': export.owner_id == self.request.couch_user.user_id,
             'sharing': export.sharing,
             'owner_username': (

--- a/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
+++ b/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
@@ -1,5 +1,5 @@
 function(doc) {
     if (doc.is_daily_saved_export || doc.auto_rebuild_enabled) {
-        emit([doc.last_accessed, doc.domain], null);
+        emit([doc.last_accessed], null);
     }
 }

--- a/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
+++ b/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
@@ -1,5 +1,5 @@
 function(doc) {
     if (doc.doc_type === "FormExportInstance" || doc.doc_type === "CaseExportInstance") {
-        emit([doc.is_daily_saved_export, doc.domain, doc.doc_type], null);
+        emit([doc.is_daily_saved_export, doc.auto_rebuild_enabled, doc.last_accessed, doc.domain, doc.doc_type], null);
     }
 }

--- a/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
+++ b/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
@@ -1,5 +1,5 @@
 function(doc) {
-    if (doc.doc_type === "FormExportInstance" || doc.doc_type === "CaseExportInstance") {
-        emit([doc.is_daily_saved_export, doc.auto_rebuild_enabled, doc.last_accessed, doc.domain, doc.doc_type], null);
+    if (doc.is_daily_saved_export || doc.auto_rebuild_enabled) {
+        emit([doc.last_accessed, doc.domain], null);
     }
 }

--- a/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
+++ b/corehq/couchapps/export_instances_by_is_daily_saved/views/view/map.js
@@ -1,5 +1,5 @@
 function(doc) {
-    if (doc.is_daily_saved_export || doc.auto_rebuild_enabled) {
+    if (doc.is_daily_saved_export && doc.auto_rebuild_enabled) {
         emit([doc.last_accessed], null);
     }
 }


### PR DESCRIPTION
We were sending a task to celery and then checking if we needed to rebuild the export or not. This now decides earlier itself.

buddy: @proteusvacuum 

also, 
added last_runtime on exports to keep a track of how much time they take to run and show it on the listing in case the user has support toggle enabled.

Follow Up PR:
Use last run time to predict export run time and take actions accordingly in terms of celery queue performance