### PR TITLE
pass return_bytes=True to fetch_attachment while preserving behavior …

### DIFF
--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -63,7 +63,11 @@ class CommCareBuild(BlobMixin, Document):
     def fetch_file(self, path, filename=None):
         if filename:
             path = '/'.join([path, filename])
-        return self.fetch_attachment(path)
+        attachment = self.fetch_attachment(path, return_bytes=True)
+        try:
+            return attachment.decode('utf-8')
+        except UnicodeDecodeError:
+            return attachment
 
     def get_jadjar(self, path, use_j2me_endpoint):
         """


### PR DESCRIPTION
…of CommCareBuild.fetch_file

This is the last usage of ```fetch_attachment``` that does not yet have ```return_bytes=True```.  After this change we'll be able to update the interface of ```fetch_attachment``` to only return bytes.