### PR TITLE
remove unused arg

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -415,7 +415,7 @@ class AutoPayInvoicePaymentHandler(object):
                     description='Auto-payment for Invoice %s' % invoice.invoice_number,
                 )
         except stripe.error.CardError as e:
-            self._handle_card_declined(invoice, payment_method, e)
+            self._handle_card_declined(invoice, e)
         except payment_method.STRIPE_GENERIC_ERROR as e:
             self._handle_card_errors(invoice, e)
         else:
@@ -443,7 +443,7 @@ class AutoPayInvoicePaymentHandler(object):
             self._handle_email_failure(payment_record)
 
     @staticmethod
-    def _handle_card_declined(invoice, payment_method, e):
+    def _handle_card_declined(invoice, e):
         from corehq.apps.accounting.tasks import send_autopay_failed
 
         # https://stripe.com/docs/api/python#error_handling
@@ -457,7 +457,7 @@ class AutoPayInvoicePaymentHandler(object):
             "error = {error}"
             .format(invoice=invoice.id, domain=invoice.get_domain(), error=err)
         )
-        send_autopay_failed.delay(invoice, payment_method)
+        send_autopay_failed.delay(invoice)
 
     @staticmethod
     def _handle_card_errors(invoice, e):

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -477,7 +477,7 @@ def send_purchase_receipt(payment_record, domain,
 
 
 @task(serializer='pickle', queue='background_queue', ignore_result=True, acks_late=True)
-def send_autopay_failed(invoice, payment_method):
+def send_autopay_failed(invoice):
     subscription = invoice.subscription
     auto_payer = subscription.account.auto_pay_user
     payment_method = StripePaymentMethod.objects.get(web_user=auto_payer)


### PR DESCRIPTION
There shouldn't be any ```send_autopay_failed``` tasks enqueued until at least the end of the month, so I'm not worried about any existing tasks in the queue failing due to the function signature changing.