### PR TITLE
Show usercase property usage in case details

### DIFF
--- a/corehq/apps/app_manager/tests/test_case_meta.py
+++ b/corehq/apps/app_manager/tests/test_case_meta.py
@@ -7,6 +7,7 @@ from django.test.testcases import SimpleTestCase
 from mock import MagicMock, patch
 from nose.tools import nottest
 
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     AdvancedOpenCaseAction,
@@ -284,7 +285,7 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
             )
 
     def test_non_case_props(self):
-        """We have special syntax in case lists and case details which shouldn't show up in the view for case types
+        """We have special syntax in case lists and case details which should be hidden or shown for the usercase
         """
         app, _ = self.get_test_app()
         app.modules[0].case_details.short.columns = [
@@ -308,6 +309,7 @@ class CaseMetaTest(SimpleTestCase, TestXmlMixin):
         self.assertFalse(prop.short_details)
         self.assertFalse(prop.long_details)
 
-        prop = metadata.get_type('parent').get_property('user/username', allow_parent=True)
-        self.assertFalse(prop.short_details)
+        # user properties should be shown under the usercase type
+        prop = metadata.get_type(USERCASE_TYPE).get_property('username')
+        self.assertTrue(prop.short_details)
         self.assertFalse(prop.long_details)

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -19,6 +19,7 @@ from dimagi.ext.jsonobject import (
     StringProperty,
 )
 from jsonobject.base import DefaultProperty
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.models import Application, FormActionCondition
 from corehq.apps.app_manager.xform import VELLUM_TYPES
@@ -252,19 +253,21 @@ class AppCaseMetadata(JsonObject):
         return prop
 
     def add_property_detail(self, detail_type, root_case_type, module_id, column):
-        if column.field == '#owner_name':
+        field = column.field
+        if field == '#owner_name':
             return None
 
-        parts = column.field.split('/')
+        parts = field.split('/')
         if parts and parts[0] == 'user':
-            return None
+            root_case_type = USERCASE_TYPE
+            field = field.split('user/')[1]
 
         if column.useXpathExpression:
             return column.field
         try:
-            props = self.get_property_list(root_case_type, column.field)
+            props = self.get_property_list(root_case_type, field)
         except CaseMetaException as e:
-            props = [self.add_property_error(root_case_type, column.field, form_id=None, message=None)]
+            props = [self.add_property_error(root_case_type, field, form_id=None, message=None)]
             error = six.text_type(e)
         else:
             error = None


### PR DESCRIPTION
Turns out usercases _are_ shown in the case summary. I was wrong in https://github.com/dimagi/commcare-hq/pull/23151#discussion_r253994801
This adds any properties mentioned in the form `user/foo` to the correct case type. 
