### PR TITLE
Implement V2 of Demo Workflow A/B Test

### DIFF
--- a/corehq/apps/analytics/ab_tests.py
+++ b/corehq/apps/analytics/ab_tests.py
@@ -139,11 +139,11 @@ APPCUES_V3_APP = SessionAbTestConfig(
 )
 
 
-DEMO_WORKFLOW_HUBSPOT = 'hubspot'
-DEMO_WORKFLOW_DRIFT = 'drift'
+DEMO_WORKFLOW_V2_CONTROL = 'control'
+DEMO_WORKFLOW_V2_VARIANT = 'variant'
 
-DEMO_WORKFLOW = SessionAbTestConfig(
-    'Demo Workflow A/B',
-    'demo_workflow_dec2018',
-    (DEMO_WORKFLOW_HUBSPOT, DEMO_WORKFLOW_DRIFT)
+DEMO_WORKFLOW_V2 = SessionAbTestConfig(
+    'Demo Workflow A/B V2',
+    'demo_workflow_mar2019',
+    (DEMO_WORKFLOW_V2_CONTROL, DEMO_WORKFLOW_V2_VARIANT)
 )

--- a/corehq/apps/analytics/static/analytix/js/drift.js
+++ b/corehq/apps/analytics/static/analytix/js/drift.js
@@ -53,39 +53,6 @@ hqDefine('analytix/js/drift', [
                 hubspot.trackEvent('Identified via Drift');
             });
 
-            $('.schedule-demo-drift-cta').click(function (e) {
-                e.preventDefault();
-
-                _drift.on('startConversation', function () {
-                    kissmetrics.track.event("Demo Workflow - Viewed Form");
-                });
-
-                _drift.on("emailCapture", function () {
-                    kissmetrics.track.event("Demo Workflow - Contact Info Received");
-                    kissmetrics.track.event("Demo Workflow - Loaded Booking Options");
-                });
-
-                _drift.on("sliderMessage:close", function () {
-                    kissmetrics.track.event("Demo Workflow - Dismissed Form");
-                    _drift.off("sliderMessage:close");
-                });
-
-                _drift.on("scheduling:meetingBooked", function () {
-                    kissmetrics.track.event("Demo Workflow - Demo Scheduled");
-                    _drift.off("sliderMessage:close");
-                });
-
-                _drift.on("message:sent", function () {
-                    kissmetrics.track.event("Demo Workflow - Interacted With Form");
-                    _drift.off("message:sent");
-                });
-
-                _drift.api.startInteraction({
-                    interactionId: 43079,
-                    goToConversation: true,
-                });
-            });
-
             $('#start-chat-cta-btn').click(function () {
                 _drift.api.startInteraction({
                     interactionId: 51834,

--- a/corehq/apps/analytics/static/analytix/js/hubspot.js
+++ b/corehq/apps/analytics/static/analytix/js/hubspot.js
@@ -41,7 +41,17 @@ hqDefine('analytix/js/hubspot', [
 
                 $.when.apply($, _.map(formScriptUrls, function (url) { return $.getScript(url); }))
                     .done(function () {
-                        _utils.loadDemoForm(apiId);
+                        var isTrial = _get('isDemoTrial'),
+                            isVariant = _get('demoABv2').version === 'variant',
+                            formId;
+
+                        if (isTrial) {
+                            formId = isVariant ? "c2381f55-9bd9-4f27-8476-82900e58bfd6" : "4474515e-fea6-4154-b3cf-1fe42b1c1333";
+                        } else {
+                            formId = isVariant ? "f6ebf161-fccf-4083-9a72-5839a0c8ac8c" : "d1897875-a5bb-4b63-9b9c-3d8fdbbe8274";
+                        }
+
+                        _utils.loadDemoForm(apiId, formId);
                     });
             });
         }
@@ -52,11 +62,12 @@ hqDefine('analytix/js/hubspot', [
      * Loads the Hubspot Request Demo form and loads a Schedule Once Calendar
      * Widget for auto-booking an appointment as soon as the form is submitted.
      * @param {string} apiId
+     * @param {string} formId
      */
-    _utils.loadDemoForm = function (apiId) {
+    _utils.loadDemoForm = function (apiId, formId) {
         hbspt.forms.create({
             portalId: apiId,
-            formId: "38980202-f1bd-412e-b490-f390f40e9ee1",
+            formId: formId,
             target: "#get-demo-cta-form-content",
             css: "",
             onFormReady: function () {

--- a/corehq/apps/analytics/templates/analytics/initial/hubspot.html
+++ b/corehq/apps/analytics/templates/analytics/initial/hubspot.html
@@ -1,3 +1,4 @@
 {% load hq_shared_tags %}
 {% initial_analytics_data 'hubspot.apiId' ANALYTICS_IDS.HUBSPOT_API_ID %}
 {% initial_analytics_data 'hubspot.isDemoVisible' is_demo_visible %}
+{% initial_analytics_data 'hubspot.isDemoTrial' is_demo_trial %}

--- a/corehq/apps/domain/templates/login_and_password/login.html
+++ b/corehq/apps/domain/templates/login_and_password/login.html
@@ -35,9 +35,6 @@
 {% endblock stylesheets %}
 
 {% block content %}
-  {% if demo_workflow_ab %}
-    {% analytics_ab_test 'kissmetrics.demo_workflow_ab' demo_workflow_ab %}
-  {% endif %}
   {% initial_page_data 'implement_password_obfuscation' implement_password_obfuscation %}
   {% block login-content %}
   {% include "login_and_password/partials/login_full.html" %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -344,6 +344,12 @@
         {% initial_page_data 'show_mobile_ux_warning' show_mobile_ux_warning %}
         {% initial_page_data 'toggles_dict' toggles_dict %}
         {% initial_page_data 'previews_dict' previews_dict %}
+
+        {% if demo_workflow_ab_v2 %}
+          {% analytics_ab_test 'kissmetrics.demo_workflow_ab_v2' demo_workflow_ab_v2 %}
+          {% initial_analytics_data 'hubspot.demoABv2' demo_workflow_ab_v2 %}
+        {% endif %}
+
         <div class="initial-page-data" class="hide">
         {% block initial_page_data %}
             {# do not override this block, use initial_page_data template tag to populate #}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -216,29 +216,20 @@
                     {% endif %}
 
                     {% if not request.user.is_authenticated %}
-                      <nav class="navbar-menus navbar-signin" role="navigation">
+                        <nav class="navbar-menus navbar-signin" role="navigation">
 
-                        <div class="nav-settings-bar pull-right">
-                          <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
-                            {% if is_saas_environment and ANALYTICS_IDS.HUBSPOT_API_ID and demo_workflow_ab %}
-                                {% if demo_workflow_ab.version == 'hubspot' %}
-                                    <a href="#cta-form-get-demo"
-                                       data-toggle="modal"
-                                       id="cta-form-get-demo-button-header"
-                                       class="btn btn-purple navbar-btn">
-                                       {% trans 'Schedule a Demo' %}
-                                    </a>
+                            <div class="nav-settings-bar pull-right">
+                                <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
+                                    {% if is_saas_environment and ANALYTICS_IDS.HUBSPOT_API_ID %}
+                                        <a href="#cta-form-get-demo"
+                                           data-toggle="modal"
+                                           id="cta-form-get-demo-button-header"
+                                           class="btn btn-purple navbar-btn">
+                                           {% trans 'Schedule a Demo' %}
+                                      </a>
                                 {% endif %}
-
-                            {% if demo_workflow_ab.version == 'drift' %}
-                                <button id="cta-form-get-demo-button-header"
-                                        class="btn btn-purple navbar-btn schedule-demo-drift-cta">
-                                        {% trans 'Schedule a Demo' %}
-                                </button>
-                            {% endif %}
-                          {% endif %}
-                        </div>
-                      </nav>
+                            </div>
+                        </nav>
                     {% endif %}
 
                     <div class="navbar-header hq-header">

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -393,15 +393,15 @@ def _login(req, domain_name):
     else:
         auth_view = HQLoginView if not domain_name else CloudCareLoginView
 
-    demo_workflow_ab = ab_tests.SessionAbTest(ab_tests.DEMO_WORKFLOW, req)
+    demo_workflow_ab_v2 = ab_tests.SessionAbTest(ab_tests.DEMO_WORKFLOW_V2, req)
 
     if settings.IS_SAAS_ENVIRONMENT:
-        context['demo_workflow_ab'] = demo_workflow_ab.context
+        context['demo_workflow_ab_v2'] = demo_workflow_ab_v2.context
 
     response = auth_view.as_view(template_name=template_name, extra_context=context)(req)
 
     if settings.IS_SAAS_ENVIRONMENT:
-        demo_workflow_ab.update_response(response)
+        demo_workflow_ab_v2.update_response(response)
 
     return response
 

--- a/corehq/apps/registration/templates/registration/partials/start_options.html
+++ b/corehq/apps/registration/templates/registration/partials/start_options.html
@@ -74,14 +74,10 @@
       </div>{# .col-sm-6 #}
       <div class="col-xs-6 col-break-reg">
         <div class="tile-wrapper get-tour">
-          <a class="well tile{% if demo_workflow_ab and demo_workflow_ab.version == 'drift' %} schedule-demo-drift-cta{% endif %}"
+          <a class="well tile"
              id="js-get-tour"
-             {% if demo_workflow_ab and demo_workflow_ab.version == 'drift' %}
-             href="#"
-             {% else %}
              href="#cta-form-get-demo"
              data-toggle="modal"
-            {% endif %}
           >
             <h3>
               {% blocktrans %}

--- a/corehq/apps/registration/templates/registration/register_new_user.html
+++ b/corehq/apps/registration/templates/registration/register_new_user.html
@@ -74,10 +74,6 @@
 {% endblock %}
 
 {% block content %}
-  {% if demo_workflow_ab %}
-    {% analytics_ab_test 'kissmetrics.demo_workflow_ab' demo_workflow_ab %}
-  {% endif %}
-
 {% initial_page_data 'hide_password_feedback' hide_password_feedback %}
 {% initial_page_data 'number_utils_script' 'intl-tel-input/build/js/utils.js'|static %}
 {% initial_page_data 'reg_form_defaults' reg_form_defaults %}
@@ -120,25 +116,17 @@
           </div>
         </form>
 
-        {% if is_saas_environment and ANALYTICS_IDS.HUBSPOT_API_ID and demo_workflow_ab %}
+        {% if is_saas_environment and ANALYTICS_IDS.HUBSPOT_API_ID %}
           <div class="form-bubble form-bubble-purple text-center">
               {% blocktrans %}
                 Want to learn more before signing up?
               {% endblocktrans %}
 
               &nbsp;&nbsp;&nbsp;
-              {% if demo_workflow_ab.version == 'hubspot' %}
               <a href="#cta-form-get-demo"
                  data-toggle="modal"
                  id="cta-form-get-demo-button-body"
                  class="btn btn-purple ">{% trans 'Schedule a Demo' %}</a>
-              {% endif %}
-
-              {% if demo_workflow_ab.version == 'drift' %}
-              <button id="cta-form-get-demo-button-drift-body"
-                      class="btn btn-purple schedule-demo-drift-cta">
-                {% trans 'Schedule a Demo' %}</button>
-              {% endif %}
 
             </div>
         {% endif %}

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -200,7 +200,7 @@ class UserRegistrationView(BasePageView):
                 return redirect("homepage")
         response = super(UserRegistrationView, self).dispatch(request, *args, **kwargs)
         if settings.IS_SAAS_ENVIRONMENT:
-            ab_tests.SessionAbTest(ab_tests.DEMO_WORKFLOW, request).update_response(response)
+            ab_tests.SessionAbTest(ab_tests.DEMO_WORKFLOW_V2, request).update_response(response)
         return response
 
     def post(self, request, *args, **kwargs):
@@ -231,7 +231,8 @@ class UserRegistrationView(BasePageView):
             'implement_password_obfuscation': settings.OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE,
         }
         if settings.IS_SAAS_ENVIRONMENT:
-            context['demo_workflow_ab'] = ab_tests.SessionAbTest(ab_tests.DEMO_WORKFLOW, self.request).context
+            context['demo_workflow_ab_v2'] = ab_tests.SessionAbTest(
+                ab_tests.DEMO_WORKFLOW_V2, self.request).context
         return context
 
     @property

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1752,3 +1752,11 @@ PARTIAL_UI_TRANSLATIONS = StaticToggle(
     TAG_PRODUCT,
     [NAMESPACE_DOMAIN]
 )
+
+
+DEMO_WORKFLOW_V2_AB_VARIANT = DynamicallyPredictablyRandomToggle(
+    'demo_workflow_v2_ab_variant',
+    'Enables the "variant" version of the Demo Workflow A/B test after login',
+    TAG_INTERNAL,
+    namespaces=[NAMESPACE_USER],
+)

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -10,7 +10,8 @@ from django.urls import resolve, reverse
 from django_prbac.utils import has_privilege
 from ws4redis.context_processors import default
 
-from corehq import privileges
+from corehq import privileges, toggles
+from corehq.apps.analytics import ab_tests
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
@@ -212,7 +213,10 @@ def mobile_experience_hidden_by_toggle(request):
 
 def get_demo(request):
     is_demo_visible = False
-    num_trial_days_remaining = 0
+    is_demo_trial = False
+
+    context = {}
+
     if (settings.IS_SAAS_ENVIRONMENT
             and settings.ANALYTICS_IDS.get('HUBSPOT_API_ID')):
         if getattr(request, 'user', None) and not request.user.is_authenticated:
@@ -221,7 +225,26 @@ def get_demo(request):
             delta = request.subscription.date_end - datetime.date.today()
             num_trial_days_remaining = max(0, delta.days)
             is_demo_visible = True
-    return {
+            is_demo_trial = True
+
+            # toggles are more reliable (and easier to implement site-wide)
+            # than a SessionAbTest, however we can't use toggles in pre-login
+            # as it requires the user namespace.
+            show_demo_variant = toggles.DEMO_WORKFLOW_V2_AB_VARIANT.enabled(
+                request.user, toggles.NAMESPACE_USER
+            )
+            context.update({
+                'demo_workflow_ab_v2': {
+                    'name': ab_tests.DEMO_WORKFLOW_V2.name,
+                    'version': (ab_tests.DEMO_WORKFLOW_V2_VARIANT
+                                if show_demo_variant
+                                else ab_tests.DEMO_WORKFLOW_V2_CONTROL),
+                },
+                'num_trial_days_remaining': num_trial_days_remaining,
+            })
+
+    context.update({
+        'is_demo_trial': is_demo_trial,
         'is_demo_visible': is_demo_visible,
-        'num_trial_days_remaining': num_trial_days_remaining,
-    }
+    })
+    return context


### PR DESCRIPTION
This version of the A/B test involves swapping between different Hubspot forms rather than Hubspot and Drift.

Note that I used a random toggle for the trial banner, as it doesn't require the set up for a cookie on each page and is more reliable as it uses the user's email to determine which variant to show.

