### PR TITLE
toggle to hide mobile ux

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/mobile_ux_warning.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/mobile_ux_warning.html
@@ -11,7 +11,7 @@
       <div class="modal-body">
         <p class="mobile-ux-lead">
           {% blocktrans %}
-              Hi {{ full_name }}, it looks like you’re on a mobile device.
+              Hi{{ " " + full_name }}, it looks like you’re on a mobile device.
           {% endblocktrans %}
         </p>
         <p class="mobile-ux-lead">

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1687,3 +1687,11 @@ RELEASE_BUILDS_PER_PROFILE = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )
+
+
+HIDE_HQ_ON_MOBILE_EXPERIENCE = StaticToggle(
+    'hide_hq_on_mobile_experience',
+    'Do not show modal on mobile that mobile hq experience is bad',
+    TAG_PRODUCT,
+    namespaces=[NAMESPACE_DOMAIN]
+)

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -66,7 +66,6 @@ def get_per_domain_context(project, request=None):
 
 def domain(request):
     """Global per-domain context variables"""
-
     project = getattr(request, 'project', None)
     return get_per_domain_context(project, request=request)
 
@@ -165,18 +164,26 @@ def mobile_experience(request):
             hasattr(request, 'user_agent') and
             settings.SERVER_ENVIRONMENT in ['production', 'staging', 'localdev']):
         mobile_ux_cookie_name = '{}-has-seen-mobile-ux-warning'.format(request.couch_user.get_id)
-        from corehq import toggles
         show_mobile_ux_warning = (
             not request.COOKIES.get(mobile_ux_cookie_name) and
             request.user_agent.is_mobile and
             request.user.is_authenticated and
             request.user.is_active and
-            not toggles.HIDE_HQ_ON_MOBILE_EXPERIENCE.enabled(request.domain, toggles.NAMESPACE_DOMAIN)
+            not mobile_experience_hidden_by_toggle(request)
         )
     return {
         'show_mobile_ux_warning': show_mobile_ux_warning,
         'mobile_ux_cookie_name': mobile_ux_cookie_name,
     }
+
+
+def mobile_experience_hidden_by_toggle(request):
+    from corehq import toggles
+    user = request.couch_user
+    for project in user.domains:
+        if toggles.HIDE_HQ_ON_MOBILE_EXPERIENCE.enabled(project, toggles.NAMESPACE_DOMAIN):
+            return True
+    return False
 
 
 def get_demo(request):

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -161,18 +161,17 @@ def commcare_hq_names(request):
 def mobile_experience(request):
     show_mobile_ux_warning = False
     mobile_ux_cookie_name = ''
-    if (hasattr(request, 'couch_user')
-        and hasattr(request, 'user_agent')
-        and (settings.SERVER_ENVIRONMENT
-             in ['production', 'staging', 'localdev'])):
+    if (hasattr(request, 'couch_user') and
+            hasattr(request, 'user_agent') and
+            settings.SERVER_ENVIRONMENT in ['production', 'staging', 'localdev']):
         mobile_ux_cookie_name = '{}-has-seen-mobile-ux-warning'.format(request.couch_user.get_id)
         from corehq import toggles
         show_mobile_ux_warning = (
-            not request.COOKIES.get(mobile_ux_cookie_name)
-            and request.user_agent.is_mobile
-            and request.user.is_authenticated
-            and request.user.is_active
-            and not toggles.HIDE_HQ_ON_MOBILE_EXPERIENCE.enabled(request.domain, toggles.NAMESPACE_DOMAIN)
+            not request.COOKIES.get(mobile_ux_cookie_name) and
+            request.user_agent.is_mobile and
+            request.user.is_authenticated and
+            request.user.is_active and
+            not toggles.HIDE_HQ_ON_MOBILE_EXPERIENCE.enabled(request.domain, toggles.NAMESPACE_DOMAIN)
         )
     return {
         'show_mobile_ux_warning': show_mobile_ux_warning,

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -166,11 +166,13 @@ def mobile_experience(request):
         and (settings.SERVER_ENVIRONMENT
              in ['production', 'staging', 'localdev'])):
         mobile_ux_cookie_name = '{}-has-seen-mobile-ux-warning'.format(request.couch_user.get_id)
+        from corehq import toggles
         show_mobile_ux_warning = (
             not request.COOKIES.get(mobile_ux_cookie_name)
             and request.user_agent.is_mobile
             and request.user.is_authenticated
             and request.user.is_active
+            and not toggles.HIDE_HQ_ON_MOBILE_EXPERIENCE.enabled(request.domain, toggles.NAMESPACE_DOMAIN)
         )
     return {
         'show_mobile_ux_warning': show_mobile_ux_warning,


### PR DESCRIPTION
PlusCare wants to not have this page show up since a bunch of their users will be using webapps apparently.

flag is `hide_hq_on_mobile_experience` to hide the modal.

@orangejenny @biyeun buddy: @snopoke 