### PR TITLE
Added protection against request.project being None

### DIFF
--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -116,9 +116,9 @@ def js_api_keys(request):
 
 
 def js_toggles(request):
-    if not hasattr(request, 'couch_user') or not request.couch_user:
+    if not getattr(request, 'couch_user', None):
         return {}
-    if not hasattr(request, 'project') or not request.project:
+    if not getattr(request, 'project', None):
         return {}
     from corehq import toggles, feature_previews
     domain = request.project.name

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -118,7 +118,7 @@ def js_api_keys(request):
 def js_toggles(request):
     if not hasattr(request, 'couch_user') or not request.couch_user:
         return {}
-    if not hasattr(request, 'project'):
+    if not hasattr(request, 'project') or not request.project:
         return {}
     from corehq import toggles, feature_previews
     domain = request.project.name


### PR DESCRIPTION
Popping up on staging: https://sentry.io/dimagi/commcarehq/issues/793393938/

Introduced in https://github.com/dimagi/commcare-hq/pull/22603

@emord 