### PR TITLE
patch assertItemsEqual

### DIFF
--- a/corehq/apps/locations/tests/test_dbaccessors.py
+++ b/corehq/apps/locations/tests/test_dbaccessors.py
@@ -60,8 +60,10 @@ class TestUsersByLocation(TestCase):
 
     def test_get_user_docs_by_location(self):
         users = get_user_docs_by_location(self.domain, self.meereen._id)
-        self.assertItemsEqual([u['doc'] for u in users],
-                              [self.tyrion.to_json(), self.daenerys.to_json()])
+        self.assertEqual(
+            [u['doc'] for u in sorted(users, key=lambda user_doc: user_doc['doc']['username'])],
+            [self.daenerys.to_json(), self.tyrion.to_json()]
+        )
 
     def test_get_all_users_by_location(self):
         users = get_all_users_by_location(self.domain, self.meereen._id)

--- a/corehq/apps/reports/tests/test_report_api.py
+++ b/corehq/apps/reports/tests/test_report_api.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import json
+
 from django import test as unittest
 from sqlagg.columns import SimpleColumn, SumColumn
 from sqlagg.filters import EQFilter
@@ -79,20 +82,23 @@ class ReportAPITest(unittest.TestCase):
     def test_basic(self):
         ds = UserDataSource({}, keys=[["user1"], ["user2"]], group_by=['user'])
         data = ds.get_data()
-        self.assertItemsEqual(data, [
-            {
-                'user': 'Bob',
-                'indicator_a': 1,
-                'indicator_b': 1,
-                'cd': 50
-            },
-            {
-                'user': 'Joe',
-                'indicator_a': 1,
-                'indicator_b': 1,
-                'cd': 100
-            }
-        ])
+        self.assertItemsEqual(
+            [json.dumps(d, sort_keys=True) for d in data],
+            [
+                json.dumps({
+                    'user': 'Bob',
+                    'indicator_a': 1,
+                    'indicator_b': 1,
+                    'cd': 50
+                }, sort_keys=True),
+                json.dumps({
+                    'user': 'Joe',
+                    'indicator_a': 1,
+                    'indicator_b': 1,
+                    'cd': 100
+                }, sort_keys=True)
+            ]
+        )
 
     def test_filter(self):
         ds = UserDataSource(

--- a/corehq/apps/sms/tests/test_dbaccessors.py
+++ b/corehq/apps/sms/tests/test_dbaccessors.py
@@ -24,9 +24,9 @@ class DBAccessorsTest(TestCase):
         super(DBAccessorsTest, cls).tearDownClass()
 
     def test_get_forwarding_rules_for_domain(self):
-        self.assertItemsEqual(
+        self.assertEqual(
             [rule.to_json()
-             for rule in get_forwarding_rules_for_domain(self.domain)],
-            [rule.to_json() for rule in self.forwarding_rules
+             for rule in sorted(get_forwarding_rules_for_domain(self.domain), key=lambda rule: rule._id)],
+            [rule.to_json() for rule in sorted(self.forwarding_rules, key=lambda rule: rule._id)
              if rule.domain == self.domain]
         )

--- a/corehq/apps/userreports/tests/test_data_source_repeats.py
+++ b/corehq/apps/userreports/tests/test_data_source_repeats.py
@@ -104,9 +104,9 @@ class RepeatDataSourceBuildTest(RepeatDataSourceTestMixin, TestCase):
             } for r in rows
         ]
         # Check those rows against the expected result
-        self.assertItemsEqual(
-            retrieved_logs,
-            logs,
+        self.assertEqual(
+            sorted(retrieved_logs, key=lambda log: log['start_time']),
+            sorted(logs, key=lambda log: log['start_time']),
             "The repeat data saved in the data source table did not match the expected data!"
         )
 

--- a/corehq/apps/userreports/tests/test_dbaccessors.py
+++ b/corehq/apps/userreports/tests/test_dbaccessors.py
@@ -47,9 +47,9 @@ class DBAccessorsTest(TestCase):
         )
 
     def test_get_all_report_configs(self):
