### PR TITLE
Zero should not be considered an empty value

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -88,6 +88,14 @@ EntryArrayAnswer.prototype.onPreProcess = function (newValue) {
 EntrySingleAnswer = function (question, options) {
     var self = this;
 
+    var getRawAnswer = function (answer) {
+        // Zero is a perfectly valid answer
+        if (answer !== 0 && !answer) {
+            return Formplayer.Const.NO_ANSWER;
+        }
+        return answer;
+    };
+
     Entry.call(self, question, options);
     self.valueUpdate = undefined;
     self.rawAnswer = ko.observable(getRawAnswer(question.answer()));
@@ -104,14 +112,6 @@ EntrySingleAnswer = function (question, options) {
             },
         });
     }
-
-    var getRawAnswer = function (answer) {
-        // Zero is a perfectly valid answer
-        if (answer !== 0 && !answer) {
-            return Formplayer.Const.NO_ANSWER;
-        }
-        return answer;
-    };
 
 };
 EntrySingleAnswer.prototype = Object.create(Entry.prototype);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -90,7 +90,7 @@ EntrySingleAnswer = function (question, options) {
 
     Entry.call(self, question, options);
     self.valueUpdate = undefined;
-    self.rawAnswer = ko.observable(question.answer() || Formplayer.Const.NO_ANSWER);
+    self.rawAnswer = ko.observable(getRawAnswer(question.answer()));
     self.placeholderText = '';
 
     self.rawAnswer.subscribe(self.onPreProcess.bind(self));
@@ -104,6 +104,15 @@ EntrySingleAnswer = function (question, options) {
             },
         });
     }
+
+    var getRawAnswer = function (answer) {
+        // Zero is a perfectly valid answer
+        if (answer !== 0 && !answer) {
+            return Formplayer.Const.NO_ANSWER;
+        }
+        return answer;
+    };
+
 };
 EntrySingleAnswer.prototype = Object.create(Entry.prototype);
 EntrySingleAnswer.prototype.constructor = Entry;


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-143

There's a bug where default values of 0 don't show up in web apps and live preview.  This is because 0 was being misinterpreted as a missing value.

I'm not 100% sure which falsy values might appear at this place, so I took a conservative approach of whitelisting `0` and leaving the existing behavior for the rest (the current behavior seems appropriate for `''`, `null`, and `undefined`)