### PR TITLE
Make reports user filters consistent

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -334,7 +334,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         # The queryset returned by this method is location-safe
         q = user_es.UserES().domain(domain)
         if ExpandedMobileWorkerFilter.no_filters_selected(mobile_user_and_group_slugs):
-            return q
+            return q.show_inactive()
 
         user_ids = cls.selected_user_ids(mobile_user_and_group_slugs)
         user_types = cls.selected_user_types(mobile_user_and_group_slugs)


### PR DESCRIPTION
Specs: https://docs.google.com/document/d/1BTvEHtHmb8G3iFK8y9V4kyyscMIumnzi2x5CQztKmVs/edit#
Trello card: https://trello.com/c/IFBobBju/89-user-filters-ux-plan-to-address-inconsistency

This PR addresses the UI inconsistencies for reports. It looks like we were just not including deactivated users in the query, but web and active mobile users were already there.

PR for exports: https://github.com/dimagi/commcare-hq/pull/23472

code buddy: @biyeun