### PR TITLE
Show properties used in case details when not referenced in forms

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -6,6 +6,7 @@ hqDefine('app_manager/js/summary/case_summary',[
     'hqwebapp/js/assert_properties',
     'app_manager/js/summary/models',
     'app_manager/js/menu',  // enable lang switcher and "Updates to publish" banner
+    'hqwebapp/js/knockout_bindings.ko', // popover
 ], function ($, _, ko, initialPageData, assertProperties, models) {
 
     var caseTypeModel = function (caseType) {

--- a/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/form_summary.js
@@ -7,6 +7,7 @@ hqDefine('app_manager/js/summary/form_summary',[
     'app_manager/js/summary/models',
     'app_manager/js/summary/utils',
     'app_manager/js/menu',  // enable lang switcher and "Updates to publish" banner
+    'hqwebapp/js/knockout_bindings.ko', // popover
 ], function ($, _, ko, initialPageData, assertProperties, models, utils) {
     var formSummaryModel = function (options) {
         var self = models.contentModel(_.extend(options, {

--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -89,9 +89,11 @@
                                     <ul>
                                         <li data-bind="visible: error, text: error"></li>
                                         <!-- ko foreach: properties -->
-                                            <li data-bind="if: has_errors">
-                                                <a data-bind="attr: {href: '#' + $parent.name + ':' + name}, text: name"></a>
+                                        <!-- ko if: has_errors -->
+                                            <li>
+                                                <a data-bind="attr: {href: '#' + $parent.name + ':' + encodeURIComponent(name)}, text: name"></a>
                                             </li>
+                                        <!-- /ko -->
                                         <!-- /ko -->
                                     </ul>
                                 </div>
@@ -135,30 +137,47 @@
                                         </td>
                                         <!-- ko if: !$index() -->
                                         <td>
-                                            <ul class="list-unstyled" data-bind="foreach: $parent.short_details">
-                                                <li>
-                                                    <span data-bind="html: $root.moduleReference($data.module_id)"></span> "<!-- ko text: $root.translate($data.header) --><!-- /ko -->"
-                                                </li>
-                                            </ul>
+                                            {% include 'app_manager/partials/case_summary_case_details.html' with detail='$parent.short_details' %}
                                         </td>
                                         <td>
-                                            <ul class="list-unstyled" data-bind="foreach: $parent.long_details">
-                                                <li>
-                                                    <span data-bind="html: $root.moduleReference($data.module_id)"></span> "<!-- ko text: $root.translate($data.header) --><!-- /ko -->"
-                                                </li>
-                                            </ul>
+                                            {% include 'app_manager/partials/case_summary_case_details.html' with detail='$parent.long_details' %}
                                         </td>
                                         <!-- /ko -->
+                                    </tr>
+                                <!-- /ko -->
+                                <!-- ko if: !forms.length && (short_details.length || long_details.length) -->
+                                    {# There is a property referenced in the case details screen that isn't referenced in any form #}
+                                    <tr data-bind="attr: {id: $parent.name + ':' + encodeURIComponent(name)}, css: {'danger': has_errors}, visible: isVisible">
+                                        <td>
+                                            <dl>
+                                                <dt data-bind="text: name"></dt>
+                                                <dd data-bind="text: description"></dd>
+                                            </dl>
+                                        </td>
+                                        <td></td><td></td><td></td>
+                                        <td>
+                                            {% include 'app_manager/partials/case_summary_case_details.html' with detail='short_details' %}
+                                        </td>
+                                        <td>
+                                            {% include 'app_manager/partials/case_summary_case_details.html' with detail='long_details' %}
+                                        </td>
                                     </tr>
                                 <!-- /ko -->
                             </tbody>
                         </table>
                     </div>
                 </div>
-            <!-- /ko -->
+                <!-- /ko -->
         </div>
     </div>
+    <script type="text/html" id="detail-errors">
+        <ul class="list-unstyled" data-bind="foreach: $data">
+            <li>
+                <span data-bind="html: $root.moduleReference($data.module_id)"></span> "<!-- ko text: $root.translate($data.header) --><!-- /ko -->"
 
+            </li>
+        </ul>
+    </script>
     {# List of forms that open/close a case type #}
     <script type="text/html" id="opened-closed-by">
         <ul data-bind="foreach: $data">

--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -170,14 +170,7 @@
                 <!-- /ko -->
         </div>
     </div>
-    <script type="text/html" id="detail-errors">
-        <ul class="list-unstyled" data-bind="foreach: $data">
-            <li>
-                <span data-bind="html: $root.moduleReference($data.module_id)"></span> "<!-- ko text: $root.translate($data.header) --><!-- /ko -->"
 
-            </li>
-        </ul>
-    </script>
     {# List of forms that open/close a case type #}
     <script type="text/html" id="opened-closed-by">
         <ul data-bind="foreach: $data">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_summary_case_details.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_summary_case_details.html
@@ -1,0 +1,9 @@
+<ul class="list-unstyled" data-bind="foreach: {{ detail }}">
+    <li>
+        <!-- ko if: error -->
+        <i class="fa fa-exclamation-triangle text-danger"
+           data-bind="popover: { content: error, placement: 'bottom', trigger: 'hover' }"></i>
+        <!-- /ko -->
+        <span data-bind="html: $root.moduleReference($data.module_id)"></span> "<!-- ko text: $root.translate($data.header) --><!-- /ko -->"
+    </li>
+</ul>

--- a/corehq/apps/app_manager/tests/test_case_meta.py
+++ b/corehq/apps/app_manager/tests/test_case_meta.py
@@ -221,6 +221,23 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
         self.assertEqual({}, meta_type.opened_by)
         self.assertTrue(m0f1.unique_id in meta_type.closed_by)
 
+    def test_non_existant_parent(self):
+        """If you reference a parent property in the case list but the case type has no parent, we should tell you
+        """
+        app, _ = self.get_test_app()
+        app.modules[0].case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'Parent prop reference'},
+                model='case',
+                field='parent/doesnt_exist',
+                format='plain',
+                case_tile_field='header'
+            ),
+        ]
+        metadata = app.get_case_metadata()
+        prop = metadata.get_type('parent').get_property('parent/doesnt_exist', allow_parent=True)
+        self.assertIsNotNone(prop.short_details[0].error)
+
     def test_multiple_parents_case_lists(self):
         """If the case has multiple parents, and you reference a parent property in the
         case list, we can't tell which parent will be shown """

--- a/corehq/apps/app_manager/tests/test_case_meta.py
+++ b/corehq/apps/app_manager/tests/test_case_meta.py
@@ -282,3 +282,32 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
                  .short_details[0].module_id),
                 app.modules[4].unique_id
             )
+
+    def test_non_case_props(self):
+        """We have special syntax in case lists and case details which shouldn't show up in the view for case types
+        """
+        app, _ = self.get_test_app()
+        app.modules[0].case_details.short.columns = [
+            DetailColumn(
+                header={'en': 'Owner Name'},
+                model='case',
+                field='#owner_name',
+                format='plain',
+                case_tile_field='header'
+            ),
+            DetailColumn(
+                header={'en': 'Username'},
+                model='case',
+                field='user/username',
+                format='plain',
+                case_tile_field='header'
+            ),
+        ]
+        metadata = app.get_case_metadata()
+        prop = metadata.get_type('parent').get_property('#owner_name')
+        self.assertFalse(prop.short_details)
+        self.assertFalse(prop.long_details)
+
+        prop = metadata.get_type('parent').get_property('user/username', allow_parent=True)
+        self.assertFalse(prop.short_details)
+        self.assertFalse(prop.long_details)

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -252,6 +252,13 @@ class AppCaseMetadata(JsonObject):
         return prop
 
     def add_property_detail(self, detail_type, root_case_type, module_id, column):
+        if column.field == '#owner_name':
+            return None
+
+        parts = column.field.split('/')
+        if parts and parts[0] == 'user':
+            return None
+
         if column.useXpathExpression:
             return column.field
         try:

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -120,6 +120,7 @@ class CaseDetailMeta(JsonObject):
     module_id = StringProperty()
     header = DictProperty()
     format = StringProperty()
+    error = StringProperty()
 
 
 class CaseProperty(JsonObject):
@@ -152,11 +153,11 @@ class CaseProperty(JsonObject):
             condition=(condition if condition and condition.type == 'if' else None)
         ))
 
-    def add_detail(self, type_, module_id, header, format):
+    def add_detail(self, type_, module_id, header, format, error=None):
         {
             "short": self.short_details,
             "long": self.long_details,
-        }[type_].append(CaseDetailMeta(module_id=module_id, header=header, format=format))
+        }[type_].append(CaseDetailMeta(module_id=module_id, header=header, format=format, error=error))
 
 
 class CaseTypeMeta(JsonObject):
@@ -209,12 +210,13 @@ class AppCaseMetadata(JsonObject):
             # find the case property from the correct case type
             parent_rel, name = name.split('/', 1)
             parent_case_types = type_.relationships.get(parent_rel)
-            parent_props = [
-                prop for parent_case_type in parent_case_types
-                for prop in self.get_property_list(parent_case_type, name)
-            ]
-            if parent_props:
-                return parent_props
+            if parent_case_types:
+                parent_props = [
+                    prop for parent_case_type in parent_case_types
+                    for prop in self.get_property_list(parent_case_type, name)
+                ]
+                if parent_props:
+                    return parent_props
             else:
                 params = {'case_type': root_case_type, 'relationship': parent_rel}
                 raise CaseMetaException(_(
@@ -244,16 +246,23 @@ class AppCaseMetadata(JsonObject):
     def add_property_error(self, case_type, case_property, form_id, message):
         prop = self.get_error_property(case_type, case_property)
         prop.has_errors = True
-        form = prop.get_form(form_id)
-        form.errors.append(message)
+        if form_id is not None:
+            form = prop.get_form(form_id)
+            form.errors.append(message)
         return prop
 
     def add_property_detail(self, detail_type, root_case_type, module_id, column):
         if column.useXpathExpression:
             return column.field
-        props = self.get_property_list(root_case_type, column.field)
+        try:
+            props = self.get_property_list(root_case_type, column.field)
+        except CaseMetaException as e:
+            props = [self.add_property_error(root_case_type, column.field, form_id=None, message=None)]
+            error = six.text_type(e)
+        else:
+            error = None
         for prop in props:
-            prop.add_detail(detail_type, module_id, column.header, column.format)
+            prop.add_detail(detail_type, module_id, column.header, column.format, error)
 
     def get_error_property(self, case_type, name):
         type_ = self.get_type(case_type)


### PR DESCRIPTION
This solves a few issues:

1. Fixes a longstanding issue where case properties referenced _only_ in case details were not shown in the case summary (`boop` in the screenshot below)
2. Fixes a bug I introduced before. If you reference a parent property in a case list/detail, but the case type doesn't have a parent then the page would 500: (https://dimagi-dev.atlassian.net/browse/REACH-100). Now we show this as an error, where before we would just hide this from the user.
3. Fixes a bug in the case and form summary where the error popovers would not show. 

![screenshot from 2019-02-04 13-58-07](https://user-images.githubusercontent.com/146896/52230255-f011c000-2884-11e9-89ce-c30bc01ea4c8.png)

