### PR TITLE
Updated primary buttons in media uploader

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_modals.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_modals.html
@@ -31,7 +31,7 @@
             </div>
             <div class="modal-footer">
                 <a href="#" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</a>
-                <a href="#" class="btn btn-default disabled hqm-upload hqm-upload-confirm">
+                <a href="#" class="btn btn-primary disabled hqm-upload hqm-upload-confirm">
                     <i class="fa fa-cloud-upload"></i> {% trans "Begin Upload" %}
                 </a>
             </div>
@@ -72,7 +72,7 @@
             </div>
             <div class="modal-footer">
                 <a href="#" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</a>
-                <a href="#" class="btn btn-default disabled hqm-upload hqm-upload-confirm">
+                <a href="#" class="btn btn-primary disabled hqm-upload hqm-upload-confirm">
                     <i class="fa fa-cloud-upload"></i> {% trans "Begin Upload" %}
                 </a>
             </div>

--- a/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
@@ -41,7 +41,7 @@
             <div class="hqm-select-files-container">
                 <button class="hqm-select btn btn-primary" role="button">{% trans 'Select Files' %}</button>
             </div>
-            <a class="hqm-upload hqm-upload-confirm btn btn-default disabled" data-toggle="modal">
+            <a class="hqm-upload hqm-upload-confirm btn btn-primary disabled" data-toggle="modal">
                 <i class="fa fa-cloud-upload"></i> {% trans 'Begin Upload' %}
             </a>
         </div>

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html
@@ -33,7 +33,7 @@
             </div>
             <div class="modal-footer">
                 <a href="#" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</a>
-                <a href="#" class="btn btn-default disabled hqm-upload hqm-upload-confirm">
+                <a href="#" class="btn btn-primary disabled hqm-upload hqm-upload-confirm">
                     <i class="fa fa-cloud-upload"></i> {% trans "Begin Upload" %}
                 </a>
             </div>


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/22679

Makes "Begin Upload" also primary.

<img width="629" alt="screen shot 2018-12-13 at 1 04 14 pm" src="https://user-images.githubusercontent.com/1486591/49958036-a4bbe080-fed7-11e8-803d-12d453b2bd79.png">

@emord 