### PR TITLE
Use smaller if statement

### DIFF
--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -173,14 +173,14 @@ def overwrite_app(app, master_build, report_map=None):
     app_json['version'] = master_json['version']
     wrapped_app = wrap_app(app_json)
     for module in wrapped_app.get_report_modules():
-        if report_map is not None:
-            for config in module.report_configs:
-                try:
-                    config.report_id = report_map[config.report_id]
-                except KeyError:
-                    raise AppEditingError(config.report_id)
-        else:
+        if report_map is None:
             raise AppEditingError('Report map not passed to overwrite_app')
+
+        for config in module.report_configs:
+            try:
+                config.report_id = report_map[config.report_id]
+            except KeyError:
+                raise AppEditingError(config.report_id)
 
     wrapped_app = _update_form_ids(wrapped_app, master_build, id_map)
     enable_usercase_if_necessary(wrapped_app)


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/23518/files#r262522479

@proteusvacuum I don't think that this is what you meant, but it does make it slightly better.

Its harder to extract the if outside of the `for` because `get_report_modules` is  a generator, and we only want this error to surface if there is a report module. It doesn't seem worth it to have another filter statement or introduce `has_report_modules` to extract it