### PR TITLE
Killed old multimedia_list_download view

### DIFF
--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -22,7 +22,7 @@ from corehq.apps.app_manager.views import (
     delete_module, delete_form, copy_form, undo_delete_app, undo_delete_module, undo_delete_form, edit_form_attr,
     edit_form_attr_api, patch_xform, validate_form_for_build, rename_language, validate_language,
     edit_form_actions, edit_advanced_form_actions, edit_visit_schedule,
-    edit_schedule_phases, multimedia_list_download, edit_module_detail_screens, edit_module_attr,
+    edit_schedule_phases, edit_module_detail_screens, edit_module_attr,
     edit_report_module, validate_module_for_build, commcare_profile, edit_commcare_profile, edit_commcare_settings,
     edit_app_langs, edit_app_attr, edit_app_ui_translations, get_app_ui_translations, rearrange, odk_qr_code,
     odk_media_qr_code, odk_install, short_url, short_odk_url, save_copy, revert_to_copy, delete_copy, list_apps,
@@ -140,8 +140,6 @@ urlpatterns = [
         name='edit_schedule_phases'),
 
     # multimedia stuff
-    url(r'^multimedia/(?P<app_id>[\w-]+)/download/$',
-        multimedia_list_download, name='multimedia_list_download'),
     url(r'^(?P<app_id>[\w-]+)/multimedia/', include(hqmedia_urls)),
     url(r'^edit_module_detail_screens/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/$',
         edit_module_detail_screens, name='edit_module_detail_screens'),

--- a/corehq/apps/app_manager/views/__init__.py
+++ b/corehq/apps/app_manager/views/__init__.py
@@ -90,7 +90,6 @@ from corehq.apps.app_manager.views.modules import (
 )
 from corehq.apps.app_manager.views.multimedia import (
     multimedia_ajax,
-    multimedia_list_download,
 )
 from corehq.apps.app_manager.views.releases import (
     AppDiffView,

--- a/corehq/apps/app_manager/views/multimedia.py
+++ b/corehq/apps/app_manager/views/multimedia.py
@@ -1,38 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
 from corehq.apps.app_manager.dbaccessors import get_app
-from corehq.apps.app_manager.decorators import require_deploy_apps, \
-    require_can_edit_apps
-from corehq.apps.app_manager.xform import XForm, validate_xform
+from corehq.apps.app_manager.decorators import require_deploy_apps
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
-from corehq.util.view_utils import set_file_download
-
-
-@require_can_edit_apps
-def multimedia_list_download(request, domain, app_id):
-    app = get_app(domain, app_id)
-    include_audio = request.GET.get("audio", True)
-    include_images = request.GET.get("images", True)
-    strip_jr = request.GET.get("strip_jr", True)
-    filelist = []
-    for m in app.get_modules():
-        for f in m.get_forms():
-            validate_xform(domain, f.source)
-            parsed = XForm(f.source)
-            if include_images:
-                filelist.extend(parsed.image_references)
-            if include_audio:
-                filelist.extend(parsed.audio_references)
-
-    if strip_jr:
-        filelist = [s.replace("jr://file/", "") for s in filelist if s]
-    response = HttpResponse()
-    set_file_download(response, 'list.txt')
-    response.write("\n".join(sorted(set(filelist))))
-    return response
 
 
 @require_deploy_apps


### PR DESCRIPTION
Found while scoping https://github.com/dimagi/commcare-hq/pull/22693 

Added [way back in 2011](https://github.com/dimagi/commcare-hq/commit/24c91895eb31f89cac8a6701b42595a1e3285228), no longer has any links to it in HQ and currently throws an XFormValidationError (doesn't seem to understand forms with easy references).

@emord / @dannyroberts 