### PR TITLE
fix when a notification does not have start_date attr

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -95,7 +95,7 @@ def send_report(notification_id):
     notification = ReportNotification.get(notification_id)
 
     # If the report's start date is later than today, return and do not send the email
-    if notification.start_date and notification.start_date > datetime.today().date():
+    if hasattr(notification, 'start_date') and notification.start_date and notification.start_date > datetime.today().date():
         return
     try:
         notification.send()

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -95,7 +95,9 @@ def send_report(notification_id):
     notification = ReportNotification.get(notification_id)
 
     # If the report's start date is later than today, return and do not send the email
-    if hasattr(notification, 'start_date') and notification.start_date and notification.start_date > datetime.today().date():
+    if (hasattr(notification, 'start_date')
+            and notification.start_date
+            and notification.start_date > datetime.today().date()):
         return
     try:
         notification.send()


### PR DESCRIPTION
this task was failing silently when triggered from `send_test_scheduled_report`

@gbova 