### PR TITLE
Add clean method for related locations

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -682,8 +682,12 @@ class RelatedLocationForm(forms.Form):
             if name.startswith('relation_distance_') and value and value < 0:
                 raise forms.ValidationError("The distance cannot be a negative value")
 
+    def clean_related_locations(self):
+        # Django uses get by default, but related_locations is actually a list
+        return self.data.getlist('related_locations')
+
     def save(self):
-        selected_location_ids = self.cleaned_data['related_locations'].split(',')
+        selected_location_ids = self.cleaned_data['related_locations']
         selected_location_ids = set(list(filter(None, selected_location_ids)))
 
         previous_location_ids = self.related_location_ids


### PR DESCRIPTION
Since, related locations is a list not the comma separated string there needs to done like this. Else it is causing only the last value of related_locations to be captured.
Not working: https://india.commcarehq.org/a/kriti-test/settings/locations/46334501110349b1945c2b8d17adf774/
working after fix: https://staging.commcarehq.org/a/ccqa/settings/locations/1573554763a12c4ca10552df4dbc4da0/#

Jira ticket: https://dimagi-dev.atlassian.net/browse/HI-230