### PR TITLE
don't pass None to AsyncResult

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -622,8 +622,12 @@ class RestoreConfig(object):
         new_task = False
         # fetch the task from celery
         task_id = self.async_restore_task_id_cache.get_value()
-        task = AsyncResult(task_id)
-        task_exists = task.status == ASYNC_RESTORE_SENT
+        if task_id:
+            task = AsyncResult(task_id)
+            task_exists = task.status == ASYNC_RESTORE_SENT
+        else:
+            task = None
+            task_exists = False
 
         if not task_exists:
             # start a new task

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -1641,8 +1641,8 @@ class DownloadPDFReport(View):
 class CheckExportReportStatus(View):
     def get(self, request, *args, **kwargs):
         task_id = self.request.GET.get('task_id', None)
-        res = AsyncResult(task_id)
-        status = res.ready()
+        res = AsyncResult(task_id) if task_id else None
+        status = res and res.ready()
 
         if status:
             return JsonResponse(


### PR DESCRIPTION
This is required in celery 4.x and is backwards compatible with celery 3.x.

Pulled from https://github.com/dimagi/commcare-hq/pull/21588