### PR TITLE
Dashboard: don't show pagination unless relevant

### DIFF
--- a/corehq/apps/dashboard/templates/dashboard/base.html
+++ b/corehq/apps/dashboard/templates/dashboard/base.html
@@ -75,6 +75,7 @@
                                 </div>
 
                                 <pagination data-apply-bindings="false"
+                                            data-bind="visible: totalItems() > itemsPerPage"
                                             params="goToPage: goToPage,
                                                     perPage: itemsPerPage,
                                                     maxPagesShown: 6,


### PR DESCRIPTION
Tiny bit of clutter reduction.

<img width="1168" alt="Screen Shot 2019-03-13 at 2 00 59 PM" src="https://user-images.githubusercontent.com/1486591/54303036-74e4ad80-4598-11e9-8d03-8815b8d0076f.png">

@czue / @kaapstorm 