### PR TITLE
Added multimedia ccz verification and debug info

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -12,6 +12,7 @@ from couchdbkit.exceptions import ResourceConflict
 from django.template.defaultfilters import filesizeformat
 
 from corehq import privileges
+from corehq import toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqmedia.exceptions import BadMediaFileException
 from corehq.util.soft_assert import soft_assert
@@ -880,7 +881,8 @@ class ApplicationMediaMixin(Document, MediaMixin):
         paths = list(self.multimedia_map) if self.multimedia_map else []
         permitted_paths = self.all_media_paths() | self.logo_paths
         deleted_media = []
-        allow_deletion = self.domain not in {'icds-cas', 'icds-test'}
+        allow_deletion = not toggles.CAUTIOUS_MULTIMEDIA.enabled(self.domain)
+        allow_deletion = allow_deletion and self.domain not in {'icds-cas', 'icds-test'}
         for path in paths:
             if path not in permitted_paths:
                 map_item = self.multimedia_map[path]

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -8,6 +8,7 @@ from celery.exceptions import Ignore
 from celery.task import task
 from celery.utils.log import get_task_logger
 from django.conf import settings
+import re
 import zipfile
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.hqmedia.cache import BulkMultimediaStatusCache
@@ -139,7 +140,7 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
         if download_targeted_version:
             fpath += '-targeted'
     else:
-        _, fpath = tempfile.mkstemp()
+        dummy, fpath = tempfile.mkstemp()
 
     DownloadBase.set_progress(build_application_zip, initial_progress, 100)
 
@@ -148,6 +149,7 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
             app, include_multimedia_files, include_index_files, build_profile_id,
             download_targeted_version=download_targeted_version,
         )
+
         with open(fpath, 'wb') as tmp:
             with zipfile.ZipFile(tmp, "w") as z:
                 progress = initial_progress
@@ -158,6 +160,22 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
                     z.writestr(path, data, file_compression)
                     progress += file_progress / file_count
                     DownloadBase.set_progress(build_application_zip, progress, 100)
+
+        # Integrity check that all media files present in media_suite.xml were added to the zip
+        with open(fpath, 'rb') as tmp:
+            with zipfile.ZipFile(tmp, "r") as z:
+                media_suites = [f for f in z.namelist() if re.search(r'\bmedia_suite.xml\b', f)]
+                if len(media_suites) == 1:
+                    with z.open(media_suites[0]) as media_suite:
+                        from corehq.apps.app_manager.xform import parse_xml
+                        parsed = parse_xml(media_suite.read())
+                        resources = {node.text for node in
+                                     parsed.findall("media/resource/location[@authority='local']")}
+                        names = z.namelist()
+                        missing = [r for r in resources if re.sub(r'^\.\/', '', r) not in names]
+                        for m in missing:
+                            errors.append(_('Media file missing from CCZ: {}').format(m))
+
         if errors:
             build_application_zip.update_state(state=states.FAILURE, meta={'errors': errors})
             raise Ignore()  # We want the task to fail hard, so ignore any future updates to it

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -155,14 +155,14 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
 
         if toggles.CAUTIOUS_MULTIMEDIA.enabled(app.domain) or app.domain in ['icds', 'icds-cas']:
             manifest = json.dumps({
-                    'include_multimedia_files': include_multimedia_files,
-                    'include_index_files': include_index_files,
-                    'download_id': download_id,
-                    'build_profile_id': build_profile_id,
-                    'compress_zip': compress_zip,
-                    'filename': filename,
-                    'download_targeted_version': download_targeted_version,
-                    'app': app.to_json(),
+                'include_multimedia_files': include_multimedia_files,
+                'include_index_files': include_index_files,
+                'download_id': download_id,
+                'build_profile_id': build_profile_id,
+                'compress_zip': compress_zip,
+                'filename': filename,
+                'download_targeted_version': download_targeted_version,
+                'app': app.to_json(),
             }, indent=4)
             files = itertools.chain(files, [('manifest.json', manifest)])
 
@@ -176,7 +176,6 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
                     z.writestr(path, data, file_compression)
                     progress += file_progress / file_count
                     DownloadBase.set_progress(build_application_zip, progress, 100)
-
 
         # Integrity check that all media files present in media_suite.xml were added to the zip
         if toggles.CAUTIOUS_MULTIMEDIA.enabled(app.domain) or app.domain in ['icds', 'icds-cas']:

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -8,6 +8,8 @@ from celery.exceptions import Ignore
 from celery.task import task
 from celery.utils.log import get_task_logger
 from django.conf import settings
+import itertools
+import json
 import re
 import zipfile
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -149,6 +151,19 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
             app, include_multimedia_files, include_index_files, build_profile_id,
             download_targeted_version=download_targeted_version,
         )
+
+        if True:
+            manifest = json.dumps({
+                    'include_multimedia_files': include_multimedia_files,
+                    'include_index_files': include_index_files,
+                    'download_id': download_id,
+                    'build_profile_id': build_profile_id,
+                    'compress_zip': compress_zip,
+                    'filename': filename,
+                    'download_targeted_version': download_targeted_version,
+                    'app': app.to_json(),
+            }, indent=4)
+            files = itertools.chain(files, [('manifest.json', manifest)])
 
         with open(fpath, 'wb') as tmp:
             with zipfile.ZipFile(tmp, "w") as z:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1274,6 +1274,13 @@ LANGUAGE_LINKED_MULTIMEDIA = StaticToggle(
     help_link="https://confluence.dimagi.com/display/ccinternal/Linking+multimedia+to+the+default+language"
 )
 
+CAUTIOUS_MULTIMEDIA = StaticToggle(
+    'cautious_multimedia',
+    'More cautious handling of multimedia: do not delete multimedia files, add logging, etc.',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+)
+
 BULK_UPDATE_MULTIMEDIA_PATHS = StaticToggle(
     'bulk_update_multimedia_paths',
     'Add a page to update multimedia paths in bulk',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-291

Taking Clayton's suggestion to add a check at the end of ccz creation that everything in the media suite has a corresponding file in the zip.

Also adding a copy of the app's json and other debugging info to the ccz. I've wanted to have this a few times while debugging.

@mkangia / @snopoke 
code buddy @dannyroberts 