### PR TITLE
use redis as default results backend

### DIFF
--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -126,6 +126,8 @@ WS4REDIS_CONNECTION = {
     'host': redis_host,
 }
 
+CELERY_RESULT_BACKEND = redis_cache['LOCATION']
+
 ELASTICSEARCH_HOST = 'elasticsearch'
 ELASTICSEARCH_PORT = 9200
 

--- a/settings.py
+++ b/settings.py
@@ -540,7 +540,7 @@ GET_URL_BASE = 'dimagi.utils.web.get_url_base'
 # celery
 BROKER_URL = 'redis://localhost:6379/0'
 
-CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
+CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 
 CELERY_ANNOTATIONS = {
     '*': {


### PR DESCRIPTION
We are moving to using redis as the celery results backend on all production systems, so we should use it locally too.