### PR TITLE
remove serializer='pickle' from celery tasks that are never passed arguments

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -239,7 +239,7 @@ def check_credit_line_balances():
             )
 
 
-@periodic_task(run_every=crontab(hour=13, minute=0, day_of_month='1'), acks_late=True)
+@periodic_task(serializer='pickle', run_every=crontab(hour=13, minute=0, day_of_month='1'), acks_late=True)
 def generate_invoices(based_on_date=None):
     """
     Generates all invoices for the past month.

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -630,7 +630,8 @@ def pay_autopay_invoices():
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue='background_queue', acks_late=True)
-def update_exchange_rates(app_id=settings.OPEN_EXCHANGE_RATES_API_ID):
+def update_exchange_rates():
+    app_id = settings.OPEN_EXCHANGE_RATES_API_ID
     if app_id:
         try:
             log_accounting_info("Updating exchange rates...")

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -694,8 +694,8 @@ def assign_explicit_community_subscription(domain_name, start_date, method, acco
 
 
 @periodic_task(run_every=crontab(minute=0, hour=9), queue='background_queue', acks_late=True)
-def run_downgrade_process(today=None):
-    today = today or datetime.date.today()
+def run_downgrade_process():
+    today = datetime.date.today()
 
     for domain, oldest_unpaid_invoice, total in _get_domains_with_invoices_over_threshold(today):
         current_subscription = Subscription.get_active_subscription_by_domain(domain)

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -214,7 +214,7 @@ def warn_subscriptions_without_domain():
         log_accounting_error('Domain %s has an active subscription but does not exist.' % domain_name)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=5), acks_late=True)
+@periodic_task(run_every=crontab(minute=0, hour=5), acks_late=True)
 def update_subscriptions():
     deactivate_subscriptions(datetime.date.today())
     deactivate_subscriptions()
@@ -239,7 +239,7 @@ def check_credit_line_balances():
             )
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour=13, minute=0, day_of_month='1'), acks_late=True)
+@periodic_task(run_every=crontab(hour=13, minute=0, day_of_month='1'), acks_late=True)
 def generate_invoices(based_on_date=None):
     """
     Generates all invoices for the past month.
@@ -375,7 +375,7 @@ def send_bookkeeper_email(month=None, year=None, emails=None):
         })
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0), acks_late=True)
+@periodic_task(run_every=crontab(minute=0, hour=0), acks_late=True)
 def remind_subscription_ending():
     """
     Sends reminder emails for subscriptions ending N days from now.
@@ -385,7 +385,7 @@ def remind_subscription_ending():
     send_subscription_reminder_emails(1)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0), acks_late=True)
+@periodic_task(run_every=crontab(minute=0, hour=0), acks_late=True)
 def remind_dimagi_contact_subscription_ending_60_days():
     """
     Sends reminder emails to Dimagi contacts that subscriptions are ending in 60 days
@@ -528,7 +528,7 @@ def send_autopay_failed(invoice):
 
 
 # Email this out every Monday morning.
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0, day_of_week=1), acks_late=True)
+@periodic_task(run_every=crontab(minute=0, hour=0, day_of_week=1), acks_late=True)
 def weekly_digest():
     today = datetime.date.today()
     in_forty_days = today + datetime.timedelta(days=40)
@@ -623,13 +623,13 @@ def weekly_digest():
         })
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour=1, minute=0,), acks_late=True)
+@periodic_task(run_every=crontab(hour=1, minute=0,), acks_late=True)
 def pay_autopay_invoices():
     """ Check for autopayable invoices every day and pay them """
     AutoPayInvoicePaymentHandler().pay_autopayable_invoices(datetime.datetime.today())
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0), queue='background_queue', acks_late=True)
+@periodic_task(run_every=crontab(minute=0, hour=0), queue='background_queue', acks_late=True)
 def update_exchange_rates(app_id=settings.OPEN_EXCHANGE_RATES_API_ID):
     if app_id:
         try:
@@ -692,7 +692,7 @@ def assign_explicit_community_subscription(domain_name, start_date, method, acco
     )
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=9), queue='background_queue', acks_late=True)
+@periodic_task(run_every=crontab(minute=0, hour=9), queue='background_queue', acks_late=True)
 def run_downgrade_process(today=None):
     today = today or datetime.date.today()
 
@@ -857,7 +857,7 @@ def restore_logos(self, domain_name):
         raise e
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month='1', hour=5, minute=0), queue='background_queue', acks_late=True)
+@periodic_task(run_every=crontab(day_of_month='1', hour=5, minute=0), queue='background_queue', acks_late=True)
 def send_prepaid_credits_export():
     if settings.ENTERPRISE_MODE:
         return
