### PR TITLE
Added sharing to export_instances_by_domain map.js

### DIFF
--- a/corehq/couchapps/export_instances_by_domain/views/view/map.js
+++ b/corehq/couchapps/export_instances_by_domain/views/view/map.js
@@ -9,6 +9,7 @@ function(doc) {
             export_format: doc.export_format,
             name: doc.name,
             owner_id: doc.owner_id,
+            sharing: doc.sharing,
         });
     }
 }


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/22982, needed because it's used in [can_view](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/export/views/list.py#L185)

@esoergel 