### PR TITLE
Node.js 5.x is deprecated.

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -117,7 +117,7 @@ you'll need to install `bower` and run `bower install`. Follow these steps to in
     For Ubuntu: In Ubuntu this is now bundled with NodeJS. An up-to-date version is available on the NodeSource
     repository. Run the following commands:
 
-        $ curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
+        $ curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
         $ sudo apt-get install -y nodejs
 
     For macOS: Install with Homebrew:


### PR DESCRIPTION
(It's also not available for Ubuntu 18.04.)

It recommends using Node.js 8 LTS instead.
