### PR TITLE
AWC reports beneficiary details page add imperfect tooltip matches fo…

### DIFF
--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -2149,17 +2149,69 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                     var attended = day ? day.attended : '0';
                     var eligible = day ? day.eligible : '0';
 
-                    var tooltip_content = "<p><strong>" + d3.time.format('%b %Y')(new Date(d.value)) + "</strong></p><br/>";
-                    tooltip_content += "<div>Number of children who attended PSE: <strong>" + attended + "</strong></div>";
-                    tooltip_content += "<div>Number of children who were eligible to attend PSE: <strong>" + eligible + "</strong></div>";
+                    var tooltipContent = "<p><strong>" + d3.time.format('%b %Y')(new Date(d.value)) + "</strong></p><br/>";
+                    tooltipContent += "<div>Number of children who attended PSE: <strong>" + attended + "</strong></div>";
+                    tooltipContent += "<div>Number of children who were eligible to attend PSE: <strong>" + eligible + "</strong></div>";
 
-                    return tooltip_content;
+                    return tooltipContent;
                 });
                 return chart;
             },
             reduceXTicks: false,
             showLegend: false,
         },
+    };
+
+    vm.beneficiaryChartCallback = function (
+        lineChartDataName,
+        nominatorName,
+        nominatorUnit,
+        denominatorName,
+        denominatorUnit
+    ) {
+        return function (chart) {
+            var tooltip = chart.interactiveLayer.tooltip;
+            tooltip.contentGenerator(function (d) {
+                var html = "";
+                var tooltipData = void(0);
+                // lineChartData can not be provided during generation
+                var lineChartData = null;
+                if (lineChartDataName === 'lineChartTwoData') {lineChartData = vm.lineChartTwoData;}
+                if (lineChartDataName === 'lineChartOneData') {lineChartData = vm.lineChartOneData;}
+                if (lineChartDataName === 'lineChartThreeData') {lineChartData = vm.lineChartThreeData;}
+                for (var i = 0; i < lineChartData.length; i++) {
+                    if (lineChartData[i].x === d.value) {
+                        tooltipData = lineChartData[i];
+                    }
+                }
+                // search for imperfect values in tooltip in Weight For Height graph
+                if (lineChartDataName === 'lineChartThreeData' && tooltipData === void(0)) {
+                    for (i = 0; i < lineChartData.length; i++) {
+                        if (Math.abs(lineChartData[i].x - d.value) < 0.5) {
+                            tooltipData = lineChartData[i];
+                        }
+                    }
+                }
+                var denominatorValue = d.value;
+                if (tooltipData) {
+                    html = "<p>" + nominatorName + ": <strong>" + tooltipData.y + "</strong> " +
+                        nominatorUnit + "</p>";
+                    denominatorValue = tooltipData.x;  // show correct X value for imperfect WFH matches
+                } else {
+                    html = "<p>" + nominatorName + ": <strong>Data Not Recorded</strong></p>";
+                }
+                if (denominatorUnit === 'month') {
+                    denominatorUnit = denominatorValue === 1 ? "month" : "months";
+                }
+                html += "<p>" + denominatorName + ": <strong>" + denominatorValue + "</strong> " +
+                    denominatorUnit + "</p>";
+                return html;
+            });
+            window.angular.forEach(d3.selectAll('g.nv-series-3 > path')[0], function (key) {
+                if (key.__data__[0].y !== null) key.classList.add('chart-dot');
+            });
+            return chart;
+        };
     };
 
     vm.beneficiaryChartOptionsHFA = {
@@ -2197,31 +2249,13 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             interactiveLayer: {
                 showGuideLine: true,
             },
-            callback: function (chart) {
-                var tooltip = chart.interactiveLayer.tooltip;
-                tooltip.contentGenerator(function (d) {
-                    var html = "";
-                    var tooltipData = void(0);
-                    for (var i = 0; i < vm.lineChartTwoData.length; i++) {
-                        if (vm.lineChartTwoData[i].x === d.value) {
-                            tooltipData = vm.lineChartTwoData[i];
-                        }
-                    }
-
-                    if (tooltipData) {
-                        html = "<p>Height: <strong>" + tooltipData.y + "</strong> cm</p>";
-                    } else {
-                        html = "<p>Height: <strong>Data Not Recorded</strong></p>";
-                    }
-                    var month = d.value === 1 ? "month" : "months";
-                    html += "<p>Age: <strong>" + d.value + "</strong> " + month + "</p>";
-                    return html;
-                });
-                window.angular.forEach(d3.selectAll('g.nv-series-3 > path')[0], function (key) {
-                    if (key.__data__[0].y !== null) key.classList.add('chart-dot');
-                });
-                return chart;
-            },
+            callback: vm.beneficiaryChartCallback(
+                'lineChartTwoData',
+                'Height',
+                'cm',
+                'Age',
+                'month'
+            ),
         },
     };
 
