### PR TITLE
Fix CouchDB case action reconciliation

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -1,20 +1,20 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import json
 import uuid
+from copy import deepcopy
+from datetime import datetime, timedelta
 
-from couchdbkit.exceptions import ResourceNotFound
-from django.test import TestCase, SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from six.moves import range, zip
+
 from casexml.apps.case import const
 from casexml.apps.case.cleanup import rebuild_case_from_forms
 from casexml.apps.case.exceptions import MissingServerDate
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
-from datetime import datetime, timedelta
-from copy import deepcopy
 from casexml.apps.case.tests.util import delete_all_cases
-from casexml.apps.case.util import primary_actions, post_case_blocks
+from casexml.apps.case.util import post_case_blocks, primary_actions
 from corehq.apps.change_feed import topics
 from corehq.form_processor.backends.couch.update_strategy import CouchCaseUpdateStrategy, _action_sort_key_function
 from corehq.form_processor.exceptions import CaseNotFound
@@ -22,10 +22,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAcce
 from corehq.form_processor.models import RebuildWithReason
 from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.form_processor.utils.general import should_use_sql_backend
-from couchforms.models import XFormInstance
 from testapps.test_pillowtop.utils import capture_kafka_changes_context
-from six.moves import zip
-from six.moves import range
 
 REBUILD_TEST_DOMAIN = 'rebuild-test'
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -540,37 +540,22 @@ class CaseRebuildTestSQL(CaseRebuildTest):
 
 class TestCheckActionOrder(SimpleTestCase):
 
+    def _action(self, datetime_):
+        return CommCareCaseAction(server_date=datetime_, date=datetime_, action_type='update')
+
     def test_already_sorted(self):
         case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
+            self._action(datetime(2001, 1, 1, 0, 0, 0)),
+            self._action(datetime(2001, 1, 2, 0, 0, 0)),
+            self._action(datetime(2001, 1, 3, 0, 0, 0)),
         ])
         self.assertTrue(CouchCaseUpdateStrategy(case).check_action_order())
 
     def test_out_of_order(self):
         case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
-        ])
-        self.assertFalse(CouchCaseUpdateStrategy(case).check_action_order())
-
-    def test_sorted_with_none(self):
-        case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
-            CommCareCaseAction(server_date=None),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
-        ])
-        self.assertTrue(CouchCaseUpdateStrategy(case).check_action_order())
-
-    def test_out_of_order_with_none(self):
-        case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
-            CommCareCaseAction(server_date=None),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            self._action(datetime(2001, 1, 1, 0, 0, 0)),
+            self._action(datetime(2001, 1, 3, 0, 0, 0)),
+            self._action(datetime(2001, 1, 2, 0, 0, 0)),
         ])
         self.assertFalse(CouchCaseUpdateStrategy(case).check_action_order())
 

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -245,11 +245,7 @@ class CouchCaseUpdateStrategy(UpdateStrategy):
         return self
 
     def soft_rebuild_case(self, xforms=None):
-        """
-        Rebuilds the case state in place from its actions.
-
-        If strict is True, this will enforce that the first action must be a create.
-        """
+        """Rebuilds the case state in place from its actions."""
         xforms = xforms or {}
         self.reset_case_state()
         # try to re-sort actions if necessary

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -69,8 +69,13 @@ class CouchCaseUpdateStrategy(UpdateStrategy):
 
     @tracer.wrap(name='form_processor.couch.check_action_order')
     def check_action_order(self):
-        action_dates = [a.server_date for a in self.case.actions if a.server_date]
-        return action_dates == sorted(action_dates)
+        """Returns true if the actions are currently in the correct order."""
+
+        sorted_actions = sorted(
+            self.case.actions,
+            key=_action_sort_key_function(self.case)
+        )
+        return self.case.actions == sorted_actions
 
     def reconcile_actions_if_necessary(self, xform):
         if not self.check_action_order():


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-359

Previously the check for whether or not we needed to reconcile case actions only looked at server_date, but the reconciliation strategy is actually much more complex https://github.com/dimagi/commcare-hq/blob/a500f078e8bc061678c53ebac3d19091831d2521/corehq/form_processor/backends/couch/update_strategy.py#L394-L429

https://github.com/dimagi/commcare-hq/blob/a500f078e8bc061678c53ebac3d19091831d2521/corehq/form_processor/backends/couch/update_strategy.py#L419 sneaky indeed