### PR TITLE
use text not bytes in migration

### DIFF
--- a/corehq/apps/notifications/migrations/0001_squashed_0003_auto_20160504_2049.py
+++ b/corehq/apps/notifications/migrations/0001_squashed_0003_auto_20160504_2049.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 class Migration(migrations.Migration):
 
-    replaces = [(b'notifications', '0001_initial'), (b'notifications', '0002_auto_20160504_1904'), (b'notifications', '0003_auto_20160504_2049')]
+    replaces = [('notifications', '0001_initial'), ('notifications', '0002_auto_20160504_1904'), ('notifications', '0003_auto_20160504_2049')]
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),


### PR DESCRIPTION
The bytes cause ```migrate_multi``` to fail in python 3.

@dimagi/py3 