### PR TITLE
remove couch attachments from tests

### DIFF
--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -251,41 +251,10 @@ class TestBlobMixin(BaseTestCase):
         self.assertTrue(blob.exists(), "not found: " + blob.path)
         self.assertEqual(doc.fetch_attachment(name), "content 1")
 
-    def test_put_attachment_deletes_couch_attachment(self):
-        name = "test"
-        content = BytesIO(b"content")
-        doc = self.make_doc(FallbackToCouchDocument)
-        doc._attachments = {name: {"length": 25}}
-        doc.put_attachment(content, name)
-        self.assertEqual(doc.fetch_attachment(name), "content")
-        self.assertNotIn(name, doc._attachments)
-
-    def test_fallback_on_fetch_fail(self):
-        name = "test.1"
-        doc = self.make_doc(FallbackToCouchDocument)
-        doc._attachments[name] = {"content": b"couch content"}
-        self.assertEqual(doc.fetch_attachment(name), b"couch content")
-
-    def test_fallback_on_delete_fail(self):
-        name = "test.1"
-        doc = self.make_doc(FallbackToCouchDocument)
-        doc._attachments[name] = {"content": b"couch content"}
-        self.assertTrue(doc.delete_attachment(name), "couch attachment not deleted")
-        self.assertNotIn(name, doc._attachments)
-
     def test_blobs_property(self):
-        couch_digest = "md5-" + b64encode(md5(b"content").digest()).decode('utf-8')
         doc = self.make_doc(FallbackToCouchDocument)
-        doc._attachments["att"] = {
-            "content": b"couch content",
-            "content_type": None,
-            "digest": couch_digest,
-            "length": 13,
-        }
         doc.put_attachment("content", "blob", content_type="text/plain")
-        self.assertIn("att", doc.blobs)
         self.assertIn("blob", doc.blobs)
-        self.assertEqual(doc.blobs["att"].content_length, 13)
         self.assertEqual(doc.blobs["blob"].content_length, 7)
 
     def test_unsaved_document(self):
@@ -398,30 +367,6 @@ class TestBlobMixin(BaseTestCase):
         blob = self.get_blob(self.obj.blobs[name].key)
         self.assertEqual(blob.listdir(), blob_files)
 
-    def test_atomic_blobs_fail_restores_couch_attachments(self):
-        couch_digest = "md5-" + b64encode(md5(b"content").digest()).decode('utf-8')
-        doc = self.make_doc(FallbackToCouchDocument)
-        doc._attachments["att"] = couch_att = {
-            "content": b"couch content",
-            "content_type": None,
-            "digest": couch_digest,
-            "length": 13,
-        }
-        with self.assertRaises(BlowUp):
-            with doc.atomic_blobs():
-                doc.put_attachment("new content", "att")
-                key = doc.blobs["att"].key
-                blob = self.get_blob(key)
-                blob_files = blob.listdir()
-                if key in blob_files:
-                    blob_files.remove(key)
-                raise BlowUp("while saving atomic blobs")
-        self.assertEqual(doc.blobs["att"].content_length, 13)
-        self.assertEqual(doc.fetch_attachment("att"), "couch content")
-        self.assertEqual(doc._attachments["att"], couch_att)
-        # verify cleanup
-        self.assertEqual(blob.listdir(), blob_files)
-
     def test_atomic_blobs_fail_restores_deleted_blob(self):
         name = "delete-fail"
         self.obj.put_attachment("content", name)
@@ -435,24 +380,6 @@ class TestBlobMixin(BaseTestCase):
         self.assertEqual(self.obj.fetch_attachment(name), "content")
         # verify cleanup
         self.assertEqual(blob.listdir(), blob_files)
-
-    def test_atomic_blobs_fail_restores_deleted_couch_attachment(self):
-        couch_digest = "md5-" + b64encode(md5(b"content").digest()).decode('utf-8')
-        doc = self.make_doc(FallbackToCouchDocument)
-        doc._attachments["att"] = couch_att = {
-            "content": b"couch content",
-            "content_type": None,
-            "digest": couch_digest,
-            "length": 13,
-        }
-        with self.assertRaises(BlowUp):
-            with doc.atomic_blobs():
-                doc.delete_attachment("att")
-                raise BlowUp("while deleting couch attachment")
-        self.assertEqual(doc.blobs["att"].content_length, 13)
-        self.assertEqual(doc.fetch_attachment("att"), "couch content")
-        self.assertEqual(doc._attachments["att"], couch_att)
-        self.assertEqual([b.key for b in doc.blobs.values()], [None])
 
     def test_atomic_blobs_bug_deleting_existing_blob(self):
         self.obj.put_attachment("file content", "file")


### PR DESCRIPTION
These are broken in python 3 because you can't assign bytes to a json object.