### PR TITLE
"readline" package is deprecated

### DIFF
--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -18,5 +18,5 @@ graphviz==0.7
 transifex-client==0.12.4
 modernize==0.6
 Fabric==1.14.0
-readline==6.2.4.1
+gnureadline==6.3.8
 pip-tools==2.0.2

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -90,6 +90,7 @@ funcsigs==1.0.2
 futures==3.2.0
 gevent==1.2.2
 ghdiff==0.4
+gnureadline==6.3.8
 graphviz==0.7
 greenlet==0.4.12
 gunicorn==19.9.0
@@ -169,7 +170,6 @@ qrcode==4.0.4
 quickcache==0.5.1
 raven==6.1.0
 rcssmin==1.0.6
-readline==6.2.4.1
 redis-py-cluster==1.3.5
 redis==2.10.6
 reportlab==3.0


### PR DESCRIPTION
It has been renamed to "gnureadline" to resolve a name clash with the standard library module.

cf. https://pypi.org/project/readline/