### PR TITLE
ECHIS Static UCR - Fix reference to fp_method value

### DIFF
--- a/custom/echis_reports/ucr/data_sources/hmis_mobile_job_aid.json
+++ b/custom/echis_reports/ucr/data_sources/hmis_mobile_job_aid.json
@@ -3033,7 +3033,7 @@
                 },
                 "type": "boolean_expression",
                 "comment": null,
-                "property_value": "injectables"
+                "property_value": "injections"
               },
               {
                 "operator": "eq",
@@ -3447,7 +3447,7 @@
                 },
                 "type": "boolean_expression",
                 "comment": null,
-                "property_value": "injectables"
+                "property_value": "injections"
               },
               {
                 "operator": "not_eq",
@@ -3663,7 +3663,7 @@
                 },
                 "type": "boolean_expression",
                 "comment": null,
-                "property_value": "injectables"
+                "property_value": "injections"
               },
               {
                 "operator": "eq",
@@ -4077,7 +4077,7 @@
                 },
                 "type": "boolean_expression",
                 "comment": null,
-                "property_value": "injectables"
+                "property_value": "injections"
               },
               {
                 "operator": "not_eq",


### PR DESCRIPTION
 Fix reference to fp_method value from "injectables" to "injections"

Updated the hmis_mobile_job_aid data source to match the values used by the app. Normally I would just update the app, but "injections" is used in so many places that updating the data source felt like the lower-risk approach.

Once this has been merged to master and deployed, I will kick off a rebuild on fmoh-echis-staging. Once the changes have been merged to the echisethiopia server by the local team and deployed there, I will also kick off a rebuild on the local server.