### PR TITLE
Releases page ui tweaks

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -53,6 +53,9 @@
             </button>
         {% endif %}
     </p>
+
+    <div id="build-errors-wrapper"></div>
+
     <div class="row">
         <div class="col-md-3 col-md-offset-9">
             <span class="input-group input-group-sm">
@@ -69,8 +72,6 @@
             </span>
         </div>
     </div>
-
-    <div id="build-errors-wrapper"></div>
 
     <div class="alert alert-danger hide"
          data-bind="visible: buildState() == 'error', css: {hide: false}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -24,7 +24,7 @@
         <span data-bind="visible: onlyShowReleased()">
             {% trans 'Released versions only' %}
         </span>
-        <a href="#" data-bind="click: toggleLimitToReleased, visible: onlyShowReleased()" class="label label-info">{% trans 'show all' %}</a>
+        <a href="#" data-bind="click: toggleLimitToReleased, visible: onlyShowReleased()" class="btn btn-default btn-xs">{% trans 'show all' %}</a>
 
         <span class="hq-help-template"
             data-title="Released Versions"

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -82,10 +82,11 @@
         </span>
     </div>
 
-    <div class="label label-primary label-lg hide"
-         data-bind="visible: fetchState() === 'pending', css: {hide: false}">
-        <i class="fa fa-spin fa-spinner"></i> {% trans "Loading Versions..." %}
-    </div>
+    <h4 id="loading" class="hide"
+        data-bind="visible: fetchState() === 'pending', css: {hide: false}">
+        <i class="fa fa-spin fa-spinner"></i>
+        {% trans "Loading versions..." %}
+    </h4>
 
     <div class="alert alert-danger hide"
          data-bind="visible: fetchState() === 'error', css: {hide: false}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -41,9 +41,9 @@
             },
             attr: {disabled: !buildButtonEnabled() ? 'disabled' : undefined},
             css: {disabled: !buildButtonEnabled()}">
+            <i class="fa fa-spin fa-spinner" data-bind="visible: buildState() === 'pending'"></i>
             {% trans 'Make New Version' %}
         </button>
-
         {% if request|toggle_enabled:"VIEW_APP_CHANGES" %}
             <button class="btn btn-default"
                 id="recent-changes-btn"
@@ -70,13 +70,7 @@
         </div>
     </div>
 
-
     <div id="build-errors-wrapper"></div>
-
-    <div class="label label-success label-lg hide"
-         data-bind="visible: buildState() === 'pending', css: {hide: false}">
-      <i class="fa fa-spin fa-spinner"></i> {% trans "Please wait while your CommCare Application builds..." %}
-    </div>
 
     <div class="alert alert-danger hide"
          data-bind="visible: buildState() == 'error', css: {hide: false}">


### PR DESCRIPTION
Minor. FYI @dimagi/product 

@emord 

old:

<img width="679" alt="screen shot 2018-12-14 at 12 41 33 pm" src="https://user-images.githubusercontent.com/1486591/50018704-2f671300-ff9e-11e8-965e-a648187f72df.png">

---

<img width="614" alt="screen shot 2018-12-14 at 12 41 51 pm" src="https://user-images.githubusercontent.com/1486591/50018712-35f58a80-ff9e-11e8-9f7b-64595ee56edd.png">

---

<img width="257" alt="screen shot 2018-12-14 at 12 43 19 pm" src="https://user-images.githubusercontent.com/1486591/50018743-473e9700-ff9e-11e8-8a7b-a85e05ea6b8f.png">


new:

<img width="765" alt="screen shot 2018-12-14 at 12 40 51 pm" src="https://user-images.githubusercontent.com/1486591/50018696-29713200-ff9e-11e8-95fe-167883e2aee5.png">

---

<img width="554" alt="screen shot 2018-12-14 at 12 42 49 pm" src="https://user-images.githubusercontent.com/1486591/50018730-3db52f00-ff9e-11e8-9d96-7dc7f9447375.png">

---

<img width="264" alt="screen shot 2018-12-14 at 12 42 58 pm" src="https://user-images.githubusercontent.com/1486591/50018735-4443a680-ff9e-11e8-9561-60f014fbd1a9.png">
