### PR TITLE
change file mode to bytes

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -971,7 +971,7 @@ def create_mbt_for_month(state_id, month):
     helpers = (CcsMbtHelper, ChildHealthMbtHelper, AwcMbtHelper)
     for helper_class in helpers:
         helper = helper_class(state_id, month)
-        with get_cursor(helper.base_class) as cursor, open(helper.output_file, 'w+') as f:
+        with get_cursor(helper.base_class) as cursor, open(helper.output_file, 'w+b') as f:
             cursor.copy_expert(helper.query(), f)
             f.seek(0)
             icds_file, _ = IcdsFile.objects.get_or_create(blob_id='{}-{}-{}'.format(helper.base_tablename, state_id, month), data_type='mbt_{}'.format(helper.base_tablename))


### PR DESCRIPTION
@emord @Rohit25negi @czue 
This fixes https://sentry.io/dimagi/commcarehq/issues/836858277/events/19bc53f9d61742189e3a5dad177737bc/ by treating the file as raw bytes instead of trying to deal with an encoding.