### PR TITLE
Fixed 500 on case summary when there are form errors

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -41,6 +41,16 @@
         </div>
     </div>
 
+    {% if has_form_errors %}
+    <div class="alert alert-danger">
+        {% url 'app_form_summary' domain latest_app_id as form_summary_url %}
+        {% blocktrans %}
+            Your app's forms contain errors.
+            Please visit the <a href='{{ form_summary_url }}'>form summary</a> for more details.
+        {% endblocktrans %}
+    </div>
+    {% endif %}
+
     <div class="row">
         <div class="col-sm-12">
             <!-- ko foreach: caseTypes -->

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -13,6 +13,7 @@ from corehq.apps.app_manager.util import get_form_data
 from corehq.apps.app_manager.view_helpers import ApplicationViewMixin
 from corehq.apps.app_manager.views.utils import get_langs
 from corehq.apps.app_manager.const import WORKFLOW_FORM
+from corehq.apps.app_manager.exceptions import XFormException
 from corehq.apps.app_manager.models import AdvancedForm, AdvancedModule
 from corehq.apps.app_manager.xform import VELLUM_TYPES
 from corehq.apps.domain.views.base import LoginAndDomainMixin
@@ -86,9 +87,16 @@ class AppCaseSummaryView(AppSummaryView):
     @property
     def page_context(self):
         context = super(AppCaseSummaryView, self).page_context
+        has_form_errors = False
+        try:
+            metadata = self.app.get_case_metadata().to_json()
+        except XFormException as e:
+            metadata = {}
+            has_form_errors = True
         context.update({
             'is_case_summary': True,
-            'case_metadata': self.app.get_case_metadata().to_json(),
+            'case_metadata': metadata,
+            'has_form_errors': has_form_errors,
         })
         return context
 

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -90,7 +90,7 @@ class AppCaseSummaryView(AppSummaryView):
         has_form_errors = False
         try:
             metadata = self.app.get_case_metadata().to_json()
-        except XFormException as e:
+        except XFormException:
             metadata = {}
             has_form_errors = True
         context.update({


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-284

@millerdev 

Replaces the 500 with an error message:
<img width="1059" alt="screen shot 2019-01-23 at 6 49 25 pm" src="https://user-images.githubusercontent.com/1486591/51644853-b913e400-1f3f-11e9-8fda-0c1e86cfe216.png">
