### PR TITLE
[VectoLink] filer records to the end of day, fix user filter

### DIFF
--- a/custom/abt/reports/late_pmt.py
+++ b/custom/abt/reports/late_pmt.py
@@ -36,7 +36,6 @@ class LatePMTUsers(SqlData):
     def filters(self):
         filters = []
         filter_fields = [
-            'user_id',
             'country',
             'level_1',
             'level_2',
@@ -46,6 +45,8 @@ class LatePMTUsers(SqlData):
         for filter_field in filter_fields:
             if filter_field in self.config and self.config[filter_field]:
                 filters.append(EQ(filter_field, filter_field))
+        if 'user_id' in self.config and self.config['user_id']:
+            filters.append(EQ('doc_id', 'user_id'))
         return filters
 
     @property
@@ -116,7 +117,7 @@ class LatePmtReport(GenericTabularReport, CustomProjectReport, DatespanMixin):
 
     @property
     def enddate(self):
-        return self.request.datespan.enddate
+        return self.request.datespan.end_of_end_day
 
     @property
     def headers(self):


### PR DESCRIPTION
Hi @nickpell 

I fix a problem in which we filter data looking to the beginning of the day. So I changed this and now in enddate property, I replace hours and minutes to the end of the day.

Also, I fixed a problem with user filter.

Please let me know if you have any questions.

Regards,
Łukasz