### PR TITLE
Fix missing media attachments in exports

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2327,7 +2327,9 @@ class MultiMediaExportColumn(ExportColumn):
     def get_value(self, domain, doc_id, doc, base_path, transform_dates=False, **kwargs):
         value = super(MultiMediaExportColumn, self).get_value(domain, doc_id, doc, base_path, **kwargs)
 
-        if not value or value == MISSING_VALUE:
+        if (not value
+                or value == MISSING_VALUE
+                or value not in doc.get('external_blobs', {})):
             return value
 
         download_url = absolute_reverse('api_form_attachment', args=(domain, doc_id, value))

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -359,25 +359,39 @@ class TestMultiMediaExportColumn(SimpleTestCase):
     )
 
     def test_get_value(self):
-        result = self.column.get_value('my-domain', '1234', {'photo': '1234.jpg'}, [PathNode(name='form')])
+        doc = {'external_blobs': {'1234.jpg': {}},
+               'photo': '1234.jpg'}
+        result = self.column.get_value('my-domain', '1234', doc, [PathNode(name='form')])
         self.assertEqual(
             result,
             absolute_reverse('api_form_attachment', args=('my-domain', '1234', '1234.jpg'))
         )
 
     def test_missing_value(self):
-        result = self.column.get_value('my-domain', '1234', {'photo': None}, [PathNode(name='form')])
+        doc = {'external_blobs': {},
+               'photo': None}
+        result = self.column.get_value('my-domain', '1234', doc, [PathNode(name='form')])
         self.assertEqual(result, MISSING_VALUE)
 
     def test_empty_string(self):
-        result = self.column.get_value('my-domain', '1234', {'photo': ''}, [PathNode(name='form')])
+        doc = {'external_blobs': {},
+               'photo': ''}
+        result = self.column.get_value('my-domain', '1234', doc, [PathNode(name='form')])
         self.assertEqual(result, '')
 
+    def test_mismatched_value_type(self):
+        doc = {'external_blobs': {},
+               'photo': "this clearly isn't a photo"}
+        result = self.column.get_value('my-domain', "this clearly isn't a photo", doc, [PathNode(name='form')])
+        self.assertEqual(result, "this clearly isn't a photo")
+
     def test_get_value_excel_format(self):
+        doc = {'external_blobs': {'1234.jpg': {}},
+               'photo': '1234.jpg'}
         result = self.column.get_value(
             'my-domain',
             '1234',
-            {'photo': '1234.jpg'},
+            doc,
             [PathNode(name='form')],
             transform_dates=True,
         )

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -352,33 +352,29 @@ class TestSplitExportColumn(SimpleTestCase):
 
 
 class TestMultiMediaExportColumn(SimpleTestCase):
+    column = MultiMediaExportColumn(
+        item=MultiMediaItem(
+            path=[PathNode(name='form'), PathNode(name='photo')],
+        ),
+    )
 
     def test_get_value(self):
-        column = MultiMediaExportColumn(
-            item=MultiMediaItem(
-                path=[PathNode(name='form'), PathNode(name='photo')],
-            ),
-        )
-
-        result = column.get_value('my-domain', '1234', {'photo': '1234.jpg'}, [PathNode(name='form')])
+        result = self.column.get_value('my-domain', '1234', {'photo': '1234.jpg'}, [PathNode(name='form')])
         self.assertEqual(
             result,
             absolute_reverse('api_form_attachment', args=('my-domain', '1234', '1234.jpg'))
         )
-        result = column.get_value('my-domain', '1234', {'photo': None}, [PathNode(name='form')])
+
+    def test_missing_value(self):
+        result = self.column.get_value('my-domain', '1234', {'photo': None}, [PathNode(name='form')])
         self.assertEqual(result, MISSING_VALUE)
 
-        result = column.get_value('my-domain', '1234', {'photo': ''}, [PathNode(name='form')])
+    def test_empty_string(self):
+        result = self.column.get_value('my-domain', '1234', {'photo': ''}, [PathNode(name='form')])
         self.assertEqual(result, '')
 
     def test_get_value_excel_format(self):
-        column = MultiMediaExportColumn(
-            item=MultiMediaItem(
-                path=[PathNode(name='form'), PathNode(name='photo')],
-            ),
-        )
-
-        result = column.get_value(
+        result = self.column.get_value(
             'my-domain',
             '1234',
             {'photo': '1234.jpg'},


### PR DESCRIPTION
Explanation here: https://dimagi-dev.atlassian.net/browse/HI-266?focusedCommentId=12383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-12383

If a question changes from multimedia to something else, then the URL lookup may fail.  This was causing exports with such forms to fail entirely.  Since we have access to the doc, we can actually inspect whether the value is an attachment on the doc.