### PR TITLE
Add regex to translations function

### DIFF
--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -829,31 +829,31 @@ def _update_case_list_translations(sheet, rows, app):
     for i, row in enumerate(rows):
         # If it's an enum case property, set index_of_last_enum_in_condensed
         if row['case_property'].endswith(" (ID Mapping Text)"):
-            row['id'] = row['case_property'].split(" ")[0]
+            row['id'] = re.match('.*(?= \()', row['case_property']).group()
             condensed_rows.append(row)
             index_of_last_enum_in_condensed = len(condensed_rows) - 1
 
         # If it's an enum value, add it to it's parent enum property
         elif row['case_property'].endswith(" (ID Mapping Value)"):
-            row['id'] = row['case_property'].split(" ")[0]
+            row['id'] = re.match('.*(?= \()', row['case_property']).group()
             parent = condensed_rows[index_of_last_enum_in_condensed]
             parent['mappings'] = parent.get('mappings', []) + [row]
 
         # If it's a graph case property, set index_of_last_graph_in_condensed
         elif row['case_property'].endswith(" (graph)"):
-            row['id'] = row['case_property'].split(" ")[0]
+            row['id'] = re.match('.*(?= \()', row['case_property']).group()
             condensed_rows.append(row)
             index_of_last_graph_in_condensed = len(condensed_rows) - 1
 
         # If it's a graph configuration item, add it to its parent
         elif row['case_property'].endswith(" (graph config)"):
-            row['id'] = row['case_property'].split(" ")[0]
+            row['id'] = re.match('.*(?= \()', row['case_property']).group()
             parent = condensed_rows[index_of_last_graph_in_condensed]
             parent['configs'] = parent.get('configs', []) + [row]
 
         # If it's a graph series configuration item, add it to its parent
         elif row['case_property'].endswith(" (graph series config)"):
-            row['id'] = row['case_property'].split(" ")[0]
+            row['id'] = re.match('.*(?= \()', row['case_property']).group()
             row['series_index'] = row['case_property'].split(" ")[1]
             parent = condensed_rows[index_of_last_graph_in_condensed]
             parent['series_configs'] = parent.get('series_configs', []) + [row]

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -826,34 +826,38 @@ def _update_case_list_translations(sheet, rows, app):
     detail_tab_headers = [None for i in module.case_details.long.tabs]
     index_of_last_enum_in_condensed = -1
     index_of_last_graph_in_condensed = -1
+
+    def remove_description_from_case_property(row):
+        return re.match('.*(?= \()', row['case_property']).group()
+
     for i, row in enumerate(rows):
         # If it's an enum case property, set index_of_last_enum_in_condensed
         if row['case_property'].endswith(" (ID Mapping Text)"):
-            row['id'] = re.match('.*(?= \()', row['case_property']).group()
+            row['id'] = remove_description_from_case_property(row)
             condensed_rows.append(row)
             index_of_last_enum_in_condensed = len(condensed_rows) - 1
 
         # If it's an enum value, add it to it's parent enum property
         elif row['case_property'].endswith(" (ID Mapping Value)"):
-            row['id'] = re.match('.*(?= \()', row['case_property']).group()
+            row['id'] = remove_description_from_case_property(row)
             parent = condensed_rows[index_of_last_enum_in_condensed]
             parent['mappings'] = parent.get('mappings', []) + [row]
 
         # If it's a graph case property, set index_of_last_graph_in_condensed
         elif row['case_property'].endswith(" (graph)"):
-            row['id'] = re.match('.*(?= \()', row['case_property']).group()
+            row['id'] = remove_description_from_case_property(row)
             condensed_rows.append(row)
             index_of_last_graph_in_condensed = len(condensed_rows) - 1
 
         # If it's a graph configuration item, add it to its parent
         elif row['case_property'].endswith(" (graph config)"):
-            row['id'] = re.match('.*(?= \()', row['case_property']).group()
+            row['id'] = remove_description_from_case_property(row)
             parent = condensed_rows[index_of_last_graph_in_condensed]
             parent['configs'] = parent.get('configs', []) + [row]
 
         # If it's a graph series configuration item, add it to its parent
         elif row['case_property'].endswith(" (graph series config)"):
