### PR TITLE
use explicit primary key

### DIFF
--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -9,6 +9,7 @@ from corehq.apps.aggregate_ucrs.aggregations import AGGREGATION_UNIT_CHOICE_MONT
 from corehq.apps.aggregate_ucrs.column_specs import PRIMARY_COLUMN_TYPE_CHOICES, PrimaryColumnAdapter, \
     SecondaryColumnAdapter, SECONDARY_COLUMN_TYPE_CHOICES, IdColumnAdapter, MonthColumnAdapter, WeekColumnAdapter
 from corehq.apps.userreports.models import get_datasource_config, SQLSettings, AbstractUCRDataSource
+from corehq.apps.userreports.sql.util import decode_column_name
 from corehq.sql_db.connections import UCR_ENGINE_ID
 
 
@@ -116,9 +117,7 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
         columns = []
         for col in self.get_columns():
             if col.is_primary_key():
-                column_name = col.database_column_name
-                if isinstance(column_name, bytes):
-                    column_name = column_name.decode('utf-8')
+                column_name = decode_column_name(col)
                 columns.append(column_name)
         return columns
 

--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -115,11 +115,12 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
     def pk_columns(self):
         columns = []
         for col in self.get_columns():
-            if col.is_primary_key:
+            if col.is_primary_key():
                 column_name = col.database_column_name
                 if isinstance(column_name, bytes):
                     column_name = column_name.decode('utf-8')
                 columns.append(column_name)
+        return columns
 
 
 class PrimaryColumn(models.Model):

--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -89,6 +89,7 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
         # todo: will probably need to make this configurable at some point
         return []
 
+    @memoized
     def get_columns(self):
         for adapter in self.get_column_adapters():
             yield adapter.to_ucr_column_spec()
@@ -109,6 +110,16 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
             yield self.time_aggregation.get_column_adapter()
         for primary_column in self.primary_columns.all():
             yield PrimaryColumnAdapter.from_db_column(primary_column)
+
+    @property
+    def pk_columns(self):
+        columns = []
+        for col in self.get_columns():
+            if col.is_primary_key:
+                column_name = col.database_column_name
+                if isinstance(column_name, bytes):
+                    column_name = column_name.decode('utf-8')
+                columns.append(column_name)
 
 
 class PrimaryColumn(models.Model):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -154,6 +154,7 @@ class AbstractUCRDataSource(object):
     def get_columns(self):
         raise NotImplementedError()
 
+    @property
     def pk_columns(self):
         raise NotImplementedError()
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -98,6 +98,7 @@ class SQLPartition(DocumentSchema):
 
 class SQLSettings(DocumentSchema):
     partition_config = SchemaListProperty(SQLPartition)
+    primary_key = ListProperty()
 
 
 class DataSourceBuildInformation(DocumentSchema):
@@ -339,6 +340,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
             return ExpressionFactory.from_spec(self.base_item_expression, context=self.get_factory_context())
         return None
 
+    @memoized
     def get_columns(self):
         return self.indicators.get_columns()
 
@@ -466,6 +468,14 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
                 prop_value = [prop_value]
             return prop_value
         return [None]
+
+    @property
+    def pk_columns(self):
+        if not self.sql_settings.primary_key:
+            columns = [i.database_column_name for i in self.get_columns() if i.is_primary_key]
+        else:
+            columns = self.sql_settings.primary_key
+        return columns
 
 
 class ReportMeta(DocumentSchema):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -154,6 +154,9 @@ class AbstractUCRDataSource(object):
     def get_columns(self):
         raise NotImplementedError()
 
+    def pk_columns(self):
+        raise NotImplementedError()
+
 
 @six.python_2_unicode_compatible
 class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDataSource):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -63,6 +63,7 @@ from corehq.apps.userreports.reports.factory import ChartFactory, \
 from corehq.apps.userreports.reports.filters.specs import FilterSpec
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.userreports.util import get_indicator_adapter, get_async_indicator_modify_lock_key
+from corehq.apps.userreports.sql.util import decode_column_name
 from corehq.pillows.utils import get_deleted_doc_types
 from corehq.util.couch import get_document_or_not_found, DocumentNotFound
 from dimagi.utils.couch import CriticalSection
