### PR TITLE
provide status code for mocked post request

### DIFF
--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -297,6 +297,7 @@ class ExportOnlyTests(SimpleTestCase):
         should not be exported.
         """
         requests = mock.Mock()
+        requests.post.return_value.status_code = 500
         info = mock.Mock(
             updates={'sex': 'M', 'dob': '1918-07-18'},
             extra_fields={},

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -700,6 +700,7 @@ class TestRepeaterFormat(BaseRepeaterTest):
     def test_new_format_payload(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
         with patch('corehq.motech.repeaters.models.simple_post') as mock_post:
+            mock_post.return_value.status_code = 200
             repeat_record.fire()
             headers = self.repeater.get_headers(repeat_record)
             mock_post.assert_called_with(


### PR DESCRIPTION
Necessary for tests in python 3, because you can't compare ```MagicMock``` with ```int```.