### PR TITLE
Fix 500s in pregnant and lactating report by fixing null ordering

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, rrule, DAILY, WEEKLY, MO
@@ -1133,7 +1133,18 @@ def get_awc_report_pregnant(start, length, order, reversed_order, awc_id):
     for row in data:
         config['data'].append(base_data(row))
 
-    config['data'].sort(key=lambda record: record[order], reverse=reversed_order)
+    def ordering_format(record):
+        if record[order]:
+            return record[order]
+        numeric_fields = ['age', 'closed', 'trimester', 'num_anc_complete', 'number_of_thrs_given']
+        if any([field in order for field in numeric_fields]):
+            return 0
+        date_fields = ['opened_on', 'edd', 'last_date_thr']
+        if any([field in order for field in date_fields]):
+            return date.today()
+        return ""
+
+    config['data'].sort(key=ordering_format, reverse=reversed_order)
     config['data'] = config['data'][start:(start + length)]
     config["recordsTotal"] = data_count
     config["recordsFiltered"] = data_count
@@ -1240,7 +1251,18 @@ def get_awc_report_lactating(start, length, order, reversed_order, awc_id):
     for row in data:
         config['data'].append(base_data(row))
 
-    config['data'].sort(key=lambda record: record[order], reverse=reversed_order)
+    def ordering_format(record):
+        if record[order]:
+            return record[order]
+        numeric_fields = ['age', 'delivery_nature', 'num_pnc_visits', 'num_rations_distributed']
+        if any([field in order for field in numeric_fields]):
+            return 0
+        date_fields = ['add']
+        if any([field in order for field in date_fields]):
+            return date.today()
+        return ""
+
+    config['data'].sort(key=ordering_format, reverse=reversed_order)
     config['data'] = config['data'][start:(start + length)]
     config["recordsTotal"] = data_count
     config["recordsFiltered"] = data_count


### PR DESCRIPTION
Hi @calellowitz,
I have fixed the issue in which DataTables was throwing an error due to failed query request caused by ordering by a field in which values were both inserted and nulls and python failing to compare them.
Fix has been achieved by creating a function that especially for sorting provides the correct type of value for nulls: empty string, 0 or current date.
Regards, Dawid