### PR TITLE
fix Application.wrap for tests with binary attachments

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3957,9 +3957,9 @@ class LazyBlobDoc(BlobMixin):
         self = super(LazyBlobDoc, cls).wrap(data)
         if attachments:
             for name, attachment in attachments.items():
-                if isinstance(attachment, six.string_types):
-                    if isinstance(attachment, six.text_type):
-                        attachment = attachment.encode('utf-8')
+                if isinstance(attachment, six.text_type):
+                    attachment = attachment.encode('utf-8')
+                if isinstance(attachment, bytes):
                     info = {"content": attachment}
                 else:
                     raise ValueError("Unknown attachment format: {!r}"


### PR DESCRIPTION
```six.string_types``` does not include ```bytes``` in python 3, so this removes ```six.string_types```.

Before upgrading python, we should remove all usages of ```six.string_types```.

(```Application.wrap``` is obsolete in production systems after the attachments migration, but there are still some hardcoded apps in tests that need to be migrated before ```Application.wrap``` can be removed.)

@dimagi/py3 