### PR TITLE
Revert "Support different landing pages on the same webworker"

### DIFF
--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -219,7 +219,7 @@ class ReportDispatcher(View):
                     and (show_in_navigation or show_in_dropdown)
                 ):
                     report_contexts.append({
-                        'url': report.get_url(domain=domain, request=request, relative=True),
+                        'url': report.get_url(domain=domain, request=request),
                         'description': _(report.description),
                         'icon': report.icon,
                         'title': _(report.name),

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -2,18 +2,16 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime
-
-import six
 from django.conf import settings
-from django.http import Http404
 from django.urls import resolve, reverse
+from django.http import Http404
 from django_prbac.utils import has_privilege
 from ws4redis.context_processors import default
-
-from corehq import privileges
-from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.accounting.utils import domain_has_privilege
+from corehq import privileges
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
+from corehq.apps.accounting.models import BillingAccount
+
 
 COMMCARE = 'commcare'
 COMMTRACK = 'commtrack'
@@ -153,26 +151,10 @@ def enterprise_mode(request):
 def commcare_hq_names(request):
     return {
         'commcare_hq_names': {
-            'COMMCARE_NAME': _get_cc_name(request, 'COMMCARE_NAME'),
-            'COMMCARE_HQ_NAME': _get_cc_name(request, 'COMMCARE_HQ_NAME'),
-        },
+            'COMMCARE_NAME': settings.COMMCARE_NAME,
+            'COMMCARE_HQ_NAME': settings.COMMCARE_HQ_NAME
+        }
     }
-
-
-def _get_cc_name(request, var):
-    value = getattr(settings, var)
-    if isinstance(value, six.string_types):
-        return value
-    try:
-        host = request.get_host()
-    except KeyError:
-        # In reporting code we create an HttpRequest object inside python which
-        # does not have an HTTP_HOST attribute. Its unclear what host would be
-        # expected in that scenario, so we're showing the default.
-        # The true fix for this lies in removing fake requests from scheduled reports
-        host = 'default'
-
-    return value.get(host) or value.get('default')
 
 
 def mobile_experience(request):

--- a/custom/icds/tests/test_views.py
+++ b/custom/icds/tests/test_views.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -8,11 +7,6 @@ from django.urls import reverse
 
 class TestViews(TestCase):
     @override_settings(CUSTOM_LANDING_TEMPLATE='icds/login.html')
-    def test_custom_login_old_format(self):
-        response = self.client.get(reverse("login"), follow=False)
-        self.assertEqual(response.status_code, 200)
-
-    @override_settings(CUSTOM_LANDING_TEMPLATE={"default": 'icds/login.html'})
     def test_custom_login(self):
         response = self.client.get(reverse("login"), follow=False)
         self.assertEqual(response.status_code, 200)

--- a/settings.py
+++ b/settings.py
@@ -854,12 +854,10 @@ KAFKA_API_VERSION = None
 
 MOBILE_INTEGRATION_TEST_TOKEN = None
 
-COMMCARE_HQ_NAME = {
-    "default": "CommCare HQ",
-}
-COMMCARE_NAME = {
-    "default": "CommCare",
-}
+# CommCare HQ - To indicate server
+COMMCARE_HQ_NAME = "CommCare HQ"
+# CommCare - To Indicate mobile
+COMMCARE_NAME = "CommCare"
 
 ENTERPRISE_MODE = False
 
@@ -892,14 +890,6 @@ NO_DEVICE_LOG_ENVS = list(ICDS_ENVS) + ['production']
 UCR_COMPARISONS = {}
 
 MAX_RULE_UPDATES_IN_ONE_RUN = 10000
-
-# used for providing separate landing pages for different URLs
-# default will be used if no hosts match
-CUSTOM_LANDING_TEMPLATE = {
-    # "icds-cas.gov.in": 'icds/login.html',
-    # "default": 'login_and_password/login.html',
-}
-
 from env_settings import *
 
 try:


### PR DESCRIPTION
Reverts dimagi/commcare-hq#22985

Seeing the dictionary of `CUSTOM_LANDING_TEMPLATE` on staging's landing page associated with this. Reverting this to be safe.