### PR TITLE
show read only release state

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -110,34 +110,35 @@
                 'error': build_broken
             }">
           <div class="panel-heading">
-              {% if can_manage_releases %}
-                  {% if request|toggle_enabled:"SUPPORT" %}
-                      <div class="release-trash-container">
-                        <a href="#"
-                           class="hide release-remove"
-                           data-bind="openModal: 'delete-build-modal-template',
-                                      visible: !_deleteState(),
-                                      css: {hide: false}">
-                            <i class="fa fa-trash"></i>
-                        </a>
-                        <div class="pending hide" data-bind="visible: _deleteState() == 'pending', css: {hide: false}">
-                            <img src="{% static 'hqwebapp/images/ajax-loader.gif' %}" alt="loading indicator" />
-                        </div>
-                        <i class="fa fa-exclamation-circle hide"
-                           data-bind="visible: _deleteState() == 'error',
-                                      css: {hide: false}"></i>
-                      </div>
-                  {% endif %}
-                  <div class="build-is-released">
-                      <!--ko if: is_released() == 'error' -->
+              {% if can_manage_releases and request|toggle_enabled:"SUPPORT" %}
+                  <div class="release-trash-container">
+                    <a href="#"
+                       class="hide release-remove"
+                       data-bind="openModal: 'delete-build-modal-template',
+                                  visible: !_deleteState(),
+                                  css: {hide: false}">
+                        <i class="fa fa-trash"></i>
+                    </a>
+                    <div class="pending hide" data-bind="visible: _deleteState() == 'pending', css: {hide: false}">
+                        <img src="{% static 'hqwebapp/images/ajax-loader.gif' %}" alt="loading indicator" />
+                    </div>
+                    <i class="fa fa-exclamation-circle hide"
+                       data-bind="visible: _deleteState() == 'error',
+                                  css: {hide: false}"></i>
+                  </div>
+              {% endif %}
+              <div class="build-is-released">
+                  <!--ko if: is_released() == 'error' -->
 
-                      <span class="label label-danger">{% trans "Could not update" %}</span>
+                  <span class="label label-danger">{% trans "Could not update" %}</span>
 
-                      <!--/ko-->
-                      <!--ko if: is_released() != 'error' -->
+                  <!--/ko-->
+                  <!--ko if: is_released() != 'error' -->
 
-                      <span class="label label-info"
-                            data-bind="visible: version() === $root.latestReleasedVersion()">{% trans "Latest" %}</span>
+                  <span class="label label-info"
+                        data-bind="visible: version() === $root.latestReleasedVersion()">{% trans "Latest" %}</span>
+
+                  {% if can_manage_releases %}
                       <i class="fa fa-spin fa-refresh hide js-release-waiting"></i>
                       <div class="btn-group">
                           <button type="button"
@@ -161,10 +162,17 @@
                               {% trans "In Test" %}
                           </button>
                       </div>
+                  {% else %}
+                      <span class="label label-success" data-bind="visible: is_released()">
+                          {% trans "Released" %}
+                      </span>
+                      <span class="label label-primary" data-bind="visible: !is_released()">
+                          {% trans "In Test" %}
+                      </span>
+                  {% endif %}
 
-                      <!--/ko-->
-                  </div>
-              {% endif %}
+                  <!--/ko-->
+              </div>
               <h4 class="panel-release-title">
                 <strong>{% trans "Version" %} <span data-bind="text: version"></span></strong> |
                 <span data-bind="text: built_on_date"></span> <span data-bind="text: built_on_time"></span> {% trans 'by' %}


### PR DESCRIPTION
Even if the user can't manage releases it's useful to be able to
see the release state of each version

![image](https://user-images.githubusercontent.com/249606/49794192-ad79ae80-fd3f-11e8-9580-c6f2dd50ce44.png)
