### PR TITLE
Updated feedback text colors on signup

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/forms.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/forms.less
@@ -188,11 +188,6 @@ textarea.vertical-resize {
     border-width: 2px;
   }
 
-  .has-success .control-label,
-  .text-success {
-    color: @cc-att-pos-hi;
-  }
-
   .has-success .form-control,
   .has-success .form-control:focus,
   .has-success input[type="text"],
@@ -216,13 +211,6 @@ textarea.vertical-resize {
     .box-shadow(0px 0px 15px 1px rgba(175, 242, 133, .75));
   }
 
-  .has-error .control-label,
-  .has-error label,
-  .text-error,
-  .text-danger {
-    color: @cc-att-neg-hi;
-  }
-
   .has-error .form-control,
   .has-error .form-control:focus,
   .has-error input[type="text"],
@@ -244,11 +232,6 @@ textarea.vertical-resize {
   .has-error input[type="number"]:focus,
   .has-error input[type="password"]:focus {
     .box-shadow(0px 0px 15px 1px rgba(239, 207, 203, .75));
-  }
-
-  .has-warning .control-label,
-  .text-warning {
-    color: @cc-light-warm-accent-hi;
   }
 
   .has-warning .form-control,


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/22679 - now that the signup form is a light background, we can just use the default font colors for `.text-warning`, etc.

@proteusvacuum 