### PR TITLE
improve efficiency of case export schema build

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -310,7 +310,7 @@ def get_built_app_ids_with_submissions_for_app_id(domain, app_id, version=None):
     return [result['id'] for result in results]
 
 
-def get_built_app_ids_with_submissions_for_app_ids_and_versions(domain, app_ids_and_versions=None):
+def get_built_app_ids_with_submissions_for_app_ids_and_versions(domain, app_ids, app_ids_and_versions=None):
     """
     Returns all the built app_ids for a domain that has submissions.
     If version is specified returns all apps after that version.
@@ -318,7 +318,6 @@ def get_built_app_ids_with_submissions_for_app_ids_and_versions(domain, app_ids_
     :app_ids_and_versions: A dictionary mapping an app_id to build version
     """
     app_ids_and_versions = app_ids_and_versions or {}
-    app_ids = get_app_ids_in_domain(domain)
     results = []
     for app_id in app_ids:
         results.extend(

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1228,12 +1228,14 @@ class FormBase(DocumentSchema):
         The returned function requires two arguments
         `(case_property_name, data_path)` and returns a string.
         """
-        try:
-            valid_paths = {question['value']: question['tag']
-                           for question in self.get_questions(langs=[])}
-        except XFormException as e:
-            # punt on invalid xml (sorry, no rich attachments)
-            valid_paths = {}
+        valid_paths = {}
+        if toggles.MM_CASE_PROPERTIES.enabled(self.get_app().domain):
+            try:
+                valid_paths = {question['value']: question['tag']
+                               for question in self.get_questions(langs=[])}
+            except XFormException as e:
+                # punt on invalid xml (sorry, no rich attachments)
+                valid_paths = {}
 
         def format_key(key, path):
             if valid_paths.get(path) == "upload":

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -157,14 +157,16 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         self.assertEqual(len(app_ids), 0)  # Should skip the one that has_submissions
 
     def test_get_built_app_ids_with_submissions_for_app_ids_and_versions(self):
+        app_ids_in_domain = get_apps_in_domain(self.domain)
         app_ids = get_built_app_ids_with_submissions_for_app_ids_and_versions(
             self.domain,
+            app_ids_in_domain,
             {self.apps[0]._id: self.first_saved_version},
         )
         self.assertEqual(len(app_ids), 0)  # Should skip the one that has_submissions
 
         app_ids = get_built_app_ids_with_submissions_for_app_ids_and_versions(
-            self.domain,
+            self.domain, app_ids_in_domain
         )
         self.assertEqual(len(app_ids), 1)  # Should get the one that has_submissions
 

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -18,7 +18,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_app_ids_and_versions,
     get_latest_released_app_doc,
     get_apps_by_id,
-    get_brief_app, get_latest_released_app_version)
+    get_brief_app, get_latest_released_app_version, get_app_ids_in_domain)
 from corehq.apps.app_manager.models import Application, RemoteApp, Module
 from corehq.apps.domain.models import Domain
 from corehq.util.test_utils import DocTestMixin
@@ -157,7 +157,7 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         self.assertEqual(len(app_ids), 0)  # Should skip the one that has_submissions
 
     def test_get_built_app_ids_with_submissions_for_app_ids_and_versions(self):
-        app_ids_in_domain = get_apps_in_domain(self.domain)
+        app_ids_in_domain = get_app_ids_in_domain(self.domain)
         app_ids = get_built_app_ids_with_submissions_for_app_ids_and_versions(
             self.domain,
             app_ids_in_domain,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1424,9 +1424,10 @@ class ExportDataSchema(Document):
         app_label = 'export'
 
     def get_number_of_apps_to_process(self):
+        app_ids_for_domain = self._get_current_app_ids_for_domain(self.domain, self.app_id)
         return len(self._get_app_build_ids_to_process(
             self.domain,
-            self.app_id,
+            app_ids_for_domain,
             self.last_app_versions,
         ))
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1994,13 +1994,14 @@ class CaseExportDataSchema(ExportDataSchema):
 
     @classmethod
     def _process_app_build(cls, current_schema, app, case_type):
-        case_property_mapping = get_case_properties(
-            app,
-            [case_type],
+        builder = ParentCasePropertyBuilder(
+            app.domain,
+            [app],
             include_parent_properties=False
         )
-        parent_types = (ParentCasePropertyBuilder.for_app(app)
-                        .get_case_relationships_for_case_type(case_type))
+        case_property_mapping = builder.get_case_property_map([case_type])
+
+        parent_types = builder.get_case_relationships_for_case_type(case_type)
         case_schemas = []
         case_schemas.append(cls._generate_schema_from_case_property_mapping(
             case_property_mapping,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1456,14 +1456,15 @@ class ExportDataSchema(Document):
         else:
             current_schema = cls()
 
+        app_ids_for_domain = cls._get_current_app_ids_for_domain(domain, app_id)
         app_build_ids = []
         if not only_process_current_builds:
             app_build_ids = cls._get_app_build_ids_to_process(
                 domain,
-                app_id,
+                app_ids_for_domain,
                 current_schema.last_app_versions,
             )
-        app_build_ids.extend(cls._get_current_app_ids_for_domain(domain, app_id))
+        app_build_ids.extend(app_ids_for_domain)
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids, chunksize=10):
             doc_type = app_doc.get('doc_type', '')
@@ -1667,12 +1668,15 @@ class FormExportDataSchema(ExportDataSchema):
 
     @classmethod
     def _get_current_app_ids_for_domain(cls, domain, app_id):
+        """Get all app IDs of 'current' apps that should be included in this schema"""
         if not app_id:
             return []
         return [app_id]
 
     @staticmethod
-    def _get_app_build_ids_to_process(domain, app_id, last_app_versions):
+    def _get_app_build_ids_to_process(domain, app_ids, last_app_versions):
+        """Get all built apps that should be included in this schema"""
+        app_id = app_ids[0] if app_ids else None
         return get_built_app_ids_with_submissions_for_app_id(
             domain,
             app_id,
@@ -1977,9 +1981,10 @@ class CaseExportDataSchema(ExportDataSchema):
         return get_app_ids_in_domain(domain)
 
     @staticmethod
-    def _get_app_build_ids_to_process(domain, app_id, last_app_versions):
+    def _get_app_build_ids_to_process(domain, app_ids, last_app_versions):
         return get_built_app_ids_with_submissions_for_app_ids_and_versions(
             domain,
+            app_ids,
             last_app_versions
         )
 


### PR DESCRIPTION
This is a re-work of https://github.com/dimagi/commcare-hq/pull/22281

* don't call `get_app_ids_in_domain` more than we have to
  * this was being called once in `_get_current_app_ids_for_domain` and then again in `_get_app_build_ids_to_process`
* don't fetch 'case sharing' apps when processing an app
  * for each app / build that get's processed the `ParentCasePropertyBuilder` was fetching all 'case sharing' apps in the domain (if the current app had case sharing enabled) (twice).
  * instead just process the current app
  * we can do this since the schema's are additive

https://manage.dimagi.com/default.asp?283993