### PR TITLE
Add autoselect capability to fixtures

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -478,15 +478,17 @@ class AutoSelectCase(DocumentSchema):
 
 class LoadCaseFromFixture(DocumentSchema):
     """
-    fixture_nodeset:    FixtureDataType.tag
-    fixture_tag:        name of the column to display in the list
-    fixture_variable:   boolean if display_column actually contains the key for the localized string
-    case_property:      name of the column whose value should be saved when the user selects an item
-    arbitrary_datum_*:  adds an arbitrary datum with function before the action
+    fixture_nodeset:     nodeset that returns the fixture options to display
+    fixture_tag:         id of session datum where the result of user selection will be stored
+    fixture_variable:    value from the fixture to store from the selection
+    auto_select_fixture: boolean to autoselect the value if the nodeset only returns 1 result
+    case_property:       case property to filter on
+    arbitrary_datum_*:   adds an arbitrary datum with function before the action
     """
     fixture_nodeset = StringProperty()
     fixture_tag = StringProperty()
     fixture_variable = StringProperty()
+    auto_select_fixture = BooleanProperty(default=False)
     case_property = StringProperty(default='')
     auto_select = BooleanProperty(default=False)
     arbitrary_datum_id = StringProperty()

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/actions.js
@@ -639,6 +639,7 @@ hqDefine('app_manager/js/forms/advanced/actions', function () {
                 'fixture_nodeset',
                 'fixture_tag',
                 'fixture_variable',
+                'auto_select_fixture',
                 'case_property',
                 'auto_select',
                 'arbitrary_datum_id',

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -525,6 +525,7 @@ class EntriesHelper(object):
                 value=load_case_from_fixture.fixture_variable,
                 detail_select=self.details_helper.get_detail_id_safe(target_module, 'case_short'),
                 detail_confirm=self.details_helper.get_detail_id_safe(target_module, 'case_long'),
+                autoselect=load_case_from_fixture.auto_select_fixture,
             ),
             case_type=action.case_type,
             requires_selection=True,

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_advanced.html
@@ -445,6 +445,13 @@
                                 <label>{% trans "Fixture Variable" %}&nbsp;</label>
                                 <input type="text" class="form-control" data-bind="value: load_case_from_fixture.fixture_variable" />
                             </div>
+                            &nbsp;&nbsp;
+                            <div class="form-group">
+                                <label>
+                                    <input type="checkbox" data-bind="checked: load_case_from_fixture.auto_select_fixture" />
+                                    {% trans "Autoselect If Only One Result Returned From Fixture" %}
+                                </label>
+                            </div>
                         </div>
                     </div>
                     <div class="well well-sm">

--- a/corehq/apps/app_manager/tests/data/suite/load_from_fixture_autoselect_session.xml
+++ b/corehq/apps/app_manager/tests/data/suite/load_from_fixture_autoselect_session.xml
@@ -1,0 +1,6 @@
+<partial>
+	<session>
+		<datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long" />
+		<datum autoselect="true" id="selected_date" nodeset="instance('item-list:table_tag')/calendar/year/month/day[@date &gt; 735992 and @date &lt; 736000]" value="./@date" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+	</session>
+</partial>

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -231,6 +231,26 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.assertXmlPartialEqual(self.get_xml('load_from_fixture_session'), suite, './entry[2]/session')
         self.assertXmlPartialEqual(self.get_xml('load_from_fixture_instance'), suite, './entry[2]/instance')
 
+    def test_advanced_suite_load_from_fixture_auto_select(self):
+        nodeset = "instance('item-list:table_tag')/calendar/year/month/day[@date > 735992 and @date < 736000]"
+        app = Application.wrap(self.get_json('suite-advanced'))
+        app.get_module(1).get_form(0).actions.load_update_cases.append(LoadUpdateAction(
+            case_type="clinic",
+            load_case_from_fixture=LoadCaseFromFixture(
+                fixture_nodeset=nodeset,
+                fixture_tag="selected_date",
+                fixture_variable="./@date",
+                auto_select_fixture=True,
+                case_property="adherence_event_date",
+                auto_select=True,
+            )
+        ))
+        suite = app.create_suite()
+        self.assertXmlPartialEqual(
+            self.get_xml('load_from_fixture_autoselect_session'),
+            suite, './entry[2]/session')
+        self.assertXmlPartialEqual(self.get_xml('load_from_fixture_instance'), suite, './entry[2]/instance')
+
     def test_tiered_select_with_advanced_module_as_parent(self):
         app = Application.new_app('domain', "Untitled Application")
 


### PR DESCRIPTION
No JIRA or asana ticket for now. Got a hot tip that this was going to be required for the AAA demo, and it seemed easy enough to add in. Will be verifying tomorrow morning whether or not it is required.

This adds a checkbox to the already awful "Load case from fixture" to automatically select (skipping the case list style selection) if there's only one selection possible. 