### PR TITLE
don't use buggy version of billiard

### DIFF
--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -16,7 +16,7 @@ backports.functools-lru-cache==1.5
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bcrypt==3.1.6             # via paramiko
 beautifulsoup4==4.7.1
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -11,7 +11,7 @@ amqp==2.4.2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -12,7 +12,7 @@ attrs==18.2.0
 babel==2.6.0
 backports-abc==0.5        # via tornado
 backports.shutil-get-terminal-size==1.0.0  # via ipython
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -10,7 +10,7 @@ amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
 babel==2.6.0              # via django-phonenumber-field
-billiard==3.5.0.5         # via celery
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108        # via boto3, s3transfer
 celery==4.1.1

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -14,7 +14,7 @@ attrs==18.2.0
 babel==2.6.0
 backports.functools-lru-cache==1.5  # via soupsieve
 beautifulsoup4==4.7.1
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -16,7 +16,7 @@ backports.functools-lru-cache==1.5
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bcrypt==3.1.6             # via paramiko
 beautifulsoup4==4.7.1
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -11,7 +11,7 @@ amqp==2.4.2
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -12,7 +12,7 @@ attrs==18.2.0
 babel==2.6.0
 backports-abc==0.5        # via tornado
 backports.shutil-get-terminal-size==1.0.0  # via ipython
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -23,6 +23,7 @@ gunicorn
 lxml~=4.3.0
 kafka-python~=1.4
 kombu!=4.3.0
+billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 mock==2.0.0
 Pillow~=5.2
 phonenumberslite~=8.8

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
 babel==2.6.0              # via django-phonenumber-field
-billiard==3.5.0.5         # via celery
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108        # via boto3, s3transfer
 celery==4.1.1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -14,7 +14,7 @@ attrs==18.2.0
 babel==2.6.0
 backports.functools-lru-cache==1.5  # via soupsieve
 beautifulsoup4==4.7.1
-billiard==3.5.0.5
+billiard==3.5.0.4
 boto3==1.9.108
 botocore==1.12.108
 celery==4.1.1


### PR DESCRIPTION
Resolves this error: https://github.com/celery/billiard/issues/260

This was preventing the async_restore_queue worker from starting in production. 