### PR TITLE
Remove implicit ./@ from load from case fixture

### DIFF
--- a/corehq/apps/app_manager/management/commands/convert_basic_module_to_advanced.py
+++ b/corehq/apps/app_manager/management/commands/convert_basic_module_to_advanced.py
@@ -14,6 +14,10 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.suite_xml.utils import get_select_chain
 
+DUE_LIST_XMLNS = "http://openrosa.org/formdesigner/619B942A-362E-43DE-8650-ED37026D9AC4"
+IMMUNIZATION_XMLNS = "http://openrosa.org/formdesigner/58C65452-D21D-4935-A746-256E7C22224D"
+ELIGIBLE_COUPLE_XMLNS = "http://openrosa.org/formdesigner/21A52E12-3C84-4307-B680-1AB194FCE647"
+
 
 class Command(BaseCommand):
     help = """
@@ -29,6 +33,7 @@ class Command(BaseCommand):
         app = get_current_app(domain, app_id)
         module = app.get_module_by_unique_id(module_id)
 
+        assert module.doc_type == 'Module', "Only support modules"
         assert module.display_style == 'list', "Doesn't support grid case lists"
         assert module.referral_list.show is False, "Doesn't support referral lists"
         assert module.ref_details.short.columns == [], "Doesn't support ref details"
@@ -59,7 +64,18 @@ class Command(BaseCommand):
             )
             new_form._parent = module
             form._parent = module
-            new_form.source = form.source
+
+            new_form_source = form.source
+            if form.xmlns in (DUE_LIST_XMLNS, IMMUNIZATION_XMLNS):
+                new_form_source = new_form_source.replace(
+                    "instance('commcaresession')/session/data/case_id",
+                    "instance('commcaresession')/session/data/case_id_load_tasks_0")
+            elif form.xmlns == ELIGIBLE_COUPLE_XMLNS:
+                new_form_source = new_form_source.replace(
+                    "instance('commcaresession')/session/data/case_id",
+                    "instance('commcaresession')/session/data/case_id_load_person_0")
+            new_form.source = new_form_source
+
             actions = form.active_actions()
             open = actions.get('open_case', None)
             update = actions.get('update_case', None)

--- a/corehq/apps/app_manager/management/commands/migrate_load_case_from_fixture.py
+++ b/corehq/apps/app_manager/management/commands/migrate_load_case_from_fixture.py
@@ -18,6 +18,9 @@ class Command(AppMigrationCommandBase):
                 for action in load_actions:
                     if action['load_case_from_fixture'] is not None:
                         old_fixture_variable = action['load_case_from_fixture']['fixture_variable']
+                        if old_fixture_variable.startswith("./@"):
+                            # Assume that this means this was already migrated
+                            continue
                         action['load_case_from_fixture']['fixture_variable'] = "./@{}".format(old_fixture_variable)
                         should_save = True
 

--- a/corehq/apps/app_manager/management/commands/migrate_load_case_from_fixture.py
+++ b/corehq/apps/app_manager/management/commands/migrate_load_case_from_fixture.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from corehq.apps.app_manager.management.commands.helpers import AppMigrationCommandBase
+from corehq.apps.app_manager.models import Application
+
+
+class Command(AppMigrationCommandBase):
+    help = "Migrate load case from fixture to enable more general usage"
+
+    include_builds = True
+
+    def migrate_app(self, app_doc):
+        modules = [m for m in app_doc['modules'] if m.get('module_type', '') == 'advanced']
+        should_save = False
+        for module in modules:
+            for form in module['forms']:
+                load_actions = form.get('actions', {}).get('load_update_cases', [])
+                for action in load_actions:
+                    if action['load_case_from_fixture'] is not None:
+                        old_fixture_variable = action['load_case_from_fixture']['fixture_variable']
+                        action['load_case_from_fixture']['fixture_variable'] = "./@{}".format(old_fixture_variable)
+                        should_save = True
+
+        return Application.wrap(app_doc) if should_save else None

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -522,7 +522,7 @@ class EntriesHelper(object):
             datum=SessionDatum(
                 id=load_case_from_fixture.fixture_tag,
                 nodeset=load_case_from_fixture.fixture_nodeset,
-                value="./@" + load_case_from_fixture.fixture_variable,
+                value=load_case_from_fixture.fixture_variable,
                 detail_select=self.details_helper.get_detail_id_safe(target_module, 'case_short'),
                 detail_confirm=self.details_helper.get_detail_id_safe(target_module, 'case_long'),
             ),

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -151,7 +151,7 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             load_case_from_fixture=LoadCaseFromFixture(
                 fixture_nodeset="instance('item-list:table_tag')/calendar/year/month/day[@date > 735992 and @date < 736000]",
                 fixture_tag="selected_date",
-                fixture_variable="date",
+                fixture_variable="./@date",
                 case_property="adherence_event_date",
                 auto_select=True,
             )
@@ -168,7 +168,7 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             load_case_from_fixture=LoadCaseFromFixture(
                 fixture_nodeset="instance('item-list:table_tag')/calendar/year/month/day[@date > 735992 and @date < 736000]",
                 fixture_tag="selected_date",
-                fixture_variable="date",
+                fixture_variable="./@date",
                 case_property="adherence_event_date",
                 auto_select=True,
                 arbitrary_datum_id="extra_id",
@@ -189,7 +189,7 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             load_case_from_fixture=LoadCaseFromFixture(
                 fixture_nodeset="instance('enikshay:calendar')/calendar/year/month/day[@date > 735992 and @date < 736000]",
                 fixture_tag="selected_date",
-                fixture_variable="date",
+                fixture_variable="./@date",
                 case_property="adherence_event_date",
                 auto_select=True,
             )
@@ -207,7 +207,7 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             load_case_from_fixture=LoadCaseFromFixture(
                 fixture_nodeset="instance('commcare:reports')/reports/report[@id='some-report-guid']/rows/row",
                 fixture_tag="selected_row",
-                fixture_variable="index",
+                fixture_variable="./@index",
             )
         ))
         suite = app.create_suite()
@@ -222,7 +222,7 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             load_case_from_fixture=LoadCaseFromFixture(
                 fixture_nodeset=nodeset,
                 fixture_tag="selected_date",
-                fixture_variable="date",
+                fixture_variable="./@date",
                 case_property="adherence_event_date",
                 auto_select=True,
             )


### PR DESCRIPTION
This is blocking some Due List changes for ICDS and REACH. The due list currently uses [Due List](https://github.com/dimagi/commcare-hq/pull/7964/) which needs this to not be an attribute in XML. I dumbly coupled this with [adherence calendar implementation](https://github.com/dimagi/commcare-hq/pull/12923/files). 

The due list is limited to basic modules (though that's not super obvious...) and we need to move it to an advanced module

I've done some investigation on prod and the projects that use this are:

* rec
* l10k/echis (I will communicate to Cody/Simon about this. Will create changelog entry, though it may not be necessary since the building occurs on prod and not echis)
* test projects
* hmis
* mc-upscale

There's also a couple of projects on india. 

My migration plan is sketchy in that I will deploy and quickly run the migration. The migration should be < 1 min based on my  investigation

EDIT: Jenny and I talked about this and the  failure in this migration path is if a domain which is using this feature is creating a build in the time between deploy and the migration being run on their domain. This would only affect that particular build, and past and future builds would be safe as the XML would already be generated. Also after the migration is run, it is easy to iterate through the builds and ensure that there were no builds with invalid load_case_from_fixture 