### PR TITLE
[VectorLink] update data for inspector-names column

### DIFF
--- a/custom/abt/reports/expressions.py
+++ b/custom/abt/reports/expressions.py
@@ -218,6 +218,13 @@ class AbtExpressionSpec(JsonObject):
             # Iterate over the repeat items, or the single submission
             for partial in repeat_items:
 
+                if not names:
+                    # Update inspector names if don't find by _get_inspector_names because in
+                    # app for 2019 we have new place for this data there is already a string
+                    # with all names joined by ','
+                    section = spec.get("section", "data")
+                    names = self._get_val(item, [section, 'supervisor_group', 'join_supervisor_name'])
+
                 form_value = self._get_val(partial, spec['question'])
                 warning_type = spec.get("warning_type", None)
 


### PR DESCRIPTION
Hi @calellowitz,

I added next changes in the expression for a supervisory report. In new app for 2019, we have new property where we have data about inspector names. More details: https://dimagi-dev.atlassian.net/browse/SL-27.

Need QA: Will be tested by me and Jensen after deploy
Environment: N/A
locally tested: No (don't have data to test this locally)

Regards,
Łukasz