### PR TITLE
Show last value in tooltip when there are multiple values on x axis i…

### DIFF
--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -2201,9 +2201,12 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                 var tooltip = chart.interactiveLayer.tooltip;
                 tooltip.contentGenerator(function (d) {
                     var html = "";
-                    var tooltip_data = _.find(vm.lineChartTwoData, function (x) {
-                        return x.x === d.value;
-                    });
+                    var tooltip_data = void(0);
+                    for (var i = 0; i < vm.lineChartTwoData.length; i++) {
+                        if (vm.lineChartTwoData[i].x === d.value) {
+                            tooltip_data = vm.lineChartTwoData[i];
+                        }
+                    }
 
                     if (tooltip_data) {
                         html = "<p>Height: <strong>" + tooltip_data.y + "</strong> cm</p>";
@@ -2261,9 +2264,12 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                 var tooltip = chart.interactiveLayer.tooltip;
                 tooltip.contentGenerator(function (d) {
                     var html = "";
-                    var tooltip_data = _.find(vm.lineChartOneData, function (x) {
-                        return x.x === d.value;
-                    });
+                    var tooltip_data = void(0);
+                    for (var i = 0; i < vm.lineChartOneData.length; i++) {
+                        if (vm.lineChartOneData[i].x === d.value) {
+                            tooltip_data = vm.lineChartOneData[i];
+                        }
+                    }
 
                     if (tooltip_data) {
                         html = "<p>Weight: <strong>" + tooltip_data.y + "</strong> kg</p>";
@@ -2321,9 +2327,12 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                 var tooltip = chart.interactiveLayer.tooltip;
                 tooltip.contentGenerator(function (d) {
                     var html = "";
-                    var tooltip_data = _.find(vm.lineChartThreeData, function (x) {
-                        return x.x === d.value;
-                    });
+                    var tooltip_data = void(0);
+                    for (var i = 0; i < vm.lineChartThreeData.length; i++) {
+                        if (vm.lineChartThreeData[i].x === d.value) {
+                            tooltip_data = vm.lineChartThreeData[i];
+                        }
+                    }
 
                     if (tooltip_data) {
                         html = "<p>Weight: <strong>" + tooltip_data.y + "</strong> kg</p>";

--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -2201,15 +2201,15 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                 var tooltip = chart.interactiveLayer.tooltip;
                 tooltip.contentGenerator(function (d) {
                     var html = "";
-                    var tooltip_data = void(0);
+                    var tooltipData = void(0);
                     for (var i = 0; i < vm.lineChartTwoData.length; i++) {
                         if (vm.lineChartTwoData[i].x === d.value) {
-                            tooltip_data = vm.lineChartTwoData[i];
+                            tooltipData = vm.lineChartTwoData[i];
                         }
                     }
 
-                    if (tooltip_data) {
-                        html = "<p>Height: <strong>" + tooltip_data.y + "</strong> cm</p>";
+                    if (tooltipData) {
+                        html = "<p>Height: <strong>" + tooltipData.y + "</strong> cm</p>";
                     } else {
                         html = "<p>Height: <strong>Data Not Recorded</strong></p>";
                     }
@@ -2264,15 +2264,15 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                 var tooltip = chart.interactiveLayer.tooltip;
                 tooltip.contentGenerator(function (d) {
                     var html = "";
-                    var tooltip_data = void(0);
+                    var tooltipData = void(0);
                     for (var i = 0; i < vm.lineChartOneData.length; i++) {
                         if (vm.lineChartOneData[i].x === d.value) {
-                            tooltip_data = vm.lineChartOneData[i];
+                            tooltipData = vm.lineChartOneData[i];
                         }
                     }
 
-                    if (tooltip_data) {
-                        html = "<p>Weight: <strong>" + tooltip_data.y + "</strong> kg</p>";
+                    if (tooltipData) {
+                        html = "<p>Weight: <strong>" + tooltipData.y + "</strong> kg</p>";
                     } else {
                         html = "<p>Weight: <strong>Data Not Recorded</strong></p>";
                     }
@@ -2327,15 +2327,15 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                 var tooltip = chart.interactiveLayer.tooltip;
                 tooltip.contentGenerator(function (d) {
                     var html = "";
-                    var tooltip_data = void(0);
+                    var tooltipData = void(0);
                     for (var i = 0; i < vm.lineChartThreeData.length; i++) {
                         if (vm.lineChartThreeData[i].x === d.value) {
-                            tooltip_data = vm.lineChartThreeData[i];
+                            tooltipData = vm.lineChartThreeData[i];
                         }
                     }
 
-                    if (tooltip_data) {
-                        html = "<p>Weight: <strong>" + tooltip_data.y + "</strong> kg</p>";
+                    if (tooltipData) {
+                        html = "<p>Weight: <strong>" + tooltipData.y + "</strong> kg</p>";
                     } else {
                         html = "<p>Weight: <strong>Data Not Recorded</strong></p>";
                     }


### PR DESCRIPTION
…n chart in AWC beneficiary details page report

Hi @calellowitz,
I have fixed the discrepancy in growth monitoring graph in AWC beneficiary details page report.
When there were multiple values with the same x (axis) value - eg. height - then tooltip that depends only on x-axis value would show the oldest record values. I have changed that to show the newest record values.
Need QA: No
Environment: n/a
Locally Tested: Yes
Regards, Dawid