### PR TITLE
Moved sorting after filtering when listing exports

### DIFF
--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -82,14 +82,14 @@ def _get_saved_exports(domain, has_deid_permissions, new_exports_getter, include
         return _get_brief_saved_exports(domain, has_deid_permissions, new_exports_getter)
     if not has_deid_permissions:
         exports = [e for e in exports if not e.is_safe]
-    return sorted(exports, key=lambda e: e.name)
+    return exports
 
 
 def _get_brief_saved_exports(domain, has_deid_permissions, new_exports_getter):
     exports = new_exports_getter(domain)
     if not has_deid_permissions:
         exports = [e for e in exports if not e['is_deidentified']]
-    return sorted(exports, key=lambda x: x['name'])
+    return exports
 
 
 # Note that if include_docs is True, this will return wrapped documents, but

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -322,7 +322,7 @@ class FormExportListHelper(ExportListHelper):
         exports = get_form_exports_by_domain(self.domain,
                                              self.permissions.has_deid_view_permissions,
                                              include_docs=False)
-        return [x for x in exports if not x['is_daily_saved_export']]
+        return sorted([x for x in exports if not x['is_daily_saved_export']], key=lambda x: x['name'])
 
     def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditNewCustomFormExportView
@@ -354,7 +354,7 @@ class CaseExportListHelper(ExportListHelper):
         exports = get_case_exports_by_domain(self.domain,
                                              self.permissions.has_deid_view_permissions,
                                              include_docs=False)
-        return [x for x in exports if not x['is_daily_saved_export']]
+        return sorted([x for x in exports if not x['is_daily_saved_export']], key=lambda x: x['name'])
 
     def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditNewCustomCaseExportView
@@ -400,7 +400,8 @@ class DashboardFeedListHelper(DailySavedExportListHelper):
                                                                self.permissions.has_deid_view_permissions,
                                                                include_docs=False))
         combined_exports = sorted(combined_exports, key=lambda x: x['name'])
-        return [x for x in combined_exports if x['is_daily_saved_export'] and x['export_format'] == "html"]
+        return sorted([x for x in combined_exports if x['is_daily_saved_export'] and x['export_format'] == "html"],
+                      key=lambda x: x['name'])
 
     def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditFormFeedView, EditCaseFeedView
@@ -435,10 +436,10 @@ class DeIdDailySavedExportListHelper(DailySavedExportListHelper):
 
     def get_saved_exports(self):
         exports = super(DeIdDailySavedExportListView, self).get_saved_exports()
-        return [
+        return sorted([
             x for x in exports
             if x['is_deidentified'] and x['is_daily_saved_export'] and not x['export_format'] == "html"
-        ]
+        ], key=lambda x: x['name'])
 
     @property
     def create_export_form(self):
@@ -450,8 +451,9 @@ class DeIdDashboardFeedListHelper(DashboardFeedListHelper):
 
     def get_saved_exports(self):
         exports = super(DeIdDashboardFeedListView, self).get_saved_exports()
-        return [x for x in exports
-                if x['is_deidentified'] and x['is_daily_saved_export'] and x['export_format'] == "html"]
+        return sorted([x for x in exports
+                if x['is_deidentified'] and x['is_daily_saved_export'] and x['export_format'] == "html"],
+                key=lambda x: x['name'])
 
     @property
     def create_export_form(self):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -452,8 +452,8 @@ class DeIdDashboardFeedListHelper(DashboardFeedListHelper):
     def get_saved_exports(self):
         exports = super(DeIdDashboardFeedListView, self).get_saved_exports()
         return sorted([x for x in exports
-                if x['is_deidentified'] and x['is_daily_saved_export'] and x['export_format'] == "html"],
-                key=lambda x: x['name'])
+                      if x['is_deidentified'] and x['is_daily_saved_export'] and x['export_format'] == "html"],
+                      key=lambda x: x['name'])
 
     @property
     def create_export_form(self):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -130,7 +130,7 @@ class ExportListHelper(object):
             raise Http404
 
         # Calls self.get_saved_exports and formats each item using self.fmt_export_data
