### PR TITLE
Actually filter out reports in the future in send_report

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -584,6 +584,15 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
             return ReportContent(_("An error occurred while generating this report."), None)
 
     @property
+    def is_active(self):
+        """
+        Returns True if the report has a start_date that is in the past or there is
+        no start date
+        :return: boolean
+        """
+        return self.start_date is None or self.start_date <= datetime.today().date()
+
+    @property
     def is_configurable_report(self):
         from corehq.apps.userreports.reports.view import ConfigurableReportView
         return self.report_type == ConfigurableReportView.prefix

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -821,8 +821,14 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
 
             attach_excel = getattr(self, 'attach_excel', False)
             content, excel_files = get_scheduled_report_response(
-                self.owner, self.domain, self._id, attach_excel=attach_excel)
-            slugs = [r.report_slug for r in self.configs]
+                self.owner, self.domain, self._id, attach_excel=attach_excel,
+                send_only_active=True
+            )
+
+            # Will be False if ALL the ReportConfigs in the ReportNotification
+            # have a start_date in the future.
+            if content is False:
+                return
 
             for email in emails:
                 body = render_full_report_notification(None, content, email, self).content

--- a/corehq/apps/reports/static/reports/js/report_config_models.js
+++ b/corehq/apps/reports/static/reports/js/report_config_models.js
@@ -39,9 +39,9 @@ hqDefine("reports/js/report_config_models", [
                 if (!_.isNumber(days) || _.isNaN(days)) {
                     error = true;
                 }
-            } else if ((date_range === 'since' || date_range === 'range') && _.isEmpty(self.start_date())) {
+            } else if ((date_range === 'since' || date_range === 'range') && _.isEmpty(ko.utils.unwrapObservable(self.start_date))) {
                 error = true;
-            } else if (date_range === 'range' && _.isEmpty(self.end_date())) {
+            } else if (date_range === 'range' && _.isEmpty(ko.utils.unwrapObservable(self.end_date))) {
                 error = true;
             }
             self.error(error);

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -94,11 +94,6 @@ def send_delayed_report(report_id):
 def send_report(notification_id):
     notification = ReportNotification.get(notification_id)
 
-    # If the report's start date is later than today, return and do not send the email
-    if (hasattr(notification, 'start_date')
-            and notification.start_date
-            and notification.start_date > datetime.today().date()):
-        return
     try:
         notification.send()
     except UnsupportedScheduledReportError:

--- a/corehq/apps/reports/templates/reports/report_email_content.html
+++ b/corehq/apps/reports/templates/reports/report_email_content.html
@@ -25,6 +25,15 @@
         {% if report.startdate %}
         <p>
             {% trans "Date range" %}: {{ report.startdate }} - {{ report.enddate }}
+            {% if not report.is_active %}
+              <br />
+              <strong>
+                {% blocktrans %}
+                  Note: This report will not appear in emails because the start
+                  date for the report is still in the future.
+                {% endblocktrans %}
+              </strong>
+            {% endif %}
         </p>
         {% endif %}
         {{ report.content|safe }}

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1110,10 +1110,15 @@ def send_test_scheduled_report(request, domain, scheduled_report_id):
     return HttpResponseRedirect(reverse("reports_home", args=(domain,)))
 
 
-def get_scheduled_report_response(couch_user, domain, scheduled_report_id, email=True, attach_excel=False):
+def get_scheduled_report_response(couch_user, domain, scheduled_report_id,
+                                  email=True, attach_excel=False,
+                                  send_only_active=False):
     """
     This function somewhat confusingly returns a tuple of: (response, excel_files)
     If attach_excel is false, excel_files will always be an empty list.
+    If send_only_active is True, then only ReportConfigs that have a start_date
+    in the past will be sent. If none of the ReportConfigs are valid, no email will
+    be sent.
     """
     # todo: clean up this API?
     from django.http import HttpRequest
@@ -1134,11 +1139,13 @@ def get_scheduled_report_response(couch_user, domain, scheduled_report_id, email
         email,
         attach_excel=attach_excel,
         lang=notification.language,
+        send_only_active=send_only_active,
     )
 
 
 def _render_report_configs(request, configs, domain, owner_id, couch_user, email,
-                           notes=None, attach_excel=False, once=False, lang=None):
+                           notes=None, attach_excel=False, once=False, lang=None,
+                           send_only_active=False):
     """
     Renders only notification's main content, which then may be used to generate full notification body.
     """
@@ -1147,6 +1154,14 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
     report_outputs = []
     excel_attachments = []
     format = Format.from_format(request.GET.get('format') or Format.XLS_2007)
+
+    # Show only the report configs that have started their reporting period
+    if send_only_active:
+        configs = filter(lambda c: c.is_active, configs)
+
+    # Don't send an email if none of the reports configs have started
+    if len(configs) == 0:
+        return False, False
 
     for config in configs:
         content, excel_file = config.get_report_content(lang, attach_excel=attach_excel)

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1176,6 +1176,7 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
             'title': config.full_name,
             'url': config.url,
             'content': content,
+            'is_active': config.is_active,
             'description': config.description,
             "startdate": date_range.get("startdate") if date_range else "",
             "enddate": date_range.get("enddate") if date_range else "",


### PR DESCRIPTION
Also fix js error when saving some report configs.

Adds a cue to the user in the send report preview that indicates if a report in the future will not show up in the email:
![screen shot 2019-01-17 at 8 55 29 pm](https://user-images.githubusercontent.com/716573/51362795-a0688180-1a9a-11e9-98a1-9ef172aa1342.png)
