### PR TITLE
resumable dry run

### DIFF
--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -11,8 +11,11 @@ from sqlalchemy.exc import OperationalError
 from corehq.apps.couch_sql_migration.couchsqlmigration import (
     do_couch_to_sql_migration, delete_diff_db, get_diff_db)
 from corehq.apps.couch_sql_migration.progress import (
-    set_couch_sql_migration_started, couch_sql_migration_in_progress,
-    set_couch_sql_migration_not_started, set_couch_sql_migration_complete
+    set_couch_sql_migration_started,
+    couch_sql_migration_in_progress,
+    set_couch_sql_migration_continuing,
+    set_couch_sql_migration_not_started,
+    set_couch_sql_migration_complete
 )
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_type
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
@@ -86,6 +89,7 @@ class Command(BaseCommand):
             if options.get('run_timestamp'):
                 if not couch_sql_migration_in_progress(domain):
                     raise CommandError("Migration must be in progress if run_timestamp is passed in")
+                set_couch_sql_migration_continuing(domain, self.dry_run)
             else:
                 set_couch_sql_migration_started(domain, self.dry_run)
 

--- a/corehq/apps/couch_sql_migration/progress.py
+++ b/corehq/apps/couch_sql_migration/progress.py
@@ -6,9 +6,10 @@ from django.conf import settings
 from corehq.apps.domain_migration_flags.api import (
     set_migration_started,
     set_migration_not_started,
-    migration_in_progress
+    migration_in_progress,
+    set_migration_continuing
 )
-from corehq.apps.domain_migration_flags.models import MigrationStatus, DomainMigrationProgress
+from corehq.apps.domain_migration_flags.models import DomainMigrationProgress
 from corehq.apps.tzmigration.api import set_tz_migration_complete
 
 COUCH_TO_SQL_SLUG = 'couch_to_sql'
@@ -20,6 +21,10 @@ def set_couch_sql_migration_started(domain, dry_run=False):
 
 def set_couch_sql_migration_not_started(domain):
     set_migration_not_started(domain, COUCH_TO_SQL_SLUG)
+
+
+def set_couch_sql_migration_continuing(domain, dry_run=False):
+    set_migration_continuing(domain, COUCH_TO_SQL_SLUG, dry_run)
 
 
 def couch_sql_migration_in_progress(domain, include_dry_runs=True):

--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -19,6 +19,19 @@ def set_migration_started(domain, slug, dry_run=False):
         )
 
 
+def set_migration_continuing(domain, slug, dry_run=False):
+    progress, _ = DomainMigrationProgress.objects.get_or_create(domain=domain, migration_slug=slug)
+    if migration_in_progress(domain, slug, True):
+        progress.migration_status = MigrationStatus.DRY_RUN if dry_run else MigrationStatus.IN_PROGRESS
+        progress.save()
+        reset_caches(domain, slug)
+    else:
+        raise DomainMigrationProgressError(
+            'Cannot resume a migration that is in state {}'
+            .format(progress.migration_status)
+        )
+
+
 def set_migration_not_started(domain, slug):
     progress, _ = DomainMigrationProgress.objects.get_or_create(domain=domain, migration_slug=slug)
     if migration_in_progress(domain, slug, True):

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
@@ -81,7 +81,8 @@ class CouchDomainDocTypeChangeProvider(ChangeProvider):
                 data_function,
                 args_provider,
                 lambda x: x.id,
-                event_handler=event_handler
+                event_handler=event_handler,
+                reset_complete=True
             )
         else:
             return paginate_function(data_function, args_provider, event_handler=event_handler)


### PR DESCRIPTION
I thought about it a bit and this seemed like it might it could be simpler now that dry run and resumable work. This basically allows me to start the migration at the end of the dry run.

Possible problems:
1) forms duplicately migrated in different categories if they are deleted or archived during the dry run
2) forms edited during migration won't have the most recent data

Basically, this still just reads new changes from the couch feed, which generally should be fine, but probably will not work for certain application workflows. I think I'd recommend to users that they don't do certain operations during the migration.

@millerdev @snopoke buddy: @calellowitz 