### PR TITLE
Move load_appcues_template_app into tasks.py

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 from celery.task import task
 from celery.utils.log import get_task_logger
@@ -72,3 +73,9 @@ def prune_auto_generated_builds(domain, app_id):
 def update_linked_app_and_notify_task(domain, app_id, user_id, email):
     from corehq.apps.app_manager.views.utils import update_linked_app_and_notify
     update_linked_app_and_notify(domain, app_id, user_id, email)
+
+
+@task(queue=settings.CELERY_MAIN_QUEUE)
+def load_appcues_template_app(domain, username, app_slug):
+    from corehq.apps.app_manager.views.apps import load_app_from_slug
+    load_app_from_slug(domain, username, app_slug)

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -9,9 +9,6 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
-from django.conf import settings
-
-from celery.task import task
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app, wrap_app, get_apps_in_domain, get_current_app
@@ -366,9 +363,3 @@ def update_linked_app(app, user_id):
 def clear_xmlns_app_id_cache(domain):
     from couchforms.analytics import get_all_xmlns_app_id_pairs_submitted_to_in_domain
     get_all_xmlns_app_id_pairs_submitted_to_in_domain.clear(domain)
-
-
-@task(queue=settings.CELERY_MAIN_QUEUE)
-def load_appcues_template_app(domain, username, app_slug):
-    from corehq.apps.app_manager.views.apps import load_app_from_slug
-    load_app_from_slug(domain, username, app_slug)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -138,7 +138,7 @@ def request_new_domain(request, form, is_new_user=True):
     if is_new_user:
         dom_req.save()
         if settings.IS_SAAS_ENVIRONMENT:
-            from corehq.apps.app_manager.views.utils import load_appcues_template_app
+            from corehq.apps.app_manager.tasks import load_appcues_template_app
             chain(
                 load_appcues_template_app.si(new_domain.name, current_user.username, HEALTH_APP),
                 load_appcues_template_app.si(new_domain.name, current_user.username, AGG_APP),


### PR DESCRIPTION
`load_appcues_template_app` is not registered in app_manager/tasks.py, so activation emails are not being sent and the template apps for appcues v3 are not being loaded

Sentry Error:
https://sentry.io/dimagi/commcarehq/issues/704322918/?query=is:unresolved