### PR TITLE
Notify user in case the pull process fails

### DIFF
--- a/corehq/apps/translations/tasks.py
+++ b/corehq/apps/translations/tasks.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
+import sys
+import six
 from io import open
 from zipfile import ZipFile
 
@@ -110,6 +112,7 @@ def pull_translation_files_from_transifex(domain, data, user_email=None):
             email.send()
     except Exception as e:
         notify_error(e)
+        six.reraise(*sys.exc_info())
     finally:
         if translation_file and os.path.exists(translation_file.name):
             os.remove(translation_file.name)


### PR DESCRIPTION
The `pull_translation_files_from_transifex` is done asynchronously and user gets no notification in case it fails. 
This PR handles any exception and notifies user in case the process fails.
My initial intent was to notify [this exception](https://sentry.io/dimagi/commcarehq/issues/797544890/?environment=softlayer) only but i see it would be useful for the user to know in case there are any other issues.