@@ -479,9 +480,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
             columns = []
             for col in self.get_columns():
                 if col.is_primary_key:
-                    column_name = col.database_column_name
-                    if isinstance(column_name, bytes):
-                        column_name = column_name.decode('utf-8')
+                    column_name = decode_column_name(col)
                     columns.append(column_name)
         else:
             columns = self.sql_settings.primary_key

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -472,7 +472,13 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
     @property
     def pk_columns(self):
         if not self.sql_settings.primary_key:
-            columns = [i.database_column_name for i in self.get_columns() if i.is_primary_key]
+            columns = []
+            for col in self.get_columns():
+                if col.is_primary_key:
+                    column_name = col.database_column_name
+                    if isinstance(column_name, bytes):
+                        column_name = column_name.decode('utf-8')
+                    columns.append(column_name)
         else:
             columns = self.sql_settings.primary_key
         return columns

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -409,6 +409,7 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
                 _('Report contains invalid referenced_doc_type: {}').format(self.referenced_doc_type))
 
         self.parsed_expression
+        self.pk_columns
 
     @classmethod
     def by_domain(cls, domain):
@@ -476,13 +477,14 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
 
     @property
     def pk_columns(self):
-        if not self.sql_settings.primary_key:
-            columns = []
-            for col in self.get_columns():
-                if col.is_primary_key:
-                    column_name = decode_column_name(col)
-                    columns.append(column_name)
-        else:
+        columns = []
+        for col in self.get_columns():
+            if col.is_primary_key:
+                column_name = decode_column_name(col)
+                columns.append(column_name)
+        if self.sql_settings.primary_key:
+            if set(columns) != set(self.sql_settings.primary_key):
+                raise BadSpecError("Primary key columns must have is_primary_key set to true")
             columns = self.sql_settings.primary_key
         return columns
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 import sqlalchemy
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.schema import Index
+from sqlalchemy.schema import Index, PrimaryKeyConstraint
 
 from corehq.apps.userreports.adapter import IndicatorAdapter
 from corehq.apps.userreports.exceptions import (
@@ -220,7 +220,8 @@ def get_indicator_table(indicator_config, custom_metadata=None):
             _assert = soft_assert('{}@{}'.format('jemord', 'dimagi.com'))
             _assert(False, "Invalid index specified on {}".format(table_name))
             break
-    columns_and_indices = sql_columns + extra_indices
+    constraints = [PrimaryKeyConstraint(*indicator_config.pk_columns)]
+    columns_and_indices = sql_columns + extra_indices + constraints
     # todo: needed to add extend_existing=True to support multiple calls to this function for the same table.
     # is that valid?
     return sqlalchemy.Table(

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -8,12 +8,10 @@ from fluff import TYPE_STRING
 from fluff.util import get_column_type
 
 from corehq.apps.userreports.columns import UCRExpandDatabaseSubcolumn
-
+from corehq.apps.userreports.sql.util import decode_column_name
 
 def column_to_sql(column):
-    column_name = column.database_column_name
-    if isinstance(column_name, bytes):
-        column_name = column_name.decode('utf-8')
+    column_name = decode_column_name(column)
     return sqlalchemy.Column(
         column_name,
         _get_column_type(column.datatype),

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -18,6 +18,7 @@ def column_to_sql(column):
         column_name,
         _get_column_type(column.datatype),
         nullable=column.is_nullable,
+        primary_key=column.is_primary_key,
         index=column.create_index,
     )
 

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -18,7 +18,6 @@ def column_to_sql(column):
         column_name,
         _get_column_type(column.datatype),
         nullable=column.is_nullable,
-        primary_key=column.is_primary_key,
         index=column.create_index,
     )
 

--- a/corehq/apps/userreports/sql/util.py
+++ b/corehq/apps/userreports/sql/util.py
@@ -28,3 +28,10 @@ def get_column_name(path, suffix=None, add_hash=True):
         new_parts.append(_hash(parts))
     full_name = "_".join(filter(None, new_parts + [suffix]))
     return full_name[-63:]
+
+
+def decode_column_name(column):
+    column_name = column.database_column_name
+    if isinstance(column_name, bytes):
+        column_name = column_name.decode('utf-8')
+    return column_name

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -456,6 +456,18 @@ class IndicatorNamedExpressionTest(SimpleTestCase):
         with self.assertRaises(BadSpecError):
             bad_config.validate()
 
+    def test_no_pk_attribute(self):
+        bad_config = DataSourceConfiguration.wrap(self.indicator_configuration.to_json())
+        bad_config.sql_settings.primary_key = ['doc_id', 'laugh_sound']
+        with self.assertRaises(BadSpecError):
+            bad_config.validate()
+
+    def test_missing_pk_column(self):
+        bad_config = DataSourceConfiguration.wrap(self.indicator_configuration.to_json())
+        bad_config.sql_settings.primary_key = ['doc_id', 'no_exist']
+        with self.assertRaises(BadSpecError):
+            bad_config.validate()
+
 
 class IndicatorNamedFilterTest(SimpleTestCase):
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -837,7 +837,7 @@ class RebuildTableTest(TestCase):
         expected_pk = ['doc_id']
         self.assertEqual(expected_pk, pk['constrained_columns'])
 
-    def text_ordered_pk(self):
+    def test_ordered_pk(self):
         self._setup_data_source('ordered_pk')
         config = self._get_config('ordered_pk')
         config.configured_indicators.append({

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -828,3 +828,33 @@ class RebuildTableTest(TestCase):
         self.assertEqual(
             len([c for c in insp.get_columns(table_name) if c['name'] == 'new_date']), 1
         )
+
+    def test_implicit_pk(self):
+        self._setup_data_source('implicit_pk')
+        insp = reflection.Inspector.from_engine(self.engine)
+        table_name = get_table_name(self.config.domain, self.config.table_id)
+        pk = insp.get_pk_constraint(table_name)
+        expected_pk = ['doc_id']
+        self.assertEqual(expected_pk, pk['constrained_columns'])
+
+    def text_ordered_pk(self):
+        self._setup_data_source('ordered_pk')
+        config = self._get_config('ordered_pk')
+        config.configured_indicators.append({
+            "column_id": "pk_key",
+            "type": "raw",
+            "datatype": "string",
+            "is_primary_key": True
+        })
+        config.save()
+        adapter = get_indicator_adapter(config)
+        engine = adapter.engine
+        config.sql_settings.primary_key = ['pk_key', 'doc_id']
+
+        # rebuild table
+        get_case_pillow(ucr_configs=[config])
+        insp = reflection.Inspector.from_engine(engine)
+        table_name = get_table_name(self.config.domain, self.config.table_id)
+        pk = insp.get_pk_constraint(table_name)
+        expected_pk = ['pk_key', 'doc_id']
+        self.assertEqual(expected_pk, pk['constrained_columns'])

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -844,6 +844,7 @@ class RebuildTableTest(TestCase):
             "column_id": "pk_key",
             "type": "raw",
             "datatype": "string",
+            "property_name": "owner_id",
             "is_primary_key": True
         })
         config.save()


### PR DESCRIPTION
Just opening for testing now, but this is part 1 of some citus work to allow UCRs to specify ordering of compound primary keys. The basic idea is that it would use the existing `sql_settings` property of the config, adding an optional `primary_key` property where you could specify the key. It utilizes sqlalchemy's `PrimaryKeyConstraint` to create a primary key with different order than the columns so we dont have to do any sorting. By default this will have the same behavior as existing code (pk in column order).
TODO: add this to icds UCRs