### PR TITLE
Add exception error details to notified exception

### DIFF
--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -361,9 +361,9 @@ def poll_custom_export_download(request, domain):
     download_id = request.GET.get('download_id')
     try:
         context = get_download_context(download_id)
-    except TaskFailedError:
+    except TaskFailedError as e:
         notify_exception(request, "Export download failed",
-                         details={'download_id': download_id})
+                         details={'download_id': download_id, 'errors': e.errors})
         return json_response({
             'error': _("Download task failed to start."),
         })


### PR DESCRIPTION
Adding more info to the sentry error here: https://sentry.io/dimagi/commcarehq/issues/784159254/
so we have more info to debug:
https://dimagi-dev.atlassian.net/browse/HI-266

It looks like this error started after this commit was merged: https://github.com/dimagi/commcare-hq/commit/e5da446959aa35019544f644f132f0840f700cc0 , but that exception was being thrown in the previous iteration of the code. 

My current hypothesis is that the migration from angular to knockout makes the page slightly faster, and means that it polls the download before that task is registered in celery, potentially throwing this error. 