### PR TITLE
Changes to UCR error handling

### DIFF
--- a/corehq/apps/userreports/adapter.py
+++ b/corehq/apps/userreports/adapter.py
@@ -59,7 +59,7 @@ class IndicatorAdapter(object):
         if not is_rate_limited(key):
             notify_exception(
                 None,
-                'unexpected error saving UCR doc: {}'.format(exception),
+                'unexpected error saving UCR doc',
                 details={
                     'domain': self.config.domain,
                     'doc_id': doc.get('_id', '<unknown>'),

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -265,21 +265,13 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Bul
             delete_ids = to_delete_by_adapter[adapter] + to_delete
             try:
                 adapter.bulk_delete(delete_ids)
-            except Exception as ex:
-                notify_exception(
-                    None,
-                    "Error in deleting changes chunk {ids}: {ex}".format(
-                        ids=delete_ids, ex=ex))
+            except Exception:
                 retry_changes.update([c for c in changes_chunk if c.id in delete_ids])
         # bulk update by adapter
         for adapter, rows in six.iteritems(rows_to_save_by_adapter):
             try:
                 adapter.save_rows(rows)
-            except Exception as ex:
-                notify_exception(
-                    None,
-                    "Error in saving changes chunk {ids}: {ex}".format(
-                        ids=[c.id for c in to_update], ex=repr(ex)))
+            except Exception:
                 retry_changes.update(to_update)
         if async_configs_by_doc_id:
             doc_type_by_id = {

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -138,8 +138,6 @@ class IndicatorSqlAdapter(IndicatorAdapter):
     def _best_effort_save_rows(self, rows, doc):
         try:
             self.save_rows(rows)
-        except IntegrityError:
-            pass  # can be due to users messing up their tables/data so don't bother logging
         except Exception as e:
             self.handle_exception(doc, e)
 


### PR DESCRIPTION
1. Don't notify on bulk errors since they get retried individually
2. Notify for integrity errors (rate limited)