### PR TITLE
Revert "Revert "require FormSource to get and set with unicode""

### DIFF
--- a/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
+++ b/corehq/apps/aggregate_ucrs/tests/test_aggregation.py
@@ -133,7 +133,7 @@ class UCRAggregationTest(TestCase, AggregationBaseTestMixin):
         xform = XFormBuilder()
         for prop_name, prop_text, datatype, _ in cls.case_properties:
             xform.new_question(prop_name, prop_text, data_type=datatype)
-        return xform.tostring()
+        return xform.tostring().decode('utf-8')
 
     @classmethod
     def _get_case_property_values(cls):

--- a/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_case_properties.py
@@ -137,7 +137,7 @@ class GetCasePropertiesTest(SimpleTestCase, TestXmlMixin):
     def _add_scheduler_to_form(self, form, module, form_abreviation):
         # (this mimics the behavior in app_manager.views.schedules.edit_visit_schedule()
         # A Form.source is required to retreive scheduler properties
-        form.source = self.get_xml('very_simple_form')
+        form.source = self.get_xml('very_simple_form').decode('utf-8')
         phase, _ = module.get_or_create_schedule_phase(anchor='date-opened')
         form.schedule_form_id = form_abreviation
         form.schedule = FormSchedule(

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -711,15 +711,15 @@ class FormSource(object):
         except AttributeError:
             pass
         else:
-            app.lazy_put_attachment(old_contents, filename)
+            app.lazy_put_attachment(old_contents.encode('utf-8'), filename)
             del form['contents']
 
         if not app.has_attachment(filename):
             source = ''
         else:
             source = app.lazy_fetch_attachment(filename)
-            if isinstance(source, bytes):
-                source = source.decode('utf-8')
+            assert isinstance(source, bytes), type(source)
+            source = source.decode('utf-8')
 
         return source
 
@@ -727,7 +727,8 @@ class FormSource(object):
         unique_id = form.get_unique_id()
         app = form.get_app()
         filename = "%s.xml" % unique_id
-        app.lazy_put_attachment(value, filename)
+        assert isinstance(value, six.text_type), type(value)
+        app.lazy_put_attachment(value.encode('utf-8'), filename)
         form.clear_validation_cache()
         try:
             form.xmlns = form.wrapped_xform().data_node.tag_xmlns
@@ -1263,8 +1264,7 @@ class FormBase(DocumentSchema):
         source = XForm(self.source)
         if source.exists():
             source.rename_language(old_code, new_code)
-            source = source.render()
-            self.source = source
+            self.source = source.render().decode('utf-8')
 
     def default_name(self):
         app = self.get_app()
@@ -4551,6 +4551,8 @@ class LazyBlobDoc(BlobMixin):
         if attachments:
             for name, attachment in attachments.items():
                 if isinstance(attachment, six.string_types):
+                    if isinstance(attachment, six.text_type):
+                        attachment = attachment.encode('utf-8')
                     info = {"content": attachment}
                 else:
                     raise ValueError("Unknown attachment format: {!r}"

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5962,7 +5962,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     @time_method()
     def _make_language_files(self, prefix, build_profile_id):
         return {
-            "{}{}/app_strings.txt".format(prefix, lang): self.create_app_strings(lang, build_profile_id)
+            "{}{}/app_strings.txt".format(prefix, lang): self.create_app_strings(lang, build_profile_id).encode('utf-8')
             for lang in ['default'] + self.get_build_langs(build_profile_id)
         }
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -195,6 +195,8 @@ ANDROID_LOGO_PROPERTY_MAPPING = {
 LATEST_APK_VALUE = 'latest'
 LATEST_APP_VALUE = 0
 
+_soft_assert = soft_assert(to="{}@{}.com".format('npellegrino', 'dimagi'), exponential_backoff=True)
+
 
 def jsonpath_update(datum_context, value):
     field = datum_context.path.fields[0]
@@ -718,8 +720,10 @@ class FormSource(object):
             source = ''
         else:
             source = app.lazy_fetch_attachment(filename)
-            assert isinstance(source, bytes), type(source)
-            source = source.decode('utf-8')
+            if isinstance(source, bytes):
+                source = source.decode('utf-8')
+            else:
+                _soft_assert(False, type(source))
 
         return source
 
@@ -727,8 +731,11 @@ class FormSource(object):
         unique_id = form.get_unique_id()
         app = form.get_app()
         filename = "%s.xml" % unique_id
-        assert isinstance(value, six.text_type), type(value)
-        app.lazy_put_attachment(value.encode('utf-8'), filename)
+        if isinstance(value, six.text_type):
+            value = value.encode('utf-8')
+        else:
+            _soft_assert(False, type(value))
+        app.lazy_put_attachment(value, filename)
         form.clear_validation_cache()
         try:
             form.xmlns = form.wrapped_xform().data_node.tag_xmlns

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4581,6 +4581,9 @@ class LazyBlobDoc(BlobMixin):
         except KeyError:
             content = cache.get(self.__attachment_cache_key(name))
             if content is not None:
+                if isinstance(content, six.text_type):
+                    _soft_assert(False, 'cached attachment has type unicode')
+                    content = content.encode('utf-8')
                 self._LAZY_ATTACHMENTS_CACHE[name] = content
         return content
 

--- a/corehq/apps/app_manager/tests/test_case_list_form.py
+++ b/corehq/apps/app_manager/tests/test_case_list_form.py
@@ -441,7 +441,8 @@ class CaseListFormFormTests(SimpleTestCase, TestXmlMixin):
     def _add_module_and_form(self, ModuleClass):
         self.module = self.app.add_module(ModuleClass.new_module('New Module', lang='en'))
         self.module.case_type = 'test_case_type'
-        self.form = self.module.new_form("Untitled Form", "en", self.get_xml('original_form', override_path=('data',)))
+        self.form = self.module.new_form("Untitled Form", "en",
+                                         self.get_xml('original_form', override_path=('data',)).decode('utf-8'))
 
     def test_case_list_form_basic(self):
         self._add_module_and_form(Module)

--- a/corehq/apps/app_manager/tests/test_case_meta.py
+++ b/corehq/apps/app_manager/tests/test_case_meta.py
@@ -25,7 +25,7 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
         m = app.add_module(Module.new_module('Module{}'.format(module_id), lang='en'))
         m.case_type = case_type
         mf = app.new_form(module_id, 'form {}'.format(case_type), lang='en',
-                          attachment=self.get_xml('standard_questions'))
+                          attachment=self.get_xml('standard_questions').decode('utf-8'))
         mf.actions.open_case = OpenCaseAction(name_path="/data/question1", external_id=None)
         mf.actions.open_case.condition.type = 'always'
         return m
@@ -87,7 +87,7 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
         app._id = uuid.uuid4().hex
         app.version = 1
         m0 = self._make_module(app, 0, 'normal_module')
-        m0f1 = m0.new_form('update case', 'en', attachment=self.get_xml('standard_questions'))
+        m0f1 = m0.new_form('update case', 'en', attachment=self.get_xml('standard_questions').decode('utf-8'))
         self._assert_properties(app.get_case_metadata(), {'name'})
 
         m0f1.actions.update_case.condition.type = 'always'
@@ -103,7 +103,7 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
         app._id = uuid.uuid4().hex
         app.version = 1
         m0 = self._make_module(app, 0, 'household')
-        m0f1 = m0.new_form('save to case', 'en', attachment=self.get_xml('standard_questions'))
+        m0f1 = m0.new_form('save to case', 'en', attachment=self.get_xml('standard_questions').decode('utf-8'))
         m0f1.case_references = CaseReferences.wrap({
             'save': {
                 "/data/question1": {
@@ -123,7 +123,7 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
         app.version = 1
         m0 = app.add_module(AdvancedModule.new_module('Module3', lang='en'))
         m0.case_type = 'household_advanced'
-        m0f1 = m0.new_form('save to case', 'en', attachment=self.get_xml('standard_questions'))
+        m0f1 = m0.new_form('save to case', 'en', attachment=self.get_xml('standard_questions').decode('utf-8'))
         m0f1.case_references = CaseReferences.wrap({
             'save': {
                 "/data/question1": {
@@ -142,7 +142,7 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
         app._id = uuid.uuid4().hex
         app.version = 1
         m0 = self._make_module(app, 0, 'household')
-        m0f1 = m0.new_form('save to case', 'en', attachment=self.get_xml('standard_questions'))
+        m0f1 = m0.new_form('save to case', 'en', attachment=self.get_xml('standard_questions').decode('utf-8'))
         m0f1.case_references = CaseReferences.wrap({
             'save': {
                 "/data/question1": {

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -122,7 +122,7 @@ class AdvancedModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
         self.factory.form_requires_case(m0f0)
 
         m1f0 = self.module_1.get_form(0)
-        m1f0.source = self.get_xml('original_form', override_path=('data',))
+        m1f0.source = self.get_xml('original_form', override_path=('data',)).decode('utf-8')
         self.factory.form_requires_case(m1f0, 'gold-fish', update={'question1': '/data/question1'})
         self.factory.form_requires_case(m1f0, 'guppy', parent_case_type='gold-fish')
 
@@ -237,7 +237,7 @@ class BasicModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
         self.factory.form_opens_case(m0f0, 'guppy', is_subcase=True)
 
         m1f0 = self.module_1.get_form(0)
-        m1f0.source = self.get_xml('original_form', override_path=('data',))
+        m1f0.source = self.get_xml('original_form', override_path=('data',)).decode('utf-8')
         self.factory.form_requires_case(m1f0, 'guppy', parent_case_type='gold-fish', update={
             'question1': '/data/question1',
             'parent/question1': '/data/question1',
@@ -348,7 +348,7 @@ class AdvancedSubModuleTests(SimpleTestCase, TestXmlMixin):
             'guppy',
             parent_module=upd_goldfish_mod,
         )
-        upd_guppy_form.source = self.get_xml('original_form', override_path=('data',))
+        upd_guppy_form.source = self.get_xml('original_form', override_path=('data',)).decode('utf-8')
         factory.form_requires_case(upd_guppy_form, 'gold-fish', update={'question1': '/data/question1'})
         factory.form_requires_case(
             upd_guppy_form,
@@ -376,7 +376,7 @@ class AdvancedSubModuleTests(SimpleTestCase, TestXmlMixin):
         lab_update_module, lab_update_form = factory.new_advanced_module('lab_update', 'lab_test', parent_module=lab_test_module)
         factory.form_requires_case(lab_update_form, 'episode', update={'episode_type': '/data/question1'})
         factory.form_requires_case(lab_update_form, 'lab_test', parent_case_type='episode')
-        lab_update_form.source = self.get_xml('original_form', override_path=('data',))
+        lab_update_form.source = self.get_xml('original_form', override_path=('data',)).decode('utf-8')
 
         expected_suite_entry = """
         <partial>
@@ -418,7 +418,7 @@ class BasicSubModuleTests(SimpleTestCase, TestXmlMixin):
             'guppy',
             parent_module=upd_goldfish_mod,
         )
-        guppy_form.source = self.get_xml('original_form', override_path=('data',))
+        guppy_form.source = self.get_xml('original_form', override_path=('data',)).decode('utf-8')
         factory.form_requires_case(
             guppy_form,
             'guppy',

--- a/corehq/apps/app_manager/tests/test_extension_case.py
+++ b/corehq/apps/app_manager/tests/test_extension_case.py
@@ -33,12 +33,12 @@ class ExtCasePropertiesTests(SimpleTestCase, TestXmlMixin):
         self.fish_module = self.app.add_module(Module.new_module('Fish Module', lang='en'))
         self.fish_module.case_type = 'fish'
         self.fish_form = self.app.new_form(0, 'New Form', lang='en')
-        self.fish_form.source = self.get_xml('original')
+        self.fish_form.source = self.get_xml('original').decode('utf-8')
 
         self.freshwater_module = self.app.add_module(Module.new_module('Freshwater Module', lang='en'))
         self.freshwater_module.case_type = 'freshwater'
         self.freshwater_form = self.app.new_form(0, 'New Form', lang='en')
-        self.freshwater_form.source = self.get_xml('original')
+        self.freshwater_form.source = self.get_xml('original').decode('utf-8')
 
         self.aquarium_module = self.app.add_module(Module.new_module('Aquarium Module', lang='en'))
         self.aquarium_module.case_type = 'aquarium'
@@ -91,7 +91,7 @@ class ExtCasePropertiesAdvancedTests(SimpleTestCase, TestXmlMixin):
         self.app.version = 3
         self.module = self.app.add_module(AdvancedModule.new_module('New Module', lang='en'))
         self.module.case_type = 'test_case_type'
-        self.form = self.module.new_form("Untitled Form", "en", self.get_xml('original'))
+        self.form = self.module.new_form("Untitled Form", "en", self.get_xml('original').decode('utf-8'))
 
         self.is_usercase_in_use_patch = patch('corehq.apps.app_manager.models.is_usercase_in_use')
         self.is_usercase_in_use_mock = self.is_usercase_in_use_patch.start()

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -32,7 +32,7 @@ class FormPreparationV2Test(SimpleTestCase, TestXmlMixin):
         self.module = self.app.add_module(Module.new_module('New Module', lang='en'))
         self.form = self.app.new_form(0, 'New Form', lang='en')
         self.module.case_type = 'test_case_type'
-        self.form.source = self.get_xml('original_form', override_path=('data',))
+        self.form.source = self.get_xml('original_form', override_path=('data',)).decode('utf-8')
 
     def test_no_actions(self):
         self.assertXmlEqual(self.get_xml('no_actions'), self.form.render_xform())
@@ -79,7 +79,7 @@ class FormPreparationV2Test(SimpleTestCase, TestXmlMixin):
 
     def test_update_attachment(self):
         self.form.requires = 'case'
-        self.form.source = self.get_xml('attachment')
+        self.form.source = self.get_xml('attachment').decode('utf-8')
         self.form.actions.update_case = UpdateCaseAction(update={'photo': '/data/thepicture'})
         self.form.actions.update_case.condition.type = 'always'
         self.assertXmlEqual(self.get_xml('update_attachment_case'), self.form.render_xform())
@@ -136,7 +136,8 @@ class SubcaseRepeatTest(SimpleTestCase, TestXmlMixin):
         module_0 = app.add_module(Module.new_module('parent', None))
         module_0.unique_id = 'm0'
         module_0.case_type = 'parent'
-        form = app.new_form(0, "Form", None, attachment=self.get_xml('subcase_repeat_mixed_form_pre'))
+        form = app.new_form(0, "Form", None,
+                            attachment=self.get_xml('subcase_repeat_mixed_form_pre').decode('utf-8'))
 
         module_1 = app.add_module(Module.new_module('subcase', None))
         module_1.unique_id = 'm1'
@@ -225,7 +226,8 @@ class FormPreparationV2TestAdvanced(SimpleTestCase, TestXmlMixin):
         self.app.version = 3
         self.module = self.app.add_module(AdvancedModule.new_module('New Module', lang='en'))
         self.module.case_type = 'test_case_type'
-        self.form = self.module.new_form("Untitled Form", "en", self.get_xml('original_form', override_path=('data',)))
+        self.form = self.module.new_form("Untitled Form", "en",
+                                         self.get_xml('original_form', override_path=('data',)).decode('utf-8'))
 
         self.is_usercase_in_use_patch = patch('corehq.apps.app_manager.models.is_usercase_in_use')
         self.is_usercase_in_use_mock = self.is_usercase_in_use_patch.start()
@@ -314,7 +316,7 @@ class FormPreparationV2TestAdvanced(SimpleTestCase, TestXmlMixin):
         self.assertXmlEqual(self.get_xml('update_parent_case'), self.form.render_xform())
 
     def test_update_attachment(self):
-        self.form.source = self.get_xml('attachment')
+        self.form.source = self.get_xml('attachment').decode('utf-8')
         self.form.actions.load_update_cases.append(LoadUpdateAction(
             case_type=self.module.case_type,
             case_tag='load_1',
@@ -338,7 +340,8 @@ class FormPreparationChildModules(SimpleTestCase, TestXmlMixin):
         """
         module = self.app.add_module(AdvancedModule.new_module('New Module', lang='en'))
         module.case_type = 'test_case_type'
-        form = module.new_form("Untitled Form", "en", self.get_xml('original_form', override_path=('data',)))
+        form = module.new_form("Untitled Form", "en",
+                               self.get_xml('original_form', override_path=('data',)).decode('utf-8'))
 
         form.actions.load_update_cases.append(LoadUpdateAction(
             case_type=module.case_type,
@@ -368,7 +371,8 @@ class FormPreparationChildModules(SimpleTestCase, TestXmlMixin):
         """
         module = self.app.add_module(Module.new_module('New Module', lang='en'))
         module.case_type = 'guppy'
-        form = module.new_form("Untitled Form", "en", self.get_xml('original_form', override_path=('data',)))
+        form = module.new_form("Untitled Form", "en",
+                               self.get_xml('original_form', override_path=('data',)).decode('utf-8'))
 
         form.requires = 'case'
         form.actions.update_case = UpdateCaseAction(update={'question1': '/data/question1'})
@@ -401,7 +405,7 @@ class BaseIndexTest(SimpleTestCase, TestXmlMixin):
         self.parent_module = self.app.add_module(Module.new_module('New Module', lang='en'))
         self.parent_form = self.app.new_form(0, 'New Form', lang='en')
         self.parent_module.case_type = 'parent_test_case_type'
-        self.parent_form.source = self.get_xml('original_form', override_path=('data',))
+        self.parent_form.source = self.get_xml('original_form', override_path=('data',)).decode('utf-8')
         self.parent_form.actions.open_case = OpenCaseAction(name_path="/data/question1", external_id=None)
         self.parent_form.actions.open_case.condition.type = 'always'
 
@@ -410,7 +414,7 @@ class BaseIndexTest(SimpleTestCase, TestXmlMixin):
         self.module.forms.append(form)
         self.form = self.module.get_form(-1)
         self.module.case_type = 'test_case_type'
-        self.form.source = self.get_xml('subcase_original')
+        self.form.source = self.get_xml('subcase_original').decode('utf-8')
 
         child_module_1 = self.app.add_module(Module.new_module('New Module', lang='en'))
         child_module_1.case_type ='child1'

--- a/corehq/apps/app_manager/tests/test_form_xmlns.py
+++ b/corehq/apps/app_manager/tests/test_form_xmlns.py
@@ -25,7 +25,7 @@ class FormXmlnsTest(SimpleTestCase, TestXmlMixin):
     def get_source(self, xmlns=DEFAULT_XMLNS):
         default_xmlns = DEFAULT_XMLNS
         xmlns_tag = ' xmlns="%s"' % default_xmlns
-        source = self.get_xml('original_form')
+        source = self.get_xml('original_form').decode('utf-8')
         assert xmlns_tag in source, source
         if xmlns is None:
             source = source.replace(xmlns_tag, '')

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -190,14 +190,14 @@ class GetFormQuestionsTest(SimpleTestCase, TestFileMixin):
             module.id,
             name="Form",
             lang='en',
-            attachment=self.get_xml('case_in_form')
+            attachment=self.get_xml('case_in_form').decode('utf-8')
         )
 
         form_with_repeats = self.app.new_form(
             module.id,
             name="Form with repeats",
             lang='en',
-            attachment=self.get_xml('form_with_repeats')
+            attachment=self.get_xml('form_with_repeats').decode('utf-8')
         )
 
         self.form_unique_id = form.unique_id

--- a/corehq/apps/app_manager/tests/test_practice_user_config.py
+++ b/corehq/apps/app_manager/tests/test_practice_user_config.py
@@ -32,7 +32,7 @@ class TestPracticeUserRestore(TestCase, TestXmlMixin):
     def setUp(self):
         self.factory = AppFactory(build_version='2.30.0', domain=self.domain)
         module, form = self.factory.new_basic_module('register', 'case')
-        form.source = self.get_xml('very_simple_form')
+        form.source = self.get_xml('very_simple_form').decode('utf-8')
         self.factory.app.save()
 
     def tearDown(self):

--- a/corehq/apps/app_manager/tests/test_release_notes_form.py
+++ b/corehq/apps/app_manager/tests/test_release_notes_form.py
@@ -182,8 +182,8 @@ class ReleaseNotesResourceFileTest(TestCase, ReleaseFormsSetupMixin, TestXmlMixi
 
     def setUp(self):
         self.set_up_app()
-        self.releases_form.source = self.get_xml('very_simple_form')
-        self.basic_form.source = self.get_xml('very_simple_form')
+        self.releases_form.source = self.get_xml('very_simple_form').decode('utf-8')
+        self.basic_form.source = self.get_xml('very_simple_form').decode('utf-8')
         self.factory.app.save()
 
         super(ReleaseNotesResourceFileTest, self).setUp()

--- a/corehq/apps/app_manager/tests/test_schedule.py
+++ b/corehq/apps/app_manager/tests/test_schedule.py
@@ -344,11 +344,6 @@ class ScheduleTest(SimpleTestCase, TestXmlMixin):
 
             self.assertXmlPartialEqual(partial, suite, './menu/command[@id="m1-f{}"]'.format(form_num))
 
-    def _fetch_sources(self):
-        for form in self.module.forms:
-            name = '{}.xml'.format(form.unique_id)
-            form.source = self.app.lazy_fetch_attachment(name)
-
     # xmlns is added because I needed to use WrappedNode.find() in the next few tests
     xmlns = ("xmlns='http://www.w3.org/2002/xforms' "
              "xmlns:h='http://www.w3.org/1999/xhtml' "
@@ -358,8 +353,6 @@ class ScheduleTest(SimpleTestCase, TestXmlMixin):
 
     def test_current_schedule_phase(self):
         """ Current Schedule Phase is set depending on transition and termination conditions """
-        self._fetch_sources()
-
         current_schedule_phase_partial = """
         <partial>
             <bind type="xs:integer"
@@ -402,7 +395,6 @@ class ScheduleTest(SimpleTestCase, TestXmlMixin):
 
     def test_current_schedule_phase_no_transitions(self):
         """The current_schedule_phase is set to the phase of the current form"""
-        self._fetch_sources()
         self._apply_schedule_phases()
 
         current_schedule_phase_partial = """
@@ -434,7 +426,6 @@ class ScheduleTest(SimpleTestCase, TestXmlMixin):
             {xmlns}/>
         </partial>
         """
-        self._fetch_sources()
         self._apply_schedule_phases()
         xform_1 = self.form_1.wrapped_xform()
         form_id = self.form_1.schedule_form_id
@@ -457,7 +448,6 @@ class ScheduleTest(SimpleTestCase, TestXmlMixin):
             {xmlns}/>
         </partial>
         """
-        self._fetch_sources()
         self._apply_schedule_phases()
         xform_1 = self.form_1.wrapped_xform()
         form_id = self.form_1.schedule_form_id
@@ -478,7 +468,6 @@ class ScheduleTest(SimpleTestCase, TestXmlMixin):
             {xmlns}/>
         </partial>
         """
-        self._fetch_sources()
         self._apply_schedule_phases()
         phase_forms = [self.form_1, self.form_2]
         xform_1 = self.form_1.wrapped_xform()

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -159,7 +159,7 @@ def save_xform(app, form, xml):
                 # or form is being updated with source copied from other form
                 xml = change_xmlns(xform, tag_xmlns, new_xmlns)
 
-    form.source = xml
+    form.source = xml.decode('utf-8')
 
     if form.is_registration_form():
         # For registration forms, assume that the first question is the

--- a/corehq/apps/cleanup/management/commands/fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/management/commands/fix_forms_and_apps_with_missing_xmlns.py
@@ -236,7 +236,7 @@ def set_xmlns_on_form(form_id, xmlns, app_build, log_file, dry_run):
         data = data.replace("undefined", xmlns, 1)
         wrapped_xml.instance_node.remove(wrapped_xml.data_node.xml)
         wrapped_xml.instance_node.append(parse_xml(data))
-        new_xml = wrapped_xml.render()
+        new_xml = wrapped_xml.render().decode('utf-8')
 
         form_in_build.source = new_xml
         form_in_build.form_migrated_from_undefined_xmlns = datetime.utcnow()

--- a/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
@@ -69,7 +69,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
 
         app = Application.new_app(DOMAIN, 'Normal App')
         module = app.add_module(Module.new_module('New Module', lang='en'))
-        form_source = self.get_xml('form_template').format(xmlns=xmlns, name=form_name)
+        form_source = self.get_xml('form_template').decode('utf-8').format(xmlns=xmlns, name=form_name)
         form = module.new_form(form_name, "en", form_source)
         app.save()
         build = app.make_build()
@@ -90,9 +90,10 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
 
         app = Application.new_app(DOMAIN, 'Normal App')
         module = app.add_module(Module.new_module('New Module', lang='en'))
-        good_form_source = self.get_xml('form_template').format(xmlns=xmlns, name=good_form_name)
+        good_form_source = self.get_xml('form_template').decode('utf-8').format(xmlns=xmlns, name=good_form_name)
         good_form = module.new_form(good_form_name, "en", good_form_source)
-        bad_form_source = self.get_xml('form_template').format(xmlns="undefined", name=bad_form_name)
+        bad_form_source = self.get_xml('form_template').decode('utf-8').format(
+            xmlns="undefined", name=bad_form_name)
         bad_form = module.new_form(bad_form_name, "en", bad_form_source)
         app.save()
         build = app.make_build()
@@ -120,7 +121,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
 
         app = Application.new_app(DOMAIN, 'Normal App')
         module = app.add_module(Module.new_module('New Module', lang='en'))
-        form_source = self.get_xml('form_template').format(
+        form_source = self.get_xml('form_template').decode('utf-8').format(
             xmlns="undefined", name=form_name
         )
         form = module.new_form(form_name, "en", form_source)
@@ -132,7 +133,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
 
         xmlns = generate_random_xmlns()
         form = app.get_form(form.unique_id)
-        form.source = self.get_xml('form_template').format(
+        form.source = self.get_xml('form_template').decode('utf-8').format(
             xmlns=xmlns, name=form_name
         )
         form.xmlns = xmlns
@@ -152,7 +153,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
 
         app = Application.new_app(DOMAIN, 'Normal App')
         module = app.add_module(Module.new_module('New Module', lang='en'))
-        form_source = self.get_xml('form_template').format(
+        form_source = self.get_xml('form_template').decode('utf-8').format(
             xmlns="undefined", name=form_name
         )
         form = module.new_form(form_name, "en", form_source)

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -560,7 +560,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
 
         factory = AppFactory(build_version='2.36.0')
         m0, f0 = factory.new_advanced_module('mod0', 'advanced')
-        f0.source = cls.get_xml('repeat_group_form')
+        f0.source = cls.get_xml('repeat_group_form').decode('utf-8')
         f0.xmlns = 'repeat-xmlns'
 
         factory.form_requires_case(f0, 'case0')
@@ -732,7 +732,7 @@ class TestAppCasePropertyReferences(TestCase, TestXmlMixin):
         super(TestAppCasePropertyReferences, cls).setUpClass()
         factory = AppFactory(domain=cls.domain)
         m0 = factory.new_basic_module('save_to_case', cls.case_type, with_form=False)
-        m0f1 = m0.new_form('save to case', 'en', attachment=cls.get_xml('basic_form'))
+        m0f1 = m0.new_form('save to case', 'en', attachment=cls.get_xml('basic_form').decode('utf-8'))
         m0f1.case_references = CaseReferences.wrap({
             'save': {
                 "/data/question1": {
@@ -829,7 +829,7 @@ class TestDelayedSchema(TestCase, TestXmlMixin):
         cls.current_app._id = '1234'
         cls.current_app.version = 10
         module = cls.current_app.add_module(Module.new_module('Untitled Module', None))
-        form = module.new_form("Untitled Form", 'en', attachment=cls.get_xml('basic_form'))
+        form = module.new_form("Untitled Form", 'en', attachment=cls.get_xml('basic_form').decode('utf-8'))
         form.xmlns = cls.xmlns
 
         cls.build = Application.new_app(cls.domain, "Untitled Application")
@@ -838,7 +838,8 @@ class TestDelayedSchema(TestCase, TestXmlMixin):
         cls.build.version = 5
         cls.build.has_submissions = True
         module = cls.build.add_module(Module.new_module('Untitled Module', None))
-        form = module.new_form("Untitled Form", 'en', attachment=cls.get_xml('basic_form_version2'))
+        form = module.new_form("Untitled Form", 'en',
+                               attachment=cls.get_xml('basic_form_version2').decode('utf-8'))
         form.xmlns = cls.xmlns
 
         cls.apps = [

--- a/corehq/apps/export/tests/test_export_form_subcases.py
+++ b/corehq/apps/export/tests/test_export_form_subcases.py
@@ -48,7 +48,7 @@ class TestFormExportSubcases(TestCase, TestXmlMixin):
     def setUpClass(cls):
         super(TestFormExportSubcases, cls).setUpClass()
         cls.app = Application.wrap(cls.get_json(cls.app_json_file))
-        cls.app.get_forms_by_xmlns(cls.form_xmlns)[0].source = cls.get_xml(cls.form_xml_file)
+        cls.app.get_forms_by_xmlns(cls.form_xmlns)[0].source = cls.get_xml(cls.form_xml_file).decode('utf-8')
         with drop_connected_signals(app_post_save):
             cls.app.save()
 

--- a/corehq/apps/export/tests/test_form_schema.py
+++ b/corehq/apps/export/tests/test_form_schema.py
@@ -33,7 +33,7 @@ class FormQuestionSchemaTest(SimpleTestCase, TestXmlMixin):
         self.assertEqual(schema.question_schema['form.repeat_1.multi_level_1_repeat'].options, ['item1', 'item2'])
         self.assertEqual(schema.question_schema['form.repeat_1.multi_level_1_repeat'].repeat_context, 'form.repeat_1')
 
-        updated_form_xml = self.get_xml('question_schema_update_form')
+        updated_form_xml = self.get_xml('question_schema_update_form').decode('utf-8')
         app.get_forms_by_xmlns(xmlns)[0].source = updated_form_xml
         app.version = 2
 
@@ -60,7 +60,7 @@ class FormQuestionSchemaTest(SimpleTestCase, TestXmlMixin):
         self.assertEqual(schema.question_schema['form.multi_root'].options, ['item1', 'item2', 'item3'])
 
         # Change the question to a different type
-        updated_form_xml = self.get_xml('question_schema_no_multi')
+        updated_form_xml = self.get_xml('question_schema_no_multi').decode('utf-8')
         app.get_forms_by_xmlns(xmlns)[0].source = updated_form_xml
         app.version = 2
 

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -71,10 +71,10 @@ class TestLinkedApps(BaseLinkedAppsTest):
 
     def test_overwrite_app_maintain_ids(self):
         module = self.plain_master_app.add_module(Module.new_module('M1', None))
-        module.new_form('f1', None, self.get_xml('very_simple_form'))
+        module.new_form('f1', None, self.get_xml('very_simple_form').decode('utf-8'))
 
         module = self.linked_app.add_module(Module.new_module('M1', None))
-        module.new_form('f1', None, self.get_xml('very_simple_form'))
+        module.new_form('f1', None, self.get_xml('very_simple_form').decode('utf-8'))
 
         id_map_before = _get_form_id_map(self.linked_app)
 
@@ -247,7 +247,7 @@ class TestRemoteLinkedApps(BaseLinkedAppsTest):
 
     def test_remote_app(self):
         module = self.master_app_with_report_modules.add_module(Module.new_module('M1', None))
-        module.new_form('f1', None, self.get_xml('very_simple_form'))
+        module.new_form('f1', None, self.get_xml('very_simple_form').decode('utf-8'))
 
         linked_app = _mock_pull_remote_master(
             self.master_app_with_report_modules, self.linked_app, {'master_report_id': 'mapped_id'}

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -777,7 +777,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
                                              text_node.find("./{f}value[@form='%s']" % trans_type),
                                              {'form': trans_type})
 
-    save_xform(app, form, etree.tostring(xform.xml, encoding="unicode"))
+    save_xform(app, form, etree.tostring(xform.xml))
     return msgs
 
 

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -675,7 +675,7 @@ class AggregateMarkdownNodeTests(SimpleTestCase, TestXmlMixin):
         self.app.langs = ['en', 'afr', 'fra']
         module1 = self.app.add_module(Module.new_module('module', None))
         form1 = self.app.new_form(module1.id, "Untitled Form", None)
-        form1.source = self.get_xml('initial_xform')
+        form1.source = self.get_xml('initial_xform').decode('utf-8')
 
         self.form1_worksheet = self.get_worksheet('module1_form1')
 

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -129,7 +129,7 @@ def get_simple_xform():
         'MN': 'MN',
         'VT': 'VT',
     })
-    return xform.tostring()
+    return xform.tostring().decode('utf-8')
 
 
 def load_data_from_db(table_name):

--- a/custom/openclinica/management/commands/odm_to_app.py
+++ b/custom/openclinica/management/commands/odm_to_app.py
@@ -138,7 +138,7 @@ class Study(StudyObject):
         xform.new_question(CC_DOB, 'Date of Birth', data_type='date')
         xform.new_question(CC_SEX, 'Sex', data_type='select1', choices={1: 'Male', 2: 'Female'})
         xform.new_question(CC_ENROLLMENT_DATE, 'Enrollment Date', data_type='date')
-        return xform.tostring(pretty_print=True)
+        return xform.tostring(pretty_print=True).decode('utf-8')
 
     def new_reg_subject_module(self, app):
 
@@ -254,7 +254,7 @@ class StudyEvent(StudyObject):
                 study_form.add_item_groups_to_xform(xform)
             xform.new_question('end_date', 'End Date', data_type='date')
             xform.new_question('end_time', 'End Time', data_type='time')
-            return xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+            return xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True).decode('utf-8')
 
         def get_preload_action():
             return PreloadAction(
@@ -381,7 +381,7 @@ class StudyForm(StudyObject):
         self.add_item_groups_to_xform(xform)
         xform.new_question('end_date', 'End Date', data_type='date')
         xform.new_question('end_time', 'End Time', data_type='time')
-        return xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        return xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True).decode('utf-8')
 
 
 class ItemGroup(StudyObject):


### PR DESCRIPTION
Reverts dimagi/commcare-hq#22607

This time, be less cocky and use soft asserts: https://github.com/dimagi/commcare-hq/pull/22609/commits/c57cd505d3cc5746454a1aedaa7cae964781771a

Also encodes any cached attachments that are unicode: https://github.com/dimagi/commcare-hq/pull/22609/commits/b0f2b5612bb0f1aa26164d5ab55d0b71ce92ee6e.  This addresses these issues: https://sentry.io/dimagi/commcarehq/issues/790973615/.  I'd expect these cached values to all be expired one day after deploy.