### PR TITLE
get right hyperlink indices regardless of other column types

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -550,10 +550,7 @@ class TableConfiguration(DocumentSchema):
         for selected_column in self.selected_columns:
             if selected_column.item.transform in [CASE_ID_TO_LINK, FORM_ID_TO_LINK]:
                 hyperlink_column_indices.append(export_column_index)
-            if isinstance(selected_column, SplitExportColumn) and split_columns:
-                export_column_index += len(selected_column.item.options)
-            else:
-                export_column_index += 1
+            export_column_index += len(selected_column.get_headers(split_column=split_columns))
         return hyperlink_column_indices
 
     def _get_sub_documents(self, document, row_number, document_id=None):


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/817093235/

This is a more general solution than https://github.com/dimagi/commcare-hq/pull/22816, which fixed the issue for ```SplitExportColumn```s but not other types.