### PR TITLE
Revert "enforce view_report permission more strictly"

### DIFF
--- a/corehq/apps/dashboard/models.py
+++ b/corehq/apps/dashboard/models.py
@@ -203,7 +203,7 @@ class DataPaginator(TilePaginator):
     @memoized
     def form_exports(self):
         exports = []
-        if self.permissions.has_form_export_permissions:
+        if self.permissions.has_edit_permissions:
             from corehq.apps.export.dbaccessors import get_form_exports_by_domain
             exports = get_form_exports_by_domain(self.request.domain, self.permissions.has_deid_view_permissions)
         return exports
@@ -212,7 +212,7 @@ class DataPaginator(TilePaginator):
     @memoized
     def case_exports(self):
         exports = []
-        if self.permissions.has_case_export_permissions:
+        if self.permissions.has_edit_permissions:
             from corehq.apps.export.dbaccessors import get_case_exports_by_domain
             exports = get_case_exports_by_domain(self.request.domain, self.permissions.has_deid_view_permissions)
         return exports

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -24,7 +24,11 @@ from corehq.apps.locations.dbaccessors import user_ids_at_accessible_locations
 from corehq.apps.reports.v2.reports.explore_case_data import (
     ExploreCaseDataReport,
 )
-from corehq.apps.users.permissions import can_download_data_files
+from corehq.apps.users.permissions import (
+    can_view_form_exports,
+    can_view_case_exports,
+    can_download_data_files,
+)
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.util.workbook_json.excel import JSONReaderError, WorkbookJSONReader, \
     InvalidExcelFileException
@@ -80,9 +84,7 @@ def default_data_view_url(request, domain):
         FormExportListView,
         DeIdFormExportListView,
     )
-    from corehq.apps.export.views.utils import (DataFileDownloadList, user_can_view_deid_exports,
-        can_view_form_exports, can_view_case_exports)
-    from corehq.apps.data_interfaces.interfaces import CaseReassignmentInterface
+    from corehq.apps.export.views.utils import DataFileDownloadList, user_can_view_deid_exports
 
     if can_view_form_exports(request.couch_user, domain):
         return reverse(FormExportListView.urlname, args=[domain])
@@ -94,9 +96,6 @@ def default_data_view_url(request, domain):
 
     if can_download_data_files(domain, request.couch_user):
         return reverse(DataFileDownloadList.urlname, args=[domain])
-
-    if request.couch_user.can_edit_data:
-        return CaseReassignmentInterface.get_url(domain)
 
     raise Http404()
 
@@ -645,7 +644,6 @@ def xform_management_job_poll(request, domain, download_id,
 @login_and_domain_required
 @require_GET
 def find_by_id(request, domain):
-    from corehq.apps.export.views.utils import can_view_form_exports, can_view_case_exports
     can_view_cases = can_view_case_exports(request.couch_user, domain)
     can_view_forms = can_view_form_exports(request.couch_user, domain)
 

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -111,12 +111,12 @@ class ExportsPermissionsManager(object):
         return user_can_view_deid_exports(self.domain, self.couch_user)
 
     def access_list_exports_or_404(self, is_deid=False):
-        if not (self.has_view_permissions
+        if not (self.has_edit_permissions or self.has_view_permissions
                 or (is_deid and self.has_deid_view_permissions)):
             raise Http404()
 
     def access_download_export_or_404(self):
-        if not (self.has_view_permissions or self.has_deid_view_permissions):
+        if not (self.has_edit_permissions or self.has_view_permissions or self.has_deid_view_permissions):
             raise Http404()
 
 
@@ -311,11 +311,3 @@ class DataFileDownloadDetail(BaseProjectDataView):
             raise Http404
         data_file.delete()
         return HttpResponse(status=204)
-
-
-def can_view_form_exports(couch_user, domain):
-    return ExportsPermissionsManager('form', domain, couch_user).has_form_export_permissions
-
-
-def can_view_case_exports(couch_user, domain):
-    return ExportsPermissionsManager('case', domain, couch_user).has_form_export_permissions

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -39,8 +39,20 @@ def can_download_data_files(domain, couch_user):
     return toggles.DATA_FILE_DOWNLOAD.enabled(domain) and role.permissions.view_file_dropzone
 
 
+def can_view_form_exports(couch_user, domain):
+    return couch_user.can_edit_data(domain) or has_permission_to_view_report(
+        couch_user, domain, FORM_EXPORT_PERMISSION
+    )
+
+
+def can_view_case_exports(couch_user, domain):
+    return couch_user.can_edit_data(domain) or has_permission_to_view_report(
+        couch_user, domain, CASE_EXPORT_PERMISSION
+    )
+
+
 def can_view_sms_exports(couch_user, domain):
-    return has_permission_to_view_report(
+    return couch_user.can_edit_data(domain) or has_permission_to_view_report(
         couch_user, domain, SMS_EXPORT_PERMISSION
     )
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -27,7 +27,8 @@ from corehq.apps.cloudcare.const import DEVICE_ID as FORMPLAYER_DEVICE_ID
 from corehq.apps.commtrack.exceptions import MissingProductId
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.users.models import CouchUser
-from corehq.apps.users.permissions import has_permission_to_view_report
+from corehq.apps.users.permissions import can_view_case_exports, can_view_form_exports, \
+    has_permission_to_view_report
 from corehq.form_processor.exceptions import CouchSaveAborted, PostSaveError
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
@@ -161,7 +162,6 @@ class SubmissionPost(object):
             return _('Form successfully saved!')
 
         from corehq.apps.export.views.list import CaseExportListView, FormExportListView
-        from corehq.apps.export.views.utils import can_view_case_exports, can_view_form_exports
         from corehq.apps.reports.views import CaseDataView, FormDataView
         form_link = case_link = form_export_link = case_export_link = None
         form_view = 'corehq.apps.reports.standard.inspect.SubmitHistory'

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -41,6 +41,8 @@ from corehq.apps.translations.integrations.transifex.utils import transifex_deta
 from corehq.apps.userreports.util import has_report_builder_access
 from corehq.apps.users.models import AnonymousCouchUser
 from corehq.apps.users.permissions import (
+    can_view_form_exports,
+    can_view_case_exports,
     can_view_sms_exports,
     can_download_data_files,
 )
@@ -404,13 +406,11 @@ class ProjectDataTab(UITab):
     @property
     @memoized
     def can_view_form_exports(self):
-        from corehq.apps.export.views.utils import can_view_form_exports
         return can_view_form_exports(self.couch_user, self.domain)
 
     @property
     @memoized
     def can_view_case_exports(self):
-        from corehq.apps.export.views.utils import can_view_case_exports
         return can_view_case_exports(self.couch_user, self.domain)
 
     @property


### PR DESCRIPTION
Reverts dimagi/commcare-hq#23625

Reverting because the async call in the daily saved exports 404s across all domains with these changes.  @sravfeyn 