### PR TITLE
Remove cython from HQ requirements

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -35,7 +35,6 @@ coverage==4.5.1
 cryptography==2.4.2
 csiphash==0.0.5
 csv342==1.0.0
-cython==0.29.1
 datadog==0.15.0
 ddtrace==0.14.1
 decorator==4.0.11

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -25,7 +25,6 @@ contextlib2==0.5.4
 cryptography==2.4.2
 csiphash==0.0.5
 csv342==1.0.0
-cython==0.29.1
 datadog==0.15.0
 ddtrace==0.14.1
 decorator==4.0.11

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -26,7 +26,6 @@ contextlib2==0.5.4
 cryptography==2.4.2
 csiphash==0.0.5
 csv342==1.0.0
-cython==0.29.1
 datadog==0.15.0
 ddtrace==0.14.1
 decorator==4.0.11

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,4 @@
 attrs==18.1.0
-# used to build jsonobject from source
-cython>=0.29.1,<1.0.0
 iso8601==0.1.12
 jsonobject==0.9.4
 jsonobject-couchdbkit==0.9.12

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,7 +24,6 @@ contextlib2==0.5.4
 cryptography==2.4.2       # via pyopenssl, requests
 csiphash==0.0.5
 csv342==1.0.0
-cython==0.29.1
 datadog==0.15.0
 ddtrace==0.14.1
 decorator==4.0.11

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -28,7 +28,6 @@ coverage==4.5.1
 cryptography==2.4.2
 csiphash==0.0.5
 csv342==1.0.0
-cython==0.29.1
 datadog==0.15.0
 ddtrace==0.14.1
 decorator==4.0.11

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -7,3 +7,4 @@ pycrypto
 restkit
 http-parser
 zeep
+cython


### PR DESCRIPTION
This is used by jsonobject and not HQ, so the required cython version should be defined there, not in HQ.