### PR TITLE
delete case rule logs after 90 days

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1403,6 +1403,12 @@ class CreateScheduleInstanceActionDefinition(CaseRuleActionDefinition):
 
 
 class CaseRuleSubmission(models.Model):
+    """This model records which forms were submitted as a result of a case
+    update rule. This serves both as a log as well as providing the ability
+    to undo the effects of rules in case of errors.
+
+    This data is not stored permanently but is removed after 90 days (see tasks file)
+    """
     domain = models.CharField(max_length=126)
     rule = models.ForeignKey('AutomaticUpdateRule', on_delete=models.PROTECT)
 


### PR DESCRIPTION
@dimagi/product this will remove the ability undo case rule effects beyond 90 days with ease (it will still be possible but require more work to determine which forms need to be archived). At present this is only possible via a management command which requires a dev to run so no real change to the product but checking that we're OK with this SLA - we don't support undo of case rule operations beyond 90 days after they happened.

Reason for changing - ICDS is currently generating 2M of these a month which although not a huge number currently will continue to grow.