### PR TITLE
get the form from the app instead of the couch view

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -954,7 +954,7 @@ class CreateDataSourceFromAppView(BaseUserConfigReportsView):
                 messages.success(request, _("Data source created for '{}'".format(app_source.source)))
             else:
                 assert app_source.source_type == 'form'
-                xform = Form.get_form(app_source.source)
+                xform = app.get_form(app_source.source)
                 data_source = get_form_data_source(app, xform)
                 data_source.save()
                 messages.success(request, _("Data source created for '{}'".format(xform.default_name())))


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-264

Thanks to Simon for [pointing me at the answer here](https://github.com/dimagi/commcare-hq/blob/c8a621ac5143ff5f9ecc2227d13d487e313541c3/corehq/apps/app_manager/_design/views/xforms_index/map.js#L13)

Seems like this will come up anytime we call `Form.get_form` from a `LinkedApplication` with `uses_master_app_form_ids = True` but thinking we can do a more holistic fix if it becomes an issue down the road? :woman_shrugging: 