### PR TITLE
Tabular reports select AWC location and assign selected location befo…

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -303,20 +303,18 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
                 if ($item.user_have_access) {
                     locationsCache[$item.location_id] = [ALL_OPTION].concat(data.locations);
                     vm.selectedLocations[level + 1] = ALL_OPTION.location_id;
-                    vm.selectedLocationId = vm.selectedLocations[selectedLocationIndex()];
                 } else {
                     locationsCache[$item.location_id] = data.locations;
                     vm.selectedLocations[level + 1] = data.locations[0].location_id;
-                    vm.selectedLocationId = vm.selectedLocations[selectedLocationIndex()];
                     if (level === 2 && vm.isISSNIPMonthlyRegisterSelected()) {
                         vm.onSelectForISSNIP(data.locations[0], level + 1);
                     } else {
                         vm.onSelect(data.locations[0], level + 1);
                     }
-
                 }
             });
         }
+        vm.selectedLocationId = vm.selectedLocations[selectedLocationIndex()];
         var levels = [];
         vm.selectedLevel = selectedLocationIndex() + 1;
         window.angular.forEach(vm.levels, function (value) {


### PR DESCRIPTION
…re searching for ancestors
Hi @calellowitz,
I have fixed the issue where multiple records were coming when the report has been downloaded at AWC level.

The AWC location was not selected in the end as selecting logic was done after getting the result from the ancestor searching that AWC was prohibited from executing as it is the last level that won't have ancestors.

For other levels that also means that selected location will be selected right after selecting it rather than after getting the result of the children of the location (before next level drop-down is available).

PR is related to [ICDS-372](https://dimagi-dev.atlassian.net/browse/ICDS-372) and [ICDS-294](https://dimagi-dev.atlassian.net/browse/ICDS-294) JIRA tickets.

Need QA: Yes
Environment: n/a
Locally Tested: Yes
Regards, Dawid