### PR TITLE
Fixed js error when #create-export isn't present

### DIFF
--- a/corehq/apps/export/static/export/js/export_list_main.js
+++ b/corehq/apps/export/static/export/js/export_list_main.js
@@ -1,21 +1,24 @@
 hqDefine("export/js/export_list_main", function () {
     $(function () {
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+            $createExport = $("#create-export");
 
-        $("#create-export").koApplyBindings(hqImport("export/js/create_export").createExportModel({
-            model_type: initialPageData.get("model_type", true),
-            drilldown_fetch_url: initialPageData.reverse('get_app_data_drilldown_values'),
-            drilldown_submit_url: initialPageData.reverse('submit_app_data_drilldown_form'),
-            page: {
-                is_daily_saved_export: initialPageData.get('is_daily_saved_export', true),
-                is_feed: initialPageData.get('is_feed', true),
-                is_deid: initialPageData.get('is_deid', true),
-                model_type: initialPageData.get('model_type', true),
-            },
-        }));
-        $('#createExportOptionsModal').on('show.bs.modal', function () {
-            hqImport('analytix/js/kissmetrix').track.event("Clicked New Export");
-        });
+        if ($createExport.length) {
+            $createExport.koApplyBindings(hqImport("export/js/create_export").createExportModel({
+                model_type: initialPageData.get("model_type", true),
+                drilldown_fetch_url: initialPageData.reverse('get_app_data_drilldown_values'),
+                drilldown_submit_url: initialPageData.reverse('submit_app_data_drilldown_form'),
+                page: {
+                    is_daily_saved_export: initialPageData.get('is_daily_saved_export', true),
+                    is_feed: initialPageData.get('is_feed', true),
+                    is_deid: initialPageData.get('is_deid', true),
+                    model_type: initialPageData.get('model_type', true),
+                },
+            }));
+            $('#createExportOptionsModal').on('show.bs.modal', function () {
+                hqImport('analytix/js/kissmetrix').track.event("Clicked New Export");
+            });
+        }
 
         var modelType = initialPageData.get("model_type");
         $("#export-list").koApplyBindings(hqImport("export/js/export_list").exportListModel({


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?286070

Introduced in https://github.com/dimagi/commcare-hq/pull/22128

@millerdev 
@jmtroth0 This would be nice to get into today's deploy, it's rather significant for the affected users (I'm going to go kill tests on some of my other PRs so they don't block this one).