### PR TITLE
Added bulk applications translation download to source files

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/download_index.html
+++ b/corehq/apps/app_manager/templates/app_manager/download_index.html
@@ -66,7 +66,18 @@
         {% endif %}
         <tr>
             <td>
-                <a href="#download_ccz" data-toggle="modal"  class='download-zip'>CommCare.ccz</a>
+                <a href="#download_ccz" data-toggle="modal"  class='download-zip'>
+                    <i class="fa fa-file-zip-o"></i>
+                    CommCare.ccz
+                </a>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <a href="{% url "download_bulk_app_translations" app.domain app.id %}">
+                    <i class="fa fa-file-excel-o"></i>
+                    {% trans "Bulk application translations" %}
+                </a>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
ICDS wants to be able to download translations for a specific version without needing to switch streams. Since they can't re-upload these translations, I stuck this on the view source files page. Not flagging this because view source files is already behind a flag.

<img width="371" alt="screen shot 2019-03-05 at 8 03 42 am" src="https://user-images.githubusercontent.com/1486591/53776808-3bb79800-3f1d-11e9-824c-116af8b999fa.png">

@millerdev / @mkangia 

Feature flag: "Support"