### PR TITLE
Set module to "Unknown" if it doesn't have an ID

### DIFF
--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -436,6 +436,7 @@ class ApplicationDataRMIHelper(object):
 
             app_langs.append(form['app']['langs'][0] if 'langs' in form['app'] else 'en')
             app_id = form['app']['id'] if has_app else self.UNKNOWN_SOURCE
+            # Set module to None if it doesn't have an ID (FB 285678)
             module = form['module'] if 'module' in form and 'id' in form['module'] else None
             module_id = (module['id'] if has_app and module is not None
                          else self.UNKNOWN_SOURCE)

--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -436,7 +436,7 @@ class ApplicationDataRMIHelper(object):
 
             app_langs.append(form['app']['langs'][0] if 'langs' in form['app'] else 'en')
             app_id = form['app']['id'] if has_app else self.UNKNOWN_SOURCE
-            module = form.get('module')
+            module = form['module'] if 'module' in form and 'id' in form['module'] else None
             module_id = (module['id'] if has_app and module is not None
                          else self.UNKNOWN_SOURCE)
             module_name = self._get_item_name(


### PR DESCRIPTION
Context:
* [FB 285678](https://manage.dimagi.com/default.asp?285678)
* [Sentry](https://sentry.io/dimagi/commcarehq/issues/770010655/?environment=production)

**Unable to repro locally** ... but my reasoning is that if `module` doesn't look the way we expect, we ought to set it to `None`.

