### PR TITLE
Clarify unrestricted SMS message

### DIFF
--- a/corehq/messaging/scheduling/templates/scheduling/dashboard.html
+++ b/corehq/messaging/scheduling/templates/scheduling/dashboard.html
@@ -100,7 +100,8 @@
                             </span>
                             <span data-bind="visible: uses_restricted_time_windows() && within_allowed_sms_times()">
                                 {% blocktrans %}
-                                Your project restricts the times of day at which SMS can be sent, but no restrictions are currently active.
+                                Your project restricts the times of day at which SMS can be sent. SMS sending is currently active. The next restricted period begins at
+                                <span data-bind="text: sms_resume_time"></span> (<span data-bind="text: project_timezone"></span>).
                                 {% endblocktrans %}
                             </span>
                             {% if request.couch_user.is_domain_admin %}

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -131,17 +131,18 @@ class MessagingDashboardView(BaseMessagingSectionView):
     def add_sms_status_info(self, result):
         if len(self.domain_object.restricted_sms_times) > 0:
             result['uses_restricted_time_windows'] = True
-            result['within_allowed_sms_times'] = time_within_windows(
+            sms_allowed = result['within_allowed_sms_times'] = time_within_windows(
                 self.domain_now,
                 self.domain_object.restricted_sms_times
             )
-            if not result['within_allowed_sms_times']:
-                for i in range(1, 7 * 24 * 60):
-                    # This is a very fast check so it's ok to iterate this many times.
-                    resume_time = self.domain_now + timedelta(minutes=i)
-                    if time_within_windows(resume_time, self.domain_object.restricted_sms_times):
-                        result['sms_resume_time'] = resume_time.strftime('%Y-%m-%d %H:%M')
-                        break
+            # find next restricted window transition
+            for i in range(1, 7 * 24 * 60):
+                # This is a very fast check so it's ok to iterate this many times.
+                future_time = self.domain_now + timedelta(minutes=i)
+                future_allowed = time_within_windows(future_time, self.domain_object.restricted_sms_times)
+                if sms_allowed != future_allowed:
+                    result['sms_resume_time'] = future_allowed.strftime('%Y-%m-%d %H:%M')
+                    break
         else:
             result['uses_restricted_time_windows'] = False
             result['within_allowed_sms_times'] = True


### PR DESCRIPTION
Previously the SMS dashboard showed a rather confusing message when SMS restrictions were configured, but not active:

> Your project restricts the times of day at which SMS can be sent, but no restrictions are currently active.

The message has been updated to

> Your project restricts the times of day at which SMS can be sent. SMS sending is currently active. The next restricted period begins at 2019-03-07 22:15 (EST)

with dynamic date/time (always in the future) and timezone.

@dannyroberts 