### PR TITLE
show system forms when searching for "Unknown Users" in Submit History Reports

### DIFF
--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -98,6 +98,12 @@ def unknown_users():
     """
     return filters.doc_type("UnknownUser")
 
+def system_users():
+    """
+    Returns system users. system users have a user_id of system
+    """
+    return username("system")
+
 
 def admin_users():
     """

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -98,12 +98,6 @@ def unknown_users():
     """
     return filters.doc_type("UnknownUser")
 
-def system_users():
-    """
-    Returns system users. system users have a user_id of system
-    """
-    return username("system")
-
 
 def admin_users():
     """

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -14,6 +14,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.locations.permissions import user_can_access_other_user
 from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.apps.commtrack.models import SQLLocation
 from corehq.toggles import FILTER_ON_GROUPS_AND_LOCATIONS
 
@@ -360,7 +361,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
             user_type_filters.append(user_es.admin_users())
         if HQUserType.UNKNOWN in user_types:
             user_type_filters.append(user_es.unknown_users())
-            user_type_filters.append(user_es.system_users())
+            user_type_filters.append(user_es.username(SYSTEM_USER_ID))
         if HQUserType.WEB in user_types:
             user_type_filters.append(user_es.web_users())
         if HQUserType.DEMO_USER in user_types:

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -360,6 +360,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
             user_type_filters.append(user_es.admin_users())
         if HQUserType.UNKNOWN in user_types:
             user_type_filters.append(user_es.unknown_users())
+            user_type_filters.append(user_es.system_users())
         if HQUserType.WEB in user_types:
             user_type_filters.append(user_es.web_users())
         if HQUserType.DEMO_USER in user_types:


### PR DESCRIPTION
adds system forms to "Unknown User" section when searching, which is my understanding of what this ticket is looking for https://manage.dimagi.com/default.asp?285161

The other option was to add a search by `xmlns` instead of user_id, but that seems more fragmented than the system user_id, as I was finding at least 3 different xmlns's that we use to denote a system transaction.

@esoergel buddy: @proteusvacuum 