### PR TITLE
Icds reports tabular reports inform user about failed report generation

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -10,6 +10,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     vm.yearsCopy = [];
     vm.task_id = $location.search()['task_id'] || '';
     vm.haveAccessToFeatures = haveAccessToFeatures;
+    vm.previousTaskFailed = null;
     $rootScope.report_link = '';
 
     var getTaskStatus = function () {
@@ -17,7 +18,8 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
             if (resp.task_ready) {
                 clearInterval(vm.statusCheck);
                 $rootScope.task_id = '';
-                $rootScope.report_link = resp.task_result.link;
+                vm.previousTaskFailed = !resp.task_successful;
+                $rootScope.report_link = resp.task_successful ? resp.task_result.link : '';
                 vm.queuedTask = false;
             }
         });
@@ -420,6 +422,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         });
         vm.queuedTask = true;
         vm.downloaded = false;
+        vm.previousTaskFailed = null;
     };
 
     vm.resetForm = function() {
@@ -514,7 +517,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     };
 
     vm.readyToDownload = function () {
-        return $rootScope.report_link;
+        return vm.previousTaskFailed ? false : $rootScope.report_link;
     };
 
     vm.goToLink = function () {

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -65,7 +65,7 @@ from custom.icds_reports.models import (
     AggLs,
     AggAwc,
     AwcLocation,
-    AwcLocationMonths)
+)
 from custom.icds_reports.models.aggregate import AggregateInactiveAWW, AggAwcDaily, DailyAttendance,\
     AggregateLsVhndForm, AggregateBeneficiaryForm, AggregateLsAWCVisitForm
 from custom.icds_reports.models.helper import IcdsFile
@@ -671,29 +671,20 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
             month=config['month'],
             aggregation_level=aggregation_level
         ).get_excel_data()
-        if aggregation_level == 1:
-            location_object = AwcLocationMonths.objects.filter(
-                state_id=location,
-                aggregation_level=aggregation_level
-            ).first()
-        elif aggregation_level == 2:
-            location_object = AwcLocationMonths.objects.filter(
-                district_id=location,
-                aggregation_level=aggregation_level
-            ).first()
-        else:
-            location_object = AwcLocationMonths.objects.filter(
-                block_id=location,
-                aggregation_level=aggregation_level
-            ).first()
         if file_format == 'xlsx':
             cache_key = create_aww_performance_excel_file(
                 excel_data,
                 data_type,
                 config['month'].strftime("%B %Y"),
-                location_object.state_name,
-                location_object.district_name if aggregation_level >= 2 else None,
-                location_object.block_name if aggregation_level == 3 else None,
+                state=SQLLocation.objects.get(
+                    location_id=config['state_id'], domain=config['domain']
+                ).name,
+                district=SQLLocation.objects.get(
+                    location_id=config['district_id'], domain=config['domain']
+                ).name if aggregation_level >= 2 else None,
+                block=SQLLocation.objects.get(
+                    location_id=config['block_id'], domain=config['domain']
+                ).name if aggregation_level == 3 else None,
             )
         else:
             cache_key = create_excel_file(excel_data, data_type, file_format)

--- a/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
@@ -228,7 +228,7 @@
                     </form>
                 </div>
             </div>
-            <div class="issnip-spinner-container" ng-if="($ctrl.showProgressBar() || $ctrl.readyToDownload() || $ctrl.queuedTask) && !$ctrl.downloaded">
+            <div class="issnip-spinner-container" ng-if="($ctrl.showProgressBar() || $ctrl.readyToDownload() || $ctrl.queuedTask || $ctrl.previousTaskFailed) && !$ctrl.downloaded">
                 <i ng-if="$ctrl.showProgressBar() || $ctrl.queuedTask" class="fa fa-circle-o-notch fa-spin"></i>
                 <span ng-if="$ctrl.showProgressBar() || $ctrl.queuedTask">Preparing your report...</span>
                 <span ng-if="$ctrl.readyToDownload()">Your report is ready to be downloaded</span>

--- a/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/download.directive.html
@@ -232,6 +232,7 @@
                 <i ng-if="$ctrl.showProgressBar() || $ctrl.queuedTask" class="fa fa-circle-o-notch fa-spin"></i>
                 <span ng-if="$ctrl.showProgressBar() || $ctrl.queuedTask">Preparing your report...</span>
                 <span ng-if="$ctrl.readyToDownload()">Your report is ready to be downloaded</span>
+                <span ng-if="$ctrl.previousTaskFailed">Generation of your report has failed</span>
                 <a class="btn btn-primary" ng-click="$ctrl.goToLink()"
                    ng-disabled="!$ctrl.readyToDownload()"><span>Download</span></a>
             </div>

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -1648,7 +1648,8 @@ class CheckExportReportStatus(View):
             return JsonResponse(
                 {
                     'task_ready': status,
-                    'task_result': res.result
+                    'task_successful': res.successful(),
+                    'task_result': res.result if res.successful() else None
                 }
             )
         return JsonResponse({'task_ready': status})


### PR DESCRIPTION
Hi @calellowitz,
This is a fix to the [ICDS-362](https://dimagi-dev.atlassian.net/browse/ICDS-362) ticket.
If report generation in celery task failed user would not be informed about it but would only see the `Preparing your report...` message and download directive would keep sending requests to the server about the status of the task, that would, in turn, respond with 500 due to the `AsyncResult`, that we use to check the status of the task, not having `.result` but being `.ready()`.

That's why I have added the check for `AsyncResult.successful()` to the view and additional information `task_successful` in the response.

Now if a task fails, download directive will get in return response with 200 status code without `task_result` and with `task_successful` equal false but still `task_ready` equal true. That will cause the directive to stop sending additional requests about the status of the task and `Preparing your report...` message will be replaced by `Generation of your report has failed`. This message will be removed upon trying to export another report.

Need QA: No
Environment: n/a
Locally Tested: Yes
Regards, Dawid