### PR TITLE
restrict ability to manage release to only specific users

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -110,59 +110,61 @@
                 'error': build_broken
             }">
           <div class="panel-heading">
-              {% if request|toggle_enabled:"SUPPORT" %}
-                  <div class="release-trash-container">
-                    <a href="#"
-                       class="hide release-remove"
-                       data-bind="openModal: 'delete-build-modal-template',
-                                  visible: !_deleteState(),
-                                  css: {hide: false}">
-                        <i class="fa fa-trash"></i>
-                    </a>
-                    <div class="pending hide" data-bind="visible: _deleteState() == 'pending', css: {hide: false}">
-                        <img src="{% static 'hqwebapp/images/ajax-loader.gif' %}" alt="loading indicator" />
-                    </div>
-                    <i class="fa fa-exclamation-circle hide"
-                       data-bind="visible: _deleteState() == 'error',
-                                  css: {hide: false}"></i>
+              {% if can_manage_releases %}
+                  {% if request|toggle_enabled:"SUPPORT" %}
+                      <div class="release-trash-container">
+                        <a href="#"
+                           class="hide release-remove"
+                           data-bind="openModal: 'delete-build-modal-template',
+                                      visible: !_deleteState(),
+                                      css: {hide: false}">
+                            <i class="fa fa-trash"></i>
+                        </a>
+                        <div class="pending hide" data-bind="visible: _deleteState() == 'pending', css: {hide: false}">
+                            <img src="{% static 'hqwebapp/images/ajax-loader.gif' %}" alt="loading indicator" />
+                        </div>
+                        <i class="fa fa-exclamation-circle hide"
+                           data-bind="visible: _deleteState() == 'error',
+                                      css: {hide: false}"></i>
+                      </div>
+                  {% endif %}
+                  <div class="build-is-released">
+                      <!--ko if: is_released() == 'error' -->
+
+                      <span class="label label-danger">{% trans "Could not update" %}</span>
+
+                      <!--/ko-->
+                      <!--ko if: is_released() != 'error' -->
+
+                      <span class="label label-info"
+                            data-bind="visible: version() === $root.latestReleasedVersion()">{% trans "Latest" %}</span>
+                      <i class="fa fa-spin fa-refresh hide js-release-waiting"></i>
+                      <div class="btn-group">
+                          <button type="button"
+                                  class="btn btn-xs"
+                                  data-bind="click: $root.toggleRelease,
+                                             css: {
+                                                'active': is_released(),
+                                                'btn-success': is_released(),
+                                                'btn-default': !is_released()
+                                             }">
+                              {% trans "Released" %}
+                          </button>
+                          <button type="button"
+                                  class="btn btn-xs btn-default"
+                                  data-bind="click: $root.toggleRelease,
+                                             css: {
+                                                'active': !is_released(),
+                                                'btn-primary': !is_released(),
+                                                'btn-default': is_released()
+                                             }">
+                              {% trans "In Test" %}
+                          </button>
+                      </div>
+
+                      <!--/ko-->
                   </div>
               {% endif %}
-              <div class="build-is-released">
-                  <!--ko if: is_released() == 'error' -->
-
-                  <span class="label label-danger">{% trans "Could not update" %}</span>
-
-                  <!--/ko-->
-                  <!--ko if: is_released() != 'error' -->
-
-                  <span class="label label-info"
-                        data-bind="visible: version() === $root.latestReleasedVersion()">{% trans "Latest" %}</span>
-                  <i class="fa fa-spin fa-refresh hide js-release-waiting"></i>
-                  <div class="btn-group">
-                      <button type="button"
-                              class="btn btn-xs"
-                              data-bind="click: $root.toggleRelease,
-                                         css: {
-                                            'active': is_released(),
-                                            'btn-success': is_released(),
-                                            'btn-default': !is_released()
-                                         }">
-                          {% trans "Released" %}
-                      </button>
-                      <button type="button"
-                              class="btn btn-xs btn-default"
-                              data-bind="click: $root.toggleRelease,
-                                         css: {
-                                            'active': !is_released(),
-                                            'btn-primary': !is_released(),
-                                            'btn-default': is_released()
-                                         }">
-                          {% trans "In Test" %}
-                      </button>
-                  </div>
-
-                  <!--/ko-->
-              </div>
               <h4 class="panel-release-title">
                 <strong>{% trans "Version" %} <span data-bind="text: version"></span></strong> |
                 <span data-bind="text: built_on_date"></span> <span data-bind="text: built_on_time"></span> {% trans 'by' %}

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -169,6 +169,8 @@ def get_releases_context(request, domain, app_id):
         'prompt_settings_url': reverse(PromptSettingsUpdateView.urlname, args=[domain, app_id]),
         'prompt_settings_form': prompt_settings_form,
         'full_name': request.couch_user.full_name,
+        'can_manage_releases': (not toggles.RESTRICT_APP_RELEASE.enabled(request.domain) or
+                                toggles.RESTRICT_APP_RELEASE.enabled(request.couch_user.username))
     }
     if not app.is_remote_app():
         context.update({

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1668,3 +1668,12 @@ SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL = DynamicallyPredictablyRandomToggle(
     TAG_PRODUCT,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+
+RESTRICT_APP_RELEASE = StaticToggle(
+    'restrict_app_release',
+    'ICDS: Restrict App Release management to only specific users for a domain',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_USER, NAMESPACE_DOMAIN],
+    relevant_environments={'icds', 'icds-new', 'softlayer'},
+)


### PR DESCRIPTION
There were couple of accidental releases on ICDS and it also reached about a 100 FLWs.

Context/Specifics/Suggestions on [asna](https://app.asana.com/0/898060497005556/918622821223990)

While we are figuring out a more robust process, if needed,
this one just revokes the default access to manage releases and provides it only to the users added in the FF.
So for example if add a domain, "icds-cas", all of its apps would not show the buttons to update build status, and when a user is added in that FF, that person would start seeing them.
