### PR TITLE
Add view to preindex plugin

### DIFF
--- a/corehq/couchapps/__init__.py
+++ b/corehq/couchapps/__init__.py
@@ -8,6 +8,7 @@ CouchAppsPreindexPlugin.register('couchapps', __file__, {
     'schemas_by_xmlns_or_case_type': 'meta',
     'export_instances_by_domain': 'meta',
     'export_instances_by_is_daily_saved': 'meta',
+    'active_data_sources': 'meta',
     'receiverwrapper': 'receiverwrapper',
     'users_extra': (settings.USERS_GROUPS_DB, settings.NEW_USERS_GROUPS_DB),
     'deleted_users_by_username': settings.USERS_GROUPS_DB,


### PR DESCRIPTION
add view introduced https://github.com/dimagi/commcare-hq/pull/22251/files

Would this have caused any issue during this time when the new view was added but was not added there and hence there is a need to reindex it again separately?