### PR TITLE
enable running celery 3.x outside of management command

### DIFF
--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import absolute_import, unicode_literals
+from .celery import app as celery_app

--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import absolute_import, unicode_literals
-from .celery import app as celery_app
+from .celery import app as celery_app  # noqa

--- a/corehq/celery.py
+++ b/corehq/celery.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import, unicode_literals
+import os
+
+import django
+from django.core.checks import run_checks
+from django.core.exceptions import AppRegistryNotReady
+
+from celery import Celery
+
+from manage import init_hq_python_path
+
+init_hq_python_path()
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+
+from django.conf import settings  # noqa
+
+app = Celery('corehq')
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+django.setup()
+try:
+    run_checks()
+except AppRegistryNotReady:
+    pass

--- a/requirements-python3_6/uninstall-requirements.txt
+++ b/requirements-python3_6/uninstall-requirements.txt
@@ -8,3 +8,4 @@ restkit
 http-parser
 zeep
 cython
+django-celery-results

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -8,3 +8,4 @@ restkit
 http-parser
 zeep
 cython
+django-celery-results

--- a/settings.py
+++ b/settings.py
@@ -545,6 +545,8 @@ GET_URL_BASE = 'dimagi.utils.web.get_url_base'
 # celery
 BROKER_URL = 'redis://localhost:6379/0'
 
+CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
+
 CELERY_ANNOTATIONS = {
     '*': {
         'on_failure': helper.celery_failure_handler,


### PR DESCRIPTION
This PR does the following:

1. Adds boilerplate code necessary for running celery without a management command: http://docs.celeryproject.org/en/3.1/django/first-steps-with-django.html
2. Adds ```CELERY_RESULT_BACKEND``` to settings.py so we can remove it from localsettings in commcare-cloud
3. Adds ```django-celery-results``` to uninstall-requirements in case we upgrade to celery 4 and then have to commit a reversion.  Otherwise, requirements will fail to upgrade (discovered on staging).