### PR TITLE
use images from new docker hub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dimagi/commcarehq_base:latest
+FROM dimagi/commcarehq_base_new:latest
 # When changing this file, also update docker/Dockerfile-py3
 
 VOLUME /mnt/commcare-hq-ro /mnt/lib

--- a/docker/Dockerfile-py3
+++ b/docker/Dockerfile-py3
@@ -1,4 +1,4 @@
-FROM dimagi/commcarehq_py3:latest
+FROM dimagi/commcarehq_py3_new:latest
 # Based on docker/Dockerfile
 
 VOLUME /mnt/commcare-hq-ro /mnt/lib


### PR DESCRIPTION
Use
https://cloud.docker.com/repository/docker/dimagi/commcarehq_base_new
and
https://cloud.docker.com/repository/docker/dimagi/commcarehq_py3_new

because these new images autobuild when master is updated.  The previous ones appear to have lost that behavior after the migration to the new docker hub.