### PR TITLE
fix icds migrations

### DIFF
--- a/custom/icds_reports/migrations/0081_auto_20181204_1213.py
+++ b/custom/icds_reports/migrations/0081_auto_20181204_1213.py
@@ -25,4 +25,3 @@ class Migration(migrations.Migration):
             new_name='awc_visits'
         )
     ]
-    operations.extend(get_view_migrations())


### PR DESCRIPTION
Build broken on master:
```
    return self.cursor.execute(sql)
ProgrammingError: column ccs_record_monthly.closed does not exist
LINE 69:         "ccs_record_monthly"."closed" AS "closed"
```

I think this is safe to do since nobody could have run these migrations yet.

@dmydlo FYI