### PR TITLE
Redirect form's source to release's page

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -60,11 +60,6 @@ logger = logging.getLogger(__name__)
 @track_domain_request(calculated_prop='cp_n_form_builder_entered')
 def form_source(request, domain, app_id, form_unique_id):
     app = get_app(domain, app_id)
-    if app and app.copy_of:
-        # redirect to "main" app rather than specific build
-        return HttpResponseRedirect(reverse(
-            "view_app", args=[domain, app.copy_of]
-        ))
 
     try:
         form = app.get_form(form_unique_id)
@@ -88,12 +83,6 @@ def form_source_legacy(request, domain, app_id, module_id=None, form_id=None):
     """
     app = get_app(domain, app_id)
 
-    if app and app.copy_of:
-        # redirect to "main" app rather than specific build
-        return HttpResponseRedirect(reverse(
-            "view_app", args=[domain, app.copy_of]
-        ))
-
     try:
         module = app.get_module(module_id)
     except ModuleNotFoundException:
@@ -108,6 +97,13 @@ def form_source_legacy(request, domain, app_id, module_id=None, form_id=None):
 
 
 def _get_form_designer_view(request, domain, app, module, form):
+    if app and app.copy_of:
+        messages.warning(request, _(
+            "You tried to edit a form that was from a previous release, so "
+            "we have directed you to the latest version of your application."
+        ))
+        return back_to_main(request, domain, app_id=app.id)
+
     if form.no_vellum:
         messages.warning(request, _(
             "You tried to edit this form in the Form Builder. "

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -7,7 +7,7 @@ import logging
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceConflict
-from django.http import HttpResponse, Http404, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import HttpResponse, Http404, HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
 from django.conf import settings

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -7,7 +7,7 @@ import logging
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceConflict
-from django.http import HttpResponse, Http404, HttpResponseBadRequest
+from django.http import HttpResponse, Http404, HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
 from django.conf import settings
@@ -60,6 +60,11 @@ logger = logging.getLogger(__name__)
 @track_domain_request(calculated_prop='cp_n_form_builder_entered')
 def form_source(request, domain, app_id, form_unique_id):
     app = get_app(domain, app_id)
+    if app and app.copy_of:
+        # redirect to "main" app rather than specific build
+        return HttpResponseRedirect(reverse(
+            "view_app", args=[domain, app.copy_of]
+        ))
 
     try:
         form = app.get_form(form_unique_id)
@@ -82,6 +87,12 @@ def form_source_legacy(request, domain, app_id, module_id=None, form_id=None):
     PLEASE DO NOT DELETE.
     """
     app = get_app(domain, app_id)
+
+    if app and app.copy_of:
+        # redirect to "main" app rather than specific build
+        return HttpResponseRedirect(reverse(
+            "view_app", args=[domain, app.copy_of]
+        ))
 
     try:
         module = app.get_module(module_id)


### PR DESCRIPTION
Before this commit, a user was able to modify a build's form's XML in
place. It's unclear if that has affected any applications before as I
have not investigated how much CCZs are cached or how often a build's
URLs are hit.

`view_generic` already does this for a majority of app builder URLs.