### PR TITLE
Move store_billable to background queue

### DIFF
--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -412,7 +412,8 @@ def send_to_sms_queue(queued_sms):
     process_sms.apply_async([queued_sms.pk], **options)
 
 
-@no_result_task(serializer='pickle', default_retry_delay=10 * 60, max_retries=10, bind=True)
+@no_result_task(serializer='pickle', queue='background_queue', default_retry_delay=10 * 60,
+                max_retries=10, bind=True)
 def store_billable(self, msg):
     if not isinstance(msg, SMS):
         raise Exception("Expected msg to be an SMS")


### PR DESCRIPTION
The other tasks here which seem do be doing various data syncing operations all use the background queue. CELERY_REMINDER_CASE_UPDATE_QUEUE also seems to be possibility.

The impetus for this switch was the observation that store_billable was substantially backing up the `celery` queue on ICDS.  The queue showed a large spike shortly before a small upload, which took a very long time to get started.  Looking in flower, I see
![image](https://user-images.githubusercontent.com/2367539/51057878-eca45500-15b4-11e9-8a85-f5547a5af485.png)
The number of tasks queued during this spike was around 15k, so this task is the only explanation.

Taking a step back, I also find it suspicious that there was a sudden, large spike:
![image](https://user-images.githubusercontent.com/2367539/51057939-2bd2a600-15b5-11e9-9aa6-074ec0cd058e.png)
This strongly suggests a bulk, automated task.  This is called during `create_billable_for_sms` which looks like it's triggered when SMSs are sent.  I wonder if there's some sort of periodic or rule-based task which queues SMSs in bulk, spinning off new `store_billable` tasks for each one rather than performing that operation synchronously.

@millerdev What is your take on this approach?