### PR TITLE
upgrade to celery 4.1.1

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -78,7 +78,6 @@ First create your `localsettings.py` file:
 
 Enter `localsettings.py` and do the following:
 - Find the `LOG_FILE` and `DJANGO_LOG_FILE` entries. Ensure that the directories for both exist and are writeable. If they do not exist, create them.
-- Find the `LOCAL_APPS` section and un-comment the line that starts with `'kombu.transport.django'`
 - You may also want to add the line `from dev_settings import *` at the top of the file, which includes some useful default settings.
 
 Create the shared directory.  If you have not modified `SHARED_DRIVE_ROOT`, then run:
@@ -298,7 +297,7 @@ Then run the following separately:
     # Keeps elasticsearch index in sync
     $ ./manage.py run_ptop --all
 
-    # Setting up the asynchronous task scheduler (only required if you have CELERY_ALWAYS_EAGER=False in settings)
+    # Setting up the asynchronous task scheduler (only required if you have CELERY_TASK_ALWAYS_EAGER=False in settings)
     # For Mac / Linux
     $ ./manage.py celeryd --verbosity=2 --beat --statedb=celery.db --events
     # Windows

--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -1,2 +1,4 @@
 from __future__ import absolute_import, unicode_literals
 from .celery import app as celery_app  # noqa
+
+__all__ = ['celery_app']

--- a/corehq/apps/locations/tasks.py
+++ b/corehq/apps/locations/tasks.py
@@ -172,9 +172,9 @@ def import_locations_async(domain, file_ref_id, user_id):
         for datasource in datasources:
             rebuild_indicators_in_place.delay(datasource.get_id)
 
-    if getattr(settings, 'CELERY_ALWAYS_EAGER', False):
+    if getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False):
         # Log results because they are not sent to the view when
-        # CELERY_ALWAYS_EAGER is true
+        # CELERY_TASK_ALWAYS_EAGER is true
         logging.getLogger(__name__).info(
             "import_locations_async %s results: %s -> success=%s",
             file_ref_id,

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -999,14 +999,14 @@ class ConfigureNewReportBase(forms.Form):
         data_source_config.save()
 
         # expire the data source
-        always_eager = hasattr(settings, "CELERY_ALWAYS_EAGER") and settings.CELERY_ALWAYS_EAGER
-        # CELERY_ALWAYS_EAGER will cause the data source to be deleted immediately. Switch it off temporarily
-        settings.CELERY_ALWAYS_EAGER = False
+        always_eager = hasattr(settings, "CELERY_TASK_ALWAYS_EAGER") and settings.CELERY_TASK_ALWAYS_EAGER
+        # CELERY_TASK_ALWAYS_EAGER will cause the data source to be deleted immediately. Switch it off temporarily
+        settings.CELERY_TASK_ALWAYS_EAGER = False
         tasks.delete_data_source_task.apply_async(
             (self.domain, data_source_config._id),
             countdown=TEMP_DATA_SOURCE_LIFESPAN
         )
-        settings.CELERY_ALWAYS_EAGER = always_eager
+        settings.CELERY_TASK_ALWAYS_EAGER = always_eager
 
         tasks.rebuild_indicators(data_source_config._id,
                                  username,

--- a/corehq/celery.py
+++ b/corehq/celery.py
@@ -14,11 +14,9 @@ run_patches()
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 
-from django.conf import settings  # noqa
-
-app = Celery('corehq')
-app.config_from_object('django.conf:settings')
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+app = Celery()
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()
 
 django.setup()
 try:

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import mock
 from io import BytesIO
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase, SimpleTestCase, override_settings
 from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 
@@ -85,6 +85,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         self.assertTrue(task.delay.called)
 
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     def test_restore_then_sync_on_same_synclog_returns_async_restore_response(self, task):
         delay = mock.MagicMock()
         delay.id = 'random_task_id'
@@ -173,6 +174,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
     @mock.patch.object(RestorePayloadPathCache, 'exists')
     @mock.patch.object(RestoreResponse, 'as_file')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     def test_clears_cache(self, task, response, exists_patch, invalidate):
         delay = mock.MagicMock()
         delay.id = 'random_task_id'
@@ -257,6 +259,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
     @mock.patch.object(RestorePayloadPathCache, 'exists')
     @mock.patch.object(RestoreResponse, 'as_file')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     def test_clears_cache(self, task, response, exists_patch, invalidate):
         delay = mock.MagicMock()
         delay.id = 'random_task_id'

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -134,7 +134,7 @@ def get_task_status(task, is_multiple_download_task=False):
 
     def progress_complete():
         return (
-            getattr(settings, 'CELERY_ALWAYS_EAGER', False) or
+            getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False) or
             progress and progress.percent == 100 and
             not progress.error
         )

--- a/corehq/util/workbook_json/excel_importer.py
+++ b/corehq/util/workbook_json/excel_importer.py
@@ -24,9 +24,9 @@ class ExcelImporter(object):
         self.task = task
         self.progress = 0
         self.total_rows = 100
-        if getattr(settings, 'CELERY_ALWAYS_EAGER', False):
+        if getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False):
             # Log progress since tasks are executed synchronously when