-            row['id'] = re.match('.*(?= \()', row['case_property']).group()
+            row['id'] = remove_description_from_case_property(row)
             row['series_index'] = row['case_property'].split(" ")[1]
             parent = condensed_rows[index_of_last_graph_in_condensed]
             parent['series_configs'] = parent.get('series_configs', []) + [row]

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -793,6 +793,10 @@ def escape_output_value(value):
         return element
 
 
+def _remove_description_from_case_property(row):
+    return re.match('.*(?= \()', row['case_property']).group()
+
+
 def _update_case_list_translations(sheet, rows, app):
     """
     Modify the translations of a module case list and detail display properties
@@ -827,37 +831,34 @@ def _update_case_list_translations(sheet, rows, app):
     index_of_last_enum_in_condensed = -1
     index_of_last_graph_in_condensed = -1
 
-    def remove_description_from_case_property(row):
-        return re.match('.*(?= \()', row['case_property']).group()
-
     for i, row in enumerate(rows):
         # If it's an enum case property, set index_of_last_enum_in_condensed
         if row['case_property'].endswith(" (ID Mapping Text)"):
-            row['id'] = remove_description_from_case_property(row)
+            row['id'] = _remove_description_from_case_property(row)
             condensed_rows.append(row)
             index_of_last_enum_in_condensed = len(condensed_rows) - 1
 
         # If it's an enum value, add it to it's parent enum property
         elif row['case_property'].endswith(" (ID Mapping Value)"):
-            row['id'] = remove_description_from_case_property(row)
+            row['id'] = _remove_description_from_case_property(row)
             parent = condensed_rows[index_of_last_enum_in_condensed]
             parent['mappings'] = parent.get('mappings', []) + [row]
 
         # If it's a graph case property, set index_of_last_graph_in_condensed
         elif row['case_property'].endswith(" (graph)"):
-            row['id'] = remove_description_from_case_property(row)
+            row['id'] = _remove_description_from_case_property(row)
             condensed_rows.append(row)
             index_of_last_graph_in_condensed = len(condensed_rows) - 1
 
         # If it's a graph configuration item, add it to its parent
         elif row['case_property'].endswith(" (graph config)"):
-            row['id'] = remove_description_from_case_property(row)
+            row['id'] = _remove_description_from_case_property(row)
             parent = condensed_rows[index_of_last_graph_in_condensed]
             parent['configs'] = parent.get('configs', []) + [row]
 
         # If it's a graph series configuration item, add it to its parent
         elif row['case_property'].endswith(" (graph series config)"):
-            row['id'] = remove_description_from_case_property(row)
+            row['id'] = _remove_description_from_case_property(row)
             row['series_index'] = row['case_property'].split(" ")[1]
             parent = condensed_rows[index_of_last_graph_in_condensed]
             parent['series_configs'] = parent.get('series_configs', []) + [row]

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -21,6 +21,7 @@ from corehq.apps.translations.app_translations import (
     update_form_translations,
     get_unicode_dicts,
     read_uploaded_app_translation_file,
+    _remove_description_from_case_property
 )
 from corehq.apps.translations.const import MODULES_AND_FORMS_SHEET_NAME
 from corehq.util.test_utils import flag_enabled
@@ -371,6 +372,16 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
                 'App Translations Updated!'
             ]
         )
+
+    def test_remove_description_from_case_property(self):
+        row = {'case_property': 'words to keep (remove this)'}
+        description = _remove_description_from_case_property(row)
+        self.assertEqual(description, 'words to keep')
+
+    def test_remove_description_from_case_property_multiple_parens(self):
+        row = {'case_property': '(words (to) keep) (remove this)'}
+        description = _remove_description_from_case_property(row)
+        self.assertEqual(description, '(words (to) keep)')
 
     def test_empty_translations(self):
         # make the form a registration form


### PR DESCRIPTION
[[Interrupt ticket]](https://dimagi-dev.atlassian.net/browse/HI-429)

**Problem:**
Currently, a case property like `health_worker (ID Mapping Value)` will turn into the row id: `health_worker`

But a case property like `if(selected(left_recommendation, 'offered_surgery_accepted'),'offered_surgery_accepted', '') (ID Mapping Text)` will turn into the row id `if(selected(left_recommendation,`

**Solution:**
This code changes it so that the row id regexes everything but the stuff after the last open paren (minus trailing whitespace).

--------
@emord 
code buddy @snopoke  