@@ -2260,31 +2294,13 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             interactiveLayer: {
                 showGuideLine: true,
             },
-            callback: function (chart) {
-                var tooltip = chart.interactiveLayer.tooltip;
-                tooltip.contentGenerator(function (d) {
-                    var html = "";
-                    var tooltipData = void(0);
-                    for (var i = 0; i < vm.lineChartOneData.length; i++) {
-                        if (vm.lineChartOneData[i].x === d.value) {
-                            tooltipData = vm.lineChartOneData[i];
-                        }
-                    }
-
-                    if (tooltipData) {
-                        html = "<p>Weight: <strong>" + tooltipData.y + "</strong> kg</p>";
-                    } else {
-                        html = "<p>Weight: <strong>Data Not Recorded</strong></p>";
-                    }
-                    var month = d.value === 1 ? "month" : "months";
-                    html += "<p>Age: <strong>" + d.value + "</strong> " + month + "</p>";
-                    return html;
-                });
-                window.angular.forEach(d3.selectAll('g.nv-series-3 > path')[0], function (key) {
-                    if (key.__data__[0].y !== null) key.classList.add('chart-dot');
-                });
-                return chart;
-            },
+            callback: vm.beneficiaryChartCallback(
+                'lineChartOneData',
+                'Weight',
+                'kg',
+                'Age',
+                'month'
+            ),
         },
     };
 
@@ -2323,30 +2339,13 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
             interactiveLayer: {
                 showGuideLine: true,
             },
-            callback: function (chart) {
-                var tooltip = chart.interactiveLayer.tooltip;
-                tooltip.contentGenerator(function (d) {
-                    var html = "";
-                    var tooltipData = void(0);
-                    for (var i = 0; i < vm.lineChartThreeData.length; i++) {
-                        if (vm.lineChartThreeData[i].x === d.value) {
-                            tooltipData = vm.lineChartThreeData[i];
-                        }
-                    }
-
-                    if (tooltipData) {
-                        html = "<p>Weight: <strong>" + tooltipData.y + "</strong> kg</p>";
-                    } else {
-                        html = "<p>Weight: <strong>Data Not Recorded</strong></p>";
-                    }
-                    html += "<p>Height: <strong>" + d.value + "</strong> cm</p>";
-                    return html;
-                });
-                window.angular.forEach(d3.selectAll('g.nv-series-3 > path')[0], function (key) {
-                    if (key.__data__[0].y !== null) key.classList.add('chart-dot');
-                });
-                return chart;
-            },
+            callback: vm.beneficiaryChartCallback(
+                'lineChartThreeData',
+                'Weight',
+                'kg',
+                'Height',
+                'cm'
+            ),
         },
     };
 


### PR DESCRIPTION
…r weight for height graph
Hi @calellowitz,
I have added imperfect tooltip matches for weight for height graph tooltip as well as I have created a generator function for tooltip callbacks for the beneficiary details page.

By the comments:

1. The `lineChartData` for example `vm.lineChartTwoData` cannot be passed as pointers to the generators, that's why the `lineChartDataName` is used instead.
2. There is an additional search for imperfect matches for tooltip if perfect was not found in weight for height graph. The helper line for this graph has a tick of 0.5 cm.
3. Finally, if the imperfect value would be shown, the X value is changed, for example, we search for value at 80.5 cm, yet we find that we don't have any measure for 80.5 cm but we have for 80.8 cm, then the height part of tooltip will show 80.8 cm rather than 80.5 cm.

This change is related to the [ICDS-354](https://dimagi-dev.atlassian.net/browse/ICDS-354) JIRA ticket.

Need QA: Yes
Environment: n/a
Locally Tested: Yes
Regards, Dawid