### PR TITLE
[up-nrhm] exclude deleted users from Location Hierarchy

### DIFF
--- a/custom/up_nrhm/data_sources/location_hierarchy.json
+++ b/custom/up_nrhm/data_sources/location_hierarchy.json
@@ -7,15 +7,31 @@
         "table_id": "location_hierarchy",
         "display_name": "Location Hierarchy",
         "configured_filter":  {
-             "operator": "eq",
-             "expression": {
-                 "datatype": null,
-                 "type": "property_name",
-                 "property_name": "is_active"
-             },
-             "type": "boolean_expression",
-             "comment": null,
-             "property_value": true
+            "type": "and",
+            "filters": [
+                {
+                    "operator": "eq",
+                    "expression": {
+                         "datatype": null,
+                         "type": "property_name",
+                         "property_name": "is_active"
+                    },
+                    "type": "boolean_expression",
+                    "comment": null,
+                    "property_value": true
+                },
+                {
+                    "operator": "eq",
+                    "expression": {
+                         "datatype": null,
+                         "type": "property_name",
+                         "property_name": "-deletion_date"
+                    },
+                    "type": "boolean_expression",
+                    "comment": null,
+                    "property_value": null
+                }
+            ]
         },
         "configured_indicators": [
             {

--- a/custom/up_nrhm/data_sources/location_hierarchy.json
+++ b/custom/up_nrhm/data_sources/location_hierarchy.json
@@ -21,15 +21,15 @@
                     "property_value": true
                 },
                 {
-                    "operator": "eq",
+                    "operator": "not_eq",
                     "expression": {
                          "datatype": null,
                          "type": "property_name",
-                         "property_name": "-deletion_date"
+                         "property_name": "base_doc"
                     },
                     "type": "boolean_expression",
                     "comment": null,
-                    "property_value": null
+                    "property_value": "CouchUser-Deleted"
                 }
             ]
         },


### PR DESCRIPTION
Hi @czue @emord 

We need exclude deleted users also in the up-nrhm domain. I talked today with Manish and the users are not deactivated but deleted. To don't have problems in future I exclude both options.

Need QA: no
Environment: production
Locally tested: yes

Regards,
Łukasz