### PR TITLE
fix get demo link in trial banner

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/get_demo_banner.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/get_demo_banner.html
@@ -12,7 +12,7 @@
     Have questions?
   {% endblocktrans %}
     &nbsp;&nbsp;&nbsp;
-  <a href="#cta-form-get-demo-new"
+  <a href="#cta-form-get-demo"
      class="btn btn-purple"
      id="cta-trial-tour-button"
      data-toggle="modal">{% trans 'Get A Tour' %}</a>


### PR DESCRIPTION
missed this link when removing the old demo modal