### PR TITLE
delete keys one at a time

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -257,7 +257,6 @@ def move_ucr_data_into_aggregation_tables(date=None, intervals=2):
                             ).apply_async()
 
             res_awc.get()
-            _bust_awc_cache.delay()
 
             first_of_month_string = monthly_date.strftime('%Y-%m-01')
             for state_id in state_ids:
@@ -268,6 +267,7 @@ def move_ucr_data_into_aggregation_tables(date=None, intervals=2):
             icds_aggregation_task.si(date=date.strftime('%Y-%m-%d'), func=aggregate_awc_daily),
             email_dashboad_team.si(aggregation_date=date.strftime('%Y-%m-%d'))
         ).delay()
+        _bust_awc_cache.delay()
 
 
 def _create_aggregate_functions(cursor):
@@ -986,4 +986,5 @@ def create_mbt_for_month(state_id, month):
 @task(queue='background_queue')
 def _bust_awc_cache():
     reach_keys = cache.keys('*cas_reach_data*')
-    cache.delete_many(reach_keys)
+    for key in reach_keys:
+        cache.delete(key)

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -36,6 +36,7 @@ from corehq.form_processor.change_publishers import publish_case_saved
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.sql_db.connections import get_icds_ucr_db_alias
 from corehq.sql_db.routers import db_for_read_write
+from corehq.util.datadog.utils import create_datadog_event
 from corehq.util.decorators import serial_task
 from corehq.util.log import send_HTML_email
 from corehq.util.soft_assert import soft_assert
@@ -985,6 +986,8 @@ def create_mbt_for_month(state_id, month):
 
 @task(queue='background_queue')
 def _bust_awc_cache():
+    create_datadog_event('Busting dashboard cache', 'start')
     reach_keys = cache.keys('*cas_reach_data*')
     for key in reach_keys:
         cache.delete(key)
+    create_datadog_event('Busting dashboard cache', 'finish')

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -986,8 +986,8 @@ def create_mbt_for_month(state_id, month):
 
 @task(queue='background_queue')
 def _bust_awc_cache():
-    create_datadog_event('Busting dashboard cache', 'start')
+    create_datadog_event('redis: delete dashboard keys', 'start')
     reach_keys = cache.keys('*cas_reach_data*')
     for key in reach_keys:
         cache.delete(key)
-    create_datadog_event('Busting dashboard cache', 'finish')
+    create_datadog_event('redis: delete dashboard keys', 'finish')


### PR DESCRIPTION
@emord  @snopoke 
I suspect this will lower load on redis during the delete which may make it not take down the servers. It also moves it to the end