### PR TITLE
handle not found error and return 404

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.decorators.cache import cache_control
 
 import ghdiff
-from couchdbkit import ResourceNotFound
+from couchdbkit import ResourceNotFound, NoResultFound
 from dimagi.utils.web import json_response
 from dimagi.utils.couch.bulk import get_docs
 from phonelog.models import UserErrorEntry
@@ -211,7 +211,10 @@ def current_app_version(request, domain, app_id):
     """
     Return current app version and the latest release
     """
-    app_version = get_current_app_version(domain, app_id)
+    try:
+        app_version = get_current_app_version(domain, app_id)
+    except NoResultFound:
+        raise Http404
     latest_build_version = get_latest_build_version(domain, app_id)
     latest_released_version = get_latest_released_app_version(domain, app_id)
     return json_response({

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -214,6 +214,7 @@ def current_app_version(request, domain, app_id):
     try:
         app_version = get_current_app_version(domain, app_id)
     except NoResultFound:
+        # occurs when passed a build
         raise Http404
     latest_build_version = get_latest_build_version(domain, app_id)
     latest_released_version = get_latest_released_app_version(domain, app_id)


### PR DESCRIPTION
This happens when viewing the app summary for a build. Decided to return a 404 rather than get the main app since it seemed a bit odd to say 'updates available to publish' when looking at a build.

*product* Marking this as `invisible` since it doesn't change anything on the UI right now. Just fixes the 500 errors we get in Sentry.