### PR TITLE
Disable device log report on envs with device log collection disabled

### DIFF
--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -2,8 +2,11 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
 import logging
+
+from django.conf import settings
 from django.db.models import Q
 from django.utils import html
+
 from corehq.apps.receiverwrapper.util import (
     get_version_from_appversion_text,
     get_commcare_version_from_appversion_text,
@@ -307,4 +310,6 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
 
 
 class DeviceLogDetailsReport(BaseDeviceLogReport, DeploymentsReport):
-    pass
+    @classmethod
+    def show_in_navigation(cls, domain=None, project=None, user=None):
+        return settings.SERVER_ENVIRONMENT not in settings.NO_DEVICE_LOG_ENVS


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-370

Hides this report

<img width="205" alt="screen shot 2019-01-24 at 4 26 12 pm" src="https://user-images.githubusercontent.com/137212/51712594-deaef500-1ff4-11e9-972d-d28c75ab19fb.png">

on production and ICDS, where we don't collect device logs.