### PR TITLE
Determine ministry based off of user data

### DIFF
--- a/custom/aaa/utils.py
+++ b/custom/aaa/utils.py
@@ -46,3 +46,13 @@ def _explain_query(cls, method, domain, window_start, window_end):
     with connections['aaa-data'].cursor() as cursor:
         cursor.execute('explain ' + agg_query, agg_params)
         return cls.__name__ + method.__name__, cursor.fetchall()
+
+
+def get_location_model_for_ministry(ministry):
+    if ministry == 'MoHFW':
+        return AggVillage
+    elif ministry == 'MWCD':
+        return AggAwc
+
+    # This should be removed eventually once ministry is reliably being passed back from front end
+    return AggVillage

--- a/custom/aaa/views.py
+++ b/custom/aaa/views.py
@@ -64,10 +64,6 @@ class ReachDashboardView(TemplateView):
         kwargs['is_web_user'] = self.couch_user.is_web_user()
         kwargs['user_role_type'] = self.user_ministry
 
-        if (not kwargs['is_web_user']
-                and (kwargs['user_role_type'] is None or kwargs['user_role_type'] == '')):
-            return no_permissions(self.request)
-
         user_location = self.couch_user.get_sql_locations(self.domain).first()
         kwargs['user_location_id'] = user_location.location_id if user_location else None
         user_locations_with_parents = SQLLocation.objects.get_queryset_ancestors(

--- a/custom/aaa/views.py
+++ b/custom/aaa/views.py
@@ -23,7 +23,7 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe
 
 from custom.aaa.const import COLORS, INDICATOR_LIST, NUMERIC, PERCENT
-from custom.aaa.models import AggVillage, Woman
+from custom.aaa.models import Woman
 from custom.aaa.tasks import (
     update_agg_awc_table,
     update_agg_village_table,
@@ -33,7 +33,7 @@ from custom.aaa.tasks import (
     update_woman_table,
     update_woman_history_table,
 )
-from custom.aaa.utils import build_location_filters
+from custom.aaa.utils import build_location_filters, get_location_model_for_ministry
 
 from dimagi.utils.dates import force_to_date
 
@@ -96,7 +96,7 @@ class ProgramOverviewReportAPI(View):
         prev_month = date(selected_year, selected_month, 1) - relativedelta(months=1)
 
         location_filters = build_location_filters(selected_location)
-        data = AggVillage.objects.filter(
+        data = get_location_model_for_ministry(self.user_ministry).objects.filter(
             (Q(month=selected_date) | Q(month=prev_month)),
             domain=self.request.domain,
             **location_filters


### PR DESCRIPTION
The ministries share state and district so we can't just use locations to determine the ministry. Also web users have acces to both hierarchies. As noted in a comment, the front end will need to pass back the ministry whenever there is a web user. I'll be making a new QA JIRA ticket for this.

This PR strictly improves the work now and uses the old behavior of falling back to `AggVillage` if it doesn't know what to do.