### PR TITLE
Combine multimedia feature flags

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -259,7 +259,7 @@ def get_app_view_context(request, app):
                                     args=(app.domain, app.get_id)),
             'adjective': _("app translation"),
             'plural_noun': _("app translations"),
-            'can_validate_app_translations': toggles.VALIDATE_APP_TRANSLATIONS.enabled_for_request(request)
+            'can_validate_app_translations': toggles.BULK_UPDATE_MULTIMEDIA_PATHS.enabled_for_request(request),
         },
     })
     context.update({

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1611,14 +1611,6 @@ APP_TRANSLATIONS_WITH_TRANSIFEX = StaticToggle(
 )
 
 
-VALIDATE_APP_TRANSLATIONS = StaticToggle(
-    'validate_app_translations',
-    'Validate app translations before uploading them',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_USER]
-)
-
-
 AGGREGATE_UCRS = StaticToggle(
     'aggregate_ucrs',
     'Enable experimental aggregate UCR support',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1291,7 +1291,7 @@ CAUTIOUS_MULTIMEDIA = StaticToggle(
 
 BULK_UPDATE_MULTIMEDIA_PATHS = StaticToggle(
     'bulk_update_multimedia_paths',
-    'Bulk multimedia path management',
+    'Controls several tools for managing large amounts of multimedia, particularly with multiple languages',
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN],
     help_link="https://confluence.dimagi.com/display/ICDS/Multimedia+Path+Manager"


### PR DESCRIPTION
Give the ICDS team one fewer feature flag to turn on. The BULK_UPDATE_MULTIMEDIA_PATHS flag has grown to include a couple of translations enhancements for ICDS; I think validating app translations falls into this bucket.

Verified that no one is using this flag on prod, and everyone using it on india is on ICDS.

@mkangia / @millerdev 