### PR TITLE
Fix couch_reindex_schedule default logic

### DIFF
--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from datetime import timedelta
-
 from celery.task.base import periodic_task
 
 from corehq.preindex.accessors import index_design_doc, get_preindex_designs
@@ -11,11 +9,7 @@ from corehq.util.decorators import serial_task
 from django.conf import settings
 
 
-# Run every 10 minutes, or as specified in settings.COUCH_REINDEX_SCHEDULE
-if hasattr(settings, 'COUCH_REINDEX_SCHEDULE'):
-    couch_reindex_schedule = deserialize_run_every_setting(settings.COUCH_REINDEX_SCHEDULE)
-else:
-    couch_reindex_schedule = timedelta(minutes=10)
+couch_reindex_schedule = deserialize_run_every_setting(settings.COUCH_REINDEX_SCHEDULE)
 
 
 @periodic_task(serializer='pickle', run_every=couch_reindex_schedule, queue=settings.CELERY_PERIODIC_QUEUE)

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -12,8 +12,10 @@ from django.conf import settings
 
 
 # Run every 10 minutes, or as specified in settings.COUCH_REINDEX_SCHEDULE
-couch_reindex_schedule = deserialize_run_every_setting(
-    getattr(settings, 'COUCH_REINDEX_SCHEDULE', timedelta(minutes=10)))
+if hasattr(settings, 'COUCH_REINDEX_SCHEDULE'):
+    couch_reindex_schedule = deserialize_run_every_setting(settings.COUCH_REINDEX_SCHEDULE)
+else:
+    couch_reindex_schedule = timedelta(minutes=10)
 
 
 @periodic_task(serializer='pickle', run_every=couch_reindex_schedule, queue=settings.CELERY_PERIODIC_QUEUE)

--- a/settings.py
+++ b/settings.py
@@ -741,7 +741,8 @@ BITLY_APIKEY = ''
 INTERNAL_DATA = defaultdict(list)
 
 COUCH_STALE_QUERY = 'update_after'  # 'ok' for cloudant
-
+# Run reindex every 10 minutes (by default)
+COUCH_REINDEX_SCHEDULE = {'timedelta': {'minutes': 10}}
 
 MESSAGE_LOG_OPTIONS = {
     "abbreviated_phone_number_domains": ["mustmgh", "mgh-cgh-uganda"],


### PR DESCRIPTION
Was causing 500s everywhere if default was relied on