### PR TITLE
Fix deprecated form attachment reparenting

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -644,11 +644,11 @@ class FormAccessorSQL(AbstractFormAccessor):
 
         with transaction.atomic(using=db_name):
             if form.form_id_updated():
-                attachments = form.original_attachments
                 operations = form.original_operations + new_operations
                 with transaction.atomic(db_name):
                     form.save()
-                    for model in itertools.chain(attachments, operations):
+                    get_blob_db().metadb.reparent(form.original_form_id, form.form_id)
+                    for model in operations:
                         model.form = form
                         model.save()
             else:


### PR DESCRIPTION
Reparent form attachments when saving deprecated form rather than when saving the new form attachments. This might not work for normal submission post (not data cleaning) form processing. I can't tell if the deprecated form (with newly assigned id, etc.) gets saved before this line (when `stub is None and not existing_form.is_error`):

https://github.com/dimagi/commcare-hq/blob/6313aaa7356e88290cf73d2007403d92644a2f12/corehq/form_processor/submission_post.py#L272

Related issue: https://dimagi-dev.atlassian.net/browse/HI-156

Wait for tests.

@snopoke cc @orangejenny 