### PR TITLE
A/B tests: force save user session if session_key is None

### DIFF
--- a/corehq/apps/analytics/ab_tests.py
+++ b/corehq/apps/analytics/ab_tests.py
@@ -47,6 +47,12 @@ class SessionAbTest(object):
         self.config = config
         self.request = request
 
+        # If the session isn't manually saved, then incognito will cause the
+        # session_key to return None, making caching unique values per user not
+        # possible.
+        if not self.request.session.session_key:
+            self.request.session.save()
+
     @property
     def _cookie_id(self):
         return "{}_ab".format(self.config.slug)


### PR DESCRIPTION
fixes a bug in incognito mode where the session_key always returns `None`, causing the a/b tests to not generate a random variant each time.