### PR TITLE
Support different landing pages on the same webworker

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -339,7 +339,7 @@ def csrf_failure(request, reason=None, template_name="csrf_failure.html"):
 
 
 @sensitive_post_parameters('auth-password')
-def _login(req, domain_name, template_name):
+def _login(req, domain_name):
 
     if req.user.is_authenticated and req.method == "GET":
         redirect_to = req.GET.get('next', '')
@@ -364,6 +364,7 @@ def _login(req, domain_name, template_name):
     req.base_template = settings.BASE_TEMPLATE
 
     context = {}
+    template_name = 'login_and_password/login.html'
     custom_landing_page = settings.CUSTOM_LANDING_TEMPLATE
     if custom_landing_page:
         if isinstance(custom_landing_page, six.string_types):
@@ -419,7 +420,7 @@ def login(req):
 
 
 @location_safe
-def domain_login(req, domain, template_name="login_and_password/login.html"):
+def domain_login(req, domain):
     # This is a wrapper around the _login view which sets a different template
     project = Domain.get_by_name(domain)
     if not project:
@@ -429,7 +430,7 @@ def domain_login(req, domain, template_name="login_and_password/login.html"):
     # necessary domain contexts:
     req.project = project
 
-    return _login(req, domain, template_name)
+    return _login(req, domain)
 
 
 class HQLoginView(LoginView):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
+
+import functools
 import json
 import logging
 import os
@@ -11,7 +13,6 @@ import uuid
 from datetime import datetime
 from six.moves.urllib.parse import urlparse
 
-import functools
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -364,8 +365,13 @@ def _login(req, domain_name, template_name):
 
     context = {}
     custom_landing_page = settings.CUSTOM_LANDING_TEMPLATE
-    if custom_landing_page is not None:
-        template_name = custom_landing_page
+    if custom_landing_page:
+        if isinstance(custom_landing_page, six.string_types):
+            template_name = custom_landing_page
+        else:
+            template_name = custom_landing_page.get(req.get_host())
+            if template_name is None:
+                template_name = custom_landing_page.get('default', template_name)
     elif domain_name:
         domain = Domain.get_by_name(domain_name)
         req_params = req.GET if req.method == 'GET' else req.POST

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -416,7 +416,7 @@ def login(req):
 
     req_params = req.GET if req.method == 'GET' else req.POST
     domain = req_params.get('domain', None)
-    return _login(req, domain, "login_and_password/login.html")
+    return _login(req, domain)
 
 
 @location_safe

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -363,8 +363,8 @@ def _login(req, domain_name, template_name):
     req.base_template = settings.BASE_TEMPLATE
 
     context = {}
