### PR TITLE
Only delete the stub if it exists

### DIFF
--- a/corehq/form_processor/submission_process_tracker.py
+++ b/corehq/form_processor/submission_process_tracker.py
@@ -50,18 +50,15 @@ def unfinished_submission(instance):
 
 @contextlib.contextmanager
 def unfinished_archive(instance, user_id, archive):
-    unfinished_archive_stub = None
-    if not getattr(instance, 'deprecated_form_id', None):
-        unfinished_archive_stub = UnfinishedArchiveStub.objects.create(
-            user_id=user_id,
-            xform_id=instance.form_id,
-            timestamp=datetime.datetime.utcnow(),
-            history_updated=False,
-            # if archive is False, this is an unarchive stub.
-            archive=archive,
-            domain=instance.domain,
-        )
+    unfinished_archive_stub = UnfinishedArchiveStub.objects.create(
+        user_id=user_id,
+        xform_id=instance.form_id,
+        timestamp=datetime.datetime.utcnow(),
+        history_updated=False,
+        # if archive is False, this is an unarchive stub.
+        archive=archive,
+        domain=instance.domain,
+    )
     tracker = ArchiveProcessTracker(unfinished_archive_stub)
     yield tracker
-    if unfinished_archive_stub:
-        unfinished_archive_stub.delete()
+    unfinished_archive_stub.delete()

--- a/corehq/form_processor/submission_process_tracker.py
+++ b/corehq/form_processor/submission_process_tracker.py
@@ -63,4 +63,5 @@ def unfinished_archive(instance, user_id, archive):
         )
     tracker = ArchiveProcessTracker(unfinished_archive_stub)
     yield tracker
-    unfinished_archive_stub.delete()
+    if unfinished_archive_stub:
+        unfinished_archive_stub.delete()


### PR DESCRIPTION
To fix this: https://sentry.io/dimagi/commcarehq/issues/795205705/?referrer=slack

I did more digging on deprecated_form_id: https://github.com/dimagi/commcare-hq/blob/master/corehq/form_processor/models.py#L349-L350

and determined that these forms should get normal archive stubs. I only added this if statement to the unfinished_archive code because of the logic in the unfinished_submission context manager, which I now think does not apply here.


@jmtroth0  @calellowitz 
cc: @snopoke 