### PR TITLE
Add loading spinner to app summary

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/base_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/base_summary.html
@@ -113,6 +113,7 @@
                 </nav>
             </div>
             <div id="hq-content" class="appmanager-main-container">
+                <div class="appmanager-loading-bg"></div>
                 <div class="appmanager-settings-content ko-template" id="js-appmanager-body">
                   {% block content_extra %}{% endblock %}
                 </div>


### PR DESCRIPTION
App summary used to have a loading spinner, but it was removed when we moved the page to KO.

https://docs.google.com/a/dimagi.com/document/d/1o9W2_eK-nNEHFuNZje_wfiCWzzZVj5441C2TKGboM3A/edit?disco=AAAACZ_kueQ 