### PR TITLE
run python code patches at all entry points

### DIFF
--- a/corehq/celery.py
+++ b/corehq/celery.py
@@ -7,9 +7,10 @@ from django.core.exceptions import AppRegistryNotReady
 
 from celery import Celery
 
-from manage import init_hq_python_path
+from manage import init_hq_python_path, run_patches
 
 init_hq_python_path()
+run_patches()
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 

--- a/deployment/gunicorn/gunicorn_conf.py
+++ b/deployment/gunicorn/gunicorn_conf.py
@@ -13,8 +13,9 @@ limit_request_line = 4500
 
 
 def post_fork(server, worker):
-    import mimetypes
-    mimetypes.init()
+    from manage import run_patches
+    run_patches()
+
     # hacky way to address gunicorn gevent requests hitting django too early before urls are loaded
     # see: https://github.com/benoitc/gunicorn/issues/527#issuecomment-19601046
     from django.urls import resolve

--- a/manage.py
+++ b/manage.py
@@ -123,6 +123,18 @@ def patch_pickle_version():
     pickle.HIGHEST_PROTOCOL = 2
 
 
+def run_patches():
+    # workaround for https://github.com/smore-inc/tinys3/issues/33
+    mimetypes.init()
+
+    patch_jsonfield()
+
+    patch_assertItemsEqual()
+
+    # After PY3 migration: remove
+    patch_pickle_version()
+
+
 if __name__ == "__main__":
     init_hq_python_path()
 
@@ -151,14 +163,7 @@ if __name__ == "__main__":
         from gevent.monkey import patch_all; patch_all(subprocess=True)
         from psycogreen.gevent import patch_psycopg; patch_psycopg()
 
-    # workaround for https://github.com/smore-inc/tinys3/issues/33
-    mimetypes.init()
-    patch_jsonfield()
-
-    patch_assertItemsEqual()
-
-    # After PY3 migration: remove
-    patch_pickle_version()
+    run_patches()
 
     set_default_settings_path(sys.argv)
     from django.core.management import execute_from_command_line


### PR DESCRIPTION
This introduces a single function ```run_patches``` to reduce the chance of new patches being added to one entry point and not others.  I haven't observed any issues with the current setup, but this seems like a change that might help avoid issues later.