-            # CELERY_ALWAYS_EAGER is true
+            # CELERY_TASK_ALWAYS_EAGER is true
             self.log = logging.getLogger(__name__).info
         else:
             self.log = lambda *a, **k: None

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -11,7 +11,6 @@ import os
 
 LOCAL_APPS = (
     'django_extensions',
-    'kombu.transport.django',
 )
 
 # TEST_RUNNER is overridden in testsettings, which is the default settings
@@ -93,7 +92,7 @@ COMPRESS_JS_COMPRESSOR = 'compressor.js.JsCompressor'
 PILLOWTOP_MACHINE_ID = 'testhq'  # for tests
 
 #  make celery synchronous
-CELERY_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = True
 # Fail hard in tasks so you get a traceback
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -193,7 +193,7 @@ ALLOWED_HOSTS = ['*']
 
 # faster compressor that doesn't do source maps
 COMPRESS_JS_COMPRESSOR = 'compressor.js.JsCompressor'
-CELERY_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 INACTIVITY_TIMEOUT = 60 * 24 * 365
 SHARED_DRIVE_ROOT = '/sharedfiles'
@@ -290,6 +290,4 @@ if os.environ.get("COMMCAREHQ_BOOTSTRAP") == "yes":
 
 BIGCOUCH = True
 
