### PR TITLE
use both id and report_id to show count

### DIFF
--- a/corehq/apps/hqadmin/tests/test_views.py
+++ b/corehq/apps/hqadmin/tests/test_views.py
@@ -57,12 +57,12 @@ class AdminRestoreViewTests(TestXmlMixin, SimpleTestCase):
                 'neighborhood': 3,
             },
             'v1_report_row_counts': {
-                '0dc41ff3e342d3ac94c06bb5c6cdd416': 3,
-                'f1761733213601f7f77defc3bc2e2c87': 3,
+                'e009c3dc89b0250a8accd09b9641c3250f4e38d0--0dc41ff3e342d3ac94c06bb5c6cdd416': 3,
+                '42dc83c562a474b7e5faba4fc3190ca37bd4777f--f1761733213601f7f77defc3bc2e2c87': 3,
             },
             'v2_report_row_counts': {
-                '0dc41ff3e342d3ac94c06bb5c6cdd416': 3,
-                'f1761733213601f7f77defc3bc2e2c87': 3,
+                'commcare-reports:e009c3dc89b0250a8accd09b9641c3250f4e38d0--0dc41ff3e342d3ac94c06bb5c6cdd416': 3,
+                'commcare-reports:42dc83c562a474b7e5faba4fc3190ca37bd4777f--f1761733213601f7f77defc3bc2e2c87': 3,
             },
             'num_ledger_entries': 0,
         })

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -187,11 +187,14 @@ class AdminRestoreView(TemplateView):
     @staticmethod
     def _parse_reports(xpath, xml_payload):
         reports = xml_payload.findall(xpath)
-        report_row_counts = {
-            report.attrib['report_id']: len(report.findall('{{{0}}}rows/{{{0}}}row'.format(RESPONSE_XMLNS)))
-            for report in reports
-            if 'report_id' in report.attrib
-        }
+        report_row_counts = {}
+        for report in reports:
+            if 'report_id' in report.attrib:
+                report_id = report.attrib['report_id']
+                if 'id' in report.attrib:
+                    report_id = '--'.join([report.attrib['id'], report_id])
+                report_row_count = len(report.findall('{{{0}}}rows/{{{0}}}row'.format(RESPONSE_XMLNS)))
+                report_row_counts[report_id] = report_row_count
         return len(reports), report_row_counts
 
     @staticmethod


### PR DESCRIPTION
Show number of rows in all reports.

for example this [restore](https://www.commcarehq.org/hq/admin/phone/restore/?as=badori@rec.commcarehq.org&version=2.0)

there are 63 reports but it does not show all because multiple reports can have the same report_id.