### PR TITLE
Add credits regression test back in

### DIFF
--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -17,6 +17,7 @@ from corehq.apps.accounting.models import (
     CustomerInvoice,
     InvoicingPlan,
     DomainUserHistory,
+    CreditLine
 )
 from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
@@ -255,6 +256,39 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
 
         num_feature_line_items = invoice.lineitem_set.get_features().count()
         self.assertEqual(num_feature_line_items, self.sub2.plan_version.feature_rates.count())
+
+    def test_account_level_product_credits(self):
+        CreditLine.add_credit(
+            amount=self.subscription.plan_version.product_rate.monthly_fee / 2,
+            account=self.account,
+            is_product=True
+        )
+        invoice_date = utils.months_from_date(self.subscription.date_start,
+                                              random.randint(2, self.subscription_length))
+        tasks.generate_invoices(invoice_date)
+
+        self.assertEqual(CustomerInvoice.objects.count(), 1)
+        invoice = CustomerInvoice.objects.first()
+        self.assertEqual(invoice.balance, Decimal('1350.0000'))
+
+    def test_subscription_level_product_credits(self):
+        CreditLine.add_credit(
+            self.subscription.plan_version.product_rate.monthly_fee / 2,
+            is_product=True,
+            subscription=self.subscription
+        )
+        CreditLine.add_credit(
+            self.sub2.plan_version.product_rate.monthly_fee / 4,
+            is_product=True,
+            subscription=self.sub2,
+        )
+        invoice_date = utils.months_from_date(self.subscription.date_start,
+                                              random.randint(2, self.subscription_length))
+        tasks.generate_invoices(invoice_date)
+
+        self.assertEqual(CustomerInvoice.objects.count(), 1)
+        invoice = CustomerInvoice.objects.first()
+        self.assertEqual(invoice.balance, Decimal('1050.0000'))
 
 
 class TestUserLineItem(BaseCustomerInvoiceCase):

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -488,6 +488,75 @@ class TestSmsLineItem(BaseCustomerInvoiceCase):
             self.assertEqual(sms_line_item.unit_cost, sms_cost)
             self.assertEqual(sms_line_item.total, sms_cost)
 
+    def test_subscription_level_sms_credits(self):
+        # Add SMS usage
+        arbitrary_sms_billables_for_domain(
+            self.domain, self.sms_date, self.sms_rate.monthly_limit + 1
+        )
+        arbitrary_sms_billables_for_domain(
+            self.domain2, self.sms_date, num_sms=self.advanced_rate.monthly_limit + 10
+        )
+
+        # Cover the cost of 1 SMS on the Standard subscription
+        CreditLine.add_credit(
+            amount=Decimal(0.7500),
+            feature_type=FeatureType.SMS,
+            subscription=self.subscription
+        )
+        # Cover the cost of 10 SMS on the Advanced subscription
+        CreditLine.add_credit(
+            amount=Decimal(7.5000),
+            feature_type=FeatureType.SMS,
+            subscription=self.sub2,
+        )
+
+        tasks.generate_invoices(self.invoice_date)
+        self.assertEqual(CustomerInvoice.objects.count(), 1)
+        invoice = CustomerInvoice.objects.first()
+        self.assertEqual(invoice.balance, Decimal('1500.0000'))
+
+    def test_one_subscription_level_sms_credit(self):
+        # Add SMS usage
+        arbitrary_sms_billables_for_domain(
+            self.domain, self.sms_date, self.sms_rate.monthly_limit + 1
+        )
+        arbitrary_sms_billables_for_domain(
+            self.domain2, self.sms_date, num_sms=self.advanced_rate.monthly_limit + 10
+        )
+
+        # Cover the cost of 1 SMS on the Standard subscription
+        CreditLine.add_credit(
+            amount=Decimal(0.7500),
+            feature_type=FeatureType.SMS,
+            subscription=self.subscription
+        )
+
+        tasks.generate_invoices(self.invoice_date)
+        self.assertEqual(CustomerInvoice.objects.count(), 1)
+        invoice = CustomerInvoice.objects.first()
+        self.assertEqual(invoice.balance, Decimal('1507.5000'))
+
+    def test_account_level_sms_credits(self):
+        # Add SMS usage
+        arbitrary_sms_billables_for_domain(
+            self.domain, self.sms_date, self.sms_rate.monthly_limit + 1
+        )
+        arbitrary_sms_billables_for_domain(
+            self.domain2, self.sms_date, num_sms=self.advanced_rate.monthly_limit + 10
+        )
+
+        # Cover the cost of 1 SMS
+        CreditLine.add_credit(
+            amount=Decimal(0.5000),
+            feature_type=FeatureType.SMS,
+            account=self.account,
+        )
+
+        tasks.generate_invoices(self.invoice_date)
+        self.assertEqual(CustomerInvoice.objects.count(), 1)
+        invoice = CustomerInvoice.objects.first()
+        self.assertEqual(invoice.balance, Decimal('1507.7500'))
+
     def _create_sms_line_items(self):
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -300,6 +300,8 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
         self.user_rate = self.subscription.plan_version.feature_rates \
             .filter(feature__feature_type=FeatureType.USER).get()
         self.advanced_rate = self.advanced_plan.feature_rates.filter(feature__feature_type=FeatureType.USER).get()
+        self.invoice_date = utils.months_from_date(self.subscription.date_start,
+                                                   random.randint(2, self.subscription_length))
 
     def test_under_limit(self):
         num_users = random.randint(0, self.user_rate.monthly_limit)
@@ -308,9 +310,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
         num_users_advanced = random.randint(0, self.advanced_rate.monthly_limit)
         generator.arbitrary_commcare_users_for_domain(self.domain2.name, num_users_advanced)
 
-        invoice_date = utils.months_from_date(self.subscription.date_start,
-                                              random.randint(2, self.subscription_length))
-        tasks.generate_invoices(invoice_date)
+        tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
 
         invoice = CustomerInvoice.objects.first()
@@ -333,9 +333,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
         num_users_advanced = self.advanced_rate.monthly_limit + 1
         generator.arbitrary_commcare_users_for_domain(self.domain2.name, num_users_advanced)
 
-        invoice_date = utils.months_from_date(self.subscription.date_start,
-                                              random.randint(2, self.subscription_length))
-        tasks.generate_invoices(invoice_date)
+        tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
 
         invoice = CustomerInvoice.objects.first()


### PR DESCRIPTION
These tests were [originally reverted](https://github.com/dimagi/commcare-hq/pull/22506), but now that Nick has added `is_using_test_plans` they're much more efficient and they shouldn't slow down our Travis tests as they did before.