### PR TITLE
remove all instances of e.message

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import unicode_literals
 import calendar
 import datetime
+
+import six
 from dateutil.relativedelta import relativedelta
 from decimal import Decimal
 
@@ -163,7 +165,7 @@ class DomainInvoiceFactory(object):
                         record.send_email(contact_email=email)
             except InvoiceEmailThrottledError as e:
                 if not self.logged_throttle_error:
-                    log_accounting_error(e.message)
+                    log_accounting_error(six.text_type(e))
                     self.logged_throttle_error = True
         else:
             record.skipped_email = True
@@ -308,7 +310,7 @@ class DomainWireInvoiceFactory(object):
             except InvoiceEmailThrottledError as e:
                 # Currently wire invoices are never throttled
                 if not self.logged_throttle_error:
-                    log_accounting_error(e.message)
+                    log_accounting_error(six.text_type(e))
                     self.logged_throttle_error = True
         else:
             record.skipped_email = True

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3350,7 +3350,7 @@ class CreditLine(models.Model):
                     'feature': (" | Feature %s" % feature_type
                                 if feature_type is not None else ""),
                     'product': (" | Product" if is_product else ""),
-                    'error': e.message,
+                    'error': six.text_type(e),
                 }
             )
         except cls.DoesNotExist:

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -114,7 +114,7 @@ def activate_subscriptions(based_on_date=None):
             _activate_subscription(subscription)
         except Exception as e:
             log_accounting_error(
-                'Error activating subscription %d: %s' % (subscription.id, e.message),
+                'Error activating subscription %d: %s' % (subscription.id, six.text_type(e)),
                 show_stack_trace=True,
             )
 
@@ -168,7 +168,7 @@ def deactivate_subscriptions(based_on_date=None):
             _deactivate_subscription(subscription)
         except Exception as e:
             log_accounting_error(
-                'Error deactivating subscription %d: %s' % (subscription.id, e.message),
+                'Error deactivating subscription %d: %s' % (subscription.id, six.text_type(e)),
                 show_stack_trace=True,
             )
 
@@ -406,7 +406,7 @@ def send_subscription_reminder_emails(num_days):
                 subscription.send_ending_reminder_email()
         except Exception as e:
             log_accounting_error(
-                "Error sending reminder for subscription %d: %s" % (subscription.id, e.message),
+                "Error sending reminder for subscription %d: %s" % (subscription.id, six.text_type(e)),
                 show_stack_trace=True,
             )
 
@@ -447,7 +447,7 @@ def create_wire_credits_invoice(domain_name,
                 record.send_email(contact_email=email)
         except Exception as e:
             log_accounting_error(
-                "Error sending email for WirePrepaymentBillingRecord %d: %s" % (record.id, e.message),
+                "Error sending email for WirePrepaymentBillingRecord %d: %s" % (record.id, six.text_type(e)),
                 show_stack_trace=True,
             )
     else:
@@ -648,7 +648,7 @@ def update_exchange_rates():
                 })
         except Exception as e:
             log_accounting_error(
-                "Error updating exchange rates: %s" % e.message,
+                "Error updating exchange rates: %s" % six.text_type(e),
                 show_stack_trace=True,
             )
 

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import date
 import json
+import six
 
 from django.conf import settings
 from django.contrib import messages
@@ -329,7 +330,7 @@ class NewSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
                 )
             except NewSubscriptionError as e:
                 errors = ErrorList()
