### PR TITLE
Add save to case saves to form summary

### DIFF
--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.http import Http404
 from django.test.testcases import TestCase
 
-import corehq.apps.app_manager.util as util
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     Application,
@@ -30,10 +29,11 @@ class TestGetDefaultFollowupForm(TestCase):
         attachment = get_default_followup_form_xml(context=context)
         followup = app.new_form(0, "Followup Form", None, attachment=attachment)
 
-        modules, _ = util.get_form_data('domain', app)
         self.assertEqual(followup.name['en'], "Followup Form")
-        self.assertEqual(modules[0]['forms'][0]['name']['en'], "Followup Form")
-        self.assertEqual(modules[0]['forms'][0]['questions'][0]['label'], " Default label message ")
+        self.assertEqual(app.modules[0].forms[0].name['en'], "Followup Form")
+
+        first_question = app.modules[0].forms[0].get_questions([], include_triggers=True, include_groups=True)[0]
+        self.assertEqual(first_question['label'], " Default label message ")
 
 
 class TestLatestAppInfo(TestCase):

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -8,71 +8,11 @@ import corehq.apps.app_manager.util as util
 from corehq.apps.app_manager.models import (
     AdvancedModule,
     Application,
-    LoadUpdateAction,
     Module,
 )
-from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.util import LatestAppInfo
 from corehq.apps.app_manager.views.utils import get_default_followup_form_xml
-from corehq.apps.app_manager.xform_builder import XFormBuilder
 from corehq.apps.domain.models import Domain
-
-
-class TestGetFormData(TestCase):
-
-    def test_form_data_with_case_properties(self):
-        factory = AppFactory()
-        app = factory.app
-        module1, form1 = factory.new_basic_module('open_case', 'household')
-        form1_builder = XFormBuilder(form1.name)
-
-        # question 0
-        form1_builder.new_question('name', 'Name')
-
-        # question 1 (a group)
-        form1_builder.new_group('demographics', 'Demographics')
-        # question 2 (a question in a group)
-        form1_builder.new_question('age', 'Age', group='demographics')
-
-        # question 3 (a question that has a load property)
-        form1_builder.new_question('polar_bears_seen', 'Number of polar bears seen')
-
-        form1.source = form1_builder.tostring(pretty_print=True).decode('utf-8')
-        factory.form_requires_case(form1, case_type='household', update={
-            'name': '/data/name',
-            'age': '/data/demographics/age',
-        }, preload={
-            '/data/polar_bears_seen': 'polar_bears_seen',
-        })
-        app.save()
-
-        modules, errors = util.get_form_data(app.domain, app)
-
-        q1_saves = modules[0]['forms'][0]['questions'][0]['save_properties'][0]
-        self.assertEqual(q1_saves.case_type, 'household')
-        self.assertEqual(q1_saves.property, 'name')
-
-        group_saves = modules[0]['forms'][0]['questions'][2]['save_properties'][0]
-        self.assertEqual(group_saves.case_type, 'household')
-        self.assertEqual(group_saves.property, 'age')
-
-        q3_loads = modules[0]['forms'][0]['questions'][3]['load_properties'][0]
-        self.assertEqual(q3_loads.case_type, 'household')
-        self.assertEqual(q3_loads.property, 'polar_bears_seen')
-
-    def test_advanced_form_get_action_type(self):
-        app = Application.new_app('domain', "Untitled Application")
-
-        parent_module = app.add_module(AdvancedModule.new_module('parent', None))
-        parent_module.case_type = 'parent'
-        parent_module.unique_id = 'id_parent_module'
-
-        form = app.new_form(0, "Untitled Form", None)
-        form.xmlns = 'http://id_m1-f0'
-        form.actions.load_update_cases.append(LoadUpdateAction(case_type="clinic", case_tag='load_0'))
-
-        modules, errors = util.get_form_data('domain', app)
-        self.assertEqual(modules[0]['forms'][0]['action_type'], 'load (load_0)')
 
 
 class TestGetDefaultFollowupForm(TestCase):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -7,9 +7,8 @@ import uuid
 import re
 import logging
 import yaml
-import six
-from collections import defaultdict, namedtuple, OrderedDict
-from copy import deepcopy, copy
+from collections import OrderedDict, namedtuple
+from copy import deepcopy
 from io import open
 
 
