### PR TITLE
XFormInstance.get_attachment should return bytes

### DIFF
--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -288,7 +288,7 @@ class XFormInstance(DeferredBlobMixin, SafeSaveDocument, UnicodeMixIn,
                 return None
 
     def get_attachment(self, attachment_name):
-        return self.fetch_attachment(attachment_name)
+        return self.fetch_attachment(attachment_name, return_bytes=True)
 
     def get_xml_element(self):
         xml_string = self.get_xml()


### PR DESCRIPTION
This means that ```form.get_xml()``` will have the same interface for couch and sql forms.