### PR TITLE
Automatically detect country in phone # box when registering

### DIFF
--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -83,6 +83,9 @@ $(function () {
         geoIpLookup: function (success) {
             $.get("https://ipinfo.io", function () {}, "jsonp").always(function (resp) {
                 var countryCode = (resp && resp.country) ? resp.country : "";
+                if (!countryCode) {
+                    countryCode = "us";
+                }
                 success(countryCode);
             });
         },

--- a/corehq/apps/registration/static/registration/js/register_new_user.js
+++ b/corehq/apps/registration/static/registration/js/register_new_user.js
@@ -79,6 +79,13 @@ $(function () {
     $number.intlTelInput({
         separateDialCode: true,
         utilsScript: initial_page_data('number_utils_script'),
+        initialCountry: "auto",
+        geoIpLookup: function (success) {
+            $.get("https://ipinfo.io", function () {}, "jsonp").always(function (resp) {
+                var countryCode = (resp && resp.country) ? resp.country : "";
+                success(countryCode);
+            });
+        },
     });
     $number.keydown(function (e) {
         // prevents non-numeric numbers from being entered.


### PR DESCRIPTION
This is part 1 of this task (I know, its a throwback):
Default the flag to the user's current country based on their IP
[Trello card](https://trello.com/c/8064FmRg/61-improvements-to-phone-number-input?menu=filter&filter=label:PQI)

I'm getting a 429 error because it looks like we hit our 1000 requests a day limit with ipinfo.io (screenshot of what this looks like below), but this code worked before (granted, I tried it a while ago, but it doesn't look like the API changed). Thoughts?

<img width="467" alt="Screen Shot 2019-03-11 at 1 52 49 PM" src="https://user-images.githubusercontent.com/35747290/54145768-fefc0d00-4404-11e9-9fac-6ab6f5e8b626.png">

@orangejenny 
@snopoke 