### PR TITLE
Improve form and module reordering logic

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -330,7 +330,7 @@ hqDefine('app_manager/js/app_manager', function () {
             var url = initialPageData.reverse('rearrange', 'modules'),
                 from = ui.item.data('index'),
                 to = _.findIndex($(".module"), function (module) {
-                    return $(module).data('index') === from;
+                    return $(module).data('uid') === ui.item.data('uid');
                 });
 
             if (to !== from) {

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -314,7 +314,7 @@ hqDefine('app_manager/js/app_manager', function () {
             if ($sortable.hasClass('sortable-forms')) {
                 rearrangeForms(ui, $sortable);
             } else {
-                rearrangeModules($sortable);
+                rearrangeModules(ui, $sortable);
             }
         }
         function rearrangeForms(ui, $sortable) {
@@ -337,17 +337,18 @@ hqDefine('app_manager/js/app_manager', function () {
                 if (movingToNewModule) {
                     resetOldModuleIndices($sortable, fromModuleUid);
                 }
-                saveRearrangement(url, from, to, fromModuleUid, toModuleUid);
+                saveRearrangement($sortable, url, from, to, fromModuleUid, toModuleUid);
             }
         }
-        function rearrangeModules($sortable) {
+        function rearrangeModules(ui, $sortable) {
             var url = initialPageData.reverse('rearrange', 'modules'),
-                move = calculateMoveWithinScope($sortable),
-                from = move[0],
-                to = move[1];
+                from = ui.item.data('index'),
+                to = _.findIndex($(".module"), function (module) {
+                    return $(module).data('index') === from;
+                });
 
             if (to !== from) {
-                saveRearrangement(url, from, to);
+                saveRearrangement($sortable, url, from, to);
             }
         }
         function calculateMoveFormToNewModule($sortable, ui, toModuleUid) {
@@ -401,7 +402,7 @@ hqDefine('app_manager/js/app_manager', function () {
                 }
             });
         }
-        function saveRearrangement(url, from, to, fromModuleUid, toModuleUid) {
+        function saveRearrangement($sortable, url, from, to, fromModuleUid, toModuleUid) {
             resetIndexes($sortable);
             var data = {
                 from: from,

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -317,18 +317,12 @@ hqDefine('app_manager/js/app_manager', function () {
             var url = initialPageData.reverse('rearrange', 'forms'),
                 toModuleUid = $sortable.parents('.edit-module-li').data('uid'),
                 fromModuleUid = ui.item.data('moduleuid'),
-                movingToNewModule = toModuleUid !== fromModuleUid;
+                from = ui.item.data('index'),
+                to = _.findIndex($sortable.children().not('.sort-disabled'), function (form) {
+                    return $(form).data('uid') === ui.item.data('uid');
+                });
 
-            var move;
-            if (movingToNewModule) {
-                move = calculateMoveFormToNewModule($sortable, ui, toModuleUid);
-            } else {
-                move = calculateMoveWithinScope($sortable);
-            }
-            var from = move[0],
-                to = move[1];
-
-            if (to !== from || movingToNewModule) {
+            if (to !== from || toModuleUid !== fromModuleUid) {
                 saveRearrangement($sortable, url, from, to, fromModuleUid, toModuleUid);
             }
         }
@@ -342,39 +336,6 @@ hqDefine('app_manager/js/app_manager', function () {
             if (to !== from) {
                 saveRearrangement($sortable, url, from, to);
             }
-        }
-        function calculateMoveFormToNewModule($sortable, ui, toModuleUid) {
-            var from = -1, to = -1;
-            $sortable.children().not('.sort-disabled').each(function (i) {
-                if ($(this).data('moduleuid') !== toModuleUid) {
-                    to = i;
-                    from = parseInt(ui.item.data('index'), 10);
-                    return false;
-                }
-            });
-            return [from, to];
-        }
-        function calculateMoveWithinScope($sortable) {
-            var from = -1, to = -1;
-            $sortable.children().not('.sort-disabled').each(function (i) {
-                var index = parseInt($(this).data('index'), 10);
-                if (from !== -1) {
-                    if (from === index) {
-                        to = i;
-                        return false;
-                    }
-                }
-                if (i !== index) {
-                    if (i + 1 === index) {
-                        from = i;
-                    } else {
-                        to = i;
-                        from = index;
-                        return false;
-                    }
-                }
-            });
-            return [from, to];
         }
         function resetIndexes() {
             $(".module").each(function (index, module) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/appnav_menu.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/appnav_menu.html
@@ -2,14 +2,9 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 
+{% registerurl 'rearrange' domain app.id '---' %}
+
 <ul class="sortable appmanager-main-menu appnav-menu appnav-module sortable-modules">
-    <li class="sort-action hide sort-disabled">
-        <form method="post"
-              action="{% url "rearrange" domain app.id 'modules' %}">
-              {% csrf_token %}
-              <input name="ajax" value="true" type="hidden" />
-        </form>
-    </li>
     {% with module as selected_module %}
         {% for module in app.get_modules %}
             <li class="edit-module-li js-sorted-li module"
@@ -24,13 +19,6 @@
                            {% ifequal module.unique_id selected_module.unique_id %}selected{% endifequal %}
                            {% if module.is_surveys %}appnav-surveys{% else %}appnav-caselist{% endif %}"
                     data-parentvar="moduleid">
-                    <li class="sort-action hide sort-disabled">
-                        <form method="post"
-                              action="{% url "rearrange" domain app.id 'forms' %}">
-                              {% csrf_token %}
-                              <input name="ajax" value="true" type="hidden" />
-                        </form>
-                    </li>
                     {% with nav_form as selected_form %}
                         {% for form in module.get_forms %}
                             <li class="edit-form-li js-sorted-li"

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/appnav_menu.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/appnav_menu.html
@@ -22,6 +22,7 @@
                             <li class="edit-form-li js-sorted-li"
                                 data-moduleuid="{{ module.unique_id }}"
                                 data-index="{{ form.id }}"
+                                data-uid="{{ form.unique_id }}"
                                 {% if form.get_action_type == 'open' %}data-appear="first"{% endif %}
                             >
                                 {% include 'app_manager/partials/menu/form_link.html' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/appnav_menu.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/appnav_menu.html
@@ -10,21 +10,18 @@
             <li class="edit-module-li js-sorted-li module"
                 data-index="{{ module.id }}"
                 data-uid="{{ module.unique_id }}"
-                data-rootmoduleuid="{{ module.root_module_id|default:"" }}"
-                data-indexvar="moduleid">
+                data-rootmoduleuid="{{ module.root_module_id|default:"" }}">
 
                 {% include 'app_manager/partials/menu/module_link.html' %}
 
                 <ul class="appnav-menu appnav-menu-nested see sortable sortable-forms
                            {% ifequal module.unique_id selected_module.unique_id %}selected{% endifequal %}
-                           {% if module.is_surveys %}appnav-surveys{% else %}appnav-caselist{% endif %}"
-                    data-parentvar="moduleid">
+                           {% if module.is_surveys %}appnav-surveys{% else %}appnav-caselist{% endif %}">
                     {% with nav_form as selected_form %}
                         {% for form in module.get_forms %}
                             <li class="edit-form-li js-sorted-li"
                                 data-moduleuid="{{ module.unique_id }}"
                                 data-index="{{ form.id }}"
-                                data-indexvar="formid"
                                 {% if form.get_action_type == 'open' %}data-appear="first"{% endif %}
                             >
                                 {% include 'app_manager/partials/menu/form_link.html' %}


### PR DESCRIPTION
PRing into https://github.com/dimagi/commcare-hq/pull/23511

There were some bugs related to reordering forms and modules.  This PR rewrites a few things:

* Rather than assembling a series of html forms only to serialize them and send in an ajax request, this does that all in javascript directly
* The rearrangement logic was written to be generic with exceptions.  This treats forms and modules separately.
* Rather than calculating indices in a relative manner, this does a top-down reset, which is much simpler and should avoid some edge cases
* We already know `from`, so this switches to use that directly, and calculates `to` by comparing uids.  This removes a big block of code that I really didn't understand.

I'd originally hoped to avoid rewriting this, but it became clear that I couldn't understand what was going on well enough to preempt bugs, so I felt this was the best way forward.

@Rohit25negi code buddy
@orangejenny @proteusvacuum since you have context on the parent PR