### PR TITLE
Swap delete and copy buttons on exports

### DIFF
--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -257,9 +257,9 @@
                     {% endif %}
                 </a>
                 {% if export_instance.get_id and can_edit %}
-                    <a class="btn btn-lg btn-danger pull-right" data-toggle="modal" href="#delete-export-modal-{{ export_instance.get_id }}">
-                        <i class="fa fa-remove fa-white"></i>
-                        {% trans "Delete this Export" %}
+                    <a class="btn btn-lg btn-default pull-right" href="{% url 'copy_export' domain export_instance.get_id %}?next={{ export_home_url }}">
+                        <i class="fa fa-copy fa-white"></i>
+                        {% trans "Copy this Export" %}
                     </a>
                 {% endif %}
                 <div class="text-danger" data-bind="if: !isValid()">
@@ -271,12 +271,4 @@
     </form>
 </div>
 {% include "export/partials/new_customize_export_templates.html" %}
-{% endblock %}
-
-{% block modals %}{{ block.super }}
-    {% if export_instance.get_id %}
-        {% with export_instance as export %}
-            {% include "export/dialogs/delete_custom_export_dialog.html" %}
-        {% endwith %}
-    {% endif %}
 {% endblock %}

--- a/corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html
@@ -1,20 +1,22 @@
 {% load hq_shared_tags %}
 {% load i18n %}
-<div id="delete-export-modal-{{ export.get_id }}" class="modal fade">
+<div data-bind="attr: {id: 'delete-export-modal-' + id()}" class="modal fade">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title">{% trans "Delete Export for" %} "{{ export.name }}"?</h4>
+                <h4 class="modal-title">
+                    {% trans "Delete Export for" %} "<!-- ko text: name --><!-- /ko -->"?
+                </h4>
             </div>
-            <form name="drop_report" action="{% url "delete_new_custom_export" domain export.type export.get_id %}" method="post">
+            <form name="drop_report" data-bind="attr: {action: deleteUrl}" method="post">
                 {% csrf_token %}
                 <div class="modal-body">
                     <p>{% trans "Are you sure you want to delete this export?" %}</p>
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-danger" type="submit"><i class="fa fa-remove"></i> {% trans "Delete" %}</button>
-                    <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</a>
+                    <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
                 </div>
             </form>
         </div>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -10,16 +10,6 @@
             {% if model_type == "case" %}
             <th class="col-sm-2">{% trans 'Case Type' %}</th>
             {% endif %}
-            {% if has_edit_permissions %}
-            <th class="col-sm-1">
-                {% if is_daily_saved_export %}
-                    {% trans "Edit Columns" %}
-                {% else %}
-                    {% trans 'Edit' %}
-                {% endif %}
-            </th>
-            <th class="col-sm-1">{% trans 'Delete' %}</th>
-            {% endif %}
             <th class="col-sm-1">
                 {% if is_daily_saved_export %}
                     {% if has_edit_permissions %}
@@ -29,9 +19,6 @@
                     {{ export_type_caps }}
                 {% endif %}
             </th>
-            {% if is_daily_saved_export %}
-            <th class="col-sm-1">{% trans "Enable/Disable" %}</th>
-            {% endif %}
             {%  if allow_bulk_export %}
             <th class="col-sm-3">
                 {% blocktrans %}Bulk {{ export_type_caps }}:{% endblocktrans %}
@@ -42,6 +29,19 @@
                     {% trans 'None' %}
                 </button>
             </th>
+            {% endif %}
+            {% if is_daily_saved_export %}
+            <th class="col-sm-1">{% trans "Enable/Disable" %}</th>
+            {% endif %}
+            {% if has_edit_permissions %}
+            <th class="col-sm-1">
+                {% if is_daily_saved_export %}
+                    {% trans "Edit Columns" %}
+                {% else %}
+                    {% trans 'Edit' %}
+                {% endif %}
+            </th>
+            <th class="col-sm-1">{% trans 'Delete' %}</th>
             {% endif %}
             <th class="col-sm-1" data-bind="visible: showOwnership">
                 <span data-bind="visible: myExports">{% trans "Share" %}</span>
@@ -281,6 +281,46 @@
             </td>
             {% endif %}
 
