### PR TITLE
Pregnant details empty table formatting

### DIFF
--- a/custom/icds_reports/static/css/icds_dashboard.css
+++ b/custom/icds_reports/static/css/icds_dashboard.css
@@ -859,6 +859,12 @@ hr {
     padding: 20px 50px;
 }
 
+#pregnantDetailsTable {
+    margin: 0 auto;
+    min-width: 50%;
+    width: auto;
+}
+
 .pregnantDetailsColumn {
     min-width: 150px;
 }


### PR DESCRIPTION
Hi @calellowitz,
I have updated empty pregnant details table formatting to be centred and to be half of the space wide.
Need QA: No
Environment: n/a
Locally Tested: Yes
Regards, Dawid