### PR TITLE
Surface errors during ccz creation

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
@@ -83,6 +83,8 @@ hqDefine('app_manager/js/download_async_modal', function () {
         self.downloadError = function (text) {
             self.init();
             self.$download_progress.html(text);
+            self.$download_progress.removeClass("hide");
+            self.$downloading.addClass("hide");
         };
 
         self.$el.on("hidden hidden.bs.modal", function () {

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -3,6 +3,8 @@ from io import open
 import os
 import tempfile
 from wsgiref.util import FileWrapper
+from celery import states
+from celery.exceptions import Ignore
 from celery.task import task
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -152,6 +154,9 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
                     z.writestr(path, data, file_compression)
                     progress += file_progress / file_count
                     DownloadBase.set_progress(build_application_zip, progress, 100)
+        if errors:
+            build_application_zip.update_state(state=states.FAILURE, meta={'errors': errors})
+            raise Ignore()  # We want the task to fail hard, so ignore any future updates to it
     else:
         DownloadBase.set_progress(build_application_zip, initial_progress + file_progress, 100)
 
@@ -175,6 +180,3 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
         )
 
     DownloadBase.set_progress(build_application_zip, 100, 100)
-    return {
-        "errors": errors,
-    }

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -116,13 +116,13 @@ def get_task_status(task, is_multiple_download_task=False):
             # no result backend / improperly configured
             pass
         else:
+            result = task.result
             if task.successful():
                 is_ready = True
-                result = task.result
                 context_result = result and result.get('messages')
-                if result and result.get('errors'):
-                    failed = True
-                    context_error = result.get('errors')
+            if result and result.get('errors'):
+                failed = True
+                context_error = result.get('errors')
         progress = get_task_progress(task)
 
     def progress_complete():

--- a/corehq/ex-submodules/soil/templates/soil/partials/dl_status.html
+++ b/corehq/ex-submodules/soil/templates/soil/partials/dl_status.html
@@ -6,8 +6,7 @@
             {{ error|unordered_list}}
         </ul>
     </div>
-{% endif %}
-{% if is_ready %}
+{% elif is_ready %}
     <div id="ready_{{ download_id }}">
     {% if has_file %}
         <p class="lead">


### PR DESCRIPTION
`iter_media_files` and `iter_app_files` both capture errors, but so far as I can tell, those errors just get thrown away.

@mkangia / @snopoke 
code buddy @dannyroberts 

<img width="1454" alt="screen shot 2019-02-15 at 9 36 57 pm" src="https://user-images.githubusercontent.com/1486591/52893419-eb44ea00-3169-11e9-9b45-2877f0fb22d0.png">