+            <td>
+                <a data-bind="attr: {href: downloadUrl}, visible: !isDailySaved(), click: $root.sendExportAnalytics"
+                   class="btn btn-primary">
+                    {{ export_type_caps }}
+                </a>
+                {% if has_edit_permissions %}
+                <a class="btn btn-default"
+                   data-bind="visible: isDailySaved() && isLocationSafeForUser(), click: function (model) { $root.filterModalExportId(model.id()); }"
+                   href="#setFeedFiltersModal"
+                   data-toggle="modal"
+                >
+                    <i class="fa fa-filter"></i>
+                    {% trans "Edit Filters" %}
+                </a>
+                {% endif %}
+            </td>
+
+            {% if allow_bulk_export %}
+            <td>
+                <div class="checkbox checkbox-table-cell">
+                    <label>
+                        <input type="checkbox" data-bind="checked: addedToBulk" />
+                    </label>
+                </div>
+            </td>
+            {% endif %}
+
+            {% if is_daily_saved_export %}
+                <td>
+                    <a class="btn btn-default"
+                            data-bind="attr: {
+                                'data-target': '#modalEnableDisableAutoRefresh-' + id() + '-' + emailedExport.groupId(),
+                            }"
+                            data-toggle="modal">
+                        <span data-bind="visible: !isAutoRebuildEnabled()">{% trans "Enable" %}</span>
+                        <span data-bind="visible: isAutoRebuildEnabled()">{% trans "Disable" %}</span>
+                    </a>
+                </td>
+            {% endif %}
+
             {% if has_edit_permissions %}
             <td>
                 <div data-bind="if: $parent.showOwnership">
@@ -327,43 +367,7 @@
                 </div>
             </td>
             {% endif %}
-            <td>
-                <a data-bind="attr: {href: downloadUrl}, visible: !isDailySaved(), click: $root.sendExportAnalytics"
-                   class="btn btn-primary">
-                    {{ export_type_caps }}
-                </a>
-                {% if has_edit_permissions %}
-                <a class="btn btn-default"
-                   data-bind="visible: isDailySaved() && isLocationSafeForUser(), click: function (model) { $root.filterModalExportId(model.id()); }"
-                   href="#setFeedFiltersModal"
-                   data-toggle="modal"
-                >
-                    <i class="fa fa-filter"></i>
-                    {% trans "Edit Filters" %}
-                </a>
-                {% endif %}
-            </td>
-            <!-- ko if: hasEmailedExport -->
-                <td>
-                    <a class="btn btn-default"
-                            data-bind="attr: {
-                                'data-target': '#modalEnableDisableAutoRefresh-' + id() + '-' + emailedExport.groupId(),
-                            }"
-                            data-toggle="modal">
-                        <span data-bind="visible: !isAutoRebuildEnabled()">{% trans "Enable" %}</span>
-                        <span data-bind="visible: isAutoRebuildEnabled()">{% trans "Disable" %}</span>
-                    </a>
-                </td>
-            <!-- /ko -->
-            {% if allow_bulk_export %}
-            <td>
-                <div class="checkbox checkbox-table-cell">
-                    <label>
-                        <input type="checkbox" data-bind="checked: addedToBulk" />
-                    </label>
-                </div>
-            </td>
-            {% endif %}
+
             <td data-bind="visible: $parent.showOwnership">
                 <div data-bind="visible: $parent.myExports">
                     <div data-bind="visible: sharing() === 'private'">

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -7,9 +7,11 @@
     <thead>
         <tr>
             <th class="col-sm-4">{% trans 'Name' %}</th>
+
             {% if model_type == "case" %}
-            <th class="col-sm-2">{% trans 'Case Type' %}</th>
+                <th class="col-sm-2">{% trans 'Case Type' %}</th>
             {% endif %}
+
             <th class="col-sm-1">
                 {% if is_daily_saved_export %}
                     {% if has_edit_permissions %}
@@ -19,34 +21,41 @@
                     {{ export_type_caps }}
                 {% endif %}
             </th>
