### PR TITLE
fix corehq.apps.userreports.tests.test_columns:TestExpandedColumn.tes…

### DIFF
--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -337,7 +337,7 @@ class TestExpandedColumn(TestCase):
 
         expected_rows = [get_expected_row(v, set(submitted_vals)) for v in submitted_vals]
         data = data_source.get_data()
-        self.assertEqual(sorted(expected_rows), sorted(data))
+        self.assertItemsEqual(expected_rows, data)
 
 
 class TestAggregateDateColumn(SimpleTestCase):


### PR DESCRIPTION
…t_none_in_values

dicts can't be sorted in python 3, so use ```assertItemsEqual```

@dimagi/py3 