### PR TITLE
call baseclass tearDown() from TestQuarterlyInvoicing.tearDown()

### DIFF
--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -386,6 +386,7 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
     def tearDown(self):
         for user_history in DomainUserHistory.objects.all():
             user_history.delete()
+        super(TestQuarterlyInvoicing, self).tearDown()
 
     def initialize_domain_user_history_objects(self):
         record_dates = []


### PR DESCRIPTION
For a time I suspected this was causing problems with python 3 travis tests, then I realized this wasn't the problem, but figured it was worth adding anyway.