### PR TITLE
[icds] change a year when we load data for the previous month in the first days in January

### DIFF
--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -259,8 +259,9 @@ class BaseReportView(View):
         year = int(request.GET.get('year', now.year))
 
         if (now.day == 1 or now.day == 2) and now.month == month and now.year == year:
-            month = (now - relativedelta(months=1)).month
-            year = now.year
+            prev_month = now - relativedelta(months=1)
+            month = prev_month.month
+            year = prev_month.year
 
         include_test = request.GET.get('include_test', False)
         domain = self.kwargs['domain']


### PR DESCRIPTION
Hi @calellowitz, @Rohit25negi 

I found a bug when we load data for the past month when is 1st or 2nd January. We changing the month but a year is not changed.

Please let me know if you have any questions.

Regards,
Łukasz