### PR TITLE
Fix report padding

### DIFF
--- a/custom/icds_reports/templates/icds_reports/icds_app/awc-opened-yesterday.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/awc-opened-yesterday.directive.html
@@ -19,7 +19,7 @@
             </div>
         </div>
     </div>
-    <div class="report-content">
+    <div class="report-content report-content-without-message">
         <div class="row" ng-if="$ctrl.step === 'map'">
             <div class="row">
                 <h2 class="dashboard-title">Percentage of AWCs Opened Yesterday</h2>

--- a/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
@@ -18,7 +18,7 @@
             <filters filters="$ctrl.filters" data="$ctrl.filtersData" selected-locations="$ctrl.selectedLocations" is-open-modal="$ctrl.message"></filters>
         </div>
     </div>
-    <div class="report-content">
+    <div class="report-content report-content-without-message">
         <div ng-if="$ctrl.data">
             <div class="row" ng-if="$ctrl.step === 'pse'">
                 <div class="row no-margin">

--- a/custom/icds_reports/templates/icds_reports/icds_app/cas-export.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/cas-export.directive.html
@@ -4,7 +4,7 @@
             <span class="breadcrump-element">Export CAS Data: </span>
         </div>
     </div>
-    <div class="report-content">
+    <div class="report-content report-content-without-message">
         <div class="alert alert-info" ng-show="!$ctrl.allFiltersSelected()">
             <strong>Info!</strong> Please select all filters!
         </div>

--- a/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
@@ -4,7 +4,7 @@
             <span class="breadcrump-element">Export Program Area Indicators: </span>
         </div>
     </div>
-    <div class="report-content">
+    <div class="report-content report-content-without-message">
         <div class="alert alert-info" ng-show="$ctrl.showWarning()">
             <strong>Info!</strong> "You are downloading data for the current calendar month. Data for this report is calculated using calendar months (for example, January 1st-January 31st). Data for this month will not be complete until the end of the month."
         </div>

--- a/custom/icds_reports/templates/icds_reports/icds_app/map-chart.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/map-chart.html
@@ -27,7 +27,7 @@
             <filters filters="$ctrl.filters" data="$ctrl.filtersData" selected-locations="$ctrl.selectedLocations"></filters>
         </div>
     </div>
-    <div class="report-content" >
+    <div class="report-content report-content-without-message" >
         <div ng-if="$ctrl.message" class="alert alert-info">
             <strong>Info!</strong> Data for this report is shown at the sector level. For AWC-level information, please use the AWC Report.
         </div>

--- a/custom/icds_reports/templates/icds_reports/icds_app/progress-report.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/progress-report.directive.html
@@ -21,7 +21,7 @@
             <filters filters="$ctrl.filters" data="$ctrl.filtersData" selected-locations="$ctrl.selectedLocations"></filters>
         </div>
     </div>
-    <div class="report-content">
+    <div class="report-content report-content-without-message">
         <div ng-if="$ctrl.data === void(0)">
             <h2>No Data</h2>
         </div>


### PR DESCRIPTION
Hi @calellowitz,
I have fixed padding of the report contents.
The issue came from the fact that while updating disclaimer I didn't want to use `!important` and removed from `report-content` CSS class padding and moved it to `report-content-without-message` and `report-content-with-message`.
Another way to do it is to remove `report-content-without-message` CSS class and add (revert) it's padding to `report-content`, yet that would result in `report-content-with-message` padding need of `!important` so because of that, I have chosen this option instead.
Regards, Dawid