### PR TITLE
Display question IDs properly in "Edit Export"

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -887,7 +887,7 @@ hqDefine('export/js/models', [
     };
 
     ExportItem.prototype.readablePath = function () {
-        return utils.readablePath(this.path());
+        return readablePath(this.path());
     };
 
     ExportItem.mapping = {

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -498,6 +498,7 @@ hqDefine('export/js/models', [
         self.showDeleted = ko.observable(false);
         self.displayType = ko.observable("labels");
         ko.mapping.fromJS(tableJSON, TableConfiguration.mapping, self);
+        self.useLabels(self);
     };
 
     TableConfiguration.prototype.isVisible = function () {

--- a/corehq/apps/export/static/export/spec/ExportColumn.spec.js
+++ b/corehq/apps/export/static/export/spec/ExportColumn.spec.js
@@ -9,23 +9,34 @@ describe('ExportColumn', function () {
         viewModels = hqImport('export/js/models');
 
     beforeEach(function () {
+        var mockObservable = function () { return 'foo'; };
+
         selectedColumn = {
             selected: true,
             is_advanced: true,
             is_deleted: true,
             deid_transform: null,
+            item: { label: mockObservable },
+            label: mockObservable,
+            tags: [],
         };
         advancedColumn = {
             selected: false,
             is_advanced: true,
             is_deleted: false,
             deid_transform: null,
+            item: { label: mockObservable },
+            label: mockObservable,
+            tags: [],
         };
         deletedColumn = {
             selected: false,
             is_advanced: false,
             is_deleted: true,
             deid_transform: null,
+            item: { label: mockObservable },
+            label: mockObservable,
+            tags: [],
         };
         table = {
             name: 'table',

--- a/corehq/apps/export/static/export/spec/data/export_instances.js
+++ b/corehq/apps/export/static/export/spec/data/export_instances.js
@@ -22,6 +22,7 @@ SampleExportInstances = {
                 "selected": false,
                 "label": "question1",
                 "doc_type": "ExportColumn",
+                "tags": [],
             }, {
                 "show": true,
                 "item": {
@@ -49,6 +50,7 @@ SampleExportInstances = {
                 "selected": false,
                 "label": "question3",
                 "doc_type": "ExportColumn",
+                "tags": [],
             }],
             "doc_type": "TableConfiguration",
         }],
@@ -78,6 +80,7 @@ SampleExportInstances = {
                 "selected": false,
                 "label": "question1",
                 "doc_type": "ExportColumn",
+                "tags": [],
             }, {
                 "show": true,
                 "item": {
@@ -105,6 +108,7 @@ SampleExportInstances = {
                 "selected": false,
                 "label": "question3",
                 "doc_type": "ExportColumn",
+                "tags": [],
             }],
             "doc_type": "TableConfiguration",
         }],


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-220
First commit addresses:
```TypeError: l.readablePath is not a function```
Second commit is a minor fix I noticed - by default, "Use question labels" is selected, and that appears intentional, however on first load it shows question IDs.  This seemed like the simplest fix.

@orangejenny @mkangia 