@@ -958,7 +958,7 @@ def email_enterprise_report(domain, slug, couch_user):
     send_html_email_async(subject, couch_user.username, body)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour=1, minute=0, day_of_month='1'), acks_late=True)
+@periodic_task(run_every=crontab(hour=1, minute=0, day_of_month='1'), acks_late=True)
 def calculate_users_in_all_domains():
     for domain in Domain.get_all_names():
         num_users = CommCareUser.total_by_domain(domain)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -449,7 +449,7 @@ def _log_failed_periodic_data(email, message):
     )
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute="0", hour="4"), queue='background_queue')
+@periodic_task(run_every=crontab(minute="0", hour="4"), queue='background_queue')
 def track_periodic_data():
     """
     Sync data that is neither event or page based with hubspot/Kissmetrics

--- a/corehq/apps/api/tasks.py
+++ b/corehq/apps/api/tasks.py
@@ -6,7 +6,7 @@ from celery.task.base import periodic_task
 from tastypie.models import ApiAccess
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0), queue='background_queue')
+@periodic_task(run_every=crontab(minute=0, hour=0), queue='background_queue')
 def clean_api_access():
     accessed = int(time.time()) - 30 * 24 * 3600  # only keep last 30 days
     ApiAccess.objects.filter(accessed__lt=accessed).delete()

--- a/corehq/apps/callcenter/tasks.py
+++ b/corehq/apps/callcenter/tasks.py
@@ -14,7 +14,7 @@ from corehq.apps.callcenter.utils import get_call_center_domains, is_midnight_fo
 logger = get_task_logger(__name__)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute='*/15'), queue='background_queue')
+@periodic_task(run_every=crontab(minute='*/15'), queue='background_queue')
 def calculate_indicators():
     """
     Although this task runs every 15 minutes it only re-calculates the

--- a/corehq/apps/cleanup/tasks.py
+++ b/corehq/apps/cleanup/tasks.py
@@ -36,7 +36,7 @@ def json_handler(obj):
         return json.JSONEncoder().default(obj)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_week=[1, 4], hour=0, minute=0))  # every Monday and Thursday
+@periodic_task(run_every=crontab(day_of_week=[1, 4], hour=0, minute=0))  # every Monday and Thursday
 def fix_xforms_with_missing_xmlns():
     log_file_name = 'undefined_xmlns.{}-timestamp.log'.format(int(time()))
     log_file_path = os.path.join(UNDEFINED_XMLNS_LOG_DIR, log_file_name)
@@ -146,7 +146,7 @@ def pprint_stats(stats, outstream):
             outstream.write("        {}\n".format(user))
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def clear_expired_sessions():
     call_command('clearsessions')
 

--- a/corehq/apps/couch_sql_migration/tasks.py
+++ b/corehq/apps/couch_sql_migration/tasks.py
@@ -8,7 +8,7 @@ from corehq.apps.es import DomainES, filters, aggregations
 from corehq.util.datadog.gauges import datadog_gauge
 
 
-@periodic_task(serializer='pickle', queue='background_queue', run_every=crontab(minute=0, hour=10),
+@periodic_task(queue='background_queue', run_every=crontab(minute=0, hour=10),
                acks_late=True, ignore_result=True)
 def couch_sql_migration_stats():
     result = (

--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -14,7 +14,7 @@ from django.conf import settings
 logger = get_task_logger(__name__)
 
 
-@periodic_task(serializer='pickle', queue='background_queue', run_every=crontab(hour=1, minute=0, day_of_month='2'),
+@periodic_task(queue='background_queue', run_every=crontab(hour=1, minute=0, day_of_month='2'),
                acks_late=True, ignore_result=True)
 def build_last_month_MALT():
     def _last_month_datespan():
@@ -39,7 +39,7 @@ def build_last_month_MALT():
     )
 
 
-@periodic_task(serializer='pickle', queue='background_queue', run_every=crontab(hour=2, minute=0, day_of_week='*'),
+@periodic_task(queue='background_queue', run_every=crontab(hour=2, minute=0, day_of_week='*'),
                ignore_result=True)
 def update_current_MALT():
     today = datetime.date.today()
@@ -47,7 +47,7 @@ def update_current_MALT():
     MALTTableGenerator([this_month]).build_table()
 
 
-@periodic_task(serializer='pickle', queue='background_queue', run_every=crontab(hour=1, minute=0, day_of_month='3'),
+@periodic_task(queue='background_queue', run_every=crontab(hour=1, minute=0, day_of_month='3'),
                acks_late=True, ignore_result=True)
 def build_last_month_GIR():
     def _last_month_datespan():

--- a/corehq/apps/domain/tasks.py
+++ b/corehq/apps/domain/tasks.py
@@ -60,7 +60,7 @@ def incomplete_domains_to_email():
     return email_domains
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(minute=0, hour=0, day_of_week="monday", day_of_month="15-21"),
     queue='background_queue'
 )
@@ -102,7 +102,7 @@ def incomplete_self_started_domains():
     return email_domains
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(minute=0, hour=0, day_of_week="monday", day_of_month="15-21"),
     queue='background_queue',
 )

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -155,7 +155,7 @@ def export_for_group_async(group_config_id):
     export_for_group(group_config, last_access_cutoff=last_access_cutoff)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="23", minute="59", day_of_week="*"),
+@periodic_task(run_every=crontab(hour="23", minute="59", day_of_week="*"),
                queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def saved_exports():
     for group_config_id in get_doc_ids_by_class(HQGroupExportConfiguration):

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -30,7 +30,7 @@ from .utils import check_for_rewind
 _soft_assert_superusers = soft_assert(notify_admins=True)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour=0, minute=0), queue='background_queue')
