### PR TITLE
Downgrade warning for customer accounts

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2140,6 +2140,10 @@ class CustomerInvoice(InvoiceBase):
         return contact_emails
 
     @property
+    def contact_emails(self):
+        return self.account.enterprise_admin_emails
+
+    @property
     def subtotal(self):
         """
         This will be inserted in the subtotal field on the printed invoice.

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -780,7 +780,7 @@ def _apply_downgrade_process(oldest_unpaid_invoice, total, today, subscription=N
     from corehq.apps.accounting.views import EnterpriseBillingStatementsView
 
     context = {
-        'total': total,
+        'total': format(total, '7.2f'),
         'date_60': oldest_unpaid_invoice.date_due + datetime.timedelta(days=60),
         'contact_email': settings.INVOICING_CONTACT_EMAIL
     }

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -861,12 +861,16 @@ def _send_overdue_notice(invoice, context):
 
 
 def _create_overdue_notification(invoice, context):
+    if invoice.is_customer_invoice:
+        domains = [subscription.subscriber.domain for subscription in invoice.subscriptions.all()]
+    else:
+        domains = [invoice.get_domain()]
     message = _('Reminder - your {} statement is past due!'.format(
         invoice.date_start.strftime('%B')
     ))
     note = Notification.objects.create(content=message, url=context['statements_url'],
-                                       domain_specific=True, type='billing',
-                                       domains=[invoice.get_domain()])
+                                       domain_specific=False if invoice.is_customer_invoice else True,
+                                       type='billing', domains=domains)
     note.activate()
 
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -892,8 +892,7 @@ def _create_overdue_notification(invoice, context):
         invoice.date_start.strftime('%B')
     ))
     note = Notification.objects.create(content=message, url=context['statements_url'],
-                                       domain_specific=False if invoice.is_customer_invoice else True,
-                                       type='billing', domains=domains)
+                                       domain_specific=True, type='billing', domains=domains)
     note.activate()
 
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -750,17 +750,14 @@ def _get_accounts_with_customer_invoices_over_threshold(today):
     accounts = set()
     for overdue_invoice in overdue_customer_invoices_in_downgrade_daterange:
         account = overdue_invoice.account.name
-        if overdue_invoice.subscriptions.count() < 1:
-            continue
-        else:
-            plan = overdue_invoice.subscriptions.first().plan_version
+        plan = overdue_invoice.subscriptions.first().plan_version
         if (account, plan) not in accounts:
             invoices = unpaid_customer_invoices.filter(
                 Q(date_due__lte=overdue_invoice.date_due)
                 | (Q(date_due__isnull=True) & Q(date_end__lte=overdue_invoice.date_end)),
                 account__name=account
             )
-            invoices = [invoice for invoice in invoices if invoice.subscriptions.count() > 0 and invoice.subscriptions.first().plan_version == plan]
+            invoices = [invoice for invoice in invoices if invoice.subscriptions.first().plan_version == plan]
             total_overdue_to_date = sum(invoice.balance for invoice in invoices)
 
             if total_overdue_to_date > 100:

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -850,13 +850,22 @@ def _send_downgrade_warning(invoice, context):
 
 
 def _send_overdue_notice(invoice, context):
+    if invoice.is_customer_invoice:
+        domain_or_account = invoice.account.name
+        bcc = None
+    else:
+        domain_or_account = invoice.get_domain()
+        bcc = [settings.GROWTH_EMAIL]
+    context.update({
+        'domain_or_account': domain_or_account
+    })
     send_html_email_async.delay(
-        _('CommCare Billing Statement 30 days Overdue for {}'.format(invoice.get_domain())),
+        _('CommCare Billing Statement 30 days Overdue for {}'.format(domain_or_account)),
         invoice.contact_emails,
         render_to_string('accounting/email/30_days.html', context),
         render_to_string('accounting/email/30_days.txt', context),
         cc=[settings.ACCOUNTS_EMAIL],
-        bcc=[settings.GROWTH_EMAIL],
+        bcc=bcc,
         email_from=get_dimagi_from_email())
 
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -713,12 +713,12 @@ def _get_domains_with_subscription_invoices_over_threshold(today):
     unpaid_saas_invoices = Invoice.objects.filter(
         is_hidden=False,
         subscription__service_type=SubscriptionType.PRODUCT,
-        date_paid__isnull=True,
+        date_paid__isnull=True
     )
 
     overdue_saas_invoices_in_downgrade_daterange = unpaid_saas_invoices.filter(
         date_due__lte=today - datetime.timedelta(days=1),
-        date_due__gte=today - datetime.timedelta(days=61),
+        date_due__gte=today - datetime.timedelta(days=61)
     ).order_by('date_due').select_related('subscription__subscriber')
 
     domains = set()
@@ -729,7 +729,7 @@ def _get_domains_with_subscription_invoices_over_threshold(today):
             total_overdue_to_date = unpaid_saas_invoices.filter(
                 Q(date_due__lte=overdue_invoice.date_due)
                 | (Q(date_due__isnull=True) & Q(date_end__lte=overdue_invoice.date_end)),
-                subscription__subscriber__domain=domain,
+                subscription__subscriber__domain=domain
             ).aggregate(Sum('balance'))['balance__sum']
             if total_overdue_to_date >= 100:
                 domains.add(domain)
@@ -739,12 +739,12 @@ def _get_domains_with_subscription_invoices_over_threshold(today):
 def _get_accounts_with_customer_invoices_over_threshold(today):
     unpaid_customer_invoices = CustomerInvoice.objects.filter(
         is_hidden=False,
-        date_paid__isnull=True,
+        date_paid__isnull=True
     )
 
     overdue_customer_invoices_in_downgrade_daterange = unpaid_customer_invoices.filter(
         date_due__lte=today - datetime.timedelta(days=1),
-        date_due__gte=today - datetime.timedelta(days=61),
+        date_due__gte=today - datetime.timedelta(days=61)
     ).order_by('date_due').select_related('account')
 
     accounts = set()

--- a/corehq/apps/accounting/templates/accounting/email/30_days.html
+++ b/corehq/apps/accounting/templates/accounting/email/30_days.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <p>
     {% blocktrans %}
-        Dear {{ domain }} administrator,
+        Dear {{ domain_or_account }} administrator,
     {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/30_days.txt
+++ b/corehq/apps/accounting/templates/accounting/email/30_days.txt
@@ -12,7 +12,7 @@ Please make a payment as soon as possible for the amount due.
 If you are not able to make a payment, your account will be downgraded to our free Community edition on {{ date_60 }}.
 As of this date, you will lose access to all paid features and direct email support from CommCare support team.
 
-If you have any questions or if you think your recent payments haven’t been reflected in this balance, please don't hesitate to contact <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.
+If you have any questions or if you think your recent payments haven’t been reflected in this balance, please don’t hesitate to contact {{ contact_email }}.
 
 Thanks,
 The CommCare HQ Team

--- a/corehq/apps/accounting/templates/accounting/email/30_days.txt
+++ b/corehq/apps/accounting/templates/accounting/email/30_days.txt
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% blocktrans %}
-Dear {{ domain }} administrator,
+Dear {{ domain_or_account }} administrator,
 
 Your billing account has unpaid CommCare Billing Statements which are more than 30 days overdue. The balance currently owed is: ${{ total }}.
 

--- a/corehq/apps/accounting/templates/accounting/email/downgrade_warning.html
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade_warning.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 <p>
     {% blocktrans %}
-        Dear {{ domain }} administrator,
+        Dear {{ domain_or_account }} administrator,
     {% endblocktrans %}
 </p>
 
 <p>
     {% blocktrans %}
-        Your CommCare subscription for {{ domain }} will be downgraded <b><i>after tomorrow</i></b> because your CommCare Billing Statements are more than 60 days overdue. If you do not make a payment before tomorrow, you will automatically be subscribed to the CommCare Community plan and lose access to all pay-only features and direct email support!
+        Your CommCare {{ subscriptions_to_downgrade }} will be downgraded <b><i>after tomorrow</i></b> because your CommCare Billing Statements are more than 60 days overdue. If you do not make a payment before tomorrow, you will automatically be subscribed to the CommCare Community plan and lose access to all pay-only features and direct email support!
     {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/downgrade_warning.txt
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade_warning.txt
@@ -1,8 +1,8 @@
 {% load i18n %}
 {% blocktrans %}
-Dear {{ domain }} administrator,
+Dear {{ domain_or_account }} administrator,
 
-Your CommCare subscription for {{ domain }} will be downgraded after tomorrow because your CommCare Billing Statements are more than 60 days overdue. If you do not make a payment before tomorrow, you will automatically be subscribed to the CommCare Community plan and lose access to all pay-only features and direct email support!
+Your CommCare {{ subscriptions_to_downgrade }} will be downgraded after tomorrow because your CommCare Billing Statements are more than 60 days overdue. If you do not make a payment before tomorrow, you will automatically be subscribed to the CommCare Community plan and lose access to all pay-only features and direct email support!
 
 To see the full list of unpaid invoices you can follow this link: {{ statements_url }}
 As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment


### PR DESCRIPTION
Sends downgrade warning emails for overdue customer invoices

Note that, while we tell users that their subscriptions will be downgraded, we're not actually going to automatically downgrade customer accounts at this time.