### PR TITLE
don't decode output of get_table_name

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/agg_ccs_record.py
+++ b/custom/icds_reports/utils/aggregation_helpers/agg_ccs_record.py
@@ -20,7 +20,7 @@ class AggCcsRecordAggregationHelper(BaseICDSAggregationHelper):
     def ccs_record_monthly_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, self.ccs_record_monthly_ucr_id)
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     def _tablename_func(self, agg_level):
         return "{}_{}_{}".format(self.base_tablename, self.month.strftime("%Y-%m-%d"), agg_level)

--- a/custom/icds_reports/utils/aggregation_helpers/ccs_record_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/ccs_record_monthly.py
@@ -25,19 +25,19 @@ class CcsRecordMonthlyAggregationHelper(BaseICDSAggregationHelper):
     def ccs_record_monthly_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, self.ccs_record_monthly_ucr_id)
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     @property
     def ccs_record_case_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-ccs_record_cases')
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     @property
     def pregnant_tasks_cases_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-pregnant-tasks_cases')
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     @property
     def tablename(self):

--- a/custom/icds_reports/utils/aggregation_helpers/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/child_health_monthly.py
@@ -38,19 +38,19 @@ class ChildHealthMonthlyAggregationHelper(BaseICDSAggregationHelper):
     def child_health_case_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-child_health_cases')
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     @property
     def child_tasks_case_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-child_tasks_cases')
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     @property
     def person_case_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-person_cases_v2')
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     @property
     def tablename(self):

--- a/custom/intrahealth/tests/__init__.py
+++ b/custom/intrahealth/tests/__init__.py
@@ -228,7 +228,7 @@ def tearDownModule():
     metadata.reflect(bind=engine, extend_existing=True)
     path = os.path.join(os.path.dirname(__file__), 'fixtures')
     for file_name in os.listdir(path):
-        table_name = get_table_name(domain.name, file_name[:-4]).decode('utf-8')
+        table_name = get_table_name(domain.name, file_name[:-4])
         table = metadata.tables[table_name]
         table.drop()
     _call_center_domain_mock.start()

--- a/custom/up_nrhm/tests/__init__.py
+++ b/custom/up_nrhm/tests/__init__.py
@@ -66,7 +66,7 @@ def tearDownModule():
     metadata.reflect(bind=engine, extend_existing=True)
     path = os.path.join(os.path.dirname(__file__), 'fixtures')
     for file_name in os.listdir(path):
-        table_name = get_table_name(domain.name, file_name[:-4]).decode('utf-8')
+        table_name = get_table_name(domain.name, file_name[:-4])
         table = metadata.tables[table_name]
         table.drop()
     _call_center_domain_mock.start()


### PR DESCRIPTION
```get_table_name``` already returns unicode, so decoding it errors in python 3.