### PR TITLE
fix corehq.motech.tests.test_utils in python 3

### DIFF
--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import doctest
+import six
 from django.test import SimpleTestCase
 import corehq.motech.utils
 from corehq.motech.utils import pad, pformat_json
@@ -29,11 +30,11 @@ class PFormatJSONTests(SimpleTestCase):
     def test_valid_json(self):
         self.assertEqual(
             pformat_json('{"ham": "spam", "eggs": "spam"}'),
-            '{\n  "eggs": "spam",\n  "ham": "spam"\n}'
+            '{\n  "eggs": "spam",\n  "ham": "spam"\n}' if six.PY3 else '{\n  "eggs": "spam", \n  "ham": "spam"\n}'
         )
         self.assertEqual(
             pformat_json({'ham': 'spam', 'eggs': 'spam'}),
-            '{\n  "eggs": "spam",\n  "ham": "spam"\n}'
+            '{\n  "eggs": "spam",\n  "ham": "spam"\n}' if six.PY3 else '{\n  "eggs": "spam", \n  "ham": "spam"\n}'
         )
 
     def test_invalid_json(self):

--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import doctest
 from django.test import SimpleTestCase
 import corehq.motech.utils
-from corehq.motech.utils import pad
+from corehq.motech.utils import pad, pformat_json
 
 
 class PadTests(SimpleTestCase):
@@ -22,6 +22,25 @@ class PadTests(SimpleTestCase):
         """
         padded = pad(b'xy\xc5\xba\xc5\xbay', 8, b'*')
         self.assertEqual(padded, b'xy\xc5\xba\xc5\xbay*')
+
+
+class PFormatJSONTests(SimpleTestCase):
+
+    def test_valid_json(self):
+        self.assertEqual(
+            pformat_json('{"ham": "spam", "eggs": "spam"}'),
+            '{\n  "eggs": "spam",\n  "ham": "spam"\n}'
+        )
+        self.assertEqual(
+            pformat_json({'ham': 'spam', 'eggs': 'spam'}),
+            '{\n  "eggs": "spam",\n  "ham": "spam"\n}'
+        )
+
+    def test_invalid_json(self):
+        self.assertEqual(
+            pformat_json('ham spam eggs spam'),
+            'ham spam eggs spam'
+        )
 
 
 class DocTests(SimpleTestCase):

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -78,20 +78,6 @@ def pformat_json(data):
     value if it can't be parsed as JSON.
 
     :return: A 2-space-indented string with sorted keys.
-
-    >>> print(pformat_json('{"ham": "spam", "eggs": "spam"}'))
-    {
-      "eggs": "spam", 
-      "ham": "spam"
-    }
-    >>> print(pformat_json({'ham': 'spam', 'eggs': 'spam'}))
-    {
-      "eggs": "spam", 
-      "ham": "spam"
-    }
-    >>> print(pformat_json('ham spam eggs spam'))
-    ham spam eggs spam
-
     """
     try:
         json_data = json.loads(data) if isinstance(data, six.string_types) else data


### PR DESCRIPTION
Python 3 doesn't handle newlines in doctests well, so I'm moving these doctests to regular unit tests.

@dimagi/py3 