### PR TITLE
port more icds reports from v2 to v3 data sources

### DIFF
--- a/custom/icds_reports/ucr/reports/testing/mpr_2a_deaths.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2a_deaths.json
@@ -1,0 +1,344 @@
+{
+  "domains": [
+    "icds-cas",
+    "cas-lab",
+    "icds-dashboard-qa",
+    "reach-sandbox",
+    "reach-test"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_2a_deaths-optimized",
+  "data_source_table": "static-person_cases_v3",
+  "config": {
+    "title": "MPR 2a - Deaths by Month  (Static)",
+    "description": "Details of Deaths during the month.  Displays person cases grouped by month of death and owner ID.",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id", "month"
+    ],
+    "filters": [
+      {
+        "slug": "date_death_exists",
+        "type": "pre",
+        "field": "date_death",
+        "pre_operator": "!=",
+        "pre_value": "",
+        "datatype": "date"
+      },
+      {
+        "display": "Date of Death",
+        "type": "date",
+        "slug": "date_death",
+        "field": "date_death",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "type": "dynamic_choice_list",
+        "slug": "awc_id",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location",
+          "include_descendants": true,
+          "show_full_path": true
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "type": "dynamic_choice_list",
+        "slug": "supervisor_id",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location",
+          "include_descendants": true,
+          "show_full_path": true
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "type": "dynamic_choice_list",
+        "slug": "block_id",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location",
+          "include_descendants": true,
+          "show_full_path": true
+        }
+      },
+      {
+        "display": "Filter by District",
+        "type": "dynamic_choice_list",
+        "slug": "district_id",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location",
+          "include_descendants": true,
+          "show_full_path": true
+        }
+      },
+      {
+        "display": "Filter by State",
+        "type": "dynamic_choice_list",
+        "slug": "state_id",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location",
+          "include_descendants": true,
+          "show_full_path": true
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": "Owner ID",
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Location Name",
+        "column_id": "location_name",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "Month",
+        "column_id": "month",
+        "type": "aggregate_date",
+        "field": "date_death",
+        "format": "%Y-%m"
+      },
+      {
+        "display": "dead_F_resident_neo_count",
+        "column_id": "dead_F_resident_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_resident_neo_count",
+        "column_id": "dead_M_resident_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident = 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_neo_count",
+        "column_id": "dead_F_migrant_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_migrant_neo_count",
+        "column_id": "dead_M_migrant_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_resident_postneo_count",
+        "column_id": "dead_F_resident_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_resident_postneo_count",
+        "column_id": "dead_M_resident_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_postneo_count",
+        "column_id": "dead_F_migrant_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_migrant_postneo_count",
+        "column_id": "dead_M_migrant_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_resident_child_count",
+        "column_id": "dead_F_resident_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_resident_child_count",
+        "column_id": "dead_M_resident_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_child_count",
+        "column_id": "dead_F_migrant_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_migrant_child_count",
+        "column_id": "dead_M_migrant_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_adult_count",
+        "column_id": "dead_F_migrant_adult_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND age_at_death_yrs >= 11": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_resident_adult_count",
+        "column_id": "dead_F_resident_adult_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND age_at_death_yrs >= 11": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_preg_resident_count",
+        "column_id": "dead_preg_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pregnant' AND resident = 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_preg_migrant_count",
+        "column_id": "dead_preg_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM  'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_del_resident_count",
+        "column_id": "dead_del_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'delivery' AND resident = 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_del_migrant_count",
+        "column_id": "dead_del_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_pnc_resident_count",
+        "column_id": "dead_pnc_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pnc' AND resident = 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_pnc_migrant_count",
+        "column_id": "dead_pnc_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 'yes'": 1
+        },
+        "else_": 0
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_2a_deaths.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2a_deaths.json
@@ -96,14 +96,14 @@
         "display": "Owner ID",
         "column_id": "owner_id",
         "type": "field",
-        "field": "owner_id",
+        "field": "awc_id",
         "aggregation": "simple"
       },
       {
         "display": "Location Name",
         "column_id": "location_name",
         "type": "field",
-        "field": "owner_id",
+        "field": "awc_id",
         "aggregation": "simple",
         "transform": {
           "type": "custom",

--- a/custom/icds_reports/ucr/reports/testing/mpr_2a_deaths.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2a_deaths.json
@@ -124,7 +124,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND date_death - dob <= 28": 1
+          "sex = 'F' AND resident = 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -135,7 +135,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident = 'yes' AND date_death - dob <= 28": 1
+          "sex = 'M' AND resident = 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -146,7 +146,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -157,7 +157,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -168,7 +168,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -179,7 +179,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -190,7 +190,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -201,7 +201,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -212,7 +212,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -223,7 +223,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -234,7 +234,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -245,7 +245,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -256,7 +256,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND age_at_death_yrs >= 11": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND age_at_death_yrs >= 11": 1
         },
         "else_": 0
       },
