### PR TITLE
Fix filename access in sentry utility

### DIFF
--- a/corehq/util/sentry.py
+++ b/corehq/util/sentry.py
@@ -58,7 +58,7 @@ def _get_rate_limit_key(exc_info):
         package, key = RATE_LIMIT_BY_PACKAGE[exc_name]
         frame_summaries = traceback.extract_tb(tb)
         for frame in frame_summaries:
-            if frame.filename.startswith(package):
+            if frame[0].startswith(package): # filename
                 return key
 
 


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/920637416/?environment=india&project=136860&referrer=alert_email&statsPeriod=14d

@snopoke I think you may have looked at python 3 docs instead of 2? `extract_tb` says it returns a 4-tuple: https://docs.python.org/2/library/traceback.html#traceback.extract_tb

\> 3.5 returns a `FrameSummary` https://docs.python.org/3.5/library/traceback.html#framesummary-objects

It appears that with FrameSummary this access will still work https://github.com/python/cpython/blob/9797b7ae4496627836c55333765e10201a9840e3/Lib/traceback.py#L272