### PR TITLE
Surface missing module errors earlier

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -62,13 +62,9 @@
                             <i class="fa fa-plus"></i> <strong>Add...</strong> to create
                             some menus.
                         {% case "missing module" %}
-                            {% blocktrans %}
-                            This application is missing a module. If you have deleted any modules recently, make sure that
-                            you have removed all references to them. If you continue to experience problems, please report an issue.
-                            {% endblocktrans %}
+                            {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
                             {% if error.message %}
-                            <br/>{% trans "Details:" %}<br/>
-                            {{ error.message }}
+                                {% trans "Details:" %}
                             {% endif %}
                         {% case "no forms" %}
                             <a href="{% url "view_module" domain app.id error.module.unique_id %}">{{ error.module.name|trans:langs }}</a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_error_message.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_error_message.html
@@ -1,0 +1,3 @@
+{# Poor spacing in this file because this template is used in the middle of sentences #}{% load xforms_extras %}{% load i18n %}{% if not not_actual_build %}
+Menu "<a href="{% url "view_module" domain app.id error.module.unique_id %}">{{ error.module.name|trans:langs }}</a>"
+{% else %}This menu{% endif %}


### PR DESCRIPTION
Part of https://dimagi-dev.atlassian.net/browse/HI-172

When a menu references another menu that turns out to be missing, show that error on the menu settings page, not just when making a build.

@dannyroberts 