-        brief_exports = self.get_saved_exports()
+        brief_exports = sorted(self.get_saved_exports(), key=lambda x: x['name'])
         if toggles.EXPORT_OWNERSHIP.enabled(self.domain):
 
             def _can_view(e, user_id):
@@ -277,7 +277,6 @@ class DailySavedExportListHelper(ExportListHelper):
             combined_exports.extend(get_case_exports_by_domain(self.domain,
                                                                self.permissions.has_deid_view_permissions,
                                                                include_docs=False))
-        combined_exports = sorted(combined_exports, key=lambda x: x['name'])
         return [x for x in combined_exports if x['is_daily_saved_export'] and not x['export_format'] == "html"]
 
     def _edit_view(self, export):
@@ -322,7 +321,7 @@ class FormExportListHelper(ExportListHelper):
         exports = get_form_exports_by_domain(self.domain,
                                              self.permissions.has_deid_view_permissions,
                                              include_docs=False)
-        return sorted([x for x in exports if not x['is_daily_saved_export']], key=lambda x: x['name'])
+        return [x for x in exports if not x['is_daily_saved_export']]
 
     def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditNewCustomFormExportView
@@ -354,7 +353,7 @@ class CaseExportListHelper(ExportListHelper):
         exports = get_case_exports_by_domain(self.domain,
                                              self.permissions.has_deid_view_permissions,
                                              include_docs=False)
-        return sorted([x for x in exports if not x['is_daily_saved_export']], key=lambda x: x['name'])
+        return [x for x in exports if not x['is_daily_saved_export']]
 
     def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditNewCustomCaseExportView
@@ -399,9 +398,7 @@ class DashboardFeedListHelper(DailySavedExportListHelper):
             combined_exports.extend(get_case_exports_by_domain(self.domain,
                                                                self.permissions.has_deid_view_permissions,
                                                                include_docs=False))
-        combined_exports = sorted(combined_exports, key=lambda x: x['name'])
-        return sorted([x for x in combined_exports if x['is_daily_saved_export'] and x['export_format'] == "html"],
-                      key=lambda x: x['name'])
+        return [x for x in combined_exports if x['is_daily_saved_export'] and x['export_format'] == "html"]
 
     def _edit_view(self, export):
         from corehq.apps.export.views.edit import EditFormFeedView, EditCaseFeedView
@@ -436,10 +433,10 @@ class DeIdDailySavedExportListHelper(DailySavedExportListHelper):
 
     def get_saved_exports(self):
         exports = super(DeIdDailySavedExportListView, self).get_saved_exports()
-        return sorted([
+        return [
             x for x in exports
             if x['is_deidentified'] and x['is_daily_saved_export'] and not x['export_format'] == "html"
-        ], key=lambda x: x['name'])
+        ]
 
     @property
     def create_export_form(self):
@@ -451,9 +448,8 @@ class DeIdDashboardFeedListHelper(DashboardFeedListHelper):
 
     def get_saved_exports(self):
         exports = super(DeIdDashboardFeedListView, self).get_saved_exports()
-        return sorted([x for x in exports
-                      if x['is_deidentified'] and x['is_daily_saved_export'] and x['export_format'] == "html"],
-                      key=lambda x: x['name'])
+        return [x for x in exports
+                if x['is_deidentified'] and x['is_daily_saved_export'] and x['export_format'] == "html"]
 
     @property
     def create_export_form(self):


### PR DESCRIPTION
Performance of the export list page still isn't great, even after https://github.com/dimagi/commcare-hq/pull/23062 (see Danny's comments on https://dimagi-dev.atlassian.net/browse/PF-257). This makes some minor updates to move sorting to happen later in the process, after exports have been filtered. I don't know that it'll help much with performance, mostly I just wanted to get the sorting out of dbaccessors and closer to the ui level.

A handful of other places depend on `_get_saved_exports` but none of them depend on the results being sorted.

@millerdev / @esoergel 