### PR TITLE
Add script to find forms missing in ES

### DIFF
--- a/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
+++ b/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+from __future__ import print_function
+from datetime import datetime
+from django.core.management.base import BaseCommand
+import sys
+from django.db.models import Q, F
+from django.db.models.functions import Greatest
+from corehq.form_processor.models import XFormInstanceSQL
+from corehq.apps.es import FormES
+import argparse
+from dimagi.utils.chunked import chunked
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+def valid_date(s):
+    try:
+        return datetime.strptime(s, DATE_FORMAT)
+    except ValueError:
+        msg = "Not a valid date: '{0}'.".format(s)
+        raise argparse.ArgumentTypeError(msg)
+
+
+class Command(BaseCommand):
+    help = "Print IDs of sql forms that are in the primary DB but not in ES."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-s',
+            '--startdate',
+            dest='start',
+            type=valid_date,
+            help="The start date. Only applicable to forms on SQL domains. - format YYYY-MM-DD",
+        )
+        parser.add_argument(
+            '-e',
+            '--enddate',
+            dest='end',
+            type=valid_date,
+            help="The end date. Only applicable to forms on SQL domains. - format YYYY-MM-DD",
+        )
+
+    def handle(self, **options):
+        startdate = options.get('start')
+        enddate = options.get('end')
+        print("Fetching all form ids...", file=sys.stderr)
+        all_ids = list(iter_form_ids_by_last_modified(startdate, enddate))
+        print("Woo! Done fetching. Here we go", file=sys.stderr)
+        for doc_ids in chunked(all_ids, 100):
+            es_ids = (FormES()
+                      .remove_default_filter('is_xform_instance')
+                      .doc_id(doc_ids).values_list('_id', flat=True))
+            missing_ids = set(doc_ids) - set(es_ids)
+            for form_id in missing_ids:
+                print(form_id)
+
+
+def iter_form_ids_by_last_modified(start_datetime, end_datetime):
+    from corehq.sql_db.util import run_query_across_partitioned_databases
+
+    annotate = {
+        'last_modified': Greatest('received_on', 'edited_on', 'deleted_on'),
+    }
+
+    return run_query_across_partitioned_databases(
+        XFormInstanceSQL,
+        (Q(last_modified__gt=start_datetime, last_modified__lt=end_datetime) &
+         Q(state=F('state').bitand(XFormInstanceSQL.DELETED) +
+            F('state').bitand(XFormInstanceSQL.DEPRECATED) +
+            F('state').bitand(XFormInstanceSQL.DUPLICATE) +
+            F('state').bitand(XFormInstanceSQL.ERROR) +
+            F('state').bitand(XFormInstanceSQL.SUBMISSION_ERROR_LOG) +
+            F('state'))),
+        annotate=annotate,
+        values=['form_id'],
+    )

--- a/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
+++ b/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
@@ -1,3 +1,11 @@
+"""
+This script prints out the SQL forms that are missing from ES within a
+certain date range.
+
+For a full description and suggestions on usage see the original PR
+description here: https://github.com/dimagi/commcare-hq/pull/22477
+
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals


### PR DESCRIPTION
*Note*: I put this together as a starting point for someone on interrupt to use to find historical damage done in this ticket https://manage.dimagi.com/default.asp?283938. I'm not currently continuing to working on it.

This script prints out the SQL forms that are missing from ES within a certain date range (for last modified). I suggest generating a file that contains 1-day date ranges going back to Sept 1

```
python -c '
from __future__ import print_function
from datetime import *
d = date(2018, 9, 1)
while d <= date.today():
    d_ = d + timedelta(days=1)
    print(d.isoformat(), d_.isoformat())
    d = d_
' > dates.txt
```
and then looping over the lines in the file to save the date ranges to different files
```
{
    while read d1 d2
    do
        ./manage.py find_sql_forms_not_in_es -s $d1 -e $d2 > missing-forms.$d1.txt
    done
} < dates.txt
```
and then you have stats for the number of these that happened on any given day, so you can see the rough trend and/or correlate with errors you see in sentry.

To count the number of occurrences per day:
```
wc -l missing-forms.*.txt
```
To just get the full list of ids on all days:
```
cat missing-forms.*.txt
```

You can do all this in a tmux session on the django_manage machine. Actually finding all the forms missing in ES will take quite a long time, so I suggest kicking it off and exiting, and then checking back in later.