### PR TITLE
If no Encounter location is set, use the standard "Unknown Location"

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -276,6 +276,12 @@ class CreateEncounterTask(WorkflowTask):
             encounter['visit'] = self.visit_uuid
         if self.location_uuid:
             encounter['location'] = self.location_uuid
+        else:
+            # If we don't set a location, OpenMRS sets it to NULL,
+            # which breaks Bahmni. Fortunately OpenMRS comes standard
+            # with an "Unknown Location". Use that.
+            location = get_unknown_location(self.requests)
+            encounter['location'] = location['uuid']
         if self.provider_uuid:
             encounter_role = get_unknown_encounter_role(self.requests)
             encounter['encounterProviders'] = [{
@@ -733,6 +739,20 @@ def get_unknown_encounter_role(requests):
             return encounter_role
     raise OpenmrsConfigurationError(
         'The standard "Unknown" EncounterRole was not found on the OpenMRS server at "{}". Please notify the '
+        'administrator of that server.'.format(requests.base_url)
+    )
+
+
+def get_unknown_location(requests):
+    """
+    Return "Unknown Location"
+    """
+    response_json = requests.get('/ws/rest/v1/location').json()
+    for location in response_json['results']:
+        if location['display'] == 'Unknown Location':
+            return location
+    raise OpenmrsConfigurationError(
+        'The standard "Unknown Location" was not found on the OpenMRS server at "{}". Please notify the '
         'administrator of that server.'.format(requests.base_url)
     )
 

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -276,12 +276,6 @@ class CreateEncounterTask(WorkflowTask):
             encounter['visit'] = self.visit_uuid
         if self.location_uuid:
             encounter['location'] = self.location_uuid
-        else:
-            # If we don't set a location, OpenMRS sets it to NULL,
-            # which breaks Bahmni. Fortunately OpenMRS comes standard
-            # with an "Unknown Location". Use that.
-            location = get_unknown_location(self.requests)
-            encounter['location'] = location['uuid']
         if self.provider_uuid:
             encounter_role = get_unknown_encounter_role(self.requests)
             encounter['encounterProviders'] = [{
@@ -743,18 +737,16 @@ def get_unknown_encounter_role(requests):
     )
 
 
-def get_unknown_location(requests):
+def get_unknown_location_uuid(requests):
     """
-    Return "Unknown Location"
+    Returns the UUID of Bahmni's "Unknown Location" or None if it
+    doesn't exist.
     """
     response_json = requests.get('/ws/rest/v1/location').json()
     for location in response_json['results']:
         if location['display'] == 'Unknown Location':
-            return location
-    raise OpenmrsConfigurationError(
-        'The standard "Unknown Location" was not found on the OpenMRS server at "{}". Please notify the '
-        'administrator of that server.'.format(requests.base_url)
-    )
+            return location['uuid']
+    return None
 
 
 def get_patient_identifier_types(requests):

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -26,6 +26,7 @@ from corehq.motech.openmrs.exceptions import OpenmrsConfigurationError
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.workflow import WorkflowTask
 from corehq.motech.value_source import CaseTriggerInfo
+from corehq.util.quickcache import quickcache
 
 OpenmrsResponse = namedtuple('OpenmrsResponse', 'status_code reason content')
 
@@ -722,6 +723,7 @@ def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extr
     return result
 
 
+@quickcache(['requests.base_url'])
 def get_unknown_encounter_role(requests):
     """
     Return "Unknown" encounter role for legacy providers with no
@@ -737,6 +739,7 @@ def get_unknown_encounter_role(requests):
     )
 
 
+@quickcache(['requests.base_url'])
 def get_unknown_location_uuid(requests):
     """
     Returns the UUID of Bahmni's "Unknown Location" or None if it


### PR DESCRIPTION
This change is not necessary for OpenMRS. But creating an Encounter without setting its location breaks certain pages in Bahmni.

Feature Flag: "Enable OpenMRS integration"
