### PR TITLE
Changed related location select2 widget to v4

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -650,7 +650,7 @@ class RelatedLocationForm(forms.Form):
         super(RelatedLocationForm, self).__init__(*args, **kwargs)
 
         self.fields['related_locations'].widget = LocationSelectWidget(
-            domain, id='id_related_locations', multiselect=True, select2_version='v3'
+            domain, id='id_related_locations', multiselect=True, select2_version='v4'
         )
 
         locations = (


### PR DESCRIPTION
Looks like it may have been broken during https://github.com/dimagi/commcare-hq/pull/21785

I didn't look into it, just noticed that v4 works locally