### PR TITLE
Update or create the object

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1487,7 +1487,10 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
 
             if self._rev and not self.to_be_deleted():
                 django_user = self.sync_to_django_user()
-                django_user.save()
+                User.objects.update_or_create(username=django_user.username, defaults={
+                    attr: getattr(django_user, attr)
+                    for attr in self.ATTRS
+                })
 
             super(CouchUser, self).save(**params)
 


### PR DESCRIPTION
User bulk upload is facing this problem https://sentry.io/dimagi/commcarehq/issues/746018455/?environment=icds.
As the code was written. It should have handled the  condition of record already existing. Searched about it. It looks like one reason for this error is the [corrupted sequences](https://stackoverflow.com/questions/244243/how-to-reset-postgres-primary-key-sequence-when-it-falls-out-of-sync). Which may take longs to debug because it's not the part of our code(if we choose to do it Because I m not sure re-syncing sequences would affect the other things or not). 
To prevent the error to occur and bulk upload to happen without any error code in this PR  uses `update_or_create` for search_key `username` which should prevent this behaviour

