### PR TITLE
add invoice filters by number and balance

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -457,6 +457,27 @@ class InvoiceNumberAsyncHandler(BaseSingleOptionFilterAsyncHandler):
         ]
 
 
+class InvoiceBalanceAsyncHandler(BaseSingleOptionFilterAsyncHandler):
+    slug = 'invoice_balance_filter'
+    allowed_actions = [
+        'invoice_balance'
+    ]
+
+    @property
+    def query(self):
+        query = Invoice.objects.order_by('balance')
+        if self.search_string:
+            query = query.filter(balance__startswith=self.search_string)
+        return query
+
+    @property
+    def invoice_balance_response(self):
+        return [
+            self._fmt_select2_data(six.text_type(p.balance), six.text_type(p.balance))
+            for p in self.paginated_data
+        ]
+
+
 class DomainFilterAsyncHandler(BaseSingleOptionFilterAsyncHandler):
     slug = 'domain_filter'
     allowed_actions = [

--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
-from django.db.models import Q
+import six
+
+from django.conf import settings
+from django.db.models import F, Q
 
 from corehq.apps.accounting.models import (
     BillingAccount,
     BillingContactInfo,
     Feature,
+    Invoice,
     SoftwarePlan,
     SoftwarePlanVersion,
     SoftwareProductRate,
@@ -428,6 +432,29 @@ class SoftwarePlanAsyncHandler(BaseSingleOptionFilterAsyncHandler):
     def name_response(self):
         return [self._fmt_select2_data(p.name, p.name)
                 for p in self.paginated_data]
+
+
+class InvoiceNumberAsyncHandler(BaseSingleOptionFilterAsyncHandler):
+    slug = 'invoice_number_filter'
+    allowed_actions = [
+        'invoice_number',
+    ]
+
+    @property
+    def query(self):
+        query = Invoice.objects.annotate(
+            number_on_invoice=F('id') + settings.INVOICE_STARTING_NUMBER
+        ).order_by('number_on_invoice')
+        if self.search_string:
+            query = query.filter(number_on_invoice__startswith=self.search_string)
+        return query
+
+    @property
+    def invoice_number_response(self):
+        return [
+            self._fmt_select2_data(six.text_type(p.id), six.text_type(p.number_on_invoice))
+            for p in self.paginated_data
+        ]
 
 
 class DomainFilterAsyncHandler(BaseSingleOptionFilterAsyncHandler):

--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -16,6 +16,7 @@ from corehq.apps.accounting.async_handlers import (
     DomainFilterAsyncHandler,
     BillingContactInfoAsyncHandler,
     SoftwarePlanAsyncHandler,
+    InvoiceNumberAsyncHandler,
 )
 from corehq.apps.accounting.models import (
     BillingAccountType,
@@ -403,6 +404,14 @@ class SoftwarePlanVisibilityFilter(BaseSingleOptionFilter):
     label = _("Visibility")
     default_text = _("All")
     options = SoftwarePlanVisibility.CHOICES
+
+
+class InvoiceNumberFilter(BaseAccountingSingleOptionFilter):
+    slug = 'invoice_number'
+    label = 'Invoice Number'
+    default_text = 'All'
+    async_handler = InvoiceNumberAsyncHandler
+    async_action = 'invoice_number'
 
 
 class PaymentStatusFilter(BaseSingleOptionFilter):

--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -17,6 +17,7 @@ from corehq.apps.accounting.async_handlers import (
     BillingContactInfoAsyncHandler,
     SoftwarePlanAsyncHandler,
     InvoiceNumberAsyncHandler,
+    InvoiceBalanceAsyncHandler,
 )
 from corehq.apps.accounting.models import (
     BillingAccountType,
@@ -412,6 +413,14 @@ class InvoiceNumberFilter(BaseAccountingSingleOptionFilter):
     default_text = 'All'
     async_handler = InvoiceNumberAsyncHandler
     async_action = 'invoice_number'
+
+
+class InvoiceBalanceFilter(BaseAccountingSingleOptionFilter):
+    slug = 'invoice_balance'
+    label = 'Invoice Balance'
+    default_text = 'All'
+    async_handler = InvoiceBalanceAsyncHandler
+    async_action = 'invoice_balance'
 
 
 class PaymentStatusFilter(BaseSingleOptionFilter):

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -34,6 +34,7 @@ from .filters import (
     DueDatePeriodFilter,
     EndDateFilter,
     EntryPointFilter,
+    InvoiceNumberFilter,
     IsHiddenFilter,
     NameFilter,
     PaymentStatusFilter,
@@ -635,6 +636,7 @@ class InvoiceInterface(InvoiceInterfaceBase):
     description = "List of all invoices"
     slug = "invoices"
     fields = [
+        'corehq.apps.accounting.interface.InvoiceNumberFilter',
         'corehq.apps.accounting.interface.NameFilter',
         'corehq.apps.accounting.interface.SubscriberFilter',
         'corehq.apps.accounting.interface.PaymentStatusFilter',
@@ -791,6 +793,10 @@ class InvoiceInterface(InvoiceInterfaceBase):
     @memoized
     def _invoices(self):
         queryset = Invoice.objects.all()
+
+        invoice_id = InvoiceNumberFilter.get_value(self.request, self.domain)
+        if invoice_id is not None:
+            queryset = queryset.filter(id=int(invoice_id))
 
         if self.subscription:
             queryset = queryset.filter(subscription=self.subscription)

--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import datetime
+from decimal import Decimal
 
 from django.urls import reverse
 from django.db.models import Q
@@ -35,6 +36,7 @@ from .filters import (
     EndDateFilter,
     EntryPointFilter,
     InvoiceNumberFilter,
+    InvoiceBalanceFilter,
     IsHiddenFilter,
     NameFilter,
     PaymentStatusFilter,
@@ -50,7 +52,7 @@ from .filters import (
     SubscriberFilter,
     SubscriptionTypeFilter,
     TrialStatusFilter,
-    CustomerAccountFilter
+    CustomerAccountFilter,
 )
 from .forms import AdjustBalanceForm
 from .models import (
@@ -637,6 +639,7 @@ class InvoiceInterface(InvoiceInterfaceBase):
     slug = "invoices"
     fields = [
         'corehq.apps.accounting.interface.InvoiceNumberFilter',
+        'corehq.apps.accounting.interface.InvoiceBalanceFilter',
         'corehq.apps.accounting.interface.NameFilter',
         'corehq.apps.accounting.interface.SubscriberFilter',
         'corehq.apps.accounting.interface.PaymentStatusFilter',
@@ -797,6 +800,10 @@ class InvoiceInterface(InvoiceInterfaceBase):
         invoice_id = InvoiceNumberFilter.get_value(self.request, self.domain)
         if invoice_id is not None:
             queryset = queryset.filter(id=int(invoice_id))
+
+        invoice_balance = InvoiceBalanceFilter.get_value(self.request, self.domain)
+        if invoice_balance is not None:
+            queryset = queryset.filter(balance=Decimal(invoice_balance))
 
         if self.subscription:
             queryset = queryset.filter(subscription=self.subscription)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -86,6 +86,7 @@ from corehq.apps.accounting.async_handlers import (
     DomainFilterAsyncHandler,
     BillingContactInfoAsyncHandler,
     SoftwarePlanAsyncHandler,
+    InvoiceNumberAsyncHandler,
 )
 from corehq.apps.accounting.models import (
     Invoice, WireInvoice, CustomerInvoice, BillingAccount, CreditLine, Subscription, CustomerBillingRecord,
@@ -1172,6 +1173,7 @@ class AccountingSingleOptionResponseView(View, AsyncHandlerMixin):
         DomainFilterAsyncHandler,
         BillingContactInfoAsyncHandler,
         SoftwarePlanAsyncHandler,
+        InvoiceNumberAsyncHandler,
     ]
 
     @method_decorator(require_superuser)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -87,6 +87,7 @@ from corehq.apps.accounting.async_handlers import (
     BillingContactInfoAsyncHandler,
     SoftwarePlanAsyncHandler,
     InvoiceNumberAsyncHandler,
+    InvoiceBalanceAsyncHandler,
 )
 from corehq.apps.accounting.models import (
     Invoice, WireInvoice, CustomerInvoice, BillingAccount, CreditLine, Subscription, CustomerBillingRecord,
@@ -1174,6 +1175,7 @@ class AccountingSingleOptionResponseView(View, AsyncHandlerMixin):
         BillingContactInfoAsyncHandler,
         SoftwarePlanAsyncHandler,
         InvoiceNumberAsyncHandler,
+        InvoiceBalanceAsyncHandler,
     ]
 
     @method_decorator(require_superuser)


### PR DESCRIPTION
Adds two new filters to the invoice report.

Screenshot:
<img width="552" alt="screen shot 2019-01-18 at 2 07 31 pm" src="https://user-images.githubusercontent.com/1757035/51407656-80809e80-1b2a-11e9-80c1-cfc5cc73d97c.png">

https://trello.com/c/j9kSBn8X/106-under-cchqs-accounting-interface-add-ability-to-search-by-invoice-and-invoice-amount