### PR TITLE
Fixed mismatched subscriptions table headers and columns

### DIFF
--- a/corehq/apps/accounting/templates/accounting/partials/subscriptions_tab.html
+++ b/corehq/apps/accounting/templates/accounting/partials/subscriptions_tab.html
@@ -18,7 +18,6 @@
                 <th>{% trans "Currently Active" %}</th>
                 <th>{% trans "Salesforce Contract ID" %}</th>
                 <th>{% trans "Last Invoice Due Date" %}</th>
-                <th>{% trans "Delay Invoicing Until" %}</th>
                 <th>{% trans "Do Not Invoice" %}</th>
                 <th>{% trans '"Do Not Invoice" Reason' %}</th>
                 <th>{% trans "Edit" %}</th>


### PR DESCRIPTION
Minor followup for https://github.com/dimagi/commcare-hq/pull/21175, removes the extra header here:

<img width="1119" alt="screen shot 2019-01-21 at 10 22 47 am" src="https://user-images.githubusercontent.com/1486591/51483274-aeeabd80-1d66-11e9-9a77-81590f78174d.png">

@nickpell / @esoergel 