### PR TITLE
Optimize riak to s3 migration

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -1,0 +1,84 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+
+from . import get_blob_db, NotFound
+from .migrate import PROCESSING_COMPLETE_MESSAGE
+from .models import BlobMeta
+from .zipdb import get_export_filename, ZipBlobDB
+
+
+class BlobDbBackendExporter(object):
+
+    def __init__(self, slug, domain):
+        self.slug = slug
+        self.db = ZipBlobDB(self.slug, domain)
+        self.total_blobs = 0
+        self.not_found = 0
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.db.close()
+        if self.not_found:
+            print(PROCESSING_COMPLETE_MESSAGE.format(self.not_found, self.total_blobs))
+
+    def process_object(self, meta):
+        from_db = get_blob_db()
+        self.total_blobs += 1
+        try:
+            content = from_db.get(key=meta.key)
+        except NotFound:
+            self.not_found += 1
+        else:
+            with content:
+                self.db.copy_blob(content, key=meta.key)
+        return True
+
+
+class ExportByDomain(object):
+
+    def __init__(self, slug):
+        self.slug = slug
+        self.domain = None
+
+    def by_domain(self, domain):
+        self.domain = domain
+
+    def migrate(self, filename=None, reset=False, max_retry=2, chunk_size=100, limit_to_db=None):
+        from corehq.apps.dump_reload.sql.dump import get_all_model_iterators_builders_for_domain
+
+        if not self.domain:
+            raise ExportError("Must specify domain")
+
+        if os.path.exists(get_export_filename(self.slug, self.domain)):
+            raise ExportError(
+                "{} exporter doesn't support resume. "
+                "To re-run the export use 'reset'".format(self.slug)
+            )
+
+        migrator = BlobDbBackendExporter(self.slug, self.domain)
+
+        with migrator:
+            builders = get_all_model_iterators_builders_for_domain(
+                BlobMeta, self.domain, limit_to_db)
+            for model_class, builder in builders:
+                for iterator in builder.iterators():
+                    for obj in iterator:
+                        migrator.process_object(obj)
+                        if migrator.total_blobs % chunk_size == 0:
+                            print("Processed {} {} objects".format(migrator.total_blobs, self.slug))
+
+        return migrator.total_blobs, 0
+
+
+class ExportError(Exception):
+    pass
+
+
+EXPORTERS = {m.slug: m for m in [
+    ExportByDomain("all_blobs"),
+]}

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 from django.core.management import BaseCommand, CommandError
-from corehq.blobs.migrate import EXPORTERS
+from corehq.blobs.export import EXPORTERS
 from corehq.blobs.zipdb import get_export_filename
 from corehq.util.decorators import change_log_level
 

--- a/corehq/blobs/management/commands/run_blob_migration.py
+++ b/corehq/blobs/management/commands/run_blob_migration.py
@@ -9,9 +9,9 @@ from django.core.management import BaseCommand, CommandError
 from corehq.blobs.migrate import MIGRATIONS
 from corehq.util.decorators import change_log_level
 from corehq.util.teeout import tee_output
