### PR TITLE
Set autocomplete='off' at form level

### DIFF
--- a/corehq/apps/hqwebapp/crispy.py
+++ b/corehq/apps/hqwebapp/crispy.py
@@ -23,6 +23,13 @@ class HQFormHelper(FormHelper):
     label_class = CSS_LABEL_CLASS
     field_class = CSS_FIELD_CLASS
 
+    def __init__(self, *args, **kwargs):
+        super(HQFormHelper, self).__init__(*args, **kwargs)
+        if 'autocomplete' not in self.attrs:
+            self.attrs.update({
+                'autocomplete': 'off',
+            })
+
 
 class HQModalFormHelper(FormHelper):
     form_class = 'form form-horizontal'


### PR DESCRIPTION
[W3C standard says this would work](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion) although Chrome might just ignore it anyway: https://bugs.chromium.org/p/chromium/issues/detail?id=468153, https://bugs.chromium.org/p/chromium/issues/detail?id=587466

@emord 
code buddies @czue @kaapstorm 