### PR TITLE
fix CaseProperty._get_commcare_value doctest in python 3

### DIFF
--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -145,7 +145,7 @@ class CaseProperty(ValueSource):
         1
         >>> CaseProperty(case_property="bar")._get_commcare_value(info)
         2
-        >>> type(CaseProperty(case_property="baz")._get_commcare_value(info)) == type(None)
+        >>> CaseProperty(case_property="baz")._get_commcare_value(info) is None
         True
 
         """

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -145,8 +145,8 @@ class CaseProperty(ValueSource):
         1
         >>> CaseProperty(case_property="bar")._get_commcare_value(info)
         2
-        >>> type(CaseProperty(case_property="baz")._get_commcare_value(info))
-        <type 'NoneType'>
+        >>> type(CaseProperty(case_property="baz")._get_commcare_value(info)) == type(None)
+        True
 
         """
         if self.case_property in case_trigger_info.updates:


### PR DESCRIPTION
Required because ```type(None)``` is printed as ```<class NoneType>``` in python 3.