+@periodic_task(run_every=crontab(hour=0, minute=0), queue='background_queue')
 def check_pillows_for_rewind():
     for pillow in get_couch_pillow_instances():
         checkpoint = pillow.checkpoint
@@ -46,7 +46,7 @@ def check_pillows_for_rewind():
             )
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour=0, minute=0), queue='background_queue')
+@periodic_task(run_every=crontab(hour=0, minute=0), queue='background_queue')
 def create_historical_checkpoints():
     today = date.today()
     thirty_days_ago = today - timedelta(days=30)
@@ -54,7 +54,7 @@ def create_historical_checkpoints():
     HistoricalPillowCheckpoint.objects.filter(date_updated__lt=thirty_days_ago).delete()
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0), queue='background_queue')
+@periodic_task(run_every=crontab(minute=0), queue='background_queue')
 def check_non_dimagi_superusers():
     non_dimagis_superuser = ', '.join((get_user_model().objects.filter(
         (Q(is_staff=True) | Q(is_superuser=True)) & ~Q(username__endswith='@dimagi.com')

--- a/corehq/apps/registration/tasks.py
+++ b/corehq/apps/registration/tasks.py
@@ -16,7 +16,7 @@ from corehq.apps.users.models import WebUser
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(minute=0),  # execute once every hour
     queue='background_queue',
 )

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -110,7 +110,7 @@ def send_report_throttled(notification_id):
     send_report(notification_id)
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(hour="*", minute="*/15", day_of_week="*"),
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
 )
@@ -119,7 +119,7 @@ def daily_reports():
         send_delayed_report(report_id)
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(hour="*", minute="*/15", day_of_week="*"),
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
 )
@@ -128,7 +128,7 @@ def weekly_reports():
         send_delayed_report(report_id)
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(hour="*", minute="*/15", day_of_week="*"),
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'),
 )
@@ -142,7 +142,7 @@ def rebuild_export_async(config, schema):
     rebuild_export(config, schema)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')
+@periodic_task(run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')
 def update_calculated_properties():
     results = DomainES().fields(["name", "_id", "cp_last_updated"]).scroll()
     all_stats = all_domain_stats()
@@ -187,7 +187,7 @@ def is_app_active(app_id, domain):
     return app_has_been_submitted_to_in_last_30_days(domain, app_id)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="2", minute="0", day_of_week="*"), queue='background_queue')
+@periodic_task(run_every=crontab(hour="2", minute="0", day_of_week="*"), queue='background_queue')
 def apps_update_calculated_properties():
     es = get_es_new()
     q = {"filter": {"and": [{"missing": {"field": "copy_of"}}]}}

--- a/corehq/apps/smsbillables/tasks.py
+++ b/corehq/apps/smsbillables/tasks.py
@@ -19,7 +19,7 @@ from corehq.util.log import send_HTML_email
 from dimagi.utils.dates import add_months_to_date
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month='1', hour=13, minute=0), queue='background_queue', acks_late=True)
+@periodic_task(run_every=crontab(day_of_month='1', hour=13, minute=0), queue='background_queue', acks_late=True)
 def send_gateway_fee_report_out():
     backend_api_ids = SmsGatewayFeeCriteria.objects.values_list('backend_api_id', flat=True).distinct()
     first_day_previous_month = add_months_to_date(date.today(), -1)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -239,7 +239,7 @@ def delete_data_source_task(domain, config_id):
     delete_data_source_shared(domain, config_id)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)
 def reprocess_archive_stubs():
     # Check for archive stubs
     from corehq.form_processor.interfaces.dbaccessors import FormAccessors
