### PR TITLE
Change data not entered message in pregnant report anemia

### DIFF
--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -383,7 +383,7 @@ def get_anamic_status(value):
     elif value['anemic_unknown']:
         return 'Unknown'
     else:
-        return 'Not entered'
+        return DATA_NOT_ENTERED
 
 
 def get_symptoms(value):


### PR DESCRIPTION
Hi @calellowitz,
This is a fix for the 'Not Entered' text in the pregnant report in anaemia field.
Regards, Dawid