### PR TITLE
check for six.text_type when variable cannot be bytes

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -171,7 +171,7 @@ class WrappedNode(object):
     def __init__(self, xml, namespaces=namespaces):
         if isinstance(xml, bytes):
             xml = xml.decode('utf-8')
-        if isinstance(xml, six.string_types):
+        if isinstance(xml, six.text_type):
             self.xml = parse_xml(xml) if xml else None
         else:
             self.xml = xml


### PR DESCRIPTION
```bytes``` are decoding in the immediately preceding if statement.