### PR TITLE
Get subscription properties synchronously

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1125,8 +1125,8 @@ class Subscription(models.Model):
         """
         Overloaded to update domain pillow with subscription information
         """
-        Subscription._get_active_subscription_by_domain.clear(Subscription, self.subscriber.domain)
         super(Subscription, self).save(*args, **kwargs)
+        Subscription._get_active_subscription_by_domain.clear(Subscription, self.subscriber.domain)
         try:
             Domain.get_by_name(self.subscriber.domain).save()
         except Exception:
@@ -1135,8 +1135,8 @@ class Subscription(models.Model):
             pass
 
     def delete(self, *args, **kwargs):
-        Subscription._get_active_subscription_by_domain.clear(Subscription, self.subscriber.domain)
         super(Subscription, self).delete(*args, **kwargs)
+        Subscription._get_active_subscription_by_domain.clear(Subscription, self.subscriber.domain)
 
     @property
     def allowed_attr_changes(self):

--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -47,7 +47,7 @@ def user_save_callback(sender, **kwargs):
 @receiver(subscription_upgrade_or_downgrade)
 def domain_save_callback(sender, domain, **kwargs):
     domain_name = domain if isinstance(domain, six.string_types) else domain.name
-    update_subscription_properties_by_domain.delay(domain_name)
+    update_subscription_properties_by_domain(domain_name)
 
 
 def get_domain_membership_properties(couch_user):

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -727,8 +727,8 @@ def get_subscription_properties_by_user(couch_user):
         subscribed_editions.append(plan_version.plan.edition)
         if subscription is not None:
             all_subscriptions.append(subscription)
-        if subscription is not None and _is_paying_subscription(subscription, plan_version):
-            paying_subscribed_editions.append(plan_version.plan.edition)
+            if _is_paying_subscription(subscription, plan_version):
+                paying_subscribed_editions.append(plan_version.plan.edition)
 
     def _is_one_of_editions(edition):
         return 'yes' if edition in subscribed_editions else 'no'

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -674,6 +674,7 @@ def get_ab_test_properties(user):
     }
 
 
+@analytics_task()  # TODO - remove analytics_task decorator after changes are deployed to all environments.
 def update_subscription_properties_by_domain(domain):
     domain_obj = Domain.get_by_name(domain)
     if domain_obj:


### PR DESCRIPTION
Fixes https://dimagi-dev.atlassian.net/browse/HI-146, introduced in https://github.com/dimagi/commcare-hq/pull/21979

The issue is that the celery task often executes before the synchronous atomic transaction has committed, so it primes the empty cache with the present subscription in the database, before the new subscription is activated.  As a result, the new subscription is not in the cache.  By moving ```get_subscription_properties_by_user``` into synchronous execution, it will reflect the changes even before the transaction is committed.

@snopoke Are there any particular domains you had in mind when implementing https://github.com/dimagi/commcare-hq/pull/21979?  I'd like to confirm that saving a domain is still performant with these changes.

🐡 