### PR TITLE
Catch case import errors

### DIFF
--- a/corehq/apps/case_importer/admin.py
+++ b/corehq/apps/case_importer/admin.py
@@ -7,7 +7,16 @@ from corehq.apps.case_importer.tracking.models import CaseUploadRecord
 
 
 class CaseUploadRecordAdmin(admin.ModelAdmin):
+    list_display = ['domain', 'task_id', 'upload_id']
     search_fields = ['task_id__exact', 'upload_id__exact']
+    readonly_fields = ['upload_file_meta']
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
 
 
 admin.site.register(CaseUploadRecord, CaseUploadRecordAdmin)

--- a/corehq/apps/case_importer/admin.py
+++ b/corehq/apps/case_importer/admin.py
@@ -18,5 +18,4 @@ class CaseUploadRecordAdmin(admin.ModelAdmin):
         return False
 
 
-
 admin.site.register(CaseUploadRecord, CaseUploadRecordAdmin)

--- a/corehq/apps/case_importer/admin.py
+++ b/corehq/apps/case_importer/admin.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.contrib import admin
+
+from corehq.apps.case_importer.tracking.models import CaseUploadRecord
+
+
+class CaseUploadRecordAdmin(admin.ModelAdmin):
+    search_fields = ['task_id__exact', 'upload_id__exact']
+
+
+admin.site.register(CaseUploadRecord, CaseUploadRecordAdmin)

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -26,6 +26,7 @@
                 <span class="label label-warning">{% trans "Success with warnings" %}</span>
                 <!--/ko-->
             <!--/ko-->
+            {# The following failed state is necessary to handle legacy errors #}
             <!--ko if: task_status().state == $root.states.SUCCESS && !task_status().result-->
             <span class="label label-danger">{% trans "Failed" %}</span>
             <!--/ko-->

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -18,13 +18,16 @@
     <!--ko foreach: case_uploads-->
     <tr>
         <td class="col-md-1">
-            <!--ko if: task_status().state == $root.states.SUCCESS-->
+            <!--ko if: task_status().state == $root.states.SUCCESS && task_status().result-->
                 <!--ko if: _.isEmpty(task_status().result.errors)-->
                 <span class="label label-success">{% trans "Success" %}</span>
                 <!--/ko-->
                 <!--ko if: !_.isEmpty(task_status().result.errors)-->
                 <span class="label label-warning">{% trans "Success with warnings" %}</span>
                 <!--/ko-->
+            <!--/ko-->
+            <!--ko if: task_status().state == $root.states.SUCCESS && !task_status().result-->
+            <span class="label label-danger">{% trans "Failed" %}</span>
             <!--/ko-->
             <!--ko if: task_status().state == $root.states.FAILED-->
             <span class="label label-danger">{% trans "Failed" %}</span>

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<!--ko if: state === $root.states.SUCCESS-->
+<!--ko if: state === $root.states.SUCCESS && result-->
     <div class="text-success">
         <!--ko if: result.match_count-->
             <p>

--- a/corehq/apps/case_importer/tracking/models.py
+++ b/corehq/apps/case_importer/tracking/models.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 from django.db import models
 from jsonfield import JSONField
-from corehq.apps.case_importer.tracking.task_status import TaskStatus, \
-    get_task_status_json
-
 from memoized import memoized
+
+from corehq.apps.case_importer.tracking.task_status import (
+    TaskStatus,
+    get_task_status_json,
+)
 from soil.util import get_task
 
 MAX_COMMENT_LENGTH = 2048
@@ -15,8 +18,12 @@ class CaseUploadRecord(models.Model):
     domain = models.CharField(max_length=256)
     created = models.DateTimeField(auto_now_add=True)
 
-    upload_id = models.UUIDField(unique=True)
-    task_id = models.UUIDField(unique=True)
+    upload_id = models.UUIDField(
+        unique=True, help_text="An HQ-level ID that is used to provide a link to this upload record"
+    )
+    task_id = models.UUIDField(
+        unique=True, help_text="The celery task id that handled this upload"
+    )
     task_status_json = JSONField(null=True)
     couch_user_id = models.CharField(max_length=256)
     case_type = models.CharField(max_length=256)

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -122,14 +122,14 @@ def get_task_status(task, is_multiple_download_task=False):
             pass
         else:
             result = task.result
-            if task.successful():
+            if result and result.get('errors'):
+                failed = True
+                context_error = result.get('errors')
+            elif task.successful():
                 is_ready = True
                 context_result = result and result.get('messages')
             elif result and isinstance(result, Exception):
                 context_error = six.text_type(result)
-            elif result and result.get('errors'):
-                failed = True
-                context_error = result.get('errors')
         progress = get_task_progress(task)
 
     def progress_complete():


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=5&projectKey=HI&modal=detail&selectedIssue=HI-449

I had to go deeper than expected on this one. The root cause of this issue is that task state is returned by celery. Failed means that there was an exception that occurred and was passed back to celery http://docs.celeryproject.org/en/latest/userguide/tasks.html#built-in-states

However, the task results are defined by HQ code. In this instance, we are returning a [dictionary with errors on failures](https://github.com/dimagi/commcare-hq/blob/177d9ff3576511f154ee521cbc92fed955519139/corehq/apps/case_importer/tasks.py#L43) and with [messages on success](https://github.com/dimagi/commcare-hq/blob/177d9ff3576511f154ee521cbc92fed955519139/corehq/apps/case_importer/tasks.py#L52-L55)

The end result of that is that they are both considered "success" by celery as the task was returned with no exception happening.

There's no current method here for giving messages on "failed" states, so these errors won't be shown.