### PR TITLE
fetch parent and type in single query

### DIFF
--- a/corehq/apps/locations/document_store.py
+++ b/corehq/apps/locations/document_store.py
@@ -19,7 +19,7 @@ class ReadonlyLocationDocumentStore(ReadOnlyDocumentStore):
 
     def __init__(self, domain):
         self.domain = domain
-        self.queryset = SQLLocation.active_objects.filter(domain=domain)
+        self.queryset = SQLLocation.active_objects.filter(domain=domain).select_related('parent', 'location_type')
 
     def get_document(self, doc_id):
         try:


### PR DESCRIPTION
These are always used in `to_json` so might as well
fetch them at the same time.

Where `location_ids()` is called Django ignores the
related models since none of their fields are included
in the values list.