### PR TITLE
move bulk delete to celery

### DIFF
--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -396,6 +396,8 @@ class FixtureDataItem(Document):
                     assert result['value']['deleted'] is True
                     deleted_fixture_ids.add(result['id'])
             if deleted_fixture_ids:
+                # delete ownership documents pointing deleted/non-existent fixture documents
+                # this cleanup is necessary since we used to not do this
                 remove_deleted_ownerships.delay(deleted_fixture_ids, user.domain)
             return docs
         else:

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -395,7 +395,8 @@ class FixtureDataItem(Document):
                 else:
                     assert result['value']['deleted'] is True
                     deleted_fixture_ids.add(result['id'])
-            remove_deleted_ownerships.delay(deleted_fixture_ids, user.domain)
+            if deleted_fixture_ids:
+                remove_deleted_ownerships.delay(deleted_fixture_ids, user.domain)
             return docs
         else:
             return fixture_ids

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -66,7 +66,7 @@ def clear_fixture_cache(domain):
     get_blob_db().delete(key=FIXTURE_BUCKET + '/' + domain)
 
 
-@task(serializer='pickle', queue='background_queue')
+@task(queue='background_queue')
 def remove_deleted_ownerships(deleted_fixture_ids, domain):
     from corehq.apps.fixtures.models import FixtureOwnership
     for fixture_ids in chunked(deleted_fixture_ids, 100):

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -3,6 +3,9 @@ from __future__ import unicode_literals
 import re
 from xml.etree import cElementTree as ElementTree
 
+from celery.task import task
+from dimagi.utils.chunked import chunked
+from corehq.apps.fixtures.models import FixtureOwnership
 from corehq.blobs import get_blob_db
 
 BAD_SLUG_PATTERN = r"([/\\<>\s])"
@@ -62,3 +65,10 @@ def get_index_schema_node(fixture_id, attrs_to_index):
 def clear_fixture_cache(domain):
     from corehq.apps.fixtures.models import FIXTURE_BUCKET
     get_blob_db().delete(key=FIXTURE_BUCKET + '/' + domain)
+
+
+@task(serializer='pickle', queue='background_queue')
+def remove_deleted_ownerships(deleted_fixture_ids, domain):
+    for fixture_ids in chunked(deleted_fixture_ids, 100):
+        bad_ownerships = FixtureOwnership.for_all_item_ids(fixture_ids, domain)
+        FixtureOwnership.get_db().bulk_delete(bad_ownerships)

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -5,7 +5,6 @@ from xml.etree import cElementTree as ElementTree
 
 from celery.task import task
 from dimagi.utils.chunked import chunked
-from corehq.apps.fixtures.models import FixtureOwnership
 from corehq.blobs import get_blob_db
 
 BAD_SLUG_PATTERN = r"([/\\<>\s])"
@@ -69,6 +68,7 @@ def clear_fixture_cache(domain):
 
 @task(serializer='pickle', queue='background_queue')
 def remove_deleted_ownerships(deleted_fixture_ids, domain):
+    from corehq.apps.fixtures.models import FixtureOwnership
     for fixture_ids in chunked(deleted_fixture_ids, 100):
         bad_ownerships = FixtureOwnership.for_all_item_ids(fixture_ids, domain)
         FixtureOwnership.get_db().bulk_delete(bad_ownerships)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-412 raised
https://sentry.io/dimagi/commcarehq/issues/888961821/?referrer=slack and
https://sentry.io/dimagi/commcarehq/issues/889257013/?referrer=slack
and possibly also addresses
https://dimagi-dev.atlassian.net/browse/HI-398

Numbers for case in ticket 412
```
In [15]: len(deleted_fixture_ids)
Out[15]: 18709

In [16]: bad_ownerships = FixtureOwnership.for_all_item_ids(deleted_fixture_ids, user.domain)

In [17]: len(bad_ownerships)
Out[17]: 1103831
```

The clean looks like something that can be handled asynchronously

@millerdev does that look like the right thing to do?