### PR TITLE
Add app summary link for each version

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
@@ -54,6 +54,7 @@
   {% registerurl "download_multimedia_zip" app.domain '---' %}
   {% registerurl "project_report_dispatcher" app.domain 'application_error' %}
   {% registerurl "formplayer_main" app.domain %}
+  {% registerurl "app_form_summary" app.domain '---' %}
   <div class="tab-pane" id="releases">
     {% include "app_manager/partials/releases/releases.html" %}
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Case Summary" %}{% endblock %}
+{% block title %}{% trans "Case Summary" %} - {% trans "Version" %} {{ app_version }}{% endblock %}
 
 {% requirejs_main 'app_manager/js/summary/case_summary' %}
 
@@ -12,7 +12,10 @@
     <div class="page-header" style="margin-top: 0;">
         <h3>
           <i class="fcc fcc-fd-external-case"></i>
-          <span>{% trans "Case Summary" %}</span>
+          <span>{% trans "Case Summary" %} - {% trans "Version" %} {{ app_version }}</span>
+          {% if app_id != latest_app_id %}
+              <small><a href="{% url 'app_case_summary' domain  latest_app_id %}">{% trans "See latest" %}</a> </small>
+          {% endif %}
         </h3>
         <div class="row">
             <div class="col-xs-3">

--- a/corehq/apps/app_manager/templates/app_manager/form_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Form Summary" %}{% endblock %}
+{% block title %}{% trans "Form Summary" %} - {% trans "Version" %} {{ app_version }}{% endblock %}
 
 {% requirejs_main "app_manager/js/summary/form_summary" %}
 
@@ -15,7 +15,10 @@
     <div class="page-header" style="margin-top: 0;">
         <h3>
           <i class="fa fa-file-text-o"></i>
-          {% trans "Form Summary" %}</h1>
+          {% trans "Form Summary" %}  - {% trans "Version" %} {{ app_version }}
+          {% if app_id != latest_app_id %}
+              <small><a href="{% url 'app_form_summary' domain  latest_app_id %}">{% trans "See latest" %}</a> </small>
+          {% endif %}
         </h3>
         <div class="row">
             <div class="col-xs-3">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -198,6 +198,11 @@
                         openModal: 'revert-build-modal-template',
                         visible: version() !== $root.currentAppVersion(),
                         css: {hide: false}">{% trans "Revert to this Version" %}</button>
+            <a class="btn btn-default" target="_blank"
+               data-bind="attr: { href: hqImport('hqwebapp/js/initial_page_data').reverse('app_form_summary', $data.id()) }">
+                <i class="fa fa-list-alt"></i>
+                {% trans "App Summary" %}
+            </a>
             {% if request|toggle_enabled:"VIEW_APP_CHANGES" %}
             <button class="btn btn-default" data-toggle="modal" data-target="#app-diff-modal" data-bind="
                 click: function() { $parent.onViewChanges($data.id(), $parent.previousBuildId($index())) }

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -193,16 +193,16 @@
             </div>
           </div><!-- .panel-body -->
           <div class="panel-footer">
-            <button class="btn btn-default hide"
-                    data-bind="
-                        openModal: 'revert-build-modal-template',
-                        visible: version() !== $root.currentAppVersion(),
-                        css: {hide: false}">{% trans "Revert to this Version" %}</button>
-            <a class="btn btn-default" target="_blank"
-               data-bind="attr: { href: hqImport('hqwebapp/js/initial_page_data').reverse('app_form_summary', $data.id()) }">
-                <i class="fa fa-list-alt"></i>
-                {% trans "App Summary" %}
-            </a>
+              <a class="btn btn-default" target="_blank"
+                 data-bind="attr: { href: hqImport('hqwebapp/js/initial_page_data').reverse('app_form_summary', $data.id()) }">
+                  <i class="fa fa-list-alt"></i>
+                  {% trans "App Summary" %}
+              </a>
+              <button class="btn btn-default hide"
+                      data-bind="
+                             openModal: 'revert-build-modal-template',
+                             visible: version() !== $root.currentAppVersion(),
+                             css: {hide: false}">{% trans "Revert to this Version" %}</button>
             {% if request|toggle_enabled:"VIEW_APP_CHANGES" %}
             <button class="btn btn-default" data-toggle="modal" data-target="#app-diff-modal" data-bind="
                 click: function() { $parent.onViewChanges($data.id(), $parent.previousBuildId($index())) }
