### PR TITLE
Add lock key tag to APM data

### DIFF
--- a/corehq/util/datadog/lockmeter.py
+++ b/corehq/util/datadog/lockmeter.py
@@ -35,6 +35,7 @@ class MeteredLock(object):
                 tracer.trace("commcare.lock.acquire", resource=self.key) as span:
             acquired = self.lock.acquire(*args, **kw)
             span.set_tags({
+                "key": self.key,
                 "name": self.name,
                 "acquired": ("true" if acquired else "false"),
             })
@@ -45,7 +46,7 @@ class MeteredLock(object):
             self.lock_timer.start()
             if self.track_unreleased:
                 self.lock_trace = tracer.trace("commcare.lock.locked", resource=self.key)
-                self.lock_trace.set_tag("name", self.name)
+                self.lock_trace.set_tags({"key": self.key, "name": self.name})
         return acquired
 
     def release(self):

--- a/corehq/util/datadog/tests/test_lockmeter.py
+++ b/corehq/util/datadog/tests/test_lockmeter.py
@@ -94,10 +94,14 @@ class TestMeteredLock(TestCase):
         self.assertListEqual(tracer.mock_calls, [
             call.trace("commcare.lock.acquire", resource="key"),
             call.trace().__enter__(),
-            call.trace().__enter__().set_tags({"name": "test", "acquired": "true"}),
+            call.trace().__enter__().set_tags({
+                "key": "key",
+                "name": "test",
+                "acquired": "true",
+            }),
             call.trace().__exit__(None, None, None),
             call.trace("commcare.lock.locked", resource="key"),
-            call.trace().set_tag("name", "test"),
+            call.trace().set_tags({"key": "key", "name": "test"}),
         ])
 
     def test_release_trace(self):
@@ -129,7 +133,11 @@ class TestMeteredLock(TestCase):
         self.assertListEqual(tracer.mock_calls, [
             call.trace("commcare.lock.acquire", resource="key"),
             call.trace().__enter__(),
-            call.trace().__enter__().set_tags({"name": "test", "acquired": "true"}),
+            call.trace().__enter__().set_tags({
+                "key": "key",
+                "name": "test",
+                "acquired": "true",
+            }),
             call.trace().__exit__(None, None, None),
         ])
 


### PR DESCRIPTION
It's hard to read the "resource" value in Datadog, but tags are very easily read, copied, etc.

@dannyroberts cc @orangejenny 