### PR TITLE
Hide empty columns in pregnant details report

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -1171,11 +1171,9 @@ def get_pregnant_details(case_id, awc_id):
             [],
         ],
     }
-    current_trimester = 1
-    current_record = 0
     for row_data in data:
-        if row_data['trimester'] >= current_trimester:
-            config['data'][row_data['trimester'] - 1].append(dict(
+        config['data'][row_data['trimester'] - 1].append(
+            dict(
                 case_id=row_data['case_id'],
                 trimester=row_data['trimester'] if row_data['trimester'] else DATA_NOT_ENTERED,
                 person_name=row_data['person_name'] if row_data['person_name'] else DATA_NOT_ENTERED,
@@ -1201,11 +1199,8 @@ def get_pregnant_details(case_id, awc_id):
                 ifa_consumed_last_seven_days='Y' if row_data['ifa_consumed_last_seven_days'] else 'N',
                 tt_taken='Y' if get_tt_dates(row_data) != 'None' else 'N',
                 tt_date=get_tt_dates(row_data),
-            ))
-            if current_trimester == 1 and row_data['trimester'] == 1 and current_record == 0:
-                current_record += 1
-            else:
-                current_trimester = row_data['trimester'] + 1
+            )
+        )
     return config
 
 

--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, date
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import MONTHLY, rrule, DAILY, WEEKLY, MO
 
+from django.db.models import F
 from django.db.models.aggregates import Sum, Avg
 from django.utils.translation import ugettext as _
 
@@ -1155,6 +1156,7 @@ def get_pregnant_details(case_id, awc_id):
         case_id=case_id,
         awc_id=awc_id,
         month__gte=ten_months_ago,
+        home_visit_date__lte=F('month') + timedelta(days=31),
     ).order_by('home_visit_date', '-month').distinct('home_visit_date').values(
         'case_id', 'trimester', 'person_name', 'age_in_months', 'mobile_number', 'edd', 'opened_on', 'preg_order',
         'home_visit_date', 'bp_sys', 'bp_dia', 'anc_weight', 'anc_hemoglobin', 'anemic_severe', 'anemic_moderate',

--- a/custom/icds_reports/static/css/icds_dashboard.css
+++ b/custom/icds_reports/static/css/icds_dashboard.css
@@ -858,3 +858,7 @@ hr {
     text-align: center;
     padding: 20px 50px;
 }
+
+.pregnantDetailsColumn {
+    min-width: 150px;
+}

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -2510,43 +2510,12 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             function (response) {
                 vm.pregnantData = response.data['data'];
                 vm.showTable = false;
-                var empty = {
-                    case_id: null,
-                    trimester: null,
-                    person_name: null,
-                    age: null,
-                    mobile_number: null,
-                    edd: null,
-                    opened_on: null,
-                    preg_order: null,
-                    home_visit_date: 'Data Not Entered',
-                    bp: null,
-                    anc_weight: null,
-                    anc_hemoglobin: null,
-                    anc_abnormalities: null,
-                    anemic: null,
-                    symptoms: null,
-                    counseling: null,
-                    using_ifa: null,
-                    ifa_consumed_last_seven_days: null,
-                    tt_taken: null,
-                    tt_date: null,
-                };
                 if (vm.pregnantData[0].length > 0) {
                     vm.pregnant = vm.pregnantData[0][0];
                 } else if (vm.pregnantData[1].length > 0) {
-                    vm.pregnantData[0].push(empty);
                     vm.pregnant = vm.pregnantData[1][0];
                 } else {
-                    vm.pregnantData[0].push(empty);
-                    vm.pregnantData[1].push(empty);
                     vm.pregnant = vm.pregnantData[2][0];
-                }
-                if (vm.pregnantData[0].length === 1) {
-                    vm.pregnantData[0].push(empty);
-                }
-                if (vm.pregnantData[2].length === 0) {
-                    vm.pregnantData[2].push(empty);
                 }
                 vm.showPregnant = true;
             },

--- a/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
@@ -180,95 +180,170 @@
                             <thead>
                                 <tr role="row">
                                     <th class="big-col"></th>
-                                    <th class="big-col" colspan="2">Trimester 1</th>
-                                    <th class="big-col">Trimester 2</th>
-                                    <th class="big-col">Trimester 3</th>
+                                    <th class="big-col"
+                                        ng-if="$ctrl.pregnantData[0].length !== 0"
+                                        colspan="{$ $ctrl.pregnantData[0].length $}" >
+                                        Trimester 1
+                                    </th>
+                                    <th class="big-col"
+                                        ng-if="$ctrl.pregnantData[1].length !== 0"
+                                        colspan="{$ $ctrl.pregnantData[1].length $}" >
+                                        Trimester 2
+                                    </th>
+                                    <th class="big-col"
+                                        ng-if="$ctrl.pregnantData[2].length !== 0"
+                                        colspan="{$ $ctrl.pregnantData[2].length $}" >
+                                        Trimester 3
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr class="odd" role="row">
-                                    <td class="big-col">Home Visit Date</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].home_visit_date $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].home_visit_date $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].home_visit_date $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].home_visit_date $}</td>
+                                    <td class="big-col pregnantDetailsColumn">Home Visit Date</td>
+                                    <td class="medium-col pregnantDetailsColumn"
+                                        ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.home_visit_date $}
+                                    </td>
+                                    <td class="medium-col pregnantDetailsColumn"
+                                        ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.home_visit_date $}
+                                    </td>
+                                    <td class="medium-col pregnantDetailsColumn"
+                                        ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.home_visit_date $}
+                                    </td>
                                 </tr>
                                 <tr class="even" role="row">
                                     <td class="big-col">BP</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].bp $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].bp $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].bp $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].bp $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.bp $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.bp $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.bp $}
