### PR TITLE
replace usages of prefetch_related with select_related

### DIFF
--- a/corehq/apps/locations/ucr_expressions.py
+++ b/corehq/apps/locations/ucr_expressions.py
@@ -13,7 +13,7 @@ from dimagi.ext.jsonobject import JsonObject, DictProperty
 @ucr_context_cache(vary_on=('location_id',))
 def _get_location(location_id, context):
     try:
-        return SQLLocation.objects.prefetch_related('location_type').get(
+        return SQLLocation.objects.select_related('location_type').get(
             domain=context.root_doc['domain'],
             location_id=location_id
         )

--- a/corehq/apps/reports/commtrack/util.py
+++ b/corehq/apps/reports/commtrack/util.py
@@ -36,7 +36,7 @@ class StockLedgerValueWrapper(jsonobject.JsonObject):
         try:
             return (
                 SQLLocation.objects
-                .prefetch_related('location_type')
+                .select_related('location_type')
                 .get(domain=self.domain, location_id=self.location_id)
             )
         except ObjectDoesNotExist:


### PR DESCRIPTION
`prefetch_related` will do a separate query for each relationship while `select_related` will do a join in the main SQL query which generally makes it more efficient.