### PR TITLE
don't double report error

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -162,7 +162,6 @@ class ESView(View):
                         querystring)
 
             msg = "Error in elasticsearch query [%s]: %s\nquery: %s" % (self.index, str(e), es_query)
-            notify_exception(None, message=msg)
             raise ESError(msg)
 
         hits = []


### PR DESCRIPTION
This notification is already recorded by Sentry when the error (next line) is raised:

* Notify: https://sentry.io/dimagi/commcarehq/issues/223161975/
* ESError: https://sentry.io/dimagi/commcarehq/issues/223315309/