### PR TITLE
Upgrade to version of pyyaml without known vulnerability

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -163,7 +163,7 @@ python-magic==0.4.13
 python-mimeparse==1.6.0
 python-termstyle==0.1.10  # via sniffer
 pytz==2017.2
-pyyaml==3.13
+pyyaml==4.2b4
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.1

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -126,7 +126,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.13
 python-mimeparse==1.6.0
 pytz==2017.2
-pyyaml==3.13
+pyyaml==4.2b4
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -136,7 +136,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.13
 python-mimeparse==1.6.0
 pytz==2017.2
-pyyaml==3.13
+pyyaml==4.2b4
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -35,7 +35,7 @@ python-dateutil==2.6.1
 python-Levenshtein
 python-magic==0.4.13
 pytz==2017.2
-PyYAML==3.13
+PyYAML>=4.2b1
 requests~=2.20
 suds-jurko==0.6
 tropo-webapi-python==0.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -121,7 +121,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.13
 python-mimeparse==1.6.0   # via django-tastypie
 pytz==2017.2
-pyyaml==3.13
+pyyaml==4.2b4
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -131,7 +131,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.13
 python-mimeparse==1.6.0
 pytz==2017.2
-pyyaml==3.13
+pyyaml==4.2b4
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.1


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2017-18342
> In PyYAML before 4.1, the yaml.load() API could execute arbitrary code.
This is something we could conceivably be affected by if we ever wrap
user-submitted data in yaml.load()

---
Update: after discussing with emord, I decided to keep this open just for the build but then close it after.