### PR TITLE
Optimized person case UCR data source 

### DIFF
--- a/custom/icds_reports/management/commands/migrate_person_cases_ucr.py
+++ b/custom/icds_reports/management/commands/migrate_person_cases_ucr.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import, print_function
+
+from __future__ import unicode_literals
+
+from django.core.management.base import BaseCommand
+
+from django.db import connections
+from corehq.apps.locations.models import SQLLocation
+from corehq.sql_db.routers import db_for_read_write
+from custom.icds_reports.models import ChildHealthMonthly
+
+
+FROM_TABLENAME = "config_report_icds-cas_static-person_cases_v2_b4b5d57a"
+TO_TABLENAME = "config_report_icds-cas_static-person_cases_v3_2ae0879a"
+
+
+def get_cursor(model):
+    db = db_for_read_write(model)
+    return connections[db].cursor()
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        columns = (
+            # person_v3, calculation from person_v2
+            ("awc_id", ),
+            ("supervisor_id", ),
+            ("block_id", ),
+            ("district_id", ),
+            ("state_id", ),
+            ("opened_on", ),
+            ("closed_on", ),
+            ("name", ),
+            ("sex", ),
+            ("dob", ),
+            ("age_at_reg", ),
+            ("date_death", ),
+            ("resident", "CASE WHEN resident = 'yes' THEN 1 WHEN resident = 'no' THEN 0 ELSE NULL END"),
+            ("age_at_death_yrs", ),
+            ("female_death_type", ),
+            ("referral_health_problem", ),
+            ("last_referral_date", ),
+            ("referral_reached_date", ),
+            ("hh_caste",
+                "CASE WHEN F_sc_count = 1 OR M_sc_count = 1 THEN 'sc'"
+                "     WHEN F_st_count = 1 OR M_st_count = 1 THEN 'st'"
+                "     ELSE NULL END"),
+            ("hh_minority", "CASE WHEN F_minority_count = 1 OR M_minority_count = 1 THEN 1 ELSE NULL END"),
+            ("disabled", "CASE WHEN F_disabled_count = 1 OR M_disabled_count = 1 THEN 1 ELSE NULL END"),
+            ("disability_type", "CONCAT_WS(' ', "
+                "CASE WHEN disability_type_1 = 1 THEN 1 ELSE NULL END, "
+                "CASE WHEN disability_type_2 = 1 THEN 2 ELSE NULL END, "
+                "CASE WHEN disability_type_3 = 1 THEN 3 ELSE NULL END, "
+                "CASE WHEN disability_type_4 = 1 THEN 4 ELSE NULL END, "
+                "CASE WHEN disability_type_5 = 1 THEN 5 ELSE NULL END, "
+                "CASE WHEN disability_type_6 = 1 THEN 6 ELSE NULL END "
+                ")"),
+            ("registered_status",
+                "CASE WHEN seeking_services = 1 THEN NULL"
+                "     WHEN seeking_services = 0 AND not_migrated = 1 THEN 0"
+                "     ELSE NULL END"),
+            ("migration_status", "CASE WHEN not_migrated = 0 THEN 1 ELSE NULL END"),
+            ("aadhar_date", ),
+            ("age_marriage", ),
+            ("is_pregnant",
+                "CASE WHEN pregnant_resident_count = 1 OR pregnant_migrant_count = 1 THEN 1 ELSE NULL END"),
+            ("marital_status", ),
+            # may need to remove if https://github.com/dimagi/commcare-hq/pull/22247 hasn't been merged
+            ("phone_number", ),
+        )
+        query_columns = [
+            "{} AS {}".format(col[0] if len(col) == 1 else col[1], col[0])
+            for col in columns
+        ]
+
+        blocks = SQLLocation.objects.filter(domain='icds-cas', location_type__name='block')
+        for block in blocks:
+            block_id = block.location_id
+            state = block.get_ancestor_of_type('state')
+            state_id = state.location_id
+
+            with get_cursor(ChildHealthMonthly) as cursor:
+                query_args = {'state_id': state_id, 'block_id': block_id, 'state_id_last_3': state_id[-3:]}
+                cursor.execute(
+                    "INSERT INTO \"{to_tablename}\" "
+                    "SELECT {columns} "
+                    "FROM \"{from_tablename}\" "
+                    "WHERE state_id = %(state_id)s "
+                    "AND lower(substring(state_id, '.{{3}}$'::text)) = %(state_id_last_3)s "
+                    "AND block_id = %(block_id)s".format(
+                        to_tablename=TO_TABLENAME,
+                        from_tablename=FROM_TABLENAME,
+                        columns=", \n".join(query_columns)
+                    ), query_args)

