### PR TITLE
Remove report start date feature flag

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -945,8 +945,6 @@ class ScheduledReportsView(BaseProjectReportSectionView):
         form = ScheduledReportForm(*args, **kwargs)
         form.fields['config_ids'].choices = self.config_choices
         form.fields['recipient_emails'].choices = [(e, e) for e in web_user_emails]
-        if not toggles.SET_SCHEDULED_REPORT_START_DATE.enabled(self.domain):
-            form.fields.pop('start_date')
 
         form.fields['hour'].help_text = "This scheduled report's timezone is %s (%s GMT)" % \
                                         (Domain.get_by_name(self.domain)['default_timezone'],

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1713,15 +1713,6 @@ RELEASE_BUILDS_PER_PROFILE = StaticToggle(
 )
 
 
-SET_SCHEDULED_REPORT_START_DATE = StaticToggle(
-    'set_scheduled_report_start_date',
-    'Allow users to set an effective start date for scheduled reports.',
-    TAG_INTERNAL,
-    namespaces=[NAMESPACE_DOMAIN],
-    description='This toggle is for QA of the Effective Start Date feature on Scheduled Reports.'
-)
-
-
 HIDE_HQ_ON_MOBILE_EXPERIENCE = StaticToggle(
     'hide_hq_on_mobile_experience',
     'Do not show modal on mobile that mobile hq experience is bad',


### PR DESCRIPTION
https://trello.com/c/UuTvlqhP/57-allowing-scheduled-reports-to-have-an-effective-start-date

has passed QA. This PR removes the feature flag
