### PR TITLE
use six.text_type so unicode is not encoded

### DIFF
--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -402,7 +402,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, task=None
             if password:
                 password = six.text_type(password)
             try:
-                username = normalize_username(str(username), domain)
+                username = normalize_username(six.text_type(username), domain)
             except TypeError:
                 username = None
             except ValidationError:


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/765710472/