### PR TITLE
Improve saved exports UI

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -2580,11 +2580,13 @@ class StockExportColumn(ExportColumn):
             return product_id
 
     def get_headers(self, **kwargs):
-        for product_id, section in self._column_tuples:
-            yield "{product} ({section})".format(
+        return [
+            "{product} ({section})".format(
                 product=self._get_product_name(product_id),
                 section=section
             )
+            for product_id, section in self._column_tuples
+        ]
 
     def get_value(self, domain, doc_id, doc, base_path, **kwargs):
         states = self.accessor.get_ledger_values_for_case(doc_id)

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -70,7 +70,7 @@ hqDefine("export/js/export_list", [
         self.pollProgressBar = function () {
             self.emailedExport.updatingData(false);
             self.emailedExport.taskStatus.percentComplete();
-            self.emailedExport.taskStatus.inProgress(true);
+            self.emailedExport.taskStatus.started(true);
             self.emailedExport.taskStatus.success(false);
             var tick = function () {
                 $.ajax({
@@ -83,12 +83,12 @@ hqDefine("export/js/export_list", [
                     },
                     success: function (data) {
                         self.emailedExport.taskStatus.percentComplete(data.taskStatus.percentComplete);
-                        self.emailedExport.taskStatus.inProgress(data.taskStatus.inProgress);
+                        self.emailedExport.taskStatus.started(data.taskStatus.started);
                         self.emailedExport.taskStatus.success(data.taskStatus.success);
                         self.emailedExport.taskStatus.justFinished(data.taskStatus.justFinished);
                         if (!data.taskStatus.success) {
                             // The first few ticks don't yet register the task
-                            self.emailedExport.taskStatus.inProgress(true);
+                            self.emailedExport.taskStatus.started(true);
                             setTimeout(tick, 1500);
                         } else {
                             self.emailedExport.taskStatus.justFinished(true);
@@ -175,7 +175,7 @@ hqDefine("export/js/export_list", [
         };
 
         _.each(self.exports, function (exp) {
-            if (exp.hasEmailedExport && exp.emailedExport.taskStatus && exp.emailedExport.taskStatus.inProgress()) {
+            if (exp.hasEmailedExport && exp.emailedExport.taskStatus && exp.emailedExport.taskStatus.started()) {
                 exp.pollProgressBar();
             }
         });

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -45,6 +45,10 @@ hqDefine("export/js/export_list", [
             }));
         }
 
+        self.justUpdated = ko.computed(function () {
+            return self.emailedExport.taskStatus.justFinished() && self.emailedExport.taskStatus.success();
+        });
+
         self.isLocationSafeForUser = function () {
             return !self.hasEmailedExport || self.emailedExport.isLocationSafeForUser();
         };
@@ -72,6 +76,7 @@ hqDefine("export/js/export_list", [
             self.emailedExport.taskStatus.percentComplete();
             self.emailedExport.taskStatus.started(true);
             self.emailedExport.taskStatus.success(false);
+            self.emailedExport.taskStatus.failed(false);
             var tick = function () {
                 $.ajax({
                     method: 'GET',
@@ -85,8 +90,9 @@ hqDefine("export/js/export_list", [
                         self.emailedExport.taskStatus.percentComplete(data.taskStatus.percentComplete);
                         self.emailedExport.taskStatus.started(data.taskStatus.started);
                         self.emailedExport.taskStatus.success(data.taskStatus.success);
+                        self.emailedExport.taskStatus.failed(data.taskStatus.failed);
                         self.emailedExport.taskStatus.justFinished(data.taskStatus.justFinished);
-                        if (!data.taskStatus.success) {
+                        if (!data.taskStatus.success & !data.taskStatus.failed) {
                             // The first few ticks don't yet register the task
                             self.emailedExport.taskStatus.started(true);
                             setTimeout(tick, 1500);

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -92,7 +92,7 @@ hqDefine("export/js/export_list", [
                         self.emailedExport.taskStatus.success(data.taskStatus.success);
                         self.emailedExport.taskStatus.failed(data.taskStatus.failed);
                         self.emailedExport.taskStatus.justFinished(data.taskStatus.justFinished);
-                        if (!data.taskStatus.success & !data.taskStatus.failed) {
+                        if (!data.taskStatus.success && !data.taskStatus.failed) {
                             // The first few ticks don't yet register the task
                             self.emailedExport.taskStatus.started(true);
                             setTimeout(tick, 1500);

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -89,7 +89,7 @@ def populate_export_download_task(export_instances, filters, download_id, filena
     email_requests.delete()
 
 
-@task(serializer='pickle', queue=SAVED_EXPORTS_QUEUE, ignore_result=True, acks_late=True)
+@task(serializer='pickle', queue=SAVED_EXPORTS_QUEUE, ignore_result=False, acks_late=True)
 def _start_export_task(export_instance_id):
     export_instance = get_properly_wrapped_export_instance(export_instance_id)
     rebuild_export(export_instance, progress_tracker=_start_export_task)

--- a/corehq/apps/export/templates/export/partials/export_list_create_export_modal.html
+++ b/corehq/apps/export/templates/export/partials/export_list_create_export_modal.html
@@ -20,7 +20,7 @@
                         <i class="fa fa-exclamation-triangle"></i>
                         <strong data-bind="text: drilldownSubmissionError"></strong>
                         <p>
-                            If this problem persists, please <a href="#modalReportIssue" data-toggle="modal">Report an Issue</a>.
+                            {% blocktrans %}If this problem persists, please <a href="#modalReportIssue" data-toggle="modal">Report an Issue</a>.{% endblocktrans %}
                         </p>
                     </div>
                     {% crispy create_export_form %}

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -104,11 +104,11 @@
                                 <span data-bind="text: emailedExport.fileData.size()"></span>
                                 &nbsp;&nbsp;&nbsp;
                                 <strong>{% trans "Last Updated:" %}</strong>
-                                <span data-bind="if: !emailedExport.taskStatus.justFinished()">
+                                <span data-bind="if: !justUpdated()">
                                     <span data-bind="text: emailedExport.fileData.lastUpdated()"></span>
                                     &nbsp;&nbsp;&nbsp;
                                 </span>
-                                <span data-bind="if: emailedExport.taskStatus.justFinished()">
+                                <span data-bind="if: justUpdated()">
                                     {% trans "Just now" %}&nbsp;&nbsp;&nbsp;
                                 </span>
                                 <strong>{% trans "Last Downloaded:" %}</strong>
@@ -188,10 +188,18 @@
                                     button and download the file.
                                 {% endblocktrans %}
                             </p>
-                            <p data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished()">
+
+                            <p class="text-success" data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.success()">
                                 <i class="fa fa-check"></i>
                                 <strong>{% trans "Data update complete" %}</strong>
                             </p>
+
+                            <p class="text-danger" data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.failed()">
+                                <i class="fa fa-exclamation-triangle"></i>
+                                <strong>{% trans "Data update failed!" %}</strong>
+                                {% blocktrans %}If this problem persists, please <a href="#modalReportIssue" data-toggle="modal">Report an Issue</a>.{% endblocktrans %}
+                            </p>
+
                         </div>
 
                         <div data-bind="if: isLocationSafeForUser">

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -125,7 +125,7 @@
                                 <button type="button"
                                         class="btn btn-default btn-xs"
                                         data-bind="
-                                            visible: !(emailedExport.updatingData() || emailedExport.taskStatus && emailedExport.taskStatus.inProgress()),
+                                            visible: !(emailedExport.updatingData() || emailedExport.taskStatus && emailedExport.taskStatus.started()),
                                             attr: {'data-target': '#modalRefreshExportConfirm-' + id() + '-' + emailedExport.groupId()}
                                         "
                                         data-toggle="modal">
@@ -139,7 +139,7 @@
                                     <i class="fa fa-refresh fa-spin"></i>
                                     {% trans "Updating Data, please wait..." %}
                                 </button>
-                                <div data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.inProgress()">
+                                <div data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.started()">
                                     <div class="progress">
                                         <div class="progress-bar progress-bar-striped active"
                                              role="progressbar"

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -190,8 +190,7 @@
                             </p>
                             <p data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished()">
                                 <i class="fa fa-check"></i>
-                                <strong>{% trans "Data update started." %}</strong><br />
-                                {% trans "Please check back later for updates. (Page refresh required)" %}
+                                <strong>{% trans "Data update complete" %}</strong>
                             </p>
                         </div>
 

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -224,7 +224,7 @@ def _get_task_status_json(export_instance_id):
     status = get_saved_export_task_status(export_instance_id)
     return {
         'percentComplete': status.progress.percent or 0,
-        'inProgress': status.started(),
+        'started': status.started(),
         'success': status.success(),
         'justFinished': False,
     }

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -226,6 +226,7 @@ def _get_task_status_json(export_instance_id):
         'percentComplete': status.progress.percent or 0,
         'started': status.started(),
         'success': status.success(),
+        'failed': status.failed(),
         'justFinished': False,
     }
 

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -140,6 +140,7 @@ class DownloadBase(object):
     def task_id(self):
         timeout = 60 * 60 * 24
         task_id = self.get_cache().get(self._task_key(), None)
+        # This resets the timeout whenever a task is accessed in any way
         self.get_cache().set(self._task_key(), task_id, timeout)
         return task_id
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-300

That user was seeing an empty progress bar for days.  This turned out to be because of a simple bug (commit 1), however it was obscured because we used the `ignore_result` celery param, which ignores results, including failures (commit 3).  This also persisted beyond the 24 hour timeout (I believe) because the timeout is reset every time it's accessed, and with a browser tab open that happens every second or two (commit 2).

Another thing I noticed is that we direct users to refresh the page when the download is complete, but that's actually not necessary, they can just click the button (commit 5).

And finally I made use of the now-accurate `task.failed()` method to let the user know when the task fails and act appropriately.  The previous (unintentional) behavior was to freeze the progress wherever it was and stay there until no one looked at it for 24 hours.  Now it will display an error message and allow you to try again.

![image](https://user-images.githubusercontent.com/2367539/50935071-c5c11400-1438-11e9-9f73-328d2287cab1.png)

@orangejenny buddy @nickpell pinging 'cause I think you touched this recently too