### PR TITLE
Catch WrappingAttributeError when fetching groups

### DIFF
--- a/corehq/pillows/utils.py
+++ b/corehq/pillows/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from couchdbkit.exceptions import ResourceNotFound
+from jsonobject.exceptions import WrappingAttributeError
 
 from corehq.apps.commtrack.const import COMMTRACK_USERNAME
 from corehq.apps.users.models import CouchUser
@@ -78,7 +79,7 @@ def get_user_type(user_id):
                 return WEB_USER_TYPE
             elif user.is_commcare_user():
                 return MOBILE_USER_TYPE
-        except ResourceNotFound:
+        except (ResourceNotFound, WrappingAttributeError):
             pass
     return UNKNOWN_USER_TYPE
 


### PR DESCRIPTION
We have over 75K pillow errors that stem from doing a user lookup with a group id.

If you look up a Group with `CouchUser.get`, you don't get a `ResourceNotFound`, you get a `WrappingAttributeError` since Groups are stored in the users db. 

```
In [20]: CouchUser.get('A group id')
... SNIP. ...
WrappingAttributeError: can't set attribute corresponding to u'name' on a <class 'corehq.apps.users.models.CouchUser'> while wrapping REDACTED
```

This was introduced here: https://github.com/dimagi/commcare-hq/pull/22749/commits/265941cecaa5b251690c558af3a52edd910e8b96