### PR TITLE
Fixed bad translation in build errors

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -213,8 +213,8 @@
                             {% endblocktrans %}
                         {% case "invalid filter xpath" %}
                             {% if error.filter %}
-                                {% url "view_module" domain app.id error.module.unique_id as module_url error_filter=error.filter %}
-                                {% blocktrans with module_name=error.module.name|trans:langs %}
+                                {% url "view_module" domain app.id error.module.unique_id as module_url %}
+                                {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
                                     Case List has invalid filter xpath <code>{{ error_filter }}</code> in
                                     <a href="{{ module_url }}">{{ module_name }}</a>
                                 {% endblocktrans %}


### PR DESCRIPTION
https://sentry.io/dimagi/commcarehq/issues/870485863

@millerdev / @dannyroberts 

New app builds were failing for apps that had an invalid case list filter, without showing the correct message.