### PR TITLE
Timeout can raise HTTPSConnectionPool exception

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -10,6 +10,7 @@ from dateutil import parser as dateutil_parser
 from dateutil.tz import tzutc
 from lxml import etree
 from requests import RequestException
+from urllib3.exceptions import HTTPError
 
 from casexml.apps.case.mock import CaseBlock
 from corehq.apps.case_importer import util as importer_util
@@ -158,7 +159,7 @@ def get_feed_updates(repeater, feed_name):
                     href = this_page[0].get('href')
                     page = href.split('/')[-1]
                 break
-    except RequestException:
+    except (RequestException, HTTPError):
         # Don't update repeater if OpenMRS is offline
         return
     else:

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -6,6 +6,7 @@ import re
 
 from requests import RequestException
 from six.moves import zip
+from urllib3.exceptions import HTTPError
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xform import extract_case_blocks
@@ -382,7 +383,7 @@ def get_patient_by_id(requests, patient_identifier_type, patient_identifier):
             return get_patient_by_uuid(requests, patient_identifier)
         else:
             return get_patient_by_identifier(requests, patient_identifier_type, patient_identifier)
-    except RequestException as err:
+    except (RequestException, HTTPError) as err:
         # This message needs to be useful to an administrator because
         # it will be shown in the Repeat Records report.
         http_error_msg = (


### PR DESCRIPTION
When a request times out, it can result in a NewConnectionError instead of a RequestException. This change handles that correctly.

([Sentry](https://sentry.io/dimagi/commcarehq/issues/511752934/?environment=production))
