### PR TITLE
only set build info when build is first created

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5228,16 +5228,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         return settings
 
     def create_build_files(self, build_profile_id=None):
-        built_on = datetime.datetime.utcnow()
         all_files = self.create_all_files(build_profile_id)
-        self.date_created = built_on
-        self.built_on = built_on
-        self.built_with = BuildRecord(
-            version=self.build_spec.version,
-            build_number=self.version,
-            datetime=built_on,
-        )
-
         for filepath in all_files:
             self.lazy_put_attachment(all_files[filepath],
                                      'files/%s' % filepath)
@@ -5424,6 +5415,14 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         # which makes tests error
         assert copy._id
 
+        built_on = datetime.datetime.utcnow()
+        copy.date_created = built_on
+        copy.built_on = built_on
+        copy.built_with = BuildRecord(
+            version=copy.build_spec.version,
+            build_number=copy.version,
+            datetime=built_on,
+        )
         copy.build_comment = comment
         copy.comment_from = user_id
         copy.is_released = False


### PR DESCRIPTION
`create_build_files` is called in a few places, most notably
when releasing an build that has build profiles. This was causing
the build fields (like date_created) to get updated when the app
was released.

Looking at the other places that call `create_build_files` I don't think this should affect anything else.

https://manage.dimagi.com/default.asp?285844