### PR TITLE
Clean up UI around missing multimedia references

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
@@ -2,14 +2,14 @@
 {% if multimedia_state.has_media %}
   <div class="panel panel-appmanager">
     <div class="panel-heading">
-      <h4 class="panel-title panel-title-nolink">{% trans 'Manage Multimedia' %}</h4>
+      <h4 class="panel-title panel-title-nolink">{% trans 'Multimedia Reference Checker' %}</h4>
     </div>
     <div class="panel-body">
-      <p>{% blocktrans %}View, upload, and download your application's multimedia{% endblocktrans %}</p>
       <p>
-          <a id="open_checker" target="_blank" class="btn btn-primary" href="{% url "hqmedia_references" domain app.get_id %}">
-              <i class="fa fa-check"></i>
-              {% blocktrans %}Multimedia Reference Checker</a> (opens in a new window){% endblocktrans %}
+          <a id="open_checker" target="_blank" href="{% url "hqmedia_references" domain app.get_id %}">
+              {% blocktrans %}View, upload, and download your application's multimedia{% endblocktrans %}
+              <i class="fa fa-external-link"></i>
+          </a>
       </p>
     </div>
   </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
@@ -19,6 +19,7 @@
       <h4 class="panel-title panel-title-nolink">{% trans 'Download Multimedia Zip' %}</h4>
     </div>
     <div class="panel-body">
+      <p>{% blocktrans %}This .zip file is structured to match the multimedia paths referenced in your CommCare Application.{% endblocktrans %}</p>
       {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True %}
     </div>
   </div>

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% if multimedia_state.has_media %}
-    <p>{% blocktrans %}This .zip file is structured to match the multimedia paths referenced in your CommCare Application.{% endblocktrans %}</p>
     {% if not include_modal and build_profile_access and not app.is_remote_app and app.build_profiles %}
         <div class="form-inline">
             <label style="font-weight: normal">{% trans "Application Profile" %}:</label>

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -39,17 +39,27 @@
 {% if multimedia_state.has_missing_refs %}
     <div class="alert alert-warning">
         <p>
-            <i class="fa fa-exclamation-triangle"></i> {% blocktrans %}<strong>Note:</strong> This application is
-            missing references, so this zip will be incomplete.
+            {% blocktrans %}
+                <i class="fa fa-exclamation-triangle"></i>
+                This application is missing references, so this zip will be incomplete.
+            {% endblocktrans %}
         </p>
-        <p>
-            Please make sure all of your application's multimedia references are linked to media files before
-            starting your Application, or it might be unstable.
-        </p>
-    {% endblocktrans %}</div>
+        {% if not is_multimedia_reference_checker %}
+            <p>
+                {% url "hqmedia_references" domain app.get_id as checker_url %}
+                {% blocktrans %}
+                    Visit the <a href='{{ checker_url }}' target= '_blank'>
+                        Multimedia Reference Checker
+                        <i class='fa fa-external-link'></i>
+                    </a>
+                    to upload any missing multimedia.
+                {% endblocktrans %}
+            </p>
+        {% endif %}
+    </div>
 {% endif %}
 
 {% if include_modal %}
-    {% url "download_multimedia_zip" domain app.get_id as multimedia_url%}
+    {% url "download_multimedia_zip" domain app.get_id as multimedia_url %}
     {% include 'app_manager/partials/download_async_modal.html' with element_id='multimedia-zip-modal' url=multimedia_url %}
 {% endif %}

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -1,4 +1,34 @@
 {% load i18n %}
+
+{% if multimedia_state.has_form_errors %}
+    <div class="alert alert-danger"><i class="fa fa-exclamation-triangle"></i> {% blocktrans %}<strong>Warning:</strong>
+        This application contains forms with errors&mdash;we cannot pull any multimedia references from those forms.
+    {% endblocktrans %}</div>
+{% endif %}
+
+{% if multimedia_state.has_missing_refs %}
+    <div class="alert alert-warning">
+        <p>
+            {% blocktrans %}
+                <i class="fa fa-exclamation-triangle"></i>
+                This application is missing references, so this zip will be incomplete.
+            {% endblocktrans %}
+        </p>
+        {% if not is_multimedia_reference_checker %}
+            <p>
+                {% url "hqmedia_references" domain app.get_id as checker_url %}
+                {% blocktrans %}
+                    Visit the <a href='{{ checker_url }}' target= '_blank'>
+                        Multimedia Reference Checker
+                        <i class='fa fa-external-link'></i>
+                    </a>
+                    to upload any missing multimedia.
+                {% endblocktrans %}
+            </p>
+        {% endif %}
+    </div>
+{% endif %}
+
 {% if multimedia_state.has_media %}
     {% if not include_modal and build_profile_access and not app.is_remote_app and app.build_profiles %}
         <div class="form-inline">
@@ -30,33 +60,6 @@
     </p>
 {% else %}
     <div class="alert alert-info">{% blocktrans %}This application currently does not contain any multimedia references.{% endblocktrans %}</div>
