### PR TITLE
Use scroll instead of Run to prevent timeout

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -467,7 +467,12 @@ class ESQuery(object):
             return self.run().hits
 
     def values_list(self, *fields, **kwargs):
-        return values_list(self.fields(fields).run().hits, *fields, **kwargs)
+        if kwargs.pop('scroll', False):
+            hits = self.fields(fields).scroll()
+        else:
+            hits = self.fields(fields).run().hits
+
+        return values_list(hits, *fields, **kwargs)
 
     def count(self):
         """Performs a minimal query to get the count of matching documents"""

--- a/corehq/apps/es/fake/es_query_fake.py
+++ b/corehq/apps/es/fake/es_query_fake.py
@@ -171,7 +171,9 @@ class ESQueryFake(object):
                 return {key: doc[key] for key in self._source_fields if key in doc}
             return doc
 
-        return ScanResult(total, (ESQuerySet.normalize_result(self, {'_source': _get_doc(r)}) for r in result_docs))
+        es_query_set = (ESQuerySet.normalize_result(self,
+                                                    {'_source': _get_doc(r)}) for r in result_docs)
+        return ScanResult(total, es_query_set)
 
     @check_deep_copy
     def term(self, field, value):

--- a/corehq/apps/es/fake/es_query_fake.py
+++ b/corehq/apps/es/fake/es_query_fake.py
@@ -98,7 +98,7 @@ class ESQueryFake(object):
         else:
             hits = self.run().hits
 
-        return values_list(self.run().hits, *fields, **kwargs)
+        return values_list(hits, *fields, **kwargs)
 
     @check_deep_copy
     def search_string_query(self, search_string, default_fields=None):

--- a/corehq/apps/es/fake/es_query_fake.py
+++ b/corehq/apps/es/fake/es_query_fake.py
@@ -93,6 +93,11 @@ class ESQueryFake(object):
             raise AttributeError('{} must define attribute _all_docs'.format(cls_name))
 
     def values_list(self, *fields, **kwargs):
+        if kwargs.pop('scroll', False):
+            hits = self.scroll()
+        else:
+            hits = self.run().hits
+
         return values_list(self.run().hits, *fields, **kwargs)
 
     @check_deep_copy

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -348,7 +348,7 @@ class GroupChoiceProvider(ChainableChoiceProvider):
     @staticmethod
     def get_choices_from_es_query(group_es):
         return [Choice(group_id, name)
-                for group_id, name in values_list(group_es.scroll(), '_id', 'name')]
+                for group_id, name in group_es.values_list('_id', 'name', scroll=True)]
 
     def default_value(self, user):
         return None

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -16,6 +16,7 @@ from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.apps.users.util import raw_username
 from corehq.util.soft_assert import soft_assert
 from corehq.util.workbook_json.excel import alphanumeric_sort_key
+from corehq.apps.es.utils import values_list
 import six
 
 DATA_SOURCE_COLUMN = 'data_source_column'
@@ -347,7 +348,7 @@ class GroupChoiceProvider(ChainableChoiceProvider):
     @staticmethod
     def get_choices_from_es_query(group_es):
         return [Choice(group_id, name)
-                for group_id, name in group_es.values_list('_id', 'name')]
+                for group_id, name in values_list(group_es.scroll(), '_id', 'name')]
 
     def default_value(self, user):
         return None

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -16,7 +16,6 @@ from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.apps.users.util import raw_username
 from corehq.util.soft_assert import soft_assert
 from corehq.util.workbook_json.excel import alphanumeric_sort_key
-from corehq.apps.es.utils import values_list
 import six
 
 DATA_SOURCE_COLUMN = 'data_source_column'


### PR DESCRIPTION
Loading the mobile user UI is throwing the because of the readtimeout error. Increasing the timeout helped for in peak times that also have timedout. Therefore Switching to Scroll to prevent the Readtimeout.
@proteusvacuum  tagging you as we had similar discussion some time back here https://github.com/dimagi/commcare-hq/pull/22030

Jira ticket: https://dimagi-dev.atlassian.net/browse/ICDS-210