+                                    </td>
                                 </tr>
                                 <tr class="odd" role="row">
                                     <td class="big-col">Weight</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].anc_weight $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].anc_weight $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].anc_weight $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].anc_weight $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.anc_weight $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.anc_weight $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.anc_weight $}
+                                    </td>
                                 </tr>
                                 <tr class="even" role="row">
                                     <td class="big-col">Haemoglobin</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].anc_hemoglobin $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].anc_hemoglobin $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].anc_hemoglobin $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].anc_hemoglobin $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.anc_hemoglobin $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.anc_hemoglobin $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.anc_hemoglobin $}
+                                    </td>
                                 </tr>
                                 <tr class="odd" role="row">
                                     <td class="big-col">Abnormalities</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].anc_abnormalities $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].anc_abnormalities $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].anc_abnormalities $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].anc_abnormalities $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.anc_abnormalities $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.anc_abnormalities $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.anc_abnormalities $}
+                                    </td>
                                 </tr>
                                 <tr class="even" role="row">
                                     <td class="big-col">Anemia</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].anemic $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].anemic $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].anemic $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].anemic $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.anemic $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.anemic $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.anemic $}
+                                    </td>
                                 </tr>
                                 <tr class="odd" role="row">
                                     <td class="big-col">Symptoms</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].symptoms $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].symptoms $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].symptoms $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].symptoms $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.symptoms $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.symptoms $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.symptoms $}
+                                    </td>
                                 </tr>
                                 <tr class="even" role="row">
                                     <td class="big-col">Counselling</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].counseling $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].counseling $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].counseling $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].counseling $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.counseling $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.counseling $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.counseling $}
+                                    </td>
                                 </tr>
                                 <tr class="odd" role="row">
                                     <td class="big-col">IFA tablet issued</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].using_ifa $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].using_ifa $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].using_ifa $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].using_ifa $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.using_ifa $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.using_ifa $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.using_ifa $}
+                                    </td>
                                 </tr>
                                 <tr class="even" role="row">
                                     <td class="big-col">IFA tablet consumed in last 7 days</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].ifa_consumed_last_seven_days $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].ifa_consumed_last_seven_days $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].ifa_consumed_last_seven_days $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].ifa_consumed_last_seven_days $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.ifa_consumed_last_seven_days $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.ifa_consumed_last_seven_days $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.ifa_consumed_last_seven_days $}
+                                    </td>
                                 </tr>
                                 <tr class="odd" role="row">
                                     <td class="big-col">TT Taken? (Y/N)</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].tt_taken $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].tt_taken $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].tt_taken $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].tt_taken $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.tt_taken $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.tt_taken $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.tt_taken $}
+                                    </td>
                                 </tr>
                                 <tr class="even" role="row">
                                     <td class="big-col">TT Date</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][0].tt_date $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[0][1].tt_date $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[1][0].tt_date $}</td>
-                                    <td class="medium-col">{$ $ctrl.pregnantData[2][0].tt_date $}</td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
+                                        {$ record.tt_date $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[1]" >
+                                        {$ record.tt_date $}
+                                    </td>
+                                    <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[2]" >
+                                        {$ record.tt_date $}
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>

--- a/custom/icds_reports/tests/reports/test_awc_reports.py
+++ b/custom/icds_reports/tests/reports/test_awc_reports.py
@@ -35,7 +35,6 @@ class FirstDayOfMayDate(date):
 
 
 class TestAWCReport(TestCase):
-    maxDiff = None # todo
     def test_beneficiary_details_recorded_weight_none(self):
         data = get_beneficiary_details(
             case_id='6b234c5b-883c-4849-9dfd-b1571af8717b',

--- a/custom/icds_reports/tests/reports/test_awc_reports.py
+++ b/custom/icds_reports/tests/reports/test_awc_reports.py
@@ -35,6 +35,7 @@ class FirstDayOfMayDate(date):
 
 
 class TestAWCReport(TestCase):
+    maxDiff = None # todo
     def test_beneficiary_details_recorded_weight_none(self):
         data = get_beneficiary_details(
             case_id='6b234c5b-883c-4849-9dfd-b1571af8717b',
@@ -2540,30 +2541,7 @@ class TestAWCReport(TestCase):
             )
             self.assertEqual(
                 data['data'][1],
-                [
-                    {
-                        'age': 23,
-                        'anc_abnormalities': 'None',
-                        'anc_hemoglobin': 'Data Not Entered',
-                        'anc_weight': 'Data Not Entered',
-                        'anemic': 'Data Not Entered',
-                        'bp': 'Data Not Entered',
-                        'case_id': '7313c174-6b63-457c-a734-6eed0a2b2ac6',
-                        'counseling': 'None',
-                        'edd': 'Data Not Entered',
-                        'home_visit_date': 'Data Not Entered',
-                        'ifa_consumed_last_seven_days': 'Y',
-                        'mobile_number': 'Data Not Entered',
-                        'opened_on': 'Data Not Entered',
-                        'person_name': 'Data Not Entered',
-                        'preg_order': 'Data Not Entered',
-                        'symptoms': 'None',
-                        'trimester': 2,
-                        'tt_date': 'None',
-                        'tt_taken': 'N',
-                        'using_ifa': 'Y'
-                    }
-                ]
+                []
             )
 
     def test_pregnant_details_first_record_third_trimester(self):


### PR DESCRIPTION
Hi @calellowitz,
I have updated pregnant details table formatting to hide all empty columns and show as many columns as there are records with different home visit date.
This should be tested on QA.
Regards, Dawid