### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/en/articles/about-code-owners
+
+/custom/aaa/ @emord


### PR DESCRIPTION
@dimagi/team-commcare-hq I ran across this while looking at draft pull requests. It allows you to specify some paths so that you are automatically added to the review list when a PR is made in that directory or for those files. 

travis build was explicitly killed