### PR TITLE
Profile more build operations

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1082,6 +1082,10 @@ class FormBase(DocumentSchema):
     def is_a_disabled_release_form(self):
         return self.is_release_notes_form and not self.enable_release_notes
 
+    @property
+    def timing_context(self):
+        return self.get_app().timing_context
+
     def validate_for_build(self, validate_module=True):
         errors = []
 
@@ -1151,7 +1155,8 @@ class FormBase(DocumentSchema):
 
         # this isn't great but two of FormBase's subclasses have form_filter
         if hasattr(self, 'form_filter') and self.form_filter:
-            is_valid, message = validate_xpath(self.form_filter, allow_case_hashtags=True)
+            with self.timing_context("validate_xpath"):
+                is_valid, message = validate_xpath(self.form_filter, allow_case_hashtags=True)
             if not is_valid:
                 error = {
                     'type': 'form filter has xpath error',
@@ -1202,6 +1207,7 @@ class FormBase(DocumentSchema):
         self.add_stuff_to_xform(xform, build_profile_id)
         return xform.render()
 
+    @time_method()
     @quickcache(['self.source', 'langs', 'include_triggers', 'include_groups', 'include_translations'])
     def get_questions(self, langs, include_triggers=False,
                       include_groups=False, include_translations=False):
@@ -1864,6 +1870,7 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
     def uses_usercase(self):
         return actions_use_usercase(self.active_actions())
 
+    @time_method()
     def extended_build_validation(self, error_meta, xml_valid, validate_module=True):
         errors = []
         if xml_valid:
@@ -3217,6 +3224,7 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
 
         return errors
 
+    @time_method()
     def extended_build_validation(self, error_meta, xml_valid, validate_module=True):
         errors = []
         if xml_valid:
@@ -3422,6 +3430,7 @@ class ShadowForm(AdvancedForm):
             open_cases=source_actions.open_cases,  # Shadow form is not allowed to specify any open case actions
         )
 
+    @time_method()
     def extended_build_validation(self, error_meta, xml_valid, validate_module=True):
         errors = super(ShadowForm, self).extended_build_validation(error_meta, xml_valid, validate_module)
         if not self.shadow_parent_form_id:

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -147,11 +147,12 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
                     file_compression = zipfile.ZIP_STORED if extension in MULTIMEDIA_EXTENSIONS else compression
                     z.writestr(path, data, file_compression)
 
-    common_kwargs = dict(
-        mimetype='application/zip' if compress_zip else 'application/x-zip-compressed',
-        content_disposition='attachment; filename="{fname}"'.format(fname=filename),
-        download_id=download_id, expiry=(1 * 60 * 60)
-    )
+    common_kwargs = {
+        'mimetype': 'application/zip' if compress_zip else 'application/x-zip-compressed',
+        'content_disposition': 'attachment; filename="{fname}"'.format(fname=filename),
+        'download_id': download_id,
+        'expiry': (1 * 60 * 60),
+    }
     if use_transfer:
         expose_file_download(
             fpath,


### PR DESCRIPTION
`_check_forms` takes up something like half of the overall build time.  This drills in to that a little more.  I'm becoming increasingly convinced that `XForm(self.source).get_questions` is the biggest issue - this addition should help validate/refute that.  `validate_xform` is also a strong contender.

It will make the app build timings page pretty verbose, however.  I'd like to walk some of this back after finding and addressing these issues.