-{% endif %}
-{% if multimedia_state.has_form_errors %}
-    <div class="alert alert-danger"><i class="fa fa-exclamation-triangle"></i> {% blocktrans %}<strong>Warning:</strong>
-        This application contains forms with errors&mdash;we cannot pull any multimedia references from those forms.
-    {% endblocktrans %}</div>
-{% endif %}
-{% if multimedia_state.has_missing_refs %}
-    <div class="alert alert-warning">
-        <p>
-            {% blocktrans %}
-                <i class="fa fa-exclamation-triangle"></i>
-                This application is missing references, so this zip will be incomplete.
-            {% endblocktrans %}
-        </p>
-        {% if not is_multimedia_reference_checker %}
-            <p>
-                {% url "hqmedia_references" domain app.get_id as checker_url %}
-                {% blocktrans %}
-                    Visit the <a href='{{ checker_url }}' target= '_blank'>
-                        Multimedia Reference Checker
-                        <i class='fa fa-external-link'></i>
-                    </a>
-                    to upload any missing multimedia.
-                {% endblocktrans %}
-            </p>
-        {% endif %}
-    </div>
 {% endif %}
 
 {% if include_modal %}

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -22,9 +22,9 @@
             id="download_zip"
         >
         {% if multimedia_state.has_form_errors or multimedia_state.has_missing_refs %}
-            <i class="fa fa-bolt"></i> {% trans 'Download Incomplete ZIP' %}
+            <i class="fa fa-exclamation-triangle"></i> {% trans 'Download Incomplete ZIP' %}
         {% else %}
-            <i class="fa fa-download"></i> {% trans 'Download ZIP' %}
+            <i class="fa fa-cloud-download"></i> {% trans 'Download ZIP' %}
         {% endif %}
         </a>
     </p>

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -54,9 +54,11 @@
                         You can manage multimedia by uploading files individually below.
                     {% endblocktrans %}
                 </p>
-                <p>
-                    <a href="#" class="btn btn-default" data-bind="click: toggleMissingRefs, text: toggleRefsText"></a>
-                </p>
+                {% if multimedia_state.has_form_errors or multimedia_state.has_missing_refs %}
+                    <p>
+                        <a href="#" class="btn btn-default" data-bind="click: toggleMissingRefs, text: toggleRefsText"></a>
+                    </p>
+                {% endif %}
             {% else %}
                 <div class="alert alert-info">
                     {% blocktrans %}This application references no multimedia.{% endblocktrans %}

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -68,13 +68,7 @@
         <div class="col-sm-5">
             {% if totals|length %}
             <div class="well">
-                <p>
-                    <a class="btn btn-primary download-zip"
-                        href="#multimedia-zip-modal"
-                        data-toggle="modal">
-                        <i class="fa fa-download"></i> {% trans 'Download ZIP' %}
-                    </a>
-                </p>
+                {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True %}
                 <ul class="media-totals-list" data-bind="foreach: totals">
                     <li class="media-totals" data-bind="event: {refMediaAdded: $parent.incrementTotals}">
                         <i data-bind="attr: {class: icon_class}"></i>
@@ -152,9 +146,4 @@
     {% endif %}
 </div>
 
-{% endblock %}
-
-{% block modals %}{{ block.super }}
-    {% url "download_multimedia_zip" domain app.get_id as media_url%}
-    {% include 'app_manager/partials/download_async_modal.html' with element_id='multimedia-zip-modal' url=media_url%}
 {% endblock %}

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -68,7 +68,7 @@
         <div class="col-sm-5">
             {% if totals|length %}
             <div class="well">
-                {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True %}
+                {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True is_multimedia_reference_checker=True %}
                 <ul class="media-totals-list" data-bind="foreach: totals">
                     <li class="media-totals" data-bind="event: {refMediaAdded: $parent.incrementTotals}">
                         <i data-bind="attr: {class: icon_class}"></i>

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -146,6 +146,7 @@ class MultimediaReferencesView(BaseMultimediaUploaderView):
             raise Http404(self)
         context.update({
             "references": self.app.get_references(),
+            "multimedia_state": self.app.check_media_state(),
             "object_map": self.app.get_object_map(),
             "totals": self.app.get_reference_totals(),
             "sessionid": self.request.COOKIES.get('sessionid'),


### PR DESCRIPTION
Minor changes, read commit list for details.

Multimedia tab on app settings
<img width="1049" alt="screen shot 2019-01-14 at 2 53 10 pm" src="https://user-images.githubusercontent.com/1486591/51137235-641ff180-180c-11e9-98fc-9668c6458ac5.png">

Multimedia reference checker
<img width="1122" alt="screen shot 2019-01-14 at 2 53 24 pm" src="https://user-images.githubusercontent.com/1486591/51137252-6b46ff80-180c-11e9-9be3-ad89cc523099.png">

@esoergel 
fyi @dimagi/product 