### PR TITLE
Add icds to blank case tags

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1639,7 +1639,7 @@ ICDS_DISHA_API = StaticToggle(
 
 ALLOW_BLANK_CASE_TAGS = StaticToggle(
     'allow_blank_case_tags',
-    'eCHIS: Allow blank case tags',
+    'eCHIS/ICDS: Allow blank case tags',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
 )


### PR DESCRIPTION
previous work found:

https://github.com/dimagi/commcare-hq/pull/21254
https://github.com/dimagi/commcare-hq/pull/21624

From those PRs/tickets I think that this blank case tag issue was meant to specifically target "load actions" that load a case. There is a separate "load case from fixture" action that is supposed to allow you to have a blank case tag in order to have separate case lists for your fixture vs case to be selected. This was originally used for enikshay, but now is used for ICDS/REACH so that the due list can be an advanced module.

The check for this still exists in code ([original PR](https://github.com/dimagi/commcare-hq/pull/13013/files#diff-a86df6df8b6c62195748605648bce855R472)).

Its possible that the long term fix for this should be to allow a blank case tag there and remove the flag from ICDS (as this is the only place a blank tag is used), but adding this flag for now until @orangejenny can confirm that would be a slightly better workflow