### PR TITLE
Added fallback form name when downloading

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -529,11 +529,12 @@ def get_xform_source(request, domain, app_id, form_unique_id):
     source = form.source
     response = HttpResponse(source)
     response['Content-Type'] = "application/xml"
+    filename = form.default_name()
     for lc in [lang] + app.langs:
         if lc in form.name:
-            filename = "%s.xml" % unidecode(form.name[lc])
+            filename = form.name[lc]
             break
-    set_file_download(response, filename)
+    set_file_download(response, "%s.xml" % unidecode(filename))
     return response
 
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-319

https://sentry.io/dimagi/commcarehq/issues/768275983/events/42748592610/

The only way I can think of for this to happen is if you have form settings open, then in another tab you delete the current language from your app, then you go back to the first tab and click download.

@esoergel 