### PR TITLE
don't rollback subscription changes if domain registration fails later

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -271,7 +271,6 @@ class RegisterDomainView(TemplateView):
         user = self.request.user
         return not (Domain.active_for_user(user) or user.is_superuser)
 
-    @transaction.atomic
     def post(self, request, *args, **kwargs):
         referer_url = request.GET.get('referer', '')
         nextpage = request.POST.get('next')


### PR DESCRIPTION
This fixes the cause of a long-standing issue where some domains are created without subscriptions.

Errors like this one shouldn't rollback the creation of a subscription:
https://sentry.io/organizations/dimagi/issues/897434050/

Now, if the code to create a subscription succeeds, it will automatically commit to the database.

@sravfeyn new code buddy