### PR TITLE
Added explicit proportions to scheduled reports table

### DIFF
--- a/corehq/apps/reports/templates/reports/partials/scheduled_reports_table.html
+++ b/corehq/apps/reports/templates/reports/partials/scheduled_reports_table.html
@@ -8,12 +8,12 @@
     <thead>
         <tr>
             {% if not is_owner %}
-            <th>{% trans "Owner" %}</th>
+                <th class="col-sm-2">{% trans "Owner" %}</th>
             {% endif %}
-            <th>{% trans "Reports" %}</th>
-            <th>{% trans "Day and Time" %}</th>
-            <th>{% trans "Recipients" %}</th>
-            <th>{% trans "Actions" %}</th>
+            <th class="{% if is_owner %}col-sm-4{% else %}col-sm-2{% endif %}">{% trans "Reports" %}</th>
+            <th class="col-sm-2">{% trans "Day and Time" %}</th>
+            <th class="col-sm-2">{% trans "Recipients" %}</th>
+            <th class="col-sm-4">{% trans "Actions" %}</th>
         </tr>
     </thead>
     <tbody>

--- a/corehq/apps/reports/templates/reports/reports_home.html
+++ b/corehq/apps/reports/templates/reports/reports_home.html
@@ -47,11 +47,11 @@
                        class="table table-striped table-bordered">
                     <thead>
                         <tr>
-                            <th>{% trans "Report" %}</th>
-                            <th>{% trans "Saved Report Name" %}</th>
-                            <th>{% trans "Description" %}</th>
-                            <th>{% trans "Date Range" %}</th>
-                            <th></th>
+                            <th class="col-sm-2">{% trans "Report" %}</th>
+                            <th class="col-sm-3">{% trans "Saved Report Name" %}</th>
+                            <th class="col-sm-3">{% trans "Description" %}</th>
+                            <th class="col-sm-2">{% trans "Date Range" %}</th>
+                            <th class="col-sm-2"></th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
@calellowitz 

Product: this enforces column sizes on this table, which can otherwise get funny-looking depending on the data in each column:

<img width="1120" alt="screen shot 2019-01-25 at 2 11 49 pm" src="https://user-images.githubusercontent.com/1486591/51767399-360f9c80-20ab-11e9-8133-a65770141470.png">
