### PR TITLE
Ajaxify multimedia references checker

### DIFF
--- a/corehq/apps/hqmedia/static/hqmedia/js/hqmedia.reference_controller.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/hqmedia.reference_controller.js
@@ -1,27 +1,34 @@
 hqDefine("hqmedia/js/hqmedia.reference_controller",[
     'jquery',
-    'underscore',
     'knockout',
-    "hqmedia/js/hqmediauploaders",
-],function ($, _, ko, hQMediaUploaders) {
-    var HQMediaUploaders = hQMediaUploaders.get();
+    'underscore',
+    'hqwebapp/js/assert_properties',
+    'hqmedia/js/hqmediauploaders',
+],function (
+    $,
+    ko,
+    _,
+    assertProperties,
+    mediaUploaders
+) {
+    var HQMediaUploaders = mediaUploaders.get();
 
-    function MultimediaReferenceController(references, objMap, totals) {
-        'use strict';
+    function MultimediaReferenceController(options) {
+        assertProperties.assert(options, ['references', 'objectMap', 'totals']);
         var self = {};
-        self.objMap = objMap;
+        self.objectMap = options.objectMap;
         self.modules = [];
         self.showMissingReferences = ko.observable(false);
-        self.totals = ko.observable(totals);
+        self.totals = ko.observable(options.totals);
 
         self.toggleRefsText = ko.computed(function () {
             return (self.showMissingReferences()) ? gettext("Show All References") : gettext("Show Only Missing References");
         }, self);
 
         self.render = function () {
-            _.each(references, function (ref) {
+            _.each(options.references, function (ref) {
                 if (!self.modules[ref.module.id]) {
-                    self.modules[ref.module.id] = ModuleReferences(ref.module.name, self.objMap, ref.module.id);
+                    self.modules[ref.module.id] = ModuleReferences(ref.module.name, self.objectMap, ref.module.id);
                 }
                 self.modules[ref.module.id].processReference(ref);
             });
@@ -60,16 +67,16 @@ hqDefine("hqmedia/js/hqmedia.reference_controller",[
             });
             self.totals(newTotals);
         };
-        
+
         return self;
     }
 
-    function BaseReferenceGroup(name, objMap, groupId) {
+    function BaseReferenceGroup(name, objectMap, groupId) {
         'use strict';
         var self = {};
         self.name = name;
         self.id = groupId;
-        self.objMap = objMap;
+        self.objectMap = objectMap;
         self.menu_references = ko.observableArray();
         self.showOnlyMissing = ko.observable(false);
 
@@ -82,7 +89,7 @@ hqDefine("hqmedia/js/hqmedia.reference_controller",[
         }, self);
 
         self.createReferenceObject = function (ref) {
-            var objRef = self.objMap[ref.path];
+            var objRef = self.objectMap[ref.path];
             if (ref.media_class === "CommCareImage") {
                 var imageRef = ImageReference(ref);
                 imageRef.setObjReference(objRef);
@@ -112,16 +119,16 @@ hqDefine("hqmedia/js/hqmedia.reference_controller",[
         return self;
     }
 
-    function ModuleReferences(name, objMap, groupId) {
+    function ModuleReferences(name, objectMap, groupId) {
         'use strict';
-        var self = BaseReferenceGroup(name, objMap, groupId);
+        var self = BaseReferenceGroup(name, objectMap, groupId);
         self.forms = [];
         self.id = "module-" + self.id;
 
         self.processReference = function (ref) {
             if (ref.form.id) {
                 if (!self.forms[ref.form.order]) {
-                    self.forms[ref.form.order] = FormReferences(ref.form.name, self.objMap, ref.form.id);
+                    self.forms[ref.form.order] = FormReferences(ref.form.name, self.objectMap, ref.form.id);
                 }
                 self.forms[ref.form.order].processReference(ref);
             } else if (ref.is_menu_media) {
@@ -135,9 +142,9 @@ hqDefine("hqmedia/js/hqmedia.reference_controller",[
     ModuleReferences.prototype.constructor = ModuleReferences;
 
 
-    function FormReferences(name, objMap, groupId) {
+    function FormReferences(name, objectMap, groupId) {
         'use strict';
-        var self = BaseReferenceGroup(name, objMap, groupId);
+        var self = BaseReferenceGroup(name, objectMap, groupId);
 
         self.images = ko.observableArray();
         self.audio = ko.observableArray();

--- a/corehq/apps/hqmedia/static/hqmedia/js/references_main.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/references_main.js
@@ -1,12 +1,13 @@
 /* globals MultimediaReferenceController */
 hqDefine("hqmedia/js/references_main", function () {
     $(function () {
-        // TODO: spinner
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data"),
+            $loading = $(".hq-loading");
         $.ajax({
             url: initialPageData.reverse('hqmedia_references'),
             data: { json: 1 },
             success: function (data) {
+                $loading.remove();
                 var referenceController = hqImport('hqmedia/js/hqmedia.reference_controller').MultimediaReferenceController({
                     references: data.references,
                     objectMap: data.object_map,
@@ -16,7 +17,11 @@ hqDefine("hqmedia/js/references_main", function () {
                 $("#multimedia-reference-checker").koApplyBindings(referenceController);
                 $('.preview-media').tooltip();
             },
-            // TODO: error
+            error: function () {
+                $loading.removeClass("alert-info");
+                $loading.addClass("alert-danger");
+                $loading.text(gettext("Error loading, please refresh the page. If this persists, please report an issue."));
+            },
         });
     });
 });

--- a/corehq/apps/hqmedia/static/hqmedia/js/references_main.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/references_main.js
@@ -1,15 +1,22 @@
 /* globals MultimediaReferenceController */
 hqDefine("hqmedia/js/references_main", function () {
     $(function () {
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
-            referenceController = hqImport('hqmedia/js/hqmedia.reference_controller').MultimediaReferenceController(
-                initialPageData("references"),
-                initialPageData("object_map"),
-                initialPageData("totals")
-            );
-        referenceController.render();
-        $("#multimedia-reference-checker").koApplyBindings(referenceController);
-
-        $('.preview-media').tooltip();
+        // TODO: spinner
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data");
+        $.ajax({
+            url: initialPageData.reverse('hqmedia_references'),
+            data: { json: 1 },
+            success: function (data) {
+                var referenceController = hqImport('hqmedia/js/hqmedia.reference_controller').MultimediaReferenceController({
+                    references: data.references,
+                    objectMap: data.object_map,
+                    totals: data.totals,
+                });
+                referenceController.render();
+                $("#multimedia-reference-checker").koApplyBindings(referenceController);
+                $('.preview-media').tooltip();
+            },
+            // TODO: error
+        });
     });
 });

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -4,15 +4,6 @@
 
 {% block stylesheets %}{{ block.super }}
     <style type="text/css">
-        .media-totals-list {
-            margin: 0;
-            padding: 0;
-        }
-
-        .media-totals {
-            list-style-type: none;
-        }
-
         .media-type-icon,
         .media-status-icon {
             font-size: 22px;
@@ -69,7 +60,7 @@
             {% if totals|length %}
             <div class="well">
                 {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True is_multimedia_reference_checker=True %}
-                <ul class="media-totals-list" data-bind="foreach: totals">
+                <ul class="list-unstyled" data-bind="foreach: totals">
                     <li class="media-totals" data-bind="event: {refMediaAdded: $parent.incrementTotals}">
                         <i data-bind="attr: {class: icon_class}"></i>
                         <span data-bind="text: matched"></span>/<span data-bind="text: totals"></span>

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -33,6 +33,13 @@
 
 <p class="lead">{{ current_page.page_name }}</p>
 
+<div class="hq-loading alert alert-info">
+    {% blocktrans %}
+        <i class="fa fa-spin fa-spinner"></i>
+        Loading...
+    {% endblocktrans %}
+</div>
+
 <div id="multimedia-reference-checker" class="ko-template">
     <div class="row">
         <div class="col-sm-7">

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -26,20 +26,17 @@
 {% endblock %}
 
 {% block page_content %}
-{% initial_page_data 'object_map' object_map %}
-{% initial_page_data 'references' references %}
 {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
 {% initial_page_data 'swfURL' 'hqmedia/MediaUploader/flashuploader.swf'|static %}
-{% initial_page_data 'totals' totals %}
 {% initial_page_data 'uploaders' uploaders_js %}
+{% registerurl 'hqmedia_references' app.domain app.id %}
 
 <p class="lead">{{ current_page.page_name }}</p>
 
-<div id="multimedia-reference-checker">
-
+<div id="multimedia-reference-checker" class="ko-template">
     <div class="row">
         <div class="col-sm-7">
-            {% if totals|length %}
+            <div data-bind="visible: totals().length">
                 <p>
                     {% blocktrans %}
                         You can manage multimedia by uploading files individually below.
@@ -50,14 +47,14 @@
                         <a href="#" class="btn btn-default" data-bind="click: toggleMissingRefs, text: toggleRefsText"></a>
                     </p>
                 {% endif %}
-            {% else %}
+            </div>
+            <div data-bind="visible: !totals().length">
                 <div class="alert alert-info">
                     {% blocktrans %}This application references no multimedia.{% endblocktrans %}
                 </div>
-            {% endif %}
+            </div>
         </div>
-        <div class="col-sm-5">
-            {% if totals|length %}
+        <div class="col-sm-5" data-bind="visible: totals().length">
             <div class="well">
                 {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True is_multimedia_reference_checker=True %}
                 <ul class="list-unstyled" data-bind="foreach: totals">
@@ -68,12 +65,10 @@
                     </li>
                 </ul>
             </div>
-            {% endif %}
         </div>
     </div>
-    {% if totals|length %}
 
-    <article class="panel panel-default" id="mm-reference-list">
+    <article class="panel panel-default" id="mm-reference-list" data-bind="visible: totals().length">
     <!-- ko foreach: modules -->
         <div class="panel-heading">
             <h3 class="panel-title">
@@ -134,7 +129,6 @@
         {% include 'hqmedia/partials/multimedia_uploader.html' %}
     {% endfor %}
 
-    {% endif %}
 </div>
 
 {% endblock %}

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -20,7 +20,7 @@ from django.views.generic import View, TemplateView
 
 from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
 
-from django.http import HttpResponse, Http404, HttpResponseServerError, HttpResponseBadRequest
+from django.http import HttpResponse, Http404, HttpResponseServerError, HttpResponseBadRequest, JsonResponse
 
 from django.shortcuts import render
 import shutil
@@ -153,11 +153,8 @@ class MultimediaReferencesView(BaseMultimediaUploaderView):
         if self.app is None:
             raise Http404(self)
         context.update({
-            "references": self.app.get_references(),
-            "multimedia_state": self.app.check_media_state(),
-            "object_map": self.app.get_object_map(),
-            "totals": self.app.get_reference_totals(),
             "sessionid": self.request.COOKIES.get('sessionid'),
+            "multimedia_state": self.app.check_media_state(),
         })
         return context
 
@@ -171,6 +168,15 @@ class MultimediaReferencesView(BaseMultimediaUploaderView):
             MultimediaVideoUploadController("hqvideo", reverse(ProcessVideoFileUploadView.urlname,
                                                                args=[self.domain, self.app_id])),
         ]
+
+    def get(self, request, *args, **kwargs):
+        if request.GET.get('json', None):
+            return JsonResponse({
+                "references": self.app.get_references(),
+                "object_map": self.app.get_object_map(),
+                "totals": self.app.get_reference_totals(),
+            })
+        return super(MultimediaReferencesView, self).get(request, *args, **kwargs)
 
 
 class BulkUploadMultimediaView(BaseMultimediaUploaderView):

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -713,13 +713,6 @@ class RemoveLogoView(BaseMultimediaView):
         return HttpResponse()
 
 
-class CheckOnProcessingFile(BaseMultimediaView):
-    urlname = "hqmedia_check_processing"
-
-    def get(self, request, *args, **kwargs):
-        return HttpResponse("workin on it")
-
-
 def iter_media_files(media_objects):
     """
     take as input the output of get_media_objects

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -20,7 +20,7 @@ from django.views.generic import View, TemplateView
 
 from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
 
-from django.http import HttpResponse, Http404, HttpResponseServerError, HttpResponseBadRequest, JsonResponse
+from django.http import HttpResponse, Http404, HttpResponseBadRequest, JsonResponse
 
 from django.shortcuts import render
 import shutil


### PR DESCRIPTION
Fetch the content for the multimedia reference checker via ajax. The point of this is to let the outer menu load faster, because going to this page is the only way to get to the other multimedia pages (bulk upload, bulk path management).

There are plenty of other improvements to make here - like making this page *not* be a gateway to the other multimedia functionality, making `multimedia_state` also fetched via ajax instead of on initial page load, etc. This PR is quick and dirty to alleviate some pain for ICDS.

@czue / @kaapstorm 

Review by commit.

Product: this shouldn't be too visible to users. Just a new spinner on the page, and hopefully faster load time.