### PR TITLE
Added notify_exception when iter_media_files encounters a NameError

### DIFF
--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -640,6 +640,7 @@ def iter_media_files(media_objects):
     errors will not include all error messages until the iterator is exhausted
 
     """
+    from dimagi.utils.logging import notify_exception
     errors = []
 
     def _media_files():
@@ -650,10 +651,12 @@ def iter_media_files(media_objects):
                 if not isinstance(data, six.text_type):
                     yield os.path.join(folder), data
             except NameError as e:
-                errors.append("%(path)s produced an ERROR: %(error)s" % {
+                message = "%(path)s produced an ERROR: %(error)s" % {
                     'path': path,
                     'error': e,
-                })
+                }
+                errors.append(message)
+                notify_exception(None, message)
     return _media_files(), errors
 
 


### PR DESCRIPTION
Minor followup for https://github.com/dimagi/commcare-hq/pull/23263

`iter_index_files` already calls `notify_exception` on error: https://github.com/dimagi/commcare-hq/blob/307c630a5face91f1a86aff97bc335d70c2513da/corehq/apps/hqmedia/views.py#L861

@mkangia / @snopoke 
code buddy @dannyroberts 