### PR TITLE
Fixed js error on new account page

### DIFF
--- a/corehq/apps/accounting/templates/accounting/accounts_base.html
+++ b/corehq/apps/accounting/templates/accounting/accounts_base.html
@@ -3,7 +3,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'accounting/js/widgets_v3' %}
+{% requirejs_main 'accounting/js/widgets_v4' %}
 
 {% block page_content %}
     {% crispy basic_form %}


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/22971/commits/e0435e50c03a7aefcce9bb3ea8b8845880b83757: I updated `NewBillingAccountView` to use select2 v4, but missed updating the template.

Verified that the only template that extends this is `accounting/accounts.html` which is the edit account page, which overwrites `requirejs_main` (and which is already using v4 anyway).

@esoergel @nickpell 