-from io import open
 
 
+DEFAULT_WORKER_POOL_SIZE = 10
 USAGE = """Usage: ./manage.py run_blob_migration [options] <slug>
 
 Slugs:
@@ -45,19 +45,33 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--chunk-size',
+            dest="chunk_size",  # redundant arg for grep
             type=int,
             default=100,
             help="Maximum number of records to read from couch at once.",
         )
+        parser.add_argument(
+            '--num-workers',
+            type=int,
+            default=DEFAULT_WORKER_POOL_SIZE,
+            help=(
+                "Worker pool size for parallel processing. This option is "
+                "ignored by migration types that do not support it."
+            ),
+        )
 
     @change_log_level('boto3', logging.WARNING)
     @change_log_level('botocore', logging.WARNING)
-    def handle(self, slug=None, log_dir=None, reset=False, chunk_size=100,
-               **options):
+    def handle(self, slug, log_dir=None, **options):
         try:
             migrator = MIGRATIONS[slug]
         except KeyError:
             raise CommandError(USAGE)
+        if not migrator.has_worker_pool:
+            num_workers = options.pop("num_workers")
+            if num_workers != DEFAULT_WORKER_POOL_SIZE:
+                print("--num-workers={} ignored because this migration "
+                      "does not use a worker pool".format(num_workers))
 
         if log_dir is None:
             summary_file = log_file = None
@@ -71,10 +85,10 @@ class Command(BaseCommand):
             assert not os.path.exists(log_file), log_file
 
         with tee_output(summary_file):
-            total, skips = migrator.migrate(
-                log_file,
-                reset=reset,
-                chunk_size=chunk_size,
-            )
-            if skips:
-                sys.exit(skips)
+            try:
+                total, skips = migrator.migrate(log_file, **options)
+                if skips:
+                    sys.exit(skips)
+            except KeyboardInterrupt:
+                print("stopped by operator")
+                sys.exit(1)

--- a/corehq/blobs/management/commands/run_blob_migration.py
+++ b/corehq/blobs/management/commands/run_blob_migration.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import unicode_literals
 import logging
 import os

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -303,7 +303,7 @@ class BlobDbBackendMigrator(BaseDocMigrator):
                 print(self.filename)
 
 
-class BlobDbBackendExporter(BaseDocProcessor):
+class BlobDbBackendExporter(object):
 
     def __init__(self, slug, domain):
         from corehq.blobs.zipdb import ZipBlobDB
@@ -312,9 +312,13 @@ class BlobDbBackendExporter(BaseDocProcessor):
         self.total_blobs = 0
         self.not_found = 0
 
+    def __enter__(self):
+        pass
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.db.close()
-        self.processing_complete()
+        if self.not_found:
+            print(PROCESSING_COMPLETE_MESSAGE.format(self.not_found, self.total_blobs))
 
     def process_object(self, meta):
         from_db = get_blob_db()
@@ -327,10 +331,6 @@ class BlobDbBackendExporter(BaseDocProcessor):
             with content:
                 self.db.copy_blob(content, key=meta.key)
         return True
-
-    def processing_complete(self):
-        if self.not_found:
-            print(PROCESSING_COMPLETE_MESSAGE.format(self.not_found, self.total_blobs))
 
 
 class BlobMetaReindexAccessor(ReindexAccessor):

--- a/corehq/blobs/migrate_metadata.py
+++ b/corehq/blobs/migrate_metadata.py
@@ -43,7 +43,7 @@ class MultiDbMigrator(object):
 
     def iter_migrators(self):
         from . import migrate as mod
-        SqlMigrator, BlobMetaMigrator = make_migrators(mod)
+        NoStateMigrator, SqlMigrator, BlobMetaMigrator = make_migrators(mod)
         couch_migrator = partial(BlobMetaMigrator, blob_helper=couch_blob_helper)
 
         def db_key(doc_type):
@@ -53,7 +53,7 @@ class MultiDbMigrator(object):
 
         for key, types in groupby(sorted(self.couch_types, key=db_key), key=db_key):
             slug = "%s-%s" % (self.slug, key)
-            yield mod.Migrator(slug, list(types), couch_migrator)
+            yield NoStateMigrator(slug, list(types), couch_migrator)
 
         for rex in self.sql_reindexers:
             slug = "%s-%s" % (self.slug, rex.model_class.__name__)
@@ -84,10 +84,7 @@ def make_migrators(mod):
             super(BlobMetaMigrator, self).__init__(*args, **kw)
             self.total_blobs = 0
 
-        def _backup_doc(self, doc):
-            pass
-
-        def _do_migration(self, doc):
+        def migrate(self, doc):
             if not doc.get("external_blobs"):
                 return True
             type_code = self.get_type_code(doc)
@@ -140,13 +137,14 @@ def make_migrators(mod):
 
         def error(self, obj, doc):
             print("Error: %s %r" % (doc["error"], obj))
-            super(BlobMetaMigrator, self)._backup_doc(doc)
+            super(BlobMetaMigrator, self).write_backup(doc)
 
-        def processing_complete(self, skipped):
-            # fake skipped to prevent writing BlobMigrationState
-            super(BlobMetaMigrator, self).processing_complete(1)
+    class NoStateMigrator(mod.Migrator):
 
-    class SqlMigrator(mod.Migrator):
+        def write_migration_completed_state(self):
+            pass
+
+    class SqlMigrator(NoStateMigrator):
 
         def __init__(self, slug, reindexer, doc_migrator_class):
             types = [reindexer.model_class]
@@ -159,10 +157,10 @@ def make_migrators(mod):
             super(SqlMigrator, self).__init__(slug, types, doc_migrator)
             self.reindexer = reindexer
 
-        def _get_document_provider(self):
+        def get_document_provider(self):
             return SqlDocumentProvider(self.iteration_key, self.reindexer)
 
-    return SqlMigrator, BlobMetaMigrator
+    return NoStateMigrator, SqlMigrator, BlobMetaMigrator
 
 
 class SqlBlobHelper(object):

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -68,7 +68,7 @@ class TestMigrateBackend(TestCase):
             filename = join(tmp, "file.txt")
 
             # do migration
-            migrated, skipped = mod.MIGRATIONS[self.slug].migrate(filename)
+            migrated, skipped = mod.MIGRATIONS[self.slug].migrate(filename, num_workers=2)
             self.assertGreaterEqual(migrated, self.test_size)
 
             # verify: migration state recorded

--- a/corehq/blobs/tests/test_migrate.py
+++ b/corehq/blobs/tests/test_migrate.py
@@ -110,7 +110,7 @@ def discard_migration_state(slug):
         migrators = migrator.iter_migrators()
     else:
         migrators = [migrator]
-    for provider in (m._get_document_provider() for m in migrators):
+    for provider in (m.get_document_provider() for m in migrators):
         provider.get_document_iterator(1).discard_state()
     mod.BlobMigrationState.objects.filter(slug=slug).delete()
 

--- a/corehq/util/doc_processor/interface.py
+++ b/corehq/util/doc_processor/interface.py
@@ -122,7 +122,7 @@ class DocumentProcessorController(object):
         self.progress.total = self.document_provider.get_total_document_count()
 
         with self.doc_processor, self.progress:
-            for doc in self.progress.items:
+            for doc in self.document_iterator:
                 self._process_doc(doc)
 
         self.doc_processor.processing_complete(self.progress.skipped)

--- a/corehq/util/doc_processor/interface.py
+++ b/corehq/util/doc_processor/interface.py
@@ -200,7 +200,7 @@ class BulkDocProcessor(DocumentProcessorController):
         """Called by the BulkDocProcessorLogHandler"""
         ok = self.doc_processor.process_bulk_docs(self.changes)
         if ok:
-            self.processed += len(self.changes)
+            self.progress.add(len(self.changes))
             self.changes = []
         else:
             raise BulkProcessingFailed("Processing batch failed")

--- a/corehq/util/doc_processor/interface.py
+++ b/corehq/util/doc_processor/interface.py
@@ -4,24 +4,15 @@ from __future__ import division
 from __future__ import unicode_literals
 import weakref
 from abc import ABCMeta, abstractmethod
-from datetime import datetime, timedelta
 
 import six
 
-from corehq.util.pagination import PaginationEventHandler, TooManyRetries
+from .progress import ProgressManager, ProcessorProgressLogger
+from ..pagination import PaginationEventHandler, TooManyRetries
 
 
 class BulkProcessingFailed(Exception):
     pass
-
-
-DOCS_SKIPPED_WARNING = """
-        WARNING {} documents were not processed due to concurrent modification
-        during migration. Run the migration again until you do not see this
-        message.
-        """
-
-MIN_PROGRESS_INTERVAL = timedelta(minutes=5)
 
 
 class BaseDocProcessor(six.with_metaclass(ABCMeta)):
@@ -72,30 +63,6 @@ class BaseDocProcessor(six.with_metaclass(ABCMeta)):
         return True
 
 
-class ProcessorProgressLogger(object):
-    def progress_starting(self, total, previously_visited):
-        print("Processing {} documents{}: ...".format(
-            total,
-            " (~{} already processed)".format(previously_visited) if previously_visited else ""
-        ))
-
-    def document_skipped(self, doc_dict):
-        print("Skip: {doc_type} {_id}".format(**doc_dict))
-
-    def progress(self, processed, visited, total, time_elapsed, time_remaining):
-        print("Processed {}/{} of {} documents in {} ({} remaining)"
-              .format(processed, visited, total, time_elapsed, time_remaining))
-
-    def progress_complete(self, processed, visited, total, previously_visited, filtered):
-        print("Processed {}/{} of {} documents ({} previously processed, {} filtered out).".format(
-            processed,
-            visited,
-            total,
-            previously_visited,
-            filtered
-        ))
-
-
 class DocumentProvider(six.with_metaclass(ABCMeta)):
     @abstractmethod
     def get_document_iterator(self, chunk_size, event_handler=None):
@@ -135,77 +102,32 @@ class DocumentProcessorController(object):
         self.reset = reset
         self.max_retry = max_retry
         self.chunk_size = chunk_size
-        self.progress_logger = progress_logger or ProcessorProgressLogger()
-
         self.document_provider = document_provider
 
         self.document_iterator = self.document_provider.get_document_iterator(chunk_size, event_handler)
-
-        self.visited = 0
-        self.previously_visited = 0
-        self.total = 0
-
-        self.processed = 0
-        self.skipped = 0
-
-        self.start = None
+        self.progress = ProgressManager(
+            self.document_iterator,
+            reset=reset,
+            chunk_size=chunk_size,
+            logger=progress_logger or ProcessorProgressLogger(),
+        )
 
     def has_started(self):
         return bool(self.document_iterator.get_iterator_detail('progress'))
-
-    @property
-    def session_visited(self):
-        return self.visited - self.previously_visited
-
-    @property
-    def session_total(self):
-        return self.total - self.previously_visited
-
-    @property
-    def attempted(self):
-        return self.processed + self.skipped
-
-    @property
-    def timing(self):
-        """Returns a tuple of (elapsed, remaining)"""
-        elapsed = datetime.now() - self.start
-        if self.session_visited > self.session_total:
-            remaining = "?"
-        else:
-            session_remaining = self.session_total - self.session_visited
-            remaining = elapsed // self.session_visited * session_remaining
-        return elapsed, remaining
-
-    def _setup(self):
-        self.total = self.document_provider.get_total_document_count()
-
-        if self.reset:
-            self.document_iterator.discard_state()
-        elif self.document_iterator.get_iterator_detail('progress'):
-            info = self.document_iterator.get_iterator_detail('progress')
-            old_total = info["total"]
-            # Estimate already visited based on difference of old/new
-            # totals. The theory is that new or deleted records will be
-            # evenly distributed across the entire set.
-            self.visited = int(round(float(self.total) / old_total * info["visited"]))
-            self.previously_visited = self.visited
-        self.progress_logger.progress_starting(self.total, self.previously_visited)
-
-        self.start = datetime.now()
 
     def run(self):
         """
         :returns: A tuple `(<num processed>, <num skipped>)`
         """
-        self._setup()
-        with self.doc_processor:
-            for doc in self.document_iterator:
+        self.progress.total = self.document_provider.get_total_document_count()
+
+        with self.doc_processor, self.progress:
+            for doc in self.progress.items:
                 self._process_doc(doc)
-                self._update_progress()
 
-        self._processing_complete()
+        self.doc_processor.processing_complete(self.progress.skipped)
 
-        return self.processed, self.skipped
+        return self.progress.processed, self.progress.skipped
 
     def _process_doc(self, doc):
         if not self.doc_processor.should_process(doc):
@@ -213,7 +135,7 @@ class DocumentProcessorController(object):
 
         ok = self.doc_processor.process_doc(doc)
         if ok:
-            self.processed += 1
+            self.progress.add()
         else:
             try:
                 self.document_iterator.retry(doc['_id'], self.max_retry)
@@ -221,43 +143,7 @@ class DocumentProcessorController(object):
                 if not self.doc_processor.handle_skip(doc):
                     raise
                 else:
-                    self.progress_logger.document_skipped(doc)
-                    self.skipped += 1
-
-    def _update_progress(self):
-        self.visited += 1
-        if self.visited > self.total:
-            self.total = self.visited
-        if self.visited % self.chunk_size == 0:
-            self.document_iterator.set_iterator_detail('progress',
-                {"visited": self.visited, "total": self.total})
-
-        now = datetime.now()
-        attempted = self.attempted
-        last_attempted = getattr(self, "_last_attempted", None)
-        if ((attempted % self.chunk_size == 0 and attempted != last_attempted)
-                or now >= getattr(self, "_next_progress_update", now)):
-            elapsed, remaining = self.timing
-            self.progress_logger.progress(
-                self.processed, self.visited, self.total, elapsed, remaining
-            )
-            self._last_attempted = attempted
-            self._next_progress_update = now + MIN_PROGRESS_INTERVAL
-
-    def _processing_complete(self):
-        if self.session_visited:
-            self.document_iterator.set_iterator_detail('progress',
-                {"visited": self.visited, "total": self.total})
-        self.doc_processor.processing_complete(self.skipped)
-        self.progress_logger.progress_complete(
-            self.processed,
-            self.visited,
-            self.total,
-            self.previously_visited,
-            self.session_visited - self.attempted
-        )
-        if self.skipped:
-            print(DOCS_SKIPPED_WARNING.format(self.skipped))
+                    self.progress.skip(doc)
 
 
 class BulkDocProcessorEventHandler(PaginationEventHandler):
@@ -318,13 +204,3 @@ class BulkDocProcessor(DocumentProcessorController):
             self.changes = []
         else:
             raise BulkProcessingFailed("Processing batch failed")
-
-    def _update_progress(self):
-        self.visited += 1
-        if self.visited % self.chunk_size == 0:
-            self.document_iterator.set_iterator_detail('progress', {"visited": self.visited, "total": self.total})
-
-            elapsed, remaining = self.timing
-            self.progress_logger.progress(
-                self.processed, self.visited, self.total, elapsed, remaining
-            )

--- a/corehq/util/doc_processor/progress.py
+++ b/corehq/util/doc_processor/progress.py
@@ -70,13 +70,13 @@ class ProgressManager(object):
             self.previously_visited = self.visited
         self.logger.progress_starting(self.total, self.previously_visited)
 
-    def add(self):
+    def add(self, num=1):
         """Increment progress by one
 
         Call for each item after it is successfully processed.
         """
-        self.processed += 1
-        self._update()
+        self.processed += num
+        self._update(num)
 
     def skip(self, doc):
         """Record skipped item
