### PR TITLE
Fix Location Site Code Validation

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -249,6 +249,11 @@ class LocationForm(forms.Form):
 
         if site_code:
             site_code = site_code.lower()
+            slug_regex = re.compile('^[-_\w\d]+$')
+            if not slug_regex.match(site_code):
+                raise forms.ValidationError(_(
+                    'The site code cannot contain spaces or special characters.'
+                ))
             if (SQLLocation.objects.filter(domain=self.domain,
                                         site_code__iexact=site_code)
                                    .exclude(location_id=self.location.location_id)

--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -74,6 +74,18 @@
       <br />
       {% endif %}
 
+      {% if creates_new_location and not form.is_valid and request.method == 'POST' %}
+        <div class="alert alert-warning">
+          <p>
+          {% url 'location_types' domain as levels_url %}
+            {% blocktrans %}
+              <strong>There was an issue creating this location.</strong><br />
+              Please make sure that at least one <a href="{{ levels_url }}">Organization Level</a>
+              has been created.
+            {% endblocktrans %}
+          </p>
+        </div>
+      {% endif %}
       <div class="tab-content">
         <div class="tab-pane {% if form_tab == "basic" %}active{% endif %}" id="basic-info">
 


### PR DESCRIPTION
make sure that the form checks that the `site code` for locations is a slug (no special characters/spaces)

if site code is invalid, throw this error:
<img width="590" alt="screen shot 2019-01-10 at 1 34 59 pm" src="https://user-images.githubusercontent.com/716573/50990716-ca410780-14e0-11e9-9e68-3c0cf35b1470.png">

Also did a tiny fix on new locations that fail silently when no organization level is present
<img width="496" alt="screen shot 2019-01-10 at 1 59 35 pm" src="https://user-images.githubusercontent.com/716573/50990752-e9d83000-14e0-11e9-8738-4c781ef2af7d.png">

