### PR TITLE
Cleaner export info generation

### DIFF
--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -951,16 +951,9 @@ def create_aww_performance_excel_file(excel_data, data_type, month, state, distr
     # export info
     worksheet2 = workbook.create_sheet("Export Info")
     worksheet2.column_dimensions['A'].width = 14
-    worksheet2['A1'].value = export_info[0][0]
-    worksheet2['B1'].value = export_info[0][1]
-    worksheet2['A2'].value = export_info[1][0]
-    worksheet2['B2'].value = export_info[1][1]
-    worksheet2['A3'].value = export_info[2][0]
-    worksheet2['B3'].value = export_info[2][1]
-    worksheet2['A4'].value = export_info[3][0]
-    worksheet2['B4'].value = export_info[3][1]
-    worksheet2['A4'].value = export_info[4][0]
-    worksheet2['B4'].value = export_info[4][1]
+    for n, export_info_item in enumerate(export_info, start=1):
+        worksheet2['A{0}'.format(n)].value = export_info_item[0]
+        worksheet2['B{0}'.format(n)].value = export_info_item[1]
 
     # saving file
     file_hash = uuid.uuid4().hex


### PR DESCRIPTION
Hi @calellowitz,
I have cleaned the export info generation in AWW Performance Report, which also fixes missing `year` export info as it was overwritten by the disclaimer.
Regards, Dawid