### PR TITLE
switch from ConcurrentLogHandler to concurrent-log-handler and log ucr_diffs concurrently

### DIFF
--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -27,7 +27,7 @@ chardet==3.0.4
 click==7.0                # via pip-tools
 cloudant==2.11.0
 colorama==0.4.1           # via sniffer
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 coverage==4.5.1
 cryptography==2.5

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -20,7 +20,7 @@ certifi==2018.11.29
 cffi==1.12.1
 chardet==3.0.4
 cloudant==2.11.0
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.5
 csiphash==0.0.5

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -21,7 +21,7 @@ certifi==2018.11.29
 cffi==1.12.1
 chardet==3.0.4
 cloudant==2.11.0
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.5
 csiphash==0.0.5

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -19,7 +19,7 @@ certifi==2018.11.29       # via requests
 cffi==1.12.1              # via cryptography, csiphash
 chardet==3.0.4            # via ghdiff, requests
 cloudant==2.11.0          # via jsonobject-couchdbkit
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.5         # via pyopenssl, requests
 csiphash==0.0.5

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -23,7 +23,7 @@ certifi==2018.11.29
 cffi==1.12.1
 chardet==3.0.4
 cloudant==2.11.0
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 coverage==4.5.1
 cryptography==2.5

--- a/requirements-python3_6/uninstall-requirements.txt
+++ b/requirements-python3_6/uninstall-requirements.txt
@@ -10,3 +10,4 @@ zeep
 cython
 django-celery-results
 numpy
+ConcurrentLogHandler

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -27,7 +27,7 @@ chardet==3.0.4
 click==7.0                # via pip-tools
 cloudant==2.11.0
 colorama==0.4.1           # via sniffer
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 coverage==4.5.1
 cryptography==2.5

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -20,7 +20,7 @@ certifi==2018.11.29
 cffi==1.12.1
 chardet==3.0.4
 cloudant==2.11.0
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.5
 csiphash==0.0.5

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -21,7 +21,7 @@ certifi==2018.11.29
 cffi==1.12.1
 chardet==3.0.4
 cloudant==2.11.0
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.5
 csiphash==0.0.5

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -82,7 +82,7 @@ httpagentparser~=1.7
 boto3~=1.9
 simpleeval~=0.9
 laboratory==0.2.0
-ConcurrentLogHandler==0.9.1
+concurrent-log-handler==0.9.12
 PyGithub==1.35
 django-bulk-update~=2.0
 csiphash==0.0.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ certifi==2018.11.29       # via requests
 cffi==1.12.1              # via cryptography, csiphash
 chardet==3.0.4            # via ghdiff, requests
 cloudant==2.11.0          # via jsonobject-couchdbkit
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.5         # via pyopenssl, requests
 csiphash==0.0.5

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -23,7 +23,7 @@ certifi==2018.11.29
 cffi==1.12.1
 chardet==3.0.4
 cloudant==2.11.0
-concurrentloghandler==0.9.1
+concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 coverage==4.5.1
 cryptography==2.5

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -10,3 +10,4 @@ zeep
 cython
 django-celery-results
 numpy
+ConcurrentLogHandler

--- a/settings.py
+++ b/settings.py
@@ -1092,7 +1092,7 @@ LOGGING = {
         },
         'ucr_diff': {
             'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'concurrent_log_handler.ConcurrentRotatingFileHandler',
             'formatter': 'ucr_diff',
             'filename': UCR_DIFF_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB


### PR DESCRIPTION
On the library upgrade - one is basically a port of the other that is actually maintained (the former was last updated in 2013, while the latter had a release in August 2018)

https://github.com/Preston-Landers/concurrent-log-handler