### PR TITLE
move reconciliation out of transaction

### DIFF
--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -145,15 +145,18 @@ class FormProcessorSQL(object):
             FormAccessorSQL.save_new_form(processed_forms.submitted)
             if cases:
                 for case in cases:
-                    if toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL.enabled(
-                            case.domain, toggles.NAMESPACE_DOMAIN):
-                        SqlCaseUpdateStrategy(case).reconcile_transactions_if_necessary()
-
                     CaseAccessorSQL.save_case(case)
 
             if stock_result:
                 ledgers_to_save = stock_result.models_to_save
                 LedgerAccessorSQL.save_ledger_values(ledgers_to_save, stock_result)
+
+        if cases:
+            for case in cases:
+                if toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL.enabled(
+                        case.domain, toggles.NAMESPACE_DOMAIN):
+                    SqlCaseUpdateStrategy(case).reconcile_transactions_if_necessary()
+                    CaseAccessorSQL.save_case(case)
 
         if publish_to_kafka:
             try:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -152,9 +152,10 @@ class FormProcessorSQL(object):
                 LedgerAccessorSQL.save_ledger_values(ledgers_to_save, stock_result)
 
         if cases:
-            for case in cases:
-                if toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL.enabled(
-                        case.domain, toggles.NAMESPACE_DOMAIN):
+            sort_submissions = toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL.enabled(
+                processed_forms.submitted.domain, toggles.NAMESPACE_DOMAIN)
+            if sort_submissions:
+                for case in cases:
                     SqlCaseUpdateStrategy(case).reconcile_transactions_if_necessary()
                     CaseAccessorSQL.save_case(case)
 


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/22341#issuecomment-437279281 yeah, this seems to work as well, although i'm not enthused by the call to `toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL` for each case. can i assume here that each case will have the same domain? or is it worth checking what domains exist and what have it set to true beforehand?

@snopoke @millerdev buddy: @orangejenny 