### PR TITLE
Add case attachments feature flag

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -717,6 +717,15 @@ PRODUCTS_PER_LOCATION = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+ALLOW_CASE_ATTACHMENTS = StaticToggle(
+    'allow_case_attachments',
+    "Allow creation of case attachments. DO NOT ENABLE THIS FLAG. Case "
+    "attachments are slated for removal. This flag is to prevent new domains "
+    "from using the feature.",
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN]
+)
+
 ALLOW_CASE_ATTACHMENTS_VIEW = StaticToggle(
     'allow_case_attachments_view',
     "Explicitly allow user to access case attachments, even if they can't view the case list report.",


### PR DESCRIPTION
Create a new flag to gate creation of case attachments. I plan to enable this flag for domains that are currently using case attachments, and then push another PR to enforce it in the form processor.

@mkangia 