### PR TITLE
Enable Supervisor option in tabular report filter while at AWC level

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -299,12 +299,10 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
             vm.myPromise = locationsService.getChildren($item.location_id).then(function (data) {
                 if ($item.user_have_access) {
                     locationsCache[$item.location_id] = [ALL_OPTION].concat(data.locations);
-                    vm.selectedLevel = selectedLocationIndex() + 1;
                     vm.selectedLocations[level + 1] = ALL_OPTION.location_id;
                     vm.selectedLocationId = vm.selectedLocations[selectedLocationIndex()];
                 } else {
                     locationsCache[$item.location_id] = data.locations;
-                    vm.selectedLevel = selectedLocationIndex() + 1;
                     vm.selectedLocations[level + 1] = data.locations[0].location_id;
                     vm.selectedLocationId = vm.selectedLocations[selectedLocationIndex()];
                     if (level === 2 && vm.isISSNIPMonthlyRegisterSelected()) {
@@ -317,8 +315,9 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
             });
         }
         var levels = [];
+        vm.selectedLevel = selectedLocationIndex() + 1;
         window.angular.forEach(vm.levels, function (value) {
-            if (value.id > selectedLocationIndex() || ((level === 4) && value.id >= selectedLocationIndex())) {
+            if (value.id > selectedLocationIndex()) {
                 levels.push(value);
             }
         });

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -318,7 +318,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         }
         var levels = [];
         window.angular.forEach(vm.levels, function (value) {
-            if (value.id > selectedLocationIndex()) {
+            if (value.id > selectedLocationIndex() || ((level === 4) && value.id >= selectedLocationIndex())) {
                 levels.push(value);
             }
         });


### PR DESCRIPTION
Hi @calellowitz,
I had made the change to the tabular report filter where at the AWC level the `Supervisor` option was chosen in the view by filter after selecting AWC but wasn't available in the drop-down.
Need QA: Yes
Environment: n/a
Locally Tested: Yes
Jira [ticket](https://dimagi-dev.atlassian.net/browse/ICDS-316)
Regards, Dawid