### PR TITLE
Pregnancy details page indicator name change

### DIFF
--- a/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
@@ -310,7 +310,7 @@
                                     </td>
                                 </tr>
                                 <tr class="even" role="row">
-                                    <td class="big-col">IFA tablet consumed in last 7 days</td>
+                                    <td class="big-col">Taken IFA in week prior to this home visit</td>
                                     <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
                                         {$ record.ifa_consumed_last_seven_days $}
                                     </td>

--- a/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/awc-reports.html
@@ -310,7 +310,7 @@
                                     </td>
                                 </tr>
                                 <tr class="even" role="row">
-                                    <td class="big-col">Taken IFA in week prior to this home visit</td>
+                                    <td class="big-col">IFA taken in week prior to home visit</td>
                                     <td class="medium-col" ng-repeat="record in $ctrl.pregnantData[0]" >
                                         {$ record.ifa_consumed_last_seven_days $}
                                     </td>


### PR DESCRIPTION
Hi @calellowitz,
This is a simple change in the name of the indicator in the pregnancy details page.
FogBugz [ticket](http://manage.dimagi.com/default.asp?289894).
Need QA: No
Environment: n/a
Locally Tested: Yes
Regards, Dawid