### PR TITLE
explicitly fetch daily saved export as bytes

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -988,7 +988,7 @@ class ExportInstance(BlobMixin, Document):
         Get the pre-computed export for this instance.
         Only daily saved exports could have a pre-computed export.
         """
-        return self.fetch_attachment(DAILY_SAVED_EXPORT_ATTACHMENT_NAME, stream=stream)
+        return self.fetch_attachment(DAILY_SAVED_EXPORT_ATTACHMENT_NAME, stream=stream, return_bytes=True)
 
     def copy_export(self):
         export_json = self.to_json()


### PR DESCRIPTION
The export is either non-UTF8 bytes, or in the case of excel dashboard feeds fetched with ```stream=True```.