### PR TITLE
Second param missing

### DIFF
--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -632,9 +632,9 @@ class CaseRuleActionsForm(forms.Form):
         self.helper.layout = Layout(
             Fieldset(
                 _("Actions"),
-                hidden_bound_field('close_case'),
-                hidden_bound_field('properties_to_update'),
-                hidden_bound_field('custom_action_definitions'),
+                hidden_bound_field('close_case', 'closeCase'),
+                hidden_bound_field('properties_to_update', 'propertiesToUpdate'),
+                hidden_bound_field('custom_action_definitions', 'customActionDefinitions'),
                 Div(data_bind="template: {name: 'case-actions'}"),
                 css_id="rule-actions",
             ),


### PR DESCRIPTION
Context: [Jira HI-144](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=5&modal=detail&selectedIssue=HI-144)

Calls to `hidden_bound_field()` are just missing the corresponding name of the Observable on the [caseRuleActions](https://github.com/dimagi/commcare-hq/blob/2f750ae609bc65fe76750056cd4c0b87098490d7/corehq/apps/data_interfaces/static/data_interfaces/js/case_rule_actions.js#L10) JavaScript class.
