### PR TITLE
replace six.string_types with six.text_type in tests

### DIFF
--- a/corehq/apps/app_manager/tests/app_factory.py
+++ b/corehq/apps/app_manager/tests/app_factory.py
@@ -45,7 +45,7 @@ class AppFactory(object):
         module.case_type = case_type
 
         def get_unique_id(module_or_form):
-            return module_or_form if isinstance(module_or_form, six.string_types) else module_or_form.unique_id
+            return module_or_form if isinstance(module_or_form, six.text_type) else module_or_form.unique_id
 
         if parent_module:
             module.root_module_id = get_unique_id(parent_module)

--- a/corehq/apps/app_manager/tests/test_commcare_settings.py
+++ b/corehq/apps/app_manager/tests/test_commcare_settings.py
@@ -121,7 +121,7 @@ class CommCareSettingsTest(SimpleTestCase):
                         value = setting.get(key)
                         if not value:
                             continue
-                        if not isinstance(value, six.string_types):
+                        if not isinstance(value, six.text_type):
                             for v in value:
                                 self.assertIn(
                                     v,

--- a/corehq/apps/app_manager/tests/test_commcare_settings.py
+++ b/corehq/apps/app_manager/tests/test_commcare_settings.py
@@ -121,7 +121,7 @@ class CommCareSettingsTest(SimpleTestCase):
                         value = setting.get(key)
                         if not value:
                             continue
-                        if not isinstance(value, six.text_type):
+                        if not isinstance(value, six.string_types):
                             for v in value:
                                 self.assertIn(
                                     v,

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -32,7 +32,7 @@ class ReportAppConfigTest(SimpleTestCase):
     def test_new_uuid(self):
         report_app_config = ReportAppConfig(report_id='report_id')
         self.assertTrue(report_app_config.uuid)
-        self.assertIsInstance(report_app_config.uuid, six.string_types)
+        self.assertIsInstance(report_app_config.uuid, six.text_type)
 
     def test_different_uuids(self):
         report_app_config_1 = ReportAppConfig(report_id='report_id')

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -171,7 +171,7 @@ class CaseAPITestMixin(object):
                                   ids_only=True)
         self.assertEqual(self.expectedAll, len(list))
         self.assertListMatches(list, lambda c: c._couch_doc is None)
-        self.assertListMatches(list, lambda c: isinstance(c.to_json(), six.string_types))
+        self.assertListMatches(list, lambda c: isinstance(c.to_json(), six.text_type))
 
     def testFiltersOnAll(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL,


### PR DESCRIPTION
```six.text_type``` is ```(unicode, bytes)``` in python 2 but is ```(unicode,)``` in python 3.  Since the behavior of ```isinstance(var, six.string_types)``` will change between python versions, we should try to remove all uses of ```six.string_types``` before migrating.