@@ -264,7 +264,7 @@ def reprocess_archive_stubs():
             xform.publish_archive_action_to_kafka(user_id=stub.user_id, archive=stub.archive)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=crontab(minute='*/5'), queue=settings.CELERY_PERIODIC_QUEUE)
 def run_queue_async_indicators_task():
     if time_in_range(datetime.utcnow(), settings.ASYNC_INDICATOR_QUEUE_TIMES):
         queue_async_indicators.delay()
@@ -460,7 +460,7 @@ def _build_async_indicators(indicator_doc_ids):
         )
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute="*/5"), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=crontab(minute="*/5"), queue=settings.CELERY_PERIODIC_QUEUE)
 def async_indicators_metrics():
     now = datetime.utcnow()
     oldest_indicator = AsyncIndicator.objects.order_by('date_queued').first()

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -230,7 +230,7 @@ def _rebuild_case_with_retries(self, domain, case_id, detail):
             )
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(hour=23, minute=55),
     queue='background_queue',
 )

--- a/corehq/blobs/tasks.py
+++ b/corehq/blobs/tasks.py
@@ -15,7 +15,7 @@ from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 log = logging.getLogger(__name__)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour='0,12'))
+@periodic_task(run_every=crontab(minute=0, hour='0,12'))
 def delete_expired_blobs():
     run_again = False
     bytes_deleted = 0

--- a/corehq/couchapps/doc_conflicts/tasks.py
+++ b/corehq/couchapps/doc_conflicts/tasks.py
@@ -5,6 +5,6 @@ from celery.task import periodic_task
 from django.core.management import call_command
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute="0", hour="2", day_of_week="0"), queue='background_queue')
+@periodic_task(run_every=crontab(minute="0", hour="2", day_of_week="0"), queue='background_queue')
 def remove_doc_conflicts():
     call_command('delete_doc_conflicts')

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -18,7 +18,7 @@ ASYNC_RESTORE_SENT = "SENT"
 SYNCLOG_RETENTION_DAYS = 9 * 7  # 63 days
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="2", minute="0", day_of_week="1"),
+@periodic_task(run_every=crontab(hour="2", minute="0", day_of_week="1"),
                queue='background_queue')
 def update_cleanliness_flags():
     """
@@ -27,7 +27,7 @@ def update_cleanliness_flags():
     set_cleanliness_flags_for_all_domains(force_full=False)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="4", minute="0", day_of_month="5"),
+@periodic_task(run_every=crontab(hour="4", minute="0", day_of_month="5"),
                queue='background_queue')
 def force_update_cleanliness_flags():
     """
@@ -75,7 +75,7 @@ def update_celery_state(sender=None, body=None, **kwargs):
     backend.store_result(body['id'], None, ASYNC_RESTORE_SENT)
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(hour="1", minute="0"),
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery')
 )

--- a/corehq/ex-submodules/phonelog/tasks.py
+++ b/corehq/ex-submodules/phonelog/tasks.py
@@ -15,7 +15,7 @@ from corehq.util.celery_utils import no_result_task
 from phonelog.models import ForceCloseEntry, UserEntry, UserErrorEntry
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
+@periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def purge_old_device_report_entries():
     max_age = datetime.utcnow() - timedelta(days=settings.DAYS_TO_KEEP_DEVICE_LOGS)
     with connection.cursor() as cursor:

--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -10,7 +10,7 @@ from corehq.util.datadog.gauges import datadog_gauge
 from pillow_retry.models import PillowError
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(minute="*/15"),
     queue=settings.CELERY_PERIODIC_QUEUE,
 )

--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -12,7 +12,7 @@ from pillowtop.utils import get_all_pillows_json
 _assert = soft_assert("{}@{}".format('jemord', 'dimagi.com'))
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute="*/2"), queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=crontab(minute="*/2"), queue=settings.CELERY_PERIODIC_QUEUE)
 def pillow_datadog_metrics():
     def _is_couch(pillow):
         # text is couch, json is kafka

--- a/corehq/ex-submodules/soil/tasks.py
+++ b/corehq/ex-submodules/soil/tasks.py
@@ -38,7 +38,7 @@ def prepare_download(download_id, payload_func, content_disposition,
                            download_id=download_id)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="*", minute="*", day_of_week="*"),
