### PR TITLE
Move district and block cells to the left and right align date when d…

### DIFF
--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -852,15 +852,16 @@ def create_aww_performance_excel_file(excel_data, data_type, month, state, distr
         worksheet[cell].alignment = warp_text_alignment
     worksheet.merge_cells('B3:C3')
     worksheet['B3'].value = "State: {}".format(state)
-    worksheet.merge_cells('D3:E3')
     worksheet['D3'].value = "District: {}".format(district)
-    worksheet.merge_cells('F3:G3')
-    worksheet['F3'].value = "Block: {}".format(block)
+    worksheet.merge_cells('E3:F3')
+    worksheet['E3'].value = "Block: {}".format(block)
     worksheet.merge_cells('H3:I3')
     worksheet['H3'].value = "Date when downloaded:"
+    worksheet['H3'].alignment = Alignment(horizontal="right")
     utc_now = datetime.now(pytz.utc)
     now_in_india = utc_now.astimezone(india_timezone)
     worksheet['J3'].value = custom_strftime('{S} %b %Y', now_in_india)
+    worksheet['J3'].alignment = Alignment(horizontal="right")
 
     # table header
     table_header_position_row = 5
@@ -906,10 +907,10 @@ def create_aww_performance_excel_file(excel_data, data_type, month, state, distr
         'A': 4,
         'B': 7,
         'C': max(15, len(state) * 4 // 3),
-        'D': 13,
-        'E': max(12, len(district) * 4 // 3),
-        'F': 13,
-        'G': max(15, len(block) * 4 // 3),
+        'D': 13 + (len(district) * 4 // 3),
+        'E': 12,
+        'F': max(13, len(block) * 4 // 3),
+        'G': 15,
         'H': 11,
         'I': 14,
         'J': 14,


### PR DESCRIPTION
…ownloaded
Hi @calellowitz,
I have added the missing changes for the aww performance report formatting, they include keeping the district in one column and moving the block information one cell to the left as well as the right alignment of the date fields. This way formatting should be more clear.
Need QA: Yes (formatting is behind feature flag)
Environment: n/a
Locally Tested: Yes
Regards, Dawid