### PR TITLE
use cmp_to_key for python 3 sorted

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 from collections import OrderedDict
 import copy
 from datetime import datetime, timedelta, date
-from functools import partial
+from functools import cmp_to_key, partial
 import itertools
 import json
 import csv342 as csv
@@ -1861,7 +1861,7 @@ def _sorted_form_metadata_keys(keys):
             return 0
 
         return cmp(x, y)
-    return sorted(keys, cmp=mycmp)
+    return sorted(keys, key=cmp_to_key(mycmp))
 
 
 def _get_edit_info(instance):


### PR DESCRIPTION
Fixes:
https://sentry.io/organizations/dimagi/issues/911608757/
and
https://sentry.io/organizations/dimagi/issues/911720712/
in python 3.

For details see https://docs.python.org/3/library/functools.html#functools.cmp_to_key