### PR TITLE
actually add system forms to export

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -14,7 +14,6 @@ from corehq.apps.groups.models import Group
 from corehq.apps.locations.permissions import user_can_access_other_user
 from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.apps.commtrack.models import SQLLocation
 from corehq.toggles import FILTER_ON_GROUPS_AND_LOCATIONS
 
@@ -347,7 +346,6 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
             user_type_filters.append(user_es.admin_users())
         if HQUserType.UNKNOWN in user_types:
             user_type_filters.append(user_es.unknown_users())
-            user_type_filters.append(user_es.username(SYSTEM_USER_ID))
         if HQUserType.WEB in user_types:
             user_type_filters.append(user_es.web_users())
         if HQUserType.DEMO_USER in user_types:

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -21,6 +21,7 @@ from corehq.apps.reports.generic import (GenericTabularReport,
 from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin, CompletionOrSubmissionTimeMixin
 from corehq.apps.reports.util import datespan_from_beginning
 from corehq.const import MISSING_APP_ID
+from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.toggles import SUPPORT
 from memoized import memoized
 
@@ -67,6 +68,9 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
                                        mobile_user_and_group_slugs,
                                        self.request.couch_user)
                     .values_list('_id', flat=True))
+
+        if HQUserType.UNKNOWN in EMWF.selected_user_types(mobile_user_and_group_slugs):
+            user_ids.append(SYSTEM_USER_ID)
         # If no filters are selected, return all results
         return form_es.user_id(user_ids)
 
@@ -102,7 +106,6 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
         if HQUserType.UNKNOWN not in EMWF.selected_user_types(mobile_user_and_group_slugs):
             for xmlns in SYSTEM_FORM_XMLNS_MAP.keys():
                 query = query.NOT(form_es.xmlns(xmlns))
-
         return query
 
     @property

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -71,7 +71,7 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
 
         if HQUserType.UNKNOWN in EMWF.selected_user_types(mobile_user_and_group_slugs):
             user_ids.append(SYSTEM_USER_ID)
-        # If no filters are selected, return all results
+
         return form_es.user_id(user_ids)
 
     @staticmethod
@@ -94,7 +94,8 @@ class SubmitHistoryMixin(ElasticProjectInspectionReport,
                  .filter(time_filter(gte=self.datespan.startdate,
                                      lt=self.datespan.enddate_adjusted))
                  .filter(self._get_users_filter(mobile_user_and_group_slugs)
-                         if not EMWF.no_filters_selected(mobile_user_and_group_slugs) else match_all()))
+                         if not EMWF.no_filters_selected(mobile_user_and_group_slugs)
+                         else match_all()))  # If no filters are selected, return all results
 
         # filter results by app and xmlns if applicable
         if FormsByApplicationFilter.has_selections(self.request):


### PR DESCRIPTION
take 2 on this one: https://github.com/dimagi/commcare-hq/pull/22460 

Unsurprisingly there isn't a CouchUser for the system user, so that didn't return anything. I sort of dislike that this is implemented as so many requests to ES, but refactoring that is a bit out of scope.

https://dimagi-dev.atlassian.net/browse/HI-72

people who were on the last one: @esoergel @proteusvacuum buddy: @kaapstorm