### PR TITLE
Location relations

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 from collections import defaultdict
 from itertools import groupby
-from xml.etree.cElementTree import Element
+from xml.etree.cElementTree import Element, SubElement
 
-from django.db.models import IntegerField
+from django.db.models import IntegerField, Q
 from django.contrib.postgres.fields.array import ArrayField
 from django_cte import With
 from django_cte.raw import raw_cte_sql
@@ -229,34 +230,6 @@ flat_location_fixture_generator = LocationFixtureProvider(
 )
 
 
-class RelatedLocationSerializer(FlatLocationSerializer):
-
-    def get_xml_nodes(self, fixture_id, restore_user, locations_queryset, data_fields):
-        all_types = LocationType.objects.filter(domain=restore_user.domain).values_list(
-            'code', flat=True
-        )
-        location_type_attrs = ['{}_id'.format(t) for t in all_types if t is not None]
-        attrs_to_index = ['@{}'.format(attr) for attr in location_type_attrs]
-        attrs_to_index.extend(_get_indexed_field_name(field.slug) for field in data_fields
-                              if field.index_in_fixture)
-        attrs_to_index.extend(['@id', '@type', 'name', '@distance'])
-
-        xml_nodes = self._get_fixture_node(fixture_id, restore_user, locations_queryset,
-                                           location_type_attrs, data_fields)
-
-        user_locations = restore_user.get_sql_locations(restore_user.domain)
-        distance_dict = LocationRelation.relation_distance_dictionary(user_locations)
-
-        child_node = xml_nodes.getchildren()[0]
-        for grandchild_node in child_node.getchildren():
-            location_id = grandchild_node.get('id')
-            if location_id in distance_dict:
-                minimum_distance = min(six.itervalues(distance_dict[location_id]))
-                grandchild_node.set('distance', str(minimum_distance))
-
-        return [get_index_schema_node(fixture_id, attrs_to_index), xml_nodes]
-
-
 class RelatedLocationsFixtureProvider(FixtureProvider):
     """This fixture is under active development for REACH, and is expected to change.
 
@@ -264,22 +237,49 @@ class RelatedLocationsFixtureProvider(FixtureProvider):
       to another location for it be included in this fixture.
     """
     id = 'related_locations'
-    serializer = RelatedLocationSerializer()
 
     def __call__(self, restore_state):
         if not toggles.RELATED_LOCATIONS.enabled(restore_state.domain):
             return []
 
