### PR TITLE
Fix list data in the widget

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -57,7 +57,7 @@ class LocationSelectWidget(forms.Widget):
             raise ValueError("select2_version must be in {}".format(", ".join(list(versioned_templates.keys()))))
         self.template = versioned_templates[select2_version]
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         location_ids = value.split(',') if value else []
         locations = list(SQLLocation.active_objects
                          .filter(domain=self.domain, location_id__in=location_ids))
@@ -75,7 +75,7 @@ class LocationSelectWidget(forms.Widget):
 
 class ParentLocWidget(forms.Widget):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         return get_template(
             'locations/manage/partials/parent_loc_widget.html'
         ).render({
@@ -86,7 +86,7 @@ class ParentLocWidget(forms.Widget):
 
 class LocTypeWidget(forms.Widget):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         return get_template(
             'locations/manage/partials/loc_type_widget.html'
         ).render({


### PR DESCRIPTION
Following up for https://github.com/dimagi/commcare-hq/pull/22759

First commit is just to remove some django deprecation warnings.

The second commit moves the cleaning logic from the form to the widget, so it's solved for future uses of multiselect. My guess is that select2 v3 submitted values in a comma separated string but v4 uses multiple GET params