### PR TITLE
Revert "Check for errors before checking if task is successful"

### DIFF
--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -122,14 +122,14 @@ def get_task_status(task, is_multiple_download_task=False):
             pass
         else:
             result = task.result
-            if result and result.get('errors'):
-                failed = True
-                context_error = result.get('errors')
-            elif task.successful():
+            if task.successful():
                 is_ready = True
                 context_result = result and result.get('messages')
             elif result and isinstance(result, Exception):
                 context_error = six.text_type(result)
+            elif result and result.get('errors'):
+                failed = True
+                context_error = result.get('errors')
         progress = get_task_progress(task)
 
     def progress_complete():


### PR DESCRIPTION
This reverts commit 9a05975d94778942a8d56e47516fb5fc43edc144.

I'm reverting my change from https://github.com/dimagi/commcare-hq/commit/9a05975d94778942a8d56e47516fb5fc43edc144#diff-319b272b94c5c896fa400e0d8529519b In the same PR, I added some UI code to fix the issue that domain was seeing, so it should not be an issue.

This code has changed a lot recently:

https://github.com/dimagi/commcare-hq/commit/757cfe22b1b7cb71e6ef74b433aa59a336d31566#diff-319b272b94c5c896fa400e0d8529519b
https://github.com/dimagi/commcare-hq/commit/8ce4fd0bf541cb2b621e46cf8ebaac8db540f890#diff-319b272b94c5c896fa400e0d8529519b
https://github.com/dimagi/commcare-hq/commit/06fd0726bcfc723ade465acdff8b3de32bc5c6d0#diff-319b272b94c5c896fa400e0d8529519b

I think that I like the current state of soil, so I am going to document the current state, and how to use soil. and then apply those practices to case importer