### PR TITLE
Add Google Optimize test for Get Demo

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/drift.js
+++ b/corehq/apps/analytics/static/analytix/js/drift.js
@@ -50,6 +50,11 @@ hqDefine('analytix/js/drift', [
                 hubspot.identify({email: e.data.email});
                 hubspot.trackEvent('Identified via Drift');
             });
+
+            $('a[href="#demo-request"]').click(function () {
+              _drift.api.startInteraction({ interactionId: 43079 });
+            });
+
         });
     });
 

--- a/corehq/apps/analytics/static/analytix/js/drift.js
+++ b/corehq/apps/analytics/static/analytix/js/drift.js
@@ -52,7 +52,7 @@ hqDefine('analytix/js/drift', [
             });
 
             $('a[href="#demo-request"]').click(function () {
-              _drift.api.startInteraction({ interactionId: 43079 });
+                _drift.api.startInteraction({ interactionId: 43079 });
             });
 
         });

--- a/corehq/apps/analytics/static/analytix/js/hubspot.get_demo.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.get_demo.js
@@ -1,41 +1,41 @@
-/* global window */
+/* global window, hbspt */
 $(function () {
-  'use strict';
+    'use strict';
 
-  hqImport("analytix/js/hubspot").then(function () {
-    var hubspot_get = hqImport('analytix/js/initial').getFn('hubspot'),
-        hubspot_api_id = hubspot_get('apiId');
+    hqImport("analytix/js/hubspot").then(function () {
+        var hubspotGet = hqImport('analytix/js/initial').getFn('hubspot'),
+            hubspotApiId = hubspotGet('apiId');
 
-    // Old (control) hubspot form:
-    hbspt.forms.create({
-      portalId: hubspot_api_id,
-      formId: "0f5de42e-b562-4ece-85e5-cfd2db97eba8",
-      target: "#get-demo-cta-form-body",
-      css: ""
+        // Old (control) hubspot form:
+        hbspt.forms.create({
+            portalId: hubspotApiId,
+            formId: "0f5de42e-b562-4ece-85e5-cfd2db97eba8",
+            target: "#get-demo-cta-form-body",
+            css: "",
+        });
+
+        // New (variant A) hubspot form:
+        hbspt.forms.create({
+            portalId: hubspotApiId,
+            formId: "38980202-f1bd-412e-b490-f390f40e9ee1",
+            target: "#get-demo-cta-form-content",
+            css: "",
+            onFormSubmit: function ($form) {
+                $('#get-demo-cta-calendar-content').fadeIn();
+                $('#get-demo-cta-form-content').addClass('hide');
+                var email = $form.find('[name="email"]').val(),
+                    firstname = $form.find('[name="firstname"]').val(),
+                    lastname = $form.find('[name="lastname"]').val(),
+                    newUrl = document.location.href + '?email=' + email + '&name=' + firstname + '%20' + lastname;
+
+                window.history.pushState(
+                    "dimagi-contact-url " + document.title, document.title, newUrl
+                );
+
+                $.getScript('//cdn.scheduleonce.com/mergedjs/so.js');
+
+            },
+        });
     });
-
-    // New (variant A) hubspot form:
-    hbspt.forms.create({
-      portalId: hubspot_api_id,
-      formId: "38980202-f1bd-412e-b490-f390f40e9ee1",
-      target: "#get-demo-cta-form-content",
-      css: "",
-      onFormSubmit: function ($form) {
-        $('#get-demo-cta-calendar-content').fadeIn();
-        $('#get-demo-cta-form-content').addClass('hide');
-        var email = $form.find('[name="email"]').val(),
-            firstname = $form.find('[name="firstname"]').val(),
-            lastname = $form.find('[name="lastname"]').val(),
-            newUrl = document.location.href + '?email=' + email + '&name=' + firstname + '%20' + lastname;
-
-        window.history.pushState(
-            "dimagi-contact-url " + document.title, document.title, newUrl
-        );
-
-        $.getScript('//cdn.scheduleonce.com/mergedjs/so.js');
-
-      },
-    });
-  });
 
 });

--- a/corehq/apps/analytics/static/analytix/js/hubspot.get_demo.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.get_demo.js
@@ -1,0 +1,41 @@
+/* global window */
+$(function () {
+  'use strict';
+
+  hqImport("analytix/js/hubspot").then(function () {
+    var hubspot_get = hqImport('analytix/js/initial').getFn('hubspot'),
+        hubspot_api_id = hubspot_get('apiId');
+
+    // Old (control) hubspot form:
+    hbspt.forms.create({
+      portalId: hubspot_api_id,
+      formId: "0f5de42e-b562-4ece-85e5-cfd2db97eba8",
+      target: "#get-demo-cta-form-body",
+      css: ""
+    });
+
+    // New (variant A) hubspot form:
+    hbspt.forms.create({
+      portalId: hubspot_api_id,
+      formId: "38980202-f1bd-412e-b490-f390f40e9ee1",
+      target: "#get-demo-cta-form-content",
+      css: "",
+      onFormSubmit: function ($form) {
+        $('#get-demo-cta-calendar-content').fadeIn();
+        $('#get-demo-cta-form-content').addClass('hide');
+        var email = $form.find('[name="email"]').val(),
+            firstname = $form.find('[name="firstname"]').val(),
+            lastname = $form.find('[name="lastname"]').val(),
+            newUrl = document.location.href + '?email=' + email + '&name=' + firstname + '%20' + lastname;
+
+        window.history.pushState(
+            "dimagi-contact-url " + document.title, document.title, newUrl
+        );
+
+        $.getScript('//cdn.scheduleonce.com/mergedjs/so.js');
+
+      },
+    });
+  });
+
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/optimize.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/optimize.less
@@ -1,0 +1,39 @@
+/* styles for Google Optimize A/B tests */
+
+.optimize-abtest {
+  a.optimize-abtest-variant-a {
+    display: none;
+  }
+
+  a.optimize-abtest-variant-b {
+    display: none;
+  }
+}
+
+.optimize-abtest.show-a {
+  a.optimize-abtest-control {
+    display: none;
+  }
+
+  a.optimize-abtest-variant-a {
+    display: inherit;
+  }
+
+  a.optimize-abtest-variant-b {
+    display: none;
+  }
+}
+
+.optimize-abtest.show-b {
+  a.optimize-abtest-control {
+    display: none;
+  }
+
+  a.optimize-abtest-variant-a {
+    display: none;
+  }
+
+  a.optimize-abtest-variant-b {
+    display: inherit;
+  }
+}

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/style-imports.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/style-imports.less
@@ -32,3 +32,4 @@
 @import "_hq/typography.less";
 @import "_hq/svg.less";
 @import "_hq/utils.less";
+@import "_hq/optimize.less";

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -199,14 +199,32 @@
 
                     {% if not request.user.is_authenticated %}
                       <nav class="navbar-menus navbar-signin" role="navigation">
+
                         <div class="nav-settings-bar pull-right">
                           <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
                           {% if is_saas_environment and ANALYTICS_IDS.HUBSPOT_API_ID %}
-                            <a href="#cta-form-get-demo"
-                               target="_blank"
-                               data-toggle="modal"
-                               id="cta-form-get-demo-button"
-                               class="btn btn-purple navbar-btn">{% trans 'Get Demo' %}</a>
+
+                            <span class="optimize-abtest">
+
+                              <a href="#cta-form-get-demo"
+                                 target="_blank"
+                                 data-toggle="modal"
+                                 id="cta-form-get-demo-button"
+                                 class="optimize-abtest-control btn btn-purple navbar-btn">{% trans 'Get Demo' %}</a>
+
+                              {# hubspot #}
+                              <a href="#cta-form-get-demo-new"
+                                 data-toggle="modal"
+                                 id="cta-form-get-demo-button-new"
+                                 class="optimize-abtest-variant-a btn btn-purple navbar-btn">{% trans 'Schedule a Demo' %}</a>
+
+                              {# drift #}
+                              <a href="#demo-request"
+                                 id="cta-form-get-demo-button-drift"
+                                 class="optimize-abtest-variant-b btn btn-purple navbar-btn">{% trans 'Schedule a Demo' %}</a>
+
+                            </span>
+
                           {% endif %}
                         </div>
                       </nav>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -501,18 +501,48 @@
               </div>
             </div>
           </div>
+
+
+          <div class="modal fade"
+               id="cta-form-get-demo-new">
+            <div class="modal-dialog">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans 'Close' %}</span></button>
+                  <h4 class="modal-title">{% trans "Request a CommCare Demo" %}</h4>
+                </div>
+                <div class="modal-body form-horizontal">
+
+                  {# Hubspot Form #}
+                  <div class="form form-horizontal"
+                           id="get-demo-cta-form-content"></div>
+
+                  {# Schedule Once Demo #}
+                  <div id="get-demo-cta-calendar-content" style="display: none;">
+                    <p>
+                      {% blocktrans %}
+                        Select a time to see CommCare in action and review
+                        questions with our team.
+                      {% endblocktrans %}
+                    </p>
+                    <div id="SOIDIV_commcaredemoform"
+                         data-so-page="commcaredemoform"
+                         data-style="border: 1px solid #d8d8d8; min-width: 290px; max-width: 900px;"
+                         data-psz="11"></div>
+                  </div>
+
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!--[if lte IE 8]>
           <script charset="utf-8" src="//js.hsforms.net/forms/v2-legacy.js"></script>
           <![endif]-->
           <script charset="utf-8" src="//js.hsforms.net/forms/v2.js"></script>
-          <script>
-            hbspt.forms.create({
-              portalId: "{{ ANALYTICS_IDS.HUBSPOT_API_ID }}",
-              formId: "0f5de42e-b562-4ece-85e5-cfd2db97eba8",
-              target: "#get-demo-cta-form-body",
-              css: ""
-            });
-          </script>
+
+          <script src="{% static 'analytix/js/hubspot.get_demo.js' %}"></script>
+
         {% endif %}
 
         {# Knockout component templates #}

--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -4,6 +4,7 @@ $(function () {
 
     // Demo CTA test
     hqImport("analytix/js/hubspot").then(function () {
+
         var kissmetrics = hqImport('analytix/js/kissmetrix');
         $("#test-cta-form-get-demo-button").click(function () {
             kissmetrics.track.event("Body Get Demo CTA clicked");
@@ -14,6 +15,24 @@ $(function () {
         $(".hs_submit .hs-button").click(function () {
             kissmetrics.track.event("Demo request sent");
         });
+
+
+        $("#cta-form-get-demo-button-new-body").click(function () {
+            kissmetrics.track.event("Body Get Demo CTA clicked (new)");
+        });
+
+        $("#cta-form-get-demo-button-drift-body").click(function () {
+            kissmetrics.track.event("Body Get Demo CTA clicked (drift)");
+        });
+
+        $("#cta-form-get-demo-button-new").click(function () {
+            kissmetrics.track.event("Header Get Demo button clicked (new form)");
+        });
+
+        $("#cta-form-get-demo-button-drift").click(function () {
+            kissmetrics.track.event("Header Get Demo button clicked (drift)");
+        });
+
     });
 
     // Link up with registration form ko model
@@ -80,4 +99,5 @@ $(function () {
     reg.setGetPhoneNumberFn(function () {
         return $number.intlTelInput("getNumber");
     });
+
 });

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -113,11 +113,28 @@
             <div class="form-bubble form-bubble-purple text-center">
                 {% blocktrans %}
                     Want to learn more before signing up?
-                    &nbsp;&nbsp;&nbsp;
-                    <a href="#cta-form-get-demo" id="test-cta-form-get-demo-button" target="_blank" data-toggle="modal" class="btn btn-purple">
-                        Get a Demo
-                    </a>
                 {% endblocktrans %}
+                  &nbsp;&nbsp;&nbsp;
+                  <span class="optimize-abtest">
+                    <a href="#cta-form-get-demo"
+                       id="test-cta-form-get-demo-button"
+                       data-toggle="modal"
+                       class="optimize-abtest-control btn btn-purple">
+                        {% trans "Get a Demo" %}
+                    </a>
+
+                    {# hubspot #}
+                    <a href="#cta-form-get-demo-new"
+                       data-toggle="modal"
+                       id="cta-form-get-demo-button-new-body"
+                       class="optimize-abtest-variant-a btn btn-purple navbar-btn">{% trans 'Schedule a Demo' %}</a>
+
+                    {# drift #}
+                    <a href="#demo-request"
+                       id="cta-form-get-demo-button-drift-body"
+                       class="optimize-abtest-variant-b btn btn-purple navbar-btn">{% trans 'Schedule a Demo' %}</a>
+
+                  </span>
             </div>
         {% endif %}
       </div>


### PR DESCRIPTION
adds marketing-controlled Google Optimize A/B test to test two new workflows for the "Schedule a Demo" button, while leaving the control / existing "Get Demo" button before marketing enables the test.

The two workflows are:

*Variant A*
- Hubspot form submission triggers Schedule Once calendar widget to pick a time slot for a demo

*Variant B*
- Triggers the Drift bot to collect scheduling information for a demo using the drift link `#demo-request`

@gbova @orangejenny @nickpell 

NOTE: We have google Optimize installed because we are running the same GTM (Google Tag Manager) setup as Dimagi.com. While it's too late for discussion for this test, I do have concerns about continuing to run Google Optimize on CommCare HQ due to the fact that an external third party script explicitly has control to change HTML and add additional scripts to the page. 

Flagging for discussion at a later time. Due to time constraints and push from marketing unfortunately we have to run the test this way for now, but I feel future tests should be designed without needing Google Optimize on HQ due to a potential security risk. If others feel there shouldn't be an issue, I'm happy to keep it.

***this affects ONLY production SaaS platforms***

