### PR TITLE
Updated messaging when web users page show no users

### DIFF
--- a/corehq/apps/users/static/users/js/web_users.js
+++ b/corehq/apps/users/static/users/js/web_users.js
@@ -25,8 +25,14 @@ hqDefine("users/js/web_users",[
             return !self.showLoadingSpinner() && !self.error() && self.users().length > 0;
         });
 
-        self.showNoUsersMessage = ko.computed(function () {
-            return !self.showLoadingSpinner() && !self.error() && self.users().length === 0;
+        self.noUsersMessage = ko.computed(function () {
+            if (!self.showLoadingSpinner() && !self.error() && self.users().length === 0) {
+                if (self.query()) {
+                    return gettext("No users matched your search.");
+                }
+                return gettext("This project has no web users. Please invite a web user above.");
+            }
+            return "";
         });
 
         self.goToPage = function (page) {

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -107,10 +107,10 @@
                 <i class="fa fa-spin fa-spinner"></i>
                 {% trans "Loading Users..." %}
             </div>
-            <div data-bind="visible: showNoUsersMessage">
+            <div data-bind="visible: noUsersMessage">
               <p class="alert alert-info">
                 <i class="fa fa-info-circle"></i>
-                {% trans "This project has no web users. Please invite a web user above." %}
+                <!-- ko text: noUsersMessage --><!-- /ko -->
               </p>
             </div>
             <table class="table table-striped table-responsive"


### PR DESCRIPTION
If there are no users in the project, show the current message. If there's a query:
<img width="1123" alt="screen shot 2019-02-06 at 7 07 45 pm" src="https://user-images.githubusercontent.com/1486591/52382300-a40c7a00-2a42-11e9-9abb-2e3a68e3b2b4.png">

@dannyroberts 