### PR TITLE
Add SQL to copy from attachments to blobmeta table

### DIFF
--- a/corehq/form_processor/management/commands/run_sql.py
+++ b/corehq/form_processor/management/commands/run_sql.py
@@ -84,7 +84,7 @@ def run_once(sql, dbname):
 class RunUntilZero(object):
     """SQL statement to be run repeatedly
 
-    ...until the first column of of the first returned row is zero.
+    ...until the first column of the first returned row is zero.
     """
 
     sql = attr.ib()

--- a/corehq/form_processor/management/commands/run_sql.py
+++ b/corehq/form_processor/management/commands/run_sql.py
@@ -25,13 +25,13 @@ class Command(BaseCommand):
         sql = STATEMENTS[name]
         dbnames = get_db_aliases_for_partitioned_query()
         if dbname or len(dbnames) == 1:
-            run_sql(dbname or dbnames[0], sql)
+            run_sql(sql, dbname or dbnames[0])
         elif not confirm(MULTI_DB % len(dbnames)):
             sys.exit('abort')
         else:
             greenlets = []
             for dbname in dbnames:
-                g = gevent.spawn(run_sql, dbname, sql)
+                g = gevent.spawn(run_sql, sql, dbname)
                 greenlets.append(g)
 
             gevent.joinall(greenlets)
@@ -46,7 +46,7 @@ def confirm(msg):
     return input(msg + "\n(y/N) ").lower() == 'y'
 
 
-def run_sql(dbname, sql):
+def run_sql(sql, dbname):
     print("running on %s database" % dbname)
     with connections[dbname].cursor() as cursor:
         cursor.execute(sql)