-                errors.extend([e.message])
+                errors.extend([six.text_type(e)])
                 self.subscription_form._errors.setdefault(NON_FIELD_ERRORS, errors)
         return self.get(request, *args, **kwargs)
 

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -135,7 +135,7 @@ class XFormInstanceResource(SimpleSortableResourceMixin, HqBaseResource, DomainS
         try:
             es_query = es_search(bundle.request, domain, ['include_archived'])
         except Http400 as e:
-            raise BadRequest(e.message)
+            raise BadRequest(six.text_type(e))
         if include_archived:
             es_query['filter']['and'].append({'or': [
                 {'term': {'doc_type': 'xforminstance'}},

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 from django.conf.urls import url
 from django.http import Http404, HttpResponse, HttpResponseNotFound
 from django.forms import ValidationError
@@ -17,6 +18,7 @@ from collections import namedtuple
 from django.contrib.auth.models import User
 from django.urls import reverse
 
+import six
 from tastypie import fields
 from tastypie.bundle import Bundle
 
@@ -198,7 +200,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                         except ValidationError as e:
                             if not hasattr(bundle.obj, 'errors'):
                                 bundle.obj.errors = []
-                            bundle.obj.errors.append(e.message)
+                            bundle.obj.errors.append(six.text_type(e))
                             return False
                     bundle.obj.set_password(bundle.data.get("password"))
                     should_save = True
@@ -762,7 +764,7 @@ class SimpleReportConfigurationResource(CouchResourceMixin, HqBaseResource, Doma
         try:
             report_configuration = get_document_or_404(ReportConfiguration, domain, pk)
         except Http404 as e:
-            raise NotFound(e.message)
+            raise NotFound(six.text_type(e))
         return report_configuration
 
     def obj_get_list(self, bundle, **kwargs):

--- a/corehq/apps/app_manager/view_helpers.py
+++ b/corehq/apps/app_manager/view_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
 from django.http import Http404
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.domain.views.base import DomainViewMixin
@@ -27,5 +29,5 @@ class ApplicationViewMixin(DomainViewMixin):
         except Http404 as e:
             raise e
         except Exception as e:
-            notify_exception(self.request, message=e.message)
+            notify_exception(self.request, message=six.text_type(e))
         return None

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import json
 import logging
 
+import six
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceConflict
@@ -188,7 +189,7 @@ def get_form_data_schema(request, domain, form_unique_id):
             "Please fix the error to see case properties in this tree")
         )
     except Exception as e:
-        notify_exception(request, message=e.message)
+        notify_exception(request, message=six.text_type(e))
         return HttpResponseBadRequest("schema error, see log for details")
 
     data.extend(

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -111,7 +111,7 @@ def delete_form(request, domain, app_id, module_unique_id, form_unique_id):
     try:
         module_id = app.get_module_by_unique_id(module_unique_id).id
     except ModuleNotFoundException as e:
-        messages.error(request, e.message)
+        messages.error(request, six.text_type(e))
         module_id = None
 
     return back_to_main(request, domain, app_id=app_id, module_id=module_id)

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -180,7 +180,7 @@ class CommCareExchangeHomeView(BaseCommCareExchangeSectionView):
                     message=(
                         "Fetched Exchange Snapshot Error: {}. "
                         "The problem snapshot id: {}".format(
-                            e.message, res['_source']['_id'])
+                            six.text_type(e), res['_source']['_id'])
                     )
                 )
 

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -341,11 +341,11 @@ def get_spreadsheet(filename):
         with open_any_workbook(filename) as workbook:
             yield WorksheetWrapper.from_workbook(workbook)
     except SpreadsheetFileEncrypted as e:
-        raise ImporterExcelFileEncrypted(e.message)
+        raise ImporterExcelFileEncrypted(six.text_type(e))
     except SpreadsheetFileNotFound as e:
-        raise ImporterFileNotFound(e.message)
+        raise ImporterFileNotFound(six.text_type(e))
     except SpreadsheetFileInvalidError as e:
-        raise ImporterExcelError(e.message)
+        raise ImporterExcelError(six.text_type(e))
 
 
 def is_valid_location_owner(owner, domain):
@@ -422,6 +422,6 @@ def get_importer_error_message(e):
         return _('The file you want to import is password protected. '
                  'Please choose a file that is not password protected.')
     elif isinstance(e, ImporterExcelError):
-        return _("The file uploaded has the following error: {}").format(e.message)
+        return _("The file uploaded has the following error: {}").format(six.text_type(e))
     else:
-        return _("Error: {}").format(e.message)
+        return _("Error: {}").format(six.text_type(e))

--- a/corehq/apps/cleanup/management/commands/fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/management/commands/fix_forms_and_apps_with_missing_xmlns.py
@@ -105,8 +105,8 @@ class Command(BaseCommand):
                 try:
                     unique_id = get_form_unique_id(xform_instance)
                 except (MultipleFormsMissingXmlns, FormNameMismatch) as e:
-                    log_file.write(e.message)
-                    print(e.message)
+                    log_file.write(six.text_type(e))
+                    print(six.text_type(e))
                     continue
 
                 if unique_id:

--- a/corehq/apps/cleanup/management/commands/fix_xforms_with_undefined_xmlns.py
+++ b/corehq/apps/cleanup/management/commands/fix_xforms_with_undefined_xmlns.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime
 from itertools import chain
 
+import six
 from couchdbkit import ResourceNotFound
 
 from corehq.apps.app_manager.dbaccessors import get_app
@@ -92,7 +93,7 @@ class Command(BaseCommand):
                 except MultiplePreviouslyFixedForms as e:
                     if xform_instance.build_id not in unfixable_builds:
                         unfixable_builds.add(xform_instance.build_id)
-                        print(e.message)
+                        print(six.text_type(e))
                     _log(log_file, WARNING, MULTI_MATCH, xform_instance)
                     continue
                 except CantMatchAForm as e:

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -286,7 +286,7 @@ class ArchiveFormView(DataInterfaceSection):
             except UnicodeDecodeError:
                 raise BulkUploadCasesException(_("Unrecognized format"))
         except JSONReaderError as e:
-            raise BulkUploadCasesException(_('Your upload was unsuccessful. %s') % e.message)
+            raise BulkUploadCasesException(_('Your upload was unsuccessful. %s') % six.text_type(e))
 
     def process(self):
         try:
@@ -434,7 +434,7 @@ class CaseGroupCaseManagementView(DataInterfaceSection, CRUDPaginatedViewMixin):
                 messages.success(self.request, _("We received your file and are processing it..."))
                 return upload_id
         except BulkUploadCasesException as e:
-            messages.error(self.request, e.message)
+            messages.error(self.request, six.text_type(e))
         return None
 
     @property
@@ -456,7 +456,7 @@ class CaseGroupCaseManagementView(DataInterfaceSection, CRUDPaginatedViewMixin):
             except UnicodeDecodeError:
                 raise BulkUploadCasesException(_("Unrecognized format"))
         except JSONReaderError as e:
-            raise BulkUploadCasesException(_('Your upload was unsuccessful. %s') % e.message)
+            raise BulkUploadCasesException(_('Your upload was unsuccessful. %s') % six.text_type(e))
 
     def _get_item_data(self, case):
         return {

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1677,7 +1677,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
         except Exception as e:
             log_accounting_error(
                 "There was an error subscribing the domain '%s' to plan '%s'. Message: %s "
-                % (self.domain, self.plan_version.plan.name, e.message),
+                % (self.domain, self.plan_version.plan.name, six.text_type(e)),
                 show_stack_trace=True,
             )
             return False

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
         try:
             return loader_class(self.stdout, self.stderr).load_from_file(extracted_dump_path, self.force)
         except DataExistsException as e:
-            raise CommandError('Some data already exists. Use --force to load anyway: {}'.format(e.message))
+            raise CommandError('Some data already exists. Use --force to load anyway: {}'.format(six.text_type(e)))
         except Exception as e:
             if not isinstance(e, CommandError):
                 e.args = ("Problem loading data '%s': %s" % (extracted_dump_path, e),)

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from __future__ import absolute_import
 import os
+import six
 import zipfile
 from collections import Counter
 

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -426,7 +426,7 @@ def _upload_fixture_api(request, domain):
     try:
         excel_file, replace = _get_fixture_upload_args_from_request(request, domain)
     except FixtureAPIRequestError as e:
-        return UploadFixtureAPIResponse('fail', e.message)
+        return UploadFixtureAPIResponse('fail', six.text_type(e))
 
     with excel_file as filename:
         try:

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -384,7 +384,7 @@ def fixture_upload_job_poll(request, domain, download_id, template="fixtures/par
     try:
         context = get_download_context(download_id, require_result=True)
     except TaskFailedError as e:
-        notify_exception(request, message=e.message)
+        notify_exception(request, message=six.text_type(e))
         return HttpResponseServerError()
 
     return render(request, template, context)

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -935,7 +935,7 @@ def iter_index_files(app, build_profile_id=None, download_targeted_version=False
     try:
         files = _download_index_files(app, build_profile_id)
     except Exception as e:
-        notify_exception(None, e.message)
+        notify_exception(None, six.text_type(e))
         errors = [six.text_type(e)]
 
     return _files(files), errors, len(files)

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -419,7 +419,7 @@ class BaseProcessUploadedView(BaseMultimediaView):
             self.validate_file()
             response.update(self.process_upload())
         except BadMediaFileException as e:
-            self.errors.append(e.message)
+            self.errors.append(six.text_type(e))
         response.update({
             'errors': self.errors,
         })

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
 
+import six
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.exceptions import ValidationError
@@ -197,7 +198,7 @@ class FormListForm(object):
                 rows = json.loads(self.data.get('child_form_data', ""))
             except ValueError as e:
                 raise ValidationError("POST request poorly formatted. {}"
-                                      .format(e.message))
+                                      .format(six.text_type(e)))
         else:
             rows = self.data
         return [

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -45,7 +45,7 @@ def JSON(obj):
     except TypeError as e:
         msg = ("Unserializable data was sent to the `|JSON` template tag.  "
                "If DEBUG is off, Django will silently swallow this error.  "
-               "{}".format(e.message))
+               "{}".format(six.text_type(e)))
         soft_assert(notify_admins=True)(False, msg)
         raise e
 

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -56,7 +56,7 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
         try:
             notification.set_as_last_seen(self.request.user)
         except IllegalModelStateException as e:
-            raise JSONResponseException(e.message)
+            raise JSONResponseException(six.text_type(e))
         return {
             'activated': notification.activated
         }

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -40,7 +40,7 @@ def turn_on_demo_mode(commcare_user, domain):
         reset_demo_user_restore(commcare_user, domain)
         return {'errors': []}
     except Exception as e:
-        notify_exception(None, message=e.message)
+        notify_exception(None, message=six.text_type(e))
         return {'errors': [
             _("Something went wrong in creating restore for the user. Please try again or report an issue")
         ]}

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -412,7 +412,7 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         except UnsupportedSavedReportError:
             return "#"
         except Exception as e:
-            logging.exception(e.message)
+            logging.exception(six.text_type(e))
             return "#"
 
     @property

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -146,7 +146,7 @@ class DatespanFilter(BaseFilter):
             startdate = date_or_nothing(startdate)
             enddate = date_or_nothing(enddate)
         except (ValueError, TypeError) as e:
-            raise FilterValueException('Error parsing date parameters: {}'.format(e.message))
+            raise FilterValueException('Error parsing date parameters: {}'.format(six.text_type(e)))
 
         if startdate or enddate:
             return DateSpan(startdate, enddate, inclusive=date_range_inclusive)
@@ -257,7 +257,7 @@ class NumericFilter(BaseFilter):
             assert operator in ["=", "!=", "<", "<=", ">", ">="]
             assert isinstance(operand, float) or isinstance(operand, int)
         except AssertionError as e:
-            raise FilterValueException('Error parsing numeric filter parameters: {}'.format(e.message))
+            raise FilterValueException('Error parsing numeric filter parameters: {}'.format(six.text_type(e)))
 
         return {"operator": operator, "operand": operand}
 

--- a/corehq/apps/smsbillables/utils.py
+++ b/corehq/apps/smsbillables/utils.py
@@ -5,6 +5,7 @@ import logging
 from django.conf import settings
 from django.utils.encoding import force_text
 
+import six
 from django_countries.data import COUNTRIES
 from phonenumbers import COUNTRY_CODE_TO_REGION_CODE
 from twilio.base.exceptions import TwilioRestException
@@ -49,4 +50,4 @@ def get_twilio_message(backend_instance, backend_message_id):
     try:
         return _get_twilio_client(backend_instance).messages.get(backend_message_id).fetch()
     except TwilioRestException as e:
-        raise RetryBillableTaskException(e.message)
+        raise RetryBillableTaskException(six.text_type(e))

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -169,7 +169,7 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
         try:
             return self._adapter.get_table().c[self.report_filter.field]
         except KeyError as e:
-            raise ColumnNotFoundError(e.message)
+            raise ColumnNotFoundError(six.text_type(e))
 
     def get_values_for_query(self, query_context):
         query = self._adapter.session_helper.Session.query(self._sql_column)
@@ -193,7 +193,7 @@ class MultiFieldDataSourceColumnChoiceProvider(DataSourceColumnChoiceProvider):
         try:
             return [self._adapter.get_table().c[field] for field in self.report_filter.fields]
         except KeyError as e:
-            raise ColumnNotFoundError(e.message)
+            raise ColumnNotFoundError(six.text_type(e))
 
     def get_values_for_query(self, query_context):
         query = self._adapter.session_helper.Session.query(*self._sql_columns)

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -411,7 +411,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             if settings.DEBUG:
                 raise
             return self.render_json_response({
-                'error': e.message,
+                'error': six.text_type(e),
                 'aaData': [],
                 'iTotalRecords': 0,
                 'iTotalDisplayRecords': 0,

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -425,10 +425,7 @@ def _build_async_indicators(indicator_doc_ids):
                     adapter.save_rows(rows)
                 except Exception as e:
                     failed_indicators.union(indicators)
-                    message = e.message
-                    if isinstance(message, bytes):
-                        # TODO - figure out where these are coming from and use unicode message from the start
-                        message = repr(message)
+                    message = six.text_type(e)
                     notify_exception(None,
                         "Exception bulk saving async indicators:{}".format(message))
                 else:

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1312,7 +1312,7 @@ def export_sql_adapter_view(request, domain, adapter, too_large_redirect_url):
             msg = ugettext_lazy('format must be one of the following: {}').format(', '.join(allowed_formats))
             return HttpResponse(msg, status=400)
     except UserQueryError as e:
-        return HttpResponse(e.message, status=400)
+        return HttpResponse(six.text_type(e), status=400)
 
     q = q.filter_by(**params.keyword_filters)
     for sql_filter in params.sql_filters:

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -435,7 +435,7 @@ class EditReportInBuilder(View):
             try:
                 return ConfigureReport.as_view(existing_report=report)(request, *args, **kwargs)
             except BadBuilderConfigError as e:
-                messages.error(request, e.message)
+                messages.error(request, six.text_type(e))
                 return HttpResponseRedirect(reverse(ConfigurableReportView.slug, args=[request.domain, report_id]))
         raise Http404("Report was not created by the report builder")
 

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime
+
+import six
 from celery.exceptions import MaxRetriesExceededError
 from celery.schedules import crontab
 from celery.task import task
@@ -275,7 +277,7 @@ def reset_demo_user_restore_task(commcare_user_id, domain):
         reset_demo_user_restore(user, domain)
         results = {'errors': []}
     except Exception as e:
-        notify_exception(None, message=e.message)
+        notify_exception(None, message=six.text_type(e))
         results = {'errors': [
             _("Something went wrong in creating restore for the user. Please try again or report an issue")
         ]}

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -932,11 +932,11 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
                 return HttpResponseBadRequest("Unrecognized format")
         except JSONReaderError as e:
             messages.error(request,
-                           'Your upload was unsuccessful. %s' % e.message)
+                           'Your upload was unsuccessful. %s' % six.text_type(e))
             return self.get(request, *args, **kwargs)
         except HeaderValueError as e:
             return HttpResponseBadRequest("Upload encountered a data type error: %s"
-                                          % e.message)
+                                          % six.text_type(e))
 
         try:
             self.user_specs = self.workbook.get_worksheet(title='users')

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -954,7 +954,7 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
         try:
             check_headers(self.user_specs)
         except UserUploadError as e:
-            messages.error(request, _(e.message))
+            messages.error(request, _(six.text_type(e)))
             return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))
 
         # convert to list here because iterator destroys the row once it has
@@ -975,13 +975,13 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
         try:
             check_existing_usernames(self.user_specs, self.domain)
         except UserUploadError as e:
-            messages.error(request, _(e.message))
+            messages.error(request, _(six.text_type(e)))
             return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))
 
         try:
             check_duplicate_usernames(self.user_specs)
         except UserUploadError as e:
