### PR TITLE
bust awc cache keys

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -14,6 +14,7 @@ from celery.schedules import crontab
 from celery.task import periodic_task, task
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
+from django.core.cache import cache
 from django.db import Error, IntegrityError, connections, transaction
 from django.db.models import F
 from io import BytesIO

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -974,7 +974,7 @@ def create_mbt_for_month(state_id, month):
             icds_file.save()
 
 
-@task(queue='icds_dashboard_reports_queue')
+@task(queue='background_queue')
 def _bust_awc_cache():
     reach_keys = cache.keys('*cas_reach_data*')
     cache.delete_many(reach_keys)

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -973,6 +973,7 @@ def create_mbt_for_month(state_id, month):
             icds_file.store_file_in_blobdb(f, expired=THREE_MONTHS)
             icds_file.save()
 
+
 @task(queue='icds_dashboard_reports_queue')
 def _bust_awc_cache():
     reach_keys = cache.keys('*cas_reach_data*')

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -256,6 +256,8 @@ def move_ucr_data_into_aggregation_tables(date=None, intervals=2):
                             ).apply_async()
 
             res_awc.get()
+            reach_keys = cache.keys('*cas_reach_data*')
+            cache.delete_many(reach_keys)
 
             first_of_month_string = monthly_date.strftime('%Y-%m-01')
             for state_id in state_ids:


### PR DESCRIPTION
@Rohit25negi 
This is quick and dirty way to prevent zeros on the dashboard, but it busts the cache for all keys related to the  "CAS REACH" page of the program summary as soon as the aggregation ends.