### PR TITLE
Standardize restore and submission timing buckets

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -165,7 +165,7 @@ def _record_metrics(tags, submission_type, response, result=None, timer=None):
 
     if response.status_code == 201 and timer and result:
         tags += [
-            'duration:%s' % bucket_value(timer.duration, (5, 10, 20), 's'),
+            'duration:%s' % bucket_value(timer.duration, (1, 5, 20, 60, 120, 300, 600), 's'),
             'case_count:%s' % bucket_value(len(result.cases), (2, 5, 10)),
             'ledger_count:%s' % bucket_value(len(result.ledgers), (2, 5, 10)),
         ]

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -745,7 +745,7 @@ class RestoreConfig(object):
             'device_type:{}'.format('webapps' if is_webapps else 'other'),
         ]
         maybe_add_domain_tag(self.domain, tags)
-        timer_buckets = (5, 20, 60, 120)
+        timer_buckets = (1, 5, 20, 60, 120, 300, 600)
         for timer in timing.to_list(exclude_root=True):
             if timer.name in RESTORE_SEGMENTS:
                 segment = RESTORE_SEGMENTS[timer.name]


### PR DESCRIPTION
Clayton requested that the buckets be standardized, and ~7 buckets fits the datadog color palette nicely~ there are actually 8 (with `over_600`), but hopefully we rarely see that one and wrapping around to the first color on that one is fine too.

@dannyroberts @ctsims 