### PR TITLE
Only return the values of the dict, not the full html dict

### DIFF
--- a/custom/intrahealth/tests/reports/test_dashboard_1.py
+++ b/custom/intrahealth/tests/reports/test_dashboard_1.py
@@ -10,6 +10,61 @@ from custom.intrahealth.reports import Dashboard1Report
 
 class TestDashboard1(YeksiTestCase):
 
+    def test_extract_value_from_report_table_row_value_input_dict(self):
+        mock = MagicMock()
+        mock.couch_user = self.user
+        mock.GET = {
+            'location_id': '',
+            'program': '',
+            'month_start': '10',
+            'year_start': '2017',
+            'month_end': '3',
+            'year_end': '2018',
+        }
+        dashboard1_report = Dashboard1Report(request=mock, domain='test-pna')
+        report_table = {
+            'fix_column': False,
+            'comment': 'test_comment',
+            'rows': [],
+            'datatables': False,
+            'title': 'test_title',
+            'total_row': [
+                {'html': 'row_0'},
+                {'html': 'row_1'},
+                {'html': 'row_2'},
+                {'html': 'row_3'}
+            ],
+            'slug': 'disponibilite',
+            'default_rows': 10
+        }
+        report_table_value = dashboard1_report._extract_value_from_report_table_row_value(report_table)
+        self.assertEqual(report_table_value, ['row_0', 'row_1', 'row_2', 'row_3'])
+
+    def test_extract_value_from_report_table_row_value_input_string(self):
+        mock = MagicMock()
+        mock.couch_user = self.user
+        mock.GET = {
+            'location_id': '',
+            'program': '',
+            'month_start': '10',
+            'year_start': '2017',
+            'month_end': '3',
+            'year_end': '2018',
+        }
+        dashboard1_report = Dashboard1Report(request=mock, domain='test-pna1')
+        report_table = {
+            'fix_column': False,
+            'comment': 'test_comment',
+            'rows': [],
+            'datatables': False,
+            'title': 'test_title',
+            'total_row': ['row_0', 'row_1', 'row_2', 'row_3'],
+            'slug': 'disponibilite',
+            'default_rows': 10
+        }
+        report_table_value = dashboard1_report._extract_value_from_report_table_row_value(report_table)
+        self.assertEqual(report_table_value, ['row_0', 'row_1', 'row_2', 'row_3'])
+
     def test_availability_report(self):
         mock = MagicMock()
         mock.couch_user = self.user

--- a/custom/intrahealth/utils.py
+++ b/custom/intrahealth/utils.py
@@ -363,11 +363,21 @@ class MultiReport(CustomProjectReport, YeksiNaaMixin, ProjectReportParametersMix
         export_tables = []
         for individual_report in self.report_context['reports']:
             report_table = individual_report['report_table']
-            # The keys contain html info, so only the values get exported to excel
-            total_row = [row_value.items()[0][1] for row_value in report_table['total_row']]
+            total_row = self._extract_value_from_report_table_row_value(report_table)
             export_tables.append(self._export_table(report_table['title'], report_table['headers'],
                                                     report_table['rows'], total_row))
         return export_tables
+
+    def _extract_value_from_report_table_row_value(self, report_table):
+        extracted_row_values = []
+        for row_value in report_table['total_row']:
+            if isinstance(row_value, dict):
+                # If keys are dicts, they contain html info (ie: row_value = {'html': 'title'})
+                extracted_row_values.append(row_value.items()[0][1])
+            else:
+                extracted_row_values = report_table['total_row']
+                break
+        return extracted_row_values
 
     def _export_table(self, export_sheet_name, headers, formatted_rows, total_row=None):
         def _unformat_row(row):

--- a/custom/intrahealth/utils.py
+++ b/custom/intrahealth/utils.py
@@ -360,8 +360,14 @@ class MultiReport(CustomProjectReport, YeksiNaaMixin, ProjectReportParametersMix
 
     @property
     def export_table(self):
-        reports = [r['report_table'] for r in self.report_context['reports']]
-        return [self._export_table(r['title'], r['headers'], r['rows'], total_row=r['total_row']) for r in reports]
+        export_tables = []
+        for individual_report in self.report_context['reports']:
+            report_table = individual_report['report_table']
+            # The keys contain html info, so only the values get exported to excel
+            total_row = [row_value.items()[0][1] for row_value in report_table['total_row']]
+            export_tables.append(self._export_table(report_table['title'], report_table['headers'],
+                                                    report_table['rows'], total_row))
+        return export_tables
 
     def _export_table(self, export_sheet_name, headers, formatted_rows, total_row=None):
         def _unformat_row(row):

--- a/custom/intrahealth/utils.py
+++ b/custom/intrahealth/utils.py
@@ -368,7 +368,8 @@ class MultiReport(CustomProjectReport, YeksiNaaMixin, ProjectReportParametersMix
                                                     report_table['rows'], total_row))
         return export_tables
 
-    def _extract_value_from_report_table_row_value(self, report_table):
+    @staticmethod
+    def _extract_value_from_report_table_row_value(report_table):
         extracted_row_values = []
         for row_value in report_table['total_row']:
             if isinstance(row_value, dict):


### PR DESCRIPTION
[[Interrupt Ticket]](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=5&projectKey=HI&modal=detail&selectedIssue=HI-347)
Problem: Exporting report to excel in PNA returns excel files that contain json-formatted answers ie `{u'style': u'', u'html': u'pas de donn\xe9es'}` instead of just `pas de donn`

I fixed this by just returning the value instead of the whole key value pair for intrahealth reports. I'm not sure if I am applying this fix somewhere where the tables are not html formatted though, I tried a few different reports but couldn't find any that touch this code and are not html formatted, so let me know if you have ideas of reports I should check. 

code buddy @czue 
@nickpell @calellowitz @emord 