### PR TITLE
pregnant details header info with empty table

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -1215,8 +1215,9 @@ def get_pregnant_details(case_id, awc_id):
             }
     if not config.get('pregnant', None):
         row_data = CcsRecordMonthlyView.objects.filter(
+            case_id=case_id,
             awc_id=awc_id,
-            pregnant_all=1,
+            month__gte=ten_months_ago,
         ).order_by('case_id', '-month').distinct('case_id').values(
             'case_id', 'trimester', 'person_name', 'age_in_months', 'mobile_number', 'edd', 'opened_on',
             'preg_order', 'home_visit_date'

--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -1203,6 +1203,33 @@ def get_pregnant_details(case_id, awc_id):
                 tt_date=get_tt_dates(row_data),
             )
         )
+        if not config.get('pregnant', None):
+            config['pregnant'] = {
+                'person_name': row_data['person_name'] if row_data['person_name'] else DATA_NOT_ENTERED,
+                'age': row_data['age_in_months'] // 12 if row_data['age_in_months'] else row_data['age_in_months'],
+                'mobile_number': row_data['mobile_number'] if row_data['mobile_number'] else DATA_NOT_ENTERED,
+                'edd': row_data['edd'] if row_data['edd'] else DATA_NOT_ENTERED,
+                'opened_on': row_data['opened_on'] if row_data['opened_on'] else DATA_NOT_ENTERED,
+                'trimester': row_data['trimester'] if row_data['trimester'] else DATA_NOT_ENTERED,
+                'preg_order': row_data['preg_order'] if row_data['preg_order'] else DATA_NOT_ENTERED,
+            }
+    if not config.get('pregnant', None):
+        row_data = CcsRecordMonthlyView.objects.filter(
+            awc_id=awc_id,
+            pregnant_all=1,
+        ).order_by('case_id', '-month').distinct('case_id').values(
+            'case_id', 'trimester', 'person_name', 'age_in_months', 'mobile_number', 'edd', 'opened_on',
+            'preg_order', 'home_visit_date'
+        ).first()
+        config['pregnant'] = {
+            'person_name': row_data['person_name'] if row_data['person_name'] else DATA_NOT_ENTERED,
+            'age': row_data['age_in_months'] // 12 if row_data['age_in_months'] else row_data['age_in_months'],
+            'mobile_number': row_data['mobile_number'] if row_data['mobile_number'] else DATA_NOT_ENTERED,
+            'edd': row_data['edd'] if row_data['edd'] else DATA_NOT_ENTERED,
+            'opened_on': row_data['opened_on'] if row_data['opened_on'] else DATA_NOT_ENTERED,
+            'trimester': row_data['trimester'] if row_data['trimester'] else DATA_NOT_ENTERED,
+            'preg_order': row_data['preg_order'] if row_data['preg_order'] else DATA_NOT_ENTERED,
+        }
     return config
 
 

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -2510,13 +2510,7 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             function (response) {
                 vm.pregnantData = response.data['data'];
                 vm.showTable = false;
-                if (vm.pregnantData[0].length > 0) {
-                    vm.pregnant = vm.pregnantData[0][0];
-                } else if (vm.pregnantData[1].length > 0) {
-                    vm.pregnant = vm.pregnantData[1][0];
-                } else {
-                    vm.pregnant = vm.pregnantData[2][0];
-                }
+                vm.pregnant = response.data['pregnant'];
                 vm.showPregnant = true;
             },
             function (error) {


### PR DESCRIPTION
Hi @calellowitz,
I have fixed the issue when pregnant details header was not populated for the cases that had an empty table.
Need QA: Yes
Environment: n/a
Locally Tested: Yes
Regards, Dawid