@@ -91,8 +91,8 @@ class ProgressManager(object):
     def _state(self):
         return {"visited": self.visited, "total": self.total}
 
-    def _update(self):
-        self.visited += 1
+    def _update(self, num=1):
+        self.visited += num
         if self.visited > self.total:
             self.total = self.visited
 

--- a/corehq/util/doc_processor/progress.py
+++ b/corehq/util/doc_processor/progress.py
@@ -1,0 +1,146 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from datetime import datetime, timedelta
+
+import attr
+
+DOCS_SKIPPED_WARNING = """
+        WARNING {} documents were not processed due to concurrent modification
+        during migration. Run the migration again until you do not see this
+        message.
+        """
+
+MIN_PROGRESS_INTERVAL = timedelta(minutes=5)
+
+
+@attr.s
+class ProgressManager(object):
+    """Manage document processing progress and estimate time remaining
+
+    :param iterable: Instance of ``ResumableFunctionIterator`` (used to
+    get and save state for resumable migrations).
+    :param total: Total number of documents in iterable (may
+    be estimated).
+    :param reset: Discard existing iteration state (if any) if true.
+    :param chunk_size: Number of items to process before updating progress.
+    :param logger: Object used for logging progress.
+    See ``ProcessorProgressLogger`` for interface.
+    """
+
+    iterable = attr.ib()
+    total = attr.ib(default=0)
+    reset = attr.ib(default=False)
+    chunk_size = attr.ib(default=100)
+    logger = attr.ib(factory=lambda: ProcessorProgressLogger())
+
+    visited = attr.ib(init=False, default=0)
+    previously_visited = attr.ib(init=False, default=0)
+    processed = attr.ib(init=False, default=0)
+    skipped = attr.ib(init=False, default=0)
+    start = attr.ib(init=False, default=None)
+
+    @property
+    def _session_total(self):
+        return self.total - self.previously_visited
+
+    @property
+    def timing(self):
+        """Returns a tuple of (elapsed, remaining)"""
+        elapsed = datetime.now() - self.start
+        if self.processed > self._session_total:
+            remaining = "?"
+        else:
+            session_remaining = self._session_total - self.processed
+            remaining = elapsed // self.processed * session_remaining
+        return elapsed, remaining
+
+    def __enter__(self):
+        self.start = datetime.now()
+        if self.reset:
+            self.iterable.discard_state()
+        elif self.iterable.get_iterator_detail('progress'):
+            info = self.iterable.get_iterator_detail('progress')
+            old_total = info["total"]
+            # Estimate already visited based on difference of old/new
+            # totals. The theory is that new or deleted records will be
+            # evenly distributed across the entire set.
+            self.visited = int(round(float(self.total) / old_total * info["visited"]))
+            self.previously_visited = self.visited
+        self.logger.progress_starting(self.total, self.previously_visited)
+
+    def add(self):
+        """Increment progress by one
+
+        Call for each item after it is successfully processed.
+        """
+        self.processed += 1
+        self._update()
+
+    def skip(self, doc):
+        """Record skipped item
+
+        Call for each item that cannot be processed.
+        """
+        self.logger.document_skipped(doc)
+        self.skipped += 1
+        self._update()
+
+    @property
+    def _state(self):
+        return {"visited": self.visited, "total": self.total}
+
+    def _update(self):
+        self.visited += 1
+        if self.visited > self.total:
+            self.total = self.visited
+
+        now = datetime.now()
+        attempted = self.processed + self.skipped
+        last_attempted = getattr(self, "_last_attempted", None)
+        if ((attempted % self.chunk_size == 0 and attempted != last_attempted)
+                or now >= getattr(self, "_next_progress_update", now)):
+            self.iterable.set_iterator_detail('progress', self._state)
+            elapsed, remaining = self.timing
+            self.logger.progress(
+                self.processed, self.visited, self.total, elapsed, remaining
+            )
+            self._last_attempted = attempted
+            self._next_progress_update = now + MIN_PROGRESS_INTERVAL
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc_type is None:
+            if self.processed:
+                self.iterable.set_iterator_detail('progress', self._state)
+            self.logger.progress_complete(
+                self.processed,
+                self.visited,
+                self.total,
+                self.previously_visited,
+            )
+            if self.skipped:
+                print(DOCS_SKIPPED_WARNING.format(self.skipped))
+
+
+class ProcessorProgressLogger(object):
+    def progress_starting(self, total, previously_visited):
+        print("Processing {} documents{}: ...".format(
+            total,
+            " (~{} already processed)".format(previously_visited) if previously_visited else ""
+        ))
+
+    def document_skipped(self, doc_dict):
+        print("Skip: {doc_type} {_id}".format(**doc_dict))
+
+    def progress(self, processed, visited, total, time_elapsed, time_remaining):
+        print("Processed {}/{} of {} documents in {} ({} remaining)"
+              .format(processed, visited, total, time_elapsed, time_remaining))
+
+    def progress_complete(self, processed, visited, total, previously_visited):
+        print("Processed {}/{} of {} documents ({} previously processed).".format(
+            processed,
+            visited,
+            total,
+            previously_visited,
+        ))

