### PR TITLE
Consistent couchdbkit imports

### DIFF
--- a/corehq/apps/casegroups/models.py
+++ b/corehq/apps/casegroups/models.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from couchdbkit.ext.django.schema import StringProperty, ListProperty
+from dimagi.ext.couchdbkit import StringProperty, ListProperty
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from dimagi.utils.couch.undo import UndoableDocument, DeleteDocRecord

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -11,7 +11,7 @@ from collections import defaultdict, OrderedDict, namedtuple
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from couchdbkit import ResourceConflict
-from couchdbkit.ext.django.schema import IntegerProperty
+from dimagi.ext.couchdbkit import IntegerProperty
 from django.core.exceptions import ValidationError
 from django.utils.datastructures import OrderedSet
 from django.utils.translation import ugettext as _

--- a/corehq/motech/dhis2/dhis2_config.py
+++ b/corehq/motech/dhis2/dhis2_config.py
@@ -2,8 +2,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import six
-from couchdbkit.ext.django.schema import DocumentSchema, ListProperty, StringProperty, SchemaProperty, \
-    SchemaListProperty
+from dimagi.ext.couchdbkit import (
+    DocumentSchema,
+    ListProperty,
+    SchemaListProperty,
+    SchemaProperty,
+    StringProperty,
+)
 
 from corehq.motech.dhis2.const import DHIS2_EVENT_STATUSES, DHIS2_EVENT_STATUS_COMPLETED
 from corehq.motech.value_source import ValueSource

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import json
 
-from couchdbkit.ext.django.schema import SchemaProperty
+from dimagi.ext.couchdbkit import SchemaProperty
 from memoized import memoized
 
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -4,7 +4,7 @@ import json
 import six
 from itertools import chain
 
-from couchdbkit.ext.django.schema import SchemaProperty, StringProperty, DateTimeProperty, BooleanProperty
+from dimagi.ext.couchdbkit import SchemaProperty, StringProperty, DateTimeProperty, BooleanProperty
 from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from collections import namedtuple
 
-from couchdbkit.ext.django.schema import DocumentSchema
+from dimagi.ext.couchdbkit import DocumentSchema
 
 from corehq.motech.serializers import serializers
 from corehq.motech.const import (


### PR DESCRIPTION
This is just to import couchdbkit consistently

```bash
    $ git grep 'from dimagi.ext.couchdbkit import' | wc -l
    73
    $ git grep 'from couchdbkit.ext.django.schema' | wc -l
    6
```

The first commit is of imports I wrote, and I had no particular reason for using `couchdbkit.ext.django.schema` instead of `dimagi.ext.couchdbkit`. The second commit is of 2 imports, written by Noah and @dannyroberts. If there is a specific reason for breaking with convention, Danny, please let me know. 
