### PR TITLE
remove obsolete .decode()

### DIFF
--- a/corehq/apps/app_manager/tests/test_extension_case.py
+++ b/corehq/apps/app_manager/tests/test_extension_case.py
@@ -209,7 +209,7 @@ class CaseBlockIndexRelationshipTest(SimpleTestCase, TestXmlMixin):
             self.form.get_case_type(),
             self.xform.resolve_path("case/@case_id"),
         )
-        self.assertXmlEqual(self.get_xml('open_subcase_child').decode('utf-8'), str(self.xform))
+        self.assertXmlEqual(self.get_xml('open_subcase_child'), str(self.xform))
 
     def test_xform_case_block_index_valid_relationship(self):
         """

--- a/corehq/apps/callcenter/tests/test_use_fixtures_configuration.py
+++ b/corehq/apps/callcenter/tests/test_use_fixtures_configuration.py
@@ -141,7 +141,7 @@ class TestIndicatorsFromApp(SimpleTestCase, TestFileMixin):
             ]/{}"/>
             """.format(instance_name, indicator)
 
-        form_template = self.get_xml('form_template').decode('utf-8')
+        form_template = self.get_xml('form_template')
         instance = '<instance id="{}" src="jr://fixture/indicators:call-center" />'.format(instance_name)
         form.source = form_template.format(
             instance=instance,

--- a/custom/champ/tests/__init__.py
+++ b/custom/champ/tests/__init__.py
@@ -42,7 +42,7 @@ def setUpModule():
         path = os.path.join(os.path.dirname(__file__), 'fixtures')
         for file_name in os.listdir(path):
             with open(os.path.join(path, file_name), encoding='utf-8') as f:
-                table_name = get_table_name(domain.name, file_name[:-4]).decode('utf-8')
+                table_name = get_table_name(domain.name, file_name[:-4])
                 table = metadata.tables[table_name]
                 postgres_copy.copy_from(
                     f, table, engine, format='csv' if six.PY3 else b'csv',


### PR DESCRIPTION
```get_table_name``` and ```TestFileMixin.get_xml``` now always return unicode, so we don't need to decode (and decoding unicode raises an exception in python 3)