### PR TITLE
Switched data corrections itemsPerPage from computed to observable

### DIFF
--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -112,9 +112,7 @@ hqDefine("reports/js/data_corrections", [
         // Handle modal size: small, large or full-screen, with one, two, or three columns, respectively.
         self.itemsPerColumn = 12;
         self.columnsPerPage = ko.observable(1);
-        self.itemsPerPage = ko.computed(function () {
-            return self.itemsPerColumn * self.columnsPerPage();
-        });
+        self.itemsPerPage = ko.observable();
         self.columnClass = ko.observable('');
         self.isFullScreenModal = ko.observable(false);
         self.isLargeModal = ko.observable(false);
@@ -123,6 +121,7 @@ hqDefine("reports/js/data_corrections", [
             self.columnClass("col-sm-" + (12 / self.columnsPerPage()));
             self.isLargeModal(self.columnsPerPage() === 2);
             self.isFullScreenModal(self.columnsPerPage() === 3);
+            self.itemsPerPage(self.itemsPerColumn * self.columnsPerPage());
             self.generateSearchableNames();
         });
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-482

Introduced in https://github.com/dimagi/commcare-hq/pull/23524

Because [perPage is now being written to](https://github.com/dimagi/commcare-hq/pull/23524/files#diff-af46b69d3aac3fb5a0742276d67ff4f7R43), it can't be an automatically-computed value but needs to be a regular observable.

@czue / @kaapstorm 