### PR TITLE
Sync locations on app changes

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -54,11 +54,12 @@ class LocationSet(object):
         return item in self.by_id
 
 
-def should_sync_locations(last_sync, locations_queryset, restore_user):
+def should_sync_locations(last_sync, locations_queryset, restore_state):
     """
     Determine if any locations (already filtered to be relevant
     to this user) require syncing.
     """
+    restore_user = restore_state.restore_user
     if (
         not last_sync or
         not last_sync.date or
@@ -105,7 +106,7 @@ class LocationFixtureProvider(FixtureProvider):
 
         # This just calls get_location_fixture_queryset but is memoized to the user
         locations_queryset = restore_user.get_locations_to_sync()
-        if not should_sync_locations(restore_state.last_sync_log, locations_queryset, restore_user):
+        if not should_sync_locations(restore_state.last_sync_log, locations_queryset, restore_state):
             return []
 
         data_fields = _get_location_data_fields(restore_user.domain)

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -59,7 +59,13 @@ def should_sync_locations(last_sync, locations_queryset, restore_state):
     Determine if any locations (already filtered to be relevant
     to this user) require syncing.
     """
+    if (last_sync and last_sync.build_id is not None
+            and restore_state.params.app_id is not None
+            and restore_state.params.app_id != last_sync.build_id):
+        return True
+
     restore_user = restore_state.restore_user
+
     if (
         not last_sync or
         not last_sync.date or

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -306,7 +306,7 @@ class RestoreParams(object):
 
     @property
     def app_id(self):
-        return self.app._id if self.app else None
+        return self.app.get_id if self.app else None
 
 
 class RestoreCacheSettings(object):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/REACH-102

This particular fix always sends down the location fixture when the build is different from the previous build. This has come up for REACH due to the frequency of reverts between the old and new apps they do with ICDS and they are now syncing flat locations for their work.

@esoergel you may have some interest in commenting on the jira ticket since own locations. There's another error where we may not be correctly invalidating locations when removoing users from a location.