### PR TITLE
Re-apply "Upgrade select2 on form view"

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -61,54 +61,51 @@
                 $(element).parent().addClass('has-error');
             }
 
-            _.delay(function () {
-                // Initialize select2
-                var options = {
-                        placeholder: gettext('Select a Question'),
-                        dropdownCssClass: 'bigdrop',
-                    },
-                    data = _(optionObjects).map(function (o) {
-                        return _.extend(o, {
-                            id: o.value,
-                            text: utils.getDisplay(o),
-                        });
-                    }),
-                    templateSelection = function (o) {
-                        if (!o.id) {
-                            // This is the placeholder
-                            return o.text;
-                        }
-                        return utils.getTruncatedDisplay(o);
-                    },
-                    templateResult = function (o) {
-                        if (!o.value) {
-                            // This is some select2 system option, like 'Searching...' text
-                            return o.text;
-                        }
-                        return utils.getTruncatedDisplay(o, 90);
-                    };
-                // Imperfect way to determine whether we're looking at select2 v3 or v4
-                // v4 must use a <select>; v3 can but usually uses an <input>
-                // Right now userreports are the only v3 usage of this binding, and they're all <input>
-                if (element.nodeName.toLowerCase() === 'select') {
-                    options = _.extend(options, {
-                        escapeMarkup: function (m) { return m; },
-                        width: '100%',
-                        data: [{id: '', text: ''}].concat(data),    // prepend option for placeholder
-                        templateSelection: templateSelection,
-                        templateResult: templateResult,
+            // Initialize select2
+            var options = {
+                    placeholder: gettext('Select a Question'),
+                    dropdownCssClass: 'bigdrop',
+                },
+                data = _(optionObjects).map(function (o) {
+                    return _.extend(o, {
+                        id: o.value,
+                        text: utils.getDisplay(o),
                     });
-                } else {
-                    options = _.extend(options, {
-                        data: { results: data },
-                        formatSelection: templateSelection,
-                        formatResult: templateResult,
-                    });
-                }
-                $(element).select2(options);
-                $(element).val(value).trigger('change.select2');
-            });
-            allBindings.optstrText = utils.getLabel;
+                }),
+                templateSelection = function (o) {
+                    if (!o.id) {
+                        // This is the placeholder
+                        return o.text;
+                    }
+                    return utils.getTruncatedDisplay(o);
+                },
+                templateResult = function (o) {
+                    if (!o.value) {
+                        // This is some select2 system option, like 'Searching...' text
+                        return o.text;
+                    }
+                    return utils.getTruncatedDisplay(o, 90);
+                };
+            // Imperfect way to determine whether we're looking at select2 v3 or v4
+            // v4 must use a <select>; v3 can but usually uses an <input>
+            // Right now userreports are the only v3 usage of this binding, and they're all <input>
+            if (element.nodeName.toLowerCase() === 'select') {
+                options = _.extend(options, {
+                    escapeMarkup: function (m) { return m; },
+                    width: '100%',
+                    data: [{id: '', text: ''}].concat(data),    // prepend option for placeholder
+                    templateSelection: templateSelection,
+                    templateResult: templateResult,
+                });
+            } else {
+                options = _.extend(options, {
+                    data: { results: data },
+                    formatSelection: templateSelection,
+                    formatResult: templateResult,
+                });
+            }
+            $(element).select2(options);
+            $(element).val(value).trigger('change.select2');
         },
         update: function (element, valueAccessor, allBindingsAccessor) {
             var optionObjects = ko.utils.unwrapObservable(valueAccessor()),

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -123,7 +123,7 @@
                     if (option.value && !_.contains(allowedValues, option.value)) {
                         $(option).remove();
                     }
-                })
+                });
                 $element.trigger('change.select2');
             }
         },

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -50,19 +50,19 @@
                 return option.value === value;
             })) {
                 var option = {
-                    label: 'Unidentified Question (' + value + ')',
+                    label: gettext('Unidentified Question') + ' (' + value + ')',
                     value: value,
                 };
                 optionObjects = [option].concat(optionObjects);
-                $warning.show().text('We cannot find this question in the allowed questions for this field. ' +
+                $warning.show().text(gettext('We cannot find this question in the allowed questions for this field. ' +
                     'It is likely that you deleted or renamed the question. ' +
-                    'Please choose a valid question from the dropdown.');
+                    'Please choose a valid question from the dropdown.'));
             } else {
                 $warning.hide();
             }
             _.delay(function () {
                 $(element).select2({
-                    placeholder: 'Select a Question',
+                    placeholder: gettext('Select a Question'),
                     data: {
                         results: _(optionObjects).map(function (o) {
                             return {id: o.value, text: utils.getDisplay(o), question: o};

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_knockout_bindings.js
@@ -61,21 +61,51 @@
                 $warning.hide();
             }
             _.delay(function () {
-                $(element).select2({
-                    placeholder: gettext('Select a Question'),
-                    data: {
-                        results: _(optionObjects).map(function (o) {
-                            return {id: o.value, text: utils.getDisplay(o), question: o};
-                        }),
+                // Initialize select2
+                var options = {
+                        placeholder: gettext('Select a Question'),
+                        dropdownCssClass: 'bigdrop',
                     },
-                    formatSelection: function (o) {
-                        return utils.getTruncatedDisplay(o.question);
+                    data = _(optionObjects).map(function (o) {
+                        return _.extend(o, {
+                            id: o.value,
+                            text: utils.getDisplay(o),
+                        });
+                    }),
+                    templateSelection = function (o) {
+                        if (!o.id) {
+                            // This is the placeholder
+                            return o.text;
+                        }
+                        return utils.getTruncatedDisplay(o);
                     },
-                    formatResult: function (o) {
-                        return utils.getTruncatedDisplay(o.question, 90);
-                    },
-                    dropdownCssClass: 'bigdrop',
-                });
+                    templateResult = function (o) {
+                        if (!o.value) {
+                            // This is some select2 system option, like 'Searching...' text
+                            return o.text;
+                        }
+                        return utils.getTruncatedDisplay(o, 90);
+                    };
+                // Imperfect way to determine whether we're looking at select2 v3 or v4
+                // v4 must use a <select>; v3 can but usually uses an <input>
+                // Right now userreports are the only v3 usage of this binding, and they're all <input>
+                if (element.nodeName.toLowerCase() === 'select') {
+                    options = _.extend(options, {
+                        escapeMarkup: function (m) { return m; },
+                        width: '100%',
+                        data: [{id: '', text: ''}].concat(data),    // prepend option for placeholder
+                        templateSelection: templateSelection,
+                        templateResult: templateResult,
+                    });
+                } else {
+                    options = _.extend(options, {
+                        data: { results: data },
+                        formatSelection: templateSelection,
+                        formatResult: templateResult,
+                    });
+                }
+                $(element).select2(options);
+                $(element).val(value).trigger('change.select2');
             });
             allBindings.optstrText = utils.getLabel;
         },

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_advanced.html
@@ -144,11 +144,11 @@
                                                        value: relationship"></select>
                                     <br />
                                     <div data-bind="visible: relationship() === 'question'">
-                                        <input type="hidden" data-bind="
+                                        <select data-bind="
                                             questionsSelect: $root.getQuestions('all', false, false),
                                             value: relationship_question,
                                             optionsCaption: ' ',
-                                        "/>
+                                        "></select>
                                     </div>
                                     <br />
                                     <button class="btn btn-danger" data-bind="click: $parent.removeCaseIndex">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -16,7 +16,6 @@
             <select class="form-control" data-bind="
                 questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
                 value: question,
-                optionsCaption: ' '
             "></select>
         </div>
         <div class="col-sm-2">
@@ -46,14 +45,9 @@
 </script>
 
 <script type="text/html" id="case-config:case-properties:question">
-    <!--
-        This would normally use .form-control, but it's going to become a select2,
-        which adds wonky height & borders on Firefox when it uses .form-control
-    -->
-    <select data-bind="
+    <select class="form-control" data-bind="
         questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
         value: path,
-        optionsCaption: ' ',
         event: { change: function(view, e) {
             if (e.target.closest('#case-config-ko')) {
                 var action = e.target.closest('.case-preload') ? 'Load' : 'Save';

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -27,13 +27,18 @@
                     ],
                     value: operator"></select>
         </div>
-        <div class="col-sm-4" data-bind="visible: $root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
-            <select class="form-control" data-bind="
-                optstr: $root.getAnswers({question: question()}),
-                value: answer"></select>
-        </div>
-        <div class="col-sm-4" data-bind="visible: !$root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
-            <input type="text" class="form-control" data-bind="value: answer"/>
+        <!-- Input for question's answer -->
+        <div class="col-sm-4" data-bind="visible: operator() != 'boolean_true'">
+            <!-- Select question: answer is a dropdown -->
+            <span data-bind="if: $root.getAnswers({question: question()}).length">
+                <select class="form-control" data-bind="
+                    optstr: $root.getAnswers({question: question()}),
+                    value: answer"></select>
+            </span>
+            <!-- Non-select question: answer is a text box -->
+            <span data-bind="if: !$root.getAnswers({question: question()}).length">
+                <input type="text" class="form-control" data-bind="value: answer"/>
+            </span>
         </div>
         <div class="col-sm-1">
             <a href="#" class="btn btn-default" data-bind="click: function () {type('always')}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -8,35 +8,39 @@
         <a href="#" class="btn btn-default" data-bind="click: function () {type('if')}"><i class="fa fa-plus"></i> {% trans "Only if the answer to..." %}</a>
     </div>
 
-    <div class="form-inline" data-bind="visible: type() === 'if'">
-        <a href="#" class="btn btn-default" data-bind="click: function () {type('always')}">
-            <i class="fa fa-remove"></i>
-        </a>
-        {% trans "Only if the answer to" %}
-        <!--
-            This would normally use .form-control, but it's going to become a select2,
-            which adds wonky height & borders on Firefox when it uses .form-control
-        -->
-        <select data-bind="
-            questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
-            value: question,
-            optionsCaption: ' '
-        "></select>
-        <select class="form-control" data-bind="
-                optstr: [
-                    {label:'{% trans "is" %}', value:'='},
-                    {label:'{% trans "has selected" %}', value:'selected'},
-                    {label:'{% trans "is true" %}', value:'boolean_true'}
-                ],
-                value: operator"></select>
-        <span data-bind="if: $root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
+    <div class="row" data-bind="visible: type() === 'if'">
+        <div class="col-sm-1">
+            {% trans "Only if the answer to" %}
+        </div>
+        <div class="col-sm-4">
+            <select class="form-control" data-bind="
+                questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
+                value: question,
+                optionsCaption: ' '
+            "></select>
+        </div>
+        <div class="col-sm-2">
+            <select class="form-control" data-bind="
+                    optstr: [
+                        {label:'{% trans "is" %}', value:'='},
+                        {label:'{% trans "has selected" %}', value:'selected'},
+                        {label:'{% trans "is true" %}', value:'boolean_true'}
+                    ],
+                    value: operator"></select>
+        </div>
+        <div class="col-sm-4" data-bind="visible: $root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
             <select class="form-control" data-bind="
                 optstr: $root.getAnswers({question: question()}),
                 value: answer"></select>
-        </span>
-        <span data-bind="if: !$root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
+        </div>
+        <div class="col-sm-4" data-bind="visible: !$root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
             <input type="text" class="form-control" data-bind="value: answer"/>
-        </span>
+        </div>
+        <div class="col-sm-1">
+            <a href="#" class="btn btn-default" data-bind="click: function () {type('always')}">
+                <i class="fa fa-remove"></i>
+            </a>
+        </div>
     </div>
     <!--/ko-->
 </script>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -17,11 +17,11 @@
             This would normally use .form-control, but it's going to become a select2,
             which adds wonky height & borders on Firefox when it uses .form-control
         -->
-        <input type="hidden" data-bind="
+        <select data-bind="
             questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
             value: question,
             optionsCaption: ' '
-        "/>
+        "></select>
         <select class="form-control" data-bind="
                 optstr: [
                     {label:'{% trans "is" %}', value:'='},
@@ -46,7 +46,7 @@
         This would normally use .form-control, but it's going to become a select2,
         which adds wonky height & borders on Firefox when it uses .form-control
     -->
-    <input type="hidden" data-bind="
+    <select data-bind="
         questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
         value: path,
         optionsCaption: ' ',
@@ -56,7 +56,7 @@
                 hqImport('analytix/js/google').track.event('Case Management', 'Form Level', action + ' Property (add/edit)');
             }
         } }
-    "/>
+    "></select>
     <p class="help-block" data-bind="visible: required() && !path()">{% trans "Required" %}</p>
     <p class="help-block" data-bind="visible: !required() && !path() && key()">{% trans "Not assigned" %}</p>
 </script>

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -727,7 +727,6 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         ],
         'can_preview_form': request.couch_user.has_permission(domain, 'edit_data'),
         'form_icon': None,
-        'legacy_select2': True,
     }
 
     if toggles.CUSTOM_ICON_BADGES.enabled(domain):


### PR DESCRIPTION
First 9 commits just re-apply https://github.com/dimagi/commcare-hq/pull/22874/  Last commit fixes bug where the answer inputs in case open conditions weren't being populated.

I was focused on testing the select2s and didn't realize I'd broken a different input by switching some `if` bindings (which remove the element's contents from the document if the condition is false) to `visible` (which just hides the element and its contents if false).

@esoergel / @emord 