### PR TITLE
Added copy of original comment when reverting a build

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -306,7 +306,6 @@ def _track_build_for_app_preview(domain, couch_user, app_id, message):
     })
 
 
-
 @no_conflict_require_POST
 @require_can_edit_apps
 def revert_to_copy(request, domain, app_id):
@@ -323,8 +322,10 @@ def revert_to_copy(request, domain, app_id):
         request,
         "Successfully reverted to version %s, now at version %s" % (copy.version, app.version)
     )
+    new_build_comment = "Reverted to version {old_version}\n\n{original_comment}".format(
+        old_version=copy.version, original_comment=copy.build_comment)
     copy = app.make_build(
-        comment="Reverted to version %s" % copy.version,
+        comment=new_build_comment,
         user_id=request.couch_user.get_id,
         previous_version=app.get_latest_app(released_only=False)
     )

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -571,7 +571,6 @@ def autoset_owner_id_for_advanced_action(action):
 
 
 def validate_xform(domain, source):
-    return
     if isinstance(source, six.text_type):
         source = source.encode("utf-8")
     # normalize and strip comments

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -571,6 +571,7 @@ def autoset_owner_id_for_advanced_action(action):
 
 
 def validate_xform(domain, source):
+    return
     if isinstance(source, six.text_type):
         source = source.encode("utf-8")
     # normalize and strip comments


### PR DESCRIPTION
Product note: When a build is reverted to a previous version, this would include a build's original comment in the new build's comment.

Didn't see an explicit decision being made in the [original PR](https://github.com/dimagi/commcare-hq/pull/16294) and this may be a bit nicer for revert heavy workflows.

Another thought was to format it like:

```
Reverted to version x. Version x's original comment:

This is a comment
```