### PR TITLE
avoid briefly flashing the maintenance alert after closing it and ope…

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -370,9 +370,8 @@ hqDefine('hqwebapp/js/main', [
         if ($maintenance.length) {
             var id = $maintenance.data("id"),
                 alertCookie = "alert_maintenance";
-            if ($.cookie(alertCookie) == id) {  // eslint-disable-line eqeqeq
-                $maintenance.addClass('hide');
-            } else {
+            if ($.cookie(alertCookie) != id) {  // eslint-disable-line eqeqeq
+                $maintenance.removeClass('hide');
                 $maintenance.on('click', '.close', function () {
                     $.cookie(alertCookie, id, { expires: 7, path: '/' });
                 });

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -470,7 +470,7 @@ def maintenance_alert(request):
     alert = MaintenanceAlert.get_latest_alert()
     if alert and (not alert.domains or getattr(request, 'domain', None) in alert.domains):
         return format_html(
-            '<div class="alert alert-warning alert-maintenance" data-id="{}">{}{}</div>',
+            '<div class="alert alert-warning alert-maintenance hide" data-id="{}">{}{}</div>',
             alert.id,
             mark_safe('<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>'),
             mark_safe(alert.html),


### PR DESCRIPTION
…ning a new page

Product Note: When there is a maintenance alert, the status quo behavior is to show the alert, then check the user's cookies to see if they have closed the alert, and then to close it if earlier specified.  On slow connections, this can result in flashing the maintenance alert momentarily before it disappears.  This change means that the maintenance alert is first hidden, then shown only if the alert has not already been closed.

For most users, there will be no difference in behavior, but a few users will avoid having the maintenance alert appear then disappear.