### PR TITLE
Send confirmation email on confirmation_email_queue

### DIFF
--- a/corehq/apps/registration/tasks.py
+++ b/corehq/apps/registration/tasks.py
@@ -58,7 +58,7 @@ FORUM_LINK = 'https://forum.dimagi.com/'
 PRICING_LINK = 'https://www.commcarehq.org/pricing'
 
 
-@task(serializer='pickle', queue="email_queue")
+@task(serializer='pickle', queue="confirmation_email_queue")
 def send_domain_registration_email(recipient, domain_name, guid, full_name, first_name):
     DNS_name = get_site_domain()
     registration_link = 'http://' + DNS_name + reverse('registration_confirm_domain') + guid + '/'


### PR DESCRIPTION
This PR uses `confirmation_email_queue` to send the new domain confirmation email, after discussino on [this PR](https://github.com/dimagi/commcare-hq/pull/23261).

Dependent on https://github.com/dimagi/commcare-cloud/pull/2661 so don't merge until that has been merged.