### PR TITLE
run gevent monkeypatch before imports

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,14 +2,8 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import sys
-import os
-import mimetypes
-import six
-import requests
-import attr
 
-import django
+import attr
 
 
 @attr.s
@@ -36,6 +30,8 @@ def _set_source_root_parent(source_root_parent):
     then foo and bar would become top-level importable
 
     """
+    import os
+    import sys
     filedir = os.path.dirname(__file__)
     submodules_list = os.listdir(os.path.join(filedir, source_root_parent))
     for d in submodules_list:
@@ -47,6 +43,8 @@ def _set_source_root_parent(source_root_parent):
 
 
 def _set_source_root(source_root):
+    import os
+    import sys
     filedir = os.path.dirname(__file__)
     sys.path.insert(1, os.path.join(filedir, source_root))
 
@@ -58,17 +56,15 @@ def _setup_once(*args, **kw):
         _setup_once.setup(*args, **kw)
 
 
-_setup_once.setup = django.setup
-django.setup = _setup_once
-
-
 def init_hq_python_path():
+    import os
     _set_source_root_parent('submodules')
     _set_source_root(os.path.join('corehq', 'ex-submodules'))
     _set_source_root(os.path.join('custom', '_legacy'))
 
 
 def _should_patch_gevent(args, gevent_commands):
+    import requests
     should_patch = False
     for gevent_command in gevent_commands:
         should_patch = args[1] == gevent_command.command
@@ -82,6 +78,7 @@ def _should_patch_gevent(args, gevent_commands):
 
 
 def set_default_settings_path(argv):
+    import os
     if len(argv) > 1 and argv[1] == 'test' or os.environ.get('CCHQ_TESTING') == '1':
         os.environ.setdefault('CCHQ_TESTING', '1')
         module = 'testsettings'
@@ -112,6 +109,7 @@ def patch_jsonfield():
 
 
 def patch_assertItemsEqual():
+    import six
     import unittest
     if six.PY3:
         unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
@@ -125,6 +123,7 @@ def patch_pickle_version():
 
 def run_patches():
     # workaround for https://github.com/smore-inc/tinys3/issues/33
+    import mimetypes
     mimetypes.init()
 
     patch_jsonfield()
@@ -134,15 +133,18 @@ def run_patches():
     # After PY3 migration: remove
     patch_pickle_version()
 
+    import django
+    _setup_once.setup = django.setup
+    django.setup = _setup_once
+
 
 if __name__ == "__main__":
-    init_hq_python_path()
-
     # important to apply gevent monkey patches before running any other code
     # applying this later can lead to inconsistencies and threading issues
     # but compressor doesn't like it
     # ('module' object has no attribute 'poll' which has to do with
     # gevent-patching subprocess)
+    import sys
     GEVENT_COMMANDS = (
         GeventCommand('run_gunicorn'),
         GeventCommand('run_sql'),
@@ -163,6 +165,7 @@ if __name__ == "__main__":
         from gevent.monkey import patch_all; patch_all(subprocess=True)
         from psycogreen.gevent import patch_psycopg; patch_psycopg()
 
+    init_hq_python_path()
     run_patches()
 
     set_default_settings_path(sys.argv)


### PR DESCRIPTION
This was causing recursion errors in the SSL library in python 3.  More up-to-date versions of gevent raise a warning about this specific issue if you don't patch gevent before running imports or other code.

For example:
https://sentry.io/organizations/dimagi/issues/555771704/