### PR TITLE
Fixed requested_media creation in multimedia_map_for_build

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -794,7 +794,8 @@ class ApplicationMediaMixin(Document, MediaMixin):
         if not build_profile or not domain_has_privilege(self.domain, privileges.BUILD_PROFILES):
             return self.multimedia_map
 
-        requested_media = self.logo_paths   # logos aren't language-specific
+        requested_media = set()
+        requested_media |= self.logo_paths   # logos aren't language-specific
         for lang in build_profile.langs:
             requested_media |= self.all_media_paths(lang=lang)
 

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from copy import copy
 import hashlib
 import json
 import logging
@@ -794,8 +795,7 @@ class ApplicationMediaMixin(Document, MediaMixin):
         if not build_profile or not domain_has_privilege(self.domain, privileges.BUILD_PROFILES):
             return self.multimedia_map
 
-        requested_media = set()
-        requested_media |= self.logo_paths   # logos aren't language-specific
+        requested_media = copy(self.logo_paths)   # logos aren't language-specific
         for lang in build_profile.langs:
             requested_media |= self.all_media_paths(lang=lang)
 


### PR DESCRIPTION
Introduced in 70f5caa1b2883171244604fd89818abf4692ebbd

I doubt this is causing issues in prod because we don't call `multimedia_map_for_build` twice in the same request with different parameters, but it is making it harder to debug https://dimagi-dev.atlassian.net/browse/ICDS-291

@mkangia 
code buddies @kaapstorm @czue 