### PR TITLE
remove dependency on django-celery

### DIFF
--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -277,7 +277,7 @@ CCHQ_API_THROTTLE_TIMEFRAME = 10  # seconds
 COVERAGE_REPORT_HTML_OUTPUT_DIR='coverage-html'
 COVERAGE_MODULE_EXCLUDES= ['tests$', 'settings$', 'urls$', 'locale$',
                            'common.views.test', '^django', 'management', 'migrations',
-                           '^south', '^djcelery', '^debug_toolbar']
+                           '^south', '^debug_toolbar']
 
 INTERNAL_DATA = {
     "business_unit": [],

--- a/manage.py
+++ b/manage.py
@@ -154,7 +154,6 @@ if __name__ == "__main__":
         GeventCommand('ptop_preindex'),
         GeventCommand('sync_prepare_couchdb_multi'),
         GeventCommand('sync_couch_views'),
-        GeventCommand('celery', contains='-P gevent'),
         GeventCommand('populate_form_date_modified'),
         GeventCommand('migrate_domain_from_couch_to_sql', http_adapter_pool_size=32),
         GeventCommand('migrate_multiple_domains_from_couch_to_sql', http_adapter_pool_size=32),

--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -43,7 +43,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -35,7 +35,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -36,7 +36,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -34,7 +34,6 @@ django-angular==0.7.16
 django-appconf==1.0.2     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -39,7 +39,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3_6/uninstall-requirements.txt
+++ b/requirements-python3_6/uninstall-requirements.txt
@@ -8,5 +8,6 @@ restkit
 http-parser
 zeep
 cython
+django-celery
 django-celery-results
 numpy

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -43,7 +43,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -35,7 +35,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -36,7 +36,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,7 +7,6 @@ celery==3.1.25
 decorator==4.0.11
 django~=1.11
 django-braces==1.13.0
-django-celery==3.2.1
 django-crispy-forms==1.7.0
 jsonfield==1.0.3
 dropbox==7.3.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -34,7 +34,6 @@ django-angular==0.7.16
 django-appconf==1.0.2     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -39,7 +39,6 @@ django-angular==0.7.16
 django-appconf==1.0.2
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -8,5 +8,6 @@ restkit
 http-parser
 zeep
 cython
+django-celery
 django-celery-results
 numpy

--- a/settings.py
+++ b/settings.py
@@ -11,11 +11,6 @@ import six
 from django.contrib import messages
 import settingshelper as helper
 
-# odd celery fix
-import djcelery
-
-djcelery.setup_loader()
-
 DEBUG = True
 LESS_DEBUG = DEBUG
 
@@ -190,7 +185,6 @@ DEFAULT_APPS = (
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
-    'djcelery',
     'django_prbac',
     'djangular',
     'captcha',
@@ -390,7 +384,6 @@ APPS_TO_EXCLUDE_FROM_TESTS = (
     'django_otp',
     'django_otp.plugins.otp_static',
     'django_otp.plugins.otp_totp',
-    'djcelery',
     'gunicorn',
     'langcodes',
     'raven.contrib.django.raven_compat',


### PR DESCRIPTION
Last blocker before we can upgrade to celery 4.x

Extracted from https://github.com/dimagi/commcare-hq/pull/21588

Recommend 🐡 

Before merging, update the following environments:

- [x] staging
  - [x] ```cchq staging update-supervisor-confs```
  - [x] ```cchq staging update-config```

- [x] swiss
  - [x] ```cchq swiss update-supervisor-confs```
  - [x] ```cchq swiss update-config```

- [x] pna
  - [x] ```cchq pna update-supervisor-confs```
  - [x] ```cchq pna update-config```

- [x] production
  - [x] ```cchq production update-supervisor-confs```
  - [x] ```cchq production update-config```

- [x] softlayer
  - [x] ```cchq softlayer update-supervisor-confs```
  - [x] ```cchq softlayer update-config```

- [x] ICDS: create ticket

After merging, update:
- [ ] https://github.com/dimagi/commcare-cloud/pull/2680#discussion_r259515317