### PR TITLE
management command to run a local commcare_export directly in HQ

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -679,6 +679,10 @@ query_param_consumers = [
 
 
 def es_search(request, domain, reserved_query_params=None):
+    return es_search_by_params(request.GET, domain, reserved_query_params)
+
+
+def es_search_by_params(search_params, domain, reserved_query_params=None):
     payload = {
         "filter": {
             "and": [
@@ -690,8 +694,8 @@ def es_search(request, domain, reserved_query_params=None):
     # ?_search=<json> for providing raw ES query, which is nonetheless restricted here
     # NOTE: The fields actually analyzed into ES indices differ somewhat from the raw
     # XML / JSON.
-    if '_search' in request.GET:
-        additions = json.loads(request.GET['_search'])
+    if '_search' in search_params:
+        additions = json.loads(search_params['_search'])
 
         if 'filter' in additions:
             payload['filter']['and'].append(additions['filter'])
@@ -700,15 +704,15 @@ def es_search(request, domain, reserved_query_params=None):
             payload['query'] = additions['query']
 
     # ?q=<lucene>
-    if 'q' in request.GET:
+    if 'q' in search_params:
         payload['query'] = payload.get('query', {})
-        payload['query']['query_string'] = {'query': request.GET['q']} # A bit indirect?
+        payload['query']['query_string'] = {'query': search_params['q']} # A bit indirect?
 
     # filters are actually going to be a more common case
     reserved_query_params = RESERVED_QUERY_PARAMS | set(reserved_query_params or [])
     query_params = {
         param: value
-        for param, value in request.GET.items()
+        for param, value in search_params.items()
         if param not in reserved_query_params and not param.endswith('__full')
     }
     for consumer in query_param_consumers:

--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -706,7 +706,7 @@ def es_search_by_params(search_params, domain, reserved_query_params=None):
     # ?q=<lucene>
     if 'q' in search_params:
         payload['query'] = payload.get('query', {})
-        payload['query']['query_string'] = {'query': search_params['q']} # A bit indirect?
+        payload['query']['query_string'] = {'query': search_params['q']}  # A bit indirect?
 
     # filters are actually going to be a more common case
     reserved_query_params = RESERVED_QUERY_PARAMS | set(reserved_query_params or [])

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -8,6 +8,7 @@ import sys
 import os
 from collections import namedtuple
 
+import dateutil
 from django.core.management.base import BaseCommand, CommandError
 from tastypie.bundle import Bundle
 
@@ -200,6 +201,7 @@ class Command(BaseCommand):
                 commcare_hq,
             )
             since = checkpoint_manager.get_time_of_last_checkpoint()
+
         else:
             since = None
 
@@ -210,6 +212,9 @@ class Command(BaseCommand):
             limit=limit,
             checkpoint_manager=checkpoint_manager
         )
+        if since is not None:
+            since = dateutil.parser.parse(since)
+
         env = (
             BuiltInEnv({'commcarehq_base_url': commcarehq_base_url})
             | CommCareHqEnv(api_client, since=since)

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -62,7 +62,7 @@ def _get_form_mock(project, params):
         payload=es_query,
         model=ESXFormInstance,
         es_client=XFormES(project),
-    ).order_by('-received_on')
+    ).order_by('received_on')
     return MockApi(
         query_set, XFormInstanceResource(), XFormInstanceSerializer()
     )

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -97,7 +97,7 @@ class LocalCommCareHqClient(object):
         from commcare_export.cli import logger
         logger.debug("Fetching batch: {}-{}".format(start, limit))
         # logger.debug("Fetching batch: %s", params)
-        return es_query_set[start:start+limit]
+        return es_query_set[start:start + limit]
 
     def iterate(self, resource, paginator, params=None):
         """
@@ -106,7 +106,8 @@ class LocalCommCareHqClient(object):
         from commcare_export.cli import logger
 
         # resource is either 'form' or 'case'
-        # params are api params (e.g. {'limit': 1000, u'type': u'pregnant_mother', 'order_by': 'server_date_modified'})
+        # params are api params
+        # (e.g. {'limit': 1000, u'type': u'pregnant_mother', 'order_by': 'server_date_modified'})
         params = dict(params or {})
         mock_api = _get_mock_api(resource, self.project, params)
 
@@ -163,7 +164,7 @@ class Command(BaseCommand):
         try:
             # local development only
             sys.path.append(os.path.join(os.getcwd(), 'lib', 'commcare-export'))
-            import commcare_export
+            import commcare_export  # noqa
         except ImportError:
             raise CommandError(
                 'This command requires commcare-export to be installed! '

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -169,7 +169,7 @@ class Command(BaseCommand):
             raise CommandError(
                 'This command requires commcare-export to be installed! '
                 'Please run: pip install commcare-export. You may also need to run: '
-                'pip install -e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink '
+                'pip install openpyxl==2.6.0b1'
                 'afterwards to run CommCare due to version incompatibilities.'
             )
         from commcare_export import misc

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -135,7 +135,7 @@ class LocalCommCareHqClient(object):
                     else:
                         more_to_fetch = False
 
-                self.checkpoint(paginator, batch)
+                self.checkpoint(paginator, batch_list)
 
         from commcare_export.repeatable_iterator import RepeatableIterator
         return RepeatableIterator(iterate_resource)
@@ -143,7 +143,7 @@ class LocalCommCareHqClient(object):
     def checkpoint(self, paginator, batch):
         from commcare_export.commcare_minilinq import DatePaginator
         if self._checkpoint_manager and isinstance(paginator, DatePaginator):
-            since_date = paginator.get_since_date(batch)
+            since_date = paginator.get_since_date({"objects": batch})
             self._checkpoint_manager.set_batch_checkpoint(checkpoint_time=since_date)
 
 

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -96,8 +96,7 @@ class LocalCommCareHqClient(object):
         """
         """
         from commcare_export.cli import logger
-        logger.debug("Fetching batch: {}-{}".format(start, self.limit))
-        # logger.debug("Fetching batch: %s", params)
+        logger.info("Fetching batch: {}-{}".format(start, start + self.limit))
         return es_query_set[start:start + self.limit]
 
     def iterate(self, resource, paginator, params=None):
@@ -121,7 +120,7 @@ class LocalCommCareHqClient(object):
             while more_to_fetch:
                 batch = self.get(mock_api.query_set, count, params)
                 batch_list = [mock_api.serialize(obj) for obj in batch]
-                logger.debug('Received {}-{} of {}', count, count + self.limit, total_count)
+                logger.info('Received {}-{} of {}'.format(count, count + self.limit, total_count))
 
                 if not batch_list:
                     more_to_fetch = False

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -1,0 +1,230 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import json
+import sys
+
+import os
+from collections import namedtuple
+
+from django.core.management.base import BaseCommand, CommandError
+from tastypie.bundle import Bundle
+
+from corehq.apps.api.es import ElasticAPIQuerySet, CaseES, es_search_by_params, XFormES
+from corehq.apps.api.models import ESCase, ESXFormInstance
+from corehq.apps.api.resources.v0_3 import CaseListFilters
+from corehq.apps.api.resources.v0_4 import CommCareCaseResource, XFormInstanceResource
+from corehq.apps.api.serializers import CommCareCaseSerializer, XFormInstanceSerializer
+from corehq.apps.cloudcare.api import ElasticCaseQuery
+
+
+class MockApi(namedtuple('MockApi', 'query_set resource serializer')):
+
+    def serialize(self, obj):
+        return json.loads(self.serializer.serialize(self.resource.full_dehydrate(Bundle(obj=obj))))
+
+
+def _get_case_mock(project, params):
+    # this is mostly copy/paste/modified from CommCareCaseResource
+    filters = CaseListFilters(params).filters
+    query = ElasticCaseQuery(project, filters).get_query()
+    if 'from' in query:
+        del query['from']
+    if 'size' in query:
+        del query['size']
+
+    query_set = ElasticAPIQuerySet(
+        payload=query,
+        model=ESCase,
+        es_client=CaseES(project),
+    ).order_by('server_modified_on')
+
+    return MockApi(
+        query_set, CommCareCaseResource(), CommCareCaseSerializer()
+    )
+
+
+def _get_form_mock(project, params):
+    # this is mostly copy/paste/modified from XFormInstanceResource
+    include_archived = 'include_archived' in params
+    es_query = es_search_by_params(params, project, ['include_archived'])
+    if include_archived:
+        es_query['filter']['and'].append({'or': [
+            {'term': {'doc_type': 'xforminstance'}},
+            {'term': {'doc_type': 'xformarchived'}},
+        ]})
+    else:
+        es_query['filter']['and'].append({'term': {'doc_type': 'xforminstance'}})
+
+    query_set = ElasticAPIQuerySet(
+        payload=es_query,
+        model=ESXFormInstance,
+        es_client=XFormES(project),
+    ).order_by('-received_on')
+    return MockApi(
+        query_set, XFormInstanceResource(), XFormInstanceSerializer()
+    )
+
+
+def _get_mock_api(resource, project, params):
+    if resource == 'case':
+        return _get_case_mock(project, params)
+    elif resource == 'form':
+        return _get_form_mock(project, params)
+    else:
+        raise ValueError("Unknown/unsupported resource type '{}'".format(resource))
+
+
+class LocalCommCareHqClient(object):
+    """
+    Like CommCareHqClient but for a local environment
+    """
+    def __init__(self, url, project, checkpoint_manager=None):
+        self.url = url
+        self.project = project
+        self._checkpoint_manager = checkpoint_manager
+
+    # todo: backoff?
+    # @backoff.on_exception(
+    #     backoff.expo, requests.exceptions.RequestException,
+    #     max_time=300, giveup=is_client_error,
+    #     on_backoff=on_backoff, on_giveup=on_giveup
+    # )
+    def get(self, es_query_set, start, limit, params=None):
+        """
+        """
+        from commcare_export.cli import logger
+        logger.debug("Fetching batch: {}-{}".format(start, limit))
+        # logger.debug("Fetching batch: %s", params)
+        return es_query_set[start:start+limit]
+
+    def iterate(self, resource, paginator, params=None):
+        """
+        Iterates through what the API would have been had it been passed in.
+        """
+        from commcare_export.cli import logger
+
+        # resource is either 'form' or 'case'
+        # params are api params (e.g. {'limit': 1000, u'type': u'pregnant_mother', 'order_by': 'server_date_modified'})
+        params = dict(params or {})
+        mock_api = _get_mock_api(resource, self.project, params)
+
+        def iterate_resource(resource=resource, params=params):
+            more_to_fetch = True
+            last_batch_ids = set()
+
+            count = 0
+            limit = params['limit']
+            total_count = mock_api.query_set.count()
+            while more_to_fetch:
+                batch = self.get(mock_api.query_set, count, limit, params)
+                batch_list = [mock_api.serialize(obj) for obj in batch]
+                logger.debug('Received {}-{} of {}', count, count + limit, total_count)
+
+                if not batch_list:
+                    more_to_fetch = False
+                else:
+                    for obj in batch_list:
+                        if obj['id'] not in last_batch_ids:
+                            yield obj
+
+                    if count < total_count:
+                        last_batch_ids = {obj['id'] for obj in batch_list}
+                        count += limit
+                    else:
+                        more_to_fetch = False
+
+                self.checkpoint(paginator, batch)
+
+        from commcare_export.repeatable_iterator import RepeatableIterator
+        return RepeatableIterator(iterate_resource)
+
+    def checkpoint(self, paginator, batch):
+        from commcare_export.commcare_minilinq import DatePaginator
+        if self._checkpoint_manager and isinstance(paginator, DatePaginator):
+            since_date = paginator.get_since_date(batch)
+            self._checkpoint_manager.set_batch_checkpoint(checkpoint_time=since_date)
+
+
+class Command(BaseCommand):
+    help = "For running commcare-export commands against a local environment. " \
+           "This is mostly a once-off for the ICDS data team."
+
+    def add_arguments(self, parser):
+        parser.add_argument('--project')
+        parser.add_argument('--query')
+        parser.add_argument('--output-format')
+        parser.add_argument('--output')
+
+    def handle(self, project, query, output_format, output, **options):
+        # note: this is heavily copy/paste/modified from commcare_export.cli
+        commcare_hq = 'local_commcare_export'
+        try:
+            # local development only
+            sys.path.append(os.path.join(os.getcwd(), 'lib', 'commcare-export'))
+            import commcare_export
+        except ImportError:
+            raise CommandError(
+                'This command requires commcare-export to be installed! '
+                'Please run: pip install commcare-export. You may also need to run: '
+                'pip install -e git+git://github.com/nickpell/openpyxl@master#egg=openpyxl_hyperlink '
+                'afterwards to run CommCare due to version incompatibilities.'
+            )
+        from commcare_export import misc
+        from commcare_export.checkpoint import CheckpointManager
+        from commcare_export.cli import _get_writer, _get_query_from_file
+        from commcare_export.commcare_minilinq import CommCareHqEnv
+        from commcare_export.env import BuiltInEnv, JsonPathEnv, EmitterEnv
+
+        print('commcare-export is installed.')
+
+        writer = _get_writer(output_format, output, strict_types=False)
+
+        query_obj = _get_query_from_file(
+            query,
+            None,  # missing_value
+            writer.supports_multi_table_write,
+            writer.max_column_length,
+            writer.required_columns
+        )
+        checkpoint_manager = None
+        if writer.support_checkpoints:
+            md5 = misc.digest_file(query)
+            checkpoint_manager = CheckpointManager(
+                output,
+                query,
+                md5,
+                project,
+                commcare_hq,
+            )
+            since = checkpoint_manager.get_time_of_last_checkpoint()
+        else:
+            since = None
+
+        commcarehq_base_url = commcare_hq
+        api_client = LocalCommCareHqClient(
+            url=commcarehq_base_url,
+            project=project,
+            checkpoint_manager=checkpoint_manager
+        )
+        env = (
+            BuiltInEnv({'commcarehq_base_url': commcarehq_base_url})
+            | CommCareHqEnv(api_client, since=since)
+            | JsonPathEnv({})
+            | EmitterEnv(writer)
+        )
+
+        with env:
+            try:
+                lazy_result = query_obj.eval(env)
+                if lazy_result is not None:
+                    # evaluate lazy results
+                    for r in lazy_result:
+                        list(r) if r else r
+            except KeyboardInterrupt:
+                print('\nExport aborted')
+                return
+
+        if checkpoint_manager:
+            checkpoint_manager.set_final_checkpoint()

--- a/corehq/apps/cleanup/management/commands/local_commcare_export.py
+++ b/corehq/apps/cleanup/management/commands/local_commcare_export.py
@@ -169,7 +169,7 @@ class Command(BaseCommand):
             raise CommandError(
                 'This command requires commcare-export to be installed! '
                 'Please run: pip install commcare-export. You may also need to run: '
-                'pip install openpyxl==2.6.0b1'
+                'pip install openpyxl==2.6.0b1 '
                 'afterwards to run CommCare due to version incompatibilities.'
             )
         from commcare_export import misc


### PR DESCRIPTION
The ICDS team wants to use this to bootstrap a bunch of export models in the old NIC data environment without having to paginate through all the APIs remotely. The implementation is a bit ugly but it seems to work to the extent that I've exercised it.

This is somewhat dependent on https://github.com/dimagi/commcare-export/pull/117 to work