### PR TITLE
Check if ref attribute is present or not

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1045,9 +1045,9 @@ class XForm(WrappedNode):
             if cnode.constraint and cnode.bind_node.attrib.get(constraint_ref_xml):
                 constraint_jr_itext = cnode.bind_node.attrib.get(constraint_ref_xml)
                 question['constraintMsg_ref'] = self._normalize_itext_id(constraint_jr_itext)
-            if node.find('{f}help').exists():
+            if node.find('{f}help').exists() and node.find('{f}help').attrib.get('ref'):
                 question['helpMsg_ref'] = self._normalize_itext_id(node.find('{f}help').attrib.get('ref'))
-            if node.find('{f}hint').exists():
+            if node.find('{f}hint').exists() and node.find('{f}hint').attrib.get('ref'):
                 question['hintMsg_ref'] = self._normalize_itext_id(node.find('{f}hint').attrib.get('ref'))
 
             questions.append(question)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-248
Code in this Pr checks whether ref attribute is present in `<hint>` and `<help>` tags. 
For multiple languages added to an app, it needs that for default locale some text is present. But for number of domains/application this is not there. Which which is why ref is not coming. This check is already present in the app manager. But one way bad forms still get in is by uploading directly from the form settings. and There are already lot present in the Hq. So, This code ignores the `<hint>s` and `<help>s` whose refs is not there to preserve the essence and the error

