### PR TITLE
Removed ability to select attachment question in app manager

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case_config_utils.js
@@ -14,11 +14,16 @@ hqDefine('app_manager/js/case_config_utils', function () {
             if (!excludeTrigger) {
                 filter.push('trigger');
             }
+            var allowAttachments = hqImport('hqwebapp/js/toggles').toggleEnabled('MM_CASE_PROPERTIES');
             for (i = 0; i < questions.length; i += 1) {
                 q = questions[i];
                 if (filter[0] === "all" || filter.indexOf(q.tag) !== -1) {
-                    if ((includeRepeat || !q.repeat) && (!excludeTrigger || q.tag !== "trigger")) {
-                        options.push(q);
+                    if (includeRepeat || !q.repeat) {
+                        if (!excludeTrigger || q.tag !== "trigger") {
+                            if (allowAttachments || q.tag !== "upload") {
+                                options.push(q);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Part of https://dimagi-dev.atlassian.net/browse/HI-269

Prevents users from saving/loading multimedia questions as case properties unless they have [the flag](https://www.commcarehq.org/hq/flags/edit/mm_case_properties/) enabled. Domains that have been saving attachments as case properties but don't have that flag turned on will start seeing the invalid question error:
<img width="1034" alt="screen shot 2019-01-09 at 2 01 19 pm" src="https://user-images.githubusercontent.com/1486591/50921920-22abd280-1417-11e9-8efe-9eba8add0dca.png">


Also hides attachments from the dropdowns for case open/close conditions and the new conditional case index relationship.

@millerdev / @snopoke 
code buddy @esoergel 
fyi @dimagi/product 