### PR TITLE
fix another bad reference to resident being text

### DIFF
--- a/custom/icds_reports/ucr/reports/testing/mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_3_children_registered.json
@@ -121,7 +121,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "closed_on IS NULL AND sex = 'F' AND resident = 'yes'": 1
+          "closed_on IS NULL AND sex = 'F' AND resident = 1": 1
         }
       },
       {
@@ -131,7 +131,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') AND resident = 'yes'": 1
+          "closed_on IS NULL AND sex IN ('M', 'O') AND resident = 1": 1
         }
       },
       {
@@ -141,7 +141,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "closed_on IS NULL AND sex = 'F' AND resident IS DISTINCT FROM 'yes'": 1
+          "closed_on IS NULL AND sex = 'F' AND resident IS DISTINCT FROM 1": 1
         }
       },
       {
@@ -151,7 +151,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') AND resident IS DISTINCT FROM 'yes'": 1
+          "closed_on IS NULL AND sex IN ('M', 'O') AND resident IS DISTINCT FROM 1": 1
         }
       }
     ],


### PR DESCRIPTION
found this while porting the new report and gave it the same treatment as https://github.com/dimagi/commcare-hq/pull/22675/commits/0281d443ff455fcd03c6adff7134c2f1ebde2c79

@emord do you know why your QA process didn't catch this?