### PR TITLE
Fixed 500 when renaming path that doesn't have a file

### DIFF
--- a/corehq/apps/hqmedia/view_helpers.py
+++ b/corehq/apps/hqmedia/view_helpers.py
@@ -93,9 +93,10 @@ def update_multimedia_paths(app, paths):
 
     # Update app's master map of multimedia
     for old_path, new_path in six.iteritems(paths):
-        app.multimedia_map.update({
-            new_path: app.multimedia_map[old_path],
-        })
+        if old_path in app.multimedia_map:  # path will not be present if file is missing from app
+            app.multimedia_map.update({
+                new_path: app.multimedia_map[old_path],
+            })
 
     # Put together success messages
     successes = []


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?288179

Followup for https://github.com/dimagi/commcare-hq/pull/22779
This is the last qabug for this feature, would like to get into deploy if possible.

@emord / @esoergel 