### PR TITLE
include user data properties in sorted order to fix many tests that depend on this

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -39,11 +39,11 @@ def dummy_user_xml(user=None):
         <uuid>{}</uuid>
         <date>{}</date>
         <user_data>
-            <data key="commcare_project">{}</data>
+            <data key="commcare_first_name"/>
             <data key="commcare_last_name"/>
             <data key="commcare_phone_number"/>
+            <data key="commcare_project">{}</data>
             <data key="something">arbitrary</data>
-            <data key="commcare_first_name"/>
         </user_data>
     </Registration>""".format(
         username,

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -135,7 +135,8 @@ def get_registration_element_for_case(case):
 
 def get_data_element(name, dict):
     elem = safe_element(name)
-    for k, v in dict.items():
+    # sorted for deterministic unit tests
+    for k, v in sorted(dict.items()):
         sub_el = safe_element("data", v)
         sub_el.attrib = {"key": k}
         elem.append(sub_el)


### PR DESCRIPTION
The alternative would be to modify each test to ignore order, but that sounds like a pain.