### PR TITLE
Unpause repeater when retiring

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -250,6 +250,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
             self['doc_type'] += DELETED
         if DELETED not in self['base_doc']:
             self['base_doc'] += DELETED
+        self.paused = False
         self.save()
 
     def pause(self):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-233

The repeater in this domain had been paused before being deleted, so deleting the records was just being postponed by an hour every time the trigger fired. 