### PR TITLE
Align scheduled reports checkboxes

### DIFF
--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -161,16 +161,16 @@ class ScheduledReportForm(forms.Form):
                     'day',
                     'hour',
                     crispy.Field(
+                        'email_subject',
+                        css_class='input-xlarge',
+                    ),
+                    crispy.Field(
                         ugettext("Send Options"),
                         'send_to_owner'
                     ),
                     crispy.Field(
                         ugettext("Excel Attachment"),
                         'attach_excel'
-                    ),
-                    crispy.Field(
-                        'email_subject',
-                        css_class='input-xlarge',
                     ),
                     'recipient_emails',
                     'language',

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -165,11 +165,9 @@ class ScheduledReportForm(forms.Form):
                         css_class='input-xlarge',
                     ),
                     crispy.Field(
-                        ugettext("Send Options"),
                         'send_to_owner'
                     ),
                     crispy.Field(
-                        ugettext("Excel Attachment"),
                         'attach_excel'
                     ),
                     'recipient_emails',

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -160,11 +160,11 @@ class ScheduledReportForm(forms.Form):
                     'interval',
                     'day',
                     'hour',
-                    B3MultiField(
+                    crispy.Field(
                         ugettext("Send Options"),
                         'send_to_owner'
                     ),
-                    B3MultiField(
+                    crispy.Field(
                         ugettext("Excel Attachment"),
                         'attach_excel'
                     ),


### PR DESCRIPTION
On the Scheduled Reports edit page, the checkboxes to select "Send to owner" and "Attach Excel Report" are misaligned (they hang out in the middle of the page). This PR replaces the `B3MultiField` they use with `crispy.Field`, so they are better aligned with everything else on the page. I also moved those checkboxes below the Email Subject field, since they no longer have labels

s/o to @orangejenny for dealing with django-generated checkbox frustration to help me

![screen shot 2019-01-10 at 11 38 06 am](https://user-images.githubusercontent.com/15271571/50983365-534e4380-14cd-11e9-8499-bc53dcb048e8.png)

@djmore9 fyi