-            messages.error(request, _(e.message))
+            messages.error(request, _(six.text_type(e)))
             return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))
 
         task_ref = expose_cached_download(payload=None, expiry=1*60*60, file_extension=None)

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -548,7 +548,7 @@ class RestoreConfig(object):
                               (type(e).__name__, self.restore_user.username, str(e)))
             is_async = False
             response = get_simple_response_xml(
-                e.message,
+                six.text_type(e),
                 ResponseNature.OTA_RESTORE_ERROR
             )
             response = HttpResponse(response, content_type="text/xml; charset=utf-8",

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -5,6 +5,7 @@ import sys
 import datetime
 from functools import cmp_to_key
 
+import six
 from iso8601 import iso8601
 from casexml.apps.case import const
 from casexml.apps.case.const import CASE_ACTION_COMMTRACK
@@ -323,7 +324,7 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
         try:
             self.reconcile_transactions()
         except ReconciliationError as e:
-            reconciliation_soft_assert(False, "ReconciliationError: %s" % e.message)
+            reconciliation_soft_assert(False, "ReconciliationError: %s" % six.text_type(e))
 
         return True
 

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -212,7 +212,7 @@ def _safely_get_report_configs(project_name):
             try:
                 configs.append(ReportConfiguration.get(config_id))
             except BadSpecError as e:
-                logging.error("%s with report config %s" % (e.message, config_id))
+                logging.error("%s with report config %s" % (six.text_type(e), config_id))
 
     try:
         configs.extend(StaticReportConfiguration.by_domain(project_name))

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
 from django import template
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
@@ -59,7 +61,7 @@ def get_all_tabs(request, domain, couch_user, project):
 
     if instantiation_errors:
         messages = (
-            '- {}: {}'.format(e.__class__.__name__, e.message)
+            '- {}: {}'.format(e.__class__.__name__, six.text_type(e))
             for e in instantiation_errors
         )
         summary_message = 'Summary of Tab Class Errors:\n{}'.format('\n'.join(messages))

--- a/corehq/util/workbook_reading/adapters/xlsx.py
+++ b/corehq/util/workbook_reading/adapters/xlsx.py
@@ -34,7 +34,7 @@ def open_xlsx_workbook(filename):
         try:
             openpyxl_workbook = openpyxl.load_workbook(f, read_only=True, data_only=True)
         except InvalidFileException as e:
-            raise SpreadsheetFileInvalidError(e.message)
+            raise SpreadsheetFileInvalidError(six.text_type(e))
         except BadZipfile as e:
             f.seek(0)
             if f.read(8) == XLSX_ENCRYPTED_MARKER:


### PR DESCRIPTION
```e.message``` is removed in python 3.  Use ```six.text_type(e)``` instead.

@dimagi/py3 