### PR TITLE
Add refreshing of years list when it was shrinked

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -346,6 +346,10 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
             });
             vm.selectedYear = latest.getFullYear();
             vm.selectedMonth = 12;
+        } else if (year.id < latest.getFullYear()) {
+            vm.years =  _.filter(vm.yearsCopy, function (y) {
+                return y.id <= latest.getFullYear();
+            });
         }
         if (year.id === latest.getFullYear()) {
             vm.months = _.filter(vm.monthsCopy, function (month) {


### PR DESCRIPTION
Hi @calellowitz,
I have fixed the year filter on tabular report to refresh the list of years not only when there is too many but also when there is too little of years displayed.
Need QA: Yes
Environment: n/a
Locally Tested: Yes
Regards, Dawid