### PR TITLE
Email translations before being sent to transifex

### DIFF
--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -182,6 +182,8 @@ class AppTranslationsForm(forms.Form):
             return BackUpAppTranslationsForm
         elif form_action == 'delete':
             return DeleteAppTranslationsForm
+        elif form_action == 'download':
+            return DownloadAppTranslationsForm
 
 
 class CreateAppTranslationsForm(AppTranslationsForm):
@@ -236,6 +238,12 @@ class DeleteAppTranslationsForm(AppTranslationsForm):
         form_fields = super(DeleteAppTranslationsForm, self).form_fields()
         form_fields.append(hqcrispy.Field('perform_translated_check'))
         return form_fields
+
+
+class DownloadAppTranslationsForm(CreateAppTranslationsForm):
+    """Used to download the files that are being uploaded to Transifex."""
+
+    form_action = 'download'
 
 
 class BackUpAppTranslationsForm(AppTranslationsForm):

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -347,4 +347,4 @@ class PoFileGenerator(object):
         for resource_name, filepath in self._generated_files:
             if os.path.exists(filepath):
                 os.remove(filepath)
-        self.generated_files = []
+        self._generated_files = []

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -11,6 +11,7 @@ import six
 from django.utils.functional import cached_property
 from memoized import memoized
 
+from corehq.apps.app_manager.dbaccessors import get_version_build_id
 from corehq.apps.app_manager.util import get_form_data
 from corehq.apps.translations.const import MODULES_AND_FORMS_SHEET_NAME
 
@@ -57,6 +58,13 @@ class AppTranslationsGenerator:
         self.slug_to_name = defaultdict(dict)
         self.slug_to_name[MODULES_AND_FORMS_SHEET_NAME] = {'en': MODULES_AND_FORMS_SHEET_NAME}
         self._build_translations()
+
+    @cached_property
+    def build_id(self):
+        if self.version:
+            return get_version_build_id(self.domain, self.app_id, self.version)
+        else:
+            return self.app_id
 
     @cached_property
     def _get_labels_to_skip(self):

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -270,6 +270,24 @@ class AppTranslationsGenerator:
                 occurrence_row)
         return list(translations.values())
 
+    def get_translations(self):
+        ret = OrderedDict()
+        for file_name in self.translations:
+            sheet_translations = self.translations[file_name]
+            po = []
+            for translation in sheet_translations:
+                source = translation.key
+                if source:
+                    entry = polib.POEntry(
+                        msgid=translation.key,
+                        msgstr=translation.translation or '',
+                        occurrences=translation.occurrences,
+                        msgctxt=translation.msgctxt,
+                    )
+                    po.append(entry)
+            ret[file_name] = po
+        return ret
+
     @property
     @memoized
     def app(self):

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -17,8 +17,8 @@ from corehq.apps.translations.const import MODULES_AND_FORMS_SHEET_NAME
 
 Translation = namedtuple('Translation', 'key translation occurrences msgctxt')
 Unique_ID = namedtuple('UniqueID', 'type id')
-HQ_MODULE_SHEET_NAME = re.compile('^module(\d+)$')
-HQ_FORM_SHEET_NAME = re.compile('^module(\d+)_form(\d+)$')
+HQ_MODULE_SHEET_NAME = re.compile(r'^module(\d+)$')
+HQ_FORM_SHEET_NAME = re.compile(r'^module(\d+)_form(\d+)$')
 POFileInfo = namedtuple("POFileInfo", "name path")
 SKIP_TRANSFEX_STRING = "SKIP TRANSIFEX"
 

--- a/corehq/apps/translations/integrations/transifex/parser.py
+++ b/corehq/apps/translations/integrations/transifex/parser.py
@@ -32,10 +32,7 @@ class TranslationsParser(object):
     @memoized
     def get_app(self):
         from corehq.apps.app_manager.dbaccessors import get_current_app
-        try:
-            app_build_id = self.transifex.app_id_to_build
-        except AttributeError:
-            app_build_id = self.transifex.app_id
+        app_build_id = self.transifex.build_id
         return get_current_app(self.transifex.domain, app_build_id)
 
     def _add_sheet(self, ws, po_entries):

--- a/corehq/apps/translations/integrations/transifex/parser.py
+++ b/corehq/apps/translations/integrations/transifex/parser.py
@@ -32,7 +32,10 @@ class TranslationsParser(object):
     @memoized
     def get_app(self):
         from corehq.apps.app_manager.dbaccessors import get_current_app
-        app_build_id = self.transifex.app_id_to_build
+        try:
+            app_build_id = self.transifex.app_id_to_build
+        except AttributeError:
+            app_build_id = self.transifex.app_id
         return get_current_app(self.transifex.domain, app_build_id)
 
     def _add_sheet(self, ws, po_entries):

--- a/corehq/apps/translations/integrations/transifex/transifex.py
+++ b/corehq/apps/translations/integrations/transifex/transifex.py
@@ -46,11 +46,7 @@ class Transifex(object):
         self.update_resource = update_resource
 
     @cached_property
-    def app_id_to_build(self):
-        return self._find_build_id()
-
-    def _find_build_id(self):
-        # find build id if version specified
+    def build_id(self):
         if self.version:
             return get_version_build_id(self.domain, self.app_id, self.version)
         else:

--- a/corehq/apps/translations/integrations/transifex/views.py
+++ b/corehq/apps/translations/integrations/transifex/views.py
@@ -3,12 +3,6 @@ from __future__ import unicode_literals
 
 from io import open
 