-            {%  if allow_bulk_export %}
-            <th class="col-sm-3">
-                {% blocktrans %}Bulk {{ export_type_caps }}:{% endblocktrans %}
-                <button type="button" class="btn btn-xs btn-default" data-bind="click: $root.selectAll">
-                    {% trans 'All' %}
-                </button> {% trans 'or' %}
-                <button type="button" class="btn btn-xs btn-default" data-bind="click: $root.selectNone">
-                    {% trans 'None' %}
-                </button>
-            </th>
+
+            {%  if allow_bulk_export %} {# form exports only #}
+                <th class="col-sm-1">
+                    {% blocktrans %}Bulk {{ export_type_caps }}{% endblocktrans %}
+                    <br>
+                    <button type="button" class="btn btn-xs btn-default" data-bind="click: $root.selectAll">
+                        {% trans 'All' %}
+                    </button> {% trans 'or' %}
+                    <button type="button" class="btn btn-xs btn-default" data-bind="click: $root.selectNone">
+                        {% trans 'None' %}
+                    </button>
+                </th>
             {% endif %}
+
             {% if is_daily_saved_export %}
-            <th class="col-sm-1">{% trans "Enable/Disable" %}</th>
+                <th class="col-sm-1">{% trans "Enable/Disable" %}</th>
             {% endif %}
+
             {% if has_edit_permissions %}
-            <th class="col-sm-1">
-                {% if is_daily_saved_export %}
-                    {% trans "Edit Columns" %}
-                {% else %}
-                    {% trans 'Edit' %}
-                {% endif %}
-            </th>
-            <th class="col-sm-1">{% trans 'Delete' %}</th>
+                <th class="col-sm-1">
+                    {% if is_daily_saved_export %}
+                        {% trans "Edit Columns" %}
+                    {% else %}
+                        {% trans 'Edit' %}
+                    {% endif %}
+                </th>
+                <th class="col-sm-1">{% trans 'Delete' %}</th>
             {% endif %}
-            <th class="col-sm-1" data-bind="visible: showOwnership">
-                <span data-bind="visible: myExports">{% trans "Share" %}</span>
-                <span data-bind="visible: !myExports">{% trans "Shared By" %}</span>
-            </th>
+
+            {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
+                <th class="col-sm-1" data-bind="visible: showOwnership">
+                    <span data-bind="visible: myExports">{% trans "Share" %}</span>
+                    <span data-bind="visible: !myExports">{% trans "Shared By" %}</span>
+                </th>
+            {% endif %}
         </tr>
     </thead>
     <tbody data-bind="foreach: exports()">
@@ -368,7 +377,8 @@
             </td>
             {% endif %}
 
-            <td data-bind="visible: $parent.showOwnership">
+            {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
+            <td>
                 <div data-bind="visible: $parent.myExports">
                     <div data-bind="visible: sharing() === 'private'">
                         {% trans 'Private' %}
@@ -387,6 +397,7 @@
                     <div data-bind="visible: owner_username !== 'unknown', text: owner_username"></div>
                 </div>
             </td>
+            {% endif %}
         </tr>
     </tbody>
 </table>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -18,7 +18,7 @@
                     {% trans 'Edit' %}
                 {% endif %}
             </th>
-            <th class="col-sm-1">{% trans 'Copy' %}</th>
+            <th class="col-sm-1">{% trans 'Delete' %}</th>
             {% endif %}
             <th class="col-sm-1">
                 {% if is_daily_saved_export %}
@@ -319,10 +319,11 @@
             </td>
             <td>
                 <div data-bind="if: isLocationSafeForUser()">
-                    <a data-bind="attr: {href: copyUrl}" class="btn btn-default">
-                        <i class="fa fa-copy"></i>
-                        <span>{% trans 'Copy' %}</span>
+                    <a class="btn btn-danger" data-toggle="modal" data-bind="attr: {href: '#delete-export-modal-' + id()}">
+                        <i class="fa fa-remove"></i>
+                        <span>{% trans 'Delete' %}</span>
                     </a>
+                    {% include "export/dialogs/delete_custom_export_dialog.html" %}
                 </div>
             </td>
             {% endif %}

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -261,7 +261,7 @@ class DailySavedExportListHelper(ExportListHelper):
         }[model]
 
     def fmt_export_data(self, export):
-        from corehq.apps.export.views.new import CopyExportView
+        from corehq.apps.export.views.new import DeleteNewCustomExportView
         from corehq.apps.export.views.download import DownloadNewCaseExportView, DownloadNewFormExportView
         if isinstance(export, FormExportInstance):
             edit_view = self._get_edit_export_class('form')
@@ -295,7 +295,8 @@ class DailySavedExportListHelper(ExportListHelper):
             'emailedExport': emailed_export,
             'editUrl': reverse(edit_view.urlname, args=(self.domain, export.get_id)),
             'downloadUrl': reverse(download_view.urlname, args=(self.domain, export.get_id)),
-            'copyUrl': reverse(CopyExportView.urlname, args=(self.domain, export.get_id)),
+            'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
+                                 args=(self.domain, export.type, export.get_id)),
         }
 
 
