### PR TITLE
Remove zeep

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/post.py
+++ b/corehq/ex-submodules/dimagi/utils/post.py
@@ -5,8 +5,6 @@ import subprocess
 import tempfile
 from subprocess import PIPE
 import requests
-from zeep import Client, Transport
-from zeep.cache import InMemoryCache
 import six
 from io import open
 
@@ -40,31 +38,6 @@ def simple_post(data, url, content_type="text/xml", timeout=60, headers=None, au
         kwargs["verify"] = verify
 
     return requests.post(url, data, **kwargs)
-
-
-def get_SOAP_client(url, verify=True):
-    # http://docs.python-zeep.org/en/master/transport.html#ssl-verification
-    # Disable SSL cert verification meanwhile a better way is found
-    session = requests.Session()
-    session.verify = verify
-    transport = Transport(cache=InMemoryCache(), session=session)
-    return Client(url, transport=transport)
-
-
-def perform_SOAP_operation(data, url, operation, verify=True):
-    client = get_SOAP_client(url, verify)
-    # for just response message use
-    # with client.options(raw_response=False) # explicitly set it to avoid caching mysteries
-    #     return client.service[operation](**data)
-    with client.options(raw_response=True):
-        return client.service[operation](**data)
-
-
-def parse_SOAP_response(url, operation, response, verify=True):
-    # parse the xml content on response object to return just the message
-    client = get_SOAP_client(url, verify)
-    binding = client.service[operation]._proxy._binding
-    return binding.process_reply(client, binding.get(operation), response)
 
 
 def post_data(data, url, curl_command="curl", use_curl=False,

--- a/corehq/motech/README.md
+++ b/corehq/motech/README.md
@@ -68,8 +68,8 @@ and can be sent as either `XML` or `JSON`.
 
 **Custom repeaters** are defined in code, and subclass any of the
 `BaseRepeater` classes. They allow the developer to create custom
-payloads that can compile data from multiple sources and be sent in any
-format, including `JSON`, `XML` and `SOAP`. Custom triggers for when to
+payloads that can compile data from multiple sources and be sent as
+`JSON` or `XML`. Custom triggers for when to
 send this data are also defined in code. These trigger methods are run
 whenever the model in question (`case`, `form`, or `application`) is
 changed.

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -260,28 +260,6 @@ class Dhis2RepeaterForm(FormRepeaterForm):
         return fields
 
 
-class SOAPCaseRepeaterForm(CaseRepeaterForm):
-    operation = forms.CharField(
-        required=False,
-        label='SOAP operation',
-    )
-
-    def get_ordered_crispy_form_fields(self):
-        fields = super(SOAPCaseRepeaterForm, self).get_ordered_crispy_form_fields()
-        return fields + ['operation']
-
-
-class SOAPLocationRepeaterForm(GenericRepeaterForm):
-    operation = forms.CharField(
-        required=False,
-        label='SOAP operation',
-    )
-
-    def get_ordered_crispy_form_fields(self):
-        fields = super(SOAPLocationRepeaterForm, self).get_ordered_crispy_form_fields()
-        return fields + ['operation']
-
-
 class EmailBulkPayload(forms.Form):
     repeater_id = forms.ChoiceField(label=_("Repeater"))
     payload_ids_file = forms.FileField(

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -48,7 +48,7 @@ from dimagi.ext.couchdbkit import (
 )
 from dimagi.utils.mixins import UnicodeMixIn
 from dimagi.utils.parsing import json_format_datetime
-from dimagi.utils.post import simple_post, perform_SOAP_operation
+from dimagi.utils.post import simple_post
 from .const import (
     MAX_RETRY_WAIT,
     MIN_RETRY_WAIT,
@@ -461,13 +461,6 @@ class UpdateCaseRepeater(CaseRepeater):
 
     def allowed_to_forward(self, payload):
         return super(UpdateCaseRepeater, self).allowed_to_forward(payload) and len(payload.xform_ids) > 1
-
-
-class SOAPRepeaterMixin(Repeater):
-    operation = StringProperty()
-
-    def send_request(self, repeat_record, payload):
-        return perform_SOAP_operation(payload, self.url, self.operation, verify=self.verify)
 
 
 class ShortFormRepeater(Repeater):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -80,11 +80,6 @@ class BasePayloadGenerator(object):
         return True
 
 
-class SOAPPayloadGeneratorMixin(object):
-    @property
-    def content_type(self):
-        return 'application/soap+xml'
-
 FormatInfo = namedtuple('FormatInfo', 'name label generator_class')
 
 

--- a/corehq/motech/repeaters/views/__init__.py
+++ b/corehq/motech/repeaters/views/__init__.py
@@ -1,7 +1,5 @@
 from .repeaters import (
     AddCaseRepeaterView,
-    AddCustomSOAPCaseRepeaterView,
-    AddCustomSOAPLocationRepeaterView,
     AddFormRepeaterView,
     AddRepeaterView,
     DomainForwardingOptionsView,

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -265,10 +265,6 @@ class RepeatRecordView(View):
             payload = indent_xml(payload)
         elif content_type == 'application/json':
             payload = pformat_json(payload)
-        elif content_type == 'application/soap+xml':
-            # we return a payload that is a dict, which is then converted to
-            # XML by the zeep library before being sent along as a SOAP request.
-            payload = json.dumps(payload, indent=4)
 
         return json_response({
             'payload': payload,

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -29,9 +29,8 @@ from corehq.motech.repeaters.forms import (
     FormRepeaterForm,
     GenericRepeaterForm,
     OpenmrsRepeaterForm,
-    SOAPCaseRepeaterForm,
-    SOAPLocationRepeaterForm,
-    Dhis2RepeaterForm)
+    Dhis2RepeaterForm,
+)
 from corehq.motech.repeaters.models import Repeater, RepeatRecord, BASIC_AUTH, DIGEST_AUTH
 from corehq.motech.repeaters.repeater_generators import RegisterGenerator
 from corehq.motech.repeaters.utils import get_all_repeater_types
@@ -236,28 +235,6 @@ class AddDhis2RepeaterView(AddFormRepeaterView):
     def set_repeater_attr(self, repeater, cleaned_data):
         repeater = super(AddDhis2RepeaterView, self).set_repeater_attr(repeater, cleaned_data)
         repeater.include_app_id_param = self.add_repeater_form.cleaned_data['include_app_id_param']
-        return repeater
-
-
-class AddCustomSOAPCaseRepeaterView(AddCaseRepeaterView):
-    repeater_form_class = SOAPCaseRepeaterForm
-
-    def make_repeater(self):
-        repeater = super(AddCustomSOAPCaseRepeaterView, self).make_repeater()
-        repeater.operation = self.add_repeater_form.cleaned_data['operation']
-        return repeater
-
-
-class AddCustomSOAPLocationRepeaterView(AddRepeaterView):
-    repeater_form_class = SOAPLocationRepeaterForm
-
-    @property
-    def page_url(self):
-        return reverse(self.urlname, args=[self.domain])
-
-    def make_repeater(self):
-        repeater = super(AddCustomSOAPLocationRepeaterView, self).make_repeater()
-        repeater.operation = self.add_repeater_form.cleaned_data['operation']
         return repeater
 
 

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -12,7 +12,6 @@ alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
-appdirs==1.4.3
 argparse==1.4.0
 asn1crypto==0.24.0
 attrs==18.1.0
@@ -23,7 +22,6 @@ beautifulsoup4==4.6.3
 billiard==3.3.0.23
 boto3==1.4.4
 botocore==1.5.95
-cached-property==1.5.1
 celery==3.1.25
 certifi==2018.11.29
 cffi==1.11.5
@@ -105,7 +103,6 @@ ipdb==0.11
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.2.2
 iso8601==0.1.12
-isodate==0.6.0
 jdcal==1.4
 jenkinsapi==0.2.28
 jinja2==2.10
@@ -176,7 +173,6 @@ redis-py-cluster==1.3.5
 redis==2.10.6
 reportlab==3.0
 requests-mock==1.5.2
-requests-toolbelt==0.8.0
 requests[security]==2.20.1
 requirements_parser==0.1.0
 restkit==4.2.2
@@ -222,4 +218,3 @@ wrapt==1.10.11
 xhtml2pdf==0.2.3
 xlrd==1.0.0
 xlwt==1.3.0
-zeep==1.6.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -9,14 +9,12 @@ alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
-appdirs==1.4.3
 asn1crypto==0.24.0
 attrs==18.1.0
 babel==2.6.0
 billiard==3.3.0.23
 boto3==1.4.4
 botocore==1.5.95
-cached-property==1.5.1
 celery==3.1.25
 certifi==2018.11.29
 cffi==1.11.5
@@ -84,7 +82,6 @@ idna==2.7
 imagesize==1.1.0          # via sphinx
 ipaddress==1.0.22
 iso8601==0.1.12
-isodate==0.6.0
 jdcal==1.4
 jinja2==2.10
 jmespath==0.9.3
@@ -139,7 +136,6 @@ rcssmin==1.0.6
 redis-py-cluster==1.3.5
 redis==2.10.6
 reportlab==3.0
-requests-toolbelt==0.8.0
 requests[security]==2.20.1
 rjsmin==1.0.12
 s3transfer==0.1.13
@@ -173,4 +169,3 @@ wrapt==1.10.11
 xhtml2pdf==0.2.3
 xlrd==1.0.0
 xlwt==1.3.0
-zeep==1.6.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -8,7 +8,6 @@ git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
-appdirs==1.4.3
 asn1crypto==0.24.0
 attrs==18.1.0
 babel==2.6.0
@@ -17,7 +16,6 @@ backports.shutil-get-terminal-size==1.0.0  # via ipython
 billiard==3.3.0.23
 boto3==1.4.4
 botocore==1.5.95
-cached-property==1.5.1
 celery==3.1.25
 certifi==2018.11.29
 cffi==1.11.5
@@ -88,7 +86,6 @@ ipaddress==1.0.22
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.2.2
 iso8601==0.1.12
-isodate==0.6.0
 jdcal==1.4
 jinja2==2.10
 jmespath==0.9.3
@@ -149,7 +146,6 @@ rcssmin==1.0.6
 redis-py-cluster==1.3.5
 redis==2.10.6
 reportlab==3.0
-requests-toolbelt==0.8.0
 requests[security]==2.20.1
 rjsmin==1.0.12
 s3transfer==0.1.13
@@ -185,7 +181,6 @@ wrapt==1.10.11
 xhtml2pdf==0.2.3
 xlrd==1.0.0
 xlwt==1.3.0
-zeep==1.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==18.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -94,7 +94,6 @@ email_validator==1.0.3
 dnspython==1.15.0
 raven==6.1.0
 quickcache==0.5.1
-zeep==1.6.0
 ethiopian-date-converter==0.1.5
 contextlib2==0.5.4
 hiredis==0.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,14 +8,12 @@ git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
 attrs==18.1.0
 babel==2.6.0              # via django-phonenumber-field
 billiard==3.3.0.23        # via celery
 boto3==1.4.4
 botocore==1.5.95          # via boto3, s3transfer
-cached-property==1.5.1    # via zeep
 celery==3.1.25
 certifi==2018.11.29       # via requests
 cffi==1.11.5              # via cryptography, csiphash
@@ -81,7 +79,6 @@ httpagentparser==1.7.8
 idna==2.7                 # via cryptography, email-validator, requests
 ipaddress==1.0.22         # via cryptography, faker
 iso8601==0.1.12
-isodate==0.6.0            # via zeep
 jdcal==1.4                # via openpyxl
 jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
@@ -134,7 +131,6 @@ rcssmin==1.0.6            # via django-compressor
 redis-py-cluster==1.3.5
 redis==2.10.6
 reportlab==3.0
-requests-toolbelt==0.8.0  # via zeep
 requests[security]==2.20.1
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.1.13        # via boto3
@@ -162,4 +158,3 @@ wrapt==1.10.11            # via ddtrace
 xhtml2pdf==0.2.3
 xlrd==1.0.0
 xlwt==1.3.0
-zeep==1.6.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -9,7 +9,6 @@ git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
-appdirs==1.4.3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0
 attrs==18.1.0
@@ -18,7 +17,6 @@ beautifulsoup4==4.6.3
 billiard==3.3.0.23
 boto3==1.4.4
 botocore==1.5.95
-cached-property==1.5.1
 celery==3.1.25
 certifi==2018.11.29
 cffi==1.11.5
@@ -87,7 +85,6 @@ httpagentparser==1.7.8
 idna==2.7
 ipaddress==1.0.22
 iso8601==0.1.12
-isodate==0.6.0
 jdcal==1.4
 jinja2==2.10
 jmespath==0.9.3
@@ -144,7 +141,6 @@ redis-py-cluster==1.3.5
 redis==2.10.6
 reportlab==3.0
 requests-mock==1.5.2
-requests-toolbelt==0.8.0
 requests[security]==2.20.1
 rjsmin==1.0.12
 s3transfer==0.1.13
@@ -176,4 +172,3 @@ wrapt==1.10.11
 xhtml2pdf==0.2.3
 xlrd==1.0.0
 xlwt==1.3.0
-zeep==1.6.0

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -6,3 +6,4 @@ feedparser
 pycrypto
 restkit
 http-parser
+zeep


### PR DESCRIPTION
@mkangia @kaapstorm (low priority) I think that this a question for you guys. I noticed zeep was quite out of date, but I also think it's effectively unused since enikshay code was deleted. What is the best way to assert they are no longer in use?

The mixin was originally used in the custom/eniskhay directory and doesn't appear to have anymore references https://github.com/dimagi/commcare-hq/blob/6fe86e4a1d7e79d1a59d2af69a5c83efbdaf2516/custom/enikshay/integrations/nikshay/repeaters.py#L191

I'm not sure what I would do with the following, but I think they could also be removed (along with some other references linked to their code):

https://github.com/dimagi/commcare-hq/blob/je/remove-zeep/corehq/motech/repeaters/views/repeat_records.py#L268-L271
https://github.com/dimagi/commcare-hq/blob/je/remove-zeep/corehq/motech/repeaters/views/repeaters.py#L242