### PR TITLE
adds a view to check whether a form has submissions

### DIFF
--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.views import (
     DownloadCaseSummaryView,
     DownloadFormSummaryView,
     DownloadAppSummaryView,
+    FormHasSubmissionsView,
     PromptSettingsUpdateView,
     view_app,
     multimedia_ajax, current_app_version, paginate_releases,
@@ -76,6 +77,8 @@ app_urls = [
         name='update_build_comment'),
     url(r'^copy/gzip$', export_gzip, name='gzip_app'),
     url(r'^update_prompts/$', PromptSettingsUpdateView.as_view(), name=PromptSettingsUpdateView.urlname),
+    url(r'^form_has_submissions/(?P<form_unique_id>[\w-]+)/$', FormHasSubmissionsView.as_view(),
+        name=FormHasSubmissionsView.urlname),
 ]
 
 

--- a/corehq/apps/app_manager/views/__init__.py
+++ b/corehq/apps/app_manager/views/__init__.py
@@ -75,6 +75,7 @@ from corehq.apps.app_manager.views.forms import (
     view_form_legacy,
     view_form,
     get_form_questions,
+    FormHasSubmissionsView,
 )
 from corehq.apps.app_manager.views.modules import (
     delete_module,

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -16,6 +16,7 @@ from django.contrib import messages
 from corehq.apps.app_manager import add_ons
 from corehq.apps.app_manager.app_schemas.casedb_schema import get_casedb_schema
 from corehq.apps.app_manager.app_schemas.session_schema import get_session_schema
+from corehq.apps.app_manager.views.forms import FormHasSubmissionsView
 from corehq.apps.domain.decorators import track_domain_request
 
 from dimagi.utils.logging import notify_exception
@@ -250,6 +251,8 @@ def _get_vellum_core_context(request, domain, app, module, form, lang):
                                  'xform']),
         'patchUrl': reverse('patch_xform',
                             args=[domain, app.id, form.get_unique_id()]),
+        'hasSubmissionsUrl': reverse(FormHasSubmissionsView.urlname,
+                                     args=[domain, app.id, form.get_unique_id()]),
         'allowedDataNodeReferences': [
             "meta/deviceID",
             "meta/instanceID",


### PR DESCRIPTION
This change won't have any effect on end users, but will be used by formbuilder to determine whether or a not a given form has been submitted, which will determine when question ID changed warnings are shown.