### PR TITLE
add reach-test to cache

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1818,7 +1818,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         self.save()
 
     # Todo; temporary fix: Sravan
-    @quickcache(['self._id'], skip_arg=lambda user: user.domain != 'reach-sandbox', timeout=60 * 60 * 4)
+    @quickcache(['self._id'], skip_arg=lambda user: user.domain not in ['reach-sandbox', 'reach-test'], timeout=60 * 60 * 4)
     def get_case_sharing_groups(self):
         from corehq.apps.groups.models import Group
         # get faked location group objects


### PR DESCRIPTION
@emord 

REACH is now using another domain where they need this optimisation.

Since we may not be able to deploy the [permanent fix ](https://github.com/dimagi/commcare-hq/pull/22989) for REACH demo, planning to deploy this via hotfix deploy.