### PR TITLE
[up-nrhm] Exclude deactivated users from location_hierarchy data source

### DIFF
--- a/custom/up_nrhm/data_sources/location_hierarchy.json
+++ b/custom/up_nrhm/data_sources/location_hierarchy.json
@@ -7,6 +7,15 @@
         "table_id": "location_hierarchy",
         "display_name": "Location Hierarchy",
         "configured_filter":  {
+             "operator": "eq",
+             "expression": {
+                 "datatype": null,
+                 "type": "property_name",
+                 "property_name": "is_active"
+             },
+             "type": "boolean_expression",
+             "comment": null,
+             "property_value": true
         },
         "configured_indicators": [
             {


### PR DESCRIPTION
Hi,

I excluded the deactivated users for location_hierarchy data source, more context in the ticket: https://dimagi-dev.atlassian.net/browse/HI-404

Need QA: no
Environment: production
locally tested: yes

Regards,
Łukasz