### PR TITLE
fix casexml.apps.case.tests.test_rebuild:CouchCaseRebuildTest.test_co…

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -85,8 +85,8 @@ class CouchCaseRebuildTest(TestCase, CaseRebuildTestMixin):
         self.assertTrue(case.actions[0] != case.actions[1])
         self.assertTrue(case.actions[1] == case.actions[1])
 
-        orig = case.actions[1]
-        copy = CommCareCaseAction.wrap(orig._doc.copy())
+        orig = case.actions[2]
+        copy = CommCareCaseAction.wrap(deepcopy(orig._doc))
         self.assertTrue(copy != case.actions[0])
         self.assertTrue(copy == orig)
 


### PR DESCRIPTION
…uch_action_equality

There were a couple of things wrong with this test:
1) The wrong case action was being compared
2) A shallow copy was used, so comparisons after modifying nested dicts were broken.

@dimagi/py3 