### PR TITLE
Make app build timings page sections collapsable

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/app_build_timings.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/app_build_timings.js
@@ -5,7 +5,7 @@ hqDefine('hqadmin/js/app_build_timings', [
     $(function () {
         $("#timingTable").treetable({
             expandable: true,
-            expanderTemplate: '<i class="fa fa-angle-double-down" />',
+            expanderTemplate: '<i class="fa fa-angle-double-down" /> ',
             initialState: 'expanded',
             clickableNodeNames: true,
             onNodeExpand: function () {

--- a/corehq/apps/hqadmin/static/hqadmin/js/app_build_timings.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/app_build_timings.js
@@ -3,6 +3,19 @@ hqDefine('hqadmin/js/app_build_timings', [
     "jquery-treetable/jquery.treetable",
 ], function ($) {
     $(function () {
-        $("#timingTable").treetable();
+        $("#timingTable").treetable({
+            expandable: true,
+            expanderTemplate: '<i class="fa fa-angle-double-down" />',
+            initialState: 'expanded',
+            clickableNodeNames: true,
+            onNodeExpand: function () {
+                $(this.expander).addClass("fa-angle-double-down");
+                $(this.expander).removeClass("fa-angle-double-right");
+            },
+            onNodeCollapse: function () {
+                $(this.expander).removeClass("fa-angle-double-down");
+                $(this.expander).addClass("fa-angle-double-right");
+            },
+        });
     });
 });

--- a/corehq/apps/hqadmin/templates/hqadmin/app_build_timings.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/app_build_timings.html
@@ -2,7 +2,7 @@
 {% load compress %}
 {% load hq_shared_tags %}
 
-{% block title %}App Build Times{% endblock %}
+{% block title %}App Build Times - "{{ app.name }}"{% endblock %}
 
 {% block stylesheets %}{{ block.super }}
     <link type="text/css" rel="stylesheet" href="{% static 'jquery-treetable/css/jquery.treetable.css' %}"/>

--- a/corehq/apps/hqadmin/templates/hqadmin/partials/timing_data_table.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/partials/timing_data_table.html
@@ -16,7 +16,7 @@
     </thead>
     <tbody>
         {% for timer in timing_data %}
-        <tr data-tt-id="{{ timer.name }}" {% if timer.parent %}data-tt-parent-id="{{ timer.parent.name }}"{% endif %}>
+        <tr data-tt-id="{{ timer.uuid }}" {% if timer.parent %}data-tt-parent-id="{{ timer.parent.uuid }}"{% endif %}>
             <td>{{ timer.name }}</td>
             <td>{{ timer.duration|stringformat:".3f" }}</td>
             <td>{{ timer.percent_of_parent|stringformat:".1f" }}</td>

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 import time
+import uuid
 
 from functools import wraps
 from memoized import memoized
@@ -18,6 +19,7 @@ class NestableTimer(object):
         self.subs = []
         self.root = self if is_root else None
         self.parent = None
+        self.uuid = uuid.uuid4()
 
     def init(self, root, parent):
         self.root = root


### PR DESCRIPTION
Making this collapsible should make it easier to navigate, as it's pretty noisy at the moment.

![image](https://user-images.githubusercontent.com/2367539/49617333-2cf33080-f982-11e8-9aed-d3f670ad7d77.png)

@millerdev @proteusvacuum 
The same thing could be done for the admin restore page timings, but that's short enough that I'm not sure it's necessary.