@@ -506,117 +505,6 @@ def get_sort_and_sort_only_columns(detail, sort_elements):
         for field, (element, element_order) in sort_elements.items()
     ]
     return sort_only_elements, sort_columns
-
-
-class _FormDataGenerator(object):
-    def __init__(self, domain, app, include_shadow_forms=True):
-        self.domain = domain
-        self.app = app
-        self.include_shadow_forms = include_shadow_forms
-
-        self.errors = []
-
-        self._seen_save_to_case = defaultdict(list)
-        self._case_meta = self.app.get_case_metadata()
-
-    def compile_app_data(self):
-        return [self._compile_module(module) for module in self.app.get_modules()], self.errors
-
-    def _compile_module(self, module):
-        return {
-            'id': module.unique_id,
-            'name': module.name,
-            'short_comment': module.short_comment,
-            'module_type': module.module_type,
-            'is_surveys': module.is_surveys,
-            'module_filter': module.module_filter,
-            'forms': [self._compile_form(form) for form in self._get_pertinent_forms(module)],
-        }
-
-    def _get_pertinent_forms(self, module):
-        from corehq.apps.app_manager.models import ShadowForm
-        if not self.include_shadow_forms:
-            return [form for form in module.get_forms() if not isinstance(form, ShadowForm)]
-        return module.get_forms()
-
-    def _compile_form(self, form):
-        form_meta = {
-            'id': form.unique_id,
-            'name': form.name,
-            'short_comment': form.short_comment,
-            'action_type': form.get_action_type(),
-            'form_filter': form.form_filter,
-        }
-        try:
-            form_meta['questions'] = [
-                question
-                for raw_question in form.get_questions(self.app.langs, include_triggers=True,
-                                                       include_groups=True, include_translations=True)
-                for question in self._get_question(form.unique_id, raw_question)
-            ]
-        except XFormException as exception:
-            form_meta['questions'] = []
-            form_meta['error'] = {
-                'details': six.text_type(exception),
-                'edit_url': reverse('form_source', args=[self.domain, self.app._id, form.unique_id]),
-            }
-            self.errors.append(form_meta)
-        return form_meta
-
-    def _get_question(self, form_unique_id, question):
-        if self._needs_save_to_case_root_node(question, form_unique_id):
-            yield self._save_to_case_root_node(form_unique_id, question)
-        yield self._serialized_question(form_unique_id, question)
-
-    def _needs_save_to_case_root_node(self, question, form_unique_id):
-        return (
-            self._is_save_to_case(question)
-            and self._save_to_case_root_path(question) not in self._seen_save_to_case[form_unique_id]
-        )
-
-    @staticmethod
-    def _is_save_to_case(question):
-        return '/case/' in question['value']
-
-    @staticmethod
-    def _save_to_case_root_path(question):
-        return question['value'].split('/case/')[0]
-
-    def _save_to_case_root_node(self, form_unique_id, question):
-        """Add an extra node with the root path of the save to case to attach case properties to
-        """
-        from corehq.apps.reports.formdetails.readable import FormQuestionResponse
-        question_path = self._save_to_case_root_path(question)
-        response = FormQuestionResponse({
-            "label": question_path,
-            "tag": question_path,
-            "value": question_path,
-            "repeat": question['repeat'],
-            "group": question['group'],
-            "type": 'SaveToCase',
-            "hashtagValue": question['hashtagValue'],
-            "relevant": None,
-            "required": False,
-            "comment": None,
-            "constraint": None,
-        }).to_json()
-        response['load_properties'] = self._case_meta.get_load_properties(form_unique_id, question_path)
-        response['save_properties'] = self._case_meta.get_save_properties(form_unique_id, question_path)
-        self._seen_save_to_case[form_unique_id].append(question_path)
-        return response
-
-    def _serialized_question(self, form_unique_id, question):
-        from corehq.apps.reports.formdetails.readable import FormQuestionResponse
-        response = FormQuestionResponse(question).to_json()
-        response['load_properties'] = self._case_meta.get_load_properties(form_unique_id, question['value'])
-        response['save_properties'] = self._case_meta.get_save_properties(form_unique_id, question['value'])
-        if self._is_save_to_case(question):
-            response['type'] = 'SaveToCase'
-        return response
-
-
-def get_form_data(domain, app, include_shadow_forms=True):
-    return _FormDataGenerator(domain, app, include_shadow_forms).compile_app_data()
 
 
 def get_and_assert_practice_user_in_domain(practice_user_id, domain):

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext_noop, ugettext_lazy as _
 from django.views.generic import View
 from dimagi.utils.web import json_response
 
