### PR TITLE
set CELERY_BROKER_HEARTBEAT = 0 to workaround bug with gevent workers

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -509,6 +509,9 @@ CELERY_BROKER_URL = 'redis://localhost:6379/0'
 # https://github.com/celery/celery/issues/4226
 CELERY_BROKER_POOL_LIMIT = None
 
+# https://github.com/celery/celery/issues/4817
+CELERY_BROKER_HEARTBEAT = 0
+
 CELERY_RESULT_BACKEND = 'django-db'
 
 CELERY_TASK_ANNOTATIONS = {


### PR DESCRIPTION
Resolves the issue mentioned in https://github.com/celery/celery/issues/4817 which was observed for the sms_queue on staging.