### PR TITLE
don't give hyperlink styling to non-string cells

### DIFF
--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -413,8 +413,10 @@ class Excel2007ExportWriter(ExportWriter):
                 cell.number_format = numbers.FORMAT_TEXT
         if isinstance(row, FormattedRow):
             for hyperlink_column_index in row.hyperlink_column_indices:
-                cells[hyperlink_column_index].hyperlink = cells[hyperlink_column_index].value
-                cells[hyperlink_column_index].style = 'Hyperlink'
+                cell_value = cells[hyperlink_column_index].value
+                if isinstance(cell_value, six.string_types):
+                    cells[hyperlink_column_index].hyperlink = cell_value
+                    cells[hyperlink_column_index].style = 'Hyperlink'
         sheet.append(cells)
 
     def _close(self):


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/817093235/

Most instances of this problem were fixed with https://github.com/dimagi/commcare-hq/pull/22816.  There's one particularly complex export that is failing to download due to an attempt to assign a hyperlink to a non-string cell.  This prevents the export from failing, as a stop-gap solution until the underlying bug is fixed.