### PR TITLE
fix corehq.motech.repeaters.tests.test_repeater:FormRepeaterTest.test…

### DIFF
--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -367,8 +367,7 @@ class XFormInstanceSQL(PartitionedModel, models.Model, RedisLockableMixIn, Attac
         if not xml:
             return None
 
-        if isinstance(xml, six.text_type):
-            xml = xml.encode('utf-8', errors='replace')
+        xml = xml.encode('utf-8', errors='replace')
 
         return etree.fromstring(xml)
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -316,7 +316,7 @@ class XFormInstanceSQL(PartitionedModel, models.Model, RedisLockableMixIn, Attac
         from corehq.form_processor.utils.metadata import scrub_form_meta
         xml = self.get_xml()
         try:
-            form_json = convert_xform_to_json(xml)
+            form_json = convert_xform_to_json(xml.encode('utf-8'))
         except XMLSyntaxError:
             return {}
         # we can assume all sql domains are new timezone domains

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -382,7 +382,7 @@ class XFormInstanceSQL(PartitionedModel, models.Model, RedisLockableMixIn, Attac
 
     @memoized
     def get_xml(self):
-        return self.get_attachment('form.xml')
+        return self.get_attachment('form.xml').decode('utf-8')
 
     def xml_md5(self):
         return self.get_attachment_meta('form.xml').md5

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -367,7 +367,7 @@ class XFormInstanceSQL(PartitionedModel, models.Model, RedisLockableMixIn, Attac
         if not xml:
             return None
 
-        xml = xml.encode('utf-8', errors='replace')
+        xml = xml.encode('utf-8')
 
         return etree.fromstring(xml)
 


### PR DESCRIPTION
…_payload

```XFormInstanceSQL.get_xml()``` should return unicode, just like ```XFormInstance```.