### PR TITLE
quickcache the thing that's very slow

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1820,7 +1820,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             django_user.delete()
         self.save()
 
-    @quickcache(['self._id'], skip_arg=lambda user: user.domain != 'reach-sandbox')
+    @quickcache(['self._id'], skip_arg=lambda user: user.domain != 'reach-sandbox', timeout=60 * 60 * 4)
     def get_case_sharing_groups(self):
         from corehq.apps.groups.models import Group
         # get faked location group objects

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1820,6 +1820,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             django_user.delete()
         self.save()
 
+    @quickcache(['self._id'], skip_arg=lambda user: user.domain != 'reach-sandbox')
     def get_case_sharing_groups(self):
         from corehq.apps.groups.models import Group
         # get faked location group objects

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1820,6 +1820,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             django_user.delete()
         self.save()
 
+    # Todo; temporary fix: Sravan
     @quickcache(['self._id'], skip_arg=lambda user: user.domain != 'reach-sandbox', timeout=60 * 60 * 4)
     def get_case_sharing_groups(self):
         from corehq.apps.groups.models import Group


### PR DESCRIPTION

The underlying slowness is in getting sql_location.get_descendents [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/locations/models.py#L632). But taking this temporary measure as REACH has a very urgent demo and I don't have a better solution for them.

This is a temporary fix, will address this for real separately.

@snopoke 