### PR TITLE
Mk confirm mm fetch

### DIFF
--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -167,3 +167,7 @@ class AppLinkError(AppManagerException):
 
 class SavedAppBuildException(AppManagerException):
     pass
+
+
+class MultimediaMissingError(AppManagerException):
+    pass

--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import requests
+import json
 from couchdbkit.exceptions import ResourceNotFound
 from django.urls.base import reverse
 from requests import ConnectionError
@@ -10,6 +11,7 @@ from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.apps.linked_domain.auth import ApiKeyAuth
 from corehq.apps.linked_domain.exceptions import RemoteRequestError, RemoteAuthError, ActionNotPermitted
 from corehq.util.view_utils import absolute_reverse
+from corehq.util.soft_assert import soft_assert
 from dimagi.utils.logging import notify_exception
 
 
@@ -56,6 +58,19 @@ def pull_missing_multimedia_for_app(app):
     missing_media = _get_missing_multimedia(app)
     remote_details = app.domain_link.remote_details
     _fetch_remote_media(app.domain, missing_media, remote_details)
+    if app.domain in {'icds-cas', 'icds-test'}:
+        still_missing_media = _get_missing_multimedia(app)
+        if still_missing_media:
+            soft_assert(to='{}@{}'.format('mkangia', 'dimagi.com'))(
+                False, "Multimedia still missing", json.dumps({
+                    'domain': app.domain,
+                    'app_id': app.get_id,
+                    'fetched-attempted': missing_media,
+                    'still-missing': still_missing_media,
+                }, indent=4)
+            )
+            return False
+    return True
 
 
 def _get_missing_multimedia(app):

--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -82,11 +82,11 @@ def _get_missing_multimedia(app):
             filename = path.split('/')[-1]
             missing.append((filename, media_info))
         else:
-            _check_domain_access(app.domain, local_media)
+            _add_domain_access(app.domain, local_media)
     return missing
 
 
-def _check_domain_access(domain, media):
+def _add_domain_access(domain, media):
     if domain not in media.valid_domains:
         media.add_domain(domain)
 


### PR DESCRIPTION
This case happened today where the linked app was updated but it still had missing multimedia,
Thought it would be a good idea to fail hard and let the user know in case the mm is still missing due to some error.
This case should ideally not happen so also notified with details of mm initially requested and mm still found missing.