### PR TITLE
use openpyxl to generate all excel tabular reports

### DIFF
--- a/custom/icds_reports/sqldata/exports/beneficiary.py
+++ b/custom/icds_reports/sqldata/exports/beneficiary.py
@@ -84,7 +84,7 @@ class BeneficiaryExport(ExportableMixin, SqlData):
             return format_decimal(x) if x else DATA_NOT_ENTERED
 
         def phone_number_fucntion(x):
-            return "'{}".format(x) if x else x
+            return "{}".format(x) if x else x
 
         columns = [
             DatabaseColumn(

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -669,8 +669,7 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
             block_id=location,
             aggregation_level=3
         ).first()
-        if file_format == 'xlsx':
-            if beta:
+        if file_format == 'xlsx' and beta:
                 cache_key = create_aww_performance_excel_file(
                     excel_data,
                     data_type,
@@ -679,12 +678,10 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
                     location_object.district_name,
                     location_object.block_name,
                 )
-            else:
-                cache_key = create_excel_file_in_openpyxl(excel_data, data_type)
         else:
             cache_key = create_excel_file(excel_data, data_type, file_format)
     if indicator != AWW_INCENTIVE_REPORT:
-        if file_format == 'xlsx':
+        if file_format == 'xlsx' and beta:
             cache_key = create_excel_file_in_openpyxl(excel_data, data_type)
         else:
             cache_key = create_excel_file(excel_data, data_type, file_format)

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -77,7 +77,7 @@ from custom.icds_reports.sqldata.exports.demographics import DemographicsExport
 from custom.icds_reports.sqldata.exports.pregnant_women import PregnantWomenExport
 from custom.icds_reports.sqldata.exports.system_usage import SystemUsageExport
 from custom.icds_reports.utils import zip_folder, create_pdf_file, icds_pre_release_features, track_time, \
-    create_excel_file, create_aww_performance_excel_file
+    create_excel_file, create_aww_performance_excel_file, create_excel_file_in_openpyxl
 from custom.icds_reports.utils.aggregation_helpers.child_health_monthly import ChildHealthMonthlyAggregationHelper
 from custom.icds_reports.utils.aggregation_helpers.mbt import CcsMbtHelper, ChildHealthMbtHelper, AwcMbtHelper
 from dimagi.utils.chunked import chunked
@@ -669,19 +669,25 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
             block_id=location,
             aggregation_level=3
         ).first()
-        if file_format == 'xlsx' and beta:
-            cache_key = create_aww_performance_excel_file(
-                excel_data,
-                data_type,
-                config['month'].strftime("%B %Y"),
-                location_object.state_name,
-                location_object.district_name,
-                location_object.block_name,
-            )
+        if file_format == 'xlsx':
+            if beta:
+                cache_key = create_aww_performance_excel_file(
+                    excel_data,
+                    data_type,
+                    config['month'].strftime("%B %Y"),
+                    location_object.state_name,
+                    location_object.district_name,
+                    location_object.block_name,
+                )
+            else:
+                cache_key = create_excel_file_in_openpyxl(excel_data, data_type)
         else:
             cache_key = create_excel_file(excel_data, data_type, file_format)
     if indicator != AWW_INCENTIVE_REPORT:
-        cache_key = create_excel_file(excel_data, data_type, file_format)
+        if file_format == 'xlsx':
+            cache_key = create_excel_file_in_openpyxl(excel_data, data_type)
+        else:
+            cache_key = create_excel_file(excel_data, data_type, file_format)
     params = {
         'domain': domain,
         'uuid': cache_key,

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -960,3 +960,28 @@ def create_aww_performance_excel_file(excel_data, data_type, month, state, distr
     icds_file.store_file_in_blobdb(export_file, expired=60 * 60 * 24)
     icds_file.save()
     return file_hash
+
+
+def create_excel_file_in_openpyxl(excel_data, data_type):
+    workbook = Workbook()
+    first_worksheet = True
+    for worksheet_data in excel_data:
+        if first_worksheet:
+            worksheet = workbook.active
+            worksheet.title = worksheet_data[0]
+            first_worksheet = False
+        else:
+            worksheet = workbook.create_sheet(worksheet_data[0])
+        for row_number, row_data in enumerate(worksheet_data[1], start=1):
+            for column_number, cell_data in enumerate(row_data, start=1):
+                worksheet.cell(row=row_number, column=column_number).value = cell_data
+
+    # saving file
+    file_hash = uuid.uuid4().hex
+    export_file = BytesIO()
+    icds_file = IcdsFile(blob_id=file_hash, data_type=data_type)
+    workbook.save(export_file)
+    export_file.seek(0)
+    icds_file.store_file_in_blobdb(export_file, expired=60 * 60 * 24)
+    icds_file.save()
+    return file_hash


### PR DESCRIPTION
Hi @calellowitz,
I have moved excel tabular reports generation from `export_from_tables` to simple openpyxl function as it is formatting the numbers in a way that we want, that means long numbers (phone numbers) are not put into their scientific notation but kept as a string. We don't need to add apostrophe by ourselves as the data is provided as a Unicode string eg. `u'1234567890'` and openpyxl recognizes that it has to do something to make it appear correctly.
I am putting it behind feature flag so we can test if everything is as it should be. 
Need QA: Yes (behind feature flag for testing)
Environment: n/a
Locally Tested: Yes