### PR TITLE
fix corehq.apps.app_manager.tests.test_suite:SuiteTest.test_graphing

### DIFF
--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -575,7 +575,7 @@ class GraphTemplate(Template):
                                     for k, v in six.iteritems(s.config)
                                 ] + [
                                     ConfigurationItem(id=k, locale_id=locale_series_config(index, k))
-                                    for k, v in six.iteritems(s.locale_specific_config)
+                                    for k, v in sorted(six.iteritems(s.locale_specific_config))
                                 ]
                             )
                         )

--- a/corehq/apps/app_manager/tests/data/suite/suite-graphing.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-graphing.xml
@@ -189,11 +189,11 @@
         <graph type="xy">
           <series nodeset="instance('casedb')/casedb/case[@case_type='point_case'][index/parent=current()/@case_id][@status='open']">
             <configuration>
-              <text id="x-name">
-                <locale id="m0.case_long.case_xy_graph_config_6.graph.series_0.key.x-name"/>
-              </text>
               <text id="name">
                 <locale id="m0.case_long.case_xy_graph_config_6.graph.series_0.key.name"/>
+              </text>
+              <text id="x-name">
+                <locale id="m0.case_long.case_xy_graph_config_6.graph.series_0.key.x-name"/>
               </text>
             </configuration>
             <x function="x_num"/>

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import os
-from collections import OrderedDict
-
 import lxml
 from lxml.doctestcompare import LXMLOutputChecker, LHTMLOutputChecker
 import mock
@@ -74,14 +72,6 @@ class SuiteMixin(TestFileMixin):
     def _test_generic_suite(self, app_tag, suite_tag=None):
         suite_tag = suite_tag or app_tag
         app = Application.wrap(self.get_json(app_tag))
-
-        # make dictionary iteration order deterministic for tests
-        for module in app.modules:
-            for column in module.case_details.long.columns:
-                if column.graph_configuration:
-                    for series in column.graph_configuration.series:
-                        series.locale_specific_config = OrderedDict(sorted(series.locale_specific_config.items()))
-
         self.assertXmlEqual(self.get_xml(suite_tag), app.create_suite())
 
     def _test_generic_suite_partial(self, app_tag, xpath, suite_tag=None):

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import os
+from collections import OrderedDict
+
 import lxml
 from lxml.doctestcompare import LXMLOutputChecker, LHTMLOutputChecker
 import mock
@@ -72,6 +74,14 @@ class SuiteMixin(TestFileMixin):
     def _test_generic_suite(self, app_tag, suite_tag=None):
         suite_tag = suite_tag or app_tag
         app = Application.wrap(self.get_json(app_tag))
+
+        # make dictionary iteration order deterministic for tests
+        for module in app.modules:
+            for column in module.case_details.long.columns:
+                if column.graph_configuration:
+                    for series in column.graph_configuration.series:
+                        series.locale_specific_config = OrderedDict(sorted(series.locale_specific_config.items()))
+
         self.assertXmlEqual(self.get_xml(suite_tag), app.create_suite())
 
     def _test_generic_suite_partial(self, app_tag, xpath, suite_tag=None):


### PR DESCRIPTION
Many of the remaining py3 tests will require handling the dict iteration order having changed:
https://portingguide.readthedocs.io/en/latest/dicts.html#changed-key-order

Depending on the situation, I'll either make the tests independent of the iteration order, or make the iteration order predictable.

@dimagi/py3 