+@periodic_task(run_every=crontab(hour="*", minute="*", day_of_week="*"),
                queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def heartbeat():
     """

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -53,7 +53,7 @@ def send_datasets(domain_name, send_now=False, send_date=None):
             requests.post(endpoint, json=dataset)
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(minute=3, hour=3),
     queue='background_queue'
 )

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -248,7 +248,6 @@ def import_patients_to_domain(domain_name, force=False):
 
 
 @periodic_task(
-    serializer='pickle',
     run_every=crontab(minute=4, hour=4),
     queue='background_queue'
 )
@@ -273,7 +272,6 @@ def poll_openmrs_atom_feeds(domain_name):
 
 
 @periodic_task(
-    serializer='pickle',
     run_every=crontab(**OPENMRS_ATOM_FEED_POLL_INTERVAL),
     queue='background_queue'
 )

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -24,7 +24,7 @@ from corehq.motech.repeaters.const import (
 logging = get_task_logger(__name__)
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=CHECK_REPEATERS_INTERVAL,
     queue=settings.CELERY_PERIODIC_QUEUE,
 )

--- a/corehq/preindex/tasks.py
+++ b/corehq/preindex/tasks.py
@@ -12,7 +12,7 @@ from django.conf import settings
 couch_reindex_schedule = deserialize_run_every_setting(settings.COUCH_REINDEX_SCHEDULE)
 
 
-@periodic_task(serializer='pickle', run_every=couch_reindex_schedule, queue=settings.CELERY_PERIODIC_QUEUE)
+@periodic_task(run_every=couch_reindex_schedule, queue=settings.CELERY_PERIODIC_QUEUE)
 def run_continuous_indexing_task():
     preindex_couch_views.delay()
 

--- a/custom/_legacy/hsph/tasks.py
+++ b/custom/_legacy/hsph/tasks.py
@@ -83,7 +83,7 @@ past_x_date = lambda tz, past_x_days: (datetime.datetime.now(tz) - datetime.time
 get_none_or_value = lambda _obj, _attr: getattr(_obj, _attr) if (hasattr(_obj, _attr)) else ''
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     run_every=crontab(minute=1, hour="*/6"),
     queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery')
 )

--- a/custom/_legacy/pact/tasks.py
+++ b/custom/_legacy/pact/tasks.py
@@ -76,7 +76,7 @@ def eval_dots_block(xform_json, callback=None):
         notify_exception(None, message="PACT error evaluating DOTS block docid %s, %s\n\tTraceback: %s" % (xform_json['_id'], ex, tb))
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="12", minute="0", day_of_week="*"))
+@periodic_task(run_every=crontab(hour="12", minute="0", day_of_week="*"))
 def update_schedule_case_properties():
     """
     Iterate through all pact patient cases in the domain and set schedule case properties if necessary.

--- a/custom/ewsghana/tasks.py
+++ b/custom/ewsghana/tasks.py
@@ -15,7 +15,7 @@ from custom.ewsghana.reminders.visit_website_reminder import VisitWebsiteReminde
 
 
 # Alert when facilities have not been reported continuously for 3 weeks
-@periodic_task(serializer='pickle', run_every=crontab(hour=10, minute=00),
+@periodic_task(run_every=crontab(hour=10, minute=00),
                queue='logistics_reminder_queue')
 def on_going_non_reporting():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -24,7 +24,7 @@ def on_going_non_reporting():
 
 
 # Ongoing STOCKOUTS at SDP and RMS
-@periodic_task(serializer='pickle', run_every=crontab(hour=10, minute=25),
+@periodic_task(run_every=crontab(hour=10, minute=25),
                queue='logistics_reminder_queue')
 def on_going_stockout():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -35,7 +35,7 @@ def on_going_stockout():
 
 # Urgent Non-Reporting
 # First monday of month
-@periodic_task(serializer='pickle', run_every=crontab(day_of_week=1, day_of_month="1-7", hour=8, minute=20),
+@periodic_task(run_every=crontab(day_of_week=1, day_of_month="1-7", hour=8, minute=20),
                queue='logistics_reminder_queue')
 def urgent_non_reporting():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -45,7 +45,7 @@ def urgent_non_reporting():
 
 # Urgent Stockout
 # First monday of month
-@periodic_task(serializer='pickle', run_every=crontab(day_of_week=1, day_of_month="1-7", hour=8, minute=20),
+@periodic_task(run_every=crontab(day_of_week=1, day_of_month="1-7", hour=8, minute=20),
                queue='logistics_reminder_queue')
 def urgent_stockout():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -54,7 +54,7 @@ def urgent_stockout():
 
 
 # Thursday 13:54
-@periodic_task(serializer='pickle', run_every=crontab(day_of_week=4, hour=13, minute=58),
+@periodic_task(run_every=crontab(day_of_week=4, hour=13, minute=58),
                queue='logistics_reminder_queue')
 def first_soh_reminder():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -63,7 +63,7 @@ def first_soh_reminder():
 
 
 # Monday 13:57
-@periodic_task(serializer='pickle', run_every=crontab(day_of_week=1, hour=13, minute=57),
+@periodic_task(run_every=crontab(day_of_week=1, hour=13, minute=57),
                queue='logistics_reminder_queue')
 def second_soh_reminder():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -72,7 +72,7 @@ def second_soh_reminder():
 
 
 # Wednesday 13:54
-@periodic_task(serializer='pickle', run_every=crontab(day_of_week=3, hour=13, minute=54),
+@periodic_task(run_every=crontab(day_of_week=3, hour=13, minute=54),
                queue='logistics_reminder_queue')
 def third_soh_to_super():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -81,7 +81,7 @@ def third_soh_to_super():
 
 
 # Wednesday 14:06
-@periodic_task(serializer='pickle', run_every=crontab(day_of_week=3, hour=14, minute=6),
+@periodic_task(run_every=crontab(day_of_week=3, hour=14, minute=6),
                queue='logistics_reminder_queue')
 def stockout_notification_to_web_supers():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -89,7 +89,7 @@ def stockout_notification_to_web_supers():
         StockoutReminder(domain).send()
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="28", hour=14, minute=15),
+@periodic_task(run_every=crontab(day_of_month="28", hour=14, minute=15),
                queue='logistics_reminder_queue')
 def reminder_to_submit_rrirv():
     domains = EWSGhanaConfig.get_all_enabled_domains()
@@ -97,7 +97,7 @@ def reminder_to_submit_rrirv():
         RRIRVReminder(domain).send()
 
 
-@periodic_task(serializer='pickle', run_every=crontab(month_of_year='1,4,7,10', day_of_month=4, hour=10, minute=3),
+@periodic_task(run_every=crontab(month_of_year='1,4,7,10', day_of_month=4, hour=10, minute=3),
                queue='logistics_reminder_queue')
 def reminder_to_visit_website():
     domains = EWSGhanaConfig.get_all_enabled_domains()

--- a/custom/icds/tasks.py
+++ b/custom/icds/tasks.py
@@ -11,7 +11,7 @@ from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.util.datadog.gauges import datadog_counter
 
 if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
-    @periodic_task(serializer='pickle', run_every=crontab(minute=0, hour='22'))
+    @periodic_task(run_every=crontab(minute=0, hour='22'))
     def delete_old_images():
         start = datetime.utcnow()
         max_age = start - timedelta(days=90)

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -133,7 +133,7 @@ SQL_FUNCTION_PATHS = [
 ]
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=30, hour=23),
+@periodic_task(run_every=crontab(minute=30, hour=23),
                acks_late=True, queue='icds_aggregation_queue')
 def run_move_ucr_data_into_aggregation_tables_task(date=None):
     move_ucr_data_into_aggregation_tables.delay(date)
@@ -560,7 +560,7 @@ def email_dashboad_team(aggregation_date):
     icds_data_validation.delay(aggregation_date)
 
 
-@periodic_task(serializer='pickle',
+@periodic_task(
     queue='background_queue',
     run_every=crontab(day_of_week='tuesday,thursday,saturday', minute=0, hour=21),
     acks_late=True
@@ -862,7 +862,7 @@ def _get_value(data, field):
     return getattr(data, field) or default
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=30, hour=23), acks_late=True, queue='icds_aggregation_queue')
+@periodic_task(run_every=crontab(minute=30, hour=23), acks_late=True, queue='icds_aggregation_queue')
 def collect_inactive_awws():
     celery_task_logger.info("Started updating the Inactive AWW")
     filename = "inactive_awws_%s.csv" % date.today().strftime('%Y-%m-%d')
@@ -913,7 +913,7 @@ def build_disha_dump():
     celery_task_logger.info("Finished dumping DISHA data")
 
 
-@periodic_task(serializer='pickle', run_every=crontab(minute=0, hour=0), queue='background_queue')
+@periodic_task(run_every=crontab(minute=0, hour=0), queue='background_queue')
 def push_missing_docs_to_es():
     if settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS:
         return

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -135,8 +135,8 @@ SQL_FUNCTION_PATHS = [
 
 @periodic_task(run_every=crontab(minute=30, hour=23),
                acks_late=True, queue='icds_aggregation_queue')
-def run_move_ucr_data_into_aggregation_tables_task(date=None):
-    move_ucr_data_into_aggregation_tables.delay(date)
+def run_move_ucr_data_into_aggregation_tables_task():
+    move_ucr_data_into_aggregation_tables.delay()
 
 
 @serial_task('move-ucr-data-into-aggregate-tables', timeout=36 * 60 * 60, queue='icds_aggregation_queue')

--- a/custom/ilsgateway/tasks.py
+++ b/custom/ilsgateway/tasks.py
@@ -34,13 +34,13 @@ from .oneoff import *
 import six
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="4", minute="00", day_of_week="*"),
+@periodic_task(run_every=crontab(hour="4", minute="00", day_of_week="*"),
                queue='logistics_background_queue')
 def report_run_periodic_task():
     report_run.delay('ils-gateway')
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="8", minute="00", day_of_week="*"),
+@periodic_task(run_every=crontab(hour="8", minute="00", day_of_week="*"),
                queue='logistics_background_queue')
 def test_domains_report_run_periodic_task():
     for domain in ILSGatewayConfig.get_all_enabled_domains():
@@ -104,37 +104,37 @@ district_delivery_partial = partial(send_for_day, cutoff=13, reminder_class=Deli
                                     location_type='DISTRICT')
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="13-15", hour=11, minute=0),
+@periodic_task(run_every=crontab(day_of_month="13-15", hour=11, minute=0),
                queue="logistics_reminder_queue")
 def first_facility_delivery_task():
     facility_delivery_partial(15)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="20-22", hour=11, minute=0),
+@periodic_task(run_every=crontab(day_of_month="20-22", hour=11, minute=0),
                queue="logistics_reminder_queue")
 def second_facility_delivery_task():
     facility_delivery_partial(22)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="26-30", hour=11, minute=0),
+@periodic_task(run_every=crontab(day_of_month="26-30", hour=11, minute=0),
                queue="logistics_reminder_queue")
 def third_facility_delivery_task():
     facility_delivery_partial(30)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="11-13", hour=5, minute=0),
+@periodic_task(run_every=crontab(day_of_month="11-13", hour=5, minute=0),
                queue="logistics_reminder_queue")
 def first_district_delivery_task():
     district_delivery_partial(13)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="18-20", hour=11, minute=0),
+@periodic_task(run_every=crontab(day_of_month="18-20", hour=11, minute=0),
                queue="logistics_reminder_queue")
 def second_district_delivery_task():
     district_delivery_partial(20)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="26-28", hour=11, minute=0),
+@periodic_task(run_every=crontab(day_of_month="26-28", hour=11, minute=0),
                queue="logistics_reminder_queue")
 def third_district_delivery_task():
     district_delivery_partial(28)
@@ -144,46 +144,46 @@ facility_randr_partial = partial(send_for_day, cutoff=5, reminder_class=RandrRem
 district_randr_partial = partial(send_for_day, cutoff=13, reminder_class=RandrReminder, location_type='DISTRICT')
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="3-5", hour=5, minute=0),
+@periodic_task(run_every=crontab(day_of_month="3-5", hour=5, minute=0),
                queue="logistics_reminder_queue")
 def first_facility():
     """Last business day before or on 5th day of the Submission month, 8:00am"""
     facility_randr_partial(5)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="8-10", hour=5, minute=0),
