### PR TITLE
add hyperlink column to cases and forms in exports

### DIFF
--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from distutils.version import StrictVersion
 from django.test import SimpleTestCase
 from io import BytesIO
 from corehq.apps.app_manager.models import Application
@@ -7,8 +8,6 @@ from corehq.apps.app_manager.ui_translations import \
     process_ui_translation_upload, get_default_translations_for_download
 from couchexport.export import export_raw
 import six
-
-from corehq.util.files import TransientTempfile
 
 
 class BulkUiTranslation(SimpleTestCase):
@@ -36,12 +35,7 @@ class BulkUiTranslation(SimpleTestCase):
         headers = (('translations', ('property', 'en')),)
         f = self._build_translation_download_file(headers)
 
-        with TransientTempfile() as temp_path:
-            with open(temp_path, 'wb') as temp_file:
-                temp_file.write(f.getvalue())
-            with open(temp_path, 'rb') as temp_file:
-                translations, error_properties, warnings = process_ui_translation_upload(self.app, temp_file)
-
+        translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
         self.assertEqual(
             dict(translations), dict()
         )
@@ -61,11 +55,7 @@ class BulkUiTranslation(SimpleTestCase):
                 ('unknown_string', 'Ding', 'Dong'))
 
         f = self._build_translation_download_file(headers, data)
