### PR TITLE
Add badges to menus in WebApps

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -47,6 +47,12 @@
             <% } %>
           </div>
         <% } %>
+        <% /*
+            Ensure backwards compatibility with formplayer backend
+            before it added the badgeText field.
+            typeof x !== 'undefined' means "the variable hasn't been defined",
+            and is different from x === undefined.
+        */ %>
         <% if (typeof badgeText !== 'undefined' && badgeText) { %>
         <span class="badge badge-info"><%- badgeText %></span>
         <% } %>

--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -47,6 +47,9 @@
             <% } %>
           </div>
         <% } %>
+        <% if (typeof badgeText !== 'undefined' && badgeText) { %>
+        <span class="badge badge-info"><%- badgeText %></span>
+        <% } %>
     </td>
     <td class="module-column module-column-name">
         <h3><%- displayText ? displayText : "" %></h3>


### PR DESCRIPTION
For feature parity with mobile.

Depends on https://github.com/dimagi/formplayer/pull/675 for the change, but shouldn't break current behavior  pre or post that change or if badges aren't defined.

Affects projects with the "custom_icon_badges" flag (unreleased, used only with express permission) that use WebApps. I believe that's only PlusCare for the time being.

<img width="748" alt="screen shot 2019-02-18 at 7 38 14 pm" src="https://user-images.githubusercontent.com/137212/52984891-02c4e280-33b7-11e9-95a2-30897b637a3f.png">