--- a/corehq/util/doc_processor/progress.py
+++ b/corehq/util/doc_processor/progress.py
@@ -66,7 +66,7 @@ class ProgressManager(object):
             # Estimate already visited based on difference of old/new
             # totals. The theory is that new or deleted records will be
             # evenly distributed across the entire set.
-            self.visited = int(round(float(self.total) / old_total * info["visited"]))
+            self.visited = int(float(self.total) / old_total * info["visited"] + 0.5)
             self.previously_visited = self.visited
         self.logger.progress_starting(self.total, self.previously_visited)
 

--- a/corehq/util/doc_processor/progress.py
+++ b/corehq/util/doc_processor/progress.py
@@ -49,7 +49,7 @@ class ProgressManager(object):
     def timing(self):
         """Returns a tuple of (elapsed, remaining)"""
         elapsed = datetime.now() - self.start
-        if self.processed > self._session_total:
+        if self.processed >= self._session_total or not self.processed:
             remaining = "?"
         else:
             session_remaining = self._session_total - self.processed

--- a/manage.py
+++ b/manage.py
@@ -129,6 +129,7 @@ if __name__ == "__main__":
         GeventCommand('mvp_force_update'),
         GeventCommand('run_gunicorn'),
         GeventCommand('run_sql'),
+        GeventCommand('run_blob_migration'),
         GeventCommand('preindex_everything'),
         GeventCommand('migrate_multi'),
         GeventCommand('prime_views'),


### PR DESCRIPTION
Use gevent to migrate multiple blobs simultaneously. The first four commits are (p)refactoring in preparation for ~the final commit~ 5368d38b7b6c1c5ed2344e6b99ab6155498f266a, which adds parallel processing.

Review by commit 🐠 

@nickpell @jmtroth0 