### PR TITLE
Fixed alignment of Message Log some more

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/panels.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/panels.less
@@ -63,6 +63,12 @@
   }
 }
 
+.form-horizontal .panel-body .form-group,
+.panel-body .form-horizontal .form-group {
+  margin-right: 0;
+  margin-left: 0;
+}
+
 .panel-group .panel-modern-gray {
   .border-top-radius(0);
   .border-bottom-radius(0);

--- a/corehq/apps/reports/templates/reports/filters/location_async.html
+++ b/corehq/apps/reports/templates/reports/filters/location_async.html
@@ -8,15 +8,15 @@
     Same with the .report-filter-location-async below.
 -->
 <div class="row">
-    <div class="form-group">
-        <label class="control-label {{ css_label_class }}">{% trans "Location Filter" %}</label>
-        <div class="{{ css_field_class }}">
-            <div class="col-sm-12">
-                <select class="form-control"
-                        data-bind="value: show_location_filter">
-                    <option value="y">{% trans "On" %}</option>
-                    <option value="n">{% trans "Off" %}</option>
-                </select>
+    <div class="col-sm-12">
+        <div class="form-group">
+            <label class="control-label {{ css_label_class }}">{% trans "Location Filter" %}</label>
+            <div class="{{ css_field_class }}">
+                    <select class="form-control"
+                            data-bind="value: show_location_filter">
+                        <option value="y">{% trans "On" %}</option>
+                        <option value="n">{% trans "Off" %}</option>
+                    </select>
             </div>
         </div>
     </div>
@@ -24,17 +24,18 @@
 {% endif %}
 
 <div class="row">
-    <div class="form-group report-filter-location-async"
-         data-bind="visible: show_location_filter_bool()"
-         data-make-optional='{{ make_optional|JSON }}'
-         data-loc-id='{{ loc_id }}'
-         data-location-url='{{ api_root }}'
-         data-hierarchy='{{ hierarchy|JSON }}'
-         data-auto-drill='{{ auto_drill|JSON }}'
-         data-locs='{{ locations|JSON }}'>
-        <label class="control-label {{ css_label_class }}">{{ control_name }}</label> {# this is wrong, see filters/single_option.html for a proper implementation #}
-        <div class="{{ css_field_class }}">
-            <div class="col-sm-12">
+    <div class="col-sm-12">
+        <div class="form-group report-filter-location-async"
+             data-bind="visible: show_location_filter_bool()"
+             data-make-optional='{{ make_optional|JSON }}'
+             data-loc-id='{{ loc_id }}'
+             data-location-url='{{ api_root }}'
+             data-hierarchy='{{ hierarchy|JSON }}'
+             data-auto-drill='{{ auto_drill|JSON }}'
+             data-locs='{{ locations|JSON }}'>
+            {# this is wrong, see filters/single_option.html for a proper implementation #}
+            <label class="control-label {{ css_label_class }}">{{ control_name }}</label>
+            <div class="{{ css_field_class }}">
                 <div data-bind="foreach: selected_path" style="display: inline-block;">
                     {% block location_select %}
                     <select class="form-control"
@@ -46,7 +47,7 @@
                 </div>
                 <i id="loc_ajax" class="fa fa-spinner fa-spin hide"></i>
             </div>
+            <input name="location_id" type="hidden" data-bind="value: selected_locid" />
         </div>
-        <input name="location_id" type="hidden" data-bind="value: selected_locid" />
     </div>
 </div>

--- a/corehq/apps/reports/templates/reports/filters/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_option.html
@@ -19,8 +19,10 @@
             placeholder="{{ select.placeholder }}"
             name="{{ slug }}" />
     {% endif %}
-    <span class="help-block">
-        <i class="fa fa-info-circle"></i>
-        {{ filter_help_inline }} {{ search_help_inline }}
-    </span>
+    {% if filter_help_inline or search_help_inline %}
+        <span class="help-block">
+            <i class="fa fa-info-circle"></i>
+            {{ filter_help_inline }} {{ search_help_inline }}
+        </span>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
A followup for the combination of https://github.com/dimagi/commcare-hq/pull/21971 and https://github.com/dimagi/commcare-hq/pull/22322

@millerdev / @proteusvacuum 

`w=1`

before
<img width="764" alt="screen shot 2018-11-26 at 11 53 40 am" src="https://user-images.githubusercontent.com/1486591/49029229-1f63cc80-f172-11e8-8395-e5e56defd75c.png">

after
<img width="790" alt="screen shot 2018-11-26 at 11 53 31 am" src="https://user-images.githubusercontent.com/1486591/49029238-238fea00-f172-11e8-9609-27e9a2843c49.png">
