### PR TITLE
Fix project space filter for Customer Invoices

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -1119,6 +1119,16 @@ class CustomerInvoiceInterface(InvoiceInterfaceBase):
                 is_hidden=(is_hidden == IsHiddenFilter.IS_HIDDEN),
             )
 
+        subscriber_domain = SubscriberFilter.get_value(self.request, self.domain)
+        if subscriber_domain is not None:
+            invoices_for_domain = []
+            for invoice in queryset.all():
+                for subscription in invoice.subscriptions.all():
+                    if subscription.subscriber.domain == subscriber_domain:
+                        invoices_for_domain.append(invoice.pk)
+                        break
+            queryset = queryset.filter(id__in=invoices_for_domain)
+
         return queryset
 
     @property


### PR DESCRIPTION
Before, the `SubscriberFilter` wasn't being used in the `CustomerInvoiceInterface` class, so filtering by project space didn't have an effect. This PR filters customer invoices by invoices with the project space name among its list of subscriptions