### PR TITLE
Revert "Added flagged profiling for bulk multimedia upload"

### DIFF
--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -17,7 +17,6 @@ from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.hqmedia.cache import BulkMultimediaStatusCache
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.util.files import file_extention_from_filename
-from dimagi.utils.decorators.profile import profile_prod
 from dimagi.utils.logging import notify_exception
 from corehq.util.soft_assert import soft_assert
 from soil import DownloadBase
@@ -32,9 +31,6 @@ MULTIMEDIA_EXTENSIONS = ('.mp3', '.wav', '.jpg', '.png', '.gif', '.3gp', '.mp4',
 
 
 @task(serializer='pickle')
-@profile_prod('process_bulk_upload_zip.prof',
-              probability=float(os.getenv('PROFILE_BULK_MULTIMEDIA_UPLOAD', 0)),
-              limit=None)
 def process_bulk_upload_zip(processing_id, domain, app_id, username=None, share_media=False,
                             license_name=None, author=None, attribution_notes=None):
     """

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1289,13 +1289,6 @@ CAUTIOUS_MULTIMEDIA = StaticToggle(
     always_enabled={'icds', 'icds-cas'},
 )
 
-PROFILE_BULK_MULTIMEDIA_UPLOAD = StaticToggle(
-    'profile_bulk_multimedia_upload',
-    'Profile bulk multimedia upload task. Do not turn this on; it ruins performance of the bulk upload.',
-    TAG_INTERNAL,
-    [NAMESPACE_DOMAIN],
-)
-
 BULK_UPDATE_MULTIMEDIA_PATHS = StaticToggle(
     'bulk_update_multimedia_paths',
     'Bulk multimedia path management',


### PR DESCRIPTION
Reverts dimagi/commcare-hq#23446

This was a bad idea, I misread the docs. Going to do this profiling in a private release instead.

@mkangia / @millerdev