### PR TITLE
Submit history: fix app filtering

### DIFF
--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -434,8 +434,10 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         if instance._show_unknown:
             return True
         for param in params:
-            if param['slug'] in [PARAM_SLUG_APP_ID, PARAM_SLUG_STATUS]:
+            if param['slug'] == PARAM_SLUG_APP_ID:
                 return True
+        if request.GET.get('show_advanced') == 'on':
+            return True
         return False
 
     def _get_filtered_data(self, filter_results):


### PR DESCRIPTION
Introduced in https://github.com/dimagi/commcare-hq/pull/21423

Submit history has been filtering by app whenever status is not blank. The problem is that by default, the status dropdown is hidden and set to "active", so system forms get excluded. This is at odds with the desired behavior described in http://manage.dimagi.com/default.asp?131005 

> My assumption is that unless you specifically choose to filter by application, we should show forms of all types. So if you choose "Unknown Users" and also "All Applications", we should show all system-submitted forms.

Updated so filtering by app is added only if an app is selected or if the "Show Advanced Options" checkbox is checked.

@Rohit25negi 
Or @esoergel since you did https://github.com/dimagi/commcare-hq/pull/4466/
code buddies @czue / @kaapstorm 
fyi @dimagi/product 

<img width="768" alt="Screen Shot 2019-03-11 at 3 03 09 PM" src="https://user-images.githubusercontent.com/1486591/54150412-cd883f00-440e-11e9-90c8-f986cdf2d432.png">
