### PR TITLE
fix corehq.apps.hqwebapp.tests.test_requirejs:TestRequireJSBuild.test…

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -83,6 +83,7 @@ class Command(ResourceStaticCommand):
                 proc = subprocess.Popen(["grep", "^\s*{% requirejs_main [^%]* %}\s*$", filename],
                                         stdout=subprocess.PIPE)
                 (out, err) = proc.communicate()
+                out = out.decode('utf-8')
                 if out:
                     match = re.search(r"{% requirejs_main .(([^%]*)/[^/%]*). %}", out)
                     if match:

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -121,6 +121,7 @@ class Command(ResourceStaticCommand):
             proc = subprocess.Popen(["git", "diff-files", "--ignore-submodules", "--name-only"],
                                     stdout=subprocess.PIPE)
             (out, err) = proc.communicate()
+            out = out.decode('utf-8')
             if out:
                 confirm = six.moves.input("You have unstaged changes to the following files: \n{} "
                                     "This script overwrites some static files. "


### PR DESCRIPTION
…_no_select2_conflicts

```proc.communicate()``` returns bytes, which must be decoded before being used with text.

@dimagi/py3 