### PR TITLE
Fix "Next Sync" button in admin restore page

### DIFF
--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -197,6 +197,7 @@ class AdminRestoreView(TemplateView):
     @staticmethod
     def get_stats_from_xml(xml_payload):
         restore_id_element = xml_payload.find('{{{0}}}Sync/{{{0}}}restore_id'.format(SYNC_XMLNS))
+        # note: restore_id_element is ALWAYS falsy, so check explicitly for `None`
         restore_id = restore_id_element.text if restore_id_element is not None else None
         cases = xml_payload.findall('{http://commcarehq.org/case/transaction/v2}case')
         num_cases = len(cases)

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -197,7 +197,7 @@ class AdminRestoreView(TemplateView):
     @staticmethod
     def get_stats_from_xml(xml_payload):
         restore_id_element = xml_payload.find('{{{0}}}Sync/{{{0}}}restore_id'.format(SYNC_XMLNS))
-        restore_id = restore_id_element.text if restore_id_element else None
+        restore_id = restore_id_element.text if restore_id_element is not None else None
         cases = xml_payload.findall('{http://commcarehq.org/case/transaction/v2}case')
         num_cases = len(cases)
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-296
`bool(restore_id_element) == False` for some reason, even when the element is present and has contents.
Very strange.  I introduced this in https://github.com/dimagi/commcare-hq/pull/21530, actually - got past testing because dropping "is not None" was a last minute response to PR feedback.

@orangejenny code buddy
@czue FYI