### PR TITLE
Hide new excel fromat for aww performance report behind feature flag

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -676,7 +676,7 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
             block_id=location,
             aggregation_level=3
         ).first()
-        if file_format == 'xlsx':
+        if file_format == 'xlsx' and beta:
             cache_key = create_aww_performance_excel_file(
                 excel_data,
                 data_type,


### PR DESCRIPTION
Hi @calellowitz,
This change puts new aww performance report excel formatting behind a feature flag.
Previously lines 675-690 were not existing and that meant that it always landed in `cache_key = create_excel_file(excel_data, data_type, file_format)` line, now it is not the case only when the format is 'xlsx' AND beta (`ICDS_DASHBOARD_REPORT_FEATURES` / ICDS: Enable access to the features in the ICDS Dashboard reports) flag is active.
Regards, Dawid