### PR TITLE
Fixed language code not displaying for tab names in case detail config

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -377,12 +377,9 @@ hqDefine('app_manager/js/details/screen_config', function () {
                     that.nodeset = uiElement.input().val(that.original.nodeset);
                     that.relevant = uiElement.input().val(that.original.relevant);
                     if (that.isTab) {
-                        // hack to wait until the input's there to prepend the Tab: label.
-                        setTimeout(function () {
-                            that.header.ui.addClass('input-group').prepend($('<span class="input-group-addon">Tab</span>'));
-                            that.nodeset.ui.addClass('input-group').prepend($('<span class="input-group-addon">Nodeset</span>'));
-                            that.relevant.ui.addClass('input-group').prepend($('<span class="input-group-addon">Display Condition</span>'));
-                        }, 0);
+                        that.header.ui.find("input[type='text']").attr("placeholder", gettext("Tab Name"));
+                        that.nodeset.ui.find("input[type='text']").attr("placeholder", gettext("Nodeset"));
+                        that.relevant.ui.find("input[type='text']").attr("placeholder", gettext("Display Condition"));
 
                         // Observe nodeset values for the sake of validation
                         if (that.hasNodeset) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_properties.html
@@ -88,7 +88,8 @@
                         </td>
                         <td class="col-sm-3 form-group" data-bind="css: {'has-error': showWarning}"></td>
                         {% else %}
-                        <td class="col-sm-8" colspan="3" data-bind="jqueryElement: header.ui"></td>
+                        <td class="col-sm-3" data-bind="jqueryElement: header.ui"></td>
+                        <td class="col-sm-5" colspan="2"></td>
                         {% endif %}
                     <!--/ko-->
                 <!--/ko-->


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-254

The language code was hidden beneath the input, because bootstrap's `.input-group` styling sets z-index and doesn't expect additional child elements. Z-index being the fragile mess that it is, I decided to get rid of the input-group and instead use placeholders for the labels...which does mean the labels no longer persist. @dimagi/product I think that tradeoff is all right, but let me know if you disagree. Tab config could use design attention; it gets pretty funny-looking when you also add in nodesets and display conditions, but both of those are currently feature flags so I'm not worrying hard about them.

before
<img width="1024" alt="screen shot 2019-01-02 at 7 13 11 pm" src="https://user-images.githubusercontent.com/1486591/50618687-86d41100-0ec2-11e9-9f09-1d4071548a7f.png">

after
<img width="1023" alt="screen shot 2019-01-02 at 7 11 49 pm" src="https://user-images.githubusercontent.com/1486591/50618690-8a679800-0ec2-11e9-86a1-e2725e77a367.png">

@emord 