### PR TITLE
Hotfix-Increasae Es timeout limit to 30 seconds

### DIFF
--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -54,7 +54,7 @@ def get_es_new():
     Returns an elasticsearch.Elasticsearch instance.
     """
     hosts = _es_hosts()
-    return Elasticsearch(hosts)
+    return Elasticsearch(hosts, timeout=30)
 
 
 @memoized


### PR DESCRIPTION
ES is returning timeouts frequently. Code increase the Es default timeout to 30 seconds
https://sentry.io/dimagi/commcarehq/issues/725369137/?environment=icds