@@ -267,7 +267,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND age_at_death_yrs >= 11": 1
+          "sex = 'F' AND resident = 1 AND age_at_death_yrs >= 11": 1
         },
         "else_": 0
       },
@@ -278,7 +278,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pregnant' AND resident = 'yes'": 1
+          "female_death_type = 'pregnant' AND resident = 1": 1
         },
         "else_": 0
       },
@@ -289,7 +289,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM  'yes'": 1
+          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM 1": 1
         },
         "else_": 0
       },
@@ -300,7 +300,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'delivery' AND resident = 'yes'": 1
+          "female_death_type = 'delivery' AND resident = 1": 1
         },
         "else_": 0
       },
@@ -311,7 +311,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 'yes'": 1
+          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 1": 1
         },
         "else_": 0
       },
@@ -322,7 +322,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pnc' AND resident = 'yes'": 1
+          "female_death_type = 'pnc' AND resident = 1": 1
         },
         "else_": 0
       },
@@ -333,7 +333,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 'yes'": 1
+          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 1": 1
         },
         "else_": 0
       }

--- a/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
@@ -98,7 +98,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND date_death - dob <= 28": 1
+          "sex = 'F' AND resident = 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -109,7 +109,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident = 'yes' AND date_death - dob <= 28": 1
+          "sex = 'M' AND resident = 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -120,7 +120,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -131,7 +131,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
         },
         "else_": 0
       },
@@ -142,7 +142,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -153,7 +153,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -164,7 +164,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -175,7 +175,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
         },
         "else_": 0
       },
@@ -186,7 +186,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -197,7 +197,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -208,7 +208,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -219,7 +219,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
         },
         "else_": 0
       },
@@ -230,7 +230,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND age_at_death_yrs >= 11": 1
+          "sex = 'F' AND resident IS DISTINCT FROM 1 AND age_at_death_yrs >= 11": 1
         },
         "else_": 0
       },
@@ -241,7 +241,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "sex = 'F' AND resident = 'yes' AND age_at_death_yrs >= 11": 1
+          "sex = 'F' AND resident = 1 AND age_at_death_yrs >= 11": 1
         },
         "else_": 0
       },
@@ -252,7 +252,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pregnant' AND resident = 'yes'": 1
+          "female_death_type = 'pregnant' AND resident = 1": 1
         },
         "else_": 0
       },
@@ -263,7 +263,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM  'yes'": 1
+          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM  1": 1
         },
         "else_": 0
       },
@@ -274,7 +274,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'delivery' AND resident = 'yes'": 1
+          "female_death_type = 'delivery' AND resident = 1": 1
         },
         "else_": 0
       },
@@ -285,7 +285,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 'yes'": 1
+          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 1": 1
         },
         "else_": 0
       },
@@ -296,7 +296,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pnc' AND resident = 'yes'": 1
+          "female_death_type = 'pnc' AND resident = 1": 1
         },
         "else_": 0
       },
@@ -307,7 +307,7 @@
         "aggregation": "sum",
         "calculate_total": true,
         "whens": {
-          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 'yes'": 1
+          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 1": 1
         },
         "else_": 0
       }

--- a/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
@@ -3,11 +3,8 @@
     "icds-dashboard-qa",
     "reach-sandbox",
     "reach-test",
-    "icds-test",
-    "icds-sql",
     "icds-cas",
-    "cas-lab",
-    "icds-cas-sandbox"
+    "cas-lab"
   ],
   "server_environment": [
     "softlayer",

--- a/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
@@ -84,7 +84,7 @@
         },
         "column_id": "owner_id",
         "type": "field",
