### PR TITLE
Handle XFormException in form summary

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1144,7 +1144,8 @@ class FormBase(DocumentSchema):
                 include_translations=include_translations,
             )
         except XFormException as e:
-            raise XFormException("Error in form {}".format(self.full_path_name), e)
+            raise XFormException(_('Error in form "{}": {}')
+                                 .format(trans(self.name), six.text_type(e)))
 
     @memoized
     def get_case_property_name_formatter(self):
@@ -1158,7 +1159,7 @@ class FormBase(DocumentSchema):
             try:
                 valid_paths = {question['value']: question['tag']
                                for question in self.get_questions(langs=[])}
-            except XFormException as e:
+            except XFormException:
                 # punt on invalid xml (sorry, no rich attachments)
                 valid_paths = {}
 

--- a/corehq/apps/app_manager/templates/app_manager/form_summary.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary.html
@@ -45,6 +45,14 @@
              </div>
         </div>
     </div>
+    <!-- ko if: errors.length -->
+    <div class="alert alert-danger">
+        <i class="fa fa-exclamation-circle"></i>
+        {% blocktrans %}
+            Your app's forms contain errors. Case and form information below may be inaccurate until you fix the issues.
+        {% endblocktrans %}
+    </div>
+    <!-- /ko -->
 
     <!-- ko foreach: errors -->
         <div class="alert alert-danger">

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -764,7 +764,7 @@ class _AppSummaryFormDataGenerator(object):
         except XFormException as exception:
             form_meta['questions'] = []
             form_meta['error'] = {
-                'details': six.text_type(exception.args[0]),
+                'details': six.text_type(exception),
             }
             self.errors.append(form_meta)
         return form_meta

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -764,7 +764,7 @@ class _AppSummaryFormDataGenerator(object):
         except XFormException as exception:
             form_meta['questions'] = []
             form_meta['error'] = {
-                'details': six.text_type(exception[0]),
+                'details': six.text_type(exception.args[0]),
             }
             self.errors.append(form_meta)
         return form_meta

--- a/corehq/apps/reports/formdetails/readable.py
+++ b/corehq/apps/reports/formdetails/readable.py
@@ -721,7 +721,10 @@ class _AppSummaryFormDataGenerator(object):
         self.errors = []
 
         self._seen_save_to_case = defaultdict(list)
-        self._case_meta = self.app.get_case_metadata()
+        try:
+            self._case_meta = self.app.get_case_metadata()
+        except XFormException:
+            self._case_meta = AppCaseMetadata()
 
     def generate(self):
         return [self._compile_module(module) for module in self.app.get_modules()], self.errors
@@ -761,8 +764,7 @@ class _AppSummaryFormDataGenerator(object):
         except XFormException as exception:
             form_meta['questions'] = []
             form_meta['error'] = {
-                'details': six.text_type(exception),
-                'edit_url': reverse('form_source', args=[self.domain, self.app._id, form.unique_id]),
+                'details': six.text_type(exception[0]),
             }
             self.errors.append(form_meta)
         return form_meta


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/910337873

Handles `XFormException` in the form summary. This error happens very rarely, but ICDS currently has one of these errors and they are blocked from using this page.

While each error is listed, I also opted to add the general message to inform people that the page they were on would be inaccurate. 