### PR TITLE
Upgrade python cloudant lib

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -28,7 +28,7 @@ certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 click==7.0                # via pip-tools
-cloudant==2.7.0
+cloudant==2.10.2
 colorama==0.4.1           # via sniffer
 concurrentloghandler==0.9.1
 contextlib2==0.5.4

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -20,7 +20,7 @@ celery==3.1.25
 certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
-cloudant==2.7.0
+cloudant==2.10.2
 concurrentloghandler==0.9.1
 contextlib2==0.5.4
 cryptography==2.4.2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -21,7 +21,7 @@ celery==3.1.25
 certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
-cloudant==2.7.0
+cloudant==2.10.2
 concurrentloghandler==0.9.1
 contextlib2==0.5.4
 cryptography==2.4.2

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,8 +1,8 @@
 attrs==18.1.0
 iso8601==0.1.12
-jsonobject==0.9.8
-jsonobject-couchdbkit==0.9.15
-cloudant==2.7.0  # Remove after version is released containg bugfix https://github.com/cloudant/python-cloudant/pull/415
+jsonobject>=0.9.8
+jsonobject-couchdbkit>=0.9.15
+cloudant>=2.10.2
 celery==3.1.25
 # required by django-digest
 decorator==4.0.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ celery==3.1.25
 certifi==2018.11.29       # via requests
 cffi==1.11.5              # via cryptography, csiphash
 chardet==3.0.4            # via ghdiff, requests
-cloudant==2.7.0
+cloudant==2.10.2
 concurrentloghandler==0.9.1
 contextlib2==0.5.4
 cryptography==2.4.2       # via pyopenssl, requests

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -22,7 +22,7 @@ celery==3.1.25
 certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
-cloudant==2.7.0
+cloudant==2.10.2
 concurrentloghandler==0.9.1
 contextlib2==0.5.4
 coverage==4.5.1


### PR DESCRIPTION
and unpin couchdbkit and jsonobject

@emord this is a followup to https://github.com/dimagi/commcare-hq/pull/22673 which we had to roll back because of the bug in cloudant 2.10.1. `jsonobject-couchdbkit` and `jsonobject` have since been updated, but I thought I'd unpin them, as well as upgrading to the new cloudant version.

I forget if there was a particular reason for upgrading the cloudant lib version, so let me know if you think this change isn't helpful / necessary. I just had left myself a note to follow up on it.