### PR TITLE
Stop accessing media_language_map

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4340,9 +4340,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     build_profiles = SchemaDictProperty(BuildProfile)
     practice_mobile_worker_id = StringProperty()
 
-    # each language is a key and the value is a list of multimedia referenced in that language
-    media_language_map = SchemaDictProperty(MediaList)
-
     use_j2me_endpoint = BooleanProperty(default=False)
 
     target_commcare_flavor = StringProperty(
@@ -4817,7 +4814,7 @@ class SavedAppBuild(ApplicationBase):
         # ignore details that are not used
         for key in ('modules', 'user_registration', 'external_blobs',
                     '_attachments', 'profile', 'translations',
-                    'description', 'short_description', 'multimedia_map', 'media_language_map'):
+                    'description', 'short_description', 'multimedia_map'):
             data.pop(key, None)
         built_on_user_time = ServerTime(self.built_on).user_time(timezone)
         data.update({
@@ -4876,6 +4873,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin):
     @classmethod
     def wrap(cls, data):
         data.pop('commtrack_enabled', None)  # Remove me after migrating apps
+        data.pop('media_language_map', None)
         data['modules'] = [module for module in data.get('modules', [])
                            if module.get('doc_type') != 'CareplanModule']
         self = super(Application, cls).wrap(data)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4243,10 +4243,6 @@ class BuildProfile(DocumentSchema):
         return not self.__eq__(other)
 
 
-class MediaList(DocumentSchema):
-    media_refs = StringListProperty()
-
-
 class ApplicationBase(VersionedDoc, SnapshotMixin,
                       CommCareFeatureSupportMixin,
                       CommentMixin):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4744,9 +4744,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         copy.comment_from = user_id
         copy.is_released = False
 
-        if not copy.is_remote_app():
-            copy.update_media_language_map()
-
         prune_auto_generated_builds.delay(self.domain, self._id)
 
         return copy
@@ -4796,14 +4793,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
 
     def set_media_versions(self):
         pass
-
-    def update_media_language_map(self):
-        self.media_language_map = {}
-        if self.build_profiles and domain_has_privilege(self.domain, privileges.BUILD_PROFILES):
-            for lang in self.langs:
-                self.media_language_map.update({
-                    lang: MediaList(media_refs=list(self.all_media_paths(lang=lang)))
-                })
 
     def get_build_langs(self, build_profile_id=None):
         if build_profile_id is not None:

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -7,8 +7,6 @@ import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 
 from django.urls import reverse
 
-from corehq import privileges
-from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.exceptions import MediaResourceError
 from corehq.apps.app_manager.suite_xml.post_process.menu import GridMenuHelper
 from corehq.apps.app_manager.suite_xml.sections.details import DetailContributor
@@ -121,7 +119,7 @@ class MediaSuiteGenerator(object):
         self.app.remove_unused_mappings()
         if self.app.multimedia_map is None:
             self.app.multimedia_map = {}
-        filter_multimedia = self.build_profile and domain_has_privilege(self.app.domain, privileges.BUILD_PROFILES)
+        filter_multimedia = self.build_profile
         if filter_multimedia:
             requested_media = set()
             for lang in self.build_profile.langs:

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -131,7 +131,6 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
             app.create_mapping(CommCareImage(_id='form_image_{}'.format(i)), path, save=False)
 
         app.set_media_versions()
-        app.update_media_language_map()
         app.remove_unused_mappings()
 
         # includes all media

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -11,6 +11,8 @@ import magic
 from couchdbkit.exceptions import ResourceConflict
 from django.template.defaultfilters import filesizeformat
 
+from corehq import privileges
+from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqmedia.exceptions import BadMediaFileException
 from corehq.util.soft_assert import soft_assert
 from dimagi.ext.couchdbkit import (
@@ -917,13 +919,16 @@ class ApplicationMediaMixin(Document, MediaMixin):
             Gets all the media objects stored in the multimedia map.
             If passed a profile, will only get those that are used
             in a language in the profile.
+
+            Returns a generator of tuples, where the first item in the tuple is
+            the path (jr://...) and the second is the object (CommCareMultimedia or a subclass)
         """
         found_missing_mm = False
-        filter_multimedia = languages and self.media_language_map
+        filter_multimedia = languages and domain_has_privilege(self.domain, privileges.BUILD_PROFILES)
         if filter_multimedia:
             requested_media = set()
             for lang in languages:
-                requested_media.update(self.media_language_map[lang].media_refs)
+                requested_media |= self.all_media_paths(lang=lang)
         # preload all the docs to avoid excessive couch queries.
         # these will all be needed in memory anyway so this is ok.
         expected_ids = [map_item.multimedia_id for map_item in self.multimedia_map.values()]


### PR DESCRIPTION
Generate the map of language => relevant multimedia on demand instead of storing it as an app property. I haven't been able to prove this is related to ICDS's missing multimedia problems, but still think it's a good idea because a) redundancy is fragile (the fact that the media_language_map needed to be updated manually, and that was only done on build, after creating all files, felt suspicious) and b) the media_language_map comprises 30% of the AWW app's app.json, so there might be a performance bump.

Marking don't merge until I test a bit more.

@calellowitz / @mkangia 
code buddy @millerdev 