### PR TITLE
exclude __pycache__/ directory from couchapps

### DIFF
--- a/corehq/preindex/preindex_plugins.py
+++ b/corehq/preindex/preindex_plugins.py
@@ -101,7 +101,7 @@ class CouchAppsPreindexPlugin(PreindexPlugin):
 
     def get_couchapps(self):
         return [d for d in os.listdir(self.dir)
-                if os.path.isdir(os.path.join(self.dir, d))]
+                if os.path.isdir(os.path.join(self.dir, d)) and d != '__pycache__']
 
     def _get_designs(self):
         return [


### PR DESCRIPTION
Necessary when syncing design docs in python 3.