### PR TITLE
Added more logging and some cleanup to CCZ multimedia generation

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from io import BytesIO
 
 import magic
-from couchdbkit.exceptions import ResourceConflict
+from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from django.template.defaultfilters import filesizeformat
 
 from corehq import privileges
@@ -956,7 +956,6 @@ class ApplicationMediaMixin(Document, MediaMixin):
             else:
                 # Re-attempt to fetch media directly from couch
                 media = CommCareMultimedia.get_doc_class(map_item.media_type)
-                success = False
                 try:
                     media = media.get(map_item.multimedia_id)
                     retry_successes.append(map_item)

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -960,8 +960,10 @@ class ApplicationMediaMixin(Document, MediaMixin):
                     media = media.get(map_item.multimedia_id)
                     retry_successes.append(map_item)
                     yield path, media
-                except ResourceNotFound:
+                except ResourceNotFound as e:
                     retry_failures.append(map_item)
+                    if toggles.CAUTIOUS_MULTIMEDIA.enabled(self.domain):
+                        raise e
 
         if toggles.CAUTIOUS_MULTIMEDIA.enabled(self.domain):
             if retry_successes or retry_failures:


### PR DESCRIPTION
Minor changes while investigating https://dimagi-dev.atlassian.net/browse/ICDS-291

* When preloading multimedia docs, only grab the ones relevant to the current build profile.
* Stop attempting to delete media from the app's multimedia_map if that media isn't found in couch. We've been doing this for years, but I don't think it makes sense. It makes sense to delete from the map when a file is no longer referenced in the app, but if the file isn't in couch that seems like more of a bug.
* If a file isn't found, retry. Track the retries and notify. I'm guessing that when this notification goes off, it'll show none of the retries will have been successful (because the media is genuinely missing from couch) but I'd like to know that for 100% certain.

@mkangia / @snopoke 
code buddy @millerdev 