### PR TITLE
Accurate trial banner on Current Subscription Page

### DIFF
--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -22,12 +22,16 @@
                     <label class="control-label col-sm-2">{% trans 'Plan' %}</label>
                     <div class="col-sm-10">
                         <div class="{{ plan.css_class }}">
-                            <h4>{% if plan.is_trial %}{% trans '30 Day Trial' %}{% else %}{{ plan.name }}{% endif %}</h4>
+                            <h4>{% if plan.is_trial %}
+                                    {{ plan.trial_length }}{% trans ' Day Trial' %}
+                                {% else %}
+                                    {{ plan.name }}
+                                {% endif %}</h4>
                             <p><i class="fa fa-info-circle"></i>
                                 {% if plan.is_trial %}
-                                    {% blocktrans with plan.name as pn %}
-                                        The 30 Day Trial includes all the features present in the {{ pn }} Software Plan,
-                                        which is our full set of features.
+                                    {% blocktrans with pn=plan.name trial_length=plan.trial_length %}
+                                        The {{ trial_length }} Day Trial includes all the features present in the
+                                        {{ pn }} Software Plan, which is our full set of features.
                                     {% endblocktrans %}
                                 {% else %}{{ plan.description }}{% endif %}</p>
                         </div>

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -202,6 +202,9 @@ class DomainSubscriptionView(DomainAccountingSettings):
                         'renew_url': reverse(SubscriptionRenewalView.urlname, args=[self.domain]),
                     })
 
+            if subscription.is_trial and subscription.date_end is not None:
+                trial_length = (subscription.date_end - subscription.date_start).days
+
         if subscription:
             credit_lines = CreditLine.get_non_general_credits_by_subscription(subscription)
             credit_lines = [cl for cl in credit_lines if cl.balance > 0]
@@ -225,6 +228,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'css_class': "label-plan label-plan-%s" % plan_version.plan.edition.lower(),
             'do_not_invoice': subscription.do_not_invoice if subscription is not None else False,
             'is_trial': subscription.is_trial if subscription is not None else False,
+            'trial_length': trial_length if subscription.is_trial else None,
             'date_start': (subscription.date_start.strftime(USER_DATE_FORMAT)
                            if subscription is not None else None),
             'date_end': date_end,


### PR DESCRIPTION
Update trial banner on Current Subscription Page with the correct #-Day Trial

e.g.:
<img width="1158" alt="screen shot 2019-01-14 at 2 23 36 pm" src="https://user-images.githubusercontent.com/15271571/51135468-1a350c80-1808-11e9-936b-dbcec7f42af5.png">