-        self.assertItemsEqual(
-            [o.to_json() for o in get_all_report_configs()],
-            [o.to_json() for o in self.report_configs]
+        self.assertEqual(
+            [o.to_json() for o in sorted(get_all_report_configs(), key=lambda report: report.title)],
+            [o.to_json() for o in sorted(self.report_configs, key=lambda report: report.title)]
         )
 
     def test_get_report_configs_for_domain(self):

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -226,7 +226,7 @@ class RetireUserTestCase(TestCase):
         expected_call_args = [mock.call(self.domain, case_id, detail) for case_id in case_ids]
 
         self.assertEqual(rebuild_case.call_count, len(case_ids))
-        self.assertItemsEqual(rebuild_case.call_args_list, expected_call_args)
+        self.assertEqual(sorted(rebuild_case.call_args_list), sorted(expected_call_args))
 
     @run_with_all_backends
     @mock.patch("casexml.apps.case.cleanup.rebuild_case_from_forms")
@@ -256,7 +256,7 @@ class RetireUserTestCase(TestCase):
         expected_call_args = [mock.call(self.domain, case_id, detail) for case_id in case_ids[1:]]
 
         self.assertEqual(rebuild_case.call_count, len(case_ids) - 1)
-        self.assertItemsEqual(rebuild_case.call_args_list, expected_call_args)
+        self.assertEqual(sorted(rebuild_case.call_args_list), sorted(expected_call_args))
 
     @run_with_all_backends
     def test_all_case_forms_deleted(self):

--- a/corehq/apps/users/tests/test_db_accessors.py
+++ b/corehq/apps/users/tests/test_db_accessors.py
@@ -152,7 +152,7 @@ class AllCommCareUsersTest(TestCase):
     def test_get_user_docs_by_username(self):
         users = [self.ccuser_1, self.web_user, self.ccuser_other_domain]
         usernames = [u.username for u in users] + ['nonexistant@username.com']
-        self.assertItemsEqual(
+        self.assertEqual(
             get_user_docs_by_username(usernames),
             [u.to_json() for u in users]
         )

--- a/corehq/apps/zapier/tests/test_fields.py
+++ b/corehq/apps/zapier/tests/test_fields.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import json
+
 from django.test.testcases import TestCase, SimpleTestCase
 from django.test.client import Client
 from tastypie.resources import Resource
@@ -155,4 +158,8 @@ class TestZapierCustomFields(TestCase):
         bundle = Resource().build_bundle(data={}, request=request)
 
         actual_fields = [field.get_content() for field in ZapierCustomFieldCaseResource().obj_get_list(bundle)]
-        self.assertItemsEqual(expected_fields, actual_fields)
+
+        def _serialize(objs):
+            return [json.dumps(obj) for obj in objs]
+
+        self.assertItemsEqual(_serialize(expected_fields), _serialize(actual_fields))

--- a/corehq/apps/zapier/tests/test_fields.py
+++ b/corehq/apps/zapier/tests/test_fields.py
@@ -160,6 +160,6 @@ class TestZapierCustomFields(TestCase):
         actual_fields = [field.get_content() for field in ZapierCustomFieldCaseResource().obj_get_list(bundle)]
 
         def _serialize(objs):
-            return [json.dumps(obj) for obj in objs]
+            return [json.dumps(obj, sort_keys=True) for obj in objs]
 
         self.assertItemsEqual(_serialize(expected_fields), _serialize(actual_fields))

--- a/custom/intrahealth/tests/reports/test_dashboard_3.py
+++ b/custom/intrahealth/tests/reports/test_dashboard_3.py
@@ -294,7 +294,7 @@ class TestDashboard3(YeksiTestCase):
             ['Produit', 'Octobre 2017', 'Novembre 2017', 'Décembre 2017', 'Janvier 2018',
              'Février 2018', 'Mars 2018']
         )
-        self.assertItemsEqual(
+        self.assertEqual(
             rows,
             sorted([
                 ['Produit A', '442.500', '717.500', '412.500', '150.000', '437.500', '150.000'],

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import sys
 import os
 import mimetypes
-from collections import namedtuple
+from collections import Counter, namedtuple
 
 import django
 
@@ -102,6 +102,18 @@ def patch_jsonfield():
     JSONField.to_python = to_python
 
 
+def patch_assertItemsEqual():
+    """
+    For Python 2/3 compatibility
+    """
+    from django.test import SimpleTestCase
+
+    def _assertItemsEqual(self, actual, expected):
+        self.assertEqual(Counter(actual), Counter(expected))
+
+    SimpleTestCase.assertItemsEqual = _assertItemsEqual
+
+
 if __name__ == "__main__":
     init_hq_python_path()
 
@@ -131,6 +143,8 @@ if __name__ == "__main__":
     # workaround for https://github.com/smore-inc/tinys3/issues/33
     mimetypes.init()
     patch_jsonfield()
+
+    patch_assertItemsEqual()
 
     set_default_settings_path(sys.argv)
     from django.core.management import execute_from_command_line

--- a/manage.py
+++ b/manage.py
@@ -108,8 +108,8 @@ def patch_assertItemsEqual():
     """
     from django.test import SimpleTestCase
 
-    def _assertItemsEqual(self, actual, expected):
-        self.assertEqual(Counter(actual), Counter(expected))
+    def _assertItemsEqual(self, actual, expected, msg=None):
+        self.assertEqual(Counter(actual), Counter(expected), msg=msg)
 
     SimpleTestCase.assertItemsEqual = _assertItemsEqual
 


### PR DESCRIPTION
After adding https://github.com/dimagi/commcare-hq/pull/22515/commits/54f5bc371017beef47d6032ba0b748180075f0ca, I had to fix tests that pass lists of dicts (which are unhashable).  I generally addressed this by dumping flat dictionaries to sorted json, or by sorting the list of dicts and using ```assertEqual```.

After merging this PR, I plan to revert PRs that replaced ```assertItemsEqual``` with a set equality comparison.