### PR TITLE
Fix proportions in multimedia reference checker

### DIFF
--- a/corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
@@ -18,8 +18,8 @@
                     <th class="col-sm-1">{% trans 'Status' %}</th>
                     <th class="col-sm-2">{% trans 'Action' %}</th>
                     <th class="col-sm-2">{% trans 'Preview' %}</th>
-                    <th class="col-sm-6">{% trans 'Size'  %}</th>
-                    <th class="col-sm-6">{% trans 'Path in Application'  %}</th>
+                    <th class="col-sm-1">{% trans 'Size'  %}</th>
+                    <th class="col-sm-5">{% trans 'Path in Application'  %}</th>
                 </tr>
             </thead>
             <tbody data-bind="foreach: {{ ref_type }}">

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/reference_table.html
@@ -34,7 +34,7 @@
                     <td>
                         <code data-bind="text: humanized_content_length"></code>
                         <!-- ko if: image_size -->
-                        (<span data-bind="text: image_size"></span>)
+                        <span data-bind="text: image_size"></span>
                         <!-- /ko -->
                     </td>
                     <td><code data-bind="text: path"></code></td>


### PR DESCRIPTION
This was bugging me.
@dannyroberts 

before
<img width="1173" alt="screen shot 2018-12-03 at 5 15 49 pm" src="https://user-images.githubusercontent.com/1486591/49404982-2153ff80-f71f-11e8-8aa3-9b045a085fd7.png">

after
<img width="1164" alt="screen shot 2018-12-03 at 5 16 00 pm" src="https://user-images.githubusercontent.com/1486591/49404989-24e78680-f71f-11e8-8fa3-fe35b7906c2b.png">