-import openpyxl
-import polib
-from corehq.apps.translations.integrations.transifex.transifex import Transifex
-from corehq.apps.translations.integrations.transifex.utils import transifex_details_available_for_domain
-from corehq.apps.translations.utils import get_file_content_from_workbook
-
 from django.contrib import messages
 from django.http import HttpResponse
 from django.shortcuts import redirect
@@ -20,7 +14,8 @@ from django.utils.translation import (
     ugettext_lazy,
 )
 from memoized import memoized
-from openpyxl import Workbook
+import openpyxl
+import polib
 
 from corehq import toggles
 from corehq.apps.domain.views.base import BaseDomainView
@@ -33,12 +28,15 @@ from corehq.apps.translations.forms import (
 )
 from corehq.apps.translations.generators import Translation, PoFileGenerator
 from corehq.apps.translations.integrations.transifex.exceptions import ResourceMissing
+from corehq.apps.translations.integrations.transifex.transifex import Transifex
+from corehq.apps.translations.integrations.transifex.utils import transifex_details_available_for_domain
 from corehq.apps.translations.tasks import (
     push_translation_files_to_transifex,
     pull_translation_files_from_transifex,
     delete_resources_on_transifex,
     backup_project_from_transifex,
 )
+from corehq.apps.translations.utils import get_file_content_from_workbook
 from corehq.util.files import safe_filename_header
 
 
@@ -216,7 +214,7 @@ class PullResource(BaseTranslationsView):
                               source_lang=target_lang,
                               project_slug=self.pull_resource_form.cleaned_data['transifex_project_slug'],
                               version=None)
-        wb = Workbook(write_only=True)
+        wb = openpyxl.Workbook(write_only=True)
         ws = wb.create_sheet(title='translations')
         ws.append(['context', 'source', 'translation', 'occurrence'])
         for po_entry in transifex.client.get_translation(resource_slug, target_lang, False):

--- a/corehq/apps/translations/tasks.py
+++ b/corehq/apps/translations/tasks.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import os
 from io import open
@@ -10,6 +9,8 @@ from django.conf import settings
 from django.core.files.temp import NamedTemporaryFile
 from django.core.mail.message import EmailMessage
 
+from corehq.apps.translations.generators import AppTranslationsGenerator
+from corehq.apps.translations.integrations.transifex.parser import TranslationsParser
 from corehq.apps.translations.integrations.transifex.transifex import Transifex
 
 
@@ -137,3 +138,28 @@ def backup_project_from_transifex(domain, data, email):
         filename = "%s-TransifexBackup.zip" % project_details.get('name')
         email.attach(filename=filename, content=tmp.read())
         email.send()
+
+
+@task
+def download_project_from_hq(domain, data, email):
+    """Emails the requester with an excel file translations to be sent to Transifex.
+
+    Used to verify translations before sending to Transifex
+    """
+    lang = data.get('source_lang')
+    project_slug = data.get('transifex_project_slug')
+    gen = AppTranslationsGenerator(domain, data.get('app_id'), data.get('version'), lang, lang, 'default_')
+    parser = TranslationsParser(gen)
+    try:
+        translation_file, filename = parser.generate_excel_file()
+        with open(translation_file.name, 'rb') as file_obj:
+            email = EmailMessage(
+                subject='[{}] - HQ translation download'.format(settings.SERVER_ENVIRONMENT),
+                body="Translations from HQ",
+                to=[email],
+                from_email=settings.DEFAULT_FROM_EMAIL)
+            filename = "{project}-{lang}-translations.xls".format(project=project_slug, lang=lang)
+            email.attach(filename=filename, content=file_obj.read())
+            email.send()
+    finally:
+        os.remove(translation_file.name)

--- a/corehq/apps/translations/templates/app_translations.html
+++ b/corehq/apps/translations/templates/app_translations.html
@@ -19,6 +19,7 @@
           <li><a data-toggle="tab" href="#push-trans-form" id="push-tab"><b>{% trans "Push" %}</b></a></li>
           <li><a data-toggle="tab" href="#pull-trans-form" id="pull-tab"><b>{% trans "Pull" %}</b></a></li>
           <li><a data-toggle="tab" href="#backup-trans-form" id="backup-tab"><b>{% trans "BackUp" %}</b></a></li>
+          <li><a data-toggle="tab" href="#download-trans-form" id="download-tab"><b>{% trans "Download" %}</b></a></li>
           <li><a data-toggle="tab" href="#del-trans-form" id="delete-tab"><b>{% trans "Delete" %}</b></a></li>
         </ul>
         <div class="tab-content">
@@ -50,6 +51,12 @@
                 <form class="form form-horizontal" name="product" method="post">
                     <legend>{% trans "BackUp Translations" %}</legend>
                     {% crispy backup_form %}
+                </form>
+            </div>
+            <div id="download-trans-form" class="tab-pane">
+                <form class="form form-horizontal" name="product" method="post">
+                    <legend>{% trans "Download Translations" %}</legend>
+                    {% crispy download_form %}
                 </form>
             </div>
             <div id="del-trans-form" class="tab-pane">


### PR DESCRIPTION
@mkangia I built this on top of your recent work. To avoid any issues where we send REACH translations, it would be good to have a way to audit these before we push them. This implements a new tab that allows you to request an excel file of the translations to be sent.

Let me know what you think of this approach. There's a bit of refactoring spread out. Best reviewed commit by commit