@@ -323,7 +324,7 @@ class FormExportListHelper(ExportListHelper):
         return reverse(DownloadNewFormExportView.urlname, args=(self.domain, export_id))
 
     def fmt_export_data(self, export):
-        from corehq.apps.export.views.new import CopyExportView
+        from corehq.apps.export.views.new import DeleteNewCustomExportView
         from corehq.apps.export.views.edit import EditNewCustomFormExportView
         emailed_export = None
         if export.is_daily_saved_export:
@@ -349,7 +350,8 @@ class FormExportListHelper(ExportListHelper):
             'editUrl': reverse(EditNewCustomFormExportView.urlname,
                                args=(self.domain, export.get_id)),
             'downloadUrl': self._get_download_url(export.get_id),
-            'copyUrl': reverse(CopyExportView.urlname, args=(self.domain, export.get_id)),
+            'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
+                                 args=(self.domain, export.type, export.get_id)),
         }
 
 
@@ -370,7 +372,7 @@ class CaseExportListHelper(ExportListHelper):
 
     def fmt_export_data(self, export):
         from corehq.apps.export.views.edit import EditNewCustomCaseExportView
-        from corehq.apps.export.views.new import CopyExportView
+        from corehq.apps.export.views.new import DeleteNewCustomExportView
         emailed_export = None
         if export.is_daily_saved_export:
             emailed_export = self._get_daily_saved_export_metadata(export)
@@ -394,7 +396,8 @@ class CaseExportListHelper(ExportListHelper):
             'emailedExport': emailed_export,
             'editUrl': reverse(EditNewCustomCaseExportView.urlname, args=(self.domain, export.get_id)),
             'downloadUrl': self._get_download_url(export._id),
-            'copyUrl': reverse(CopyExportView.urlname, args=(self.domain, export.get_id)),
+            'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
+                                 args=(self.domain, export.type, export.get_id)),
         }
 
     @property

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -158,12 +158,39 @@ class ExportListHelper(object):
         """
         raise NotImplementedError("must implement get_saved_exports")
 
+    def _edit_view(self, export):
+        raise NotImplementedError("must implement _edit_view")
+
+    def _download_view(self, export):
+        raise NotImplementedError("must implement _download_view")
+
     def fmt_export_data(self, export):
         """Returns the object used for each row (per export) in the exports table.
         This data will eventually be processed as a JSON object.
         :return dict
         """
-        raise NotImplementedError("must implement fmt_export_data")
+        from corehq.apps.export.views.new import DeleteNewCustomExportView
+        formname = export.formname if isinstance(export, FormExportInstance) else None
+        return {
+            'id': export.get_id,
+            'isDeid': export.is_safe,
+            'name': export.name,
+            'description': export.description,
+            'sharing': export.sharing,
+            'owner_username': (
+                WebUser.get_by_user_id(export.owner_id).username
+                if export.owner_id else UNKNOWN_EXPORT_OWNER
+            ),
+            'can_edit': export.can_edit(self.request.couch_user),
+            'exportType': export.type,
+            'formname': formname,
+            'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
+                                 args=(self.domain, export.type, export.get_id)),
+            'downloadUrl': reverse(self._download_view(export).urlname, args=(self.domain, export.get_id)),
+            'editUrl': reverse(self._edit_view(export).urlname, args=(self.domain, export.get_id)),
+            'lastBuildDuration': '',
+            'addedToBulk': False,
+        }
 
     def _get_daily_saved_export_metadata(self, export):
         """
@@ -253,51 +280,29 @@ class DailySavedExportListHelper(ExportListHelper):
         combined_exports = sorted(combined_exports, key=lambda x: x['name'])
         return [x for x in combined_exports if x['is_daily_saved_export'] and not x['export_format'] == "html"]
 
-    def _get_edit_export_class(self, model):
+    def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditFormDailySavedExportView, EditCaseDailySavedExportView
-        return {
-            "form": EditFormDailySavedExportView,
-            "case": EditCaseDailySavedExportView
-        }[model]
+        if isinstance(export, FormExportInstance):
+            return EditFormDailySavedExportView
+        return EditCaseDailySavedExportView
 
