### PR TITLE
don't pass normalized ID to normalize function

### DIFF
--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -84,7 +84,7 @@ class BlobMixin(Document):
                 if value["doc_type"] == "BlobMetaRef":
                     blobs[key] = value
                 else:
-                    blobs[key] = normalize(dbname, doc_id, value)
+                    blobs[key] = normalize(dbname, data['_id'], value)
                     normalized = True
             if normalized:
                 data = data.copy()

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -447,6 +447,22 @@ class TestBlobMixin(BaseTestCase):
         with self.assertRaises(AttributeError):
             meta.id
 
+    def test_wrap_with_bad_id(self):
+        doc = {
+            "_id": "uuid:9855adcb-da3a-41e2-afaf-71d5b42c7e5e",
+            "external_blobs": {
+                "form.xml": {
+                    "content_length": 34282,
+                    "content_type": "text/xml",
+                    "digest": "md5-EhgFC+ZQGc7pGTu7CwMRwA==",
+                    "doc_type": "BlobMeta",
+                    "id": "form.xml.11764c68ee5e41b69b748fc76d69e309"
+                }
+            }
+        }
+        # this line previously failed hard when called
+        FakeCouchDocument.wrap(doc)
+
 
 class TestBlobMixinWithS3Backend(TestBlobMixin):
 


### PR DESCRIPTION
should fix [this issue](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=5&modal=detail&selectedIssue=HI-271)

The ID was already getting normalized by [this line](https://github.com/dimagi/commcare-hq/blob/master/corehq/blobs/mixin.py#L78) so passing it into the [`_normalize_json` function](https://github.com/dimagi/commcare-hq/blob/master/corehq/blobs/mixin.py#L49) was tripping [this error](https://github.com/dimagi/commcare-hq/blob/master/corehq/blobs/mixin.py#L618).