### PR TITLE
Fixed progress bar on daily saved exports

### DIFF
--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -147,7 +147,7 @@
                                              aria-valuemax="100"
                                              data-bind="attr: {
                                                 'aria-valuenow': emailedExport.taskStatus.percentComplete(),
-                                                'style': 'width: ' + emailedExport.taskStatus.percentComplete(),
+                                                'style': 'width: ' + emailedExport.taskStatus.percentComplete() + '%',
                                              }">
                                         </div>
                                     </div>


### PR DESCRIPTION
Progress bar was showing blank:
<img width="449" alt="screen shot 2019-01-15 at 1 53 23 pm" src="https://user-images.githubusercontent.com/1486591/51202604-1f0fc400-18cd-11e9-8386-9ca2c98498f0.png">

Now it's working:
<img width="449" alt="screen shot 2019-01-15 at 1 46 02 pm" src="https://user-images.githubusercontent.com/1486591/51202598-1ae3a680-18cd-11e9-9efe-1f8a90f82e8c.png">

I broke this when converting from angular to knockout: https://github.com/dimagi/commcare-hq/pull/22170/files#diff-6642e09d9c6022c818a55d29396fa264L151

@esoergel 