### PR TITLE
Docker fixes

### DIFF
--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -24,7 +24,7 @@ services:
       - "8000:8000"
     volumes:
       - ..:/mnt/commcare-hq-ro:ro
-      - hqservice-lib:/mnt/lib
+      - ${VOLUME_PREFIX}lib:/mnt/lib
 
   formplayer:
     extends:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -77,7 +77,7 @@ services:
     expose:
       - "9200"
     volumes:
-      - ${DATA_VOLUME_PREFIX}${BLANK_IF_TESTS-elasticsearch:}/usr/share/elasticsearch/data
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-elasticsearch:}/usr/share/elasticsearch/data
 
   kafka:
     image: spotify/kafka
@@ -95,7 +95,7 @@ services:
     expose:
       - "9980"
     volumes:
-      - ${DATA_VOLUME_PREFIX}${BLANK_IF_TESTS-riakcs:}/var/lib/riak-data
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-riakcs:}/var/lib/riak-data
 
   citus_master:
     image: 'citusdata/citus:8.1.1'

--- a/scripts/docker
+++ b/scripts/docker
@@ -218,7 +218,6 @@ else
     export KAFKA_ADVERTISED_HOST_NAME="$KAFKA_ADVERTISED_HOST_NAME"
 fi
 # export variables for compose file (they must be set or it complains)
-export DATA_VOLUME_PREFIX=${VOLUME_PREFIX}
 export DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 export PYTHON_VERSION="${PYTHON_VERSION:-py2}"
 export JS_SETUP="${JS_SETUP:-no}"


### PR DESCRIPTION
Fixes `ERROR: Named volume "hqservice-lib:/mnt/lib:rw" is used in service "web" but no declaration was found in the volumes section.` plus a little cleanup.

Review by commit 🐠 

@snopoke @gbova 