### PR TITLE
Fixed UnicodeDecodeError on pulling linked app master

### DIFF
--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -80,7 +80,7 @@ def _fetch_remote_media(local_domain, missing_media, remote_app_details):
     for filename, item in missing_media:
         media_class = CommCareMultimedia.get_doc_class(item['media_type'])
         content = _fetch_remote_media_content(item, remote_app_details)
-        media_item = media_class.get_by_data(content.encode('utf-8'))
+        media_item = media_class.get_by_data(content)
         media_item._id = item['multimedia_id']
         media_item.attach_data(content, original_filename=filename)
         media_item.add_domain(local_domain, owner=True)

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -303,7 +303,7 @@ class TestRemoteLinkedApps(BaseLinkedAppsTest):
         remote_details = RemoteLinkDetails(
             'http://localhost:8000', 'user', 'key'
         )
-        data = 'this is a test'
+        data = b'this is a test'
         media_details = list(self.master_app_with_report_modules.multimedia_map.values())[0]
         media_details['multimedia_id'] = uuid.uuid4().hex
         media_details['media_type'] = 'CommCareMultimedia'


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/23008/ - `content` is a multimedia file that shouldn't be encoded. This is causing https://sentry.io/dimagi/commcarehq/issues/849141968/ which prevents linked apps from pulling in missing multimedia, which looks like the core problem in https://dimagi-dev.atlassian.net/browse/ICDS-291

@nickpell 
code buddy @millerdev 