### PR TITLE
Make export user filters consistent

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -418,10 +418,8 @@ class DashboardFeedFilterForm(forms.Form):
         )
         assert(export_type == 'form' or export_type == 'case')
         if export_type == 'form':
-            # It's a form export # TODO: Remove redundant comments
             return self._to_form_export_instance_filters(can_access_all_locations, accessible_location_ids)
         else:
-            # it's a case export
             return self._to_case_export_instance_filters(can_access_all_locations, accessible_location_ids)
 
     def _to_case_export_instance_filters(self, can_access_all_locations, accessible_location_ids):

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -1027,10 +1027,12 @@ class FilterCaseESExportDownloadForm(EmwfFilterExportMixin, BaseFilterExportDown
         :return: set of filters
         """
         filter_builder = CaseExportFilterBuilder(self.domain_object, self.timezone)
+        show_all_data = self.dynamic_filter_class.show_all_data(mobile_user_and_group_slugs) or \
+            self.dynamic_filter_class.no_filters_selected(mobile_user_and_group_slugs)
         return filter_builder.get_filters(
             can_access_all_locations,
             accessible_location_ids,
-            self.dynamic_filter_class.show_all_data(mobile_user_and_group_slugs),
+            show_all_data,
             self.dynamic_filter_class.show_project_data(mobile_user_and_group_slugs),
             self.dynamic_filter_class.show_deactivated_data(mobile_user_and_group_slugs),
             self.dynamic_filter_class.selected_user_types(mobile_user_and_group_slugs),

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -418,10 +418,8 @@ class DashboardFeedFilterForm(forms.Form):
         )
         assert(export_type == 'form' or export_type == 'case')
         if export_type == 'form':
-            # It's a form export
             return self._to_form_export_instance_filters(can_access_all_locations, accessible_location_ids)
         else:
-            # it's a case export
             return self._to_case_export_instance_filters(can_access_all_locations, accessible_location_ids)
 
     def _to_case_export_instance_filters(self, can_access_all_locations, accessible_location_ids):

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -411,6 +411,11 @@ class DashboardFeedFilterForm(forms.Form):
         """
         Serialize the bound form as an ExportInstanceFilters object.
         """
+        # Confirm that either form filter data or case filter data but not both has been submitted.
+        assert (
+            (self.cleaned_data['emwf_form_filter'] is not None) !=
+            (self.cleaned_data['emwf_case_filter'] is not None)
+        )
         assert(export_type == 'form' or export_type == 'case')
         if export_type == 'form':
             # It's a form export # TODO: Remove redundant comments

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -407,17 +407,13 @@ class DashboardFeedFilterForm(forms.Form):
             )
         ]
 
-    def to_export_instance_filters(self, can_access_all_locations, accessible_location_ids):
+    def to_export_instance_filters(self, can_access_all_locations, accessible_location_ids, export_type):
         """
         Serialize the bound form as an ExportInstanceFilters object.
         """
-        # Confirm that either form filter data or case filter data but not both has been submitted.
-        assert (
-            (self.cleaned_data['emwf_form_filter'] is not None) !=
-            (self.cleaned_data['emwf_case_filter'] is not None)
-        )
-        if self.cleaned_data['emwf_form_filter']:
-            # It's a form export
+        assert(export_type == 'form' or export_type == 'case')
+        if export_type == 'form':
+            # It's a form export # TODO: Remove redundant comments
             return self._to_form_export_instance_filters(can_access_all_locations, accessible_location_ids)
         else:
             # it's a case export

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -418,8 +418,10 @@ class DashboardFeedFilterForm(forms.Form):
         )
         assert(export_type == 'form' or export_type == 'case')
         if export_type == 'form':
+            # It's a form export
             return self._to_form_export_instance_filters(can_access_all_locations, accessible_location_ids)
         else:
+            # it's a case export
             return self._to_case_export_instance_filters(can_access_all_locations, accessible_location_ids)
 
     def _to_case_export_instance_filters(self, can_access_all_locations, accessible_location_ids):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -648,8 +648,8 @@ class ExportInstanceFilters(DocumentSchema):
 
 class CaseExportInstanceFilters(ExportInstanceFilters):
     sharing_groups = ListProperty(StringProperty)
-    show_all_data = BooleanProperty(default=True)
-    show_project_data = BooleanProperty()
+    show_all_data = BooleanProperty()
+    show_project_data = BooleanProperty(default=True)
     show_deactivated_data = BooleanProperty()
 
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -654,7 +654,7 @@ class CaseExportInstanceFilters(ExportInstanceFilters):
 
 
 class FormExportInstanceFilters(ExportInstanceFilters):
-    user_types = ListProperty(IntegerProperty, default=[HQUserType.ACTIVE])
+    user_types = ListProperty(IntegerProperty, default=[HQUserType.ACTIVE, HQUserType.DEACTIVATED])
 
 
 class ExportInstance(BlobMixin, Document):

--- a/corehq/apps/export/tests/test_export_forms.py
+++ b/corehq/apps/export/tests/test_export_forms.py
@@ -393,12 +393,11 @@ class TestFilterCaseESExportDownloadForm(TestCase):
         data = {'date_range': '1992-01-30 to 2016-11-28'}
         self.export_filter = self.subject(self.domain, pytz.utc, data=data)
         self.assertTrue(self.export_filter.is_valid())
-        case_filters = self.export_filter.get_model_filter('', True, None)
+        case_filters = self.export_filter.get_model_filter(self.group_ids_slug, True, None)
 
         fetch_user_ids_patch.assert_called_once_with(admin=False, commtrack=True, demo=True, unknown=True,
                                                      web=False)
         assert not filters_from_slugs_patch.called
-
         self.assertIsInstance(case_filters[0], NOT)
         self.assertIsInstance(case_filters[0].operand_filter, OwnerFilter)
         self.assertEqual(case_filters[0].operand_filter.owner_id, ['123'])
@@ -415,12 +414,11 @@ class TestFilterCaseESExportDownloadForm(TestCase):
         data = {'date_range': '1992-01-30 to 2016-11-28'}
         self.export_filter = self.subject(self.domain, pytz.utc, data=data)
         self.assertTrue(self.export_filter.is_valid())
-        case_filters = self.export_filter.get_model_filter('', True, None)
+        case_filters = self.export_filter.get_model_filter(self.group_ids_slug, True, None)
 
         fetch_user_ids_patch.assert_called_once_with(admin=False, commtrack=True, demo=True, unknown=True,
                                                      web=False)
         assert not filters_from_slugs_patch.called
-
         self.assertIsInstance(case_filters[0], NOT)
         self.assertIsInstance(case_filters[0].operand_filter, OwnerFilter)
         self.assertEqual(case_filters[0].operand_filter.owner_id, ['123'])
@@ -433,12 +431,11 @@ class TestFilterCaseESExportDownloadForm(TestCase):
         data = {'date_range': '1992-01-30 to 2016-11-28'}
         self.export_filter = self.subject(self.domain, pytz.utc, data=data)
         self.assertTrue(self.export_filter.is_valid())
-        case_filters = self.export_filter.get_model_filter('', True, None)
+        case_filters = self.export_filter.get_model_filter(self.group_ids_slug, True, None)
 
         fetch_user_ids_patch.assert_called_once_with(admin=True, commtrack=True, demo=True, unknown=True,
                                                      web=True, active=True, deactivated=False)
         assert not filters_from_slugs_patch.called
-
         self.assertIsInstance(case_filters[0], NOT)
         self.assertIsInstance(case_filters[0].operand_filter, OwnerFilter)
         self.assertEqual(case_filters[0].operand_filter.owner_id, ['123'])
@@ -501,3 +498,16 @@ class TestFilterCaseESExportDownloadForm(TestCase):
         get_locations_ids.assert_called_once_with([])
         get_users_filter.assert_called_once_with(list(get_user_ids.return_value))
         get_user_ids.assert_called_once_with(self.group_ids_slug)
+
+    @patch.object(filter_builder, '_get_filters_from_slugs')
+    @patch.object(filter_builder, 'get_user_ids_for_user_types', return_value=['123'])
+    def test_get_model_filter_for_default_data(self, fetch_user_ids_patch, filters_from_slugs_patch, *patches):
+        data = {'date_range': '1992-01-30 to 2016-11-28'}
+        self.export_filter = self.subject(self.domain, pytz.utc, data=data)
+        self.assertTrue(self.export_filter.is_valid())
+        # Default should be all data when filters are blank
+        case_filters = self.export_filter.get_model_filter('', True, None)
+
+        assert not fetch_user_ids_patch.called
+        assert not filters_from_slugs_patch.called
+        self.assertEqual(case_filters, [])

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -389,14 +389,14 @@ class TestExportInstanceDefaultFilters(SimpleTestCase):
         form_export = FormExportInstance()
         form_export_wrapped = FormExportInstance.wrap({})
         for e in [form_export, form_export_wrapped]:
-            self.assertListEqual(e.filters.user_types, [0])
+            self.assertListEqual(e.filters.user_types, [0, 5])
 
     def test_default_case_values(self):
-        # Confirm that CaseExportInstances set the default show_all_data flag correctly
+        # Confirm that CaseExportInstances set the default project_data flag correctly
         case_export = CaseExportInstance()
         case_export_wrapped = CaseExportInstance.wrap({})
         for e in [case_export, case_export_wrapped]:
-            self.assertTrue(e.filters.show_all_data)
+            self.assertTrue(e.filters.show_project_data)
 
 
 class TestExportInstance(SimpleTestCase):

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -272,7 +272,7 @@ class ExportViewTest(ViewTestCase):
             "external_blobs": {},
             "export_format": "csv",
             "include_errors": False,
-            "type": "form",
+            "type": "case",
             "name": "A Villager's Health > Registrationaa > Reg form: 2016-06-27"
         })
         resp = self.client.post(

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -628,7 +628,8 @@ def commit_filters(request, domain):
             # restrictions on an export that a more restricted user created (which would mean the more
             # restricted user would lose access to the export)
             old_can_access_all_locations,
-            old_accessible_location_ids
+            old_accessible_location_ids,
+            export.type
         )
         if export.filters != filters:
             export.filters = filters


### PR DESCRIPTION
Specs: https://docs.google.com/document/d/1BTvEHtHmb8G3iFK8y9V4kyyscMIumnzi2x5CQztKmVs/edit#
Trello card: https://trello.com/c/IFBobBju/89-user-filters-ux-plan-to-address-inconsistency

This PR addresses the UI inconsistencies for exports (regular and daily saved case and form exports, and the exports for the excel dashboard)

PR for reports: https://github.com/dimagi/commcare-hq/pull/23485

code buddy: @biyeun 