### PR TITLE
fix bulk app translations upload if app is huge

### DIFF
--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -8,7 +8,7 @@ import openpyxl
 from openpyxl.utils.exceptions import InvalidFileException
 import six
 from six.moves import zip
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.uploadedfile import UploadedFile
 
 
 class InvalidExcelFileException(Exception):
@@ -193,10 +193,10 @@ class WorkbookJSONReader(object):
 
     def __init__(self, file_or_filename):
         if six.PY3:
-            check_types = (InMemoryUploadedFile, io.RawIOBase, io.BufferedIOBase)
+            check_types = (UploadedFile, io.RawIOBase, io.BufferedIOBase)
         else:
             from types import FileType
-            check_types = (InMemoryUploadedFile, FileType, io.BytesIO)
+            check_types = (UploadedFile, FileType, io.BytesIO)
 
         if isinstance(file_or_filename, check_types):
             tmp = NamedTemporaryFile(mode='wb', suffix='.xlsx', delete=False)


### PR DESCRIPTION
If an app is particularly huge, the uploaded bulk translations file will be an instance of `TemporaryUploadedFile` not `InMemoryUploadedFile` as the workflow expects. as both are sublcasses of `UploadedFile`, this adds `UploadedFile` to the `check_types` tuple.

This however, doesn't address how unbearably slow the progress of this operation will be, but at least it doesn't `500`. 😄 