### PR TITLE
remove old soft_asserts

### DIFF
--- a/corehq/ex-submodules/dimagi/ext/couchdbkit.py
+++ b/corehq/ex-submodules/dimagi/ext/couchdbkit.py
@@ -5,8 +5,6 @@ from dimagi.ext.jsonobject import USecDateTimeMeta, \
     DateTimeProperty, OldDateTimeProperty
 from dimagi.utils.couch.database import SafeSaveDocument
 
-from corehq.util.soft_assert import soft_assert
-
 __all__ = [
     'Property', 'StringProperty', 'IntegerProperty',
     'DecimalProperty', 'BooleanProperty', 'FloatProperty',
@@ -28,26 +26,8 @@ OldSafeSaveDocument = SafeSaveDocument
 DateTimeProperty = DateTimeProperty
 
 
-_couch_attachment_soft_assert = soft_assert(
-    to='{}@{}'.format('npellegrino', 'dimagi.com'),
-    exponential_backoff=False,
-)
-
-
 class Document(OldDocument):
     Meta = USecDateTimeMeta
-
-    def put_attachment(self, *args, **kwargs):
-        _couch_attachment_soft_assert(False, 'Document.put_attachment was called')
-        super(Document, self).put_attachment(*args, **kwargs)
-
-    def fetch_attachment(self, *args, **kwargs):
-        _couch_attachment_soft_assert(False, 'Document.fetch_attachment was called')
-        super(Document, self).fetch_attachment(*args, **kwargs)
-
-    def delete_attachment(self, *args, **kwargs):
-        _couch_attachment_soft_assert(False, 'Document.delete_attachment was called')
-        super(Document, self).delete_attachment(*args, **kwargs)
 
 
 class DocumentSchema(OldDocumentSchema):
@@ -56,18 +36,6 @@ class DocumentSchema(OldDocumentSchema):
 
 class SafeSaveDocument(OldSafeSaveDocument):
     Meta = USecDateTimeMeta
-
-    def put_attachment(self, *args, **kwargs):
-        _couch_attachment_soft_assert(False, 'SafeSaveDocument.put_attachment was called')
-        super(SafeSaveDocument, self).put_attachment(*args, **kwargs)
-
-    def fetch_attachment(self, *args, **kwargs):
-        _couch_attachment_soft_assert(False, 'SafeSaveDocument.fetch_attachment was called')
-        super(SafeSaveDocument, self).fetch_attachment(*args, **kwargs)
-
-    def delete_attachment(self, *args, **kwargs):
-        _couch_attachment_soft_assert(False, 'SafeSaveDocument.delete_attachment was called')
-        super(SafeSaveDocument, self).delete_attachment(*args, **kwargs)
 
 
 # A formatter configured in HQ settings (`couch-request-formatter`) logs


### PR DESCRIPTION
These were used when we were getting off of restkit, but are no longer needed.