### PR TITLE
Conditional relationships followup

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -397,7 +397,7 @@ class OpenSubCaseAction(FormAction, IndexedSchema):
     repeat_context = StringProperty()
     # relationship = "child" for index to a parent case (default)
     # relationship = "extension" for index to a host case
-    relationship = StringProperty(choices=['child', 'extension', 'question'], default='child')
+    relationship = StringProperty(choices=['child', 'extension'], default='child')
 
     close_condition = SchemaProperty(FormActionCondition)
 
@@ -442,7 +442,9 @@ class CaseIndex(DocumentSchema):
     tag = StringProperty()
     reference_id = StringProperty(default='parent')
     relationship = StringProperty(choices=['child', 'extension', 'question'], default='child')
-    relationship_question = StringProperty(default='')  # if relationship is 'question', this is the question path
+    # if relationship is 'question', this is the question path
+    # question's response must be either "child" or "extension"
+    relationship_question = StringProperty(default='')
 
 
 class AdvancedAction(IndexedSchema):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1875,7 +1875,7 @@ class FormExportDataSchema(ExportDataSchema):
         if case_indices:
             for index in case_indices:
                 props = ('#text', '@case_type',)
-                if index.relationship == 'extension':
+                if index.relationship != 'child':
                     props = props + ('@relationship',)
                 for prop in props:
                     identifier = index.reference_id or 'parent'


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/22802#issuecomment-449406092

Traced through the various places case index relationships are referenced, did some testing, and made a couple of minor changes.

App manager primarily uses the reference id rather than doing things with the relationship type. This goes for the code in `app_manager.app_schema` (most of the relationship-related code is in case_properties.py and is ultimately pulled from https://github.com/dimagi/commcare-hq/blob/438f022bb33143f6647841e92440e5a26c66259d/corehq/apps/app_manager/models.py#L1989-L1990) and also the app summary. The app properties window in form builder also looks at case relationships, but it doesn't work for advanced modules anyway.

Exports: This behaves as expected. Subcases created with a dynamic index appear in exports like child/extension cases, and if parent cases are included, the `relationship_type` column is set correctly for each specific case.

@proteusvacuum 