### PR TITLE
Fix app logo changes on app update

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5073,6 +5073,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         if logo_refs and domain_has_privilege(self.domain, privileges.COMMCARE_LOGO_UPLOADER):
             for logo_name in logo_refs:
                 app_profile['properties'][ANDROID_LOGO_PROPERTY_MAPPING[logo_name]] = {
+                    'force': True,
                     'value': self.logo_refs[logo_name]['path'],
                 }
 


### PR DESCRIPTION
If a property is passed to mobile without force=true, then that property
is not updated if a value already exists. This means that new installs
will use the same value, but updating from a previous build uses the old
icon

This one's been around since 2015 or so. surprising no one's mentioned it, though it is a very custom feature https://dimagi-dev.atlassian.net/browse/MOB-79