### PR TITLE
Fix SQL migration script to work on proxy

### DIFF
--- a/corehq/blobs/sql_templates/drop_blobmeta_view.sql
+++ b/corehq/blobs/sql_templates/drop_blobmeta_view.sql
@@ -1,4 +1,35 @@
+-- Re-create function so it works on the proxy as well as shards
+-- which have differing function definitions. For some reason this
+-- is necessary, but possibly only on the proxy?
+
+-- temporary function to evaluate a string -> create function
+create function tmp_eval(expression text) returns void as
+$body$
+declare
+  result integer;
+begin
+  execute expression;
+end;
+$body$ language plpgsql;
+
+-- temporary table holding get_blobmetas source
+CREATE TEMPORARY TABLE temp_func_src(src TEXT);
+INSERT INTO temp_func_src (src)
+SELECT routine_definition
+FROM information_schema.routines
+WHERE specific_schema = 'public' AND routine_name = 'get_blobmetas';
+
+-- do the stuff
 DROP TRIGGER blobs_blobmeta_trigger ON blobs_blobmeta;
 DROP FUNCTION mutate_blobs_blobmeta();
+DROP FUNCTION get_blobmetas(TEXT[], SMALLINT);
 DROP VIEW blobs_blobmeta;
 ALTER TABLE blobs_blobmeta_tbl RENAME TO blobs_blobmeta;
+
+-- re-create get_blobmetas function
+SELECT tmp_eval(
+    'CREATE OR REPLACE FUNCTION get_blobmetas(parent_ids TEXT[], '
+    || 'type_code_ SMALLINT) RETURNS SETOF blobs_blobmeta AS $func$ '
+    || src || ' $func$ LANGUAGE plproxy'
+)
+FROM temp_func_src;


### PR DESCRIPTION
Not sure why this didn't fail in tests, but it did during deployment (applying migrations) on production environments.

@dannyroberts @calellowitz @esoergel 