### PR TITLE
Bump PyYAML to 5.1

### DIFF
--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -155,7 +155,7 @@ python-magic==0.4.15
 python-mimeparse==1.6.0
 python-termstyle==0.1.10  # via sniffer
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -123,7 +123,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -133,7 +133,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -118,7 +118,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0   # via django-tastypie
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -128,7 +128,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -156,7 +156,7 @@ python-magic==0.4.15
 python-mimeparse==1.6.0
 python-termstyle==0.1.10  # via sniffer
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -124,7 +124,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -134,7 +134,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -35,7 +35,7 @@ python-dateutil~=2.6
 python-Levenshtein
 python-magic~=0.4.13
 pytz>=2017.2
-PyYAML==3.13
+PyYAML~=5.1
 requests~=2.20
 suds-jurko==0.6
 tropo-webapi-python==0.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -119,7 +119,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0   # via django-tastypie
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -129,7 +129,7 @@ python-levenshtein==0.12.0
 python-magic==0.4.15
 python-mimeparse==1.6.0
 pytz==2018.9
-pyyaml==3.13
+pyyaml==5.1
 pyzxcvbn==0.8.0
 qrcode==4.0.4
 quickcache==0.5.3


### PR DESCRIPTION
Should satisfy github's security alerts. Will likely add deprecation warnings that can be fixed in a separate PR https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation