### PR TITLE
remove unnecessary conversion

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/django/management.py
+++ b/corehq/ex-submodules/dimagi/utils/django/management.py
@@ -31,13 +31,6 @@ def export_as_csv_action(description="Export selected objects as CSV file",
     'fields' and 'exclude' work like in django ModelForm
     'header' is whether or not to output the column names as the first row
     """
-    def safe_utf8(value):
-        if isinstance(value, bytes):
-            # This will needlessly decode, and then re-encode UTF-8 strings.
-            # All other encodings will be converted to UTF-8 (the conversion
-            # is potentially lossy).
-            return value.decode('utf-8', 'replace').encode('utf-8')
-        return six.text_type(value).encode('utf-8')
 
     def export_as_csv(modeladmin, request, queryset):
         """
@@ -60,7 +53,7 @@ def export_as_csv_action(description="Export selected objects as CSV file",
         if header:
             writer.writerow(list(field_names))
         for obj in queryset:
-            writer.writerow([safe_utf8(getattr(obj, field)) for field in field_names])
+            writer.writerow([getattr(obj, field) for field in field_names])
         return response
 
     export_as_csv.short_description = description


### PR DESCRIPTION
@nickpell @sravfeyn @jmtroth0 
I think this code is no longer necessary (because of the change to `csv342`) and the conversion was causing issues with text that was already unicode.