-        "field": "owner_id",
+        "field": "awc_id",
         "aggregation": "simple",
         "transform": {
           "type": "custom",

--- a/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2a_person_cases.json
@@ -1,0 +1,318 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-sandbox",
+    "reach-test",
+    "icds-test",
+    "icds-sql",
+    "icds-cas",
+    "cas-lab",
+    "icds-cas-sandbox"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds"
+  ],
+  "report_id": "static-mpr_2a_person_cases-optimized",
+  "data_source_table": "static-person_cases_v3",
+  "config": {
+    "title": "MPR - 2a - Person cases  (Static)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "display": "Date of Death",
+        "slug": "date_death",
+        "type": "date",
+        "field": "date_death",
+        "datatype": "date"
+      },
+      {
+        "display": "Filter by AWW",
+        "slug": "awc_id",
+        "type": "dynamic_choice_list",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Supervisor",
+        "slug": "supervisor_id",
+        "type": "dynamic_choice_list",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by Block",
+        "slug": "block_id",
+        "type": "dynamic_choice_list",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by District",
+        "slug": "district_id",
+        "type": "dynamic_choice_list",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      },
+      {
+        "display": "Filter by State",
+        "slug": "state_id",
+        "type": "dynamic_choice_list",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        }
+      }
+    ],
+    "columns": [
+      {
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "column_id": "owner_id",
+        "type": "field",
+        "field": "owner_id",
+        "aggregation": "simple",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        }
+      },
+      {
+        "display": "dead_F_resident_neo_count",
+        "column_id": "dead_F_resident_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_resident_neo_count",
+        "column_id": "dead_M_resident_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident = 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_neo_count",
+        "column_id": "dead_F_migrant_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_migrant_neo_count",
+        "column_id": "dead_M_migrant_neo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob <= 28": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_resident_postneo_count",
+        "column_id": "dead_F_resident_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_resident_postneo_count",
+        "column_id": "dead_M_resident_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_postneo_count",
+        "column_id": "dead_F_migrant_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_migrant_postneo_count",
+        "column_id": "dead_M_migrant_postneo_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 29 AND 364": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_resident_child_count",
+        "column_id": "dead_F_resident_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_resident_child_count",
+        "column_id": "dead_M_resident_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident = 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_child_count",
+        "column_id": "dead_F_migrant_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_M_migrant_child_count",
+        "column_id": "dead_M_migrant_child_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'M' AND resident IS DISTINCT FROM 'yes' AND date_death - dob BETWEEN 365 AND 1826": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_migrant_adult_count",
+        "column_id": "dead_F_migrant_adult_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident IS DISTINCT FROM 'yes' AND age_at_death_yrs >= 11": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_F_resident_adult_count",
+        "column_id": "dead_F_resident_adult_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "sex = 'F' AND resident = 'yes' AND age_at_death_yrs >= 11": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_preg_resident_count",
+        "column_id": "dead_preg_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pregnant' AND resident = 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_preg_migrant_count",
+        "column_id": "dead_preg_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM  'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_del_resident_count",
+        "column_id": "dead_del_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'delivery' AND resident = 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_del_migrant_count",
+        "column_id": "dead_del_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_pnc_resident_count",
+        "column_id": "dead_pnc_resident_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pnc' AND resident = 'yes'": 1
+        },
+        "else_": 0
+      },
+      {
+        "display": "dead_pnc_migrant_count",
+        "column_id": "dead_pnc_migrant_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 'yes'": 1
+        },
+        "else_": 0
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/testing/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2bi_preg_delivery_death_list.json
@@ -89,6 +89,18 @@
     ],
     "columns": [
       {
+        "display": "dead_preg_count (for filter only)",
+        "column_id": "dead_preg_count",
+        "type": "sum_when",
+        "aggregation": "sum",
+        "calculate_total": true,
+        "whens": {
+          "female_death_type IS NOT NULL AND age_at_death_yrs >= 11": 1
+        },
+        "else_": 0,
+        "visible": false
+      },
+      {
         "format": "default",
         "aggregation": "simple",
         "column_id": "name",

--- a/custom/icds_reports/ucr/reports/testing/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2bi_preg_delivery_death_list.json
@@ -3,11 +3,8 @@
     "icds-dashboard-qa",
     "reach-sandbox",
     "reach-test",
-    "icds-test",
-    "icds-sql",
     "icds-cas",
-    "cas-lab",
-    "icds-cas-sandbox"
+    "cas-lab"
   ],
   "server_environment": [
     "softlayer",

--- a/custom/icds_reports/ucr/reports/testing/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/testing/mpr_2bi_preg_delivery_death_list.json
@@ -1,0 +1,307 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "reach-sandbox",
+    "reach-test",
+    "icds-test",
+    "icds-sql",
+    "icds-cas",
+    "cas-lab",
+    "icds-cas-sandbox"
+  ],
+  "server_environment": [
+    "softlayer",
+    "icds-new",
+    "icds"
+  ],
+  "report_id": "static-mpr_2bi_preg_delivery_death_list-optimized",
+  "data_source_table": "static-person_cases_v3",
+  "config": {
+    "title": "MPR - 2bi - Preg & Delivery Death List (Static)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "doc_id"
+    ],
+    "filters": [
+      {
+        "compare_as_string": false,
+        "datatype": "date",
+        "required": false,
+        "display": "Date of Death",
+        "field": "date_death",
+        "type": "date",
+        "slug": "date_death"
+      },
+      {
+        "compare_as_string": false,
+        "display": "List Type",
+        "datatype": "string",
+        "show_all": true,
+        "choices": [
+          {
+            "display": "Female deaths during preg or 42 days after delivery",
+            "value": "1"
+          }
+        ],
+        "field": "dead_preg_count",
+        "type": "choice_list",
+        "slug": "dead_preg_count"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "awc_id",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by AWW"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "supervisor_id",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Supervisor"
+      },
+      {
+        "compare_as_string": false,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "owner_id",
+        "field": "owner_id",
+        "choice_provider": {
+          "type": "owner"
+        },
+        "display": "Owner Name"
+      }
+    ],
+    "columns": [
+      {
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "name",
+        "field": "name",
+        "type": "field",
+        "display": {
+          "mar": "नांव",
+          "tel": "పేరు",
+          "hin": "नाम",
+          "en": "Name",
+          "tam": "பெயர்",
+          "lus": "Hming",
+          "pan": "ਨਾਮ",
+          "grt": "Bimung",
+          "kha": "Kyrteng",
+          "asm": "নাম",
+          "ben": "নাম",
+          "guj": "નામ",
+          "mni": "মিং",
+          "mal": "പേര്"
+        }
+      },
+      {
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "age_at_death_yrs",
+        "field": "age_at_death_yrs",
+        "type": "field",
+        "display": {
+          "mar": "वय",
+          "tel": "వయస్సు",
+          "hin": "उम्र",
+          "en": "Age",
+          "tam": "வயது",
+          "lus": "Kum",
+          "pan": "ਉਮਰ",
+          "grt": "Bilsi",
+          "kha": "Kyrta",
+          "asm": "বয়স",
+          "ben": "বয়স",
+          "guj": "ઉંમર",
+          "mni": "চহি",
+          "mal": "വയസ്സ്"
+        }
+      },
+      {
+        "format": "default",
+        "transform": {
+          "type": "translation",
+          "mobile_or_web": "mobile",
+          "translations": {
+            "delivery": {
+              "mar": "प्रसूति",
+              "tel": "కాన్పు వివరాలు ",
+              "hin": "प्रसव",
+              "en": "Delivery",
+              "tam": "பிரசவம்",
+              "lus": "Nau neih",
+              "pan": "ਡਿਲੀਵਰੀ",
+              "grt": "An·paka",
+              "kha": "Ka jingkha khyllung",
+              "asm": "প্ৰসৱ",
+              "ben": "প্রসব",
+              "guj": "પ્રસવ",
+              "mni": "অঙাং উন্নবা",
+              "mal": "പ്രസവം"
+            },
+            "pnc": {
+              "mar": "प्रसुतीनंतरची देखभाल",
+              "tel": "కాన్పు తరువాత సంరక్షణ ",
+              "hin": "प्रसव के बाद देख-रेख",
+              "en": "PNC",
+              "tam": "பிரவேசத்திற்கு பின் பராமரிப்பு",
+              "lus": "Nau neih hnu a in enkawl dan",
+              "pan": "ਜਣੇਪੇ ਤੋਂ ਬਾਅਦ ਜਾਂਚ",
+              "grt": "PNC",
+              "kha": "PNC",
+              "asm": "প্ৰসবোত্তৰ যতন",
+              "ben": "প্রসব পরবর্তী পরীক্ষা",
+              "guj": "પ્રસુતિ બાદની સંંભાળ",
+              "mni": "পি.এন.সি.",
+              "mal": "പ്രസവാനന്തര പരിശോധന"
+            },
+            "pregnant": {
+              "mar": "गरोदर",
+              "tel": "గర్భవతా",
+              "hin": "गर्भवती",
+              "en": "Pregnant",
+              "tam": "கர்ப்பிணி",
+              "lus": "Naupai",
+              "pan": "ਗਰਭਵਤੀ",
+              "grt": "An∙o donga",
+              "kha": "Ar Met",
+              "asm": "গর্ভৱতী",
+              "ben": "গর্ভবতী",
+              "guj": "સગર્ભા",
+              "mni": "মীরোলবী",
+              "mal": "ഗർഭിണി"
+            }
+          }
+        },
+        "column_id": "female_death_type",
+        "field": "female_death_type",
+        "type": "field",
+        "display": {
+          "mar": "प्रकार",
+          "tel": "రకం",
+          "hin": "प्रकार",
+          "en": "Type",
+          "tam": "வகை",
+          "lus": "Thih chhan",
+          "pan": "ਕਿਸਮ",
+          "grt": "Rokom",
+          "kha": "Ka rukom",
+          "asm": "প্ৰকাৰ",
+          "ben": "ধরণ",
+          "guj": "પ્રકાર",
+          "mni": "মখল",
+          "mal": "തരം"
+        },
+        "aggregation": "simple"
+      },
+      {
+        "format": "default",
+        "transform": {
+          "type": "translation",
+          "mobile_or_web": "mobile",
+          "translations": {
+            "yes": {
+              "mar": "होय",
+              "tel": "అవును",
+              "hin": "हाँ",
+              "en": "Yes",
+              "tam": "ஆம்",
+              "lus": "Aw",
+              "pan": "ਹਾਂ",
+              "grt": "Yes",
+              "kha": "Hooid",
+              "asm": "হয়",
+              "ben": "হ্যাঁ",
+              "guj": "હા",
+              "mni": "হোই",
+              "mal": "അതെ"
+            },
+            "no": {
+              "mar": "नाही",
+              "tel": "కాదు",
+              "hin": "नहीं",
+              "en": "No",
+              "tam": "இல்லை",
+              "lus": "Aih",
+              "pan": "ਨਹੀਂ",
+              "grt": "No",
+              "kha": "Em",
+              "asm": "নহয়",
+              "ben": "না",
+              "guj": "ના",
+              "mni": "নত্তে",
+              "mal": "അല്ല"
+            }
+          }
+        },
+        "column_id": "resident",
+        "field": "resident",
+        "type": "field",
+        "display": {
+          "mar": "निवासी",
+          "tel": "నివాసితుడు",
+          "hin": "निवासी",
+          "en": "Resident",
+          "tam": "வசிப்பவர்",
+          "lus": "Chenna",
+          "pan": "ਨਿਵਾਸੀ",
+          "grt": "Songdonggipa",
+          "kha": "Nongshong shnong",
+          "asm": "বাসিন্দা",
+          "ben": "বাসিন্দা",
+          "guj": "નિવાસસ્થાન",
+          "mni": "লৈফম",
+          "mal": "പ്രദേശവാസി"
+        },
+        "aggregation": "simple"
+      },
+      {
+        "format": "default",
+        "aggregation": "simple",
+        "column_id": "date_death",
+        "field": "date_death",
+        "type": "field",
+        "display": {
+          "mar": "मृत्युची  तारीख",
+          "tel": "మరణించిన తేదీ",
+          "hin": "मृत्यु की तारीख",
+          "en": "Date Death",
+          "tam": "இறந்த தேதி",
+          "lus": "Thih ni",
+          "pan": "ਮੌਤ ਦੀ ਮਿਤੀ",
+          "grt": "Sani tarik",
+          "kha": "Sngi Khlad",
+          "asm": "মৃত্য়ুৰ তাৰিখ",
+          "ben": "মৃত্যুর তারিখ",
+          "guj": "મૃૃત્યુની તારીખ",
+          "mni": "লৈখিদবগী তারিখ",
+          "mal": "മരണതീയതി"
+        }
+      }
+    ],
+    "sort_expression": [
+      {
+        "field": "date_death",
+        "order": "DESC"
+      }
+    ],
+    "configured_charts": []
+  }
+}


### PR DESCRIPTION
this ports the `mpr_2a_person_cases`, `mpr_2a_deaths`, and `mpr_2bi_preg_delivery_death_list` reports from the v2 to v3 data source

this was pretty straightforward. can review by commit :fish: 