### PR TITLE
Improve app summary performance

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -1,4 +1,3 @@
-// knockout_bindings.ko is a part of this dependency because page uses 'slideVisible' binding in case_summary.html
 hqDefine('app_manager/js/summary/case_summary',[
     'jquery',
     'underscore',
@@ -6,7 +5,6 @@ hqDefine('app_manager/js/summary/case_summary',[
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/assert_properties',
     'app_manager/js/summary/models',
-    'hqwebapp/js/knockout_bindings.ko',
     'app_manager/js/menu',  // enable lang switcher and "Updates to publish" banner
 ], function ($, _, ko, initialPageData, assertProperties, models) {
 

--- a/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
@@ -1,4 +1,3 @@
-// knockout_bindings.ko is a part of this dependency because page uses 'slideVisible' binding form_summary.html
 hqDefine('app_manager/js/summary/form_summary',[
     'jquery',
     'underscore',
@@ -7,7 +6,6 @@ hqDefine('app_manager/js/summary/form_summary',[
     'hqwebapp/js/assert_properties',
     'app_manager/js/summary/models',
     'app_manager/js/summary/utils',
-    'hqwebapp/js/knockout_bindings.ko',
     'app_manager/js/menu',  // enable lang switcher and "Updates to publish" banner
 ], function ($, _, ko, initialPageData, assertProperties, models, utils) {
     var formSummaryModel = function (options) {

--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -44,7 +44,7 @@
     <div class="row">
         <div class="col-sm-12">
             <!-- ko foreach: caseTypes -->
-                <div class="panel panel-appmanager" data-bind="slideVisible: isVisible">
+                <div class="panel panel-appmanager" data-bind="visible: isVisible">
                     <div class="panel-heading">
                         <h4 class="panel-title panel-title-nolink">
                             <i class="fcc fcc-fd-external-case"></i>
@@ -99,7 +99,7 @@
                             </thead>
                             <tbody data-bind="foreach: properties">
                                 <!-- ko foreach: forms -->
-                                    <tr data-bind="attr: {id: $parents[1].name + ':' + $parent.name}, css: {'danger': $parent.has_errors}, slideVisible: $parent.isVisible">
+                                    <tr data-bind="attr: {id: $parents[1].name + ':' + $parent.name}, css: {'danger': $parent.has_errors}, visible: $parent.isVisible">
                                         <!-- ko if: !$index() -->
                                         <td data-bind="attr: {rowspan: $parent.forms.length}">
                                             <dl>
@@ -145,7 +145,7 @@
             <li>
                 <span data-bind="html: $root.moduleFormReference(formId)"></span>
                 <!-- ko: if: conditions -->
-                    <ul class="fa-ul" data-bind="slideVisible: $root.showConditions, foreach: conditions">
+                    <ul class="fa-ul" data-bind="visible: $root.showConditions, foreach: conditions">
                         <li>
                             <i class="fa fa-sitemap"></i>
                             <span data-bind="text: question"></span>
@@ -169,7 +169,7 @@
                     <li data-bind="visible: $root.showIds, text: value"></li>
                     <li data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></li>
                 </ul>
-                <ul class="fa-ul" data-bind="if: condition, slideVisible: $root.showConditions">
+                <ul class="fa-ul" data-bind="if: condition, visible: $root.showConditions">
                     <li>
                         <i class="fa-li fa fa-sitemap text-muted"></i>
                         <span data-bind="text: condition.question"></span>
@@ -177,7 +177,7 @@
                         <span data-bind="text: condition.answer"></span>
                     </li>
                 </ul>
-                <ul class="fa-ul" data-bind="if: question.calculate, slideVisible: $root.showCalculations">
+                <ul class="fa-ul" data-bind="if: question.calculate, visible: $root.showCalculations">
                     <li>
                         <i class="fa-li fa fa-calculator text-muted"></i>
                         <span data-bind="text: question.calculate"></span>

--- a/corehq/apps/app_manager/templates/app_manager/form_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary.html
@@ -54,7 +54,7 @@
     <!-- /ko -->
 
     <ul class="fa-ul" data-bind="foreach: modules">
-        <li data-bind="slideVisible: isVisible">
+        <li data-bind="visible: isVisible">
             <h4>
                 <a data-bind="ifnot: $root.readOnly, attr: { href: url }">
                     <i data-bind="attr: { 'class': icon }"></i>
@@ -69,7 +69,7 @@
             <!-- ko template: {name: 'question-attribute', data: { attribute: module_filter, icon: 'fa-code-fork',
                  visibleObs: $root.showRelevance } }--><!-- /ko -->
             <ul class="fa-ul" data-bind="foreach: forms">
-                <li data-bind="slideVisible: isVisible">
+                <li data-bind="visible: isVisible">
                     <h5>
                         <a data-bind="ifnot: $root.readOnly, attr: { href: url }">
                             <i data-bind="attr: { 'class': icon }"></i>
@@ -84,7 +84,7 @@
                     <!-- ko template: {name: 'question-attribute', data: { attribute: form_filter, icon: 'fa-code-fork',
                          visibleObs: $root.showRelevance } }--><!-- /ko -->
                     <ol data-bind="foreach: questions">
-                        <li data-bind="slideVisible: isVisible">
+                        <li data-bind="visible: isVisible">
                             <i data-bind="attr: { 'class': $root.questionIcon($data) }" title="type"></i>
                             <span data-bind="visible: $root.showIds, text: value"></span>
                             <span data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></span>
@@ -113,7 +113,7 @@
 
     {# Button to toggle question attribute #}
     <script type="text/html" id="question-attribute">
-        <ul class="fa-ul" data-bind="if: attribute, slideVisible: visibleObs">
+        <ul class="fa-ul" data-bind="if: attribute, visible: visibleObs">
             <li>
                 <i data-bind="attr: {'class': 'fa-li fa text-muted ' + icon}"></i>
                 <span data-bind="text: attribute"></span>

--- a/corehq/apps/app_manager/templates/app_manager/form_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary.html
@@ -70,7 +70,7 @@
             <ul class="fa-ul" data-bind="visible: $root.showRelevance">
                 <li>
                     <i data-bind="attr: {'class': 'fa-li fa text-muted fa-code-fork'}"></i>
-                    <span data-bind="text: module_filter"></span>
+                    <!-- ko text: module_filter --><!-- /ko -->
                 </li>
             </ul>
             <!-- /ko -->
@@ -98,45 +98,44 @@
                     <ol data-bind="foreach: questions">
                         <li data-bind="visible: isVisible">
                             <i data-bind="attr: { 'class': $root.questionIcon($data) }" title="type"></i>
-                            <span data-bind="visible: $root.showIds, text: value"></span>
-                            <span data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></span>
+                            <!-- ko text: $root.showIds() ? value :  $root.translateQuestion($data) --><!-- /ko -->
                             <!-- ko if: required -->
                             <span title="{% trans "This question is required"|escapejs %}">*</span>
                             <!-- /ko -->
                             <!-- ko if: comment -->
                             <span class="text-muted" data-bind="visible: $root.showComments">
-                                &nbsp; <span data-bind="text: comment"></span>
+                                &nbsp; <!-- ko text: comment --><!-- /ko -->
                             </span>
                             <!-- /ko -->
-                            <!-- ko if: function(){ return calculate() || relevant() || constraint() || setvalue() } -->
+                            <!-- ko if:  calculate || relevant || constraint || setvalue  -->
                             <ul class="fa-ul">
                                 <!-- ko if: calculate -->
                                 <li data-bind="visible: $root.showCalculations">
                                     <i data-bind="attr: {'class': 'fa-li fa text-muted fa-calculator'}"></i>
-                                    <span data-bind="text: calculate"></span>
+                                    <!-- ko text: calculate --><!-- /ko -->
                                 </li>
                                 <!-- /ko -->
                                 <!-- ko if: relevant -->
                                 <li data-bind="visible: $root.showRelevance">
                                     <i data-bind="attr: {'class': 'fa-li fa text-muted fa-code-fork'}"></i>
-                                    <span data-bind="text: relevant"></span>
+                                    <!-- ko text: relevant --><!-- /ko -->
                                 </li>
                                 <!-- /ko -->
                                 <!-- ko if: constraint -->
                                 <li data-bind="visible: $root.showConstraints">
                                     <i data-bind="attr: {'class': 'fa-li fa text-muted fa-ban'}"></i>
-                                    <span data-bind="text: constraint"></span>
+                                    <!-- ko text: constraint --><!-- /ko -->
                                 </li>
                                 <!-- /ko -->
                                 <!-- ko if: setvalue -->
                                 <li data-bind="visible: $root.showDefaultValues">
                                     <i data-bind="attr: {'class': 'fa-li fa text-muted fa-home'}"></i>
-                                    <span data-bind="text: setvalue"></span>
+                                    <!-- ko text: setvalue --><!-- /ko -->
                                 </li>
                                 <!-- /ko -->
                             </ul>
                             <!-- /ko -->
-                            <!-- ko if: options -->
+                            <!-- ko if: options.length -->
                             <ol data-bind="foreach: options">
                                 <li data-bind="visible: $root.showIds, text: value"></li>
                                 <li data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></li>

--- a/corehq/apps/app_manager/templates/app_manager/form_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary.html
@@ -66,8 +66,14 @@
                 </div>
                 <span class="text-muted" data-bind="visible: $root.showComments"> &nbsp; <span data-bind="text: short_comment"></span></span>
             </h4>
-            <!-- ko template: {name: 'question-attribute', data: { attribute: module_filter, icon: 'fa-code-fork',
-                 visibleObs: $root.showRelevance } }--><!-- /ko -->
+            <!-- ko if: module_filter -->
+            <ul class="fa-ul" data-bind="visible: $root.showRelevance">
+                <li>
+                    <i data-bind="attr: {'class': 'fa-li fa text-muted fa-code-fork'}"></i>
+                    <span data-bind="text: module_filter"></span>
+                </li>
+            </ul>
+            <!-- /ko -->
             <ul class="fa-ul" data-bind="foreach: forms">
                 <li data-bind="visible: isVisible">
                     <h5>
@@ -81,45 +87,67 @@
                         </div>
                         <span class="text-muted" data-bind="visible: $root.showComments"> &nbsp; <span data-bind="text: short_comment"></span></span>
                     </h5>
-                    <!-- ko template: {name: 'question-attribute', data: { attribute: form_filter, icon: 'fa-code-fork',
-                         visibleObs: $root.showRelevance } }--><!-- /ko -->
+                    <!-- ko if: form_filter -->
+                    <ul class="fa-ul" data-bind="visible: $root.showRelevance">
+                        <li>
+                            <i data-bind="attr: {'class': 'fa-li fa text-muted fa-code-fork'}"></i>
+                            <span data-bind="text: form_filter"></span>
+                        </li>
+                    </ul>
+                    <!-- /ko -->
                     <ol data-bind="foreach: questions">
                         <li data-bind="visible: isVisible">
                             <i data-bind="attr: { 'class': $root.questionIcon($data) }" title="type"></i>
                             <span data-bind="visible: $root.showIds, text: value"></span>
                             <span data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></span>
-                            <span data-bind="visible: required" title="{% trans "This question is required"|escapejs %}">*</span>
+                            <!-- ko if: required -->
+                            <span title="{% trans "This question is required"|escapejs %}">*</span>
+                            <!-- /ko -->
+                            <!-- ko if: comment -->
                             <span class="text-muted" data-bind="visible: $root.showComments">
                                 &nbsp; <span data-bind="text: comment"></span>
                             </span>
-                            <!-- ko template: {name: 'question-attribute', data: { attribute: calculate, icon: 'fa-calculator',
-                                               visibleObs: $root.showCalculations } }--><!-- /ko -->
-                            <!-- ko template: {name: 'question-attribute', data: { attribute: relevant, icon: 'fa-code-fork',
-                                               visibleObs: $root.showRelevance } }--><!-- /ko -->
-                            <!-- ko template: {name: 'question-attribute', data: { attribute: constraint, icon: 'fa-ban',
-                                               visibleObs: $root.showConstraints } }--><!-- /ko -->
-                            <!-- ko template: {name: 'question-attribute', data: { attribute: setvalue, icon: 'fa-home',
-                                               visibleObs: $root.showDefaultValues } }--><!-- /ko -->
+                            <!-- /ko -->
+                            <!-- ko if: function(){ return calculate() || relevant() || constraint() || setvalue() } -->
+                            <ul class="fa-ul">
+                                <!-- ko if: calculate -->
+                                <li data-bind="visible: $root.showCalculations">
+                                    <i data-bind="attr: {'class': 'fa-li fa text-muted fa-calculator'}"></i>
+                                    <span data-bind="text: calculate"></span>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko if: relevant -->
+                                <li data-bind="visible: $root.showRelevance">
+                                    <i data-bind="attr: {'class': 'fa-li fa text-muted fa-code-fork'}"></i>
+                                    <span data-bind="text: relevant"></span>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko if: constraint -->
+                                <li data-bind="visible: $root.showConstraints">
+                                    <i data-bind="attr: {'class': 'fa-li fa text-muted fa-ban'}"></i>
+                                    <span data-bind="text: constraint"></span>
+                                </li>
+                                <!-- /ko -->
+                                <!-- ko if: setvalue -->
+                                <li data-bind="visible: $root.showDefaultValues">
+                                    <i data-bind="attr: {'class': 'fa-li fa text-muted fa-home'}"></i>
+                                    <span data-bind="text: setvalue"></span>
+                                </li>
+                                <!-- /ko -->
+                            </ul>
+                            <!-- /ko -->
+                            <!-- ko if: options -->
                             <ol data-bind="foreach: options">
                                 <li data-bind="visible: $root.showIds, text: value"></li>
                                 <li data-bind="visible: $root.showLabels, text: $root.translateQuestion($data)"></li>
                             </ol>
+                            <!-- /ko -->
                         </li>
                     </ol>
                 </li>
             </ul>
         </li>
     </ul>
-
-    {# Button to toggle question attribute #}
-    <script type="text/html" id="question-attribute">
-        <ul class="fa-ul" data-bind="if: attribute, visible: visibleObs">
-            <li>
-                <i data-bind="attr: {'class': 'fa-li fa text-muted ' + icon}"></i>
-                <span data-bind="text: attribute"></span>
-            </li>
-        </ul>
-    </script>
 
     {# Button for question attribute #}
     <script type="text/html" id="attribute-toggle">


### PR DESCRIPTION
Very large apps sometimes crash the browser when viewed in the form summary (and if they do load, they take an extremely long time, and peg the CPU).

- Most importantly, this removes slideVisible which made the eCHIS app able to load (before it would just crash my browser, and sometimes my computer, and peg the CPU at 100%)
- Removes the use of templates in loops (I got the idea from here: https://stackoverflow.com/a/9723763/2957657), this reduced the time to load call applyBindings for the eCHIS app from 24s to 15s
- It also removes nodes from the DOM which will never have data in them, as the number of nodes was becoming insane when there are thousands of questions. This improved scroll performance and the responsiveness of the page when clicking the sidebar links.
- Removes extraneous span nodes which also add thousands of DOM nodes

For the eCHIS app, this now takes 15-20 seconds to load, which is still not good, but better late than never.

There is no significant difference for very small apps that I could see (reduces page load time from 236ms to 114ms, but this isn't noticeable)