-LOCAL_APPS = (
-    'kombu.transport.django',  # required for celery
-)
+LOCAL_APPS = ()

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -211,7 +211,6 @@ LOCAL_APPS = (
 #    'dimagi.utils',
 #    'testapps.test_elasticsearch',
 #    'testapps.test_pillowtop',
-#    'kombu.transport.django', # required for celery
 )
 
 LOCAL_MIDDLEWARE = [
@@ -274,7 +273,7 @@ CCHQ_API_THROTTLE_TIMEFRAME = 10  # seconds
 COVERAGE_REPORT_HTML_OUTPUT_DIR='coverage-html'
 COVERAGE_MODULE_EXCLUDES= ['tests$', 'settings$', 'urls$', 'locale$',
                            'common.views.test', '^django', 'management', 'migrations',
-                           '^south', '^djcelery', '^debug_toolbar']
+                           '^south', '^debug_toolbar']
 
 INTERNAL_DATA = {
     "business_unit": [],

--- a/manage.py
+++ b/manage.py
@@ -156,7 +156,6 @@ if __name__ == "__main__":
         GeventCommand('ptop_preindex'),
         GeventCommand('sync_prepare_couchdb_multi'),
         GeventCommand('sync_couch_views'),
-        GeventCommand('celery', contains='-P gevent'),
         GeventCommand('populate_form_date_modified'),
         GeventCommand('migrate_domain_from_couch_to_sql', http_adapter_pool_size=32),
         GeventCommand('migrate_multiple_domains_from_couch_to_sql', http_adapter_pool_size=32),

--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -19,7 +19,7 @@ beautifulsoup4==4.7.1
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -7,8 +7,7 @@
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 argparse==1.4.0
 asn1crypto==0.24.0
 attrs==18.2.0
@@ -17,10 +16,10 @@ backports.functools-lru-cache==1.5
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bcrypt==3.1.6             # via paramiko
 beautifulsoup4==4.7.1
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -43,7 +42,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -107,7 +106,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 line_profiler==1.0
 linecache2==1.0.0
@@ -199,6 +198,7 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.24.1
 user-agents==1.1.0
+vine==1.2.0
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1
 werkzeug==0.11.15

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -14,7 +14,7 @@ babel==2.6.0
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -7,15 +7,14 @@
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -35,7 +34,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -89,7 +88,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.2
 mako==1.0.7
@@ -160,6 +159,7 @@ ua-parser==0.8.0
 unidecode==0.04.20
 urllib3==1.24.1
 user-agents==1.1.0
+vine==1.2.0
 webencodings==0.5.1
 werkzeug==0.11.15
 wrapt==1.11.1

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -15,7 +15,7 @@ backports.shutil-get-terminal-size==1.0.0  # via ipython
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -6,17 +6,16 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
 backports-abc==0.5        # via tornado
 backports.shutil-get-terminal-size==1.0.0  # via ipython
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -36,7 +35,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -93,7 +92,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.2
 mako==1.0.7
@@ -171,6 +170,7 @@ unidecode==0.04.20
 urllib3==1.24.1
 user-agents==1.1.0
 uwsgi==2.0.18
+vine==1.2.0
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1
 werkzeug==0.11.15

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -6,15 +6,14 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
+amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
 babel==2.6.0              # via django-phonenumber-field
-billiard==3.3.0.23        # via celery
+billiard==3.5.0.5         # via celery
 boto3==1.9.108
 botocore==1.12.108        # via boto3, s3transfer
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29       # via requests
 cffi==1.12.2              # via cryptography, csiphash
 chardet==3.0.4            # via ghdiff, requests
@@ -34,7 +33,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -86,7 +85,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37             # via celery
+kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.2
 mako==1.0.7               # via alembic
@@ -149,6 +148,7 @@ ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 urllib3==1.24.1           # via botocore, dropbox, elasticsearch, py-kissmetrics, requests
 user-agents==1.1.0        # via django-user-agents
+vine==1.2.0               # via amqp
 webencodings==0.5.1       # via html5lib
 werkzeug==0.11.15
 wrapt==1.11.1             # via ddtrace

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -13,7 +13,7 @@ babel==2.6.0              # via django-phonenumber-field
 billiard==3.5.0.5         # via celery
 boto3==1.9.108
 botocore==1.12.108        # via boto3, s3transfer
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29       # via requests
 cffi==1.12.2              # via cryptography, csiphash
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -7,18 +7,17 @@
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
 backports.functools-lru-cache==1.5  # via soupsieve
 beautifulsoup4==4.7.1
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -39,7 +38,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -93,7 +92,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2
 lxml==4.3.2
@@ -165,6 +164,7 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.24.1
 user-agents==1.1.0
+vine==1.2.0
 webencodings==0.5.1
 werkzeug==0.11.15
 wrapt==1.11.1

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -17,7 +17,7 @@ beautifulsoup4==4.7.1
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements-python3_6/uninstall-requirements.txt
+++ b/requirements-python3_6/uninstall-requirements.txt
@@ -8,6 +8,6 @@ restkit
 http-parser
 zeep
 cython
-django-celery-results
+django-celery
 numpy
 ConcurrentLogHandler

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -7,8 +7,7 @@
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 argparse==1.4.0
 asn1crypto==0.24.0
 attrs==18.2.0
@@ -17,10 +16,10 @@ backports.functools-lru-cache==1.5
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bcrypt==3.1.6             # via paramiko
 beautifulsoup4==4.7.1
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -43,7 +42,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -108,7 +107,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 line_profiler==1.0
 linecache2==1.0.0
@@ -200,6 +199,7 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.24.1
 user-agents==1.1.0
+vine==1.2.0
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1
 werkzeug==0.11.15

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -19,7 +19,7 @@ beautifulsoup4==4.7.1
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -14,7 +14,7 @@ babel==2.6.0
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -7,15 +7,14 @@
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -35,7 +34,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -90,7 +89,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.2
 mako==1.0.7
@@ -161,6 +160,7 @@ ua-parser==0.8.0
 unidecode==0.04.20
 urllib3==1.24.1
 user-agents==1.1.0
+vine==1.2.0
 webencodings==0.5.1
 werkzeug==0.11.15
 wrapt==1.11.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -6,17 +6,16 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
 backports-abc==0.5        # via tornado
 backports.shutil-get-terminal-size==1.0.0  # via ipython
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -36,7 +35,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -94,7 +93,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.2
 mako==1.0.7
@@ -172,6 +171,7 @@ unidecode==0.04.20
 urllib3==1.24.1
 user-agents==1.1.0
 uwsgi==2.0.18
+vine==1.2.0
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1
 werkzeug==0.11.15

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -15,7 +15,7 @@ backports.shutil-get-terminal-size==1.0.0  # via ipython
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@ attrs~=18.1
 iso8601==0.1.12
 jsonobject==0.9.8
 jsonobject-couchdbkit~=0.9
-celery==4.1.1
+celery==4.1.1  # upgrade when https://github.com/celery/celery/issues/4980 is fixed
 # required by django-digest
 decorator==4.0.11
 django~=1.11

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,12 +2,12 @@ attrs~=18.1
 iso8601==0.1.12
 jsonobject==0.9.8
 jsonobject-couchdbkit~=0.9
-celery==3.1.25
+celery~=4.2
 # required by django-digest
 decorator==4.0.11
 django~=1.11
 django-braces==1.13.0
-django-celery==3.2.1
+django-celery-results~=1.0
 django-crispy-forms==1.7.0
 jsonfield==1.0.3
 dropbox==7.3.1
@@ -22,6 +22,7 @@ ghdiff==0.4
 gunicorn
 lxml~=4.3.0
 kafka-python~=1.4
+kombu!=4.3.0
 mock==2.0.0
 Pillow~=5.2
 phonenumberslite~=8.8

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@ attrs~=18.1
 iso8601==0.1.12
 jsonobject==0.9.8
 jsonobject-couchdbkit~=0.9
-celery~=4.2
+celery==4.1.1
 # required by django-digest
 decorator==4.0.11
 django~=1.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,15 +6,14 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
+amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
 babel==2.6.0              # via django-phonenumber-field
-billiard==3.3.0.23        # via celery
+billiard==3.5.0.5         # via celery
 boto3==1.9.108
 botocore==1.12.108        # via boto3, s3transfer
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29       # via requests
 cffi==1.12.2              # via cryptography, csiphash
 chardet==3.0.4            # via ghdiff, requests
@@ -34,7 +33,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -87,7 +86,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37             # via celery
+kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.2
 mako==1.0.7               # via alembic
@@ -150,6 +149,7 @@ ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 urllib3==1.24.1           # via botocore, dropbox, elasticsearch, py-kissmetrics, requests
 user-agents==1.1.0        # via django-user-agents
+vine==1.2.0               # via amqp
 webencodings==0.5.1       # via html5lib
 werkzeug==0.11.15
 wrapt==1.11.1             # via ddtrace

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,7 +13,7 @@ babel==2.6.0              # via django-phonenumber-field
 billiard==3.5.0.5         # via celery
 boto3==1.9.108
 botocore==1.12.108        # via boto3, s3transfer
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29       # via requests
 cffi==1.12.2              # via cryptography, csiphash
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -7,18 +7,17 @@
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.4.2
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
 backports.functools-lru-cache==1.5  # via soupsieve
 beautifulsoup4==4.7.1
-billiard==3.3.0.23
+billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==3.1.25
+celery==4.2.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4
@@ -39,7 +38,7 @@ django-angular==0.7.16
 django-appconf==1.0.3
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery==3.2.1
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0
@@ -94,7 +93,7 @@ jsonobject-couchdbkit==0.9.16
 jsonobject==0.9.8
 jsonpath-rw==1.4.0
 kafka-python==1.4.4
-kombu==3.0.37
+kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2
 lxml==4.3.2
@@ -166,6 +165,7 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.24.1
 user-agents==1.1.0
+vine==1.2.0
 webencodings==0.5.1
 werkzeug==0.11.15
 wrapt==1.11.1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -17,7 +17,7 @@ beautifulsoup4==4.7.1
 billiard==3.5.0.5
 boto3==1.9.108
 botocore==1.12.108
-celery==4.2.1
+celery==4.1.1
 certifi==2018.11.29
 cffi==1.12.2
 chardet==3.0.4

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -8,6 +8,6 @@ restkit
 http-parser
 zeep
 cython
-django-celery-results
+django-celery
 numpy
 ConcurrentLogHandler

--- a/settings.py
+++ b/settings.py
@@ -506,9 +506,6 @@ GET_URL_BASE = 'dimagi.utils.web.get_url_base'
 # celery
 CELERY_BROKER_URL = 'redis://localhost:6379/0'
 
-# https://github.com/celery/celery/issues/4226
-CELERY_BROKER_POOL_LIMIT = None
-
 CELERY_RESULT_BACKEND = 'django-db'
 
 CELERY_TASK_ANNOTATIONS = {

--- a/settings.py
+++ b/settings.py
@@ -11,11 +11,6 @@ import six
 from django.contrib import messages
 import settingshelper as helper
 
-# odd celery fix
-import djcelery
-
-djcelery.setup_loader()
-
 DEBUG = True
 LESS_DEBUG = DEBUG
 
@@ -189,7 +184,7 @@ DEFAULT_APPS = (
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
-    'djcelery',
+    'django_celery_results',
     'django_prbac',
     'djangular',
     'captcha',
@@ -509,11 +504,14 @@ TRANSFER_FILE_DIR_NAME = None
 GET_URL_BASE = 'dimagi.utils.web.get_url_base'
 
 # celery
-BROKER_URL = 'redis://localhost:6379/0'
+CELERY_BROKER_URL = 'redis://localhost:6379/0'
 
-CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
+# https://github.com/celery/celery/issues/4226
+CELERY_BROKER_POOL_LIMIT = None
 
-CELERY_ANNOTATIONS = {
+CELERY_RESULT_BACKEND = 'django-db'
+
+CELERY_TASK_ANNOTATIONS = {
     '*': {
         'on_failure': helper.celery_failure_handler,
         'trail': False,
@@ -528,7 +526,7 @@ CELERY_REPEAT_RECORD_QUEUE = 'repeat_record_queue'
 
 # Will cause a celery task to raise a SoftTimeLimitExceeded exception if
 # time limit is exceeded.
-CELERYD_TASK_SOFT_TIME_LIMIT = 86400 * 2  # 2 days in seconds
+CELERY_TASK_SOFT_TIME_LIMIT = 86400 * 2  # 2 days in seconds
 
 # http://docs.celeryproject.org/en/3.1/configuration.html#celery-event-queue-ttl
 # Keep messages in the events queue only for 2 hours

--- a/testsettings.py
+++ b/testsettings.py
@@ -65,7 +65,7 @@ del key, value
 if "SKIP_TESTS_REQUIRING_EXTRA_SETUP" not in globals():
     SKIP_TESTS_REQUIRING_EXTRA_SETUP = False
 
-CELERY_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = True
 # keep a copy of the original PILLOWTOPS setting around in case other tests want it.
 _PILLOWTOPS = PILLOWTOPS
 PILLOWTOPS = {}


### PR DESCRIPTION
By not upgrading to the latest version of celery we avoid this bug:
https://github.com/celery/celery/issues/4980

The bug is on the 4.3.x roadmap so we should be able to upgrade once that is released.