### PR TITLE
Add iteration for couch form ids

### DIFF
--- a/corehq/ex-submodules/couchforms/dbaccessors.py
+++ b/corehq/ex-submodules/couchforms/dbaccessors.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+from datetime import datetime
+
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 from corehq.util.test_utils import unit_testing_only
-from couchforms.const import DEVICE_LOG_XMLNS
 from couchforms.models import XFormInstance, doc_types
 from dimagi.utils.couch.database import iter_docs
 
@@ -88,16 +90,43 @@ def get_form_ids_for_user(domain, user_id):
     return [result['id'] for result in results]
 
 
-def get_form_ids_by_xmlns(domain, xmlns=None):
+def iter_form_ids_by_xmlns(domain, xmlns):
     if xmlns:
         key = ['submission xmlns', domain, xmlns]
     else:
-        key = ['submission xmlns', domain]
+        key = ['submission', domain]
+
+    endkey = key + [datetime.utcnow().isoformat()]
+
+    # pull the first 1000 documents sorted by submission time
+    LIMIT = 1000
     results = XFormInstance.get_db().view(
         'all_forms/view',
         startkey=key,
-        endkey=key + [{}],
+        endkey=endkey,
         reduce=False,
         include_docs=False,
-    )
-    return [result['id'] for result in results]
+        limit=LIMIT,
+        descending=False,
+    ).all()
+
+    while results:
+        for result in results:
+            yield result['id']
+
+        # add the last document's submitted_on time to the startkey
+        last_result = results[-1]
+        startkey = key + [last_result['key'][-1]]
+
+        # pull 1000 documents starting with the last document pulled in the previous iteration
+        results = XFormInstance.get_db().view(
+            'all_forms/view',
+            startkey=startkey,
+            endkey=endkey,
+            reduce=False,
+            include_docs=False,
+            limit=LIMIT,
+            descending=False,
+        ).all()
+        # remove the first document in this new iteration so that we do not process it twice
+        results.pop(0)

--- a/corehq/ex-submodules/couchforms/dbaccessors.py
+++ b/corehq/ex-submodules/couchforms/dbaccessors.py
@@ -114,7 +114,7 @@ def iter_form_ids_by_xmlns(domain, xmlns):
         for result in results:
             yield result['id']
 
-        # add the last document's submitted_on time to the startkey
+        # add the last document's received_on time to the startkey
         last_result = results[-1]
         startkey = key + [last_result['key'][-1]]
 

--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -39,7 +39,7 @@ from couchforms.dbaccessors import (
     get_form_ids_for_user,
     get_forms_by_id,
     get_form_ids_by_type,
-    get_form_ids_by_xmlns,
+    iter_form_ids_by_xmlns,
 )
 from couchforms.models import XFormInstance, doc_types, XFormOperation
 from dimagi.utils.couch.database import iter_docs
@@ -140,7 +140,7 @@ class FormAccessorCouch(AbstractFormAccessor):
 
     @staticmethod
     def iter_form_ids_by_xmlns(domain, xmlns=None):
-        return get_form_ids_by_xmlns(domain, xmlns)
+        return iter_form_ids_by_xmlns(domain, xmlns)
 
 
 class CaseAccessorCouch(AbstractCaseAccessor):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/projects/HI/issues/HI-474?filter=allopenissues

the rebuild task on couch domains tried to load all ids into memory. For a rec rebuild that was 24 GB of data. I think that was because it pulls way more information than just id (`{id: id, keys: ['list', 'of', 'keys'], 'value': 'value from view'}`) 

SQL already does this a bit smarter as it only loads the ids from one partition (still a lot of ids, but probably not enough to be concerned except for icds)

