### PR TITLE
Remove old LOGSTASH_* settings

### DIFF
--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -256,11 +256,6 @@ CACHES = {
 ELASTICSEARCH_HOST = 'localhost'
 ELASTICSEARCH_PORT = 9200
 
-# our production logstash aggregation
-LOGSTASH_DEVICELOG_PORT = 10777
-LOGSTASH_AUDITCARE_PORT = 10999
-LOGSTASH_HOST = 'localhost'
-
 LOCAL_PILLOWTOPS = {
 #    'my_pillows': ['some.pillow.Class', ],
 #    'and_more': []

--- a/settings.py
+++ b/settings.py
@@ -721,11 +721,6 @@ ENABLE_PRELOGIN_SITE = False
 # dimagi.com urls
 PRICING_PAGE_URL = "https://www.dimagi.com/commcare/pricing/"
 
-# our production logstash aggregation
-LOGSTASH_DEVICELOG_PORT = 10777
-LOGSTASH_AUDITCARE_PORT = 10999
-LOGSTASH_HOST = 'localhost'
-
 # Sumologic log aggregator
 SUMOLOGIC_URL = None
 
@@ -2213,7 +2208,6 @@ COMPRESS_OFFLINE_CONTEXT = {
 }
 
 COMPRESS_CSS_HASHING_METHOD = 'content'
-
 
 
 if 'locmem' not in CACHES:


### PR DESCRIPTION
I wish we used logstash in some way. introduced https://github.com/dimagi/commcare-hq/pull/30. appears that we used to have logstash for monitoring prod logs https://github.com/dimagi/pillowtop/pull/4/files#diff-6dac4be25b780fb79c406285662331fcR234