### PR TITLE
Fix phone number formatting in beneficiary report

### DIFF
--- a/custom/icds_reports/sqldata/exports/beneficiary.py
+++ b/custom/icds_reports/sqldata/exports/beneficiary.py
@@ -84,7 +84,7 @@ class BeneficiaryExport(ExportableMixin, SqlData):
             return "%.2f" % x if x else "Data Not Entered"
 
         def phone_number_fucntion(x):
-            return '"{}"'.format(x) if x else x
+            return "'{}".format(x) if x else x
 
         columns = [
             DatabaseColumn(


### PR DESCRIPTION
Hi @calellowitz,
I have fixed long numbers - phone numbers - formatting in the beneficiary report to show as strings rather as numbers in mathematical notation but without additional characters being seen in excel.
Regards, Dawid