### PR TITLE
Fixed always-displaying error message in parent child selection

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -242,7 +242,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
             return name[firstLang];
         }
         self.hasError = ko.computed(function () {
-            return !_.contains(self.parentModules(), self.moduleId());
+            return !_.contains(_.pluck(self.parentModules(), 'unique_id'), self.moduleId());
         });
         self.moduleOptions = ko.computed(function () {
             var options = _(self.parentModules()).map(function (module) {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-222

Introduced in https://github.com/dimagi/commcare-hq/pull/22615/

Note to self: always test the negative case.

@emord / @dannyroberts 
