### PR TITLE
Added HQModalFormHelper to standardize modal form proportions

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django import forms
 
-from crispy_forms.helper import FormHelper
+from corehq.apps.hqwebapp.crispy import HQFormHelper, HQModalFormHelper
 from crispy_forms.layout import Layout, Fieldset, Div, HTML, Field
 
 from memoized import memoized
@@ -133,10 +133,11 @@ class CustomDataEditor(object):
             field_names = list(fields)
 
         CustomDataForm = type('CustomDataForm' if six.PY3 else b'CustomDataForm', (forms.Form,), fields)
-        CustomDataForm.helper = FormHelper()
+        if self.angular_model:
+            CustomDataForm.helper = HQModalFormHelper()
+        else:
+            CustomDataForm.helper = HQFormHelper()
         CustomDataForm.helper.form_tag = False
-        CustomDataForm.helper.label_class = 'col-sm-4' if self.angular_model else 'col-lg-3'
-        CustomDataForm.helper.field_class = 'col-sm-8' if self.angular_model else 'col-lg-9'
 
         additional_fields = []
         if field_names:

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -38,7 +38,7 @@ from corehq.apps.reports.util import (
     case_users_filter,
     datespan_from_beginning,
 )
-from corehq.apps.hqwebapp.crispy import HQFormHelper
+from corehq.apps.hqwebapp.crispy import HQFormHelper, HQModalFormHelper
 from corehq.apps.hqwebapp.widgets import DateRangePickerWidget, Select2AjaxV3
 from corehq.pillows import utils
 
@@ -101,11 +101,8 @@ class CreateExportTagForm(forms.Form):
             model_field.widget.attrs['readonly'] = True
             model_field.widget.attrs['disabled'] = True
 
-        # This form appears inside a modal, so it's differently proportioned than most forms
-        self.helper = FormHelper()
+        self.helper = HQModalFormHelper()
         self.helper.form_tag = False
-        self.helper.label_class = 'col-sm-2'
-        self.helper.field_class = 'col-sm-10'
 
         self.helper.layout = crispy.Layout(
             crispy.Div(
@@ -330,11 +327,8 @@ class DashboardFeedFilterForm(forms.Form):
             reverse(ExpandedMobileWorkerFilter.options_url, args=(self.domain_object.name,))
         )
 
-        # This form appears inside a modal, so it's differently proportioned than most forms
-        self.helper = FormHelper()
+        self.helper = HQModalFormHelper()
         self.helper.form_tag = False
-        self.helper.label_class = 'col-sm-3 col-md-2 col-lg-2'
-        self.helper.field_class = 'col-sm-9 col-md-10 col-lg-10'
         self.helper.layout = Layout(*self.layout_fields)
 
     def clean(self):

--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -24,6 +24,12 @@ class HQFormHelper(FormHelper):
     field_class = CSS_FIELD_CLASS
 
 
+class HQModalFormHelper(FormHelper):
+    form_class = 'form form-horizontal'
+    label_class = 'col-xs-12 col-sm-3 col-md-3 col-lg-2'
+    field_class = 'col-xs-12 col-sm-9 col-md-9 col-lg-6'
+
+
 class HiddenFieldWithErrors(OldField):
     template = "hqwebapp/crispy/field/hidden_with_errors.html"
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -32,6 +32,7 @@ from corehq.apps.users.models import CouchUser, UserRole
 from corehq.apps.users.util import format_username, cc_user_domain
 from corehq.apps.app_manager.models import validate_lang
 from corehq.apps.programs.models import Program
+from corehq.apps.hqwebapp.crispy import HQModalFormHelper
 from corehq.apps.hqwebapp.utils import decode_password
 # Bootstrap 3 Crispy Forms
 from crispy_forms import layout as cb3_layout
@@ -583,10 +584,8 @@ class NewMobileWorkerForm(forms.Form):
                 ng_model='mobileWorker.location_id',
             )
 
-        self.helper = FormHelper()
+        self.helper = HQModalFormHelper()
         self.helper.form_tag = False
-        self.helper.label_class = 'col-sm-4'
-        self.helper.field_class = 'col-sm-8'
         self.helper.layout = Layout(
             Fieldset(
                 _('Basic Information'),


### PR DESCRIPTION
Same pattern as https://github.com/dimagi/commcare-hq/pull/22325

@dannyroberts 
fyi @dimagi/product - note that these proportions are responsive to screen size, so you may see different results on your own computer.

Create mobile worker before:
<img width="1274" alt="screen shot 2018-12-03 at 12 26 28 pm" src="https://user-images.githubusercontent.com/1486591/49390677-93185300-f6f7-11e8-9395-66badde6d537.png">

Create mobile worker after:
<img width="1274" alt="screen shot 2018-12-03 at 12 26 29 pm" src="https://user-images.githubusercontent.com/1486591/49390685-99a6ca80-f6f7-11e8-9ecc-c18c30b0c8f0.png">

Create export before:
<img width="1274" alt="screen shot 2018-12-03 at 12 26 32 pm" src="https://user-images.githubusercontent.com/1486591/49390691-9f041500-f6f7-11e8-9983-26e67958d985.png">

Create export after:
<img width="1274" alt="screen shot 2018-12-03 at 12 26 39 pm" src="https://user-images.githubusercontent.com/1486591/49390705-a7f4e680-f6f7-11e8-9995-56934c30740e.png">
