### PR TITLE
fix corehq.apps.users.tests.permissions:PermissionsTest.test_OR

### DIFF
--- a/corehq/apps/users/tests/permissions.py
+++ b/corehq/apps/users/tests/permissions.py
@@ -24,14 +24,14 @@ class PermissionsTest(TestCase):
             view_reports=True,
             view_report_list=['report2'],
         )
-        self.assertEqual(dict(p1 | p2), dict(Permissions(
+        self.assertEqual(p1 | p2, Permissions(
             edit_apps=True,
             edit_web_users=True,
             view_web_users=True,
             view_roles=True,
             view_reports=True,
             view_report_list=['report1', 'report2'],
-        )))
+        ))
 
 
 @mock.patch('corehq.apps.export.views.utils.domain_has_privilege',


### PR DESCRIPTION
This fixes an intermittent py3 test error by using ```Permission.__eq__```, which ignores the order of ```view_report_list```.

https://travis-ci.org/dimagi/commcare-hq/jobs/493229581

```
FAIL: corehq.apps.users.tests.permissions:PermissionsTest.test_OR
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/commcare-hq-ro/corehq/apps/users/tests/permissions.py", line 34, in test_OR
    view_report_list=['report1', 'report2'],
AssertionError: {'edit_web_users': True, 'view_web_users': True,[562 chars]ons'} != {'edit_apps': True, 'edit_web_users': True, 'vie[562 chars]ons'}
  {'access_all_locations': True,
   'doc_type': 'Permissions',
   'edit_apps': True,
   'edit_billing': False,
   'edit_commcare_users': False,
   'edit_data': False,
   'edit_groups': False,
   'edit_locations': False,
   'edit_motech': False,
   'edit_shared_exports': False,
   'edit_web_users': True,
   'manage_releases': True,
   'manage_releases_list': [],
   'report_an_issue': True,
   'view_commcare_users': False,
   'view_file_dropzone': False,
   'view_groups': False,
   'view_locations': False,
-  'view_report_list': ['report2', 'report1'],
?                                -----------
+  'view_report_list': ['report1', 'report2'],
?                       +++++++++++
   'view_reports': True,
   'view_roles': True,
   'view_web_apps': True,
   'view_web_apps_list': [],
   'view_web_users': True}
```

@dimagi/py3 