### PR TITLE
Added button to set language as default

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/supported_languages.js
+++ b/corehq/apps/app_manager/static/app_manager/js/supported_languages.js
@@ -134,6 +134,10 @@ hqDefine('app_manager/js/supported_languages',[
             self.languages.remove(language);
             self.removedLanguages.push(language);
         };
+        self.setAsDefault = function (language) {
+            self.languages.remove(language);
+            self.languages.unshift(language);
+        };
         self.unremoveLanguage = function (language) {
             self.removedLanguages.remove(language);
             self.languages.push(language);

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/supported_languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/supported_languages.html
@@ -13,12 +13,15 @@
                 <input class="short form-control"
                        data-bind="langcode: langcode, valueUpdate: 'textchange', inputHandlers: {hasfocus: $root.seen}"/>
             </td>
-            <td class="col-sm-2">
+            <td class="col-sm-1">
                 <span class="label label-default" data-bind="visible: isDefaultLang()">default</span>
             </td>
-            <td class="col-sm-5">
+            <td class="col-sm-4">
                 <p class="help-block" data-bind="text: message"></p>
                 <p class="help-block" data-bind="text: originalLangcodeMessage, visible: originalLangcode() !== langcode()"></p>
+            </td>
+            <td class="col-sm-2">
+                <a href="#" data-bind="click: $root.setAsDefault, visible: !isDefaultLang()" class="btn btn-default">{% trans "Set as default" %}</a>
             </td>
             <td class="col-sm-1">
                 <a href="#" data-bind="click: $root.removeLanguage" class="btn btn-danger"><i class="fa fa-trash-o"></i></a>


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/22676 - I realized it's now harder to tell how to make a language the default (move it to the top of the list). Added a button to do this explicitly, since I don't think the old behavior was entirely clear.

<img width="1025" alt="screen shot 2018-12-10 at 7 12 47 pm" src="https://user-images.githubusercontent.com/1486591/49769822-bc188500-fcaf-11e8-8dbf-85ae34d174c7.png">

@ohmegasquared does this seem reasonable?

@dannyroberts 