-        restore_user = restore_state.restore_user
-        user_locations = restore_user.get_sql_locations(restore_user.domain)
-        related_location_ids = LocationRelation.from_locations(user_locations)
-        related_location_pks = (
-            SQLLocation.objects.filter(location_id__in=related_location_ids)
-            .values_list('pk', flat=True)
+        location_relations = self._users_related_locations(restore_state.restore_user)
+
+        root_node = Element('fixture', {'id': self.id,
+                                        'user_id': restore_state.restore_user.user_id,
+                                        'indexed': 'true'})
+        outer_node = SubElement(root_node, 'locations')
+
+        for location, relations in location_relations:
+            location_node = SubElement(outer_node, 'location', {'id': location.location_id})
+            for location, distance in relations:
+                node = SubElement(location_node, 'related_location')
+                node.text = location.location_id
+                if distance:
+                    node.attrib['distance'] = str(distance)
+
+        return [get_index_schema_node(self.id, ['@id']), root_node]
+
+    def _users_related_locations(self, restore_user):
+        user_location_ids = restore_user.get_location_ids(restore_user.domain)
+        user_locations_with_descendants = SQLLocation.objects.get_descendants(
+            Q(domain=restore_user.domain, location_id__in=user_location_ids)
         )
-        locations_queryset = _location_queryset_helper(restore_user.domain, list(related_location_pks))
-        data_fields = _get_location_data_fields(restore_user.domain)
-        return self.serializer.get_xml_nodes(self.id, restore_user, locations_queryset, data_fields)
+        location_relations = LocationRelation.objects.filter(
+            Q(location_a__in=user_locations_with_descendants) | Q(location_b__in=user_locations_with_descendants)
+        ).prefetch_related('location_a', 'location_a__location_type', 'location_b', 'location_b__location_type')
+
+        related_location_dict = defaultdict(list)
+
+        for relation in location_relations:
+            related_location_dict[relation.location_a].append((relation.location_b, relation.distance))
+            related_location_dict[relation.location_b].append((relation.location_a, relation.distance))
+
+        for loc in related_location_dict:
+            related_location_dict[loc].sort(key=lambda tup: tup[0].name)
+
+        related_locations = list(related_location_dict.items())
+        related_locations.sort(key=lambda tup: tup[0].name)
+        return related_locations
 
 
 related_locations_fixture_generator = RelatedLocationsFixtureProvider()
@@ -298,7 +298,17 @@ def get_location_fixture_queryset(user):
     if user_locations.query.is_empty():
         return user_locations
 
-    return _location_queryset_helper(user.domain, list(user_locations.order_by().values_list("id", flat=True)))
+    user_location_ids = list(user_locations.order_by().values_list("id", flat=True))
+
+    if toggles.RELATED_LOCATIONS.enabled(user.domain):
+        related_location_ids = LocationRelation.from_locations(
+            SQLLocation.objects.get_descendants(Q(domain=user.domain, id__in=user_location_ids))
+        )
+        user_location_ids.extend(
+            list(SQLLocation.objects.filter(location_id__in=related_location_ids).values_list('id', flat=True))
+        )
+
+    return _location_queryset_helper(user.domain, user_location_ids)
 
 
 def _location_queryset_helper(domain, location_pks):

--- a/corehq/apps/locations/tests/data/related_location.xml
+++ b/corehq/apps/locations/tests/data/related_location.xml
@@ -1,34 +1,10 @@
 <fixture id="related_locations" indexed="true" user_id="{user_id}">
     <locations>
-        <location city_id="{cambridge_id}" county_id="{middlesex_id}" id="{cambridge_id}" state_id="{massachusetts_id}" type="city">
-            <name>Cambridge</name>
-            <site_code>cambridge</site_code>
-            <external_id/>
-            <latitude/>
-            <longitude/>
-            <location_type>city</location_type>
-            <supply_point_id/>
-            <location_data/>
+		<location id="{boston_id}">
+			<related_location>{cambridge_id}</related_location>
         </location>
-        <location city_id="" id="{massachusetts_id}" type="state" county_id="" state_id="{massachusetts_id}">
-            <name>Massachusetts</name>
-            <site_code>massachusetts</site_code>
-            <external_id/>
-            <latitude/>
-            <longitude/>
-            <location_type>state</location_type>
-            <supply_point_id/>
-            <location_data/>
-        </location>
-        <location city_id="" county_id="{middlesex_id}" id="{middlesex_id}" state_id="{massachusetts_id}" type="county">
-            <name>Middlesex</name>
-            <site_code>middlesex</site_code>
-            <external_id/>
-            <latitude/>
-            <longitude/>
-            <location_type>county</location_type>
-            <supply_point_id/>
-            <location_data/>
+		<location id="{cambridge_id}">
+			<related_location>{boston_id}</related_location>
         </location>
     </locations>
 </fixture>

--- a/corehq/apps/locations/tests/data/related_location_flat_fixture.xml
+++ b/corehq/apps/locations/tests/data/related_location_flat_fixture.xml
@@ -1,0 +1,54 @@
+<fixture id="locations" indexed="true" user_id="{user_id}">
+    <locations>
+        <location city_id="{boston_id}" county_id="{suffolk_id}" id="{boston_id}" state_id="{massachusetts_id}" type="city">
+            <name>Boston</name>
+            <site_code>boston</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="{cambridge_id}" county_id="{middlesex_id}" id="{cambridge_id}" state_id="{massachusetts_id}" type="city">
+            <name>Cambridge</name>
+            <site_code>cambridge</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="" id="{massachusetts_id}" type="state" county_id="" state_id="{massachusetts_id}">
+            <name>Massachusetts</name>
+            <site_code>massachusetts</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>state</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="" county_id="{middlesex_id}" id="{middlesex_id}" state_id="{massachusetts_id}" type="county">
+            <name>Middlesex</name>
+            <site_code>middlesex</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>county</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="" county_id="{suffolk_id}" id="{suffolk_id}" state_id="{massachusetts_id}" type="county">
+            <name>Suffolk</name>
+            <site_code>suffolk</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>county</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+    </locations>
+</fixture>

--- a/corehq/apps/locations/tests/data/related_location_with_distance.xml
+++ b/corehq/apps/locations/tests/data/related_location_with_distance.xml
@@ -1,34 +1,10 @@
 <fixture id="related_locations" indexed="true" user_id="{user_id}">
     <locations>
-        <location city_id="{cambridge_id}" county_id="{middlesex_id}" id="{cambridge_id}" state_id="{massachusetts_id}" type="city" distance="5">
-            <name>Cambridge</name>
-            <site_code>cambridge</site_code>
-            <external_id/>
-            <latitude/>
-            <longitude/>
-            <location_type>city</location_type>
-            <supply_point_id/>
-            <location_data/>
+		<location id="{boston_id}">
+			<related_location distance="5">{cambridge_id}</related_location>
         </location>
-        <location city_id="" id="{massachusetts_id}" type="state" county_id="" state_id="{massachusetts_id}">
-            <name>Massachusetts</name>
-            <site_code>massachusetts</site_code>
-            <external_id/>
-            <latitude/>
-            <longitude/>
-            <location_type>state</location_type>
-            <supply_point_id/>
-            <location_data/>
-        </location>
-        <location city_id="" county_id="{middlesex_id}" id="{middlesex_id}" state_id="{massachusetts_id}" type="county">
-            <name>Middlesex</name>
-            <site_code>middlesex</site_code>
-            <external_id/>
-            <latitude/>
-            <longitude/>
-            <location_type>county</location_type>
-            <supply_point_id/>
-            <location_data/>
+		<location id="{cambridge_id}">
+			<related_location distance="5">{boston_id}</related_location>
         </location>
     </locations>
 </fixture>

--- a/corehq/apps/locations/tests/data/related_location_with_distance_flat_fixture.xml
+++ b/corehq/apps/locations/tests/data/related_location_with_distance_flat_fixture.xml
@@ -1,0 +1,54 @@
+<fixture id="locations" indexed="true" user_id="{user_id}">
+    <locations>
+        <location city_id="{boston_id}" county_id="{suffolk_id}" id="{boston_id}" state_id="{massachusetts_id}" type="city">
+            <name>Boston</name>
+            <site_code>boston</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="{cambridge_id}" county_id="{middlesex_id}" id="{cambridge_id}" state_id="{massachusetts_id}" type="city">
+            <name>Cambridge</name>
+            <site_code>cambridge</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="" id="{massachusetts_id}" type="state" county_id="" state_id="{massachusetts_id}">
+            <name>Massachusetts</name>
+            <site_code>massachusetts</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>state</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="" county_id="{middlesex_id}" id="{middlesex_id}" state_id="{massachusetts_id}" type="county">
+            <name>Middlesex</name>
+            <site_code>middlesex</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>county</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location city_id="" county_id="{suffolk_id}" id="{suffolk_id}" state_id="{massachusetts_id}" type="county">
+            <name>Suffolk</name>
+            <site_code>suffolk</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>county</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+    </locations>
+</fixture>

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -695,6 +695,20 @@ class RelatedLocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocations
             related=True
         )
 
