### PR TITLE
Transifex ui niceties

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/widgets_v4.js
+++ b/corehq/apps/app_manager/static/app_manager/js/widgets_v4.js
@@ -11,7 +11,7 @@ hqDefine("app_manager/js/widgets_v4", [
 ) {
     var initVersionDropdown = function ($select, options) {
         options = options || {};
-        assertProperties.assertRequired(options, [], ['url', 'width']);
+        assertProperties.assert(options, [], ['url', 'width']);
 
         $select.select2({
             ajax: {

--- a/corehq/apps/app_manager/static/app_manager/js/widgets_v4.js
+++ b/corehq/apps/app_manager/static/app_manager/js/widgets_v4.js
@@ -1,16 +1,21 @@
 // Note that this file exists only for select2 v4 and it depends on the paginate_releases URL being registered
 hqDefine("app_manager/js/widgets_v4", [
     'jquery',
+    'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
     'select2/dist/js/select2.full.min',
 ], function (
     $,
+    assertProperties,
     initialPageData
 ) {
-    $(".app-manager-version-dropdown").each(function () {
-        $(this).select2({
+    var initVersionDropdown = function ($select, options) {
+        options = options || {};
+        assertProperties.assertRequired(options, [], ['url', 'width']);
+
+        $select.select2({
             ajax: {
-                url: initialPageData.reverse('paginate_releases'),
+                url: options.url || initialPageData.reverse('paginate_releases'),
                 dataType: 'json',
                 data: function (params) {
                     return {
@@ -31,7 +36,17 @@ hqDefine("app_manager/js/widgets_v4", [
                     };
                 },
             },
-            width: '200px',
+            width: options.width || '200px',
+        });
+    };
+
+    $(function () {
+        $(".app-manager-version-dropdown").each(function () {
+            initVersionDropdown($(this));
         });
     });
+
+    return {
+        initVersionDropdown: initVersionDropdown,
+    };
 });

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -95,7 +95,7 @@ class PullResourceForm(forms.Form):
                 tuple((project.slug, project) for project in projects)
             )
         self.helper.layout = crispy.Layout(
-            'transifex_project_slug',
+            crispy.Field('transifex_project_slug', css_class="ko-select2"),
             crispy.Field('target_lang', css_class="ko-select2"),
             'resource_slug',
             hqcrispy.FormActions(
@@ -164,10 +164,10 @@ class AppTranslationsForm(forms.Form):
 
     def form_fields(self):
         return [
-            hqcrispy.Field('app_id'),
+            hqcrispy.Field('app_id', css_class="ko-select2"),
             hqcrispy.Field('version'),
             hqcrispy.Field('use_version_postfix'),
-            hqcrispy.Field('transifex_project_slug'),
+            hqcrispy.Field('transifex_project_slug', css_class="ko-select2"),
             hqcrispy.Field('action')
         ]
 

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -4,6 +4,7 @@ import openpyxl
 import langcodes
 
 from django import forms
+from django.forms.widgets import Select
 from zipfile import ZipFile
 
 from crispy_forms.helper import FormHelper
@@ -111,7 +112,8 @@ class PullResourceForm(forms.Form):
 class AppTranslationsForm(forms.Form):
     app_id = forms.ChoiceField(label=ugettext_lazy("Application"), choices=(), required=True)
     version = forms.IntegerField(label=ugettext_lazy("Application Version"), required=False,
-                                 help_text=ugettext_lazy("Leave blank to use current saved state"))
+                                 help_text=ugettext_lazy("Leave blank to use current saved state"),
+                                 widget=Select(choices=[]))
     use_version_postfix = forms.MultipleChoiceField(
         choices=[
             ('yes', 'Track resources per version'),

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -151,14 +151,19 @@ class AppTranslationsForm(forms.Form):
                 tuple((project.slug, project) for project in projects)
             )
         form_fields = self.form_fields()
-        form_fields.append(hqcrispy.Field(StrictButton(
-            ugettext_lazy("Submit"),
-            type="submit",
-            css_class="btn btn-primary btn-lg disable-on-submit",
-            onclick="return confirm('%s')" % ugettext_lazy("Please confirm that you want to proceed?")
-        )))
         self.helper.layout = crispy.Layout(
-            *form_fields
+            crispy.Fieldset(
+                "",
+                *form_fields
+            ),
+            hqcrispy.FormActions(
+                twbscrispy.StrictButton(
+                    ugettext_lazy("Submit"),
+                    type="submit",
+                    css_class="btn btn-primary disable-on-submit",
+                    onclick="return confirm('%s')" % ugettext_lazy("Please confirm that you want to proceed?")
+                )
+            )
         )
         self.fields['action'].initial = self.form_action
 

--- a/corehq/apps/translations/forms.py
+++ b/corehq/apps/translations/forms.py
@@ -28,9 +28,15 @@ class ConvertTranslationsForm(forms.Form):
         self.helper = FormHelper()
         self.helper.form_method = 'post'
         self.helper.layout = crispy.Layout(
-            crispy.Field(
-                'upload_file',
-                data_bind="value: file",
+            hqcrispy.B3MultiField(
+                "",
+                crispy.Div(
+                    crispy.Field(
+                        'upload_file',
+                        data_bind="value: file",
+                    ),
+                    css_class='col-sm-4'
+                ),
             ),
             StrictButton(
                 ugettext_lazy('Convert'),

--- a/corehq/apps/translations/static/translations/js/app_translations.js
+++ b/corehq/apps/translations/static/translations/js/app_translations.js
@@ -1,0 +1,31 @@
+hqDefine("translations/js/app_translations", [
+    "jquery",
+    "hqwebapp/js/initial_page_data",
+    "app_manager/js/widgets_v4",
+    "hqwebapp/js/widgets_v4",   // .ko-select2
+], function (
+    $,
+    initialPageData,
+    appManagerWidgets,
+) {
+    $(function () {
+        // Application version select2: pagination, display comment
+        $("[name='version']").each(function () {
+            var $select = $(this);
+            appManagerWidgets.initVersionDropdown($select, {
+                url: function () {
+                    var $form = $select.closest("form"),
+                        appId = $form.find("[name='app_id']").val();
+                    return initialPageData.reverse("paginate_releases", appId);
+                },
+                width: '100%',
+            });
+        });
+
+        // Clear version when application changes
+        $("[name='app_id']").change(function () {
+            var $form = $(this).closest("form");
+            $form.find("[name='version']").val('').trigger('change');
+        });
+    });
+});

--- a/corehq/apps/translations/static/translations/js/app_translations.js
+++ b/corehq/apps/translations/static/translations/js/app_translations.js
@@ -6,7 +6,7 @@ hqDefine("translations/js/app_translations", [
 ], function (
     $,
     initialPageData,
-    appManagerWidgets,
+    appManagerWidgets
 ) {
     $(function () {
         // Application version select2: pagination, display comment

--- a/corehq/apps/translations/templates/app_translations.html
+++ b/corehq/apps/translations/templates/app_translations.html
@@ -3,9 +3,12 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% requirejs_main "hqwebapp/js/widgets_v4" %}
+{% requirejs_main "translations/js/app_translations" %}
+
 
 {% block page_content %}
+    {% registerurl "paginate_releases" domain '---' %}
+
     {% if not transifex_details_available %}
         <p class="text-error">
             <span class="label label-danger">

--- a/corehq/apps/translations/templates/app_translations.html
+++ b/corehq/apps/translations/templates/app_translations.html
@@ -17,12 +17,12 @@
         </p>
     {% else %}
         <ul class="nav nav-tabs sticky-tabs" style="margin-bottom: 10px;">
-          <li><a data-toggle="tab" href="#create-trans-form" id="create-tab"><b>{% trans "Create" %}</b></a></li>
-          <li><a data-toggle="tab" href="#update-trans-form" id="update-tab"><b>{% trans "Update" %}</b></a></li>
-          <li><a data-toggle="tab" href="#push-trans-form" id="push-tab"><b>{% trans "Push" %}</b></a></li>
-          <li><a data-toggle="tab" href="#pull-trans-form" id="pull-tab"><b>{% trans "Pull" %}</b></a></li>
-          <li><a data-toggle="tab" href="#backup-trans-form" id="backup-tab"><b>{% trans "BackUp" %}</b></a></li>
-          <li><a data-toggle="tab" href="#del-trans-form" id="delete-tab"><b>{% trans "Delete" %}</b></a></li>
+          <li><a data-toggle="tab" href="#create-trans-form" id="create-tab">{% trans "Create" %}</a></li>
+          <li><a data-toggle="tab" href="#update-trans-form" id="update-tab">{% trans "Update" %}</a></li>
+          <li><a data-toggle="tab" href="#push-trans-form" id="push-tab">{% trans "Push" %}</a></li>
+          <li><a data-toggle="tab" href="#pull-trans-form" id="pull-tab">{% trans "Pull" %}</a></li>
+          <li><a data-toggle="tab" href="#backup-trans-form" id="backup-tab">{% trans "BackUp" %}</a></li>
+          <li><a data-toggle="tab" href="#del-trans-form" id="delete-tab">{% trans "Delete" %}</a></li>
         </ul>
         <div class="tab-content">
             <div id="create-trans-form" class="tab-pane">


### PR DESCRIPTION
@mkangia I noticed in a meeting that the Application dropdown in the transifex UI is a bit long and unwieldy for ICDS, so I went to switch to to a select2 and ended up making a handful of minor UI changes.

The convert translations page's alignment was bugging me:
<img width="470" alt="screen shot 2019-03-05 at 7 44 08 am" src="https://user-images.githubusercontent.com/1486591/53776056-d1055d00-3f1a-11e9-942b-097a065c9f08.png">

Fixed:
<img width="475" alt="screen shot 2019-03-05 at 7 42 55 am" src="https://user-images.githubusercontent.com/1486591/53776064-dc588880-3f1a-11e9-84a8-d6eb480459a3.png">

Old manage app translations page:
<img width="798" alt="screen shot 2019-03-05 at 7 44 18 am" src="https://user-images.githubusercontent.com/1486591/53776091-fb571a80-3f1a-11e9-95e0-17a0a560dd11.png">

New:
<img width="797" alt="screen shot 2019-03-05 at 7 43 13 am" src="https://user-images.githubusercontent.com/1486591/53776106-04e08280-3f1b-11e9-8b5b-a8760ee34934.png">

Feature flag: "Translate Application Content With Transifex"

code buddy @millerdev 