### PR TITLE
Return app ID in get_app_build

### DIFF
--- a/custom/succeed/utils.py
+++ b/custom/succeed/utils.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.utils.translation import ugettext_noop
 import dateutil
-from corehq.apps.app_manager.dbaccessors import get_latest_build_id, get_latest_released_app
+from corehq.apps.app_manager.dbaccessors import (
+    get_latest_build_id,
+    get_latest_released_app,
+    get_latest_released_build_id
+)
 from corehq.apps.domain.models import Domain
 from datetime import timedelta
 from pytz import timezone
@@ -60,7 +64,7 @@ def has_any_role(user):
 def get_app_build(app_dict):
     domain = Domain.get_by_name(app_dict['domain'])
     if domain.use_cloudcare_releases:
-        return get_latest_released_app(app_dict['domain'], app_dict['_id'])
+        return get_latest_released_build_id(app_dict['domain'], app_dict['_id'])
     else:
         return get_latest_build_id(app_dict['domain'], app_dict['_id'])
     return None

--- a/custom/succeed/utils.py
+++ b/custom/succeed/utils.py
@@ -2,11 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.utils.translation import ugettext_noop
 import dateutil
-from corehq.apps.app_manager.dbaccessors import (
-    get_latest_build_id,
-    get_latest_released_app,
-    get_latest_released_build_id
-)
+from corehq.apps.app_manager.dbaccessors import get_latest_build_id, get_latest_released_build_id
 from corehq.apps.domain.models import Domain
 from datetime import timedelta
 from pytz import timezone

--- a/custom/succeed/utils.py
+++ b/custom/succeed/utils.py
@@ -63,7 +63,6 @@ def get_app_build(app_dict):
         return get_latest_released_build_id(app_dict['domain'], app_dict['_id'])
     else:
         return get_latest_build_id(app_dict['domain'], app_dict['_id'])
-    return None
 
 
 def get_form_dict(case, form_xmlns):


### PR DESCRIPTION
Return app ID in `get_app_build`, instead of the app itself (introduced here https://github.com/dimagi/commcare-hq/commit/0d8cc9a300afc0199cdcd4df1250d4b965174d23)

FB: https://dimagi-dev.atlassian.net/browse/HI-355
Sentry error: https://sentry.io/dimagi/commcarehq/issues/847268891/events/oldest/