-    custom_landing_page = getattr(settings, 'CUSTOM_LANDING_TEMPLATE', False)
-    if custom_landing_page:
+    custom_landing_page = settings.CUSTOM_LANDING_TEMPLATE
+    if custom_landing_page is not None:
         template_name = custom_landing_page
     elif domain_name:
         domain = Domain.get_by_name(domain_name)

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -219,7 +219,7 @@ class ReportDispatcher(View):
                     and (show_in_navigation or show_in_dropdown)
                 ):
                     report_contexts.append({
-                        'url': report.get_url(domain=domain, request=request),
+                        'url': report.get_url(domain=domain, request=request, relative=True),
                         'description': _(report.description),
                         'icon': report.icon,
                         'title': _(report.name),

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -2,16 +2,18 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime
+
+import six
 from django.conf import settings
-from django.urls import resolve, reverse
 from django.http import Http404
+from django.urls import resolve, reverse
 from django_prbac.utils import has_privilege
 from ws4redis.context_processors import default
-from corehq.apps.accounting.utils import domain_has_privilege
-from corehq import privileges
-from corehq.apps.hqwebapp.utils import get_environment_friendly_name
-from corehq.apps.accounting.models import BillingAccount
 
+from corehq import privileges
+from corehq.apps.accounting.models import BillingAccount
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.hqwebapp.utils import get_environment_friendly_name
 
 COMMCARE = 'commcare'
 COMMTRACK = 'commtrack'
@@ -151,10 +153,17 @@ def enterprise_mode(request):
 def commcare_hq_names(request):
     return {
         'commcare_hq_names': {
-            'COMMCARE_NAME': settings.COMMCARE_NAME,
-            'COMMCARE_HQ_NAME': settings.COMMCARE_HQ_NAME
-        }
+            'COMMCARE_NAME': _get_cc_name(request, 'COMMCARE_NAME'),
+            'COMMCARE_HQ_NAME': _get_cc_name(request, 'COMMCARE_HQ_NAME'),
+        },
     }
+
+
+def _get_cc_name(request, var):
+    value = getattr(settings, var)
+    if isinstance(value, six.string_types):
+        return value
+    return value.get(request.get_host()) or value['default']
 
 
 def mobile_experience(request):

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -163,7 +163,16 @@ def _get_cc_name(request, var):
     value = getattr(settings, var)
     if isinstance(value, six.string_types):
         return value
-    return value.get(request.get_host()) or value['default']
+    try:
+        host = request.get_host()
+    except KeyError:
+        # In reporting code we create an HttpRequest object inside python which
+        # does not have an HTTP_HOST attribute. Its unclear what host would be
+        # expected in that scenario, so we're showing the default.
+        # The true fix for this lies in removing fake requests from scheduled reports
+        host = 'default'
+
+    return value.get(host) or value.get('default')
 
 
 def mobile_experience(request):

--- a/custom/icds/tests/test_views.py
+++ b/custom/icds/tests/test_views.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -7,6 +8,11 @@ from django.urls import reverse
 
 class TestViews(TestCase):
     @override_settings(CUSTOM_LANDING_TEMPLATE='icds/login.html')
+    def test_custom_login_old_format(self):
+        response = self.client.get(reverse("login"), follow=False)
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(CUSTOM_LANDING_TEMPLATE={"default": 'icds/login.html'})
     def test_custom_login(self):
         response = self.client.get(reverse("login"), follow=False)
         self.assertEqual(response.status_code, 200)

--- a/settings.py
+++ b/settings.py
@@ -890,6 +890,8 @@ NO_DEVICE_LOG_ENVS = list(ICDS_ENVS) + ['production']
 UCR_COMPARISONS = {}
 
 MAX_RULE_UPDATES_IN_ONE_RUN = 10000
+CUSTOM_LANDING_TEMPLATE = None
+
 from env_settings import *
 
 try:

--- a/settings.py
+++ b/settings.py
@@ -890,7 +890,13 @@ NO_DEVICE_LOG_ENVS = list(ICDS_ENVS) + ['production']
 UCR_COMPARISONS = {}
 
 MAX_RULE_UPDATES_IN_ONE_RUN = 10000
-CUSTOM_LANDING_TEMPLATE = None
+
+# used for providing separate landing pages for different URLs
+# default will be used if no hosts match
+CUSTOM_LANDING_TEMPLATE = {
+    # "icds-cas.gov.in": 'icds/login.html',
+    # "default": 'login_and_password/login.html',
+}
 
 from env_settings import *
 

--- a/settings.py
+++ b/settings.py
@@ -854,10 +854,12 @@ KAFKA_API_VERSION = None
 
 MOBILE_INTEGRATION_TEST_TOKEN = None
 
-# CommCare HQ - To indicate server
-COMMCARE_HQ_NAME = "CommCare HQ"
-# CommCare - To Indicate mobile
-COMMCARE_NAME = "CommCare"
+COMMCARE_HQ_NAME = {
+    "default": "CommCare HQ",
+}
+COMMCARE_NAME = {
+    "default": "CommCare",
+}
 
 ENTERPRISE_MODE = False
 


### PR DESCRIPTION
A bit of context here: https://docs.google.com/document/d/1YCO2_rLXgfOGABpjmKkaQyje1GX2hLmdAih1tW_CM54/edit#

Basically we're planning to run the REACH pilot on TCL on the same servers as ICDS-CAS, but we can't have ICDS-CAS's custom pages displayed for them. This PR is the first part of that work and will switch the landing page and commcare names based on the url.

There will be some followup commcare-cloud PRs, but I intentionally made this support the current format and new format, so they are not blocking