-        with TransientTempfile() as temp_path:
-            with open(temp_path, 'wb') as temp_file:
-                temp_file.write(f.getvalue())
-            with open(temp_path, 'rb') as temp_file:
-                translations, error_properties, warnings = process_ui_translation_upload(self.app, temp_file)
+        translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
 
         self.assertEqual(
             dict(translations),
@@ -92,10 +82,6 @@ class BulkUiTranslation(SimpleTestCase):
         # test existing translations get updated correctly
         data = (('home.start.demo', 'change_1', 'change_2'))
         f = self._build_translation_download_file(headers, data)
-        with TransientTempfile() as temp_path:
-            with open(temp_path, 'wb') as temp_file:
-                temp_file.write(f.getvalue())
-            with open(temp_path, 'rb') as temp_file:
-                translations, error_properties, warnings = process_ui_translation_upload(self.app, temp_file)
+        translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
         self.assertEqual(translations["fra"]["home.start.demo"], "change_2")
         self.assertEqual(translations["en"]["home.start.demo"], "change_1")

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -10,6 +10,8 @@ from couchexport.deid import (
 )
 from corehq.apps.export.transforms import (
     case_id_to_case_name,
+    case_id_to_link,
+    form_id_to_link,
     user_id_to_username,
     owner_id_to_display,
     workflow_transform,
@@ -30,6 +32,8 @@ DEID_TRANSFORM_FUNCTIONS = {
     DEID_DATE_TRANSFORM: deid_date,
 }
 CASE_NAME_TRANSFORM = "case_name_transform"
+CASE_ID_TO_LINK = "case_link_transform"
+FORM_ID_TO_LINK = "form_link_transform"
 USERNAME_TRANSFORM = "username_transform"
 OWNER_ID_TRANSFORM = "owner_id_transform"
 WORKFLOW_TRANSFORM = "workflow_transform"
@@ -38,6 +42,8 @@ CASE_OR_USER_ID_TRANSFORM = "case_or_user_id_transform"
 CASE_CLOSE_TO_BOOLEAN = "case_close_to_boolean"
 TRANSFORM_FUNCTIONS = {
     CASE_NAME_TRANSFORM: case_id_to_case_name,
+    CASE_ID_TO_LINK: case_id_to_link,
+    FORM_ID_TO_LINK: form_id_to_link,
     USERNAME_TRANSFORM: user_id_to_username,
     OWNER_ID_TRANSFORM: owner_id_to_display,
     WORKFLOW_TRANSFORM: workflow_transform,

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -105,14 +105,16 @@ class _ExportWriter(object):
             finally:
                 self.writer.close()
 
-    def write(self, table, row, hyperlink_column_indices):
+    def write(self, table, row):
         """
         Write the given row to the given table of the export.
         _Writer must be opened first.
         :param table: A TableConfiguration
         :param row: An ExportRow
         """
-        return self.writer.write([(table, [FormattedRow(data=row.data)])], hyperlink_column_indices)
+        return self.writer.write([
+            (table, [FormattedRow(data=row.data, hyperlink_column_indices=row.hyperlink_column_indices)])
+        ])
 
     def get_preview(self):
         return self.writer.get_preview()
@@ -368,14 +370,10 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
             compute_total += _time_in_milliseconds() - compute_start
 
             write_start = _time_in_milliseconds()
-            hyperlink_column_indices = [
-                i for i, column in enumerate(table.columns)
-                if column.item.transform in [CASE_ID_TO_LINK, FORM_ID_TO_LINK]
-            ]
             for row in rows:
                 # It might be bad to write one row at a time when you can do more (from a performance perspective)
                 # Regardless, we should handle the batching of rows in the _Writer class, not here.
-                writer.write(table, row, hyperlink_column_indices)
+                writer.write(table, row)
             write_total += _time_in_milliseconds() - write_start
 
             total_rows += len(rows)

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -31,7 +31,7 @@ from corehq.apps.export.models.new import (
     FormExportInstance,
     SMSExportInstance,
 )
-from corehq.apps.export.const import MAX_EXPORTABLE_ROWS, CASE_ID_TO_LINK, FORM_ID_TO_LINK
+from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
 import six
 from io import open
 

--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -31,7 +31,7 @@ from corehq.apps.export.models.new import (
     FormExportInstance,
     SMSExportInstance,
 )
-from corehq.apps.export.const import MAX_EXPORTABLE_ROWS
+from corehq.apps.export.const import MAX_EXPORTABLE_ROWS, CASE_ID_TO_LINK, FORM_ID_TO_LINK
 import six
 from io import open
 
@@ -105,14 +105,14 @@ class _ExportWriter(object):
             finally:
                 self.writer.close()
 
-    def write(self, table, row):
+    def write(self, table, row, hyperlink_column_indices):
         """
         Write the given row to the given table of the export.
         _Writer must be opened first.
         :param table: A TableConfiguration
         :param row: An ExportRow
         """
-        return self.writer.write([(table, [FormattedRow(data=row.data)])])
+        return self.writer.write([(table, [FormattedRow(data=row.data)])], hyperlink_column_indices)
 
     def get_preview(self):
         return self.writer.get_preview()
@@ -368,10 +368,14 @@ def write_export_instance(writer, export_instance, documents, progress_tracker=N
             compute_total += _time_in_milliseconds() - compute_start
 
             write_start = _time_in_milliseconds()
+            hyperlink_column_indices = [
+                i for i, column in enumerate(table.columns)
+                if column.item.transform in [CASE_ID_TO_LINK, FORM_ID_TO_LINK]
+            ]
             for row in rows:
                 # It might be bad to write one row at a time when you can do more (from a performance perspective)
                 # Regardless, we should handle the batching of rows in the _Writer class, not here.
-                writer.write(table, row)
+                writer.write(table, row, hyperlink_column_indices)
             write_total += _time_in_milliseconds() - write_start
 
             total_rows += len(rows)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -787,7 +787,7 @@ class ExportInstance(BlobMixin, Document):
                 column.update_properties_from_app_ids_and_versions(latest_app_ids_and_versions)
                 prev_index = index
 
-            cls._insert_system_properties(instance.domain, schema.type, table)
+            instance._insert_system_properties(instance.domain, schema.type, table)
             table.columns = cls._move_selected_columns_to_top(table.columns)
 
             if not instance.get_table(group_schema.path):
@@ -811,8 +811,7 @@ class ExportInstance(BlobMixin, Document):
         ordered_columns.extend([column for column in columns if not column.selected])
         return ordered_columns
 
-    @classmethod
-    def _insert_system_properties(cls, domain, export_type, table):
+    def _insert_system_properties(self, domain, export_type, table):
         from corehq.apps.export.system_properties import (
             ROW_NUMBER_COLUMN,
             TOP_MAIN_FORM_TABLE_PROPERTIES,
@@ -832,48 +831,47 @@ class ExportInstance(BlobMixin, Document):
         }
         if export_type == FORM_EXPORT:
             if table.path == MAIN_TABLE:
-                cls.__insert_system_properties(
+                self.__insert_system_properties(
                     table,
                     TOP_MAIN_FORM_TABLE_PROPERTIES,
                     **column_initialization_data
                 )
-                cls.__insert_system_properties(
+                self.__insert_system_properties(
                     table,
                     BOTTOM_MAIN_FORM_TABLE_PROPERTIES,
                     top=False,
                     **column_initialization_data
                 )
-                cls.__insert_case_name(table, top=False)
+                self.__insert_case_name(table, top=False)
             else:
-                cls.__insert_system_properties(table, [ROW_NUMBER_COLUMN], **column_initialization_data)
+                self.__insert_system_properties(table, [ROW_NUMBER_COLUMN], **column_initialization_data)
         elif export_type == CASE_EXPORT:
             if table.path == MAIN_TABLE:
                 if Domain.get_by_name(domain).commtrack_enabled:
                     top_properties = TOP_MAIN_CASE_TABLE_PROPERTIES + [STOCK_COLUMN]
                 else:
                     top_properties = TOP_MAIN_CASE_TABLE_PROPERTIES
-                cls.__insert_system_properties(
+                self.__insert_system_properties(
                     table,
                     top_properties,
                     **column_initialization_data
                 )
-                cls.__insert_system_properties(
+                self.__insert_system_properties(
                     table,
                     BOTTOM_MAIN_CASE_TABLE_PROPERTIES,
                     top=False,
                     **column_initialization_data
                 )
             elif table.path == CASE_HISTORY_TABLE:
-                cls.__insert_system_properties(table, CASE_HISTORY_PROPERTIES, **column_initialization_data)
+                self.__insert_system_properties(table, CASE_HISTORY_PROPERTIES, **column_initialization_data)
             elif table.path == PARENT_CASE_TABLE:
-                cls.__insert_system_properties(table, PARENT_CASE_TABLE_PROPERTIES,
+                self.__insert_system_properties(table, PARENT_CASE_TABLE_PROPERTIES,
                         **column_initialization_data)
         elif export_type == SMS_EXPORT:
             if table.path == MAIN_TABLE:
-                cls.__insert_system_properties(table, SMS_TABLE_PROPERTIES, **column_initialization_data)
+                self.__insert_system_properties(table, SMS_TABLE_PROPERTIES, **column_initialization_data)
 
-    @classmethod
-    def __insert_system_properties(cls, table, properties, top=True, **column_initialization_data):
+    def __insert_system_properties(self, table, properties, top=True, **column_initialization_data):
         """
         Inserts system properties into the table configuration
 
@@ -886,7 +884,7 @@ class ExportInstance(BlobMixin, Document):
         if top:
             properties = reversed(properties)
 
-        insert_fn = cls._get_insert_fn(table, top)
+        insert_fn = self._get_insert_fn(table, top)
 
         for static_column in properties:
             index, existing_column = table.get_column(

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -899,6 +899,8 @@ class ExportInstance(BlobMixin, Document):
                 column.update_domain(column_initialization_data.get('domain'))
 
             if not existing_column:
+                if static_column.label in ['case_link', 'form_link'] and self.get_id:
+                    static_column.selected = False
                 insert_fn(static_column)
 
     @classmethod

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1126,7 +1126,7 @@ class SMSExportInstance(ExportInstance):
             ))
 
         instance = cls(domain=schema.domain, tables=[main_table])
-        cls._insert_system_properties(instance.domain, schema.type, instance.tables[0])
+        instance._insert_system_properties(instance.domain, schema.type, instance.tables[0])
         return instance
 
 

--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -15,7 +15,9 @@ from corehq.apps.export.const import (
     OWNER_ID_TRANSFORM,
     USERNAME_TRANSFORM,
     WORKFLOW_TRANSFORM,
-    PROPERTY_TAG_NONE
+    PROPERTY_TAG_NONE,
+    CASE_ID_TO_LINK,
+    FORM_ID_TO_LINK,
 )
 from corehq.apps.export.models import (
     ExportColumn,
@@ -200,6 +202,20 @@ BOTTOM_MAIN_FORM_TABLE_PROPERTIES = [
         is_advanced=True,
         help_text=_("The IP address from which the form was submitted")
     ),
+    ExportColumn(
+        tags=[PROPERTY_TAG_INFO],
+        label="form_link",
+        item=ExportItem(
+            path=[
+                PathNode(name='form'),
+                PathNode(name='meta'),
+                PathNode(name='instanceID')
+            ],
+            transform=FORM_ID_TO_LINK,
+        ),
+        help_text=_('Link to this form'),
+        selected=True,
+    ),
 ]
 MAIN_FORM_TABLE_PROPERTIES = TOP_MAIN_FORM_TABLE_PROPERTIES + BOTTOM_MAIN_FORM_TABLE_PROPERTIES
 
@@ -364,6 +380,13 @@ BOTTOM_MAIN_CASE_TABLE_PROPERTIES = [
         label='state',
         item=ExportItem(path=[PathNode(name='doc_type')]),
         is_advanced=True,
+    ),
+    ExportColumn(
+        tags=[PROPERTY_TAG_INFO],
+        label='case_link',
+        item=ExportItem(path=[PathNode(name='_id')], transform=CASE_ID_TO_LINK),
+        help_text=_("Link to this case"),
+        selected=True
     ),
 ]
 MAIN_CASE_TABLE_PROPERTIES = TOP_MAIN_CASE_TABLE_PROPERTIES + BOTTOM_MAIN_CASE_TABLE_PROPERTIES

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -223,12 +223,12 @@ class TestCaseExportInstanceGeneration(SimpleTestCase):
         instance = self._generate_instance({self.app_id: 3}, self.schema)
 
         self.assertEqual(len(instance.tables), 1)
-        self.assertEqual(len(instance.tables[0].columns), 20)
+        self.assertEqual(len(instance.tables[0].columns), 21)
 
         # adding in 'name' shouldn't create any new columns
         instance = self._generate_instance({self.app_id: 3}, self.new_schema, instance)
         self.assertEqual(len(instance.tables), 1)
-        self.assertEqual(len(instance.tables[0].columns), 20)
+        self.assertEqual(len(instance.tables[0].columns), 21)
 
 
 @mock.patch(

--- a/corehq/apps/export/transforms.py
+++ b/corehq/apps/export/transforms.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 
 from corehq.apps.export.esaccessors import get_case_name
 from corehq.apps.users.util import cached_user_id_to_username, cached_owner_id_to_display
+from corehq.util import reverse
 
 """
 Module for transforms used in exports.
@@ -24,6 +25,16 @@ def owner_id_to_display(owner_id, doc):
 
 def case_id_to_case_name(case_id, doc):
     return _cached_case_id_to_case_name(case_id)
+
+
+def case_id_to_link(case_id, doc):
+    from corehq.apps.reports.views import CaseDataView
+    return reverse(CaseDataView.urlname, args=[doc['domain'], case_id], absolute=True)
+
+
+def form_id_to_link(form_id, doc):
+    from corehq.apps.reports.views import FormDataView
+    return reverse(FormDataView.urlname, args=[doc['domain'], form_id], absolute=True)
 
 
 def case_or_user_id_to_name(id, doc):

--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -14,7 +14,6 @@ from corehq.apps.fixtures.upload import validate_fixture_file_format
 from corehq.apps.fixtures.upload.failure_messages import FAILURE_MESSAGES
 from corehq.apps.fixtures.upload.run_upload import _run_fixture_upload
 from corehq.apps.fixtures.upload.workbook import get_workbook
-from corehq.util.files import TransientTempfile
 from corehq.util.test_utils import make_make_path
 from corehq.util.test_utils import generate_cases
 
@@ -186,13 +185,11 @@ class TestFixtureUpload(TestCase):
         return get_workbook(_make_path('test_upload', '{}.xlsx'.format(filename)))
 
     def _get_workbook_from_data(self, headers, rows):
-        f = BytesIO()
-        export_raw(headers, rows, f, format=Format.XLS_2007)
-        with TransientTempfile() as temp_path:
-            with open(temp_path, 'wb') as temp_file:
-                temp_file.write(f.getvalue())
-            with open(temp_path, 'rb') as temp_file:
-                return get_workbook(temp_file)
+        file = BytesIO()
+        export_raw(headers, rows, file, format=Format.XLS_2007)
+        with tempfile.TemporaryFile(suffix='.xlsx') as f:
+            f.write(file.getvalue())
+            return get_workbook(f)
 
     def get_fixture_items(self, attribute):
         # return list of 'attribute' values of fixture table 'things'

--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -189,6 +189,7 @@ class TestFixtureUpload(TestCase):
         export_raw(headers, rows, file, format=Format.XLS_2007)
         with tempfile.TemporaryFile(suffix='.xlsx') as f:
             f.write(file.getvalue())
+            f.seek(0)
             return get_workbook(f)
 
     def get_fixture_items(self, attribute):

--- a/corehq/apps/fixtures/tests/test_upload.py
+++ b/corehq/apps/fixtures/tests/test_upload.py
@@ -14,6 +14,7 @@ from corehq.apps.fixtures.upload import validate_fixture_file_format
 from corehq.apps.fixtures.upload.failure_messages import FAILURE_MESSAGES
 from corehq.apps.fixtures.upload.run_upload import _run_fixture_upload
 from corehq.apps.fixtures.upload.workbook import get_workbook
+from corehq.util.files import TransientTempfile
 from corehq.util.test_utils import make_make_path
 from corehq.util.test_utils import generate_cases
 
@@ -185,11 +186,13 @@ class TestFixtureUpload(TestCase):
         return get_workbook(_make_path('test_upload', '{}.xlsx'.format(filename)))
 
     def _get_workbook_from_data(self, headers, rows):
-        file = BytesIO()
-        export_raw(headers, rows, file, format=Format.XLS_2007)
-        with tempfile.TemporaryFile(suffix='.xlsx') as f:
-            f.write(file.getvalue())
-            return get_workbook(f)
+        f = BytesIO()
+        export_raw(headers, rows, f, format=Format.XLS_2007)
+        with TransientTempfile() as temp_path:
+            with open(temp_path, 'wb') as temp_file:
+                temp_file.write(f.getvalue())
+            with open(temp_path, 'rb') as temp_file:
+                return get_workbook(temp_file)
 
     def get_fixture_items(self, attribute):
         # return list of 'attribute' values of fixture table 'things'

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -61,6 +61,7 @@ class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
 
         with tempfile.TemporaryFile(suffix='.xlsx') as f:
             f.write(file.getvalue())
+            f.seek(0)
             workbook, messages = read_uploaded_app_translation_file(f)
             assert workbook, messages
             messages = process_bulk_app_translation_upload(self.app, workbook)
@@ -572,6 +573,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
 
         with tempfile.TemporaryFile(suffix='.xlsx') as f:
             f.write(file.getvalue())
+            f.seek(0)
             wb_reader = WorkbookJSONReader(f)
             cls.expected_workbook = [{'name': ws.title, 'rows': list(ws)}
                                      for ws in wb_reader.worksheets]

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -23,7 +23,6 @@ from corehq.apps.translations.app_translations import (
     read_uploaded_app_translation_file,
 )
 from corehq.apps.translations.const import MODULES_AND_FORMS_SHEET_NAME
-from corehq.util.files import TransientTempfile
 from corehq.util.test_utils import flag_enabled
 from corehq.util.workbook_json.excel import WorkbookJSONReader
 
@@ -60,13 +59,11 @@ class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
         file = BytesIO()
         export_raw(excel_headers, excel_data, file, format=Format.XLS_2007)
 
-        with TransientTempfile() as temp_path:
-            with open(temp_path, 'wb') as temp_file:
-                temp_file.write(file.getvalue())
-            with open(temp_path, 'rb') as temp_file:
-                workbook, messages = read_uploaded_app_translation_file(temp_file)
-        assert workbook, messages
-        messages = process_bulk_app_translation_upload(self.app, workbook)
+        with tempfile.TemporaryFile(suffix='.xlsx') as f:
+            f.write(file.getvalue())
+            workbook, messages = read_uploaded_app_translation_file(f)
+            assert workbook, messages
+            messages = process_bulk_app_translation_upload(self.app, workbook)
 
         self.assertListEqual(
             [m[1] for m in messages], expected_messages
@@ -573,13 +570,11 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
         file = BytesIO()
         export_raw(cls.excel_headers, cls.excel_data, file, format=Format.XLS_2007)
 
-        with TransientTempfile() as temp_path:
-            with open(temp_path, 'wb') as temp_file:
-                temp_file.write(file.getvalue())
-            with open(temp_path, 'rb') as temp_file:
-                wb_reader = WorkbookJSONReader(temp_file)
-        cls.expected_workbook = [{'name': ws.title, 'rows': list(ws)}
-                                 for ws in wb_reader.worksheets]
+        with tempfile.TemporaryFile(suffix='.xlsx') as f:
+            f.write(file.getvalue())
+            wb_reader = WorkbookJSONReader(f)
+            cls.expected_workbook = [{'name': ws.title, 'rows': list(ws)}
+                                     for ws in wb_reader.worksheets]
 
     def test_download(self):
         actual_headers = expected_bulk_app_sheet_headers(self.app)
@@ -669,11 +664,10 @@ class AggregateMarkdownNodeTests(SimpleTestCase, TestXmlMixin):
            '', '', '', '', '', '', '', '', ''))))
 
     def get_worksheet(self, title):
-        with TransientTempfile() as temp_path:
-            with open(temp_path, 'wb') as temp_file:
-                export_raw(self.headers, self.data, temp_file, format=Format.XLS_2007)
-            with open(temp_path, 'rb') as temp_file:
-                workbook = WorkbookJSONReader(temp_file)  # __init__ will read string_io
+        string_io = BytesIO()
+        export_raw(self.headers, self.data, string_io, format=Format.XLS_2007)
+        string_io.seek(0)
+        workbook = WorkbookJSONReader(string_io)  # __init__ will read string_io
         return workbook.worksheets_by_title[title]
 
     def setUp(self):

--- a/corehq/apps/userreports/app_manager/helpers.py
+++ b/corehq/apps/userreports/app_manager/helpers.py
@@ -68,7 +68,10 @@ def get_form_data_source(app, form):
         xform.data_node.tag_xmlns,
         only_process_current_builds=True,
     )
-    meta_properties = [_export_column_to_ucr_indicator(c) for c in BOTTOM_MAIN_FORM_TABLE_PROPERTIES]
+    meta_properties = [
+        _export_column_to_ucr_indicator(c) for c in BOTTOM_MAIN_FORM_TABLE_PROPERTIES
+        if c.label != 'form_link'
+    ]
     dynamic_properties = _get_dynamic_indicators_from_export_schema(schema)
     form_name = form.default_name()
     return DataSourceConfiguration(

--- a/corehq/ex-submodules/couchexport/export.py
+++ b/corehq/ex-submodules/couchexport/export.py
@@ -133,7 +133,7 @@ def export_from_tables(tables, file, format, max_column_size=2000):
     tables = FormattedRow.wrap_all_rows(tables)
     writer = get_writer(format)
     writer.open(tables, file, max_column_size=max_column_size)
-    writer.write(tables, skip_first=True)
+    writer.write(tables, [], skip_first=True)
     writer.close()
 
 

--- a/corehq/ex-submodules/couchexport/export.py
+++ b/corehq/ex-submodules/couchexport/export.py
@@ -133,7 +133,7 @@ def export_from_tables(tables, file, format, max_column_size=2000):
     tables = FormattedRow.wrap_all_rows(tables)
     writer = get_writer(format)
     writer.open(tables, file, max_column_size=max_column_size)
-    writer.write(tables, [], skip_first=True)
+    writer.write(tables, skip_first=True)
     writer.close()
 
 
@@ -185,7 +185,7 @@ def export_raw_to_writer(headers, data, file, format=Format.XLS_2007,
 
     # do the same for the data
     data = FormattedRow.wrap_all_rows(data)
-    writer.write(data, [])
+    writer.write(data)
     yield writer
     writer.close()
 
@@ -378,12 +378,13 @@ class FormattedRow(object):
     """
 
     def __init__(self, data, id=None, separator=".", id_index=0,
-                 is_header_row=False):
+                 is_header_row=False, hyperlink_column_indices=()):
         self.data = data
         self.id = id
         self.separator = separator
         self.id_index = id_index
         self.is_header_row = is_header_row
+        self.hyperlink_column_indices = hyperlink_column_indices
 
     def __iter__(self):
         for i in self.get_data():

--- a/corehq/ex-submodules/couchexport/export.py
+++ b/corehq/ex-submodules/couchexport/export.py
@@ -185,7 +185,7 @@ def export_raw_to_writer(headers, data, file, format=Format.XLS_2007,
 
     # do the same for the data
     data = FormattedRow.wrap_all_rows(data)
-    writer.write(data)
+    writer.write(data, [])
     yield writer
     writer.close()
 

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -214,9 +214,9 @@ class ExportWriter(object):
                 headers = [g.next_unique(header) for header in headers]
 
         self._init_table(table_index, table_title_truncated)
-        self.write_row(table_index, headers, [])
+        self.write_row(table_index, headers)
 
-    def write(self, document_table, hyperlink_column_indices, skip_first=False):
+    def write(self, document_table, skip_first=False):
         """
         Given a document that's been parsed into the appropriate
         rows, write those rows to the resulting files.
@@ -235,17 +235,17 @@ class ExportWriter(object):
                 if row_has_id:
                     row.id = (self._current_primary_id,) + tuple(row.id[1:])
 
-                self.write_row(table_index, row, hyperlink_column_indices)
+                self.write_row(table_index, row)
 
         self._current_primary_id += 1
 
-    def write_row(self, table_index, row, hyperlink_column_indices):
+    def write_row(self, table_index, row):
         """
         Currently just calls the subclass's implementation
         but if we were to add a universal validation step,
         such a thing would happen here.
         """
-        return self._write_row(table_index, row, hyperlink_column_indices)
+        return self._write_row(table_index, row)
 
     def close(self):
         """
@@ -261,7 +261,7 @@ class ExportWriter(object):
     def _init_table(self, table_index, table_title):
         raise NotImplementedError
 
-    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
+    def _write_row(self, sheet_index, row):
         raise NotImplementedError
 
     def _close(self):
@@ -290,7 +290,7 @@ class OnDiskExportWriter(ExportWriter):
         writer.open(table_title)
         self.table_names[table_index] = table_title
 
-    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
+    def _write_row(self, sheet_index, row):
 
         def _transform(val):
             if isinstance(val, six.text_type):
@@ -386,7 +386,8 @@ class Excel2007ExportWriter(ExportWriter):
         self.tables[table_index] = sheet
         self.table_indices[table_index] = 0
 
-    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
+    def _write_row(self, sheet_index, row):
+        from couchexport.export import FormattedRow
         sheet = self.tables[sheet_index]
 
         # Source: http://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
@@ -410,9 +411,10 @@ class Excel2007ExportWriter(ExportWriter):
         if self.format_as_text:
             for cell in cells:
                 cell.number_format = numbers.FORMAT_TEXT
-        for hyperlink_column_index in hyperlink_column_indices:
-            cells[hyperlink_column_index].hyperlink = cells[hyperlink_column_index].value
-            cells[hyperlink_column_index].style = 'Hyperlink'
+        if isinstance(row, FormattedRow):
+            for hyperlink_column_index in row.hyperlink_column_indices:
+                cells[hyperlink_column_index].hyperlink = cells[hyperlink_column_index].value
+                cells[hyperlink_column_index].style = 'Hyperlink'
         sheet.append(cells)
 
     def _close(self):
@@ -436,7 +438,7 @@ class Excel2003ExportWriter(ExportWriter):
         self.tables[table_index] = sheet
         self.table_indices[table_index] = 0
 
-    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
+    def _write_row(self, sheet_index, row):
         row_index = self.table_indices[sheet_index]
         sheet = self.tables[sheet_index]
 
@@ -465,7 +467,7 @@ class InMemoryExportWriter(ExportWriter):
         self.table_names[table_index] = table_title
         self.tables[table_index] = []
 
-    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
+    def _write_row(self, sheet_index, row):
         table = self.tables[sheet_index]
         # have to deal with primary ids
         table.append(list(row))
@@ -581,7 +583,7 @@ class CdiscOdmExportWriter(InMemoryExportWriter):
     def _init_table(self, table_index, table_title):
         pass
 
-    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
+    def _write_row(self, sheet_index, row):
         if sheet_index == 'study':
             if not self.study_keys:
                 self.study_keys = row

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -214,9 +214,9 @@ class ExportWriter(object):
                 headers = [g.next_unique(header) for header in headers]
 
         self._init_table(table_index, table_title_truncated)
-        self.write_row(table_index, headers)
+        self.write_row(table_index, headers, [])
 
-    def write(self, document_table, skip_first=False):
+    def write(self, document_table, hyperlink_column_indices, skip_first=False):
         """
         Given a document that's been parsed into the appropriate
         rows, write those rows to the resulting files.
@@ -235,17 +235,17 @@ class ExportWriter(object):
                 if row_has_id:
                     row.id = (self._current_primary_id,) + tuple(row.id[1:])
 
-                self.write_row(table_index, row)
+                self.write_row(table_index, row, hyperlink_column_indices)
 
         self._current_primary_id += 1
 
-    def write_row(self, table_index, headers):
+    def write_row(self, table_index, row, hyperlink_column_indices):
         """
         Currently just calls the subclass's implementation
         but if we were to add a universal validation step,
         such a thing would happen here.
         """
-        return self._write_row(table_index, headers)
+        return self._write_row(table_index, row, hyperlink_column_indices)
 
     def close(self):
         """
@@ -261,7 +261,7 @@ class ExportWriter(object):
     def _init_table(self, table_index, table_title):
         raise NotImplementedError
 
-    def _write_row(self, sheet_index, row):
+    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
         raise NotImplementedError
 
     def _close(self):
@@ -290,7 +290,7 @@ class OnDiskExportWriter(ExportWriter):
         writer.open(table_title)
         self.table_names[table_index] = table_title
 
-    def _write_row(self, sheet_index, row):
+    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
 
         def _transform(val):
             if isinstance(val, six.text_type):
@@ -386,7 +386,7 @@ class Excel2007ExportWriter(ExportWriter):
         self.tables[table_index] = sheet
         self.table_indices[table_index] = 0
 
-    def _write_row(self, sheet_index, row):
+    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
         sheet = self.tables[sheet_index]
 
         # Source: http://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
@@ -405,10 +405,14 @@ class Excel2007ExportWriter(ExportWriter):
                 value = ''
             return dirty_chars.sub('?', value)
 
-        cells = [WriteOnlyCell(sheet, get_write_value(val)) for val in row]
+        write_values = [get_write_value(val) for val in row]
+        cells = [WriteOnlyCell(sheet, val) for val in write_values]
         if self.format_as_text:
             for cell in cells:
                 cell.number_format = numbers.FORMAT_TEXT
+        for hyperlink_column_index in hyperlink_column_indices:
+            cells[hyperlink_column_index].hyperlink = cells[hyperlink_column_index].value
+            cells[hyperlink_column_index].style = 'Hyperlink'
         sheet.append(cells)
 
     def _close(self):
@@ -432,7 +436,7 @@ class Excel2003ExportWriter(ExportWriter):
         self.tables[table_index] = sheet
         self.table_indices[table_index] = 0
 
-    def _write_row(self, sheet_index, row):
+    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
         row_index = self.table_indices[sheet_index]
         sheet = self.tables[sheet_index]
 
@@ -461,7 +465,7 @@ class InMemoryExportWriter(ExportWriter):
         self.table_names[table_index] = table_title
         self.tables[table_index] = []
 
-    def _write_row(self, sheet_index, row):
+    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
         table = self.tables[sheet_index]
         # have to deal with primary ids
         table.append(list(row))
@@ -577,7 +581,7 @@ class CdiscOdmExportWriter(InMemoryExportWriter):
     def _init_table(self, table_index, table_title):
         pass
 
-    def _write_row(self, sheet_index, row):
+    def _write_row(self, sheet_index, row, hyperlink_column_indices=None):
         if sheet_index == 'study':
             if not self.study_keys:
                 self.study_keys = row

--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+from io import BytesIO
 from zipfile import BadZipfile
 from tempfile import NamedTemporaryFile
 import openpyxl
@@ -190,9 +192,13 @@ class WorksheetJSONReader(IteratorJSONReader):
 class WorkbookJSONReader(object):
 
     def __init__(self, file_or_filename):
-        if isinstance(file_or_filename, (InMemoryUploadedFile, file)):
+        if isinstance(file_or_filename, (InMemoryUploadedFile, file, BytesIO)):
             tmp = NamedTemporaryFile(mode='wb', suffix='.xlsx', delete=False)
-            tmp.write(file_or_filename.read())
+            if isinstance(file_or_filename, (InMemoryUploadedFile, file)):
+                value = file_or_filename.read()
+            else:
+                value = file_or_filename.getvalue()
+            tmp.write(value)
             tmp.close()
             file_or_filename = tmp.name
         try:

--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -190,7 +190,7 @@ class WorksheetJSONReader(IteratorJSONReader):
 class WorkbookJSONReader(object):
 
     def __init__(self, file_or_filename):
-        if isinstance(file_or_filename, InMemoryUploadedFile):
+        if isinstance(file_or_filename, (InMemoryUploadedFile, file)):
             tmp = NamedTemporaryFile(mode='wb', suffix='.xlsx', delete=False)
             tmp.write(file_or_filename.read())
             tmp.close()

--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from io import BytesIO
 from zipfile import BadZipfile
 from tempfile import NamedTemporaryFile
+from types import FileType
 import openpyxl
 from openpyxl.utils.exceptions import InvalidFileException
 import six
@@ -192,13 +193,10 @@ class WorksheetJSONReader(IteratorJSONReader):
 class WorkbookJSONReader(object):
 
     def __init__(self, file_or_filename):
-        if isinstance(file_or_filename, (InMemoryUploadedFile, file, BytesIO)):
+        if isinstance(file_or_filename, (InMemoryUploadedFile, FileType, BytesIO)):
             tmp = NamedTemporaryFile(mode='wb', suffix='.xlsx', delete=False)
-            if isinstance(file_or_filename, (InMemoryUploadedFile, file)):
-                value = file_or_filename.read()
-            else:
-                value = file_or_filename.getvalue()
-            tmp.write(value)
+            file_or_filename.seek(0)
+            tmp.write(file_or_filename.read())
             tmp.close()
             file_or_filename = tmp.name
         try:

--- a/corehq/util/workbook_reading/tests/test_spreadsheets.py
+++ b/corehq/util/workbook_reading/tests/test_spreadsheets.py
@@ -40,27 +40,53 @@ class SpreadsheetCellTypeTest(SimpleTestCase):
 @run_on_all_adapters(SpreadsheetCellTypeTest)
 def test_xlsx_types(self, open_workbook, ext):
     with open_workbook(get_file('types', ext)) as workbook:
-        self.assert_workbooks_equal(
-            workbook,
-            Workbook(
-                worksheets=[
-                    make_worksheet(title='Sheet1', rows=[
-                        ['String', 'Danny'],
-                        ['Date', date(1988, 7, 7)],
-                        ['Date Time', datetime(2016, 1, 1, 12, 0)],
-                        ['Time', time(12, 0)],
-                        ['Midnight', time(0, 0)],
-                        ['Int', 28],
-                        ['Int.0', 5],
-                        ['Float', 5.1],
-                        ['Bool-F', False],
-                        ['Bool-T', True],
-                        ['Empty', None],
-                        ['Percent', 0.49],
-                        ['Calculation', 2],
-                        ['Styled', 'Styled'],
-                        ['Empty Date', None],
-                    ]),
-                ]
+        if ext == 'xlsx':
+            self.assert_workbooks_equal(
+                workbook,
+                Workbook(
+                    worksheets=[
+                        make_worksheet(title='Sheet1', rows=[
+                            ['String', 'Danny'],
+                            ['Date', date(1988, 7, 7)],
+                            ['Date Time', datetime(2016, 1, 1, 12, 0)],
+                            ['Time', time(12, 0)],
+                            ['Midnight', date(1899, 12, 30)],
+                            ['Int', 28],
+                            ['Int.0', 5],
+                            ['Float', 5.1],
+                            ['Bool-F', False],
+                            ['Bool-T', True],
+                            ['Empty', None],
+                            ['Percent', 0.49],
+                            ['Calculation', 2],
+                            ['Styled', 'Styled'],
+                            ['Empty Date', None],
+                        ]),
+                    ]
+                )
             )
-        )
+        else:
+            self.assert_workbooks_equal(
+                workbook,
+                Workbook(
+                    worksheets=[
+                        make_worksheet(title='Sheet1', rows=[
+                            ['String', 'Danny'],
+                            ['Date', date(1988, 7, 7)],
+                            ['Date Time', datetime(2016, 1, 1, 12, 0)],
+                            ['Time', time(12, 0)],
+                            ['Midnight', time(0, 0)],
+                            ['Int', 28],
+                            ['Int.0', 5],
+                            ['Float', 5.1],
+                            ['Bool-F', False],
+                            ['Bool-T', True],
+                            ['Empty', None],
+                            ['Percent', 0.49],
+                            ['Calculation', 2],
+                            ['Styled', 'Styled'],
+                            ['Empty Date', None],
+                        ]),
+                    ]
+                )
+            )

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -8,6 +8,7 @@ git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/dimagi/couchdbkit-debugpanel.git#egg=couchdbkit-debugpanel
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 -e git+git://github.com/nickpell/django-package-monitor@np/handle-no-semver#egg=django-package-monitor
+-e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==1.4.9
@@ -126,7 +127,6 @@ msgpack-python==0.5.6
 nose-exclude==0.5.0
 nose==1.3.7
 numpy==1.7.1
-openpyxl==2.5.12
 paramiko==2.4.2           # via fabric
 pathlib2==2.3.3           # via ipython, pickleshare
 pbr==5.1.1

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==1.4.9
@@ -99,7 +100,6 @@ markupsafe==1.1.0
 mock==2.0.0
 msgpack-python==0.5.6
 numpy==1.7.1
-openpyxl==2.5.12
 packaging==18.0           # via sphinx
 pbr==5.1.1
 phonenumberslite==8.8.9

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
@@ -105,7 +106,6 @@ monotonic==1.5            # via eventlet
 msgpack-python==0.5.6
 ndg-httpsclient==0.5.1
 numpy==1.7.1
-openpyxl==2.5.12
 pathlib2==2.3.3           # via ipython, pickleshare
 pbr==5.1.1
 pexpect==4.6.0            # via ipython

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -24,7 +24,6 @@ gunicorn
 lxml==3.4.4
 kafka-python~=1.4
 mock==2.0.0
-openpyxl~=2.5
 Pillow==5.2.0
 phonenumberslite==8.8.9
 psycopg2~=2.7
@@ -111,3 +110,4 @@ werkzeug==0.11.15
 # but once they're in requirements.txt we will strip the -e
 
 -e git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alembic==0.8.6
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
@@ -62,7 +63,7 @@ dropbox==7.3.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 enum34==1.1.6             # via cryptography
-et-xmlfile==1.0.1         # via openpyxl
+et-xmlfile==1.0.1
 ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 faker==0.8.15
@@ -78,7 +79,7 @@ httpagentparser==1.7.8
 idna==2.7                 # via cryptography, email-validator, requests
 ipaddress==1.0.22         # via cryptography, faker
 iso8601==0.1.12
-jdcal==1.4                # via openpyxl
+jdcal==1.4
 jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 json-delta==2.0
@@ -96,7 +97,6 @@ markupsafe==1.1.0         # via jinja2, mako
 mock==2.0.0
 msgpack-python==0.5.6     # via ddtrace
 numpy==1.7.1
-openpyxl==2.5.12
 pbr==5.1.1                # via mock
 phonenumberslite==8.8.9
 pillow==5.2.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -6,6 +6,7 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
+-e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
@@ -105,7 +106,6 @@ msgpack-python==0.5.6
 nose-exclude==0.5.0
 nose==1.3.7
 numpy==1.7.1
-openpyxl==2.5.12
 pbr==5.1.1
 phonenumberslite==8.8.9
 pillow==5.2.0


### PR DESCRIPTION
Product Note: Adds a column to exports containing a hyperlink to the case or form represented in that row.

By default, the column is selected in all new exports.  The column is unselected by default in all existing exports.

https://trello.com/c/rxR9cvq6/86-crs-item-for-q4-new-column-in-form-and-case-exports

🐡