+@periodic_task(run_every=crontab(day_of_month="8-10", hour=5, minute=0),
                queue="logistics_reminder_queue")
 def second_facility():
     """Last business day before or on 10th day of the submission month, 8:00am"""
     facility_randr_partial(10)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="10-12", hour=5, minute=0),
+@periodic_task(run_every=crontab(day_of_month="10-12", hour=5, minute=0),
                queue="logistics_reminder_queue")
 def third_facility():
     """Last business day before or on 12th day of the submission month, 8:00am"""
     facility_randr_partial(12)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="11-13", hour=5, minute=0),
+@periodic_task(run_every=crontab(day_of_month="11-13", hour=5, minute=0),
                queue="logistics_reminder_queue")
 def first_district():
     district_randr_partial(13)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="13-15", hour=5, minute=0),
+@periodic_task(run_every=crontab(day_of_month="13-15", hour=5, minute=0),
                queue="logistics_reminder_queue")
 def second_district():
     district_randr_partial(15)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="15-17", hour=11, minute=0),
+@periodic_task(run_every=crontab(day_of_month="15-17", hour=11, minute=0),
                queue="logistics_reminder_queue")
 def third_district():
     district_randr_partial(17)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="26-31", hour=11, minute=15),
+@periodic_task(run_every=crontab(day_of_month="26-31", hour=11, minute=15),
                queue="logistics_reminder_queue")
 def supervision_task():
     now = datetime.utcnow()
