### PR TITLE
fix password obfuscation tests in python 3

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -92,10 +92,9 @@ def get_username_and_password_from_request(request):
         except UnicodeDecodeError:
             pass
     elif auth[0].lower() == BASIC:
-        username, password = base64.b64decode(auth[1]).split(b':', 1)
+        username, password = _decode(base64.b64decode(auth[1])).split(':', 1)
         # decode password submitted from mobile app login
         password = decode_password(password, username)
-        username, password = _decode(username), _decode(password)
     return username, password
 
 

--- a/custom/nic_compliance/tests/test_utils.py
+++ b/custom/nic_compliance/tests/test_utils.py
@@ -53,9 +53,9 @@ class TestDecodePassword(TestCase):
             obfuscated_password = "sha256$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="
             client = Client(enforce_csrf_checks=False)
             auth_headers = {
-                'HTTP_AUTHORIZATION': 'Basic ' + base64.b64encode('%s:%s' % (
-                    self.username, obfuscated_password
-                )),
+                'HTTP_AUTHORIZATION': 'Basic ' + base64.b64encode(
+                    ('%s:%s' % (self.username, obfuscated_password)).encode('utf-8')
+                ).decode('utf-8'),
             }
             key_name = obfuscated_password_redis_key_for_user(self.username, obfuscated_password)
             self.assertEqual(redis_client.get(key_name), None)
@@ -77,9 +77,9 @@ class TestDecodePassword(TestCase):
             obfuscated_password = "sha256$1e2d5bc2hhMjU2JDFlMmQ1Yk1USXpORFUyZjc5MTI3PQ==f79127="
             client = Client(enforce_csrf_checks=False)
             auth_headers = {
-                'HTTP_AUTHORIZATION': 'Basic ' + base64.b64encode('%s:%s' % (
-                    self.username, obfuscated_password
-                )),
+                'HTTP_AUTHORIZATION': 'Basic ' + base64.b64encode(
+                    ('%s:%s' % (self.username, obfuscated_password)).encode('utf-8')
+                ).decode('utf-8'),
             }
             # ensure that login attempt gets stored
             key_name = obfuscated_password_redis_key_for_user(self.username, obfuscated_password)

--- a/custom/nic_compliance/utils.py
+++ b/custom/nic_compliance/utils.py
@@ -73,9 +73,9 @@ def verify_password(password, encoded_password):
 
 
 def obfuscated_password_redis_key_for_user(username, obfuscated_password):
-    return REDIS_LOGIN_ATTEMPTS_LIST_PREFIX + hashlib.md5("%s%s" % (
-        username, obfuscated_password
-    )).hexdigest()
+    return REDIS_LOGIN_ATTEMPTS_LIST_PREFIX + hashlib.md5(
+        ("%s%s" % (username, obfuscated_password)).encode('utf-8')
+    ).hexdigest()
 
 
 def get_raw_password(obfuscated_password, username=None):


### PR DESCRIPTION
This fixes tests in python 3, and also fixes this bug where users with non-ascii characters in their passwords couldn't log into ICDS: https://sentry.io/dimagi/commcarehq/issues/766891884/

@dimagi/py3 