### PR TITLE
agg ucr fixes

### DIFF
--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -90,7 +90,6 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
         # todo: will probably need to make this configurable at some point
         return []
 
-    @memoized
     def get_columns(self):
         for adapter in self.get_column_adapters():
             yield adapter.to_ucr_column_spec()

--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -115,7 +115,7 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
     def pk_columns(self):
         columns = []
         for col in self.get_columns():
-            if col.is_primary_key():
+            if col.is_primary_key:
                 column_name = decode_column_name(col)
                 columns.append(column_name)
         return columns


### PR DESCRIPTION
Looks like this has been broken for a while but only revealed because we're removing the tables from SQLAlchemy metadata when we drop them. Previously calling `sqlalchemy.Table(..., extends_existing=True)` even with no columns etc. would return the table definition from the metadata.