### PR TITLE
include info to debug instances of bytes

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -952,8 +952,7 @@ class GenericTabularReport(GenericReportView):
         """
         return dict(num=1, width=200)
 
-    @staticmethod
-    def _strip_tags(value):
+    def _strip_tags(self, value):
         """
         Strip HTML tags from a value
         """
@@ -964,7 +963,7 @@ class GenericTabularReport(GenericReportView):
         # take the knock. Assuming we won't have values with angle brackets,
         # using regex for now.
         if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+            soft_assert_type_text(value, data=(self.domain, six.text_type(self)))
             return re.sub('<[^>]*?>', '', value)
         return value
 

--- a/corehq/motech/repeaters/views/repeat_records.py
+++ b/corehq/motech/repeaters/views/repeat_records.py
@@ -264,7 +264,7 @@ class RepeatRecordView(View):
         if content_type == 'text/xml':
             payload = indent_xml(payload)
         elif content_type == 'application/json':
-            payload = pformat_json(payload)
+            payload = pformat_json(payload, domain=domain)
 
         return json_response({
             'payload': payload,

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -73,7 +73,7 @@ def b64_aes_decrypt(message):
     return plaintext.rstrip(PAD_CHAR)
 
 
-def pformat_json(data):
+def pformat_json(data, domain=None):
     """
     Pretty-formats `data` for readability, or returns the original
     value if it can't be parsed as JSON.
@@ -82,7 +82,7 @@ def pformat_json(data):
     """
     try:
         if isinstance(data, six.string_types):
-            soft_assert_type_text(data)
+            soft_assert_type_text(data, data=domain)
         json_data = json.loads(data) if isinstance(data, six.string_types) else data
         return json.dumps(json_data, indent=2, sort_keys=True)
     except ValueError:

--- a/corehq/util/python_compatibility.py
+++ b/corehq/util/python_compatibility.py
@@ -12,5 +12,8 @@ _soft_assert_type_text = soft_assert(
 
 
 # After PY3 migration: remove
-def soft_assert_type_text(value):
-    _soft_assert_type_text(isinstance(value, six.text_type), 'expected unicode, got: %s' % type(value))
+def soft_assert_type_text(value, data=None):
+    _soft_assert_type_text(
+        isinstance(value, six.text_type),
+        'expected unicode, got: %s%s' % (type(value), "; %s" % data if data is not None else '')
+    )


### PR DESCRIPTION
Adds some domain-level information to soft asserts that check for unicode.