### PR TITLE
Bump openpyxl 2.6.0b1

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -8,7 +8,6 @@ git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/dimagi/couchdbkit-debugpanel.git#egg=couchdbkit-debugpanel
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 -e git+git://github.com/nickpell/django-package-monitor@np/handle-no-semver#egg=django-package-monitor
--e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==1.4.9
@@ -128,6 +127,7 @@ msgpack-python==0.5.6
 nose-exclude==0.5.0
 nose==1.3.7
 numpy==1.7.1
+openpyxl==2.6.0b1
 paramiko==2.4.2           # via fabric
 pathlib2==2.3.3           # via ipython, pickleshare
 pbr==5.1.1

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==1.4.9
@@ -100,6 +99,7 @@ markupsafe==1.1.0
 mock==2.0.0
 msgpack-python==0.5.6
 numpy==1.7.1
+openpyxl==2.6.0b1
 packaging==18.0           # via sphinx
 pbr==5.1.1
 phonenumberslite==8.8.9

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
@@ -106,6 +105,7 @@ monotonic==1.5            # via eventlet
 msgpack-python==0.5.6
 ndg-httpsclient==0.5.1
 numpy==1.7.1
+openpyxl==2.6.0b1
 pathlib2==2.3.3           # via ipython, pickleshare
 pbr==5.1.1
 pexpect==4.6.0            # via ipython

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -46,6 +46,7 @@ sh==1.09
 gevent==1.2.2
 greenlet==0.4.12
 numpy==1.7.1
+openpyxl==2.6.0b1
 six==1.11.0
 socketpool==0.5.3
 markdown==2.2.1
@@ -110,4 +111,3 @@ werkzeug==0.11.15
 # but once they're in requirements.txt we will strip the -e
 
 -e git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alembic==0.8.6
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
@@ -63,7 +62,7 @@ dropbox==7.3.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 enum34==1.1.6             # via cryptography
-et-xmlfile==1.0.1
+et-xmlfile==1.0.1         # via openpyxl
 ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 faker==0.8.15
@@ -79,7 +78,7 @@ httpagentparser==1.7.8
 idna==2.8                 # via cryptography, email-validator, requests
 ipaddress==1.0.22         # via cryptography, faker
 iso8601==0.1.12
-jdcal==1.4
+jdcal==1.4                # via openpyxl
 jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 json-delta==2.0
@@ -97,6 +96,7 @@ markupsafe==1.1.0         # via jinja2, mako
 mock==2.0.0
 msgpack-python==0.5.6     # via ddtrace
 numpy==1.7.1
+openpyxl==2.6.0b1
 pbr==5.1.1                # via mock
 phonenumberslite==8.8.9
 pillow==5.2.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -6,7 +6,6 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
--e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink
 alembic==0.8.6
 amqp==1.4.9
 anyjson==0.3.3
@@ -107,6 +106,7 @@ msgpack-python==0.5.6
 nose-exclude==0.5.0
 nose==1.3.7
 numpy==1.7.1
+openpyxl==2.6.0b1
 pbr==5.1.1
 phonenumberslite==8.8.9
 pillow==5.2.0


### PR DESCRIPTION
@nickpell  It looks like your bug was solved in this version https://openpyxl.readthedocs.io/en/2.6/changes.html and it makes it a little more obvious what version we're on instead of the forked repo