### PR TITLE
Remove btn, it overwrites the other btn classes

### DIFF
--- a/corehq/apps/reports/templates/reports/filters/submit_error_types.html
+++ b/corehq/apps/reports/templates/reports/filters/submit_error_types.html
@@ -4,7 +4,7 @@
 {% block filter_content %}
     <div id="{{ css_id }}" class="btn-group btn-group-separated report-filter-button-group" data-toggle="buttons-checkbox">
     {% for type in submission_types %}
-        <button class="{% if type.show %} active{% else %} btn-default{% endif %}" data-checkfilter="submission-filter-{{ forloop.counter }}">{{ type.name }}</button>
+        <button class="btn {% if type.show %} active{% else %} btn-default{% endif %}" data-toggle="button" data-checkfilter="submission-filter-{{ forloop.counter }}">{{ type.name }}</button>
     {% endfor %}
     </div>
     {% for type in submission_types %}

--- a/corehq/apps/reports/templates/reports/filters/submit_error_types.html
+++ b/corehq/apps/reports/templates/reports/filters/submit_error_types.html
@@ -4,7 +4,7 @@
 {% block filter_content %}
     <div id="{{ css_id }}" class="btn-group btn-group-separated report-filter-button-group" data-toggle="buttons-checkbox">
     {% for type in submission_types %}
-        <button class="btn {% if type.show %} active{% else %} btn-default{% endif %}" data-checkfilter="submission-filter-{{ forloop.counter }}">{{ type.name }}</button>
+        <button class="{% if type.show %} active{% else %} btn-default{% endif %}" data-checkfilter="submission-filter-{{ forloop.counter }}">{{ type.name }}</button>
     {% endfor %}
     </div>
     {% for type in submission_types %}


### PR DESCRIPTION
Interrupt ticket: https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=5&projectKey=HI&modal=detail&selectedIssue=HI-375&quickFilter=3
Follow up to this PR: https://github.com/dimagi/commcare-hq/pull/23238

Turns out adding `btn` here overwrites btn-primary and btn-default, and makes the buttons look the same whether they're clicked or not (my bad, should have tested more thoroughly post-review). You mentioned that btn is what sets the formatting, but it seems to be formatted the same if I remove it. I guess that somewhere is bootstrap.css it defines btn-<whatever> as a kind of btn, does that seem likely?

@orangejenny 
@proteusvacuum 