### PR TITLE
Make child modules displaying only forms use parent name

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2289,6 +2289,7 @@ class ModuleBase(IndexedSchema, ModuleMediaMixin, NavMenuItemMediaMixin, Comment
     case_type = StringProperty()
     case_list_form = SchemaProperty(CaseListForm)
     module_filter = StringProperty()
+    put_in_root = BooleanProperty(default=False)
     root_module_id = StringProperty()
     fixture_select = SchemaProperty(FixtureSelect)
     auto_select_case = BooleanProperty(default=False)
@@ -2527,7 +2528,6 @@ class Module(ModuleBase, ModuleDetailsMixin):
     forms = SchemaListProperty(Form)
     case_details = SchemaProperty(DetailPair)
     ref_details = SchemaProperty(DetailPair)
-    put_in_root = BooleanProperty(default=False)
     case_list = SchemaProperty(CaseList)
     referral_list = SchemaProperty(CaseList)
     task_list = SchemaProperty(CaseList)
@@ -3092,7 +3092,6 @@ class AdvancedModule(ModuleBase):
     forms = SchemaListProperty(FormBase)
     case_details = SchemaProperty(DetailPair)
     product_details = SchemaProperty(DetailPair)
-    put_in_root = BooleanProperty(default=False)
     case_list = SchemaProperty(CaseList)
     has_schedule = BooleanProperty()
     schedule_phases = SchemaListProperty(SchedulePhase)
@@ -3735,6 +3734,7 @@ class ReportModule(ModuleBase):
     report_configs = SchemaListProperty(ReportAppConfig)
     forms = []
     _loaded = False
+    put_in_root = False
 
     @property
     @memoized
@@ -3818,7 +3818,6 @@ class ShadowModule(ModuleBase, ModuleDetailsMixin):
     excluded_form_ids = SchemaListProperty()
     case_details = SchemaProperty(DetailPair)
     ref_details = SchemaProperty(DetailPair)
-    put_in_root = BooleanProperty(default=False)
     case_list = SchemaProperty(CaseList)
     referral_list = SchemaProperty(CaseList)
     task_list = SchemaProperty(CaseList)

--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -26,7 +26,7 @@ class WorkflowHelper(PostProcessor):
     @property
     @memoized
     def root_module_datums(self):
-        root_modules = [module for module in self.modules if getattr(module, 'put_in_root', False)]
+        root_modules = [module for module in self.modules if module.put_in_root]
         return [
             datum for module in root_modules
             for datum in self.get_module_datums('m{}'.format(module.id)).values()

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -71,7 +71,7 @@ class MenuContributor(SuiteContributorByModule):
             if hasattr(module, 'case_list') and module.case_list.show:
                 yield Command(id=id_strings.case_list_command(module))
 
-        supports_module_filter = self.app.enable_module_filtering and getattr(module, 'module_filter', None)
+        supports_module_filter = self.app.enable_module_filtering and module.module_filter
 
         menus = []
         if hasattr(module, 'get_menus'):
@@ -84,15 +84,14 @@ class MenuContributor(SuiteContributorByModule):
 
             shadow_modules = [m for m in self.app.get_modules()
                               if isinstance(m, ShadowModule) and m.source_module_id]
-            put_in_root = getattr(module, 'put_in_root', False)
-            if not put_in_root and getattr(module, 'root_module', False):
+            if not module.put_in_root and module.root_module:
                 root_modules.append(module.root_module)
                 for shadow in shadow_modules:
                     if module.root_module.unique_id == shadow.source_module_id:
                         root_modules.append(shadow)
             else:
                 root_modules.append(None)
-                if put_in_root and getattr(module, 'root_module', False):
+                if module.put_in_root and module.root_module:
                     for shadow in shadow_modules:
                         if module.root_module.unique_id == shadow.source_module_id:
                             id_modules.append(shadow)
@@ -129,7 +128,7 @@ class MenuContributor(SuiteContributorByModule):
                         menu = LocalizedMenu(**menu_kwargs)
                     else:
                         if (module.put_in_root
-                                and getattr(module, 'root_module', False)
+                                and module.root_module
                                 and not module.root_module.put_in_root):
                             # Mobile will combine this module with its parent
                             # Reference the parent's name to avoid ambiguity

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -128,8 +128,16 @@ class MenuContributor(SuiteContributorByModule):
                         })
                         menu = LocalizedMenu(**menu_kwargs)
                     else:
+                        if (module.put_in_root
+                                and getattr(module, 'root_module', False)
+                                and not module.root_module.put_in_root):
+                            # Mobile will combine this module with its parent
+                            # Reference the parent's name to avoid ambiguity
+                            locale_id = id_strings.module_locale(module.root_module)
+                        else:
+                            locale_id = id_strings.module_locale(module)
                         menu_kwargs.update({
-                            'locale_id': id_strings.module_locale(module),
+                            'locale_id': locale_id,
                             'media_image': module.default_media_image,
                             'media_audio': module.default_media_audio,
                         })

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -60,7 +60,7 @@ class ModuleAsChildTestBase(TestXmlMixin):
           </menu>
           <menu id="m0">
             <text>
-              <locale id="modules.m1"/>
+              <locale id="modules.m0"/>
             </text>
             <command id="m1-f0"/>
           </menu>

--- a/corehq/apps/app_manager/tests/test_shadow_modules.py
+++ b/corehq/apps/app_manager/tests/test_shadow_modules.py
@@ -174,7 +174,7 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
                   </menu>
                   <menu id="m0">
                     <text>
