### PR TITLE
Add 5th build to travis so they always run in under 50 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ branches:
 env:
   matrix:
     # need node installs for app_manager.XpathValidatorTest
-    - TEST=python NOSE_DIVIDED_WE_RUN=05 JS_SETUP=yes
-    - TEST=python NOSE_DIVIDED_WE_RUN=6a JS_SETUP=yes
-    - TEST=python NOSE_DIVIDED_WE_RUN=bf JS_SETUP=yes
+    - TEST=python NOSE_DIVIDED_WE_RUN=03 JS_SETUP=yes
+    - TEST=python NOSE_DIVIDED_WE_RUN=47 JS_SETUP=yes
+    - TEST=python NOSE_DIVIDED_WE_RUN=8b JS_SETUP=yes
+    - TEST=python NOSE_DIVIDED_WE_RUN=cf JS_SETUP=yes
     - TEST=python-sharded-and-javascript JS_SETUP=yes TEST_MAKE_REQUIREMENTS=yes
   global:
     # TRAVIS_HQ_USERNAME


### PR DESCRIPTION
Is this a good idea? I'm not making a PR because I think there's already a buildup of travis tests to run and I don't want to add this to it if we reject this out of hand.