### PR TITLE
Removed borders from modals

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/modals.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/modals.less
@@ -13,6 +13,10 @@
     font-size: 16px;
 }
 
+.modal-header, .modal-footer {
+    border-width: 0;
+}
+
 // Modal that takes up virtually the entire screen, with a variable amount of padding around it
 .absolute-center-modal(@spacing) {
     .modal-dialog {


### PR DESCRIPTION
Lighten up modals a bit, as described in new style guidelines.

before
<img width="616" alt="screen shot 2018-12-27 at 9 33 11 am" src="https://user-images.githubusercontent.com/1486591/50483871-b1523580-09bb-11e9-9902-d9ef8897c98c.png">

after
<img width="633" alt="screen shot 2018-12-27 at 9 32 41 am" src="https://user-images.githubusercontent.com/1486591/50483880-b57e5300-09bb-11e9-9a7d-a138604610ac.png">

fyi @dimagi/product 
code buddy @emord 