### PR TITLE
Fix filtering on sector/supervisor

### DIFF
--- a/custom/aaa/static/aaa/js/filters/location_filter.js
+++ b/custom/aaa/static/aaa/js/filters/location_filter.js
@@ -56,16 +56,16 @@ hqDefine('aaa/js/filters/location_filter', [
                     ]);
                 } else {
                     var block = locationModel.locationModel({slug: 'block', name: 'Block', parent: district, userLocationId: self.userLocationIds[2], postData: params.postData});
-                    var sector = locationModel.locationModel({slug: 'sector', name: 'Sector (Project)', parent: block, userLocationId: self.userLocationIds[3], postData: params.postData});
-                    var awc = locationModel.locationModel({slug: 'awc', name: 'AWC', parent: sector, userLocationId: self.userLocationIds[4], postData: params.postData});
+                    var supervisor = locationModel.locationModel({slug: 'supervisor', name: 'Sector (Project)', parent: block, userLocationId: self.userLocationIds[3], postData: params.postData});
+                    var awc = locationModel.locationModel({slug: 'awc', name: 'AWC', parent: supervisor, userLocationId: self.userLocationIds[4], postData: params.postData});
                     district.setChild((block));
-                    block.setChild(sector);
-                    sector.setChild(awc);
+                    block.setChild(supervisor);
+                    supervisor.setChild(awc);
                     self.hierarchyConfig([
                         state,
                         district,
                         block,
-                        sector,
+                        supervisor,
                         awc,
                     ]);
                 }

--- a/custom/aaa/static/aaa/spec/filters/location_filter.spec.js
+++ b/custom/aaa/static/aaa/spec/filters/location_filter.spec.js
@@ -42,15 +42,15 @@ describe('Reach Location Filter', function () {
             state.setChild(district);
             var block = locationModel.locationModel({slug: 'block', name: 'Block', parent: district, userLocationId: void(0), postData: {}});
             district.setChild(block);
-            var sector = locationModel.locationModel({slug: 'sector', name: 'Sector (Project)', parent: block, userLocationId: void(0), postData: {}});
-            block.setChild(sector);
-            var awc = locationModel.locationModel({slug: 'awc', name: 'AWC', parent: sector, userLocationId: void(0), postData: {}});
-            sector.setChild(awc);
+            var supervisor = locationModel.locationModel({slug: 'supervisor', name: 'Sector (Project)', parent: block, userLocationId: void(0), postData: {}});
+            block.setChild(supervisor);
+            var awc = locationModel.locationModel({slug: 'awc', name: 'AWC', parent: supervisor, userLocationId: void(0), postData: {}});
+            supervisor.setChild(awc);
             var expectedHierarchy = [
                 state,
                 district,
                 block,
-                sector,
+                supervisor,
                 awc,
             ];
             _.each(expectedHierarchy, function (element, idx) {


### PR DESCRIPTION
@lwyszomi I noticed this today. The location type codes are supervisor even though the display names are sector. I think the test domain was setup incorrectly at some point, so its easy to get confused