### PR TITLE
use unicode for couch config

### DIFF
--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -100,10 +100,10 @@ COUCH_DATABASES = {
     'default': {
         # for production this ought to be set to true on your configured couch instance
         'COUCH_HTTPS': False,
-        'COUCH_SERVER_ROOT': b'couch:5984',  # 6984 for https couch
+        'COUCH_SERVER_ROOT': 'couch:5984',  # 6984 for https couch
         'COUCH_USERNAME': '',
         'COUCH_PASSWORD': '',
-        'COUCH_DATABASE_NAME': b'commcarehq'
+        'COUCH_DATABASE_NAME': 'commcarehq'
     }
 }
 

--- a/settings.py
+++ b/settings.py
@@ -939,11 +939,6 @@ except ImportError as error:
     from dev_settings import *
 
 
-COUCH_DATABASES['default'] = {
-    k: v.encode('utf-8') if isinstance(v, six.text_type) else v
-    for (k, v) in COUCH_DATABASES['default'].items()
-}
-
 # Unless DISABLE_SERVER_SIDE_CURSORS has explicitly been set, default to True because Django >= 1.11.1 and our
 # hosting environments use pgBouncer with transaction pooling. For more information, see:
 # https://docs.djangoproject.com/en/1.11/releases/1.11.1/#allowed-disabling-server-side-cursors-on-postgresql


### PR DESCRIPTION
I think we needed bytes when we were on restkit - but now that we are off of it, we can use unicode the entire time