### PR TITLE
Remove all Application wrapping from current app version checking

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -100,6 +100,12 @@ def get_latest_build_id(domain, app_id):
     return res['id'] if res else None
 
 
+def get_latest_build_version(domain, app_id):
+    """Get id of the latest build of the application, regardless of star."""
+    res = _get_latest_build_view(domain, app_id, include_docs=False)
+    return res['value']['version'] if res else None
+
+
 def get_build_doc_by_version(domain, app_id, version):
     from .models import Application
     res = Application.get_db().view(
@@ -117,6 +123,15 @@ def wrap_app(app_doc, wrap_cls=None):
     from corehq.apps.app_manager.util import get_correct_app_class
     cls = wrap_cls or get_correct_app_class(app_doc)
     return cls.wrap(app_doc)
+
+
+def get_current_app_version(domain, app_id):
+    from .models import Application
+    result = Application.get_db().view(
+        'app_manager/applications_brief',
+        key=[domain, app_id],
+    ).one(except_all=True)
+    return result['value']['version']
 
 
 def get_current_app_doc(domain, app_id):

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -42,8 +42,14 @@ from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
 from corehq.apps.users.permissions import can_manage_releases
 from corehq.util.timezones.utils import get_timezone_for_user
 
-from corehq.apps.app_manager.dbaccessors import get_app, get_latest_build_doc, get_latest_build_id, \
-    get_latest_released_app_version, get_built_app_ids_for_app_id
+from corehq.apps.app_manager.dbaccessors import (
+    get_app,
+    get_built_app_ids_for_app_id,
+    get_current_app_version,
+    get_latest_build_id,
+    get_latest_build_version,
+    get_latest_released_app_version,
+)
 from corehq.apps.app_manager.models import BuildProfile, LatestEnabledBuildProfiles
 from corehq.apps.app_manager.const import DEFAULT_FETCH_LIMIT
 from corehq.apps.users.models import CommCareUser
@@ -205,12 +211,12 @@ def current_app_version(request, domain, app_id):
     """
     Return current app version and the latest release
     """
-    app = get_app(domain, app_id)
-    latest_build = get_latest_build_doc(domain, app_id)
+    app_version = get_current_app_version(domain, app_id)
+    latest_build_version = get_latest_build_version(domain, app_id)
     latest_released_version = get_latest_released_app_version(domain, app_id)
     return json_response({
-        'currentVersion': app.version,
-        'latestBuild': latest_build['version'] if latest_build else None,
+        'currentVersion': app_version,
+        'latestBuild': latest_build_version,
         'latestReleasedBuild': latest_released_version if latest_released_version else None,
     })
 


### PR DESCRIPTION
@dannyroberts This may help with softlayer slowness. My gut feeling is that there are a lot of app builder pages open and the ICDS app is huge. This URL is hit every 10 seconds on every tab and attempts to wrap the app twice.