@@ -199,7 +199,7 @@ def get_last_and_nth_business_day(date, n):
     return last_month_last_day, nth_business_day
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="26-31", hour=11, minute=0),
+@periodic_task(run_every=crontab(day_of_month="26-31", hour=11, minute=0),
                queue="logistics_reminder_queue")
 def first_soh_task():
     now = datetime.utcnow()
@@ -208,7 +208,7 @@ def first_soh_task():
         send_for_all_domains(last_business_day, SOHReminder)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="1-3", hour=6, minute=0),
+@periodic_task(run_every=crontab(day_of_month="1-3", hour=6, minute=0),
                queue="logistics_reminder_queue")
 def second_soh_task():
     now = datetime.utcnow()
@@ -217,7 +217,7 @@ def second_soh_task():
         send_for_all_domains(last_month_last_day, SOHReminder)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="5-7", hour=5, minute=15),
+@periodic_task(run_every=crontab(day_of_month="5-7", hour=5, minute=15),
                queue="logistics_reminder_queue")
 def third_soh_task():
     now = datetime.utcnow()
@@ -226,7 +226,7 @@ def third_soh_task():
         send_for_all_domains(last_month_last_day, SOHReminder)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="6-8", hour=13, minute=0),
+@periodic_task(run_every=crontab(day_of_month="6-8", hour=13, minute=0),
                queue="logistics_reminder_queue")
 def soh_summary_task():
     """
@@ -242,7 +242,7 @@ def soh_summary_task():
             send_translated_message(user, REMINDER_MONTHLY_SOH_SUMMARY, **construct_soh_summary(user.location))
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="26-31", hour=13, minute=0),
+@periodic_task(run_every=crontab(day_of_month="26-31", hour=13, minute=0),
                queue="logistics_reminder_queue")
 def delivery_summary_task():
     """
