### PR TITLE
Revert "Fixed 500 when updating linked app custom properties"

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -731,14 +731,10 @@ def edit_app_attr(request, domain, app_id, attr):
     """
     app = get_app(domain, app_id)
 
-    resp = {"update": {}}
     try:
         hq_settings = json.loads(request.body)['hq']
     except ValueError:
         hq_settings = request.POST
-    except KeyError:
-        # No hq settings are present, this is likely a linked app
-        return HttpResponse(json.dumps(resp))
 
     attributes = [
         'all',
@@ -770,6 +766,7 @@ def edit_app_attr(request, domain, app_id, attr):
         except ValueError:
             pass
 
+    resp = {"update": {}}
     # For either type of app
     easy_attrs = (
         ('build_spec', BuildSpec.from_string),


### PR DESCRIPTION
Reverts dimagi/commcare-hq#23158

It seems that displaying/saving custom properties for linked apps is a loophole that half works: you can save, but the app's version doesn't increment, you can't make a new build after saving (because the version didn't increment), and the properties get overwritten the next time you pull the master app.

Ideally there wouldn't be a save button on the app settings at all for linked apps, and custom properties wouldn't be displayed, but for the moment I'd just like to get rid of this code & comment.

@dannyroberts / @emord 