### PR TITLE
Use SQLLocation for AWC performance report

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -667,18 +667,19 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
             block=location,
             month=config['month']
         ).get_excel_data()
-        location_object = AwcLocationMonths.objects.filter(
-            block_id=location,
-            aggregation_level=3
-        ).first()
+
+        block = SQLLocation.objects.filter(location_id=location).first()
+        district = block.parent
+        state = district.parent
+
         if file_format == 'xlsx':
             cache_key = create_aww_performance_excel_file(
                 excel_data,
                 data_type,
                 config['month'].strftime("%B %Y"),
-                location_object.state_name,
-                location_object.district_name,
-                location_object.block_name,
+                state.name,
+                district.name,
+                block.name,
             )
         else:
             cache_key = create_excel_file(excel_data, data_type, file_format)


### PR DESCRIPTION
This Error was happening  Because when UI fetches the Locations from Backend(BE). BE uses the SQLLocation table to give the locations and when export is clicked AwcLocationMonths is used. Therefore the location_id(uuid) present in SQLLocation table cant be found in AwcLocationMonths table. 
This Code makes it consistent.

https://dimagi-dev.atlassian.net/browse/ICDS-226