-    def fmt_export_data(self, export):
-        from corehq.apps.export.views.new import DeleteNewCustomExportView
+    def _download_view(self, export):
         from corehq.apps.export.views.download import DownloadNewCaseExportView, DownloadNewFormExportView
         if isinstance(export, FormExportInstance):
-            edit_view = self._get_edit_export_class('form')
-            download_view = DownloadNewFormExportView
-            formname = export.formname
-        else:
-            edit_view = self._get_edit_export_class('case')
-            download_view = DownloadNewCaseExportView
-            formname = None
+            return DownloadNewFormExportView
+        return DownloadNewCaseExportView
 
-        emailed_export = self._get_daily_saved_export_metadata(export)
+    def fmt_export_data(self, export):
+        data = super(DailySavedExportListHelper, self).fmt_export_data(export)
 
-        return {
-            'id': export.get_id,
-            'isDeid': export.is_safe,
-            'name': export.name,
-            'description': export.description,
+        data.update({
             'lastBuildDuration': (str(timedelta(milliseconds=export.last_build_duration))
                                   if export.last_build_duration else ''),
-            'sharing': export.sharing,
-            'owner_username': (
-                WebUser.get_by_user_id(export.owner_id).username
-                if export.owner_id else UNKNOWN_EXPORT_OWNER
-            ),
-            'can_edit': export.can_edit(self.request.couch_user),
-            'formname': formname,
-            'addedToBulk': False,
-            'exportType': export.type,
             'isDailySaved': True,
             'isAutoRebuildEnabled': export.auto_rebuild_enabled,
-            'emailedExport': emailed_export,
-            'editUrl': reverse(edit_view.urlname, args=(self.domain, export.get_id)),
-            'downloadUrl': reverse(download_view.urlname, args=(self.domain, export.get_id)),
-            'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
-                                 args=(self.domain, export.type, export.get_id)),
-        }
+            'emailedExport': self._get_daily_saved_export_metadata(export),
+        })
+        return data
 
 
 class FormExportListHelper(ExportListHelper):
@@ -319,40 +324,26 @@ class FormExportListHelper(ExportListHelper):
                                              include_docs=False)
         return [x for x in exports if not x['is_daily_saved_export']]
 
-    def _get_download_url(self, export_id):
+    def _edit_view(self, export):
+        from corehq.apps.export.views.edit import EditNewCustomFormExportView
+        return EditNewCustomFormExportView
+
+    def _download_view(self, export):
         from corehq.apps.export.views.download import DownloadNewFormExportView
-        return reverse(DownloadNewFormExportView.urlname, args=(self.domain, export_id))
+        return DownloadNewFormExportView
 
     def fmt_export_data(self, export):
-        from corehq.apps.export.views.new import DeleteNewCustomExportView
+        data = super(FormExportListHelper, self).fmt_export_data(export)
+
         from corehq.apps.export.views.edit import EditNewCustomFormExportView
         emailed_export = None
         if export.is_daily_saved_export:
             emailed_export = self._get_daily_saved_export_metadata(export)
-        owner_username = (
-            WebUser.get_by_user_id(export.owner_id).username
-            if export.owner_id else UNKNOWN_EXPORT_OWNER
-        )
 
-        return {
-            'id': export.get_id,
-            'isDeid': export.is_safe,
-            'name': export.name,
-            'description': export.description,
-            'lastBuildDuration': '',
-            'sharing': export.sharing,
-            'owner_username': owner_username,
-            'can_edit': export.can_edit(self.request.couch_user),
-            'formname': export.formname,
-            'addedToBulk': False,
-            'exportType': export.type,
+        data.update({
             'emailedExport': emailed_export,
-            'editUrl': reverse(EditNewCustomFormExportView.urlname,
-                               args=(self.domain, export.get_id)),
-            'downloadUrl': self._get_download_url(export.get_id),
-            'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
-                                 args=(self.domain, export.type, export.get_id)),
-        }
+        })
+        return data
 
 
 class CaseExportListHelper(ExportListHelper):
@@ -366,39 +357,26 @@ class CaseExportListHelper(ExportListHelper):
                                              include_docs=False)
         return [x for x in exports if not x['is_daily_saved_export']]
 
