### PR TITLE
Remove a few empty apps views from the main db

### DIFF
--- a/corehq/couchapps/__init__.py
+++ b/corehq/couchapps/__init__.py
@@ -19,12 +19,9 @@ CouchAppsPreindexPlugin.register('couchapps', __file__, {
         settings.NEW_DOMAINS_DB, settings.NEW_APPS_DB),
     'last_modified': (settings.USERS_GROUPS_DB, settings.DOMAINS_DB, settings.NEW_APPS_DB),
 
-    # register these views to both the main db AND the apps db.
-    'app_translations_by_popularity': (None, settings.NEW_APPS_DB),
-    'exports_forms_by_app': (None, settings.NEW_APPS_DB),
-    'forms_by_app_info': (None, settings.NEW_APPS_DB),
-
-    # register just to the new apps db
+    'app_translations_by_popularity': settings.NEW_APPS_DB,
+    'exports_forms_by_app': settings.NEW_APPS_DB,
+    'forms_by_app_info': settings.NEW_APPS_DB,
     'apps_with_submissions': settings.NEW_APPS_DB,
     'saved_apps_auto_generated': settings.NEW_APPS_DB,
     'global_app_config_by_app_id': settings.NEW_APPS_DB,


### PR DESCRIPTION
I think this was just never cleaned up after the migration 3 years ago.
We are not going to get huge space savings from this or anything (since they are empty
they are at most in the low GBs), but these empty views do actually still cause
indexing load as we iterate through all changes and just filter out everything.