### PR TITLE
Avoid clearing feature_id in select2

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -122,12 +122,12 @@ class Select2RateAsyncHandler(BaseSelect2AsyncHandler):
     """
     slug = 'select2_rate'
     allowed_actions = [
-        'feature_id',
+        'select2_feature_id',
         'product_rate_id',
     ]
 
     @property
-    def feature_id_response(self):
+    def select2_feature_id_response(self):
         features = Feature.objects
         if self.existing:
             features = features.exclude(name__in=self.existing)

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1147,7 +1147,7 @@ class SoftwarePlanVersionForm(forms.Form):
         widget=forms.HiddenInput,
     )
 
-    feature_id = forms.CharField(
+    select2_feature_id = forms.CharField(
         required=False,
         label="Search for or Create Feature",
         widget=forms.Select(choices=[]),
@@ -1290,7 +1290,7 @@ class SoftwarePlanVersionForm(forms.Form):
                 InlineField('feature_rates', data_bind="value: featureRates.ratesString"),
                 hqcrispy.B3MultiField(
                     "Add Feature",
-                    InlineField('feature_id', css_class="input-xxlarge",
+                    InlineField('select2_feature_id', css_class="input-xxlarge",
                                 data_bind="value: featureRates.select2.value"),
                     StrictButton(
                         "Select Feature",
@@ -1403,7 +1403,7 @@ class SoftwarePlanVersionForm(forms.Form):
             'currentValue': self['feature_rates'].value(),
             'handlerSlug': FeatureRateAsyncHandler.slug,
             'select2Options': {
-                'fieldName': 'feature_id',
+                'fieldName': 'select2_feature_id',
             }
         }
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-401
Sentry error: https://sentry.io/dimagi/commcarehq/issues/873536977/events/45168261773/?environment=softlayer

When someone adds new features to a custom software plan, clearing the value in `select2` simultaneously wiped out all the `feature_id` data we need to search for features and update the plan version on the back end. I still can't pinpoint when exactly this bug was introduced, but renaming the variables that `select2` needs to search for features to choose from avoids clearing the `feature_id` ko variable.

code buddy: @proteusvacuum 