### PR TITLE
Add app summary button to form builder

### DIFF
--- a/corehq/apps/analytics/README.md
+++ b/corehq/apps/analytics/README.md
@@ -44,6 +44,8 @@ Used primarily by product team.
 
 No server component, just [google.js](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/analytics/static/analytix/js/google.js). We track events using `<module>.track.click` and `<module>.track.event`. We also use the default tracking (page views, etc.). Google has a few tracking options; we use their [gtag.js](https://developers.google.com/analytics/devguides/collection/gtagjs/).
 
+You can also add the `.track-usage-link` class to a link to track it in Google Analytics if it includes `hqwebapp/js/main.js`.
+
 ### Kissmetrics
 
 Used primarily by product team.

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -185,7 +185,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                     };
                     _prependTemplateToSelector(
                         '.fd-form-actions',
-                        $('#js-fd-manage-case').html(),
+                        $('#js-fd-form-actions').html(),
                         0,
                         function () {
                         }

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -65,12 +65,15 @@
 
     <div id="formdesigner" class="clearfix loading"></div>
 
-    <script type="text/html" id="js-fd-manage-case">
-      <div class="btn-group pull-right">
-        <a class="btn btn-manage" href="{% url "view_form" domain app.id form.unique_id %}">
-          <i class="fa fa-cog"></i> {% trans 'Manage Case' %}
-        </a>
-      </div>
+    <script type="text/html" id="js-fd-form-actions">
+        <div class="btn-group pull-right">
+            <a class="btn btn-form-action" href="{% url "app_form_summary" domain app.id %}">
+                <i class="fa fa-list-alt"></i> {% trans 'App Summary' %}
+            </a>
+            <a class="btn btn-form-action" href="{% url "view_form" domain app.id form.unique_id %}">
+                <i class="fa fa-cog"></i> {% trans 'Manage Case' %}
+            </a>
+        </div>
     </script>
 
     <script type="text/html" id="fd-hq-helptext-registration">

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -67,10 +67,14 @@
 
     <script type="text/html" id="js-fd-form-actions">
         <div class="btn-group pull-right">
-            <a class="btn btn-form-action" href="{% url "app_form_summary" domain app.id %}">
+            <a class="btn btn-form-action track-usage-link" href="{% url "app_form_summary" domain app.id %}"
+               data-category="App Builder" data-action="Form Action Link" data-label="App Summary"
+            >
                 <i class="fa fa-list-alt"></i> {% trans 'App Summary' %}
             </a>
-            <a class="btn btn-form-action" href="{% url "view_form" domain app.id form.unique_id %}">
+            <a class="btn btn-form-action track-usage-link" href="{% url "view_form" domain app.id form.unique_id %}"
+               data-category="App Builder" data-action="Form Action Link" data-label="Manage Case"
+            >
                 <i class="fa fa-cog"></i> {% trans 'Manage Case' %}
             </a>
         </div>

--- a/corehq/apps/hqwebapp/static/app_manager/less/form_editing.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/form_editing.less
@@ -35,7 +35,7 @@
   }
 }
 
-.btn-manage {
+.btn-form-action {
   color: white;
   .transition(.5s background);
 


### PR DESCRIPTION
The missing piece of the app building puzzle. How do you know what your app does? Look at the summary!

![screenshot from 2019-02-06 22-53-16](https://user-images.githubusercontent.com/146896/52389611-4556f880-2a62-11e9-86dd-a497f2d878e0.png)
