### PR TITLE
Fix service delivery report: remove month filter.

### DIFF
--- a/custom/icds_reports/migrations/sql_templates/database_views/service_delivery_monthly.sql
+++ b/custom/icds_reports/migrations/sql_templates/database_views/service_delivery_monthly.sql
@@ -67,7 +67,6 @@ INNER JOIN (
         SUM(CASE WHEN agg_ccs_record.ccs_status in ('lactating', 'pregnant') THEN agg_ccs_record.rations_21_plus_distributed ELSE 0 END) as mother_thr,
         SUM(valid_in_month) as mother_thr_eligible
         from agg_ccs_record
-        where month='2018-05-01'
         group by state_id,district_id,block_id,supervisor_id,awc_id,aggregation_level, month
 
         ) ccr on (


### PR DESCRIPTION
Remove specific month selected.
This is silly mistake I left in this and caught be self QA.
@calellowitz  can you have a look.
I have cross checked the view. and removed such problems. Can you please given 10 mins and see I caught everything. I don't want any hanging stuff and other person need to correct that for me. 


