### PR TITLE
Show calculated case list properties in case summary

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -9,11 +9,18 @@ hqDefine('app_manager/js/summary/case_summary',[
     'hqwebapp/js/knockout_bindings.ko', // popover
 ], function ($, _, ko, initialPageData, assertProperties, models) {
 
-    var caseTypeModel = function (caseType) {
+    var caseTypeModel = function (caseType, showCalculations) {
         var self = models.contentItemModel(caseType);
 
         self.properties = _.map(caseType.properties, function (property) {
             return models.contentItemModel(property);
+        });
+
+        self.visibleProperties = ko.computed(function () {
+            return _.filter(self.properties, function (property) {
+                // only show case list / detail calculated properties if calculations are turned on
+                return showCalculations() || !property.use_xpath_expression;
+            });
         });
 
         // Convert these from objects to lists so knockout can process more easily
@@ -60,11 +67,6 @@ hqDefine('app_manager/js/summary/case_summary',[
             },
         }));
 
-        assertProperties.assertRequired(options, ['case_types']);
-        self.caseTypes = _.map(options.case_types, function (caseType) {
-            return caseTypeModel(caseType);
-        });
-
         self.showConditions = ko.observable(false);
         self.toggleConditions = function () {
             self.showConditions(!self.showConditions());
@@ -74,6 +76,11 @@ hqDefine('app_manager/js/summary/case_summary',[
         self.toggleCalculations = function () {
             self.showCalculations(!self.showCalculations());
         };
+
+        assertProperties.assertRequired(options, ['case_types']);
+        self.caseTypes = _.map(options.case_types, function (caseType) {
+            return caseTypeModel(caseType, self.showCalculations);
+        });
 
         return self;
     };

--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -19,7 +19,7 @@ hqDefine('app_manager/js/summary/case_summary',[
         self.visibleProperties = ko.computed(function () {
             return _.filter(self.properties, function (property) {
                 // only show case list / detail calculated properties if calculations are turned on
-                return showCalculations() || !property.use_xpath_expression;
+                return showCalculations() || !property.is_detail_calculation;
             });
         });
 
@@ -56,7 +56,7 @@ hqDefine('app_manager/js/summary/case_summary',[
                     _.each(caseType.properties, function (property) {
                         var isVisible = !query || property.name.indexOf(query) !== -1;
                         property.matchesQuery(isVisible);
-                        self.showCalculations(self.showCalculations() || (query && isVisible && property.use_xpath_expression));
+                        self.showCalculations(self.showCalculations() || (query && isVisible && property.is_detail_calculation));
                         hasVisible = hasVisible || isVisible;
                     });
                     caseType.matchesQuery(hasVisible || !query && !caseType.properties.length);

--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -50,6 +50,7 @@ hqDefine('app_manager/js/summary/case_summary',[
         var self = models.contentModel(_.extend(options, {
             query_label: gettext("Filter properties"),
             onQuery: function (query) {
+                query = query.trim().toLowerCase();
                 _.each(self.caseTypes, function (caseType) {
                     var hasVisible = false;
                     _.each(caseType.properties, function (property) {

--- a/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/case_summary.js
@@ -55,6 +55,7 @@ hqDefine('app_manager/js/summary/case_summary',[
                     _.each(caseType.properties, function (property) {
                         var isVisible = !query || property.name.indexOf(query) !== -1;
                         property.matchesQuery(isVisible);
+                        self.showCalculations(self.showCalculations() || (query && isVisible && property.use_xpath_expression));
                         hasVisible = hasVisible || isVisible;
                     });
                     caseType.matchesQuery(hasVisible || !query && !caseType.properties.length);

--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -111,7 +111,7 @@
                                     <th>{% trans "Case Details" %}</th>
                                 </tr>
                             </thead>
-                            <tbody data-bind="foreach: properties">
+                            <tbody data-bind="foreach: visibleProperties">
                                 <!-- ko foreach: forms -->
                                     <tr data-bind="attr: {id: $parents[1].name + ':' + $parent.name}, css: {'danger': $parent.has_errors}, visible: $parent.isVisible">
                                         <!-- ko if: !$index() -->
@@ -150,7 +150,10 @@
                                     <tr data-bind="attr: {id: $parent.name + ':' + encodeURIComponent(name)}, css: {'danger': has_errors}, visible: isVisible">
                                         <td>
                                             <dl>
-                                                <dt data-bind="text: name"></dt>
+                                                <dt>
+                                                    <!-- ko if: use_xpath_expression --><i class="fa fa-calculator"></i><!-- /ko -->
+                                                    <!-- ko text: name --><!-- /ko -->
+                                                </dt>
                                                 <dd data-bind="text: description"></dd>
                                             </dl>
                                         </td>

--- a/corehq/apps/app_manager/templates/app_manager/case_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/case_summary.html
@@ -151,7 +151,7 @@
                                         <td>
                                             <dl>
                                                 <dt>
-                                                    <!-- ko if: use_xpath_expression --><i class="fa fa-calculator"></i><!-- /ko -->
+                                                    <!-- ko if: is_detail_calculation --><i class="fa fa-calculator"></i><!-- /ko -->
                                                     <!-- ko text: name --><!-- /ko -->
                                                 </dt>
                                                 <dd data-bind="text: description"></dd>

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -132,6 +132,7 @@ class CaseProperty(JsonObject):
     long_details = ListProperty(CaseDetailMeta)
     has_errors = BooleanProperty()
     description = StringProperty()
+    use_xpath_expression = BooleanProperty()
 
     def get_form(self, form_id):
         try:
@@ -155,7 +156,8 @@ class CaseProperty(JsonObject):
             condition=(condition if condition and condition.type == 'if' else None)
         ))
 
-    def add_detail(self, type_, module_id, header, error=None):
+    def add_detail(self, type_, module_id, header, use_xpath_expression=False, error=None):
+        self.use_xpath_expression = use_xpath_expression
         {
             "short": self.short_details,
             "long": self.long_details,
@@ -318,8 +320,6 @@ class AppCaseMetadata(JsonObject):
             root_case_type = USERCASE_TYPE
             field = field.split('user/')[1]
 
-        if column.useXpathExpression:
-            return column.field
         try:
             props = self.get_property_list(root_case_type, field)
         except CaseMetaException as e:
@@ -328,7 +328,7 @@ class AppCaseMetadata(JsonObject):
         else:
             error = None
         for prop in props:
-            prop.add_detail(detail_type, module_id, column.header, error)
+            prop.add_detail(detail_type, module_id, column.header, column.useXpathExpression, error)
 
     def get_error_property(self, case_type, name):
         type_ = self.get_type(case_type)

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -121,7 +121,6 @@ class CaseFormMeta(JsonObject):
 class CaseDetailMeta(JsonObject):
     module_id = StringProperty()
     header = DictProperty()
-    format = StringProperty()
     error = StringProperty()
 
 
@@ -156,11 +155,11 @@ class CaseProperty(JsonObject):
             condition=(condition if condition and condition.type == 'if' else None)
         ))
 
-    def add_detail(self, type_, module_id, header, format, error=None):
+    def add_detail(self, type_, module_id, header, error=None):
         {
             "short": self.short_details,
             "long": self.long_details,
-        }[type_].append(CaseDetailMeta(module_id=module_id, header=header, format=format, error=error))
+        }[type_].append(CaseDetailMeta(module_id=module_id, header=header, error=error))
 
 
 class CaseTypeMeta(JsonObject):
@@ -329,7 +328,7 @@ class AppCaseMetadata(JsonObject):
         else:
             error = None
         for prop in props:
-            prop.add_detail(detail_type, module_id, column.header, column.format, error)
+            prop.add_detail(detail_type, module_id, column.header, error)
 
     def get_error_property(self, case_type, name):
         type_ = self.get_type(case_type)

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -132,7 +132,7 @@ class CaseProperty(JsonObject):
     long_details = ListProperty(CaseDetailMeta)
     has_errors = BooleanProperty()
     description = StringProperty()
-    use_xpath_expression = BooleanProperty()
+    is_detail_calculation = BooleanProperty()
 
     def get_form(self, form_id):
         try:
@@ -156,8 +156,8 @@ class CaseProperty(JsonObject):
             condition=(condition if condition and condition.type == 'if' else None)
         ))
 
-    def add_detail(self, type_, module_id, header, use_xpath_expression=False, error=None):
-        self.use_xpath_expression = use_xpath_expression
+    def add_detail(self, type_, module_id, header, is_detail_calculation=False, error=None):
+        self.is_detail_calculation = is_detail_calculation
         {
             "short": self.short_details,
             "long": self.long_details,


### PR DESCRIPTION
Shows calculated properties that are used in the case summary. 
![screenshot from 2019-02-16 15-37-54](https://user-images.githubusercontent.com/146896/52904955-e8490880-3200-11e9-9276-82d22105e721.png)

This means you can search for "foo" and if that shows up in a case list calculated property, you'll be able to see this. Previously these were just never shown.