### PR TITLE
Retry on 'Connection aborted.', BadStatusLine("''",)

### DIFF
--- a/corehq/util/pagination.py
+++ b/corehq/util/pagination.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import hashlib
+import time
 from datetime import datetime
 
 from couchdbkit import ResourceNotFound
 from jsonobject.properties import ListProperty, BooleanProperty, JsonArray, JsonSet, JsonDict
+from requests.exceptions import ConnectionError
 
 from dimagi.ext.jsonobject import JsonObject, StringProperty, DateTimeProperty, DictProperty
 from dimagi.utils.couch.database import get_db
@@ -291,7 +293,15 @@ class ResumableFunctionIterator(object):
     def _save_state(self):
         self.state.timestamp = datetime.utcnow()
         state_json = self.state.to_json()
-        self.couch_db.save_doc(state_json)
+        for x in range(5):
+            try:
+                self.couch_db.save_doc(state_json)
+            except ConnectionError as err:
+                if x < 4 and "BadStatusLine(\"''\",)" in repr(err):
+                    time.sleep(x)
+                    continue
+                raise
+            break
         self._state = ResumableIteratorState(state_json)
 
     def discard_state(self):


### PR DESCRIPTION
This is happening too frequently during the Riak to S3 migration, so I'm doing this hacky workaround. This is the most common place where the error occurs, although maybe not the only place?

@dannyroberts @mkangia 