-from corehq.apps.app_manager.util import get_form_data
 from corehq.apps.app_manager.view_helpers import ApplicationViewMixin
 from corehq.apps.app_manager.views.utils import get_langs
 from corehq.apps.app_manager.const import WORKFLOW_FORM
@@ -18,7 +17,7 @@ from corehq.apps.app_manager.models import AdvancedForm, AdvancedModule
 from corehq.apps.app_manager.xform import VELLUM_TYPES
 from corehq.apps.domain.views.base import LoginAndDomainMixin
 from corehq.apps.hqwebapp.views import BasePageView
-from corehq.apps.reports.formdetails.readable import FormQuestionResponse
+from corehq.apps.reports.formdetails.readable import FormQuestionResponse, get_app_summary_formdata
 from couchexport.export import export_raw
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
@@ -109,7 +108,7 @@ class AppFormSummaryView(AppSummaryView):
     @property
     def page_context(self):
         context = super(AppFormSummaryView, self).page_context
-        modules, errors = get_form_data(self.domain, self.app, include_shadow_forms=False)
+        modules, errors = get_app_summary_formdata(self.domain, self.app, include_shadow_forms=False)
         context.update({
             'is_form_summary': True,
             'modules': modules,
@@ -123,7 +122,7 @@ class AppDataView(View, LoginAndDomainMixin, ApplicationViewMixin):
     urlname = 'app_data_json'
 
     def get(self, request, *args, **kwargs):
-        modules, errors = get_form_data(self.domain, self.app, include_shadow_forms=False)
+        modules, errors = get_app_summary_formdata(self.domain, self.app, include_shadow_forms=False)
         return json_response({
             'response': {
                 'form_data': {

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from copy import deepcopy
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 import datetime
 from pydoc import html
 from django.http import Http404
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from corehq.apps.app_manager.exceptions import XFormException
 from corehq.form_processor.utils.xform import get_node
@@ -709,3 +710,114 @@ def get_data_cleaning_data(form_data, instance):
         })
 
     return (question_response_map, ordered_question_values)
+
+
+class _AppSummaryFormDataGenerator(object):
+    def __init__(self, domain, app, include_shadow_forms=True):
+        self.domain = domain
+        self.app = app
+        self.include_shadow_forms = include_shadow_forms
+
+        self.errors = []
+
+        self._seen_save_to_case = defaultdict(list)
+        self._case_meta = self.app.get_case_metadata()
+
+    def generate(self):
+        return [self._compile_module(module) for module in self.app.get_modules()], self.errors
+
+    def _compile_module(self, module):
+        return {
+            'id': module.unique_id,
+            'name': module.name,
+            'short_comment': module.short_comment,
+            'module_type': module.module_type,
+            'is_surveys': module.is_surveys,
+            'module_filter': module.module_filter,
+            'forms': [self._compile_form(form) for form in self._get_pertinent_forms(module)],
+        }
+
+    def _get_pertinent_forms(self, module):
+        from corehq.apps.app_manager.models import ShadowForm
+        if not self.include_shadow_forms:
+            return [form for form in module.get_forms() if not isinstance(form, ShadowForm)]
+        return module.get_forms()
+
+    def _compile_form(self, form):
+        form_meta = {
+            'id': form.unique_id,
+            'name': form.name,
+            'short_comment': form.short_comment,
+            'action_type': form.get_action_type(),
+            'form_filter': form.form_filter,
+        }
+        try:
+            form_meta['questions'] = [
+                question
+                for raw_question in form.get_questions(self.app.langs, include_triggers=True,
+                                                       include_groups=True, include_translations=True)
+                for question in self._get_question(form.unique_id, raw_question)
+            ]
+        except XFormException as exception:
+            form_meta['questions'] = []
+            form_meta['error'] = {
+                'details': six.text_type(exception),
+                'edit_url': reverse('form_source', args=[self.domain, self.app._id, form.unique_id]),
+            }
+            self.errors.append(form_meta)
+        return form_meta
+
+    def _get_question(self, form_unique_id, question):
+        if self._needs_save_to_case_root_node(question, form_unique_id):
+            yield self._save_to_case_root_node(form_unique_id, question)
+        yield self._serialized_question(form_unique_id, question)
+
+    def _needs_save_to_case_root_node(self, question, form_unique_id):
+        return (
+            self._is_save_to_case(question)
+            and self._save_to_case_root_path(question) not in self._seen_save_to_case[form_unique_id]
+        )
+
+    @staticmethod
+    def _is_save_to_case(question):
+        return '/case/' in question['value']
+
+    @staticmethod
+    def _save_to_case_root_path(question):
+        return question['value'].split('/case/')[0]
+
+    def _save_to_case_root_node(self, form_unique_id, question):
+        """Add an extra node with the root path of the save to case to attach case properties to
+        """
+        question_path = self._save_to_case_root_path(question)
+        response = FormQuestionResponse({
+            "label": question_path,
+            "tag": question_path,
+            "value": question_path,
+            "repeat": question['repeat'],
+            "group": question['group'],
+            "type": 'SaveToCase',
+            "hashtagValue": question['hashtagValue'],
+            "relevant": None,
+            "required": False,
+            "comment": None,
+            "constraint": None,
+        }).to_json()
+        response['load_properties'] = self._case_meta.get_load_properties(form_unique_id, question_path)
+        response['save_properties'] = self._case_meta.get_save_properties(form_unique_id, question_path)
+        self._seen_save_to_case[form_unique_id].append(question_path)
+        return response
+
+    def _serialized_question(self, form_unique_id, question):
+        response = FormQuestionResponse(question).to_json()
+        response['load_properties'] = self._case_meta.get_load_properties(form_unique_id, question['value'])
+        response['save_properties'] = self._case_meta.get_save_properties(form_unique_id, question['value'])
+        if self._is_save_to_case(question):
+            response['type'] = 'SaveToCase'
+        return response
+
+
+def get_app_summary_formdata(domain, app, include_shadow_forms=True):
+    """Returns formdata formatted for the app summary
+    """
+    return _AppSummaryFormDataGenerator(domain, app, include_shadow_forms).generate()

--- a/corehq/apps/reports/tests/test_readable_formdata.py
+++ b/corehq/apps/reports/tests/test_readable_formdata.py
@@ -1,27 +1,38 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import json
 import os
 import uuid
-
 from collections import OrderedDict
-from django.test import SimpleTestCase
+from io import open
+
 import yaml
+from django.test import SimpleTestCase
 from django.test.testcases import TestCase
 from mock import patch
 
+from corehq.apps.app_manager.models import (
+    AdvancedModule,
+    Application,
+    LoadUpdateAction,
+)
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.xform import XForm
 from corehq.apps.app_manager.xform_builder import XFormBuilder
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.reports.formdetails.readable import (
     FormQuestionResponse,
+    get_app_summary_formdata,
     get_data_cleaning_data,
     get_questions_from_xform_node,
+    get_readable_data_for_submission,
     get_readable_form_data,
-    get_readable_data_for_submission)
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
+)
+from corehq.form_processor.tests.utils import (
+    FormProcessorTestUtils,
+    use_sql_backend,
+)
 from corehq.form_processor.utils.xform import FormSubmissionBuilder
-from io import open
 
 
 class ReadableFormdataTest(SimpleTestCase):
@@ -403,3 +414,60 @@ class ReadableFormTest(TestCase):
 @use_sql_backend
 class ReadableFormSQLTest(ReadableFormTest):
     pass
+
+
+class TestGetFormData(TestCase):
+
+    def test_form_data_with_case_properties(self):
+        factory = AppFactory()
+        app = factory.app
+        module1, form1 = factory.new_basic_module('open_case', 'household')
+        form1_builder = XFormBuilder(form1.name)
+
+        # question 0
+        form1_builder.new_question('name', 'Name')
+
+        # question 1 (a group)
+        form1_builder.new_group('demographics', 'Demographics')
+        # question 2 (a question in a group)
+        form1_builder.new_question('age', 'Age', group='demographics')
+
+        # question 3 (a question that has a load property)
+        form1_builder.new_question('polar_bears_seen', 'Number of polar bears seen')
+
+        form1.source = form1_builder.tostring(pretty_print=True).decode('utf-8')
+        factory.form_requires_case(form1, case_type='household', update={
+            'name': '/data/name',
+            'age': '/data/demographics/age',
+        }, preload={
+            '/data/polar_bears_seen': 'polar_bears_seen',
+        })
+        app.save()
+
+        modules, errors = get_app_summary_formdata(app.domain, app)
+
+        q1_saves = modules[0]['forms'][0]['questions'][0]['save_properties'][0]
+        self.assertEqual(q1_saves.case_type, 'household')
+        self.assertEqual(q1_saves.property, 'name')
+
+        group_saves = modules[0]['forms'][0]['questions'][2]['save_properties'][0]
+        self.assertEqual(group_saves.case_type, 'household')
+        self.assertEqual(group_saves.property, 'age')
+
+        q3_loads = modules[0]['forms'][0]['questions'][3]['load_properties'][0]
+        self.assertEqual(q3_loads.case_type, 'household')
+        self.assertEqual(q3_loads.property, 'polar_bears_seen')
+
+    def test_advanced_form_get_action_type(self):
+        app = Application.new_app('domain', "Untitled Application")
+
+        parent_module = app.add_module(AdvancedModule.new_module('parent', None))
+        parent_module.case_type = 'parent'
+        parent_module.unique_id = 'id_parent_module'
+
+        form = app.new_form(0, "Untitled Form", None)
+        form.xmlns = 'http://id_m1-f0'
+        form.actions.load_update_cases.append(LoadUpdateAction(case_type="clinic", case_tag='load_0'))
+
+        modules, errors = get_app_summary_formdata('domain', app)
+        self.assertEqual(modules[0]['forms'][0]['action_type'], 'load (load_0)')

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -11,7 +11,6 @@ import polib
 from django.utils.functional import cached_property
 from memoized import memoized
 
-from corehq.apps.reports.formdetails.readable import get_app_summary_formdata
 from corehq.apps.translations.const import MODULES_AND_FORMS_SHEET_NAME
 from corehq.apps.translations.models import TransifexBlacklist
 
@@ -80,17 +79,18 @@ class AppTranslationsGenerator:
 
         labels_to_skip = defaultdict(set)
         necessary_labels = defaultdict(set)
-        module_data, errors = get_app_summary_formdata(self.domain, self.app)
 
-        for module in module_data:
-            for form in module['forms']:
-                for question in form['questions']:
+        for module in self.app.modules:
+            for form in module.forms:
+                questions = form.get_questions(self.app.langs, include_triggers=True,
+                                               include_groups=True, include_translations=True)
+                for question in questions:
                     if not question.get('label_ref'):
                         continue
                     if question['comment'] and SKIP_TRANSFEX_STRING in question['comment']:
-                        labels_to_skip[form['id']] |= _labels_from_question(question)
+                        labels_to_skip[form.unique_id] |= _labels_from_question(question)
                     else:
-                        necessary_labels[form['id']] |= _labels_from_question(question)
+                        necessary_labels[form.unique_id] |= _labels_from_question(question)
 
         for form_id in labels_to_skip.keys():
             labels_to_skip[form_id] = labels_to_skip[form_id] - necessary_labels[form_id]

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -8,11 +8,10 @@ import tempfile
 from collections import namedtuple, OrderedDict, defaultdict
 
 import polib
-from django.conf import settings
 from django.utils.functional import cached_property
 from memoized import memoized
 
-from corehq.apps.app_manager.util import get_form_data
+from corehq.apps.reports.formdetails.readable import get_app_summary_formdata
 from corehq.apps.translations.const import MODULES_AND_FORMS_SHEET_NAME
 from corehq.apps.translations.models import TransifexBlacklist
 
@@ -81,7 +80,7 @@ class AppTranslationsGenerator:
 
         labels_to_skip = defaultdict(set)
         necessary_labels = defaultdict(set)
-        module_data, errors = get_form_data(self.domain, self.app)
+        module_data, errors = get_app_summary_formdata(self.domain, self.app)
 
         for module in module_data:
             for form in module['forms']:


### PR DESCRIPTION
This adds an extra "node" for each save to case question which then shows which case properties are being updated by that particular question. 

Unfortunately Vellum only sends back the case updates in "bulk" under this root node, otherwise I would have wanted to add this information under each sub node. 

It also changes the icon for these questions to be a diskette, like we have elsewhere. 

![screenshot from 2019-02-25 17-22-36](https://user-images.githubusercontent.com/146896/53372883-01993580-3922-11e9-8471-25806ba0df50.png)

The second commit does a bit of refactoring. 