### PR TITLE
require django_redis to use pickle version 2

### DIFF
--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -112,7 +112,9 @@ redis_host = 'redis'
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
     'LOCATION': 'redis://{}:6379/0'.format(redis_host),
-    'OPTIONS': {},
+    'OPTIONS': {
+        'PICKLE_VERSION': 2,  # After PY3 migration: remove
+    },
 }
 
 CACHES = {

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -233,7 +233,9 @@ REPORT_CACHE = 'default'  # or e.g. 'redis'
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
     'LOCATION': 'redis://127.0.0.1:6379/0',
-    'OPTIONS': {},
+    'OPTIONS': {
+        'PICKLE_VERSION': 2,  # After PY3 migration: remove
+    },
 }
 # example redis cluster setting
 redis_cluster_cache = {
@@ -244,7 +246,8 @@ redis_cluster_cache = {
         'CONNECTION_POOL_CLASS': 'rediscluster.connection.ClusterConnectionPool',
         'CONNECTION_POOL_KWARGS': {
             'skip_full_coverage_check': True
-        }
+        },
+        'PICKLE_VERSION': 2,  # After PY3 migration: remove
     }
 }
 CACHES = {

--- a/manage.py
+++ b/manage.py
@@ -158,6 +158,7 @@ if __name__ == "__main__":
 
     patch_assertItemsEqual()
 
+    # After PY3 migration: remove
     patch_pickle_version()
 
     set_default_settings_path(sys.argv)


### PR DESCRIPTION
With this change, the redis cache can be used interchangeably between python 2 and 3, which makes it easy to go back and forth between the python versions.

https://django-redis-cache.readthedocs.io/en/latest/advanced_configuration.html#pickle-version

@dimagi/py3 