### PR TITLE
Allow case import with empty cells in first column

### DIFF
--- a/corehq/util/workbook_reading/adapters/xlsx.py
+++ b/corehq/util/workbook_reading/adapters/xlsx.py
@@ -67,9 +67,9 @@ class _XLSXWorksheetAdaptor(object):
         # That means that if formatting is applied, that will be the xlsx row limit
         # Note that this is 1-indexed for consistency with openpyxl
         max_row = 1
-        for row in self._worksheet.iter_rows():
+        for i, row in enumerate(self._worksheet.iter_rows(), 1):
             if any(cell.value for cell in row):
-                max_row = row[0].row
+                max_row = i
         return max_row
 
     def iter_rows(self):


### PR DESCRIPTION
Only cells with data have row numbers for some reason.  If the first column in an import has blank values, this old version would fail

https://sentry.io/dimagi/commcarehq/issues/783336520/events/37942892828/?environment=production
introduced in https://github.com/dimagi/commcare-hq/pull/22486