--- a/custom/icds_reports/management/commands/migrate_person_cases_ucr.py
+++ b/custom/icds_reports/management/commands/migrate_person_cases_ucr.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand
 from django.db import connections
 from corehq.apps.locations.models import SQLLocation
 from corehq.sql_db.routers import db_for_read_write
+from corehq.util.log import with_progress_bar
 from custom.icds_reports.models import ChildHealthMonthly
 
 
@@ -74,7 +75,7 @@ class Command(BaseCommand):
         ]
 
         blocks = SQLLocation.objects.filter(domain='icds-cas', location_type__name='block')
-        for block in blocks:
+        for block in with_progress_bar(blocks, blocks.count()):
             block_id = block.location_id
             state = block.get_ancestor_of_type('state')
             state_id = state.location_id

--- a/custom/icds_reports/ucr/data_sources/person_cases_v3.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v3.json
@@ -1,0 +1,485 @@
+{
+  "domains": [
+    "reach-test",
+    "icds-dashboard-qa",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "config": {
+    "table_id": "static-person_cases_v3",
+    "display_name": "Cases - Person v3 (Static)",
+    "referenced_doc_type": "CommCareCase",
+    "description": "",
+    "base_item_expression": {},
+    "configured_filter": {
+      "operator": "eq",
+      "type": "boolean_expression",
+      "expression": {
+        "type": "property_name",
+        "property_name": "type"
+      },
+      "property_value": "person"
+    },
+    "configured_indicators": [
+      {
+        "column_id": "awc_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "datatype": null,
+          "type": "property_name",
+          "property_name": "owner_id"
+        },
+        "create_index": true
+      },
+      {
+        "column_id": "supervisor_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "ancestor_location",
+          "location_id": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "location_type": "supervisor",
+          "location_property": "_id"
+        },
+        "create_index": true
+      },
+      {
+        "column_id": "block_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "ancestor_location",
+          "location_id": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "location_type": "block",
+          "location_property": "_id"
+        },
+        "create_index": true
+      },
+      {
+        "column_id": "district_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "ancestor_location",
+          "location_id": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "location_type": "district",
+          "location_property": "_id"
+        }
+      },
+      {
+        "column_id": "state_id",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "ancestor_location",
+          "location_id": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "location_type": "state",
+          "location_property": "_id"
+        }
+      },
+      {
+        "column_id": "opened_on",
+        "datatype": "datetime",
+        "type": "raw",
+        "property_name": "opened_on"
+      },
+      {
+        "column_id": "closed_on",
+        "datatype": "datetime",
+        "type": "raw",
+        "property_name": "closed_on"
+      },
+      {
+        "column_id": "name",
+        "datatype": "string",
+        "type": "raw",
+        "property_name": "name"
+      },
+      {
+        "column_id": "sex",
+        "datatype": "string",
+        "type": "raw",
+        "property_name": "sex"
+      },
+      {
+        "column_id": "dob",
+        "datatype": "date",
+        "type": "raw",
+        "property_name": "dob"
+      },
+      {
+        "comment": "This is the age at registration in years",
+        "column_id": "age_at_reg",
+        "datatype": "small_integer",
+        "type": "raw",
+        "property_name": "age_at_reg"
+      },
+      {
+        "column_id": "date_death",
+        "datatype": "date",
+        "type": "raw",
+        "property_name": "date_death"
+      },
+      {
+        "column_id": "resident",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "switch",
+          "switch_on": {
+            "type": "property_name",
+            "property_name": "resident"
+          },
+          "cases": {
+            "no": {
+              "type": "constant",
+              "constant": 0
+            },
+            "yes": {
+              "type": "constant",
+              "constant": 1
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": null
+          }
+        }
+      },
+      {
+        "column_id": "age_at_death_yrs",
+        "datatype": "small_integer",
+        "type": "raw",
+        "property_name": "age_at_death_yrs"
+      },
+      {
+        "column_id": "female_death_type",
+        "datatype": "string",
+        "type": "raw",
+        "property_name": "female_death_type"
+      },
+      {
+        "column_id": "referral_health_problem",
+        "datatype": "string",
+        "type": "raw",
+        "property_name": "referral_health_problem"
+      },
+      {
+        "column_id": "last_referral_date",
+        "datatype": "date",
+        "type": "raw",
+        "property_name": "last_referral_date"
+      },
+      {
+        "column_id": "referral_reached_date",
+        "datatype": "date",
+        "type": "raw",
+        "property_name": "referral_reached_date"
+      },
+      {
+        "column_id": "hh_caste",
+        "datatype": "string",
+        "type": "expression",
+        "expression": {
+          "type": "related_doc",
+          "related_doc_type": "CommCareCase",
+          "doc_id_expression": {
+            "type": "icds_parent_id"
+          },
+          "value_expression": {
+            "type": "property_name",
+            "property_name": "hh_caste"
+          }
+        }
+      },
+      {
+        "column_id": "hh_minority",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "switch",
+          "switch_on": {
+            "type": "related_doc",
+            "related_doc_type": "CommCareCase",
+            "doc_id_expression": {
+              "type": "icds_parent_id"
+            },
+            "value_expression": {
+              "type": "property_name",
+              "property_name": "hh_minority"
+            }
+          },
+          "cases": {
+            "no": {
+              "type": "constant",
+              "constant": 0
+            },
+            "yes": {
+              "type": "constant",
+              "constant": 1
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": null
+          }
+        }
+      },
+      {
+        "column_id": "disabled",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "switch",
+          "switch_on": {
+            "type": "property_name",
+            "property_name": "disabled"
+          },
+          "cases": {
+            "no": {
+              "type": "constant",
+              "constant": 0
+            },
+            "yes": {
+              "type": "constant",
+              "constant": 1
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": null
+          }
+        }
+      },
+      {
+        "column_id": "disability_type",
+        "datatype": "string",
+        "type": "raw",
+        "property_name": "disability_type"
+      },
+      {
+        "column_id": "registered_status",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "switch",
+          "switch_on": {
+            "type": "property_name",
+            "property_name": "registered_status"
+          },
+          "cases": {
+            "not_registered": {
+              "type": "constant",
+              "constant": 0
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": null
+          }
+        }
+      },
+      {
+        "column_id": "migration_status",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "switch",
+          "switch_on": {
+            "type": "property_name",
+            "property_name": "migration_status"
+          },
+          "cases": {
+            "migrated": {
+              "type": "constant",
+              "constant": 1
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": null
+          }
+        }
+      },
+      {
+        "column_id": "aadhar_date",
+        "type": "expression",
+        "datatype": "date",
+        "expression": {
+          "type": "conditional",
+          "test": {
+            "type": "not",
+            "filter": {
+              "operator": "in",
+              "type": "boolean_expression",
+              "expression": {
+                "type": "property_name",
+                "property_name": "aadhar_number"
+              },
+              "property_value": [
+                "",
+                null
+              ]
+            }
+          },
+          "expression_if_true": {
+            "type": "coalesce",
+            "expression": {
+              "type": "property_name",
+              "property_name": "aadhar_date"
+            },
+            "default_expression": {
+              "type": "nested",
+              "argument_expression": {
+                "type": "reduce_items",
+                "aggregation_fn": "first_item",
+                "items_expression": {
+                  "type": "filter_items",
+                  "items_expression": {
+                    "type": "icds_get_case_history_by_date",
+                    "xmlns": [
+                      "http://openrosa.org/formdesigner/1D568275-1D19-46DB-8C54-2C9765DF6335",
+                      "http://openrosa.org/formdesigner/756ec44475658f3f463f8012632def2bc9fbe731",
+                      "http://openrosa.org/formdesigner/991c712a8588b52505d50a6f2262ca962a85e21c"
+                    ]
+                  },
+                  "filter_expression": {
+                    "type": "not",
+                    "filter": {
+                      "operator": "in",
+                      "type": "boolean_expression",
+                      "expression": {
+                        "type": "property_path",
+                        "property_path": [
+                          "update",
+                          "aadhar_number"
+                        ]
+                      },
+                      "property_value": [
+                        "",
+                        null
+                      ]
+                    }
+                  }
+                }
+              },
+              "value_expression": {
+                "type": "property_name",
+                "property_name": "@date_modified"
+              }
+            }
+          },
+          "expression_if_false": {
+            "type": "property_name",
+            "property_name": "no_exist"
+          }
+        }
+      },
+      {
+        "column_id": "age_marriage",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "age_marriage"
+        }
+      },
+      {
+        "column_id": "is_pregnant",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "switch",
+          "switch_on": {
+            "type": "property_name",
+            "property_name": "is_pregnant"
+          },
+          "cases": {
+            "no": {
+              "type": "constant",
+              "constant": 0
+            },
+            "yes": {
+              "type": "constant",
+              "constant": 1
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": null
+          }
+        }
+      },
+      {
+        "column_id": "marital_status",
+        "datatype": "small_integer",
+        "type": "expression",
+        "expression": {
+          "type": "switch",
+          "switch_on": {
+            "type": "property_name",
+            "property_name": "marital_status"
+          },
+          "cases": {
+            "married": {
+              "type": "constant",
+              "constant": 1
+            },
+            "other": {
+              "type": "constant",
+              "constant": 0
+            }
+          },
+          "default": {
+            "type": "constant",
+            "constant": null
+          }
+        }
+      },
+      {
+        "column_id": "phone_number",
+        "datatype": "string",
+        "type": "raw",
+        "property_name": "phone_number"
+        }
+      }
+    ],
+    "named_expressions": {},
+    "named_filters": {},
+    "engine_id": "icds-ucr",
+    "sql_settings": {
+      "partition_config": [
+        {
+          "column": "state_id",
+          "subtype": "string_lastchars",
+          "constraint": "3"
+        }
+      ]
+    },
+    "sql_column_indexes": [
+      {
+        "column_ids": [
+          "opened_on",
+          "closed_on"
+        ]
+      }
+    ],
+    "disable_destructive_rebuild": true
+  }
+}

