### PR TITLE
Remove lazy CommCare Sense migration

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -706,7 +706,7 @@ def edit_app_attr(request, domain, app_id, attr):
 
     attributes = [
         'all',
-        'recipients', 'name', 'use_commcare_sense',
+        'recipients', 'name',
         'text_input', 'platform', 'build_spec',
         'use_custom_suite', 'custom_suite',
         'admin_password',

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -131,15 +131,6 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
             "view_app", args=[domain, app.copy_of]
         ))
 
-    # grandfather in people who set commcare sense earlier
-    if app and 'use_commcare_sense' in app:
-        if app['use_commcare_sense']:
-            if 'features' not in app.profile:
-                app.profile['features'] = {}
-            app.profile['features']['sense'] = 'true'
-        del app['use_commcare_sense']
-        app.save()
-
     context.update({
         'module': module,
         'form': form,


### PR DESCRIPTION
This migration was added on April 22, 2011 in commit
d9241d4251c21ca49e9212dbd68ae59387c03437. Sense then only five apps have
not been migrated.

Found via:

In [10]: for doc in iter_docs(Application.get_db(), ids, chunksize=50):
...:     if doc.get('use_commcare_sense'):
...:         print("old commcare sense", doc["_id"])
...:

('old commcare sense', u'13fb26d1d491f89636a699ddf7fa59ce')
('old commcare sense', u'598068af0ec1bb974028db919f96d386')
('old commcare sense', u'13fb26d1d491f89636a699ddf7facc71')
('old commcare sense', u'13fb26d1d491f89636a699ddf7fa2de3')
('old commcare sense', u'c451e501deda54d89583f9904659acd5')

I opened each of these apps release pages so that the lazy migration
would run.


@dannyroberts because I bet you love seeing your old 2011 code