### PR TITLE
Show saved labels in exports

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -496,9 +496,7 @@ hqDefine('export/js/models', [
         // Whether or not to show advanced columns in the UI
         self.showAdvanced = ko.observable(false);
         self.showDeleted = ko.observable(false);
-        self.displayType = ko.observable("labels");
         ko.mapping.fromJS(tableJSON, TableConfiguration.mapping, self);
-        self.useLabels(self);
     };
 
     TableConfiguration.prototype.isVisible = function () {
@@ -551,7 +549,6 @@ hqDefine('export/js/models', [
                 column.label(column.item.label() || column.label());
             }
         });
-        table.displayType('labels');
     };
 
     /**
@@ -567,7 +564,6 @@ hqDefine('export/js/models', [
                 column.label(column.item.readablePath() || column.label());
             }
         });
-        table.displayType('ids');
     };
 
     TableConfiguration.prototype.getColumn = function (path) {

--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -119,13 +119,13 @@
                         {% trans "Display" %}<br />
                         {% if export_instance.type == 'form' %}
                         <a
-                            class="btn btn-xs"
-                            data-bind="click: table.useLabels, css: { 'btn-primary': table.displayType() === 'labels', 'btn-default': table.displayType() !== 'labels'}">
+                            class="btn btn-xs btn-default"
+                            data-bind="click: table.useLabels">
                             {% trans "Use question labels" %}
                         </a>
                         <a
-                            class="btn btn-xs"
-                            data-bind="click: table.useIds, css: { 'btn-primary': table.displayType() === 'ids', 'btn-default': table.displayType() !== 'ids'}">
+                            class="btn btn-xs btn-default"
+                            data-bind="click: table.useIds">
                             {% trans "Use question ids" %}
                         </a>
                         {% endif %}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-261 and https://dimagi-dev.atlassian.net/browse/HI-268

By defaulting to "labels", we were overwriting any changes the user has made. 

I changed the buttons to both look like buttons, since these aren't a state but an action. 

Before:
![screenshot from 2018-12-24 20-11-24](https://user-images.githubusercontent.com/146896/50408435-235a2d00-07b8-11e9-8cb5-5850e40f3b29.png)


After:
![screenshot from 2018-12-24 20-11-32](https://user-images.githubusercontent.com/146896/50408436-26edb400-07b8-11e9-992c-5278f127b25a.png)
