### PR TITLE
Build profiles: only include language-specific non-form media

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -11,7 +11,7 @@ from corehq.apps.app_manager.util import module_offers_search,\
     create_temp_sort_column, get_sort_and_sort_only_columns
 import langcodes
 import commcare_translations
-from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
+from corehq.apps.app_manager.templatetags.xforms_extras import trans as trans_tag
 from corehq.util.translation import localize
 from langcodes import langs_by_code
 import six
@@ -41,7 +41,7 @@ def _get_custom_icon_app_locale_and_value(custom_icon_form, custom_icon_text, fo
 def _create_custom_app_strings(app, lang, for_default=False):
 
     def trans(d):
-        return clean_trans(d, langs)
+        return trans_tag(d, langs)
 
     def maybe_add_index(text):
         if app.build_version and app.build_version >= LooseVersion('2.8'):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4745,7 +4745,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         copy.is_released = False
 
         if not copy.is_remote_app():
-            copy.update_mm_map()
+            copy.update_media_language_map()
 
         prune_auto_generated_builds.delay(self.domain, self._id)
 
@@ -4797,7 +4797,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     def set_media_versions(self):
         pass
 
-    def update_mm_map(self):
+    def update_media_language_map(self):
         self.media_language_map = {}
         if self.build_profiles and domain_has_privilege(self.domain, privileges.BUILD_PROFILES):
             for lang in self.langs:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4798,23 +4798,12 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         pass
 
     def update_mm_map(self):
+        self.media_language_map = {}
         if self.build_profiles and domain_has_privilege(self.domain, privileges.BUILD_PROFILES):
             for lang in self.langs:
-                self.media_language_map[lang] = MediaList()
-            for form in self.get_forms():
-                xml = form.wrapped_xform()
-                for lang in self.langs:
-                    media = []
-                    for path in xml.all_media_references(lang):
-                        if path is not None:
-                            media.append(path)
-                            map_item = self.multimedia_map.get(path)
-                            #dont break if multimedia is missing
-                            if map_item:
-                                map_item.form_media = True
-                    self.media_language_map[lang].media_refs.extend(media)
-        else:
-            self.media_language_map = {}
+                self.media_language_map.update({
+                    lang: MediaList(media_refs=list(self.all_media_paths(lang=lang)))
+                })
 
     def get_build_langs(self, build_profile_id=None):
         if build_profile_id is not None:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1529,17 +1529,20 @@ class NavMenuItemMediaMixin(DocumentSchema):
     def set_audio(self, lang, audio_path):
         self._set_media('media_audio', lang, audio_path)
 
-    def _all_media_paths(self, media_attr):
+    def _all_media_paths(self, media_attr, lang=None):
         assert media_attr in ('media_image', 'media_audio')
         media_dict = getattr(self, media_attr) or {}
-        valid_media_paths = {media for media in media_dict.values() if media}
-        return list(valid_media_paths)
+        valid_media_paths = []
+        for key, value in media_dict.items():
+            if value and (lang is None or key == lang):
+                valid_media_paths.append(value)
+        return valid_media_paths
 
-    def all_image_paths(self):
-        return self._all_media_paths('media_image')
+    def all_image_paths(self, lang=None):
+        return self._all_media_paths('media_image', lang=lang)
 
-    def all_audio_paths(self):
-        return self._all_media_paths('media_audio')
+    def all_audio_paths(self, lang=None):
+        return self._all_media_paths('media_audio', lang=lang)
 
     def icon_app_string(self, lang, for_default=False):
         """

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1532,10 +1532,10 @@ class NavMenuItemMediaMixin(DocumentSchema):
     def _all_media_paths(self, media_attr, lang=None):
         assert media_attr in ('media_image', 'media_audio')
         media_dict = getattr(self, media_attr) or {}
-        valid_media_paths = []
+        valid_media_paths = set()
         for key, value in media_dict.items():
             if value and (lang is None or key == lang):
-                valid_media_paths.append(value)
+                valid_media_paths.add(value)
         return valid_media_paths
 
     def all_image_paths(self, lang=None):

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -126,7 +126,7 @@ class MediaSuiteGenerator(object):
                 media_list += self.app.media_language_map[lang].media_refs
             requested_media = set(media_list)
         for path, m in sorted(list(self.app.multimedia_map.items()), key=lambda item: item[0]):
-            if filter_multimedia and m.form_media and path not in requested_media:
+            if filter_multimedia and path not in requested_media:
                 continue
             unchanged_path = path
             if path.startswith(PREFIX):

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -5,7 +5,7 @@
 {% load url_extras %}
 {% load xforms_extras %}
 
-{% block title %}{{ module.name|clean_trans:langs }}{% endblock %}
+{% block title %}{{ module.name|trans:langs }}{% endblock %}
 
 {% block js %}
     {{ block.super }}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 
-{% block title %}{{ module.name|clean_trans:langs }} - {% trans 'Menu Settings' %}{% endblock %}
+{% block title %}{{ module.name|trans:langs }} - {% trans 'Menu Settings' %}{% endblock %}
 
 {% block stylesheets %}{{ block.super }}
     <style>

--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -128,10 +128,3 @@ def _input_trans(template, name, langs=None, allow_blank=True):
             break
     options = {key: html.escapejs(value) for (key, value) in six.iteritems(options)}
     return mark_safe(template % options)
-
-
-@register.filter
-def clean_trans(name, langs=None):
-    if langs is None:
-        langs = ["default"]
-    return trans(name, langs, False)

--- a/corehq/apps/app_manager/tests/data/suite/form_media_suite_en.xml
+++ b/corehq/apps/app_manager/tests/data/suite/form_media_suite_en.xml
@@ -11,11 +11,6 @@
     </resource>
   </media>
   <media path="../../commcare">
-    <resource id="media-3827580cd02c0bc38ccfe9e28f0b3a0e-module0_hin.mp3" version="1">
-      <location authority="remote">http://192.cc.hq.1/hq/multimedia/file/CommCareAudio/789/module0_hin.mp3</location>
-    </resource>
-  </media>
-  <media path="../../commcare">
     <resource id="media-947716527b2fc7772737f1bae597930b-q1_en.jpg" version="1">
       <location authority="remote">http://192.cc.hq.1/hq/multimedia/file/CommCareImage/form_image_0/q1_en.jpg</location>
     </resource>

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -102,9 +102,7 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
     @patch('corehq.apps.app_manager.models.ApplicationBase.get_previous_version', lambda _: None)
     @override_settings(BASE_ADDRESS='192.cc.hq.1')
     def test_form_media_with_app_profile(self, dom_has_priv):
-        # Test that form media for languages not in the profile are removed from the media suite
-        # Media outside of forms is still included in the suite file even for langs not in the profile
-        #    See note as to why that's the case: https://github.com/dimagi/commcare-hq/pull/11295#discussion_r126147881
+        # Test that media for languages not in the profile are removed from the media suite
 
         app = Application.wrap(self.get_json('app'))
         app.build_profiles['profid'] = BuildProfile(

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -100,8 +100,9 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
 
     @patch('corehq.apps.app_manager.models.domain_has_privilege', return_value=True)
     @patch('corehq.apps.app_manager.models.ApplicationBase.get_previous_version', lambda _: None)
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
     @override_settings(BASE_ADDRESS='192.cc.hq.1')
-    def test_form_media_with_app_profile(self, dom_has_priv):
+    def test_form_media_with_app_profile(self, *args):
         # Test that media for languages not in the profile are removed from the media suite
 
         app = Application.wrap(self.get_json('app'))

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -130,7 +130,7 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
             app.create_mapping(CommCareImage(_id='form_image_{}'.format(i)), path, save=False)
 
         app.set_media_versions()
-        app.update_mm_map()
+        app.update_media_language_map()
         app.remove_unused_mappings()
 
         # includes all media

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -36,7 +36,7 @@ from corehq import toggles, privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.exceptions import (
     FormNotFoundException, XFormValidationFailed)
-from corehq.apps.app_manager.templatetags.xforms_extras import trans, clean_trans
+from corehq.apps.app_manager.templatetags.xforms_extras import trans
 from corehq.apps.es import FormES
 from corehq.apps.programs.models import Program
 from corehq.apps.app_manager.util import (
@@ -577,7 +577,7 @@ def get_apps_modules(domain, current_app_id=None, current_module_id=None, app_do
             'is_current': app.id == current_app_id,
             'modules': [{
                 'module_id': module.id,
-                'name': clean_trans(module.name, app.langs),
+                'name': trans(module.name, app.langs),
                 'is_current': module.unique_id == current_module_id,
             } for module in app.modules]
         }

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -699,14 +699,6 @@ class XForm(WrappedNode):
             return self.media_references_by_lang(lang=lang, form="video")
         return self.media_references(form="video") + self.media_references(form="video-inline")
 
-    def all_media_references(self, lang):
-        images = self.media_references_by_lang(lang=lang, form="image")
-        video = self.media_references_by_lang(lang=lang, form="video")
-        audio = self.media_references_by_lang(lang=lang, form="audio")
-        inline_video = self.media_references_by_lang(lang=lang, form="video-inline")
-        expanded_audio = self.media_references_by_lang(lang=lang, form="expanded-audio")
-        return images + video + audio + inline_video + expanded_audio
-
     def rename_media(self, old_path, new_path):
         update_count = 0
         for node in self.itext_node.findall('{f}translation/{f}text/{f}value'):

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -664,13 +664,9 @@ class XForm(WrappedNode):
             return self.data_node.find('{x}case')
 
     @requires_itext(list)
-    def media_references(self, form):
-        nodes = self.itext_node.findall('{f}translation/{f}text/{f}value[@form="%s"]' % form)
-        return list(set([n.text for n in nodes]))
-
-    @requires_itext(list)
-    def media_references_by_lang(self, lang, form):
-        nodes = self.itext_node.findall('{f}translation[@lang="%s"]/{f}text/{f}value[@form="%s"]' % (lang, form))
+    def media_references(self, form, lang=None):
+        lang_condition = '[@lang="%s"]' % lang if lang else ''
+        nodes = self.itext_node.findall('{f}translation%s/{f}text/{f}value[@form="%s"]' % (lang_condition, form))
         return list(set([n.text for n in nodes]))
 
     @property
@@ -685,19 +681,13 @@ class XForm(WrappedNode):
         return list(set(n.attrib.get('ref').strip("'") for n in nodes))
 
     def image_references(self, lang=None):
-        if lang:
-            return self.media_references_by_lang(lang=lang, form="image")
-        return self.media_references(form="image")
+        return self.media_references("image", lang=lang)
 
     def audio_references(self, lang=None):
-        if lang:
-            return self.media_references_by_lang(lang=lang, form="audio") + self.media_references_by_lang(lang=lang, form="expanded-audio")
-        return self.media_references(form="audio") + self.media_references(form="expanded-audio")
+        return self.media_references("audio", lang=lang) + self.media_references("expanded-audio", lang=lang)
 
     def video_references(self, lang=None):
-        if lang:
-            return self.media_references_by_lang(lang=lang, form="video")
-        return self.media_references(form="video") + self.media_references(form="video-inline")
+        return self.media_references("video", lang=lang) + self.media_references("video-inline", lang=lang)
 
     def rename_media(self, old_path, new_path):
         update_count = 0

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -678,21 +678,25 @@ class XForm(WrappedNode):
         nodes = self.findall('{h}head/{odk}intent')
         return list(set(n.attrib.get('class') for n in nodes))
 
-    @property
-    def text_references(self):
+    def text_references(self, lang=None):
+        # Accepts lang param for consistency with image_references, etc.,
+        # but current text references aren't language-specific
         nodes = self.findall('{h}head/{odk}intent[@class="org.commcare.dalvik.action.PRINT"]/{f}extra[@key="cc:print_template_reference"]')
         return list(set(n.attrib.get('ref').strip("'") for n in nodes))
 
-    @property
-    def image_references(self):
+    def image_references(self, lang=None):
+        if lang:
+            return self.media_references_by_lang(lang=lang, form="image")
         return self.media_references(form="image")
 
-    @property
-    def audio_references(self):
+    def audio_references(self, lang=None):
+        if lang:
+            return self.media_references_by_lang(lang=lang, form="audio") + self.media_references_by_lang(lang=lang, form="expanded-audio")
         return self.media_references(form="audio") + self.media_references(form="expanded-audio")
 
-    @property
-    def video_references(self):
+    def video_references(self, lang=None):
+        if lang:
+            return self.media_references_by_lang(lang=lang, form="video")
         return self.media_references(form="video") + self.media_references(form="video-inline")
 
     def all_media_references(self, lang):

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -449,7 +449,6 @@ class HQMediaMapItem(DocumentSchema):
     output_size = DictProperty()
     version = IntegerProperty()
     unique_id = StringProperty()
-    form_media = BooleanProperty(default=False)
 
     @property
     def url(self):
@@ -933,7 +932,7 @@ class ApplicationMediaMixin(Document, MediaMixin):
         deleted_media = []
         allow_deletion = self.domain not in {'icds-cas', 'icds-test'}
         for path, map_item in list(self.multimedia_map.items()):
-            if not filter_multimedia or not map_item.form_media or path in requested_media:
+            if not filter_multimedia or path in requested_media:
                 media_item = raw_docs.get(map_item.multimedia_id)
                 if media_item:
                     media_cls = CommCareMultimedia.get_doc_class(map_item.media_type)

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -34,6 +34,7 @@ from django.utils.translation import ugettext as _
 from PIL import Image
 
 from corehq.apps.app_manager.exceptions import XFormException
+from corehq.apps.app_manager.templatetags.xforms_extras import trans
 from corehq.apps.app_manager.xform import XFormValidationError
 from corehq.apps.domain import SHARED_DOMAIN
 from corehq.apps.domain.models import LICENSES, LICENSE_LINKS
@@ -563,7 +564,7 @@ class MediaMixin(object):
     def get_media_ref_kwargs():
         raise NotImplementedError
 
-    def all_media(self):
+    def all_media(self, lang=None):
         """
             Finds all the multimedia IMAGES and AUDIO referenced in this object
             Returns list of ApplicationMediaReference objects
@@ -578,14 +579,14 @@ class MediaMixin(object):
         raise NotImplementedError
 
     @memoized
-    def all_media_paths(self):
-        return set([m.path for m in self.all_media()])
+    def all_media_paths(self, lang=None):
+        return set([m.path for m in self.all_media(lang=lang)])
 
     @memoized
     def get_all_paths_of_type(self, media_type):
         return set([m.path for m in self.all_media() if m.media_class.__name__ == media_type])
 
-    def menu_media(self, menu):
+    def menu_media(self, menu, lang=None):
         """
             Convenience method. Gets the ApplicationMediaReference for a menu that's
             associated with this MediaMixin (which may be self or a different attribute)
@@ -596,9 +597,9 @@ class MediaMixin(object):
         kwargs = self.get_media_ref_kwargs()
         media = []
         media.extend([ApplicationMediaReference(image, media_class=CommCareImage, is_menu_media=True, **kwargs)
-                      for image in menu.all_image_paths() if image])
+                      for image in menu.all_image_paths(lang=lang) if image])
         media.extend([ApplicationMediaReference(audio, media_class=CommCareAudio, is_menu_media=True, **kwargs)
-                      for audio in menu.all_audio_paths() if audio])
+                      for audio in menu.all_audio_paths(lang=lang) if audio])
         return media
 
     def rename_menu_media(self, menu, old_path, new_path):
@@ -628,27 +629,27 @@ class ModuleMediaMixin(MediaMixin):
             'form_order': None,
         }
 
-    def all_media(self):
+    def all_media(self, lang=None):
         kwargs = self.get_media_ref_kwargs()
         media = []
 
-        media.extend(self.menu_media(self))
+        media.extend(self.menu_media(self, lang=lang))
 
         # Registration from case list
         if self.case_list_form.form_id:
-            media.extend(self.menu_media(self.case_list_form))
+            media.extend(self.menu_media(self.case_list_form, lang=lang))
 
         # Case list menu item
         if hasattr(self, 'case_list') and self.case_list.show:
-            media.extend(self.menu_media(self.case_list))
+            media.extend(self.menu_media(self.case_list, lang=lang))
 
         for name, details, display in self.get_details():
-            # Case list lookup
+            # Case list lookup - not language-specific
             if display and details.display == 'short' and details.lookup_enabled and details.lookup_image:
                 media.append(ApplicationMediaReference(details.lookup_image, media_class=CommCareImage,
                                                        is_menu_media=True, **kwargs))
 
-            # Print template
+            # Print template - not language-specific
             if display and details.display == 'long' and details.print_template:
                 media.append(ApplicationMediaReference(details.print_template['path'],
                                                        media_class=CommCareMultimedia, **kwargs))
@@ -657,10 +658,10 @@ class ModuleMediaMixin(MediaMixin):
             for column in details.get_columns():
                 if column.format == 'enum-image':
                     for map_item in column.enum:
-                        icons = list(map_item.value.values())
-                        media.extend([ApplicationMediaReference(icon, media_class=CommCareImage,
-                                                                is_menu_media=True, **kwargs)
-                                      for icon in icons if icon])
+                        icon = trans(map_item.value, [lang] + self.get_app().langs, include_lang=False)
+                        if icon:
+                            media.append(ApplicationMediaReference(icon, media_class=CommCareImage,
+                                                                   is_menu_media=True, **kwargs))
 
         return media
 
@@ -717,25 +718,25 @@ class FormMediaMixin(MediaMixin):
     def memoized_xform(self):
         return self.wrapped_xform()
 
-    def all_media(self):
+    def all_media(self, lang=None):
         kwargs = self.get_media_ref_kwargs()
 
-        media = self.menu_media(self)
+        media = self.menu_media(self, lang=lang)
 
         # Form questions
         parsed = self.wrapped_xform()
         if parsed.exists():
             self.validate_form()
-            for image in parsed.image_references:
+            for image in parsed.image_references(lang=lang):
                 if image:
                     media.append(ApplicationMediaReference(image, media_class=CommCareImage, **kwargs))
-            for audio in parsed.audio_references:
+            for audio in parsed.audio_references(lang=lang):
                 if audio:
                     media.append(ApplicationMediaReference(audio, media_class=CommCareAudio, **kwargs))
-            for video in parsed.video_references:
+            for video in parsed.video_references(lang=lang):
                 if video:
                     media.append(ApplicationMediaReference(video, media_class=CommCareVideo, **kwargs))
-            for text in parsed.text_references:
+            for text in parsed.text_references(lang=lang):
                 if text:
                     media.append(ApplicationMediaReference(text, media_class=CommCareMultimedia, **kwargs))
 
@@ -764,7 +765,7 @@ class ApplicationMediaMixin(Document, MediaMixin):
     archived_media = DictProperty()  # where we store references to the old logos (or other multimedia) on a downgrade, so that information is not lost
 
     @memoized
-    def all_media(self):
+    def all_media(self, lang=None):
         """
             Somewhat counterituitively, this contains all media in the app EXCEPT app-level media (logos).
         """
@@ -772,10 +773,10 @@ class ApplicationMediaMixin(Document, MediaMixin):
         self.media_form_errors = False
 
         for module in [m for m in self.get_modules() if m.uses_media()]:
-            media.extend(module.all_media())
+            media.extend(module.all_media(lang=lang))
             for form in module.get_forms():
                 try:
-                    media.extend(form.all_media())
+                    media.extend(form.all_media(lang=lang))
                 except (XFormValidationError, XFormException):
                     self.media_form_errors = True
         return media

--- a/corehq/apps/hqmedia/tests/test_manage_paths.py
+++ b/corehq/apps/hqmedia/tests/test_manage_paths.py
@@ -164,7 +164,7 @@ class ManagePathsTest(SimpleTestCase, TestXmlMixin):
             )
 
             # Form media
-            form_images = app.modules[1].forms[0].wrapped_xform().image_references
+            form_images = app.modules[1].forms[0].wrapped_xform().image_references()
             self.assertTrue('jr://file/commcare/nin/ghosts.jpg' in form_images)
             self.assertTrue('jr://file/commcare/nin/sin.jpg' in form_images)
 


### PR DESCRIPTION
Updates the behavior described in https://github.com/dimagi/commcare-hq/pull/11295#discussion_r126147881 so cczs now contain only the multimedia relevant to the language(s) in the profile.

Review by commit.

@calellowitz / @mkangia 
code buddy @millerdev 