### PR TITLE
tweaks to user import / export

### DIFF
--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -232,7 +232,7 @@ class SiteCodeToLocationCache(BulkCacheBase):
             loc_type.name for loc_type in Domain.get_by_name(domain).location_types
             if not loc_type.administrative
         ]
-        return super(SiteCodeToLocationCache, self).__init__(domain)
+        super(SiteCodeToLocationCache, self).__init__(domain)
 
     def lookup(self, site_code):
         """

--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -1,46 +1,45 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import uuid
+
 import logging
+import uuid
 
-from django import forms
-from django.conf import settings
-from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
-from django.utils.translation import ugettext as _
-from corehq.util.workbook_json.excel import flatten_json, json_to_headers, \
-    alphanumeric_sort_key
-from dimagi.utils.parsing import string_to_boolean
-
+import six
 from couchdbkit.exceptions import (
     BulkSaveError,
     MultipleResultsFound,
     ResourceNotFound,
 )
-from couchexport.writers import Excel2007ExportWriter
-from soil import DownloadBase
+from django import forms
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from django.utils.translation import ugettext as _
+from six.moves import map
+from six.moves import range
 
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.commtrack.util import get_supply_point_and_location
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
-from corehq.apps.groups.models import Group
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.domain.models import Domain
+from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.dbaccessors.all_commcare_users import (
     get_commcare_users_by_filters,
-    get_user_docs_by_username,
-)
+    get_existing_usernames)
 from corehq.apps.users.models import UserRole
+from corehq.util.workbook_json.excel import flatten_json, json_to_headers, \
+    alphanumeric_sort_key
+from couchexport.writers import Excel2007ExportWriter
+from dimagi.utils.chunked import chunked
+from dimagi.utils.parsing import string_to_boolean
+from soil import DownloadBase
 from soil.util import get_download_file_path, expose_download
-
 from .forms import get_mobile_worker_max_username_length
 from .models import CommCareUser, CouchUser
 from .util import normalize_username, raw_username
-import six
-from six.moves import range
-from six.moves import map
 
 
 class UserUploadError(Exception):
@@ -115,7 +114,9 @@ def check_existing_usernames(user_specs, domain):
     if invalid_usernames:
         raise UserUploadError(_('The following usernames are invalid: ' + ', '.join(invalid_usernames)))
 
-    existing_usernames = [u.get('username') for u in get_user_docs_by_username(usernames_without_ids)]
+    existing_usernames = set()
+    for usernames in chunked(usernames_without_ids, 500):
+        existing_usernames.update(get_existing_usernames(usernames))
 
     if existing_usernames:
         raise UserUploadError(_("The following usernames already exist and must "

--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -46,7 +46,7 @@ def get_commcare_users_by_filters(domain, user_filters, count_only=False):
 
     if count_only:
         return query.count()
-    user_ids = [u['_id'] for u in query.source(['_id']).run().hits]
+    user_ids = query.scroll_ids()
     return map(CommCareUser.wrap, iter_docs(CommCareUser.get_db(), user_ids))
 
 

--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -34,12 +34,10 @@ def get_commcare_users_by_filters(domain, user_filters, count_only=False):
     """
     role_id = user_filters.get('role_id', None)
     search_string = user_filters.get('search_string', None)
+    if not role_id and not search_string and not count_only:
+        return get_all_commcare_users_by_domain(domain)
+
     query = UserES().domain(domain).mobile_users()
-    if not role_id and not search_string:
-        if count_only:
-            query.count()
-        else:
-            return get_all_commcare_users_by_domain(domain)
 
     if role_id:
         query = query.role_id(role_id)

--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -143,13 +143,25 @@ def get_all_user_rows(domain, include_web_users=True, include_mobile_users=True,
 
 
 def get_user_docs_by_username(usernames):
+    return [
+        ret['doc'] for ret in _get_user_results_by_username(usernames)
+    ]
+
+
+def get_existing_usernames(usernames):
+    return [
+        ret['key'] for ret in _get_user_results_by_username(usernames, include_docs=False)
+    ]
+
+
+def _get_user_results_by_username(usernames, include_docs=True):
     from corehq.apps.users.models import CouchUser
-    return [res['doc'] for res in CouchUser.get_db().view(
+    return CouchUser.get_db().view(
         'users/by_username',
         keys=list(usernames),
         reduce=False,
-        include_docs=True,
-    ).all()]
+        include_docs=include_docs,
+    ).all()
 
 
 def get_all_user_ids():

--- a/corehq/apps/users/tests/bulk_upload.py
+++ b/corehq/apps/users/tests/bulk_upload.py
@@ -350,6 +350,6 @@ class TestUserBulkUploadUtils(SimpleTestCase):
             },
         ]
 
-        with patch('corehq.apps.users.bulkupload.get_user_docs_by_username',
+        with patch('corehq.apps.users.bulkupload.get_existing_usernames',
                 return_value=['hello@domain.commcarehq.org']):
             self.assertRaises(UserUploadError, check_existing_usernames, user_specs, 'domain')

--- a/corehq/apps/users/tests/bulk_upload.py
+++ b/corehq/apps/users/tests/bulk_upload.py
@@ -351,5 +351,5 @@ class TestUserBulkUploadUtils(SimpleTestCase):
         ]
 
         with patch('corehq.apps.users.bulkupload.get_user_docs_by_username',
-                return_value=[{'username': 'hello@domain.commcarehq.org'}]):
+                return_value=['hello@domain.commcarehq.org']):
             self.assertRaises(UserUploadError, check_existing_usernames, user_specs, 'domain')

--- a/corehq/apps/users/tests/test_db_accessors.py
+++ b/corehq/apps/users/tests/test_db_accessors.py
@@ -9,7 +9,7 @@ from corehq.apps.users.dbaccessors.all_commcare_users import (
     delete_all_users,
     get_all_user_ids,
     get_deleted_user_by_username,
-    get_all_usernames_by_domain)
+    get_all_usernames_by_domain, get_existing_usernames)
 from corehq.apps.users.dbaccessors.couch_users import (
     get_user_id_by_username,
 )
@@ -160,6 +160,14 @@ class AllCommCareUsersTest(TestCase):
         self.assertItemsEqual(
             get_user_docs_by_username(usernames),
             [u.to_json() for u in users]
+        )
+
+    def test_get_existing_usernames(self):
+        users = [self.ccuser_1, self.web_user, self.ccuser_other_domain]
+        usernames = [u.username for u in users] + ['nonexistant@username.com']
+        self.assertItemsEqual(
+            get_existing_usernames(usernames),
+            [u.username for u in users]
         )
 
     def test_get_all_ids(self):


### PR DESCRIPTION
Prompted by https://dimagi-dev.atlassian.net/browse/ICDS-413

First commit is the main one - switch from loading ALL users to just loading the usernames in chunks.

Best reviewed by commit.

@dimagi/product this should improve the speed and reliability of large user imports