### PR TITLE
Catch columns greater than 256 at last minute

### DIFF
--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -135,8 +135,8 @@ class Excel2003ExportWriterTests(SimpleTestCase):
         format_ = Format.XLS
         file_ = io.BytesIO()
         table = [
-            ['header{}'.format(i) for i in range(MAX_XLS_COLUMNS)],
-            ['row{}'.format(i) for i in range(MAX_XLS_COLUMNS)],
+            ['header{}'.format(i) for i in range(MAX_XLS_COLUMNS + 1)],
+            ['row{}'.format(i) for i in range(MAX_XLS_COLUMNS + 1)],
         ]
         tables = [['title', table]]
 
@@ -144,8 +144,8 @@ class Excel2003ExportWriterTests(SimpleTestCase):
             export_from_tables(tables, file_, format_)
 
         table = [
-            ['header{}'.format(i) for i in range(MAX_XLS_COLUMNS - 1)],
-            ['row{}'.format(i) for i in range(MAX_XLS_COLUMNS - 1)],
+            ['header{}'.format(i) for i in range(MAX_XLS_COLUMNS)],
+            ['row{}'.format(i) for i in range(MAX_XLS_COLUMNS)],
         ]
         tables = [['title', table]]
         export_from_tables(tables, file_, format_)

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -444,11 +444,10 @@ class Excel2003ExportWriter(ExportWriter):
         row_index = self.table_indices[sheet_index]
         sheet = self.tables[sheet_index]
 
-        if hasattr(row, 'data') and len(row.data) >= MAX_XLS_COLUMNS:
-            raise XlsLengthException
-
         # have to deal with primary ids
         for i, val in enumerate(row):
+            if i >= MAX_XLS_COLUMNS:
+                raise XlsLengthException
             sheet.write(row_index, i, six.text_type(val))
         self.table_indices[sheet_index] = row_index + 1
 


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/836150499/
https://dimagi-dev.atlassian.net/browse/HI-266

`row` is sometimes a `FormattedRow`, sometimes just a list.  Rather than anticipating the failure, just catch it when it happens.

Note also that the old behavior failed at 256 columns. The xls library failure occurs when the column index is 256 (counting from zero). This commit changes the check to fail at column index 256 (ie the 257th column).