### PR TITLE
Add pagination to conditional alerts

### DIFF
--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -89,24 +89,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
             ],
             "columnDefs": [
                 {
-                    "targets": [3],
-                    "render": function (data, type, row) {
-                        var active_text = '';
-                        if (row.active) {
-                            active_text = '<span class="label label-success">' + gettext("Active") + '</span> ';
-                        } else {
-                            active_text = '<span class="label label-danger">' + gettext("Inactive") + '</span> ';
-                        }
-
-                        var processing_text = '';
-                        if (row.locked_for_editing) {
-                            processing_text = '<span class="label label-default">' + gettext("Processing") + ': ' + row.progress_pct + '%</span> ';
-                        }
-
-                        return active_text + processing_text;
-                    },
-                },
-                {
                     "targets": [4],
                     "render": function (data, type, row) {
                         var html = null;

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -4,8 +4,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
     'underscore',
     'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
-    'datatables',
-    'datatables.bootstrap',
+    'hqwebapp/js/components.ko',    // pagination widget
 ], function (
     $,
     ko,
@@ -73,16 +72,23 @@ hqDefine("scheduling/js/conditional_alert_list", [
 
         self.rules = ko.observableArray();
 
+        self.itemsPerPage = ko.observable();
+        self.totalItems = ko.observable();
+        self.showPaginationSpinner = ko.observable(false);
+
         self.goToPage = function (page) {
+            self.showPaginationSpinner(true);
             $.ajax({
                 url: options.listUrl,
                 data: {
                     action: 'list_conditional_alerts',
                     page: page,
-                    limit: 10,  // TODO
+                    limit: self.itemsPerPage(),
                 },
                 success: function (data) {
+                    self.showPaginationSpinner(false);
                     self.rules(_.map(data.rules, function (r) { return rule(r); }));
+                    self.totalItems(data.total);
                 },
             });
         };
@@ -97,9 +103,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
             listUrl: initialPageData.reverse("conditional_alert_list"),
         }));
 
-        /*var conditonalAlterListUrl = initialPageData.reverse("conditional_alert_list");
-
-        table = $("#conditional-alert-list").dataTable({
+        /*table = $("#conditional-alert-list").dataTable({
             "lengthChange": false,
             "filter": false,
             "sort": false,
@@ -116,13 +120,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
                 "infoEmpty": gettext('There are no alerts to display.'),
                 "info": gettext('Showing _START_ to _END_ of _TOTAL_ alerts'),
             },
-            "columns": [
-                {"data": ""},
-                {"data": "name"},
-                {"data": "case_type"},
-                {"data": "active"},
-                {"data": ""},
-            ],
         });
 
         function reloadTable() {

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -50,7 +50,19 @@ hqDefine("scheduling/js/conditional_alert_list", [
             if (confirm(prompt)) {
                 alertAction('restart', self.id());
             }
-        }
+        };
+
+        self.projectName = ko.observable('');
+        self.copy = function () {
+            if (self.projectName() === '') {
+                alert(gettext("Please enter a project name first."));
+                return;
+            }
+
+            if (confirm(interpolate(gettext("Copy this alert to project %s?"), [self.projectName()]))) {
+                alertAction('copy', self.id(), self.projectName());
+            }
+        };
 
         return self;
     };
@@ -111,21 +123,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
                 {"data": "active"},
                 {"data": ""},
             ],
-            "columnDefs": [
-                {
-                    "targets": [5],
-                    "visible": initialPageData.get("allow_copy"),
-                    "render": function (data, type, row) {
-                        var disabled = (row.locked_for_editing || !row.editable) ? 'disabled' : '';
-                        var html = '<input type="text" id="copy-to-project-for-' + row.id + '" placeholder="' + gettext("Project") + '" class="textinput textInput form-control copy-project-name" />';
-                        html += ' <button ' + disabled + ' id="copy-button-for-' + row.id + '" class="btn btn-default alert-copy" data-id="' + row.id + '" >' + gettext("Copy") + '</button>';
-                        return html;
-                    },
-                },
-            ],
         });
-
-        $(document).on('click', '.alert-copy', copyRule);
 
         function reloadTable() {
             // Don't redraw the table if someone is typing a project name in the copy input
@@ -202,19 +200,5 @@ hqDefine("scheduling/js/conditional_alert_list", [
             .always(function () {
                 table.fnDraw(false);
             });
-    }
-
-    function copyRule() {
-        var ruleId = $(this).data("id");
-        var projectName = $.trim($("#copy-to-project-for-" + ruleId).val());
-
-        if (projectName === '') {
-            alert(gettext("Please enter a project name first."));
-            return;
-        }
-
-        if (confirm(interpolate(gettext("Copy this alert to project %s?"), [projectName]))) {
-            alertAction('copy', ruleId, projectName);
-        }
     }
 });

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -28,6 +28,30 @@ hqDefine("scheduling/js/conditional_alert_list", [
             }
         };
 
+        self.toggleStatus = function () {
+            var action = self.active() ? "deactivate" : "activate";
+            alertAction(action, self.id());
+        };
+
+        self.restart = function () {
+            var prompt = null;
+            if (initialPageData.get("limit_rule_restarts")) {
+                prompt = gettext(
+                    "A rule should only be restarted when you believe it is stuck and is not progressing. " +
+                    "You will only be able to restart this rule once every two hours. Restart this rule?"
+                );
+            } else {
+                prompt = gettext(
+                    "A rule should only be restarted when you believe it is stuck and is not progressing. " +
+                    "Your user is able to restart as many times as you like, but restarting too many times without " +
+                    "finishing can place a burden on the system. Restart this rule?"
+                );
+            }
+            if (confirm(prompt)) {
+                alertAction('restart', self.id());
+            }
+        }
+
         return self;
     };
 
@@ -89,36 +113,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
             ],
             "columnDefs": [
                 {
-                    "targets": [4],
-                    "render": function (data, type, row) {
-                        var html = null;
-                        var button_id = 'activate-button-for-' + row.id;
-                        var disabled = (row.locked_for_editing || !row.editable) ? 'disabled' : '';
-                        if (row.active) {
-                            html = '<button id="' + button_id + '" \
-                                            class="btn btn-default alert-activate" \
-                                            data-id="' + row.id + '"\
-                                            data-action="deactivate"\
-                                            ' + disabled + '> \
-                                   ' + gettext("Deactivate") + '</button>';
-                        } else {
-                            html = '<button id="' + button_id + '" + \
-                                            class="btn btn-default alert-activate" + \
-                                            data-action="activate"\
-                                            data-id="' + row.id + '"\
-                                            ' + disabled + '> \
-                                   ' + gettext("Activate") + '</button>';
-                        }
-
-                        if (row.locked_for_editing) {
-                            html += ' <button class="btn btn-default alert-restart" data-id="' + row.id + '" >';
-                            html += '<i class="fa fa-refresh"></i> ' + gettext("Restart Rule") + '</button>';
-                        }
-
-                        return html;
-                    },
-                },
-                {
                     "targets": [5],
                     "visible": initialPageData.get("allow_copy"),
                     "render": function (data, type, row) {
@@ -131,8 +125,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
             ],
         });
 
-        $(document).on('click', '.alert-activate', activateAlert);
-        $(document).on('click', '.alert-restart', restartRule);
         $(document).on('click', '.alert-copy', copyRule);
 
         function reloadTable() {
@@ -210,29 +202,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
             .always(function () {
                 table.fnDraw(false);
             });
-    }
-
-    function activateAlert() {
-        alertAction($(this).data("action"), $(this).data("id"));
-    }
-
-    function restartRule(rule_id) {
-        var prompt = null;
-        if (initialPageData.get("limit_rule_restarts")) {
-            prompt = gettext(
-                "A rule should only be restarted when you believe it is stuck and is not progressing. " +
-                "You will only be able to restart this rule once every two hours. Restart this rule?"
-            );
-        } else {
-            prompt = gettext(
-                "A rule should only be restarted when you believe it is stuck and is not progressing. " +
-                "Your user is able to restart as many times as you like, but restarting too many times without " +
-                "finishing can place a burden on the system. Restart this rule?"
-            );
-        }
-        if (confirm(prompt)) {
-            alertAction('restart', $(this).data("id"));
-        }
     }
 
     function copyRule() {

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -119,7 +119,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
 
         self.rules = ko.observableArray();
 
-        self.itemsPerPage = ko.observable();
+        self.itemsPerPage = ko.observable(25);
         self.totalItems = ko.observable();
         self.showPaginationSpinner = ko.observable(false);
 

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -70,7 +70,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
         };
 
         self.remove = function (model, e) {
-            debugger;
             if (confirm(gettext("Are you sure you want to remove this conditional message?"))) {
                 self.action('delete', e);
             }

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -1,13 +1,59 @@
 hqDefine("scheduling/js/conditional_alert_list", [
     'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
     'datatables',
     'datatables.bootstrap',
-], function ($, initialPageData) {
+], function (
+    $,
+    ko,
+    _,
+    assertProperties,
+    initialPageData
+) {
     var table = null;
 
+    var rule = function (options) {
+        var self = _.extend({}, options);
+
+        self.editUrl = initialPageData.reverse("edit_conditional_alert", self.id);
+
+        return self;
+    };
+
+    var ruleList = function (options) {
+        assertProperties.assert(options, ['listUrl']);
+        var self = {};
+
+        self.rules = ko.observableArray();
+
+        self.goToPage = function (page) {
+            $.ajax({
+                url: options.listUrl,
+                data: {
+                    action: 'list_conditional_alerts',
+                    page: page,
+                    limit: 10,  // TODO
+                },
+                success: function (data) {
+                    self.rules(_.map(data.rules, function (r) { return rule(r); }));
+                },
+            });
+        };
+
+        self.goToPage(1);
+
+        return self;
+    };
+
     $(function () {
-        var conditonalAlterListUrl = initialPageData.reverse("conditional_alert_list");
+        $("#conditional-alert-list").koApplyBindings(ruleList({
+            listUrl: initialPageData.reverse("conditional_alert_list"),
+        }));
+
+        /*var conditonalAlterListUrl = initialPageData.reverse("conditional_alert_list");
 
         table = $("#conditional-alert-list").dataTable({
             "lengthChange": false,
@@ -45,13 +91,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
                                         data-id="' + row.id + '"\
                                         ' + disabled + '> \
                                 <i class="fa fa-remove"></i></button>';
-                    },
-                },
-                {
-                    "targets": [1],
-                    "render": function (data, type, row) {
-                        var url = initialPageData.reverse('edit_conditional_alert', row.id);
-                        return "<a href='" + url + "'>" + row.name + "</a>";
                     },
                 },
                 {
@@ -136,8 +175,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
             setTimeout(reloadTable, 10000);
         }
 
-        setTimeout(reloadTable, 10000);
-
+        setTimeout(reloadTable, 10000);*/
     });
 
     function alertAction(action, rule_id, projectName) {
@@ -241,5 +279,4 @@ hqDefine("scheduling/js/conditional_alert_list", [
             alertAction('copy', ruleId, projectName);
         }
     }
-
 });

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -16,9 +16,17 @@ hqDefine("scheduling/js/conditional_alert_list", [
     var table = null;
 
     var rule = function (options) {
-        var self = _.extend({}, options);
+        var self = ko.mapping.fromJS(options);
 
-        self.editUrl = initialPageData.reverse("edit_conditional_alert", self.id);
+        self.editUrl = ko.computed(function () {
+            return initialPageData.reverse("edit_conditional_alert", self.id());
+        });
+
+        self.remove = function () {
+            if (confirm(gettext("Are you sure you want to remove this conditional message?"))) {
+                alertAction('delete', self.id());
+            }
+        };
 
         return self;
     };
@@ -81,19 +89,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
             ],
             "columnDefs": [
                 {
-                    "targets": [0],
-                    "className": "text-center",
-                    "render": function (data, type, row) {
-                        var button_id = 'delete-button-for-' + row.id;
-                        var disabled = row.locked_for_editing ? 'disabled' : '';
-                        return '<button id="' + button_id + '" \
-                                        class="btn btn-danger alert-delete" \
-                                        data-id="' + row.id + '"\
-                                        ' + disabled + '> \
-                                <i class="fa fa-remove"></i></button>';
-                    },
-                },
-                {
                     "targets": [3],
                     "render": function (data, type, row) {
                         var active_text = '';
@@ -154,7 +149,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
             ],
         });
 
-        $(document).on('click', '.alert-delete', deleteAlert);
         $(document).on('click', '.alert-activate', activateAlert);
         $(document).on('click', '.alert-restart', restartRule);
         $(document).on('click', '.alert-copy', copyRule);
@@ -238,13 +232,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
 
     function activateAlert() {
         alertAction($(this).data("action"), $(this).data("id"));
-    }
-
-
-    function deleteAlert() {
-        if (confirm(gettext("Are you sure you want to delete this conditional message?"))) {
-            alertAction('delete', $(this).data("id"));
-        }
     }
 
     function restartRule(rule_id) {

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -76,8 +76,10 @@ hqDefine("scheduling/js/conditional_alert_list", [
         self.totalItems = ko.observable();
         self.showPaginationSpinner = ko.observable(false);
 
+        self.currentPage = ko.observable(1);
         self.goToPage = function (page) {
             self.showPaginationSpinner(true);
+            self.currentPage(page);
             $.ajax({
                 url: options.listUrl,
                 data: {
@@ -93,7 +95,13 @@ hqDefine("scheduling/js/conditional_alert_list", [
             });
         };
 
-        self.goToPage(1);
+        self.goToPage(self.currentPage());
+        // Refresh table periodically, unless someone is typing a project name in the copy input
+        setInterval(function () {
+            if (!_.find(self.rules(), function (r) { return r.projectName(); })) {
+                self.goToPage(self.currentPage());
+            }
+        }, 10000);
 
         return self;
     };
@@ -103,6 +111,7 @@ hqDefine("scheduling/js/conditional_alert_list", [
             listUrl: initialPageData.reverse("conditional_alert_list"),
         }));
 
+        // TODO
         /*table = $("#conditional-alert-list").dataTable({
             "lengthChange": false,
             "filter": false,
@@ -120,28 +129,10 @@ hqDefine("scheduling/js/conditional_alert_list", [
                 "infoEmpty": gettext('There are no alerts to display.'),
                 "info": gettext('Showing _START_ to _END_ of _TOTAL_ alerts'),
             },
-        });
-
-        function reloadTable() {
-            // Don't redraw the table if someone is typing a project name in the copy input
-            var canDraw = true;
-            $('.copy-project-name').each(function () {
-                if ($(this).val()) {
-                    canDraw = false;
-                }
-            });
-
-            if (canDraw) {
-                table.fnDraw(false);
-            }
-
-            setTimeout(reloadTable, 10000);
-        }
-
-        setTimeout(reloadTable, 10000);*/
+        });*/
     });
 
-    function alertAction(action, rule_id, projectName) {
+    function alertAction(action, rule_id, projectName) {    // TODO
         var activateButton = $('#activate-button-for-' + rule_id);
         var deleteButton = $('#delete-button-for-' + rule_id);
         var copyButton = $('#copy-button-for-' + rule_id);

--- a/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/conditional_alert_list.js
@@ -76,6 +76,9 @@ hqDefine("scheduling/js/conditional_alert_list", [
         self.totalItems = ko.observable();
         self.showPaginationSpinner = ko.observable(false);
 
+        self.emptyTable = ko.computed(function () {
+            return self.totalItems() === 0;
+        });
         self.currentPage = ko.observable(1);
         self.goToPage = function (page) {
             self.showPaginationSpinner(true);
@@ -110,26 +113,6 @@ hqDefine("scheduling/js/conditional_alert_list", [
         $("#conditional-alert-list").koApplyBindings(ruleList({
             listUrl: initialPageData.reverse("conditional_alert_list"),
         }));
-
-        // TODO
-        /*table = $("#conditional-alert-list").dataTable({
-            "lengthChange": false,
-            "filter": false,
-            "sort": false,
-            "displayLength": 10,
-            "processing": false,
-            "serverSide": true,
-            "ajaxSource": conditonalAlterListUrl,
-            "fnServerParams": function (aoData) {
-                aoData.push({"name": "action", "value": "list_conditional_alerts"});
-            },
-            "sDom": "rtp",
-            "language": {
-                "emptyTable": gettext('There are no alerts to display.'),
-                "infoEmpty": gettext('There are no alerts to display.'),
-                "info": gettext('Showing _START_ to _END_ of _TOTAL_ alerts'),
-            },
-        });*/
     });
 
     function alertAction(action, rule_id, projectName) {    // TODO

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -26,7 +26,12 @@
     </div>
     <h4>{% trans 'Conditional Alerts' %}</h4>
     <div id="conditional-alert-list" class="ko-template">
-        <table class="table table-striped table-bordered">
+        <div class="alert alert-info" data-bind="visible: emptyTable()">
+            {% blocktrans %}
+                There are no alerts to display.
+            {% endblocktrans %}
+        </div>
+        <table class="table table-striped table-bordered" data-bind="visible: !emptyTable()">
             <thead>
                 <tr>
                     <th class="col-md-1">{% trans 'Delete' %}</th>
@@ -93,6 +98,7 @@
             </tbody>
         </table>
         <pagination data-apply-bindings="false"
+                    data-bind="visible: !emptyTable()"
                     params="goToPage: goToPage,
                             perPage: itemsPerPage,
                             totalItems: totalItems,

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -56,7 +56,20 @@
                             {% trans "Processing" %}: <span data-bind="text: progress_pct"></span>%
                         </span>
                     </td>
-                    <td>TODO</td>
+                    <td>
+                        <button class="btn btn-default"
+                                data-bind="attr: {id: 'activate-button-for-' + id()},
+                                           disable: locked_for_editing() || !editable(),
+                                           click: toggleStatus">
+                            <span data-bind="visible: active()">{% trans "Deactivate" %}</span>
+                            <span data-bind="visible: !active()">{% trans "Activate" %}</span>
+                        </button>
+                        <div data-bind="visible: locked_for_editing">
+                            <button class="btn btn-default" data-bind="click: restart">
+                                <i class="fa fa-refresh"></i> {% trans "Restart Rule" %}
+                            </button>
+                        </div>
+                    </td>
                     <td>TODO</td>
                 </tr>
             </tbody>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -25,8 +25,8 @@
         </a>
     </div>
     <h4>{% trans 'Conditional Alerts' %}</h4>
-    <div>
-        <table id="conditional-alert-list" class="table table-striped table-bordered">
+    <div id="conditional-alert-list" class="ko-template">
+        <table class="table table-striped table-bordered">
             <thead>
                 <tr>
                     <th class="col-md-1">{% trans 'Delete' %}</th>
@@ -89,5 +89,10 @@
                 </tr>
             </tbody>
         </table>
+        <pagination data-apply-bindings="false"
+                    params="goToPage: goToPage,
+                            perPage: itemsPerPage,
+                            totalItems: totalItems,
+                            showSpinner: showPaginationSpinner"></pagination>
     </div>
 {% endblock %}

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -47,8 +47,7 @@
             <tbody data-bind="foreach: rules">
                 <tr>
                     <td class="text-center">
-                        <button data-bind="attr: {id: 'delete-button-for-' + id()},
-                                           disable: locked_for_editing,
+                        <button data-bind="disable: locked_for_editing() || requestInProgress(),
                                            click: remove"
                                 class="btn btn-danger">
                                 <i class="fa fa-remove"></i>
@@ -65,15 +64,15 @@
                     </td>
                     <td>
                         <button class="btn btn-default"
-                                data-bind="attr: {id: 'activate-button-for-' + id()},
-                                           disable: locked_for_editing() || !editable(),
+                                data-bind="disable: locked_for_editing() || !editable() || requestInProgress(),
                                            click: toggleStatus">
                             <span data-bind="visible: active()">{% trans "Deactivate" %}</span>
                             <span data-bind="visible: !active()">{% trans "Activate" %}</span>
                         </button>
                         <div data-bind="visible: locked_for_editing">
                             <button class="btn btn-default" data-bind="click: restart">
-                                <i class="fa fa-refresh"></i> {% trans "Restart Rule" %}
+                                <i class="fa fa-refresh"></i>
+                                {% trans "Restart Rule" %}
                             </button>
                         </div>
                     </td>
@@ -85,8 +84,7 @@
                                        placeholder="{% trans_html_attr "Project" %}"
                                        data-bind="value: projectName, valueUpdate: 'afterkeydown'" />
                                 <button class="btn btn-default"
-                                        data-bind="attr: {id: 'copy-button-for-' + id()},
-                                                  disable: locked_for_editing() || !editable(),
+                                        data-bind="disable: locked_for_editing() || !editable() || requestInProgress(),
                                                   click: copy,">
                                     <i class="fa fa-copy"></i>
                                     {% trans "Copy" %}

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -49,7 +49,13 @@
                     </td>
                     <td><a data-bind="attr: {href: editUrl}, text: name"></a></td>
                     <td data-bind="text: case_type"></td>
-                    <td>TODO</td>
+                    <td>
+                        <span class="label label-success" data-bind="visible: active()">{% trans "Active" %}</span>
+                        <span class="label label-danger" data-bind="visible: !active()">{% trans "Inactive" %}</span>
+                        <span class="label label-default" data-bind="visible: locked_for_editing()">
+                            {% trans "Processing" %}: <span data-bind="text: progress_pct"></span>%
+                        </span>
+                    </td>
                     <td>TODO</td>
                     <td>TODO</td>
                 </tr>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -39,9 +39,16 @@
             </thead>
             <tbody data-bind="foreach: rules">
                 <tr>
-                    <td>TODO</td>
+                    <td class="text-center">
+                        <button data-bind="attr: {id: 'delete-button-for-' + id()},
+                                           disable: locked_for_editing,
+                                           click: remove"
+                                class="btn btn-danger">
+                                <i class="fa fa-remove"></i>
+                        </button>
+                    </td>
                     <td><a data-bind="attr: {href: editUrl}, text: name"></a></td>
-                    <td>TODO</td>
+                    <td data-bind="text: case_type"></td>
                     <td>TODO</td>
                     <td>TODO</td>
                     <td>TODO</td>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -30,11 +30,13 @@
             <thead>
                 <tr>
                     <th class="col-md-1">{% trans 'Delete' %}</th>
-                    <th class="col-md-5">{% trans 'Name' %}</th>
+                    <th class="{% if allow_copy %}col-md-2{% else %}col-md-5{% endif %}">{% trans 'Name' %}</th>
                     <th class="col-md-2">{% trans 'Case Type' %}</th>
                     <th class="col-md-2">{% trans 'Status' %}</th>
                     <th class="col-md-2">{% trans 'Action' %}</th>
-                    <th class="col-md-2">{% trans 'Copy To' %}</th>
+                    {% if allow_copy %}
+                        <th class="col-md-3">{% trans 'Copy To' %}</th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody data-bind="foreach: rules">
@@ -70,7 +72,20 @@
                             </button>
                         </div>
                     </td>
-                    <td>TODO</td>
+                    {% if allow_copy %}
+                        <td>
+                            <div class="form-inline">
+                                <input type="text" placeholder="{% trans_html_attr "Project" %}" class="form-control copy-project-name" data-bind="value: projectName" />
+                                <button class="btn btn-default"
+                                        data-bind="attr: {id: 'copy-button-for-' + id()},
+                                                  disable: locked_for_editing() || !editable(),
+                                                  click: copy,">
+                                    <i class="fa fa-copy"></i>
+                                    {% trans "Copy" %}
+                                </button>
+                            </div>
+                        </td>
+                    {% endif %}
                 </tr>
             </tbody>
         </table>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -2,9 +2,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-
 {% requirejs_main "scheduling/js/conditional_alert_list" %}
-
 
 {% block stylesheets %}{{ block.super }}
 <style>
@@ -39,6 +37,16 @@
                     <th class="col-md-2">{% trans 'Copy To' %}</th>
                 </tr>
             </thead>
+            <tbody data-bind="foreach: rules">
+                <tr>
+                    <td>TODO</td>
+                    <td><a data-bind="attr: {href: editUrl}, text: name"></a></td>
+                    <td>TODO</td>
+                    <td>TODO</td>
+                    <td>TODO</td>
+                    <td>TODO</td>
+                </tr>
+            </tbody>
         </table>
     </div>
 {% endblock %}

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -75,7 +75,10 @@
                     {% if allow_copy %}
                         <td>
                             <div class="form-inline">
-                                <input type="text" placeholder="{% trans_html_attr "Project" %}" class="form-control copy-project-name" data-bind="value: projectName" />
+                                <input type="text"
+                                       class="form-control"
+                                       placeholder="{% trans_html_attr "Project" %}"
+                                       data-bind="value: projectName, valueUpdate: 'afterkeydown'" />
                                 <button class="btn btn-default"
                                         data-bind="attr: {id: 'copy-button-for-' + id()},
                                                   disable: locked_for_editing() || !editable(),

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -590,7 +590,7 @@ class ConditionalAlertListView(BaseMessagingSectionView):
         query = self.get_conditional_alerts_queryset()
         total_records = query.count()
 
-        limit = int(request.GET.get('limit'))
+        limit = int(request.GET.get('limit', 25))
         page = int(request.GET.get('page', 1))
         skip = (page - 1) * limit
 
@@ -608,7 +608,10 @@ class ConditionalAlertListView(BaseMessagingSectionView):
                 'id': rule.pk,
             })
 
-        return json_response({'rules': data})
+        return json_response({
+            'rules': data,
+            'total': total_records,
+        })
 
     def get(self, request, *args, **kwargs):
         action = request.GET.get('action')

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -601,7 +601,7 @@ class ConditionalAlertListView(BaseMessagingSectionView):
         query = self.get_conditional_alerts_queryset()
         total_records = query.count()
 
-        limit = int(request.GET.get('limit', 25))
+        limit = int(request.GET.get('limit'))
         page = int(request.GET.get('page', 1))
         skip = (page - 1) * limit
 


### PR DESCRIPTION
This started as ICDS pointing out that the conditional alerts page doesn't let you select the number of items per page. I decided to rewrite it in knockout rather than fuss with datatables. I'd like to kill `DataTablesAJAXPaginationMixin` altogether - it's only used here and in the broadcast list view - so that we have one fewer way of doing things, but that can be another PR.

Review by commit.

@millerdev 

Product: This makes minor changes to the conditional alerts page that make it look more like most of the rest of our paginated tables.

old
<img width="1098" alt="screen shot 2019-03-04 at 11 40 02 pm" src="https://user-images.githubusercontent.com/1486591/53753283-db9e0300-3ed6-11e9-9659-b1556c86c481.png">

new
<img width="1103" alt="screen shot 2019-03-04 at 11 38 23 pm" src="https://user-images.githubusercontent.com/1486591/53753239-c1642500-3ed6-11e9-9a0a-27131c785562.png">
