### PR TITLE
Fixed pagination on data corrections modal

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -38,9 +38,18 @@ hqDefine('hqwebapp/js/components/pagination', [
             });
 
             self.slug = params.slug;
-            self.perPageCookieName = 'ko-pagination-' + self.slug;
+            self.inlinePageListOnly = !!params.inlinePageListOnly;
             self.perPage = ko.isObservable(params.perPage) ? params.perPage : ko.observable(params.perPage);
-            self.perPage($.cookie(self.perPageCookieName) || self.perPage());
+            if (!self.inlinePageListOnly) {
+                self.perPageCookieName = 'ko-pagination-' + self.slug;
+                self.perPage($.cookie(self.perPageCookieName) || self.perPage());
+                self.perPage.subscribe(function (newValue) {
+                    self.goToPage(1);
+                    if (self.slug) {
+                        $.cookie(self.perPageCookieName, newValue, { expires: 365, path: '/' });
+                    }
+                });
+            }
 
             self.perPageOptionsText = function (num) {
                 return _.template(gettext('<%= num %> per page'))({ num: num });
@@ -50,14 +59,6 @@ hqDefine('hqwebapp/js/components/pagination', [
                 return Math.ceil(self.totalItems() / self.perPage());
             });
 
-            self.perPage.subscribe(function (newValue) {
-                self.goToPage(1);
-                if (self.slug) {
-                    $.cookie(self.perPageCookieName, newValue, { expires: 365, path: '/' });
-                }
-            });
-
-            self.inlinePageListOnly = !!params.inlinePageListOnly;
             self.maxPagesShown = params.maxPagesShown || 9;
             self.showSpinner = params.showSpinner || ko.observable(false);
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/ko_pagination.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/ko_pagination.html
@@ -2,7 +2,7 @@
 <!-- used by corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js -->
 <script type="text/html" id="ko-pagination-template">
     <div data-bind="css: {row: !inlinePageListOnly}">
-        <div class="col-sm-5" data-bind="visible: !inlinePageListOnly">
+        <div class="col-sm-5" data-bind="if: !inlinePageListOnly">
             <div class="form-inline pagination-text">
                 <span data-bind="text: itemsText"></span>
                 <span>


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-482

Followup for https://github.com/dimagi/commcare-hq/pull/23673

What was happening was the pagination widget was writing the default "5" value to the `perPage` value. Data corrections does things differently; it controls the number of items per page itself and uses `inlinePageListOnly` to tell the pagination widget not to display the usual "X items per page" dropdown. This PR makes it so that if `inlinePageListOnly` is set, the pagination widget won't attempt to alter the value of `perPage`.

@gbova 