### PR TITLE
Fix custom sql by changing column name to owner_id

### DIFF
--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -46,7 +46,7 @@ class ChildHealthMonthlyUCR(ConfigurableReportCustomQueryProvider):
 
     def get_total_row(self):
         query_obj = self._get_query_object(total_row=True)
-        return ["Total"] + [r for r in query_obj.first()]
+        return ["Total"] + [r or 0 for r in query_obj.first()]
 
     def get_total_records(self):
         return self._get_query_object().count()

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -40,7 +40,7 @@ class ChildHealthMonthlyUCR(ConfigurableReportCustomQueryProvider):
         if limit:
             query_obj = query_obj.limit(limit)
         return OrderedDict([
-            (r.awc_id, r._asdict())
+            (r.owner_id, r._asdict())
             for r in query_obj.all()
         ])
 

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -122,10 +122,10 @@ class MPR6acChildHealth(ChildHealthMonthlyUCR):
             self._column_helper("16_days", "female", "minority"),
             self._column_helper("absent", "male"),
             self._column_helper("absent", "female"),
-            self._column_helper("partial", "male"),
-            self._column_helper("partial", "female"),
-            func.count(self.table.c.case_id).filter(self.table.c.sex == 'M').label("child_count_male"),
             func.count(self.table.c.case_id).filter(self.table.c.sex == 'F').label("child_count_female"),
+            func.count(self.table.c.case_id).filter(self.table.c.sex == 'M').label("child_count_male"),
+            self._column_helper("partial", "female"),
+            self._column_helper("partial", "male"),
         )
 
         if not total_row:

--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -64,7 +64,7 @@ class MPR6bChildHealth(ChildHealthMonthlyUCR):
             self._column_helper('F').label('pse_daily_attendance_female'),
         )
         if not total_row:
-            columns = (self.table.c.awc_id.label("awc_id"),) + columns
+            columns = (self.table.c.awc_id.label("owner_id"),) + columns
         return columns
 
     def _get_query_object(self, total_row=False):
@@ -129,7 +129,7 @@ class MPR6acChildHealth(ChildHealthMonthlyUCR):
         )
 
         if not total_row:
-            return (self.table.c.awc_id.label("awc_id"),) + columns
+            return (self.table.c.awc_id.label("owner_id"),) + columns
 
         return columns
 
@@ -213,7 +213,7 @@ class MPR5ChildHealth(ChildHealthMonthlyUCR):
         )
 
         if not total_row:
-            return (self.table.c.awc_id.label("awc_id"),) + columns
+            return (self.table.c.awc_id.label("owner_id"),) + columns
 
         return columns
 


### PR DESCRIPTION
Found this from the output in log files.

Originally confused field vs column_id: https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/ucr/reports/custom_mpr_6ac_child_health_cases_v2.json#L127-L128

@pr33thi This was the cause of the nulls in those comparisons