### PR TITLE
replace positional argument with keyword argument for clarity

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3027,7 +3027,8 @@ class InvoicePdf(BlobMixin, SafeSaveDocument):
         }
 
     def get_data(self, invoice):
-        return self.fetch_attachment(self.get_filename(invoice), stream=True).read()
+        with self.fetch_attachment(self.get_filename(invoice), stream=True) as fh:
+            return fh.read()
 
 
 class LineItemManager(models.Manager):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3027,7 +3027,7 @@ class InvoicePdf(BlobMixin, SafeSaveDocument):
         }
 
     def get_data(self, invoice):
-        return self.fetch_attachment(self.get_filename(invoice), True).read()
+        return self.fetch_attachment(self.get_filename(invoice), stream=True).read()
 
 
 class LineItemManager(models.Manager):


### PR DESCRIPTION
Helps clarify which argument is being passed.  I'm working towards having ```stream``` or ```return_bytes``` be true for all calls to ```fetch_attachment``` so that it always returns bytes.