--- a/custom/icds_reports/ucr/data_sources/person_cases_v3.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v3.json
@@ -457,7 +457,6 @@
         "datatype": "string",
         "type": "raw",
         "property_name": "phone_number"
-        }
       }
     ],
     "named_expressions": {},

--- a/custom/icds_reports/ucr/reports/testing/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/testing/asr_2_3_beneficiaries.json
@@ -1,0 +1,266 @@
+{
+  "domains": [
+    "icds-cas",
+    "icds-dashboard-qa",
+    "reach-test"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-asr_2_3_beneficiaries-optimized",
+  "data_source_table": "static-person_cases_v3",
+  "config": {
+    "title": "ASR 2,3 - Beneficiaries (Static) (optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id",
+      "age_group"
+    ],
+    "filters": [
+      {
+        "display": "Date of Birth",
+        "slug": "dob",
+        "type": "date",
+        "field": "dob",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Age Group",
+        "column_id": "age_group",
+        "type": "conditional_aggregation",
+        "whens": {
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 0 and 5": "0_to_5",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 6 and 11": "6_to_11",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 12 and 35": "12_to_35",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 36 and 59": "36_to_59",
+          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 60 and 71": "60_to_71"
+        }
+      },
+      {
+        "display": "open_count",
+        "column_id": "open_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL": 1
+        }
+      },
+      {
+        "display": "F_st_count",
+        "column_id": "F_st_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_caste = 'st'": 1
+        }
+      },
+      {
+        "display": "F_sc_count",
+        "column_id": "F_sc_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'": 1
+        }
+      },
+      {
+        "display": "F_other_count",
+        "column_id": "F_other_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('sc', 'st')": 1
+        }
+      },
+      {
+        "display": "F_minority_count",
+        "column_id": "F_minority_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_minority = 1": 1
+        }
+      },
+      {
+        "display": "F_disabled_count",
+        "column_id": "F_disabled_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and disabled = 1": 1
+        }
+      },
+      {
+        "display": "M_st_count",
+        "column_id": "M_st_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'": 1
+        }
+      },
+      {
+        "display": "M_sc_count",
+        "column_id": "M_sc_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'": 1
+        }
+      },
+      {
+        "display": "M_other_count",
+        "column_id": "M_other_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('sc', 'st')": 1
+        }
+      },
+      {
+        "display": "M_minority_count",
+        "column_id": "M_minority_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1": 1
+        }
+      },
+      {
+        "display": "M_disabled_count",
+        "column_id": "M_disabled_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', '0') and disabled = 1": 1
+        }
+      },
+      {
+        "display": "disabled_movement_count",
+        "column_id": "disabled_movement_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y1\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_mental_count",
+        "column_id": "disabled_mental_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y2\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_seeing_count",
+        "column_id": "disabled_seeing_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y3\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_hearing_count",
+        "column_id": "disabled_hearing_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y4\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_speaking_count",
+        "column_id": "disabled_speaking_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y5\\y'": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/asr_2_3_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/asr_2_3_person_cases.json
@@ -1,0 +1,253 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-test",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-asr_2_3_person_cases-optimized",
+  "data_source_table": "static-person_cases_v3",
+  "config": {
+    "title": "ASR - 2,3 - Person Cases (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "display": "Date of Birth",
+        "slug": "dob",
+        "type": "date",
+        "field": "dob",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "open_count",
+        "column_id": "open_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL": 1
+        }
+      },
+      {
+        "display": "F_st_count",
+        "column_id": "F_st_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_caste = 'st'": 1
+        }
+      },
+      {
+        "display": "F_sc_count",
+        "column_id": "F_sc_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'": 1
+        }
+      },
+      {
+        "display": "F_other_count",
+        "column_id": "F_other_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('st', 'sc')": 1
+        }
+      },
+      {
+        "display": "F_minority_count",
+        "column_id": "F_minority_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and hh_minority = 1": 1
+        }
+      },
+      {
+        "display": "F_disabled_count",
+        "column_id": "F_disabled_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex = 'F' and disabled = 1": 1
+        }
+      },
+      {
+        "display": "M_st_count",
+        "column_id": "M_st_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'": 1
+        }
+      },
+      {
+        "display": "M_sc_count",
+        "column_id": "M_sc_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'": 1
+        }
+      },
+      {
+        "display": "M_other_count",
+        "column_id": "M_other_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('st', 'sc')": 1
+        }
+      },
+      {
+        "display": "M_minority_count",
+        "column_id": "M_minority_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1": 1
+        }
+      },
+      {
+        "display": "M_disabled_count",
+        "column_id": "M_disabled_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND sex IN ('M', '0') and disabled = 1": 1
+        }
+      },
+      {
+        "display": "disabled_movement_count",
+        "column_id": "disabled_movement_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y1\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_mental_count",
+        "column_id": "disabled_mental_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y2\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_seeing_count",
+        "column_id": "disabled_seeing_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y3\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_hearing_count",
+        "column_id": "disabled_hearing_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type ~ '\\y4\\y'": 1
+        }
+      },
+      {
+        "display": "disabled_speaking_count",
+        "column_id": "disabled_speaking_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND disability_type '\\y5\\y'": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_3i_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_3i_person_cases.json
@@ -1,0 +1,113 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-test",
+    "icds-cas"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_3i_person_cases-optimized",
+  "data_source_table": "static-person_cases_v3",
+  "config": {
+    "title": "MPR - 3i - Person cases (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "display": "Date Case Opened",
+        "slug": "opened_on",
+        "type": "date",
+        "field": "opened_on",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "pregnant_resident_count",
+        "column_id": "pregnant_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident = 1": 1
+        }
+      },
+      {
+        "display": "pregnant_migrant_count",
+        "column_id": "pregnant_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident != 1": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_3i_pregnancies.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_3i_pregnancies.json
@@ -1,0 +1,121 @@
+{
+  "domains": [
+    "icds-cas",
+    "icds-dashboard-qa",
+    "reach-test"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_3i_pregnancies-optimized",
+  "data_source_table": "static-person_cases_v3",
+  "config": {
+    "title": "MPR 3i - Pregnancies Registered (Static) (Optimized)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id",
+      "month"
+    ],
+    "filters": [
+      {
+        "display": "Date Case Opened",
+        "slug": "opened_on",
+        "type": "date",
+        "field": "opened_on",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "opened_on",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "pregnant_resident_count",
+        "column_id": "pregnant_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident = 1": 1
+        }
+      },
+      {
+        "display": "pregnant_migrant_count",
+        "column_id": "pregnant_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident != 1": 1
+        }
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/settings.py
+++ b/settings.py
@@ -1947,6 +1947,7 @@ STATIC_DATA_SOURCES = [
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'it_report_follow_issue.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'ls_home_visit_forms_filled.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'person_cases_v2.json'),
+    os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'person_cases_v3.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'tasks_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'tech_issue_cases.json'),
     os.path.join('custom', 'icds_reports', 'ucr', 'data_sources', 'thr_forms_v2.json'),


### PR DESCRIPTION
I've gone through all the UCR reports and aggregation and believe that this will cover everything we need for reports in a more efficient and easier to parse format. **This new table has 73 fewer columns**

All of the reports I have written in  https://github.com/dimagi/commcare-hq/pull/22165 should be compatible with this new data source by just flipping it from v2 to v3, which will be done after the testing detailed in that PR. All the reports here are dependent on the v3 table. 

Rollout for this data source is going to look like this:

- [x] deploy this PR
- [x] stop pillows
- [x] run the migration in this PR to put data into person case v3
- [x] update the pillow's config to include this new data source
- [x] start pillows
- [x] include these reports in the laboratory config for comparing out UCR reports
- [ ] verify that the reports are returning the same data vai the laboratory tests and fix any bugs
- [ ] change the UCRs that depend on v2 to depend on v3, and remove the laboratory tests
- [x] Update the aggregation script to depend on v3 instead of v2
- [ ] Remove person case v2 data source

May want to add household_case_id in the future, but nothing would be using it right now and its not in the current person_case_v2 ucr

Possibly interested parties: @snopoke @esoergel @calellowitz 

The commit history here is the result of rebasing https://github.com/dimagi/commcare-hq/compare/je/new-person-cases into fewer commits. I did this because I felt like that commit history wasn't super useful as there was some back and forth during development, but if you're interested in some more granular commits then feel free to peruse that.