### PR TITLE
Add redis lock metrics

### DIFF
--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -30,10 +30,8 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.messaging.util import use_phone_entries
 from corehq.toggles import RETRY_SMS_INDEFINITELY, USE_SMS_WITH_INACTIVE_CONTACTS
 from corehq.util.celery_utils import no_result_task
-from corehq.util.datadog.lockmeter import LockMeter
 from corehq.util.timezones.conversions import ServerTime
-from dimagi.utils.couch import CriticalSection, release_lock
-from dimagi.utils.couch.cache.cache_core import get_redis_client
+from dimagi.utils.couch import CriticalSection, get_redis_client, get_redis_lock, release_lock
 from dimagi.utils.rate_limit import rate_limit
 
 
@@ -87,10 +85,11 @@ def delay_processing(msg, minutes):
     msg.save()
 
 
-def get_lock(client, key):
-    return LockMeter(
-        client.lock(key, timeout=settings.SMS_QUEUE_PROCESSING_LOCK_TIMEOUT * 60),
-        "_".join(key.split("-", 3)[:3]),
+def get_lock(key):
+    return get_redis_lock(
+        key,
+        timeout=settings.SMS_QUEUE_PROCESSING_LOCK_TIMEOUT * 60,
+        name="_".join(key.split("-", 3)[:3]),
     )
 
 
@@ -165,8 +164,7 @@ def get_connection_slot_lock(phone_number, backend, max_simultaneous_connections
     """
     slot = get_connection_slot_from_phone_number(phone_number, max_simultaneous_connections)
     key = 'backend-%s-connection-slot-%s' % (backend.couch_id, slot)
-    client = get_redis_client()
-    return LockMeter(client.lock(key, timeout=60), "connection_slot")
+    return get_redis_lock(key, timeout=60, name="connection_slot")
 
 
 def passes_trial_check(msg):
@@ -325,11 +323,10 @@ def process_sms(queued_sms_pk):
     """
     queued_sms_pk - pk of a QueuedSMS entry
     """
-    client = get_redis_client()
     utcnow = get_utcnow()
     # Prevent more than one task from processing this SMS, just in case
     # the message got enqueued twice.
-    message_lock = get_lock(client, "sms-queue-processing-%s" % queued_sms_pk)
+    message_lock = get_lock("sms-queue-processing-%s" % queued_sms_pk)
 
     if message_lock.acquire(blocking=False):
         try:
@@ -366,12 +363,14 @@ def process_sms(queued_sms_pk):
         # of time because timestamps can differ between machines which
         # can cause us to miss sending the message the first time and
         # result in an unnecessary delay.
-        if (isinstance(msg.processed, bool)
-            and not msg.processed
-            and not msg.error
-            and msg.datetime_to_process < (utcnow + timedelta(seconds=10))):
+        if (
+            isinstance(msg.processed, bool) and
+            not msg.processed and
+            not msg.error and
+            msg.datetime_to_process < (utcnow + timedelta(seconds=10))
+        ):
             if recipient_block:
-                recipient_lock = get_lock(client, 
+                recipient_lock = get_lock(
                     "sms-queue-recipient-phone-%s" % msg.phone_number)
                 recipient_lock.acquire(blocking=True)
 

--- a/corehq/apps/smsforms/management/commands/handle_survey_actions.py
+++ b/corehq/apps/smsforms/management/commands/handle_survey_actions.py
@@ -4,9 +4,8 @@ from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.smsforms.tasks import handle_due_survey_action
 from corehq.sql_db.util import handle_connection_failure
-from corehq.util.datadog.lockmeter import LockMeter
 from datetime import datetime
-from dimagi.utils.couch.cache.cache_core import get_redis_client
+from dimagi.utils.couch import get_redis_lock
 from dimagi.utils.logging import notify_exception
 from django.core.management.base import BaseCommand
 from time import sleep
@@ -27,14 +26,14 @@ class Command(BaseCommand):
     help = "Spawns tasks to handle the next actions due in SMS surveys"
 
     def get_enqueue_lock(self, session_id, current_action_due):
-        client = get_redis_client()
         key = "create-task-for-smsforms-session-%s-%s" % (
             session_id,
             current_action_due.strftime('%Y-%m-%d %H:%M:%S')
         )
-        return LockMeter(
-            client.lock(key, timeout=60 * 60),
-            "smsforms_task",
+        return get_redis_lock(
+            key,
+            timeout=60 * 60,
+            name="smsforms_task",
             track_unreleased=False,
         )
 

--- a/corehq/ex-submodules/dimagi/utils/couch/__init__.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/__init__.py
@@ -11,7 +11,7 @@ import json
 import six
 import sys
 
-from corehq.util.datadog.lockmeter import LockMeter
+from corehq.util.datadog.lockmeter import MeteredLock
 
 LOCK_EXPIRATION = timedelta(hours=1)
 
@@ -95,7 +95,7 @@ def get_redis_lock(key, timeout=None, name=None, track_unreleased=True, **kw):
     if name is None:
         raise ValueError("'name' (DataDog 'name' tag value) is required")
     lock = get_redis_client().lock(key, timeout=timeout, **kw)
-    return LockMeter(lock, name, track_unreleased)
+    return MeteredLock(lock, name, track_unreleased)
 
 
 def acquire_lock(lock, degrade_gracefully, **kwargs):

--- a/corehq/messaging/management/commands/queue_schedule_instances.py
+++ b/corehq/messaging/management/commands/queue_schedule_instances.py
@@ -19,9 +19,8 @@ from corehq.messaging.scheduling.tasks import (
 )
 from corehq.sql_db.util import handle_connection_failure, get_default_and_partitioned_db_aliases
 from corehq.toggles import REMINDERS_MIGRATION_IN_PROGRESS
-from corehq.util.datadog.lockmeter import LockMeter
 from datetime import datetime
-from dimagi.utils.couch.cache.cache_core import get_redis_client
+from dimagi.utils.couch import get_redis_lock
 from dimagi.utils.logging import notify_exception
 from django.core.management.base import BaseCommand
 from time import sleep
@@ -58,15 +57,15 @@ class Command(BaseCommand):
         raise ValueError("Unexpected class: %s" % cls)
 
     def get_enqueue_lock(self, cls, schedule_instance_id, next_event_due):
-        client = get_redis_client()
         key = "create-task-for-%s-%s-%s" % (
             cls.__name__,
             schedule_instance_id.hex,
             next_event_due.strftime('%Y-%m-%d %H:%M:%S')
         )
-        return LockMeter(
-            client.lock(key, timeout=60 * 60),
-            "create_task_for_%s" % cls.__name__,
+        return get_redis_lock(
+            key,
+            timeout=60 * 60,
+            name="create_task_for_%s" % cls.__name__,
             track_unreleased=False,
         )
 

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -9,6 +9,7 @@ from celery.task import periodic_task, task
 from celery.utils.log import get_task_logger
 from redis.exceptions import LockError
 from corehq.util.datadog.gauges import datadog_gauge_task
+from corehq.util.datadog.lockmeter import LockMeter
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
@@ -35,10 +36,10 @@ def check_repeaters():
     redis_client = get_redis_client().client.get_client()
 
     # Timeout for slightly less than periodic check
-    check_repeater_lock = redis_client.lock(
+    check_repeater_lock = LockMeter(redis_client.lock(
         CHECK_REPEATERS_KEY,
         timeout=CHECK_REPEATERS_INTERVAL.seconds - 10
-    )
+    ), CHECK_REPEATERS_KEY)
     if not check_repeater_lock.acquire(blocking=False):
         return
 
@@ -49,7 +50,7 @@ def check_repeaters():
         if now > cutoff:
             break
 
-        lock = redis_client.lock(lock_key, timeout=60 * 60 * 48)
+        lock = LockMeter(redis_client.lock(lock_key, timeout=60 * 60 * 48), "repeat_record")
         if not lock.acquire(blocking=False):
             continue
 

--- a/corehq/util/datadog/lockmeter.py
+++ b/corehq/util/datadog/lockmeter.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from corehq.util.datadog.gauges import datadog_counter, datadog_bucket_timer
+
+
+class LockMeter(object):
+    """A lock wrapper that measures various lock characteristics
+
+    This was built for profiling Redis locks, but will for any type of
+    lock that has `acquire()` and `release()` methods.
+    """
+
+    timing_buckets = (0.1, 1, 5, 10, 30, 60, 120, 60 * 5, 60 * 10, 60 * 15, 60 * 30)
+
+    def __init__(self, lock, name):
+        self.lock = lock
+        self.tags = ["name:%s" % name]
+        self.lock_timer = datadog_bucket_timer(
+            "commcare.lock.locked_time", self.tags, self.timing_buckets)
+
+    def acquire(self, *args, **kw):
+        tags = self.tags
+        buckets = self.timing_buckets
+        with datadog_bucket_timer("commcare.lock.acquire_time", tags, buckets):
+            acquired = self.lock.acquire(*args, **kw)
+        if acquired:
+            self.lock_timer.start()
+        return acquired
+
+    def release(self):
+        self.lock.release()
+        if self.lock_timer.is_started():
+            self.lock_timer.stop()
+
+    def __enter__(self):
+        self.acquire(blocking=True)
+        return self
+
+    def __exit__(self, *exc_info):
+        self.release()
+
+    def __del__(self):
+        if self.lock_timer.is_started():
+            datadog_counter("commcare.lock.not_released", tags=self.tags)
+
+    def release_failed(self):
+        """Indicate that the lock was not released"""
+        datadog_counter("commcare.lock.release_failed", tags=self.tags)
+
+    def degraded(self):
+        """Indicate that the lock has "degraded gracefully"
+
+        The lock was not acquired, but processing continued as if it had
+        been acquired.
+        """
+        datadog_counter("commcare.lock.degraded", tags=self.tags)

--- a/corehq/util/datadog/lockmeter.py
+++ b/corehq/util/datadog/lockmeter.py
@@ -6,7 +6,7 @@ import time
 from corehq.util.datadog.gauges import datadog_counter, datadog_bucket_timer
 
 
-class LockMeter(object):
+class MeteredLock(object):
     """A lock wrapper that measures various lock characteristics
 
     This was built for profiling Redis locks, but will for any type of

--- a/corehq/util/datadog/lockmeter.py
+++ b/corehq/util/datadog/lockmeter.py
@@ -9,8 +9,8 @@ from corehq.util.datadog.gauges import datadog_counter, datadog_bucket_timer
 class MeteredLock(object):
     """A lock wrapper that measures various lock characteristics
 
-    This was built for profiling Redis locks, but will for any type of
-    lock that has `acquire()` and `release()` methods.
+    This was built for profiling Redis locks, but should work with any
+    type of lock that has `acquire()` and `release()` methods.
     """
 
     timing_buckets = (0.1, 1, 5, 10, 30, 60, 120, 60 * 5, 60 * 10, 60 * 15, 60 * 30)

--- a/corehq/util/datadog/tests/test_lockmeter.py
+++ b/corehq/util/datadog/tests/test_lockmeter.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from unittest import TestCase
+
+from mock import patch, call, ANY
+
+from ..lockmeter import LockMeter
+
+
+class TestLockMeter(TestCase):
+
+    def test_initially_not_locked(self):
+        fake = FakeLock()
+        LockMeter(fake, "test")
+        self.assertFalse(fake.locked)
+
+    def test_acquire(self):
+        fake = FakeLock()
+        lock = LockMeter(fake, "test")
+        with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
+            lock.acquire()
+            self.assertTrue(fake.locked)
+        timer.assert_called_once_with("commcare.lock.acquire_time", tags=["name:test", ANY])
+
+    def test_not_acquired(self):
+        fake = FakeLock()
+        lock = LockMeter(fake, "test")
+        with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
+            self.assertFalse(lock.acquire(blocking=False))
+        timer.assert_called_once_with("commcare.lock.acquire_time", tags=["name:test", ANY])
+
+    def test_release(self):
+        fake = FakeLock()
+        lock = LockMeter(fake, "test")
+        lock.acquire()
+        with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
+            lock.release()
+            self.assertFalse(fake.locked)
+        timer.assert_called_once_with("commcare.lock.locked_time", tags=["name:test", ANY])
+
+    def test_release_not_locked(self):
+        fake = FakeLock()
+        lock = LockMeter(fake, "test")
+        with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
+            lock.release()
+            self.assertFalse(fake.locked)
+        timer.assert_not_called()
+
+    def test_lock_as_context_manager(self):
+        fake = FakeLock()
+        lock = LockMeter(fake, "test")
+        with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
+            with lock:
+                self.assertTrue(fake.locked)
+            self.assertFalse(fake.locked)
+        timer.assert_has_calls([
+            call("commcare.lock.acquire_time", tags=["name:test", ANY]),
+            call("commcare.lock.locked_time", tags=["name:test", ANY]),
+        ])
+        self.assertEqual(timer.call_count, 2, timer.call_args_list)
+
+    def test_release_failed(self):
+        lock = LockMeter(FakeLock(), "test")
+        with patch("corehq.util.datadog.lockmeter.datadog_counter") as counter:
+            lock.release_failed()
+        counter.assert_called_once_with("commcare.lock.release_failed", tags=["name:test"])
+
+    def test_degraded(self):
+        lock = LockMeter(FakeLock(), "test")
+        with patch("corehq.util.datadog.lockmeter.datadog_counter") as counter:
+            lock.degraded()
+        counter.assert_called_once_with("commcare.lock.degraded", tags=["name:test"])
+
+
+class FakeLock(object):
+
+    locked = False
+
+    def acquire(self, blocking=True):
+        self.locked = True
+        return blocking
+
+    def release(self):
+        self.locked = False

--- a/corehq/util/datadog/tests/test_lockmeter.py
+++ b/corehq/util/datadog/tests/test_lockmeter.py
@@ -5,19 +5,19 @@ from unittest import TestCase
 import attr
 from mock import patch, call, ANY
 
-from ..lockmeter import LockMeter
+from ..lockmeter import MeteredLock
 
 
-class TestLockMeter(TestCase):
+class TestMeteredLock(TestCase):
 
     def test_initially_not_locked(self):
         fake = FakeLock()
-        LockMeter(fake, "test")
+        MeteredLock(fake, "test")
         self.assertFalse(fake.locked)
 
     def test_acquire(self):
         fake = FakeLock()
-        lock = LockMeter(fake, "test")
+        lock = MeteredLock(fake, "test")
         with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
             lock.acquire()
             self.assertTrue(fake.locked)
@@ -25,14 +25,14 @@ class TestLockMeter(TestCase):
 
     def test_not_acquired(self):
         fake = FakeLock()
-        lock = LockMeter(fake, "test")
+        lock = MeteredLock(fake, "test")
         with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
             self.assertFalse(lock.acquire(blocking=False))
         timer.assert_called_once_with("commcare.lock.acquire_time", tags=["name:test", ANY])
 
     def test_release(self):
         fake = FakeLock()
-        lock = LockMeter(fake, "test")
+        lock = MeteredLock(fake, "test")
         lock.acquire()
         with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
             lock.release()
@@ -41,7 +41,7 @@ class TestLockMeter(TestCase):
 
     def test_release_not_locked(self):
         fake = FakeLock()
-        lock = LockMeter(fake, "test")
+        lock = MeteredLock(fake, "test")
         with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
             lock.release()
             self.assertFalse(fake.locked)
@@ -49,7 +49,7 @@ class TestLockMeter(TestCase):
 
     def test_lock_as_context_manager(self):
         fake = FakeLock()
-        lock = LockMeter(fake, "test")
+        lock = MeteredLock(fake, "test")
         with patch("corehq.util.datadog.gauges.datadog_counter") as timer:
             with lock:
                 self.assertTrue(fake.locked)
@@ -61,19 +61,19 @@ class TestLockMeter(TestCase):
         self.assertEqual(timer.call_count, 2, timer.call_args_list)
 
     def test_release_failed(self):
-        lock = LockMeter(FakeLock(), "test")
+        lock = MeteredLock(FakeLock(), "test")
         with patch("corehq.util.datadog.lockmeter.datadog_counter") as counter:
             lock.release_failed()
         counter.assert_called_once_with("commcare.lock.release_failed", tags=["name:test"])
 
     def test_degraded(self):
-        lock = LockMeter(FakeLock(), "test")
+        lock = MeteredLock(FakeLock(), "test")
         with patch("corehq.util.datadog.lockmeter.datadog_counter") as counter:
             lock.degraded()
         counter.assert_called_once_with("commcare.lock.degraded", tags=["name:test"])
 
     def test_released_after_timeout(self):
-        lock = LockMeter(FakeLock(timeout=-1), "test")
+        lock = MeteredLock(FakeLock(timeout=-1), "test")
         lock.acquire()
         with patch("corehq.util.datadog.lockmeter.datadog_counter") as counter:
             lock.release()
@@ -83,7 +83,7 @@ class TestLockMeter(TestCase):
         fake = FakeLock()
         del fake.timeout
         assert not hasattr(fake, "timeout")
-        lock = LockMeter(fake, "test")
+        lock = MeteredLock(fake, "test")
         lock.acquire()  # should not raise
 
 

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -5,7 +5,6 @@ from functools import wraps
 import logging
 import requests
 from corehq.util.global_request import get_request
-from dimagi.utils.couch import release_lock
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from dimagi.utils.logging import notify_exception
 from django.conf import settings
@@ -115,6 +114,8 @@ def serial_task(unique_key, default_retry_delay=30, timeout=5*60, max_retries=3,
     """
     def decorator(fn):
         # register task with celery.  Note that this still happens on import
+        from dimagi.utils.couch import release_lock
+
         @task(serializer='pickle', bind=True, queue=queue, ignore_result=ignore_result,
               default_retry_delay=default_retry_delay, max_retries=max_retries)
         @wraps(fn)

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -5,7 +5,6 @@ from functools import wraps
 import logging
 import requests
 from corehq.util.global_request import get_request
-from dimagi.utils.couch.cache.cache_core import get_redis_client
 from dimagi.utils.logging import notify_exception
 from django.conf import settings
 from six.moves import zip
@@ -114,8 +113,7 @@ def serial_task(unique_key, default_retry_delay=30, timeout=5*60, max_retries=3,
     """
     def decorator(fn):
         # register task with celery.  Note that this still happens on import
-        from corehq.util.datadog.lockmeter import LockMeter
-        from dimagi.utils.couch import release_lock
+        from dimagi.utils.couch import get_redis_lock, release_lock
 
         @task(serializer='pickle', bind=True, queue=queue, ignore_result=ignore_result,
               default_retry_delay=default_retry_delay, max_retries=max_retries)
@@ -124,9 +122,8 @@ def serial_task(unique_key, default_retry_delay=30, timeout=5*60, max_retries=3,
             if settings.UNIT_TESTING:  # Don't depend on redis
                 return fn(*args, **kwargs)
 
-            client = get_redis_client()
             key = _get_unique_key(unique_key, fn, *args, **kwargs)
-            lock = LockMeter(client.lock(key, timeout=timeout), fn.__name__)
+            lock = get_redis_lock(key, timeout=timeout, name=fn.__name__)
             if lock.acquire(blocking=False):
                 try:
                     return fn(*args, **kwargs)

--- a/corehq/util/timer.py
+++ b/corehq/util/timer.py
@@ -123,7 +123,12 @@ class TimingContext(object):
         return not self.stack
 
     def is_started(self):
-        return self.peek().beginning is not None
+        """Check if the timer has been started
+
+        Returns false if the timer has not yet started or was started
+        and then stopped, otherwise true.
+        """
+        return bool(self.stack) and self.peek().beginning is not None
 
     def start(self):
         if self.is_started():

--- a/custom/m4change/signals.py
+++ b/custom/m4change/signals.py
@@ -4,6 +4,7 @@ from casexml.apps.case.signals import cases_received
 from casexml.apps.case.models import XFormInstance
 from fluff.signals import indicator_document_updated
 import json
+from corehq.util.datadog.lockmeter import LockMeter
 from dimagi.utils.couch import release_lock
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from django.core.exceptions import ObjectDoesNotExist
@@ -124,7 +125,7 @@ def handle_fixture_location_update(sender, doc, diff, backend, **kwargs):
             client = get_redis_client()
             redis_key = REDIS_FIXTURE_KEYS[xform.domain]
             redis_lock_key = REDIS_FIXTURE_LOCK_KEYS[xform.domain]
-            lock = client.lock(redis_lock_key, timeout=5)
+            lock = LockMeter(client.lock(redis_lock_key, timeout=5), redis_lock_key)
             if lock.acquire(blocking=True):
                 try:
                     location_ids_str = client.get(redis_key)

--- a/custom/m4change/tasks.py
+++ b/custom/m4change/tasks.py
@@ -6,11 +6,9 @@ from celery.task import periodic_task
 
 from django.conf import settings
 
-from dimagi.utils.couch import release_lock
-from dimagi.utils.couch.cache.cache_core import get_redis_client
+from dimagi.utils.couch import get_redis_client, get_redis_lock, release_lock
 
 from corehq.apps.locations.models import SQLLocation
-from corehq.util.datadog.lockmeter import LockMeter
 from custom.m4change.constants import NUMBER_OF_MONTHS_FOR_FIXTURES, M4CHANGE_DOMAINS, REDIS_FIXTURE_KEYS, \
     REDIS_FIXTURE_LOCK_KEYS
 from custom.m4change.fixtures.report_fixtures import get_last_n_months
@@ -69,7 +67,7 @@ def generate_fixtures_for_locations():
     for domain in M4CHANGE_DOMAINS:
         redis_key = REDIS_FIXTURE_KEYS[domain]
         redis_lock_key = REDIS_FIXTURE_LOCK_KEYS[domain]
-        lock = LockMeter(client.lock(redis_lock_key, timeout=5), redis_lock_key)
+        lock = get_redis_lock(redis_lock_key, timeout=5, name=redis_lock_key)
         location_ids = []
         if lock.acquire(blocking=True):
             try:

--- a/custom/m4change/tasks.py
+++ b/custom/m4change/tasks.py
@@ -10,6 +10,7 @@ from dimagi.utils.couch import release_lock
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 
 from corehq.apps.locations.models import SQLLocation
+from corehq.util.datadog.lockmeter import LockMeter
 from custom.m4change.constants import NUMBER_OF_MONTHS_FOR_FIXTURES, M4CHANGE_DOMAINS, REDIS_FIXTURE_KEYS, \
     REDIS_FIXTURE_LOCK_KEYS
 from custom.m4change.fixtures.report_fixtures import get_last_n_months
@@ -68,7 +69,7 @@ def generate_fixtures_for_locations():
     for domain in M4CHANGE_DOMAINS:
         redis_key = REDIS_FIXTURE_KEYS[domain]
         redis_lock_key = REDIS_FIXTURE_LOCK_KEYS[domain]
-        lock = client.lock(redis_lock_key, timeout=5)
+        lock = LockMeter(client.lock(redis_lock_key, timeout=5), redis_lock_key)
         location_ids = []
         if lock.acquire(blocking=True):
             try:


### PR DESCRIPTION
Adds count metrics to all redis locks. Things that are tracked:

- acquire time (with `duration` bucket tag)
- locked time (with `duration` bucket tag)
- "degraded gracefully" (proceed as if locked, but without lock)
- not released
- released after timeout expired
- release failed

@dannyroberts cc @orangejenny 