### PR TITLE
IPM-senegal: Add a missing args to the function input

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2592,7 +2592,7 @@ class ModuleBase(IndexedSchema, NavMenuItemMediaMixin, CommentMixin):
                 domain = self.get_app().domain
                 project = Domain.get_by_name(domain)
                 try:
-                    if not should_sync_hierarchical_fixture(project):
+                    if not should_sync_hierarchical_fixture(project, self.get_app()):
                         # discontinued feature on moving to flat fixture format
                         raise LocationXpathValidationError(
                             _('That format is no longer supported. To reference the location hierarchy you need to'


### PR DESCRIPTION
[Sentry error](https://sentry.io/dimagi/commcarehq/issues/761100692/?environment=production)
[Zendesk error](https://dimagi.zendesk.com/agent/tickets/5826)

Cause of the error: a function called by the (deprecated) feature flag `HIERARCHICAL_LOCATION_FIXTURE` did not have all the required input args.

@emord 
code buddy @sravfeyn 

