### PR TITLE
Make sure data rows don't show html formatting in excel exports [PNA]

### DIFF
--- a/custom/intrahealth/tests/reports/test_dashboard_1.py
+++ b/custom/intrahealth/tests/reports/test_dashboard_1.py
@@ -40,10 +40,10 @@ class TestDashboard1(YeksiTestCase):
             'slug': 'disponibilite',
             'default_rows': 10
         }
-        total_row = dashboard1_report._extract_single_row_from_report(report_table['total_row'])
+        total_row = dashboard1_report._sanitize_single_row(report_table['total_row'])
         self.assertEqual(total_row, ['row_0', 'row_1', 'row_2', 'row_3'])
 
-        all_rows = dashboard1_report._extract_all_rows_from_report(report_table)
+        all_rows = dashboard1_report._sanitize_all_rows(report_table)
         self.assertEqual(all_rows, [['0', '4', '8', '12'],
                                     ['1', '5', '9', '13'],
                                     ['2', '6', '10', '14'],
@@ -74,10 +74,10 @@ class TestDashboard1(YeksiTestCase):
             'slug': 'disponibilite',
             'default_rows': 10
         }
-        report_table_value = dashboard1_report._extract_single_row_from_report(report_table['total_row'])
+        report_table_value = dashboard1_report._sanitize_single_row(report_table['total_row'])
         self.assertEqual(report_table_value, ['row_0', 'row_1', 'row_2', 'row_3'])
 
-        all_rows = dashboard1_report._extract_all_rows_from_report(report_table)
+        all_rows = dashboard1_report._sanitize_all_rows(report_table)
         self.assertEqual(all_rows, [['0', '4', '8', '12'],
                                     ['1', '5', '9', '13'],
                                     ['2', '6', '10', '14'],

--- a/custom/intrahealth/tests/reports/test_dashboard_1.py
+++ b/custom/intrahealth/tests/reports/test_dashboard_1.py
@@ -25,29 +25,28 @@ class TestDashboard1(YeksiTestCase):
         report_table = {
             'fix_column': False,
             'comment': 'test_comment',
-            'rows': [[{'html': '0'}, {'html': '4'}, {'html': '8'}, {'html': '12'}],
-                     [{'html': '1'}, {'html': '5'}, {'html': '9'}, {'html': '13'}],
-                     [{'html': '2'}, {'html': '6'}, {'html': '10'}, {'html': '14'}],
-                     [{'html': '3'}, {'html': '7'}, {'html': '11'}, {'html': '15'}]],
+            'rows': [[{'style': 'style0', 'html': 'html0'}, {'style': 'style3', 'html': 'html3'}],
+                     [{'style': 'style1', 'html': 'html1'}, {'style': 'style4', 'html': 'html4'}],
+                     [{'style': 'style2', 'html': 'html2'}, {'style': 'style5', 'html': 'html5'}]],
             'datatables': False,
             'title': 'test_title',
             'total_row': [
-                {'html': 'row_0'},
-                {'html': 'row_1'},
-                {'html': 'row_2'},
-                {'html': 'row_3'}
+                {'html': 'pas de donn\xe9es0'},
+                {'html': 'pas de donn\xe9es1'},
+                {'html': 'pas de donn\xe9es2'},
+                {'html': 'pas de donn\xe9es3'}
             ],
             'slug': 'disponibilite',
             'default_rows': 10
         }
         total_row = dashboard1_report._sanitize_single_row(report_table['total_row'])
-        self.assertEqual(total_row, ['row_0', 'row_1', 'row_2', 'row_3'])
+        self.assertEqual(total_row, ['pas de donn\xe9es0', 'pas de donn\xe9es1',
+                                     'pas de donn\xe9es2', 'pas de donn\xe9es3'])
 
         all_rows = dashboard1_report._sanitize_all_rows(report_table)
-        self.assertEqual(all_rows, [['0', '4', '8', '12'],
-                                    ['1', '5', '9', '13'],
-                                    ['2', '6', '10', '14'],
-                                    ['3', '7', '11', '15']])
+        self.assertEqual(all_rows, [['html0', 'html3'],
+                                    ['html1', 'html4'],
+                                    ['html2', 'html5']])
 
     def test_extract_value_from_report_table_row_value_input_string(self):
         mock = MagicMock()

--- a/custom/intrahealth/tests/reports/test_dashboard_1.py
+++ b/custom/intrahealth/tests/reports/test_dashboard_1.py
@@ -25,7 +25,10 @@ class TestDashboard1(YeksiTestCase):
         report_table = {
             'fix_column': False,
             'comment': 'test_comment',
-            'rows': [],
+            'rows': [[{'html': '0'}, {'html': '4'}, {'html': '8'}, {'html': '12'}],
+                     [{'html': '1'}, {'html': '5'}, {'html': '9'}, {'html': '13'}],
+                     [{'html': '2'}, {'html': '6'}, {'html': '10'}, {'html': '14'}],
+                     [{'html': '3'}, {'html': '7'}, {'html': '11'}, {'html': '15'}]],
             'datatables': False,
             'title': 'test_title',
             'total_row': [
@@ -37,8 +40,14 @@ class TestDashboard1(YeksiTestCase):
             'slug': 'disponibilite',
             'default_rows': 10
         }
-        report_table_value = dashboard1_report._extract_value_from_report_table_row_value(report_table)
-        self.assertEqual(report_table_value, ['row_0', 'row_1', 'row_2', 'row_3'])
+        total_row = dashboard1_report._extract_single_row_from_report(report_table['total_row'])
+        self.assertEqual(total_row, ['row_0', 'row_1', 'row_2', 'row_3'])
+
+        all_rows = dashboard1_report._extract_all_rows_from_report(report_table)
+        self.assertEqual(all_rows, [['0', '4', '8', '12'],
+                                    ['1', '5', '9', '13'],
+                                    ['2', '6', '10', '14'],
+                                    ['3', '7', '11', '15']])
 
     def test_extract_value_from_report_table_row_value_input_string(self):
         mock = MagicMock()
@@ -55,15 +64,24 @@ class TestDashboard1(YeksiTestCase):
         report_table = {
             'fix_column': False,
             'comment': 'test_comment',
-            'rows': [],
+            'rows': [['0', '4', '8', '12'],
+                     ['1', '5', '9', '13'],
+                     ['2', '6', '10', '14'],
+                     ['3', '7', '11', '15']],
             'datatables': False,
             'title': 'test_title',
             'total_row': ['row_0', 'row_1', 'row_2', 'row_3'],
             'slug': 'disponibilite',
             'default_rows': 10
         }
-        report_table_value = dashboard1_report._extract_value_from_report_table_row_value(report_table)
+        report_table_value = dashboard1_report._extract_single_row_from_report(report_table['total_row'])
         self.assertEqual(report_table_value, ['row_0', 'row_1', 'row_2', 'row_3'])
+
+        all_rows = dashboard1_report._extract_all_rows_from_report(report_table)
+        self.assertEqual(all_rows, [['0', '4', '8', '12'],
+                                    ['1', '5', '9', '13'],
+                                    ['2', '6', '10', '14'],
+                                    ['3', '7', '11', '15']])
 
     def test_availability_report(self):
         mock = MagicMock()

--- a/custom/intrahealth/utils.py
+++ b/custom/intrahealth/utils.py
@@ -382,7 +382,7 @@ class MultiReport(CustomProjectReport, YeksiNaaMixin, ProjectReportParametersMix
         for row_value in row:
             if isinstance(row_value, dict):
                 # If keys are dicts, they contain html info (ie: row_value = {'html': 'title'})
-                extracted_row_values.append(row_value.items()[0][1])
+                extracted_row_values.append(row_value['html'])
             else:
                 extracted_row_values = row
                 break

--- a/custom/intrahealth/utils.py
+++ b/custom/intrahealth/utils.py
@@ -363,20 +363,28 @@ class MultiReport(CustomProjectReport, YeksiNaaMixin, ProjectReportParametersMix
         export_tables = []
         for individual_report in self.report_context['reports']:
             report_table = individual_report['report_table']
-            total_row = self._extract_value_from_report_table_row_value(report_table)
-            export_tables.append(self._export_table(report_table['title'], report_table['headers'],
-                                                    report_table['rows'], total_row))
+            extracted_rows = self._extract_all_rows_from_report(report_table)
+            extracted_total_row = self._extract_single_row_from_report(report_table['total_row'])
+            export_tables.append(self._export_table(report_table['title'],
+                                                    report_table['headers'],
+                                                    extracted_rows, extracted_total_row))
         return export_tables
 
+    def _extract_all_rows_from_report(self, report_table):
+        extracted_rows = []
+        for row in report_table['rows']:
+            extracted_rows.append(self._extract_single_row_from_report(row))
+        return extracted_rows
+
     @staticmethod
-    def _extract_value_from_report_table_row_value(report_table):
+    def _extract_single_row_from_report(list_to_extract_from):
         extracted_row_values = []
-        for row_value in report_table['total_row']:
+        for row_value in list_to_extract_from:
             if isinstance(row_value, dict):
                 # If keys are dicts, they contain html info (ie: row_value = {'html': 'title'})
                 extracted_row_values.append(row_value.items()[0][1])
             else:
-                extracted_row_values = report_table['total_row']
+                extracted_row_values = list_to_extract_from
                 break
         return extracted_row_values
 

--- a/custom/intrahealth/utils.py
+++ b/custom/intrahealth/utils.py
@@ -363,28 +363,28 @@ class MultiReport(CustomProjectReport, YeksiNaaMixin, ProjectReportParametersMix
         export_tables = []
         for individual_report in self.report_context['reports']:
             report_table = individual_report['report_table']
-            extracted_rows = self._extract_all_rows_from_report(report_table)
-            extracted_total_row = self._extract_single_row_from_report(report_table['total_row'])
+            extracted_rows = self._sanitize_all_rows(report_table)
+            extracted_total_row = self._sanitize_single_row(report_table['total_row'])
             export_tables.append(self._export_table(report_table['title'],
                                                     report_table['headers'],
                                                     extracted_rows, extracted_total_row))
         return export_tables
 
-    def _extract_all_rows_from_report(self, report_table):
+    def _sanitize_all_rows(self, report_table):
         extracted_rows = []
         for row in report_table['rows']:
-            extracted_rows.append(self._extract_single_row_from_report(row))
+            extracted_rows.append(self._sanitize_single_row(row))
         return extracted_rows
 
     @staticmethod
-    def _extract_single_row_from_report(list_to_extract_from):
+    def _sanitize_single_row(row):
         extracted_row_values = []
-        for row_value in list_to_extract_from:
+        for row_value in row:
             if isinstance(row_value, dict):
                 # If keys are dicts, they contain html info (ie: row_value = {'html': 'title'})
                 extracted_row_values.append(row_value.items()[0][1])
             else:
-                extracted_row_values = list_to_extract_from
+                extracted_row_values = row
                 break
         return extracted_row_values
 


### PR DESCRIPTION
[[Interrupt ticket]](https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=5&projectKey=HI&modal=detail&selectedIssue=HI-347&quickFilter=3)

My original fix (https://github.com/dimagi/commcare-hq/pull/23203) only addressed the `total_rows`, which is the row at the very bottom of the excel spreadsheet (and all I saw when I reproduced this- my tables don't have data locally). This covers all the data rows as well. 

@czue 