### PR TITLE
get_xml() for couchforms should return bytes

### DIFF
--- a/corehq/apps/cleanup/management/commands/fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/management/commands/fix_forms_and_apps_with_missing_xmlns.py
@@ -199,7 +199,7 @@ def set_xmlns_on_submission(xform_instance, xmlns, xform_db, log_file, dry_run):
     """
     Set the xmlns on an XFormInstance, and the save the document.
     """
-    old_xml = xform_instance.get_xml()
+    old_xml = xform_instance.get_xml().decode('utf-8')
     assert old_xml.count('xmlns="undefined"') == 1
     new_xml = old_xml.replace('xmlns="undefined"', 'xmlns="{}"'.format(xmlns))
     if not dry_run:

--- a/corehq/apps/cleanup/management/commands/fix_xforms_with_undefined_xmlns.py
+++ b/corehq/apps/cleanup/management/commands/fix_xforms_with_undefined_xmlns.py
@@ -185,7 +185,7 @@ def set_xmlns_on_submission(xform_instance, xmlns, xform_db, log_file, dry_run):
     """
     Set the xmlns on an XFormInstance, and the save the document.
     """
-    old_xml = xform_instance.get_xml()
+    old_xml = xform_instance.get_xml().decode('utf-8')
     assert old_xml.count('xmlns="undefined"') == 1
     new_xml = old_xml.replace('xmlns="undefined"', 'xmlns="{}"'.format(xmlns))
     if not dry_run:

--- a/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
@@ -54,7 +54,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         super(TestFixFormsWithMissingXmlns, cls).tearDownClass()
 
     def _submit_form(self, xmlns, form_name, app_id, build_id):
-        xform_source = self.get_xml('xform_template').format(xmlns=xmlns, name=form_name, id=uuid.uuid4().hex)
+        xform_source = self.get_xml('xform_template').decode('utf-8').format(xmlns=xmlns, name=form_name, id=uuid.uuid4().hex)
         result = submit_form_locally(xform_source, DOMAIN, app_id=app_id, build_id=build_id)
         send_to_elasticsearch('forms', transform_xform_for_elasticsearch(result.xform.to_json()))
         return result.xform

--- a/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
@@ -54,7 +54,8 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         super(TestFixFormsWithMissingXmlns, cls).tearDownClass()
 
     def _submit_form(self, xmlns, form_name, app_id, build_id):
-        xform_source = self.get_xml('xform_template').decode('utf-8').format(xmlns=xmlns, name=form_name, id=uuid.uuid4().hex)
+        xform_source = self.get_xml('xform_template').decode('utf-8').format(
+            xmlns=xmlns, name=form_name, id=uuid.uuid4().hex)
         result = submit_form_locally(xform_source, DOMAIN, app_id=app_id, build_id=build_id)
         send_to_elasticsearch('forms', transform_xform_for_elasticsearch(result.xform.to_json()))
         return result.xform

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -137,7 +137,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
 
         self.assertIsNotNone(log)
         self.assertIn('Invalid XML', log.problem)
-        self.assertEqual("this isn't even close to xml", log.get_xml())
+        self.assertEqual("this isn't even close to xml", log.get_xml().decode('utf-8'))
         self.assertEqual(log.form_data, {})
 
     def test_missing_xmlns(self):

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -279,7 +279,7 @@ class XFormInstance(DeferredBlobMixin, SafeSaveDocument, UnicodeMixIn,
 
     def get_xml(self):
         try:
-            return self.fetch_attachment(ATTACHMENT_NAME)
+            return self.fetch_attachment(ATTACHMENT_NAME, return_bytes=True)
         except ResourceNotFound:
             logging.warn("no xml found for %s, trying old attachment scheme." % self.get_id)
             try:
@@ -344,7 +344,7 @@ class XFormInstance(DeferredBlobMixin, SafeSaveDocument, UnicodeMixIn,
             if name != ATTACHMENT_NAME}
 
     def xml_md5(self):
-        return hashlib.md5(self.get_xml().encode('utf-8')).hexdigest()
+        return hashlib.md5(self.get_xml()).hexdigest()
 
     def archive(self, user_id=None):
         if self.is_archived:
@@ -466,7 +466,7 @@ class SubmissionErrorLog(XFormError):
         return "Doc id: %s, Error %s" % (self.get_id, self.problem)
 
     def get_xml(self):
-        return self.fetch_attachment(ATTACHMENT_NAME)
+        return self.fetch_attachment(ATTACHMENT_NAME, return_bytes=True)
 
     def save(self, *args, **kwargs):
         # we have to override this because XFormError does too

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -74,10 +74,10 @@ class EditFormTest(TestCase, TestFileMixin):
         self.assertTrue(xform.edited_on > deprecated_xform.received_on)
 
         self.assertEqual(
-            deprecated_xform.get_xml(),
-            original_xml
+            deprecated_xform.get_xml().decode('utf-8'),
+            original_xml.decode('utf-8')
         )
-        self.assertEqual(xform.get_xml(), edit_xml)
+        self.assertEqual(xform.get_xml().decode('utf-8'), edit_xml.decode('utf-8'))
 
     def test_edit_form_with_attachments(self):
         attachment_source = './corehq/ex-submodules/casexml/apps/case/tests/data/attachments/fruity.jpg'
@@ -113,7 +113,7 @@ class EditFormTest(TestCase, TestFileMixin):
         )
         form = self.formdb.get_form(form_id)
         self.assertIn('fruity_file', form.attachments)