-                      <locale id="modules.m2"/>
+                      <locale id="modules.m0"/>
                     </text>
                     <command id="m2-f0"/>
                   </menu>
@@ -206,7 +206,7 @@ class ShadowModuleFormSelectionSuiteTest(SimpleTestCase, TestXmlMixin):
                   </menu>
                   <menu id="m0">
                     <text>
-                      <locale id="modules.m2"/>
+                      <locale id="modules.m0"/>
                     </text>
                     <command id="m2-f0"/>
                   </menu>

--- a/corehq/apps/app_manager/tests/test_suite_shadow_module.py
+++ b/corehq/apps/app_manager/tests/test_suite_shadow_module.py
@@ -18,39 +18,35 @@ class ShadowModuleSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def test_shadow_module_cases(self):
         self._test_generic_suite('shadow_module_cases')
 
-    def _get_family_app(self):
-        app = Application.new_app('domain', "Untitled Application")
 
-        parent = app.add_module(Module.new_module('module', None))
-        app.new_form(parent.id, "Untitled Form", None)
+class ShadowModuleWithChildSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
+    file_path = ('data', 'suite')
 
-        child = app.add_module(Module.new_module('module', None))
-        child.root_module_id = parent.unique_id
+    def setUp(self):
+        self.app = Application.new_app('domain', "Untitled Application")
 
-        app.new_form(child.id, "Untitled Form", None)
-        shadow = app.add_module(ShadowModule.new_module('module', None))
+        self.parent = self.app.add_module(Module.new_module('module', None))
+        self.app.new_form(self.parent.id, "Untitled Form", None)
 
-        return (app, shadow)
+        self.child = self.app.add_module(Module.new_module('module', None))
+        self.child.root_module_id = self.parent.unique_id
+
+        self.app.new_form(self.child.id, "Untitled Form", None)
+        self.shadow = self.app.add_module(ShadowModule.new_module('module', None))
 
     def test_shadow_module_source_parent(self):
-        (app, shadow) = self._get_family_app()
-        parent = [m for m in app.get_modules() if m.doc_type == 'Module' and m.root_module_id is None][0]
-        shadow.source_module_id = parent.unique_id
+        self.shadow.source_module_id = self.parent.unique_id
         self.assertXmlPartialEqual(self.get_xml('shadow_module_families_source_parent'),
-                                   app.create_suite(), "./menu")
+                                   self.app.create_suite(), "./menu")
 
     def test_shadow_module_source_parent_forms_only(self):
-        (app, shadow) = self._get_family_app()
-        parent = [m for m in app.get_modules() if m.doc_type == 'Module' and m.root_module_id is None][0]
-        shadow.source_module_id = parent.unique_id
-        for m in app.get_modules():
+        self.shadow.source_module_id = self.parent.unique_id
+        for m in self.app.get_modules():
             m.put_in_root = True
         self.assertXmlPartialEqual(self.get_xml('shadow_module_families_source_parent_forms_only'),
-                                   app.create_suite(), "./menu")
+                                   self.app.create_suite(), "./menu")
 
     def test_shadow_module_source_child(self):
-        (app, shadow) = self._get_family_app()
-        child = [m for m in app.get_modules() if m.doc_type == 'Module' and m.root_module_id is not None][0]
-        shadow.source_module_id = child.unique_id
+        self.shadow.source_module_id = self.child.unique_id
         self.assertXmlPartialEqual(self.get_xml('shadow_module_families_source_child'),
-                                   app.create_suite(), "./menu")
+                                   self.app.create_suite(), "./menu")

--- a/corehq/apps/app_manager/tests/test_suite_shadow_module.py
+++ b/corehq/apps/app_manager/tests/test_suite_shadow_module.py
@@ -25,14 +25,14 @@ class ShadowModuleWithChildSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     def setUp(self):
         self.app = Application.new_app('domain', "Untitled Application")
 
-        self.parent = self.app.add_module(Module.new_module('module', None))
-        self.app.new_form(self.parent.id, "Untitled Form", None)
+        self.parent = self.app.add_module(Module.new_module('Parent Module', None))
+        self.app.new_form(self.parent.id, "Parent Form", None)
 
-        self.child = self.app.add_module(Module.new_module('module', None))
+        self.child = self.app.add_module(Module.new_module('Child Module', None))
         self.child.root_module_id = self.parent.unique_id
+        self.app.new_form(self.child.id, "Child Form", None)
 
-        self.app.new_form(self.child.id, "Untitled Form", None)
-        self.shadow = self.app.add_module(ShadowModule.new_module('module', None))
+        self.shadow = self.app.add_module(ShadowModule.new_module('Shadow Module', None))
 
     def test_shadow_module_source_parent(self):
         self.shadow.source_module_id = self.parent.unique_id


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?188908

This fixes a bug where child modules set to "display only forms" would sometimes result in the child module name appearing where the parent name should.

"Display only forms" operates by setting the menu node's ID to the ID of the parent in the suite xml.  When this happens with normal modules, the parent ID is "root".  With child modules, the menu node is set to the name of the parent module.  This means mobile sees two menu nodes with the same ID but different names, and it doesn't know which one to use (since there's no indication which is the parent).  This PR makes child modules set to display only forms and gives them the label from their parent module, so it doesn't matter which one mobile picks.  Not a perfectly clean solution, but it should do the trick.

@orangejenny @Rohit25negi 