### PR TITLE
Do not track unreleased "repeat_record" locks

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -48,7 +48,12 @@ def check_repeaters():
         if now > cutoff:
             break
 
-        lock = get_redis_lock(lock_key, timeout=60 * 60 * 48, name="repeat_record")
+        lock = get_redis_lock(
+            lock_key,
+            timeout=60 * 60 * 48,
+            name="repeat_record",
+            track_unreleased=False,
+        )
         if not lock.acquire(blocking=False):
             continue
 


### PR DESCRIPTION
These locks are created with a 48-hour timeout and never released. There are many of them (near 100 per second), and they're wildly skewing the [graph of `commcare.lock.not_released`](https://app.datadoghq.com/dashboard/gph-fab-nek/redis-locks).

@dannyroberts cc @orangejenny 