### PR TITLE
Allow multiple parents with same reference in case details

### DIFF
--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -208,32 +208,38 @@ class AppCaseMetadata(JsonObject):
         if '/' in name:
             # find the case property from the correct case type
             parent_rel, name = name.split('/', 1)
-            parent_case_type = type_.relationships.get(parent_rel)
-            if parent_case_type:
-                return self.get_property(parent_case_type, name)
+            parent_case_types = type_.relationships.get(parent_rel)
+            parent_props = [
+                prop for parent_case_type in parent_case_types
+                for prop in self.get_property(parent_case_type, name)
+            ]
+            if parent_props:
+                return parent_props
             else:
                 params = {'case_type': root_case_type, 'relationship': parent_rel}
                 raise CaseMetaException(_(
                     "Case type '%(case_type)s' has no '%(relationship)s' "
                     "relationship to any other case type.") % params)
 
-        return type_.get_property(name)
+        return [type_.get_property(name)]
 
     def add_property_load(self, root_case_type, name, form_id, question):
         try:
-            prop = self.get_property(root_case_type, name)
+            props = self.get_property(root_case_type, name)
         except CaseMetaException as e:
-            prop = self.add_property_error(root_case_type, name, form_id, str(e))
+            props = [self.add_property_error(root_case_type, name, form_id, str(e))]
 
-        prop.add_load(form_id, question)
+        for prop in props:
+            prop.add_load(form_id, question)
 
     def add_property_save(self, root_case_type, name, form_id, question, condition=None):
         try:
-            prop = self.get_property(root_case_type, name)
+            props = self.get_property(root_case_type, name)
         except CaseMetaException as e:
-            prop = self.add_property_error(root_case_type, name, form_id, str(e))
+            props = [self.add_property_error(root_case_type, name, form_id, str(e))]
 
-        prop.add_save(form_id, question, condition)
+        for prop in props:
+            prop.add_save(form_id, question, condition)
 
     def add_property_error(self, case_type, case_property, form_id, message):
         prop = self.get_error_property(case_type, case_property)
@@ -245,9 +251,9 @@ class AppCaseMetadata(JsonObject):
     def add_property_detail(self, detail_type, root_case_type, module_id, column):
         if column.useXpathExpression:
             return column.field
-        prop = self.get_property(root_case_type, column.field)
-        prop.add_detail(detail_type, module_id, column.header, column.format)
-        return prop
+        props = self.get_property(root_case_type, column.field)
+        for prop in props:
+            prop.add_detail(detail_type, module_id, column.header, column.format)
 
     def get_error_property(self, case_type, name):
         type_ = self.get_type(case_type)

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -203,7 +203,7 @@ class AppCaseMetadata(JsonObject):
     case_types = ListProperty(CaseTypeMeta)  # case_type -> CaseTypeMeta
     type_hierarchy = DictProperty()  # case_type -> {child_case -> {}}
 
-    def get_property(self, root_case_type, name):
+    def get_property_list(self, root_case_type, name):
         type_ = self.get_type(root_case_type)
         if '/' in name:
             # find the case property from the correct case type
@@ -211,7 +211,7 @@ class AppCaseMetadata(JsonObject):
             parent_case_types = type_.relationships.get(parent_rel)
             parent_props = [
                 prop for parent_case_type in parent_case_types
-                for prop in self.get_property(parent_case_type, name)
+                for prop in self.get_property_list(parent_case_type, name)
             ]
             if parent_props:
                 return parent_props
@@ -225,7 +225,7 @@ class AppCaseMetadata(JsonObject):
 
     def add_property_load(self, root_case_type, name, form_id, question):
         try:
-            props = self.get_property(root_case_type, name)
+            props = self.get_property_list(root_case_type, name)
         except CaseMetaException as e:
             props = [self.add_property_error(root_case_type, name, form_id, str(e))]
 
@@ -234,7 +234,7 @@ class AppCaseMetadata(JsonObject):
 
     def add_property_save(self, root_case_type, name, form_id, question, condition=None):
         try:
-            props = self.get_property(root_case_type, name)
+            props = self.get_property_list(root_case_type, name)
         except CaseMetaException as e:
             props = [self.add_property_error(root_case_type, name, form_id, str(e))]
 
@@ -251,7 +251,7 @@ class AppCaseMetadata(JsonObject):
     def add_property_detail(self, detail_type, root_case_type, module_id, column):
         if column.useXpathExpression:
             return column.field
-        props = self.get_property(root_case_type, column.field)
+        props = self.get_property_list(root_case_type, column.field)
         for prop in props:
             prop.add_detail(detail_type, module_id, column.header, column.format)
 


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/854613425/

When there are case types with 2 parents with the same reference id, and you reference a parent property in the case list, HQ doesn't know what to do. I introduced this in https://github.com/dimagi/commcare-hq/pull/23044
Now, it shows the property you are referencing under both parent case types. 

This bug probably only exists for eCHIS or other very complicated apps. 