### PR TITLE
Aggregate on non-analyzed case types

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -482,7 +482,7 @@ def get_case_types_from_apps(domain):
     :returns: A set of case_types
     """
     case_types_agg = NestedAggregation('modules', 'modules').aggregation(
-        TermsAggregation('case_types', 'case_type'))
+        TermsAggregation('case_types', 'modules.case_type.exact'))
     q = (AppES()
          .domain(domain)
          .is_build(False)


### PR DESCRIPTION
This is so uppercase letters appear uppercase
From https://dimagi-dev.atlassian.net/browse/HI-472
Thought this was gonna be a lot harder - found a solution here:
https://stackoverflow.com/questions/32129152/aggregations-on-multiple-fields-in-nested-object-not-working-in-elastic-search-1
Verified that it resolves the issue locally.

@proteusvacuum @Rohit25negi 