### PR TITLE
don't decode output of get_table_name

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/ccs_record_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/ccs_record_monthly.py
@@ -56,7 +56,7 @@ class CcsRecordMonthlyAggregationHelper(BaseICDSAggregationHelper):
     def person_case_ucr_tablename(self):
         doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-person_cases_v3')
         config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id).decode('utf-8')
+        return get_table_name(self.domain, config.table_id)
 
     def aggregation_query(self):
         start_month_string = self.month.strftime("'%Y-%m-%d'::date")


### PR DESCRIPTION
Decoding a unicode value fails in python 3.