### PR TITLE
Removed help icon when there's no help

### DIFF
--- a/corehq/apps/reports/templates/reports/filters/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_option.html
@@ -19,8 +19,10 @@
             placeholder="{{ select.placeholder }}"
             name="{{ slug }}" />
     {% endif %}
-    <span class="help-block">
-        <i class="fa fa-info-circle"></i>
-        {{ filter_help_inline }} {{ search_help_inline }}
-    </span>
+    {% if filter_help_inline or search_help_inline %}
+        <span class="help-block">
+            <i class="fa fa-info-circle"></i>
+            {{ filter_help_inline }} {{ search_help_inline }}
+        </span>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
For example, the message type in the Message Log:

![screenshot from 2018-11-23 10-53-01](https://user-images.githubusercontent.com/1486591/49026676-749cdf80-f16c-11e8-9db6-156e7e44e4bb.png)

@millerdev / @proteusvacuum 