### PR TITLE
ignore order of elasticsearch filters in tests

### DIFF
--- a/corehq/apps/es/tests/test_esquery.py
+++ b/corehq/apps/es/tests/test_esquery.py
@@ -38,7 +38,12 @@ class TestESQuery(ElasticTestMixin, TestCase):
                     'query': {'match_all': {}}}},
             'size': 1000000
         }
-        self.checkQuery(query, json_output)
+        raw_query = query.raw_query
+        self.assertItemsEqual(
+            raw_query['query']['filtered']['filter'].pop('and'),
+            json_output['query']['filtered']['filter'].pop('and')
+        )
+        self.checkQuery(raw_query, json_output, is_raw_query=True)
 
     def test_basic_query(self):
         json_output = {
@@ -96,7 +101,12 @@ class TestESQuery(ElasticTestMixin, TestCase):
             "size": SIZE_LIMIT
         }
         query = forms.FormES()
-        self.checkQuery(query, json_output)
+        raw_query = query.raw_query
+        self.assertItemsEqual(
+            raw_query['query']['filtered']['filter'].pop('and'),
+            json_output['query']['filtered']['filter'].pop('and')
+        )
+        self.checkQuery(raw_query, json_output, is_raw_query=True)
 
     def test_user_query(self):
         json_output = {
@@ -114,7 +124,12 @@ class TestESQuery(ElasticTestMixin, TestCase):
             "size": SIZE_LIMIT
         }
         query = users.UserES()
-        self.checkQuery(query, json_output)
+        raw_query = query.raw_query
+        self.assertItemsEqual(
+            raw_query['query']['filtered']['filter'].pop('and'),
+            json_output['query']['filtered']['filter'].pop('and')
+        )
+        self.checkQuery(raw_query, json_output, is_raw_query=True)
 
     def test_filtered_forms(self):
         json_output = {
@@ -141,7 +156,12 @@ class TestESQuery(ElasticTestMixin, TestCase):
         query = forms.FormES()\
                 .filter(filters.domain("zombocom"))\
                 .xmlns('banana')
-        self.checkQuery(query, json_output)
+        raw_query = query.raw_query
+        self.assertItemsEqual(
+            raw_query['query']['filtered']['filter'].pop('and'),
+            json_output['query']['filtered']['filter'].pop('and')
+        )
+        self.checkQuery(raw_query, json_output, is_raw_query=True)
 
     def test_users_at_locations(self):
         location_ids = ['09d1a58cb849e53bb3a456a5957d998a', '09d1a58cb849e53bb3a456a5957d99ba']

--- a/corehq/apps/es/tests/utils.py
+++ b/corehq/apps/es/tests/utils.py
@@ -5,10 +5,14 @@ import json
 
 class ElasticTestMixin(object):
 
-    def checkQuery(self, query, json_output):
+    def checkQuery(self, query, json_output, is_raw_query=False):
+        if is_raw_query:
+            raw_query = query
+        else:
+            raw_query = query.raw_query
         msg = "Expected Query:\n{}\nGenerated Query:\n{}".format(
             json.dumps(json_output, indent=4),
-            query.dumps(pretty=True),
+            json.dumps(raw_query, indent=4),
         )
         # NOTE: This method thinks [a, b, c] != [b, c, a]
-        self.assertEqual(query.raw_query, json_output, msg=msg)
+        self.assertEqual(raw_query, json_output, msg=msg)


### PR DESCRIPTION
For py3 compatibility