-        self.assertIn(original_xml, form.get_xml())
+        self.assertIn(original_xml, form.get_xml().decode('utf-8'))
 
         # edit form
         edit_xml = _get_xml('2016-04-01T12:04:16Z', form_id)
@@ -125,7 +125,7 @@ class EditFormTest(TestCase, TestFileMixin):
         self.assertIsNotNone(form.edited_on)
         self.assertIsNotNone(form.deprecated_form_id)
         self.assertIn('fruity_file', form.attachments)
-        self.assertIn(edit_xml, form.get_xml())
+        self.assertIn(edit_xml, form.get_xml().decode('utf-8'))
 
     def test_edit_an_error(self):
         form_id = uuid.uuid4().hex

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -132,7 +132,7 @@ class FormAccessorTestsSQL(TestCase):
         self.assertEqual('form.xml', attachment_meta.name)
         self.assertEqual('text/xml', attachment_meta.content_type)
         with attachment_meta.open() as content:
-            self.assertEqual(form_xml, content.read())
+            self.assertEqual(form_xml, content.read().decode('utf-8'))
 
     def test_get_form_operations(self):
         form = create_form_for_test(DOMAIN)

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -487,7 +487,7 @@ class FormAccessorsTestsSQL(FormAccessorsTests):
         ).save(using=db)
         xform = acc.get_form(xform.form_id)
         self.assertLess(xform.get_attachments()[0].id, 0)
-        self.assertEqual(xform.get_xml(), formxml)
+        self.assertEqual(xform.get_xml().decode('utf-8'), formxml)
 
         updates = {'breakfast': 'fruit'}
         FormProcessorInterface(DOMAIN).update_responses(xform, updates, 'user1')
@@ -495,8 +495,8 @@ class FormAccessorsTestsSQL(FormAccessorsTests):
         new_xml = new_form.get_xml()
         old_xml = acc.get_form(new_form.deprecated_form_id).get_xml()
         self.assertNotEqual(old_xml, new_xml)
-        self.assertNotIn("fruit", old_xml)
-        self.assertIn("fruit", new_xml)
+        self.assertNotIn("fruit", old_xml.decode('utf-8'))
+        self.assertIn("fruit", new_xml.decode('utf-8'))
 
 
 class DeleteAttachmentsFSDBTests(TestCase):

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -433,8 +433,8 @@ class FormAccessorsTests(TestCase, TestXmlMixin):
         self.assertIn("image", form.attachments)
         self.assertEqual(form.get_attachment("image"), b"fake")
         self.assertXmlEqual(
-            form.get_attachment("form.xml"),
-            formxml.replace(b"toast", b"fruit"),
+            form.get_attachment("form.xml").decode('utf-8'),
+            formxml.replace("toast", "fruit"),
         )
 
     def test_update_responses_error(self):

--- a/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
+++ b/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
@@ -71,7 +71,7 @@ class GDPRScrubUserFromFormsCouchTests(TestCase):
         FormAccessors(DOMAIN).modify_attachment_xml_and_metadata(form, new_form_xml, NEW_USERNAME)
 
         # Test that the metadata changed in the database
-        actual_form_xml = form.get_attachment("form.xml")
+        actual_form_xml = form.get_attachment("form.xml").decode('utf-8')
         self.assertXMLEqual(EXPECTED_FORM_XML, actual_form_xml)
 
         # Test that the operations history is updated in this form


### PR DESCRIPTION
This ensures consistency with sql forms.  Consistency is important so tests run on both backends will pass in python 3.