### PR TITLE
Bump lxml to 4.3.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -118,7 +118,7 @@ kombu==3.0.37
 laboratory==0.2.0
 line_profiler==1.0
 linecache2==1.0.0
-lxml==3.4.4
+lxml==4.3.0
 mako==1.0.7
 markdown==2.2.1
 markupsafe==1.1.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -93,7 +93,7 @@ jsonpath-rw==1.4.0
 kafka-python==1.4.4
 kombu==3.0.37
 laboratory==0.2.0
-lxml==3.4.4
+lxml==4.3.0
 mako==1.0.7
 markdown==2.2.1
 markupsafe==1.1.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -97,7 +97,7 @@ jsonpath-rw==1.4.0
 kafka-python==1.4.4
 kombu==3.0.37
 laboratory==0.2.0
-lxml==3.4.4
+lxml==4.3.0
 mako==1.0.7
 markdown==2.2.1
 markupsafe==1.1.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -21,7 +21,7 @@ elasticsearch==1.9.0
 eulxml==1.1.3
 ghdiff==0.4
 gunicorn
-lxml==3.4.4
+lxml~=4.3.0
 kafka-python~=1.4
 mock==2.0.0
 Pillow==5.2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -90,7 +90,7 @@ jsonpath-rw==1.4.0
 kafka-python==1.4.4
 kombu==3.0.37             # via celery
 laboratory==0.2.0
-lxml==3.4.4
+lxml==4.3.0
 mako==1.0.7               # via alembic
 markdown==2.2.1
 markupsafe==1.1.0         # via jinja2, mako

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -98,7 +98,7 @@ kafka-python==1.4.4
 kombu==3.0.37
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2
-lxml==3.4.4
+lxml==4.3.0
 mako==1.0.7
 markdown==2.2.1
 markupsafe==1.1.0


### PR DESCRIPTION
Curious to see if this works. According to changelogs there's a lot of modules moved to Cython, so maybe it's faster?

The only breaking change should be:

>  The html5parser no longer passes the useChardet option if the input is a Unicode string, unless explicitly requested

But we don't use html5parser anywhere https://lxml.de/4.3/changes-4.3.0.html