@@ -260,7 +260,7 @@ def delivery_summary_task():
             )
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="15-17", hour=13, minute=0),
+@periodic_task(run_every=crontab(day_of_month="15-17", hour=13, minute=0),
                queue="logistics_reminder_queue")
 def randr_summary_task():
     """
@@ -279,7 +279,7 @@ def randr_summary_task():
             )
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="18-20", hour=14, minute=0),
+@periodic_task(run_every=crontab(day_of_month="18-20", hour=14, minute=0),
                queue="logistics_reminder_queue")
 def soh_thank_you_task():
     """
@@ -295,7 +295,7 @@ def soh_thank_you_task():
         SOHThankYouReminder(domain=domain, date=last_month).send()
 
 
-@periodic_task(serializer='pickle', run_every=crontab(day_of_month="6-10", hour=8, minute=0),
+@periodic_task(run_every=crontab(day_of_month="6-10", hour=8, minute=0),
                queue="logistics_reminder_queue")
 def stockout_reminder_task():
     """

--- a/custom/m4change/tasks.py
+++ b/custom/m4change/tasks.py
@@ -18,7 +18,7 @@ from custom.m4change.reports.reports import M4ChangeReportDataSource
 from dimagi.utils.parsing import json_format_date
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="3", minute="0", day_of_week="*"),
+@periodic_task(run_every=crontab(hour="3", minute="0", day_of_week="*"),
                queue='background_queue')
 def generate_production_fixtures():
     db = FixtureReportResult.get_db()
@@ -56,7 +56,7 @@ def generate_fixtures_for_domain(domain, db, data_source):
                                                 report_slug, rows, name)
 
 
-@periodic_task(serializer='pickle', run_every=crontab(hour="*", minute="*/30", day_of_week="*"),
+@periodic_task(run_every=crontab(hour="*", minute="*/30", day_of_week="*"),
                queue=getattr(settings, "CELERY_PERIODIC_QUEUE", "celery"))
 def generate_fixtures_for_locations():
 


### PR DESCRIPTION
Eventually we should stop using pickle as a celery serializer.  Doing so may help smooth out the python 3 migration, since django model objects pickled in python 2 have trouble being unpickled in python 3.

This is a quick pass at removing ```serializer='pickle'``` from functions that are never passed any arguments.