### PR TITLE
fix couch blob attachments meta to have correct type code

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -564,15 +564,30 @@ def _migrate_form_attachments(sql_form, couch_form):
     attachments = []
     metadb = get_blob_db().metadb
     for name, blob in six.iteritems(couch_form.blobs):
+        def try_to_get_blob_meta(parent_id, type_code, name):
+            try:
+                meta = metadb.get(
+                    parent_id=parent_id,
+                    type_code=type_code,
+                    name=name
+                )
+                assert meta.domain == couch_form.domain, (meta.domain, couch_form.domain)
+                return meta
+            except BlobMeta.DoesNotExist:
+                return None
+
         type_code = CODES.form_xml if name == "form.xml" else CODES.form_attachment
-        try:
-            meta = metadb.get(
-                parent_id=sql_form.form_id,
-                type_code=type_code,
-                name=name
-            )
-            assert meta.domain == couch_form.domain, (meta.domain, couch_form.domain)
-        except BlobMeta.DoesNotExist:
+        meta = try_to_get_blob_meta(sql_form.form_id, type_code, name)
+
+        # there was a bug in a migration causing the type code for many form attachments to be set as form_xml
+        # this checks the db for a meta resembling this and fixes it for postgres
+        # https://github.com/dimagi/commcare-hq/blob/3788966119d1c63300279418a5bf2fc31ad37f6f/corehq/blobs/migrate.py#L371
+        if not meta and name != "form.xml":
+            meta = try_to_get_blob_meta(sql_form.form_id, CODES.form_xml, name)
+            if meta:
+                meta.type_code = CODES.form_attachment
+
+        if not meta:
             meta = metadb.new(
                 domain=couch_form.domain,
                 name=name,
@@ -583,6 +598,7 @@ def _migrate_form_attachments(sql_form, couch_form):
                 key=blob.key,
             )
             meta.save()
+
         attachments.append(meta)
     sql_form.attachments_list = attachments
 

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -587,6 +587,7 @@ def _migrate_form_attachments(sql_form, couch_form):
             meta = try_to_get_blob_meta(sql_form.form_id, CODES.form_xml, name)
             if meta:
                 meta.type_code = CODES.form_attachment
+                meta.save()
 
         if not meta:
             meta = metadb.new(

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -563,19 +563,20 @@ def _migrate_form_attachments(sql_form, couch_form):
     """Copy over attachment meta - includes form.xml"""
     attachments = []
     metadb = get_blob_db().metadb
-    for name, blob in six.iteritems(couch_form.blobs):
-        def try_to_get_blob_meta(parent_id, type_code, name):
-            try:
-                meta = metadb.get(
-                    parent_id=parent_id,
-                    type_code=type_code,
-                    name=name
-                )
-                assert meta.domain == couch_form.domain, (meta.domain, couch_form.domain)
-                return meta
-            except BlobMeta.DoesNotExist:
-                return None
 
+    def try_to_get_blob_meta(parent_id, type_code, name):
+        try:
+            meta = metadb.get(
+                parent_id=parent_id,
+                type_code=type_code,
+                name=name
+            )
+            assert meta.domain == couch_form.domain, (meta.domain, couch_form.domain)
+            return meta
+        except BlobMeta.DoesNotExist:
+            return None
+
+    for name, blob in six.iteritems(couch_form.blobs):
         type_code = CODES.form_xml if name == "form.xml" else CODES.form_attachment
         meta = try_to_get_blob_meta(sql_form.form_id, type_code, name)
 


### PR DESCRIPTION
For posterity: couch attachments were given the wrong type code in a migration awhile ago since the `_blobdb_type_code` for all xforminstancesql's is the one for `form_xml` https://github.com/dimagi/commcare-hq/blob/3788966119d1c63300279418a5bf2fc31ad37f6f/corehq/blobs/migrate.py#L371

@millerdev buddy: @kaapstorm