### PR TITLE
begin transitioning fetch_attachment to only return bytes

### DIFF
--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -181,7 +181,7 @@ class AppManagerTest(TestCase):
 
     def _check_has_build_files(self, build, paths):
         for path in paths:
-            self.assertTrue(build.fetch_attachment(path))
+            self.assertTrue(build.fetch_attachment(path, return_bytes=True))
 
     def _check_legacy_odk_files(self, build):
         self.assertTrue(build.copy_of)
@@ -194,7 +194,7 @@ class AppManagerTest(TestCase):
         build.save()
         build = Application.get(build.get_id)
         self.assertEqual(build.version, build_version)
-        self.assertTrue(build.fetch_attachment(path))
+        self.assertTrue(build.fetch_attachment(path, return_bytes=True))
         self.assertEqual(build.odk_profile_created_after_build, True)
 
     @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)

--- a/corehq/apps/app_manager/tests/test_form_versioning.py
+++ b/corehq/apps/app_manager/tests/test_form_versioning.py
@@ -113,7 +113,7 @@ class FormVersioningTest(TestCase):
         from lxml import etree
 
         suite = suite_models.Suite(
-            etree.fromstring(build.fetch_attachment('files/suite.xml').encode('utf-8'))
+            etree.fromstring(build.fetch_attachment('files/suite.xml', return_bytes=True))
         )
         return [r.version for r in suite.xform_resources]
 

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -308,7 +308,7 @@ class TestRemoteLinkedApps(BaseLinkedAppsTest):
 
         media = CommCareMultimedia.get(media_details['multimedia_id'])
         self.addCleanup(media.delete)
-        content = media.fetch_attachment(list(media.blobs.keys())[0])
+        content = media.fetch_attachment(list(media.blobs.keys())[0], return_bytes=True).decode('utf-8')
         self.assertEqual(data, content)
 
 


### PR DESCRIPTION
Right now ```fetch_attachment``` will try to decode (when ```stream=False```), and if that fails, just returns bytes.  We should guarantee a consistent interface and let client code handle decoding (if necessary).  This consistency will make attachments much easier to reason about in python 3.

I plan on tackling this one app at a time, to manage risk.

@dimagi/py3 