### PR TITLE
incrementing for all processed docs

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -379,7 +379,7 @@ class CouchSqlDomainMigrator(object):
 
         self._diff_ledgers(case_ids)
 
-        self.processed_docs += 1
+        self.processed_docs += len(case_ids)
         self._log_case_diff_count(throttled=True)
 
     def _rebuild_couch_case_and_re_diff(self, couch_case, sql_case_json):
@@ -438,7 +438,7 @@ class CouchSqlDomainMigrator(object):
             return iterable
 
     def _log_processed_docs_count(self, tags, throttled=False):
-        if throttled and self.processed_docs % 100 != 0:
+        if throttled and self.processed_docs < 100:
             return
 
         processed_docs = self.processed_docs


### PR DESCRIPTION
@calellowitz i realized this was incrementing once for every 100 docs processed. This doesn't matter much, but it'll make [this chart](https://app.datadoghq.com/dash/773587/jordans-checks?screenId=773587&screenName=jordans-checks&from_ts=1545845789386&is_auto=false&live=false&page=0&tile_size=m&to_ts=1545846117972&fullscreen_widget=387229609) a bit better