### PR TITLE
Appcues v3

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -10,18 +10,14 @@ import zipfile
 from collections import defaultdict
 from wsgiref.util import FileWrapper
 
-from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
+from couchdbkit.exceptions import ResourceConflict
 from django.contrib import messages
 from django.http import HttpResponse, Http404, HttpResponseBadRequest, HttpResponseRedirect
-from django.http.request import QueryDict
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.decorators import method_decorator
 from django.utils.http import urlencode as django_urlencode
 from django.utils.text import slugify
 from django.utils.translation import ugettext as _
-from django.views import View
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 from django_prbac.utils import has_privilege
 
@@ -40,7 +36,7 @@ from corehq.apps.app_manager.const import (
 )
 from corehq.apps.app_manager.dbaccessors import get_app, get_current_app, get_latest_released_app_version
 from corehq.apps.app_manager.decorators import no_conflict_require_POST, \
-    require_can_edit_apps, require_deploy_apps, no_conflict
+    require_can_edit_apps, require_deploy_apps
 from corehq.apps.app_manager.exceptions import IncompatibleFormTypeException, RearrangeError, AppLinkError
 from corehq.apps.app_manager.forms import CopyApplicationForm
 from corehq.apps.app_manager.models import (
@@ -48,11 +44,8 @@ from corehq.apps.app_manager.models import (
     ApplicationBase,
     DeleteApplicationRecord,
     Form,
-    FormNotFoundException,
-    LinkedApplication,
     Module,
     ModuleNotFoundException,
-    ReportModule,
     app_template_dir,
     load_app_template,
 )

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -20,14 +20,12 @@ from dimagi.utils.couch import CriticalSection
 from dimagi.utils.name_to_url import name_to_url
 from dimagi.utils.web import get_ip, get_url_base, get_site_domain
 from django.conf import settings
-from django.urls import reverse
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser, CouchUser, UserRole
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from dimagi.utils.couch.database import get_safe_write_kwargs
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.analytics.tasks import send_hubspot_form, HUBSPOT_CREATED_NEW_PROJECT_SPACE_FORM_ID
-from corehq import toggles
 from corehq.util.view_utils import absolute_reverse
 
 HEALTH_APP = 'health'

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -46,7 +46,6 @@ from corehq.apps.hqwebapp.decorators import use_jquery_ui, \
     use_ko_validation
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq.apps.users.landing_pages import get_cloudcare_urlname
-from corehq import toggles
 from django.contrib.auth.models import User
 
 from corehq.util.soft_assert import soft_assert

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -144,9 +144,6 @@ class ProcessRegistrationView(JSONResponseMixin, View):
                         'project name unavailable': [],
                     }
                 }
-
-            username = reg_form.cleaned_data['email']
-
             return {
                 'success': True,
                 'appcues_ab_test': appcues_ab_test


### PR DESCRIPTION
There's been some concern that the template apps for Appcues take too long to load, and delay the confirmation email (which is bad for a new user's experience). This PR loads the three template apps in parallel and sends the confirmation email to the user after all three have finished loading.

I'm still not 100% confident this will fix the issue we discussed over email, where it takes 1.5 - 7 minutes for the confirmation email to show up in your inbox. We keep the user on the "Creating Account..." loading page until we've done everything on the backend that we need to:
<img width="1189" alt="creating_account" src="https://user-images.githubusercontent.com/15271571/52879984-f2460b00-311d-11e9-9f76-ab3504e1e27a.png">

We only show the "Success! An email was just sent to ..." page after the apps have been loaded and a call to `send_domain_registration_email` has been made:
<img width="1199" alt="success" src="https://user-images.githubusercontent.com/15271571/52880005-02f68100-311e-11e9-8947-5bcf3f1c390c.png">

Seeing as this success page loads for me in seconds, but I don't receive the confirmation email for a while, there may still be an issue with `send_domain_registration_email` or the queue it's on (email_queue).

Either way, I'm hopeful that loading these apps in parallel can only help the situation

Jira ticket: https://trello.com/c/BcDom7IC/114-performance-improvements-activation-email-delay?menu=filter&filter=member:gabriellabova1

Original Appcues specs: https://docs.google.com/document/d/17ml1B5evU3Z45Y2a5q4Nrrli-nWVhlL-PAkvrzMlFt0/edit# 
Original Appcues PR: https://github.com/dimagi/commcare-hq/pull/22487/files