-    def _get_download_url(self, export_id):
+    def _edit_view(self, export):
+        from corehq.apps.export.views.edit import EditNewCustomCaseExportView
+        return EditNewCustomCaseExportView
+
+    def _download_view(self, export):
         from corehq.apps.export.views.download import DownloadNewCaseExportView
-        return reverse(DownloadNewCaseExportView.urlname, args=(self.domain, export_id))
+        return DownloadNewCaseExportView
 
     def fmt_export_data(self, export):
-        from corehq.apps.export.views.edit import EditNewCustomCaseExportView
-        from corehq.apps.export.views.new import DeleteNewCustomExportView
+        data = super(CaseExportListHelper, self).fmt_export_data(export)
+
         emailed_export = None
         if export.is_daily_saved_export:
             emailed_export = self._get_daily_saved_export_metadata(export)
-        owner_username = (
-            WebUser.get_by_user_id(export.owner_id).username
-            if export.owner_id else UNKNOWN_EXPORT_OWNER
-        )
 
-        return {
-            'id': export.get_id,
-            'isDeid': export.is_safe,
-            'name': export.name,
+        data.update({
             'case_type': export.case_type,
-            'description': export.description,
-            'lastBuildDuration': '',
-            'sharing': export.sharing,
-            'owner_username': owner_username,
-            'can_edit': export.can_edit(self.request.couch_user),
-            'addedToBulk': False,
-            'exportType': export.type,
             'emailedExport': emailed_export,
-            'editUrl': reverse(EditNewCustomCaseExportView.urlname, args=(self.domain, export.get_id)),
-            'downloadUrl': self._get_download_url(export._id),
-            'deleteUrl': reverse(DeleteNewCustomExportView.urlname,
-                                 args=(self.domain, export.type, export.get_id)),
-        }
+        })
+        return data
 
     @property
     def create_export_form_title(self):
@@ -425,12 +403,17 @@ class DashboardFeedListHelper(DailySavedExportListHelper):
         combined_exports = sorted(combined_exports, key=lambda x: x['name'])
         return [x for x in combined_exports if x['is_daily_saved_export'] and x['export_format'] == "html"]
 
-    def _get_edit_export_class(self, model):
+    def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditFormFeedView, EditCaseFeedView
-        return {
-            "form": EditFormFeedView,
-            "case": EditCaseFeedView
-        }[model]
+        if isinstance(export, FormExportInstance):
+            return EditFormFeedView
+        return EditCaseFeedView
+
+    def _download_view(self, export):
+        from corehq.apps.export.views.download import DownloadNewCaseExportView, DownloadNewFormExportView
+        if isinstance(export, FormExportInstance):
+            return DownloadNewFormExportView
+        return DownloadNewCaseExportView
 
     def fmt_export_data(self, export):
         data = super(DashboardFeedListHelper, self).fmt_export_data(export)

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -330,5 +330,13 @@ class CopyExportView(View):
                 new_export.owner_id = request.couch_user.user_id
                 new_export.sharing = SharingOption.PRIVATE
             new_export.save()
-        referer = request.META.get('HTTP_REFERER', reverse('data_interfaces_default', args=[domain]))
-        return HttpResponseRedirect(referer)
+            messages.success(
+                request,
+                mark_safe(
+                    _("Export <strong>{}</strong> created.").format(
+                        new_export.name
+                    )
+                )
+            )
+        redirect = request.GET.get('next', reverse('data_interfaces_default', args=[domain]))
+        return HttpResponseRedirect(redirect)


### PR DESCRIPTION
Note that this is a PR into https://github.com/dimagi/commcare-hq/pull/23062 since product decreed these should be merged together.

This replaces the copy button in the exports list with a delete button:
<img width="1124" alt="screen shot 2019-01-22 at 5 21 36 pm" src="https://user-images.githubusercontent.com/1486591/51569471-73391c00-1e6a-11e9-83e7-595e5123d26a.png">

And replaces the delete button when editing an export with a copy button:
<img width="1123" alt="screen shot 2019-01-22 at 5 21 54 pm" src="https://user-images.githubusercontent.com/1486591/51569487-7cc28400-1e6a-11e9-9854-cc456558256c.png">

@millerdev 
or @esoergel since you reviewed https://github.com/dimagi/commcare-hq/pull/23062

fyi @dimagi/product 