### PR TITLE
fix teardown and reset of dependant databases

### DIFF
--- a/CITUSDB_SETUP.md
+++ b/CITUSDB_SETUP.md
@@ -34,6 +34,8 @@ DATABASES.update({
         'PORT': '5600',
         'TEST': {
             'SERIALIZE': False,
+            # this ensures the master gets created after / destroyed before the workers
+            'DEPENDENCIES': ['citus-ucr-worker1', 'citus-ucr-worker2'],
         },
         'ROLE': 'citus_master'
     },
@@ -47,8 +49,6 @@ DATABASES.update({
         'PORT': '5601',
         'TEST': {
             'SERIALIZE': False,
-            # this ensures the master gets created / destroyed before the workers
-            'DEPENDENCIES': ['icds-ucr'],
         },
         'ROLE': 'citus_worker',
         'CITUS_NODE_NAME': 'citus_worker1:5432'
@@ -63,7 +63,6 @@ DATABASES.update({
         'PORT': '5602',
         'TEST': {
             'SERIALIZE': False,
-            'DEPENDENCIES': ['icds-ucr'],
         },
         'ROLE': 'citus_worker',
         'CITUS_NODE_NAME': 'citus_worker2:5432'

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -22,6 +22,7 @@ from fnmatch import fnmatch
 from couchdbkit import ResourceNotFound
 from couchdbkit.ext.django import loading
 from django.core.management import call_command
+from django.test.utils import get_unique_databases_and_mirrors
 from mock import patch, Mock
 from nose.plugins import Plugin
 from nose.tools import nottest
@@ -203,6 +204,7 @@ class HqdbContext(DatabaseContext):
 
         from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
         self.blob_db = TemporaryFilesystemBlobDB()
+        self.old_names = self._get_databases()
 
         if self.skip_setup_for_reuse_db and self._databases_ok():
             if self.reuse_db == "migrate":
@@ -212,7 +214,7 @@ class HqdbContext(DatabaseContext):
             return  # skip remaining setup
 
         if self.reuse_db == "reset":
-            self.delete_couch_databases()
+            self.reset_databases()
 
         print("", file=sys.__stdout__)  # newline for creating database message
         if self.reuse_db:
@@ -223,10 +225,20 @@ class HqdbContext(DatabaseContext):
             self.runner.keepdb = True
         super(HqdbContext, self).setup()
 
+    def reset_databases(self):
+        self.delete_couch_databases()
+        # tear down all databases together to avoid dependency issues
+        teardown = []
+        for connection, db_name, is_first in self.old_names:
+            try:
+                connection.ensure_connection()
+                teardown.append((connection, db_name, is_first))
+            except OperationalError:
+                pass  # ignore databases that don't exist
+        self.runner.teardown_databases(reversed(teardown))
+
     def _databases_ok(self):
-        from django.db import connections
-        old_names = []
-        for connection in connections.all():
+        for connection, db_name, _ in self.old_names:
             db = connection.settings_dict
             assert db["NAME"].startswith(TEST_DATABASE_PREFIX), db["NAME"]
             try:
@@ -234,10 +246,18 @@ class HqdbContext(DatabaseContext):
             except OperationalError as e:
                 print(str(e), file=sys.__stderr__)
                 return False
-            old_names.append((connection, db["NAME"], True))
-
-        self.old_names = old_names
         return True
+
+    def _get_databases(self):
+        from django.db import connections
+        old_names = []
+        test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
+        assert not mirrored_aliases, "DB mirrors not supported"
+        for signature, (db_name, aliases) in test_databases.items():
+            alias = list(aliases)[0]
+            connection = connections[alias]
+            old_names.append((connection, db_name, True))
+        return old_names
 
     def delete_couch_databases(self):
         for db in get_all_test_dbs():
@@ -265,6 +285,9 @@ class HqdbContext(DatabaseContext):
 
         # in case this was set before we want to remove it now
         self.runner.keepdb = False
+
+        # tear down in reverse order
+        self.old_names = reversed(self.old_names)
         super(HqdbContext, self).teardown()
 
 

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -108,6 +108,7 @@ DATABASES.update({
         'PORT': '5432',
         'TEST': {
             'SERIALIZE': False,
+            'DEPENDENCIES': ['citus-ucr-worker1', 'citus-ucr-worker2'],
         },
         'ROLE': 'citus_master'
     },
@@ -121,7 +122,6 @@ DATABASES.update({
         'PORT': '5432',
         'TEST': {
             'SERIALIZE': False,
-            'DEPENDENCIES': ['icds-ucr'],
         },
         'ROLE': 'citus_worker'
     },
@@ -135,7 +135,6 @@ DATABASES.update({
         'PORT': '5432',
         'TEST': {
             'SERIALIZE': False,
-            'DEPENDENCIES': ['icds-ucr'],
         },
         'ROLE': 'citus_worker'
     },


### PR DESCRIPTION
Normal django setup (withouth reusedb or with `reusedb='reset'`) will delete and re-create each DB individually. With CitusDB this fails because of connections from the master to the workers.