+    def test_related_locations_parent_location(self, *args):
+        # verify that being assigned to a parent location pulls in sub location's relations
+        self.user._couch_user.add_to_assigned_locations(self.locations['Middlesex'])
+        self._assert_fixture_matches_file(
+            'related_location_flat_fixture',
+            ['Massachusetts', 'Middlesex', 'Cambridge', 'Boston', 'Suffolk'],
+            flat=True
+        )
+        self._assert_fixture_matches_file(
+            'related_location',
+            ['Boston', 'Cambridge'],
+            related=True
+        )
+
     def test_related_locations_with_distance(self, *args):
         self.user._couch_user.add_to_assigned_locations(self.locations['Boston'])
         self.relation.distance = 5

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -685,8 +685,13 @@ class RelatedLocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocations
     def test_related_locations(self, *args):
         self.user._couch_user.add_to_assigned_locations(self.locations['Boston'])
         self._assert_fixture_matches_file(
+            'related_location_flat_fixture',
+            ['Massachusetts', 'Middlesex', 'Cambridge', 'Boston', 'Suffolk'],
+            flat=True
+        )
+        self._assert_fixture_matches_file(
             'related_location',
-            ['Massachusetts', 'Middlesex', 'Cambridge'],
+            ['Boston', 'Cambridge'],
             related=True
         )
 
@@ -696,8 +701,13 @@ class RelatedLocationFixturesTest(LocationHierarchyTestCase, FixtureHasLocations
         self.relation.save()
         self.addCleanup(lambda: LocationRelation.objects.filter(pk=self.relation.pk).update(distance=None))
         self._assert_fixture_matches_file(
+            'related_location_with_distance_flat_fixture',
+            ['Massachusetts', 'Middlesex', 'Cambridge', 'Boston', 'Suffolk'],
+            flat=True
+        )
+        self._assert_fixture_matches_file(
             'related_location_with_distance',
-            ['Massachusetts', 'Middlesex', 'Cambridge'],
+            ['Boston', 'Cambridge'],
             related=True
         )
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -98,6 +98,9 @@ class OTARestoreUser(object):
     def get_sql_locations(self, domain):
         return self._couch_user.get_sql_locations(domain)
 
+    def get_location_ids(self, domain):
+        return self._couch_user.get_location_ids(domain)
+
     def get_fixture_data_items(self):
         raise NotImplementedError()
 


### PR DESCRIPTION

This only affects REACH as their the only ones using/playing around with this feature. Probably easiest to just look at the resulting code without much respect to the original code.

Use case:

REACH is introducing a new location hierarchy so that MoH and MWCD can maintain their different structures (meaning ICDS now has two location hierarchies, one with village as the base unit, another with AWC), and we are using "location relations" to link AWCs with Villages so that we can assing beneficiaries to the relevant location.

The general behavior is:

Flat location fixture will now include information on the related locations (so that we are not storing location information in two different places)
A new related locations fixture will include the links between locations

Specification: https://docs.google.com/document/d/1wNwvNX8BjxaQ5aZKJSLngUNBG2ans9VIndWHXSAru08/edit?ts=5c5afc69#heading=h.dbpil7pjt52
