### PR TITLE
SMS export page shouldn't be location_safe

### DIFF
--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -479,6 +479,12 @@ class DownloadNewSmsExportView(BaseDownloadExportView):
     def parent_pages(self):
         return []
 
+    def dispatch(self, request, *args, **kwargs):
+        # for some reason, even though this export is not marked @location_safe
+        #   it is getting marked as location_safe due to some logic in the parent
+        #   dispatch method, this is a dirty hack to unmark it location_safe
+        return super(DownloadNewSmsExportView, self).dispatch(request, *args, **kwargs)
+
 
 class BulkDownloadNewFormExportView(DownloadNewFormExportView):
     urlname = 'new_bulk_download_forms'

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -370,7 +370,7 @@ def poll_custom_export_download(request, domain):
     return json_response(context)
 
 
-@location_safe
+@method_decorator(location_safe, 'dispatch')
 class DownloadNewFormExportView(BaseDownloadExportView):
     urlname = 'new_export_download_forms'
     export_filter_class = ExpandedMobileWorkerFilter
@@ -452,7 +452,7 @@ def has_multimedia(request, domain):
     })
 
 
-@location_safe
+@method_decorator(location_safe, 'dispatch')
 class DownloadNewCaseExportView(BaseDownloadExportView):
     urlname = 'new_export_download_cases'
     export_filter_class = CaseListFilter
@@ -478,12 +478,6 @@ class DownloadNewSmsExportView(BaseDownloadExportView):
     @property
     def parent_pages(self):
         return []
-
-    def dispatch(self, request, *args, **kwargs):
-        # for some reason, even though this export is not marked @location_safe
-        #   it is getting marked as location_safe due to some logic in the parent
-        #   dispatch method, this is a dirty hack to unmark it location_safe
-        return super(DownloadNewSmsExportView, self).dispatch(request, *args, **kwargs)
 
 
 class BulkDownloadNewFormExportView(DownloadNewFormExportView):

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -370,7 +370,7 @@ def poll_custom_export_download(request, domain):
     return json_response(context)
 
 
-@method_decorator(location_safe, 'dispatch')
+@location_safe
 class DownloadNewFormExportView(BaseDownloadExportView):
     urlname = 'new_export_download_forms'
     export_filter_class = ExpandedMobileWorkerFilter
@@ -452,7 +452,7 @@ def has_multimedia(request, domain):
     })
 
 
-@method_decorator(location_safe, 'dispatch')
+@location_safe
 class DownloadNewCaseExportView(BaseDownloadExportView):
     urlname = 'new_export_download_cases'
     export_filter_class = CaseListFilter

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -76,6 +76,7 @@ from functools import wraps
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.modules import to_function
 from django.http import Http404
+from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy
 from django.views.generic import View
@@ -160,11 +161,7 @@ def location_safe(view):
 
         # Django class-based views
         if issubclass(view, View):
-            # `View.as_view()` preserves stuff set on `dispatch`
-            if six.PY3:
-                view.dispatch.is_location_safe = True
-            else:
-                view.dispatch.__func__.is_location_safe = True
+            view = method_decorator(location_safe, 'dispatch')(view)
 
         # tastypie resources
         if issubclass(view, Resource):
@@ -188,10 +185,7 @@ def conditionally_location_safe(conditional_function):
 
             # Django class-based views
             if issubclass(view_fn, View):
-                if six.PY3:
-                    view_fn.dispatch._conditionally_location_safe_function = conditional_function
-                else:
-                    view_fn.dispatch.__func__._conditionally_location_safe_function = conditional_function
+                view_fn = method_decorator(_inner, 'dispatch')(view_fn)
 
             # HQ report classes
             if issubclass(view_fn, GenericReportView):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-444

Hey @esoergel 

For some reason even though, DownloadNewSmsExportView or any of its parent classes or not marked `@location_safe`, when the location middleware looks at the view, it finds that it has `is_location_safe` set to True. I haven't been able to figure out why that might be, but overriding the dispatch method fixes the issue. This is not a good solution, so if you have any idea what's going on here, I will do that instead.