### PR TITLE
Revert "Upgrade select2 in report modules"

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
@@ -2,6 +2,7 @@ hqDefine("app_manager/js/modules/module_view_report", function () {
     $(function () {
         var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get;
         var initNavMenuMedia = hqImport('app_manager/js/app_manager_media').initNavMenuMedia;
+        var select2Separator = hqImport('app_manager/js/modules/report_module').select2Separator;
         var reportModuleModel = hqImport('app_manager/js/modules/report_module').reportModuleModel;
         var staticFilterDataModel = hqImport('app_manager/js/modules/report_module').staticFilterDataModel;
         var choiceListUtils = hqImport('reports_core/js/choice_list_utils_v4');
@@ -47,37 +48,30 @@ hqDefine("app_manager/js/modules/module_view_report", function () {
         var select2s = $('.choice_filter');
         for (var i = 0; i < select2s.length; i++) {
             var element = select2s.eq(i);
-            var initialValues = element.data('initial');
 
-            // Any initially-selected values need to be appended to the <select> as options
-            // This needs to happen before the .select2() call, otherwise it'd need a
-            // change event to take effect
-            if (initialValues) {
-                if (!_.isArray(initialValues)) {
-                    initialValues = [initialValues];
-                }
-                _.each(initialValues, function (value) {
-                    element.append(new Option(value, value));
-                });
-                element.val(initialValues);
-            }
-
+            var separator = select2Separator;
+            var initialValues = element.val() !== "" ? element.val().split(separator) : [];
             element.select2({
                 minimumInputLength: 0,
                 multiple: true,
+                separator: separator,
                 allowClear: true,
                 // allowClear only respected if there is a non empty placeholder
                 placeholder: " ",
                 ajax: {
+                    // TODO - this is pretty hackish
                     url: (hqImport("hqwebapp/js/initial_page_data").reverse("choice_list_api").split('report_id')[0]
-                          + element.data("filter-name") + "/"),
+                          + element.parent()[0].lastElementChild.value + "/"),
                     dataType: 'json',
                     quietMillis: 250,
                     data: choiceListUtils.getApiQueryParams,
-                    processResults: choiceListUtils.formatPageForSelect2,
+                    results: choiceListUtils.formatPageForSelect2,
                     cache: true,
                 },
             });
+            element.select2('data', _.map(initialValues, function (v) {
+                return {id: v, text: v};
+            }));
         }
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/report_module.js
@@ -1,5 +1,9 @@
 /* globals hqDefine _ */
 hqDefine('app_manager/js/modules/report_module', function () {
+    // TODO: Ideally the separator would be defined in one place. Right now it is
+    //       also defined corehq.apps.userreports.reports.filters.CHOICE_DELIMITER
+    var select2Separator = "\u001F";
+
     function graphConfigModel(reportId, reportName, availableReportIds, reportCharts, graphConfigs,
         columnXpathTemplate, dataPathPlaceholders, lang, langs, changeSaveButton) {
         var self = {},
@@ -127,15 +131,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
                         filter.selectedValue[filterFields[filterFieldsIndex]] = ko.observable(startVal || '');
                     }
                 }
-                var initial = filter.selectedValue.value;
-                if (initial) {
-                    if (!_.isArray(initial)) {
-                        initial = [initial];
-                    }
-                } else {
-                    initial = [];
-                }
-                filter.selectedValue.value = ko.observableArray(initial);
+                filter.selectedValue.value = ko.observable(filter.selectedValue.value ? filter.selectedValue.value.join(select2Separator) : '');
 
                 filter.dynamicFilterName = ko.computed(function () {
                     return selectedReportId() + '/' + filter.slug;
@@ -178,7 +174,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
                         }
                     });
                     if (filter.selectedValue.doc_type() === 'StaticChoiceListFilter') {
-                        selectedFilterValues[filter.slug].value = filter.selectedValue.value();
+                        selectedFilterValues[filter.slug].value = filter.selectedValue.value().split(select2Separator);
                     }
                 }
             }
@@ -446,6 +442,7 @@ hqDefine('app_manager/js/modules/report_module', function () {
     return {
         reportModuleModel: reportModuleModel,
         staticFilterDataModel: staticFilterDataModel,
+        select2Separator: select2Separator,
     };
 });
 

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -41,11 +41,7 @@ appmanager-main-container{% if formdesigner %} formdesigner-content-wrapper{% en
     {% endcompress %}
 
     {% include 'hqwebapp/includes/atwho.html' %}
-    {% if legacy_select2 %}
-        <script src="{% static 'select2-3.5.2-legacy/select2.js' %}"></script>
-    {% else %}
-        <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
-    {% endif %}
+    <script src="{% static 'select2-3.5.2-legacy/select2.js' %}"></script>
     <script src="{% static 'bootstrap3-typeahead/bootstrap3-typeahead.min.js' %}"></script>
     <script src="{% static 'hqwebapp/js/bootstrap-multi-typeahead.js' %}"></script>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/apps_stylesheets.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/apps_stylesheets.html
@@ -4,13 +4,9 @@
 {% compress css %}
   {# Explicitly include these because app manager doesn't really do class-based views, can't use the decorators #}
   <link type="text/css" rel="stylesheet" media="screen" href="{% static 'jquery-ui/themes/redmond/jquery-ui.min.css' %}"/>
-{% endcompress %}
-{% if legacy_select2 %}
-    <link type="text/css" rel="stylesheet" media="all" href="{% static 'select2-3.5.2-legacy/select2.css' %}" />
-    <link type="text/css" rel="stylesheet" media="all" href="{% static 'select2-3.5.2-legacy/select2-bootstrap.css' %}" />
-{% else %}
-    <link type="text/css" rel="stylesheet" media="all" href="{% static 'select2/dist/css/select2.min.css' %}" />
-{% endif %}
+  <link type="text/css" rel="stylesheet" media="all" href="{% static 'select2-3.5.2-legacy/select2.css' %}" />
+  <link type="text/css" rel="stylesheet" media="all" href="{% static 'select2-3.5.2-legacy/select2-bootstrap.css' %}" />
+  {% endcompress %}
 
   {% if less_debug %}
     <link type="text/less"

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/filter_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/filter_configs.html
@@ -78,12 +78,11 @@
                         <input class="form-control" type="text" data-bind="value: filter.selectedValue.custom_data_property"/>
                     </div>
                     <div data-bind="visible: filter.selectedValue.doc_type() === 'StaticChoiceListFilter'">
-                        <select class="choice_filter form-control"
-                                multiple="true"
-                                data-bind="
-                                    selectedOptions: filter.selectedValue.value,
-                                    attr: {'data-filter-name': dynamicFilterName, 'data-initial': JSON.stringify(filter.selectedValue.value())}">
-                        </select>
+                        <input type="text"
+                               class="choice_filter form-control"
+                               style="width:300px"
+                               data-bind="value: filter.selectedValue.value"/>
+                        <input type="hidden" data-bind="value: dynamicFilterName">
                     </div>
                     <div data-bind="visible: filter.selectedValue.doc_type() === 'StaticChoiceFilter'">
                         <select class="form-control" data-bind="

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -163,9 +163,7 @@ def get_app_view_context(request, app):
     This is where additional app or domain specific context can be added to any individual
     commcare-setting defined in commcare-app-settings.yaml or commcare-profile-settings.yaml
     """
-    context = {
-        'legacy_select2': True,
-    }
+    context = {}
 
     settings_layout = copy.deepcopy(
         get_commcare_settings_layout(app.get_doc_type())

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -141,8 +141,7 @@ def _get_shared_module_view_context(app, module, case_property_builder, lang=Non
                 module.search_config.search_button_display_condition if module_offers_search(module) else "",
             'blacklisted_owner_ids_expression': (
                 module.search_config.blacklisted_owner_ids_expression if module_offers_search(module) else ""),
-        },
-        'legacy_select2': True,
+        }
     }
     if toggles.CASE_DETAIL_PRINT.enabled(app.domain):
         slug = 'module_%s_detail_print' % module.unique_id
@@ -228,7 +227,6 @@ def _get_report_module_context(app, module):
             'charts': [chart for chart in report.charts if
                        chart.type == 'multibar'],
             'filter_structure': report.filters_without_prefilters,
-            'legacy_select2': False,
         }
 
     all_reports = ReportConfiguration.by_domain(app.domain) + \

--- a/corehq/apps/reports_core/static/reports_core/js/choice_list_utils_v4.js
+++ b/corehq/apps/reports_core/static/reports_core/js/choice_list_utils_v4.js
@@ -1,18 +1,19 @@
 hqDefine('reports_core/js/choice_list_utils_v4', ['underscore'], function (_) {
     var module = {};
+    // todo: we may need to support configuring this in the future
     var pageSize = 20;
 
-    module.getApiQueryParams = function (params) {
+    module.getApiQueryParams = function (term, page) {
         return {
-            q: params.term, // search term
-            page: params.page,
+            q: term, // search term
+            page: page,
             limit: pageSize,
         };
     };
     module.formatValueForSelect2 = function (val) {
         return {'id': val.value, 'text': val.display || ''};
     };
-    module.formatPageForSelect2 = function (data, params) {
+    module.formatPageForSelect2 = function (data) {
         // parse the results into the format expected by Select2.
         var formattedData = _.map(data, module.formatValueForSelect2);
         return {


### PR DESCRIPTION
Reverts dimagi/commcare-hq#22870 which missed the select2s used in graph configuration. Because graph configuration also appears in regular modules, which are still on legacy select2, I'm just going to revert this until the rest of regular modules can be migrated.

https://dimagi-dev.atlassian.net/browse/HI-391

@millerdev 