### PR TITLE
Mark export downloads as location safe

### DIFF
--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -283,6 +283,7 @@ def _check_deid_permissions(permissions, export_instances):
 
 @require_POST
 @login_and_domain_required
+@location_safe
 def prepare_custom_export(request, domain):
     """Uses the current exports download framework (with some nasty filters)
     to return the current download id to POLL for the download status.
@@ -346,6 +347,7 @@ def prepare_custom_export(request, domain):
 
 @require_GET
 @login_and_domain_required
+@location_safe
 def poll_custom_export_download(request, domain):
     """Polls celery to see how the export download task is going.
     :return: final response: {

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -755,6 +755,7 @@ def download_daily_saved_export(req, domain, export_instance_id):
 
 @require_GET
 @login_and_domain_required
+@location_safe
 def get_app_data_drilldown_values(request, domain):
     if json.loads(request.GET.get('is_deid')):
         raise Http404()
@@ -776,6 +777,7 @@ def get_app_data_drilldown_values(request, domain):
 
 @require_POST
 @login_and_domain_required
+@location_safe
 def submit_app_data_drilldown_form(request, domain):
     if json.loads(request.POST.get('is_deid')):
         raise Http404()


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-208

The recent migration to knockout meant that these views were no longer marked as location safe.

More details in the ticket. 