### PR TITLE
RequireJS migration: custom data fields

### DIFF
--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -1,4 +1,17 @@
-hqDefine('custom_data_fields/js/custom_data_fields', function () {
+hqDefine('custom_data_fields/js/custom_data_fields', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/toggles',
+    'hqwebapp/js/knockout_bindings.ko',     // needed for sortable binding
+], function (
+    $,
+    ko,
+    _,
+    initialPageData,
+    toggles
+) {
     function Choice(choice) {
         var self = this;
         self.value = ko.observable(choice);
@@ -16,7 +29,7 @@ hqDefine('custom_data_fields/js/custom_data_fields', function () {
         self.regex_msg = ko.observable();
         self.index_in_fixture = ko.observable();
 
-        if (!hqImport('hqwebapp/js/toggles').toggleEnabled('REGEX_FIELD_VALIDATION')) {
+        if (!toggles.toggleEnabled('REGEX_FIELD_VALIDATION')) {
             // if toggle isn't enabled - always show "choice" option
             self.validationMode('choice');
         }
@@ -162,7 +175,7 @@ hqDefine('custom_data_fields/js/custom_data_fields', function () {
 
     $(function () {
         var customDataFieldsModel = new CustomDataFieldsModel();
-        customDataFieldsModel.init(hqImport('hqwebapp/js/initial_page_data').get('custom_fields'));
+        customDataFieldsModel.init(initialPageData.get('custom_fields'));
         customDataFieldsModel.data_fields.subscribe(function () {
             $("#save-custom-fields").prop("disabled", false);
         });

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -3,11 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block js %}
-{{ block.super }}
-    <script src="{% static 'custom_data_fields/js/custom_data_fields.js' %}"></script>
-{% endblock %}
-
+{% requirejs_main 'custom_data_fields/js/custom_data_fields' %}
 
 {% block stylesheets %}
 {{ block.super }}

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -25,7 +25,6 @@ from corehq.apps.case_search.models import (
     enable_case_search,
     disable_case_search,
 )
-from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.hqwebapp.decorators import use_select2
 from corehq.apps.users.models import CouchUser
@@ -503,7 +502,6 @@ class FeaturePreviewsView(BaseAdminProjectSettingsView):
 
     def update_feature(self, feature, current_state, new_state):
         if current_state != new_state:
-            toggle_js_domain_cachebuster.clear(self.domain)
             feature.set(self.domain, new_state, NAMESPACE_DOMAIN)
             if feature.save_fn is not None:
                 feature.save_fn(self.domain, new_state)

--- a/corehq/apps/hqadmin/management/commands/clone_domain.py
+++ b/corehq/apps/hqadmin/management/commands/clone_domain.py
@@ -122,7 +122,6 @@ class Command(BaseCommand):
     def set_flags(self):
         from corehq.toggles import all_toggles, NAMESPACE_DOMAIN
         from corehq.feature_previews import all_previews
-        from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster
 
         for toggle in all_toggles():
             if toggle.enabled(self.existing_domain, NAMESPACE_DOMAIN):
@@ -137,8 +136,6 @@ class Command(BaseCommand):
                     preview.set(self.new_domain, True, NAMESPACE_DOMAIN)
                     if preview.save_fn is not None:
                         preview.save_fn(self.new_domain, True)
-
-        toggle_js_domain_cachebuster.clear(self.new_domain)
 
     def copy_fixtures(self):
         from corehq.apps.fixtures.models import FixtureDataItem

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
@@ -11,10 +11,10 @@ hqDefine('hqwebapp/js/toggles', function () {
     };
     return {
         toggleEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('hqwebapp/js/toggles_template').toggles, toggleName);
+            return genericToggleEnabled(hqImport('hqwebapp/js/initial_page_data').get('toggles_dict'), toggleName);
         },
         previewEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('hqwebapp/js/toggles_template').previews, toggleName);
+            return genericToggleEnabled(hqImport('hqwebapp/js/initial_page_data').get('previews_dict'), toggleName);
         },
     };
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
@@ -1,4 +1,10 @@
-hqDefine('hqwebapp/js/toggles', function () {
+hqDefine('hqwebapp/js/toggles', [
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+], function (
+    _,
+    initialPageData
+) {
     var genericToggleEnabled = function (allToggles, toggleName) {
         var value = allToggles[toggleName];
         if (typeof value === 'undefined') {
@@ -11,10 +17,10 @@ hqDefine('hqwebapp/js/toggles', function () {
     };
     return {
         toggleEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('hqwebapp/js/initial_page_data').get('toggles_dict'), toggleName);
+            return genericToggleEnabled(initialPageData.get('toggles_dict'), toggleName);
         },
         previewEnabled: function (toggleName) {
-            return genericToggleEnabled(hqImport('hqwebapp/js/initial_page_data').get('previews_dict'), toggleName);
+            return genericToggleEnabled(initialPageData.get('previews_dict'), toggleName);
         },
     };
 });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -346,8 +346,8 @@
         {% endblock %}
         {% initial_page_data 'mobile_ux_cookie_name' mobile_ux_cookie_name %}
         {% initial_page_data 'show_mobile_ux_warning' show_mobile_ux_warning %}
-        {% initial_page_data 'toggles_dict' TOGGLES_DICT %}
-        {% initial_page_data 'previews_dict' PREVIEWS_DICT %}
+        {% initial_page_data 'toggles_dict' toggles_dict %}
+        {% initial_page_data 'previews_dict' previews_dict %}
         <div class="initial-page-data" class="hide">
         {% block initial_page_data %}
             {# do not override this block, use initial_page_data template tag to populate #}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -344,8 +344,10 @@
                 awkward or impossible to include it in another block
             {% endcomment %}
         {% endblock %}
-        {%  initial_page_data 'mobile_ux_cookie_name' mobile_ux_cookie_name %}
-        {%  initial_page_data 'show_mobile_ux_warning' show_mobile_ux_warning %}
+        {% initial_page_data 'mobile_ux_cookie_name' mobile_ux_cookie_name %}
+        {% initial_page_data 'show_mobile_ux_warning' show_mobile_ux_warning %}
+        {% initial_page_data 'toggles_dict' TOGGLES_DICT %}
+        {% initial_page_data 'previews_dict' PREVIEWS_DICT %}
         <div class="initial-page-data" class="hide">
         {% block initial_page_data %}
             {# do not override this block, use initial_page_data template tag to populate #}
@@ -516,11 +518,6 @@
         {% include 'hqwebapp/ko_pagination.html' %}
         {% include 'hqwebapp/partials/ko_inline_edit.html' %}
 
-        {# This should be loaded relatively late, because as a non-static import it takes longer to load #}
-        {# If it's loaded early, then execution of all following scripts block on it #}
-        {% if request.domain and request.user.username and not requirejs_main %}
-            <script src="{% toggle_js_url request.domain request.user.username %}"></script>
-        {% endif %}
         {% block js %}{% endblock js %}
 
         {% block js-inline %}{% endblock js-inline %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/js/toggles_template.js
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/js/toggles_template.js
@@ -1,7 +1,0 @@
-{% load hq_shared_tags %}
-hqDefine('hqwebapp/js/toggles_template', function () {
-    return {
-        toggles: {{ toggles_dict|JSON }},
-        previews: {{ previews_dict|JSON }}
-    };
-});

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -291,21 +291,6 @@ def can_use_restore_as(request):
 
 
 @register.simple_tag
-def toggle_js_url(domain, username):
-    return (
-        '{url}?username={username}'
-        '&cachebuster={toggles_cb}-{previews_cb}-{domain_cb}-{user_cb}'
-    ).format(
-        url=reverse('toggles_js', args=[domain]),
-        username=username,
-        domain_cb=toggle_js_domain_cachebuster(domain),
-        user_cb=toggle_js_user_cachebuster(username),
-        toggles_cb=toggles_cachebuster(),
-        previews_cb=previews_cachebuster(),
-    )
-
-
-@register.simple_tag
 def css_label_class():
     from corehq.apps.hqwebapp.crispy import CSS_LABEL_CLASS
     return CSS_LABEL_CLASS
@@ -323,19 +308,6 @@ def css_action_class():
     return CSS_ACTION_CLASS
 
 
-@quickcache(['domain'], timeout=30 * 24 * 60 * 60)
-def toggle_js_domain_cachebuster(domain):
-    # to get fresh cachebusters on the next deploy
-    # change the date below (output from *nix `date` command)
-    #   Wed Apr 25 14:12:12 EDT 2018
-    return random_hex()[:3]
-
-
-@quickcache(['username'], timeout=30 * 24 * 60 * 60)
-def toggle_js_user_cachebuster(username):
-    return random_hex()[:3]
-
-
 def _get_py_filename(module):
     """
     return the full path to the .py file of a module
@@ -343,20 +315,6 @@ def _get_py_filename(module):
 
     """
     return module.__file__.rstrip('c')
-
-
-@memoized
-def toggles_cachebuster():
-    import corehq.toggles
-    with open(_get_py_filename(corehq.toggles)) as f:
-        return hashlib.sha1(f.read().encode('utf-8')).hexdigest()[:3]
-
-
-@memoized
-def previews_cachebuster():
-    import corehq.feature_previews
-    with open(_get_py_filename(corehq.feature_previews)) as f:
-        return hashlib.sha1(f.read().encode('utf-8')).hexdigest()[:3]
 
 
 @register.filter

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -14,7 +14,7 @@ from corehq.apps.hqwebapp.views import (
     yui_crossdomain, password_change, no_permissions, login, logout,
     debug_notify,
     quick_find, osdd, create_alert, activate_alert, deactivate_alert, jserror,
-    dropbox_upload, domain_login, retrieve_download, toggles_js,
+    dropbox_upload, domain_login, retrieve_download,
     server_up, BugReportView,
     redirect_to_dimagi,
     temporary_google_verify,
@@ -66,7 +66,6 @@ domain_specific = [
     url(r'^retreive_download/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         retrieve_download, {'template': 'hqwebapp/includes/file_download.html'},
         name='hq_soil_download'),
-    url(r'toggles.js$', toggles_js, name='toggles_js'),
 ]
 
 prelogin_root = [

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -59,7 +59,6 @@ from no_exceptions.exceptions import Http403
 from soil import DownloadBase
 from soil import views as soil_views
 
-from corehq import toggles, feature_previews
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import require_superuser, login_and_domain_required, two_factor_exempt, \
     track_domain_request
@@ -1198,16 +1197,6 @@ class DataTablesAJAXPaginationMixin(object):
             'iTotalRecords': total_records,
             'iTotalDisplayRecords': filtered_records or total_records,
         }))
-
-
-@always_allow_browser_caching
-@login_and_domain_required
-@location_safe
-def toggles_js(request, domain, template='hqwebapp/js/toggles_template.js'):
-    return render(request, template, {
-        'toggles_dict': toggles.toggle_values_by_name(username=request.user.username, domain=domain),
-        'previews_dict': feature_previews.preview_values_by_name(domain=domain)
-    })
 
 
 # Use instead of djangular's base JSONResponseMixin

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -9,8 +9,6 @@ from django.contrib import messages
 from django.urls import reverse
 from django.http.response import Http404, HttpResponse
 from django.utils.decorators import method_decorator
-from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster, \
-    toggle_js_user_cachebuster
 from couchforms.analytics import get_last_form_submission_received
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import require_superuser_or_contractor
@@ -275,12 +273,10 @@ def _call_save_fn_and_clear_cache(toggle_slug, changed_entries, currently_enable
             domain = entry
             if static_toggle.save_fn is not None:
                 static_toggle.save_fn(domain, enabled)
-            toggle_js_domain_cachebuster.clear(domain)
         else:
             # these are sent down with no namespace
             assert ':' not in entry, entry
             username = entry
-            toggle_js_user_cachebuster.clear(username)
 
 
 def _clear_caches_for_dynamic_toggle(toggle_meta):

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -123,8 +123,8 @@ def js_toggles(request):
     from corehq import toggles, feature_previews
     domain = request.project.name
     return {
-        'TOGGLES_DICT': toggles.toggle_values_by_name(username=request.couch_user.username, domain=domain),
-        'PREVIEWS_DICT': feature_previews.preview_values_by_name(domain=domain)
+        'toggles_dict': toggles.toggle_values_by_name(username=request.couch_user.username, domain=domain),
+        'previews_dict': feature_previews.preview_values_by_name(domain=domain)
     }
 
 

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -115,6 +115,19 @@ def js_api_keys(request):
     }
 
 
+def js_toggles(request):
+    if not hasattr(request, 'couch_user') or not request.couch_user:
+        return {}
+    if not hasattr(request, 'project'):
+        return {}
+    from corehq import toggles, feature_previews
+    domain = request.project.name
+    return {
+        'TOGGLES_DICT': toggles.toggle_values_by_name(username=request.couch_user.username, domain=domain),
+        'PREVIEWS_DICT': feature_previews.preview_values_by_name(domain=domain)
+    }
+
+
 def websockets_override(request):
     # for some reason our proxy setup doesn't properly detect these things, so manually override them
     try:

--- a/settings.py
+++ b/settings.py
@@ -989,6 +989,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.mobile_experience',
                 'corehq.util.context_processors.get_demo',
                 'corehq.util.context_processors.js_api_keys',
+                'corehq.util.context_processors.js_toggles',
                 'corehq.util.context_processors.websockets_override',
                 'corehq.util.context_processors.commcare_hq_names',
             ],


### PR DESCRIPTION
This makes feature flags available in requirejs by moving them to initial page data.

Review by commit.

@dannyroberts / @millerdev 