--- a/corehq/form_processor/management/commands/run_sql.py
+++ b/corehq/form_processor/management/commands/run_sql.py
@@ -126,6 +126,58 @@ ON public.form_processor_xformattachmentsql (((
 """
 
 
+# Move rows incrementally.
+# WARNING monitor disk usage when running in large environments.
+# Does not require downtime, but may be slow.
+MOVE_FORM_ATTACHMENTS = RunUntilZero("""
+WITH deleted AS (
+    DELETE FROM form_processor_xformattachmentsql
+    WHERE id IN (
+        SELECT id FROM form_processor_xformattachmentsql
+        LIMIT {chunk_size}
+    )
+    RETURNING *
+), moved AS (
+    INSERT INTO blobs_blobmeta_tbl (
+        "domain",
+        parent_id,
+        "name",
+        "key",
+        type_code,
+        content_type,
+        properties,
+        created_on,
+        content_length
+    ) SELECT
+        COALESCE(xform."domain", '<unknown>'),
+        att.form_id AS parent_id,
+        att."name",
+        (CASE
+            WHEN att.blob_bucket = '' THEN '' -- empty bucket -> blob_id is the key
+            ELSE COALESCE(att.blob_bucket, 'form/' || att.attachment_id) || '/'
+        END || att.blob_id)::VARCHAR(255) AS "key",
+        CASE
+            WHEN att."name" = 'form.xml' THEN 1 -- corehq.blobs.CODES.form_xml
+            ELSE 2 -- corehq.blobs.CODES.form_attachment
+        END::SMALLINT AS type_code,
+        att.content_type,
+        CASE
+            WHEN att.properties = '{{}}' THEN NULL
+            ELSE att.properties
+        END AS properties,
+        COALESCE(xform.received_on, CURRENT_TIMESTAMP) AS created_on,
+        att.content_length
+    FROM deleted att
+    -- outer join so we move deleted rows with no corresponding xform instance
+    -- should not happen, but just in case (without this they would be lost)
+    LEFT OUTER JOIN form_processor_xforminstancesql xform
+        ON xform.form_id = att.form_id
+    RETURNING *
+) SELECT COUNT(*) FROM moved
+""")
+
+
 TEMPLATES = {
     "blobmeta_key": BLOBMETA_KEY_SQL,
+    "move_form_attachments_to_blobmeta": MOVE_FORM_ATTACHMENTS,
 }

--- a/corehq/form_processor/management/commands/run_sql.py
+++ b/corehq/form_processor/management/commands/run_sql.py
@@ -19,19 +19,19 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('name', choices=list(STATEMENTS), help="SQL statement name.")
-        parser.add_argument('-d', '--db_name', help='Django DB alias to run on')
+        parser.add_argument('-d', '--dbname', help='Django DB alias to run on')
 
-    def handle(self, name, db_name, **options):
+    def handle(self, name, dbname, **options):
         sql = STATEMENTS[name]
-        db_names = get_db_aliases_for_partitioned_query()
-        if db_name or len(db_names) == 1:
-            run_sql(db_name or db_names[0], sql)
-        elif not confirm(MULTI_DB % len(db_names)):
+        dbnames = get_db_aliases_for_partitioned_query()
+        if dbname or len(dbnames) == 1:
+            run_sql(dbname or dbnames[0], sql)
+        elif not confirm(MULTI_DB % len(dbnames)):
             sys.exit('abort')
         else:
             greenlets = []
-            for db_name in db_names:
-                g = gevent.spawn(run_sql, db_name, sql)
+            for dbname in dbnames:
+                g = gevent.spawn(run_sql, dbname, sql)
                 greenlets.append(g)
 
             gevent.joinall(greenlets)
@@ -46,9 +46,9 @@ def confirm(msg):
     return input(msg + "\n(y/N) ").lower() == 'y'
 
 
-def run_sql(db_name, sql):
-    print("running on %s database" % db_name)
-    with connections[db_name].cursor() as cursor:
+def run_sql(dbname, sql):
+    print("running on %s database" % dbname)
+    with connections[dbname].cursor() as cursor:
         cursor.execute(sql)
 
 

--- a/corehq/form_processor/management/commands/run_sql.py
+++ b/corehq/form_processor/management/commands/run_sql.py
@@ -1,9 +1,16 @@
+"""Run SQL concurrently on partition databases
+
+SQL statement templates may use the `{chunk_size}` placeholder, which
+will be replaced with the value of the --chunk-size=N command argument.
+"""
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 import sys
+import time
 import traceback
 
+import attr
 import gevent
 from django.core.management.base import BaseCommand
 from django.db import connections
@@ -18,20 +25,24 @@ class Command(BaseCommand):
     help = """Run SQL concurrently on partition databases."""
 
     def add_arguments(self, parser):
-        parser.add_argument('name', choices=list(STATEMENTS), help="SQL statement name.")
+        parser.add_argument('name', choices=list(TEMPLATES), help="SQL statement name.")
         parser.add_argument('-d', '--dbname', help='Django DB alias to run on')
+        parser.add_argument('--chunk-size', type=int, default=1000,
+            help="Maximum number of records to move at once.")
 
-    def handle(self, name, dbname, **options):
-        sql = STATEMENTS[name]
+    def handle(self, name, dbname, chunk_size, **options):
+        template = TEMPLATES[name]
+        sql = template.format(chunk_size=chunk_size)
+        run = getattr(template, "run", run_once)
         dbnames = get_db_aliases_for_partitioned_query()
         if dbname or len(dbnames) == 1:
-            run_sql(sql, dbname or dbnames[0])
+            run(sql, dbname or dbnames[0])
         elif not confirm(MULTI_DB % len(dbnames)):
             sys.exit('abort')
         else:
             greenlets = []
             for dbname in dbnames:
-                g = gevent.spawn(run_sql, sql, dbname)
+                g = gevent.spawn(run, sql, dbname)
                 greenlets.append(g)
 
             gevent.joinall(greenlets)
@@ -46,10 +57,47 @@ def confirm(msg):
     return input(msg + "\n(y/N) ").lower() == 'y'
 
 
-def run_sql(sql, dbname):
+def run_once(sql, dbname):
+    """Run sql statement once on database
+
+    This is the default run mode for statements
+    """
     print("running on %s database" % dbname)
     with connections[dbname].cursor() as cursor:
         cursor.execute(sql)
+
+
+@attr.s
+class RunUntilZero(object):
+    """SQL statement to be run repeatedly
+
+    ...until the first column of of the first returned row is zero.
+    """
+
+    sql = attr.ib()
+
+    def format(self, **kw):
+        return self.sql.format(**kw)
+
+    @staticmethod
+    def run(sql, dbname):
+        next_update = 0
+        total = 0
+        with connections[dbname].cursor() as cursor:
+            while True:
+                cursor.execute(sql)
+                rows = cursor.fetchmany(2)
+                assert len(rows) == 1 and len(rows[0]) == 1, \
+                    "expected 1 row with 1 column, got %r" % (rows,)
+                moved = rows[0][0]
+                if not moved:
+                    break
+                total += moved
+                now = time.time()
+                if now > next_update:
+                    print("{}: processed {} items".format(dbname, total))
+                    next_update = now + 5
+        print("{} final: processed {} items".format(dbname, total))
 
 
 # see https://github.com/dimagi/commcare-hq/pull/21631
@@ -64,6 +112,6 @@ ON public.form_processor_xformattachmentsql (((
 """
 
 
-STATEMENTS = {
+TEMPLATES = {
     "blobmeta_key": BLOBMETA_KEY_SQL,
 }

--- a/corehq/form_processor/management/commands/run_sql.py
+++ b/corehq/form_processor/management/commands/run_sql.py
@@ -11,7 +11,7 @@ from six.moves import input
 
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 
-MULTI_DB = 'Execute on ALL (%s) databases in parallel. Continue?'
+MULTI_DB = 'Executing on ALL (%s) databases in parallel. Continue?'
 
 
 class Command(BaseCommand):

--- a/manage.py
+++ b/manage.py
@@ -113,6 +113,7 @@ if __name__ == "__main__":
     GEVENT_COMMANDS = (
         GeventCommand('mvp_force_update', None),
         GeventCommand('run_gunicorn', None),
+        GeventCommand('run_sql', None),
         GeventCommand('preindex_everything', None),
         GeventCommand('migrate_multi', None),
         GeventCommand('prime_views', None),


### PR DESCRIPTION
This will be run after #21631 has been merged to reduce the amount of time spent in inefficient queries resulting from the `blobs_blobmeta` view. Once this has been run on all environments (I may add something like this to a django migration to automate small environments), we can remove the `blobs_blobmeta` view and `form_processor_xformattachmentsql` table.

Tested locally. Review by commit 🐠

@snopoke cc @orangejenny 