### PR TITLE
pass information as argument to track in celery

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -636,8 +636,7 @@ class RestoreConfig(object):
             # context associated with this side of the fork will not be
             # recorded since it is async (see self.get_response).
             with self.timing_context("wait_for_task_to_start"):
-                # pass in extra args to have information about the task when viewing in celery/flower
-                task = get_async_restore_payload.delay(self, self.domain, self.restore_user.username, self.params)
+                task = get_async_restore_payload.delay(self, self.domain, self.restore_user.username)
             new_task = True
             # store the task id in cache
             self.async_restore_task_id_cache.set_value(task.id)

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -636,7 +636,8 @@ class RestoreConfig(object):
             # context associated with this side of the fork will not be
             # recorded since it is async (see self.get_response).
             with self.timing_context("wait_for_task_to_start"):
-                task = get_async_restore_payload.delay(self)
+                # pass in extra args to have information about the task when viewing in celery/flower
+                task = get_async_restore_payload.delay(self, self.domain, self.restore_user.username, self.params)
             new_task = True
             # store the task id in cache
             self.async_restore_task_id_cache.set_value(task.id)

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -40,8 +40,10 @@ def force_update_cleanliness_flags():
 
 
 @task(serializer='pickle', queue=ASYNC_RESTORE_QUEUE)
-def get_async_restore_payload(restore_config, *args):
-    """Process an async restore
+def get_async_restore_payload(restore_config, domain=None, username=None):
+    """
+    Process an async restore
+    domain and username: added for displaying restore request details on flower
     """
     response = restore_config.generate_payload(async_task=current_task)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -40,7 +40,7 @@ def force_update_cleanliness_flags():
 
 
 @task(serializer='pickle', queue=ASYNC_RESTORE_QUEUE)
-def get_async_restore_payload(restore_config):
+def get_async_restore_payload(restore_config, *args):
     """Process an async restore
     """
     response = restore_config.generate_payload(async_task=current_task)


### PR DESCRIPTION
on flower you just see
`
(<casexml.apps.phone.restore.RestoreConfig object at 0x7fbae7b4e850>,)
`
which is not helpful to debug. Just adding some information there as arguments so that we can see them on flower dashboard.

Added domain and username so that we can generate a restore. Added `params` as well but fine to drop it if it consists a lot of data or sensitive data.

buddy @dannyroberts 
