### PR TITLE
increase Odata max page size for testing only

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -967,6 +967,7 @@ class ODataCommCareCaseResource(v0_4.CommCareCaseResource):
     class Meta(v0_4.CommCareCaseResource.Meta):
         resource_name = 'odata/{}'.format(ODATA_CASE_RESOURCE_NAME)
         serializer = ODataCommCareCaseSerializer()
+        max_limit = 10000  # This is for experimental purposes only.  TODO: set to a better value soon after testing
 
     def prepend_urls(self):
         return [


### PR DESCRIPTION
Product Note: This is a temporary change to increase maximum page size of an Odata feed.  After further testing we will set this to its permanent value.  Only Dev and I are using this right now, so we don't have to worry about others making non-performant queries.