@@ -210,17 +210,19 @@
                 {% trans "View Changes" %}
             </button>
             {% endif %}
-            <a class="btn"
-               data-bind="
-                openModal: 'deploy-build-modal-template',
-                css: {'btn-primary': !build_broken(), 'btn-danger': build_broken},
-                click: clickDeploy
-            ">
-                <span class="fa fa-exclamation-circle hide"
-                      data-bind="visible: build_broken, css: {hide: false}">
-                </span>
-                {% trans "Publish" %}
-            </a>
+            <span class="pull-right">
+                <a class="btn"
+                   data-bind="
+                          openModal: 'deploy-build-modal-template',
+                          css: {'btn-primary': !build_broken(), 'btn-danger': build_broken},
+                          click: clickDeploy
+                          ">
+                    <span class="fa fa-exclamation-circle hide"
+                          data-bind="visible: build_broken, css: {hide: false}">
+                    </span>
+                    {% trans "Publish" %}
+                </a>
+            </span>
           </div><!-- .panel-footer -->
         </div><!-- .panel-release -->
     </div> <!-- .releases-container -->

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -55,6 +55,8 @@ class AppSummaryView(LoginAndDomainMixin, BasePageView, ApplicationViewMixin):
             'app_id': self.app.id,
             'app_name': self.app.name,
             'read_only': self.app.doc_type == 'LinkedApplication',
+            'app_version': self.app.version,
+            'latest_app_id': self.app.master_id,
         }
 
     @property

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -1,17 +1,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import io
-from copy import copy
 from collections import namedtuple
 
 from django.urls import reverse
 from django.http import Http404
 from django.utils.translation import ugettext_noop, ugettext_lazy as _
-from djangular.views.mixins import allow_remote_invocation
 from django.views.generic import View
 from dimagi.utils.web import json_response
 
-from corehq.apps.app_manager.exceptions import XFormException
 from corehq.apps.app_manager.util import get_form_data
 from corehq.apps.app_manager.view_helpers import ApplicationViewMixin
 from corehq.apps.app_manager.views.utils import get_langs
@@ -20,7 +17,6 @@ from corehq.apps.app_manager.xform import VELLUM_TYPES
 from corehq.apps.domain.views.base import LoginAndDomainMixin
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.reports.formdetails.readable import FormQuestionResponse
-from corehq.apps.hqwebapp.decorators import use_angular_js
 from couchexport.export import export_raw
 from couchexport.models import Format
 from couchexport.shortcuts import export_response

--- a/corehq/apps/hqwebapp/static/app_manager/less/panel.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/panel.less
@@ -132,7 +132,6 @@
 }
 
 .panel-release > .panel-footer {
-  text-align: right;
   border-top: 0;
   background-color: transparent;
   padding-top: 0;


### PR DESCRIPTION
Did you know that you can see the app summary for every single version of the app you ever made? You can! This PR exposes that functionality so you can see what your app looked like in the past without you needing to know some magic URL. 

![screenshot from 2018-11-27 16-06-28](https://user-images.githubusercontent.com/146896/49111662-c160e300-f25e-11e8-9a26-e5972cfd222b.png)

I changed the summary page titles so you know what version you are looking at: 
![screenshot from 2018-11-27 16-10-08](https://user-images.githubusercontent.com/146896/49111716-ef462780-f25e-11e8-96e6-8f467c6be8b0.png)

Pinging @dimagi/product in case you want me to hide this or put the button elsewhere.