### PR TITLE
Prevent user from changing report start date to be in the past

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -846,6 +846,16 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
         except ValueError:
             pass
 
+    def update_attributes(self, items):
+        for k, v in items:
+            if k == 'start_date':
+                self.verify_start_date(v)
+            self.__setattr__(k, v)
+
+    def verify_start_date(self, start_date):
+        if start_date != self.start_date and start_date < datetime.today().date():
+            raise ValidationError("You can not specify a start date in the past.")
+
 
 class AppNotFound(Exception):
     pass

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -990,9 +990,12 @@ class ScheduledReportsView(BaseProjectReportSectionView):
 
     def post(self, request, *args, **kwargs):
         if self.scheduled_report_form.is_valid():
-            for k, v in self.scheduled_report_form.cleaned_data.items():
-                setattr(self.report_notification, k, v)
-
+            try:
+                self.report_notification.update_attributes(self.scheduled_report_form.cleaned_data.items())
+            except ValidationError as err:
+                kwargs['error'] = err.message
+                messages.error(request, ugettext_lazy(kwargs['error']))
+                return self.get(request, *args, **kwargs)
             time_difference = get_timezone_difference(self.domain)
             (self.report_notification.hour, day_change) = calculate_hour(
                 self.report_notification.hour, int(time_difference[:3]), int(time_difference[3:])

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -993,7 +993,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
             try:
                 self.report_notification.update_attributes(self.scheduled_report_form.cleaned_data.items())
             except ValidationError as err:
-                kwargs['error'] = err.message
+                kwargs['error'] = six.text_type(err)
                 messages.error(request, ugettext_lazy(kwargs['error']))
                 return self.get(request, *args, **kwargs)
             time_difference = get_timezone_difference(self.domain)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-233

Displays an error if a user tries to set a start date in the past for a scheduled report.

code buddy: @nickpell 