### PR TITLE
Fix bug preventing printing and allow for correct styles to be applie…

### DIFF
--- a/custom/icds_reports/static/css/icds_dashboard.css
+++ b/custom/icds_reports/static/css/icds_dashboard.css
@@ -288,11 +288,13 @@ nvd3#sectorChart > div.title.h4 {
 
 .report-content {
     color: #ffffff !important;
+}
+
+.report-content-without-message {
     padding: 20px 20px 80px;
 }
 
 .report-content-with-message {
-    color: #ffffff !important;
     padding: 20px 20px 160px;
 }
 

--- a/custom/icds_reports/static/js/directives/print/print.directive.js
+++ b/custom/icds_reports/static/js/directives/print/print.directive.js
@@ -19,8 +19,9 @@ function PrintReportController() {
             head_copy.innerHTML +
             '<body style="width: 1100px !important;" onload="window.print()">' +
             reportMetaData +
+            "<div class='report-content'>" +
             innerContents +
-            '</body>'
+            '</div></body>'
         );
         popupWindow.document.close();
     };

--- a/custom/icds_reports/templates/icds_reports/icds_app/system-usage.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/system-usage.directive.html
@@ -16,7 +16,10 @@
             <filters filters="$ctrl.filters" data="$ctrl.filtersData" selected-locations="$ctrl.selectedLocations"></filters>
         </div>
     </div>
-    <div class="{$ $ctrl.label === 'Program Summary' && $ctrl.showSystemUsageMessage ? 'report-content-with-message' : 'report-content' $}">
+    <div class="
+        {$ $ctrl.label === 'Program Summary' ? 'report-content' : '' $}
+        {$ $ctrl.showSystemUsageMessage ? 'report-content-with-message' : 'report-content-without-message' $}
+    ">
         <kpi data="$ctrl.data"></kpi>
     </div>
     <div class="row fixed-dots">


### PR DESCRIPTION
…d to printed version
Hi @calellowitz,
this PR fixed bug that prevented system usage (program summary) to be printed.
In print.directive.js we use
`var innerContents = document.getElementsByClassName('report-content')[0].innerHTML;`
and during changes to the position of diclaimer I had added case in which we disclaimer was shown there was only `report-content-with-message` class and no `report-content`.
Second change - adding div with `report-content` in print.directive.js allows for rendering correct colours for KPIs.
Regards, Dawid