### PR TITLE
Update sidebar when child modules are created or changed

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5410,17 +5410,15 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
     def rearrange_modules(self, from_index, to_index):
         modules = self.modules
         try:
+            # remove module
             moving_module = modules.pop(from_index)
-            module_id = moving_module.unique_id
-            modules.insert(to_index, moving_module)
 
-            non_children = [m for m in modules if m.root_module_id != module_id]
-            children = [m for m in modules if m.root_module_id == module_id]
-            modules = []
-            for module in non_children:
-                modules.append(module)
-                if module.unique_id == module_id:
-                    modules.extend(children)
+            # remove its children
+            children = [m for m in modules if m.root_module_id == moving_module.unique_id]
+            modules = [m for m in modules if m.root_module_id != moving_module.unique_id]
+
+            # add back in module and children
+            modules = modules[:to_index] + [moving_module] + children + modules[to_index:]
 
         except IndexError:
             raise RearrangeError()

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -233,6 +233,7 @@ hqDefine('app_manager/js/app_manager', function () {
      * @private
      */
     var _initMenuItemSorting = function () {
+        var MODULE_SELECTOR = ".appmanager-main-menu .module";
         if (!hqImport('hqwebapp/js/toggles').toggleEnabled('LEGACY_CHILD_MODULES')) {
             nestChildModules();
             initChildModuleUpdateListener();
@@ -247,8 +248,9 @@ hqDefine('app_manager/js/app_manager', function () {
         }
 
         function initDragHandles() {
-            $('.drag_handle').addClass('fa fa-arrows-v');
-            $('.js-appnav-drag-module').on('mouseenter', function () {
+            var $scope = $(".appmanager-main-menu");
+            $scope.find('.drag_handle').addClass('fa fa-arrows-v');
+            $scope.find('.js-appnav-drag-module').on('mouseenter', function () {
                 $(this).closest('.js-sorted-li').addClass('appnav-highlight');
             }).on('mouseleave', function () {
                 $(this).closest('.js-sorted-li').removeClass('appnav-highlight');
@@ -257,7 +259,7 @@ hqDefine('app_manager/js/app_manager', function () {
         function nestChildModules() {
             var modulesByUid = getModulesByUid(),
                 childModules = [];
-            $(".module").each(function (index, element) {
+            $(MODULE_SELECTOR).each(function (index, element) {
                 // Set index here so we know whether we've rearranged anything
                 $(element).data('index', index);
                 if ($(element).data('rootmoduleuid')) {
@@ -275,7 +277,7 @@ hqDefine('app_manager/js/app_manager', function () {
         }
         function getModulesByUid() {
             var modulesByUid = {};
-            $(".module").each(function (index, element) {
+            $(MODULE_SELECTOR).each(function (index, element) {
                 modulesByUid[ $(element).data('uid') ] = element;
             });
             return modulesByUid;
@@ -289,15 +291,16 @@ hqDefine('app_manager/js/app_manager', function () {
             childList.append(childModule);
         }
         function moveModuleToBottom(module) {
-            $("ul.appnav-module").append(module);
+            $("ul.appmanager-main-menu").append(module);
         }
         function initChildModuleUpdateListener() {
             // If a child module is created or removed, update the sidebar
             $('#module-settings-form').on('saved-app-manager-form', function () {
-                var modulesByUid = getModulesByUid(),
-                    module = modulesByUid[$('#module-settings-form').data('moduleuid')],
+                var $form = $(this),
+                    modulesByUid = getModulesByUid(),
+                    module = modulesByUid[$form.data('moduleuid')],
                     oldRoot = $(module).data('rootmoduleuid'),
-                    newRoot = $('select[name=root_module_id]').val();
+                    newRoot = $form.find('select[name=root_module_id]').val();
 
                 if (newRoot !== oldRoot) {
                     $(module).data('rootmoduleuid', newRoot);
@@ -312,7 +315,7 @@ hqDefine('app_manager/js/app_manager', function () {
             });
         }
         function modulesWereReordered() {
-            return _.some($(".module"), function (element, index) {
+            return _.some($(MODULE_SELECTOR), function (element, index) {
                 return index !== $(element).data('index');
             });
         }
@@ -358,7 +361,7 @@ hqDefine('app_manager/js/app_manager', function () {
         function rearrangeModules($module) {
             var url = initialPageData.reverse('rearrange', 'modules'),
                 from = $module.data('index'),
-                to = _.findIndex($(".module"), function (module) {
+                to = _.findIndex($(MODULE_SELECTOR), function (module) {
                     return $(module).data('uid') === $module.data('uid');
                 });
 
@@ -367,7 +370,7 @@ hqDefine('app_manager/js/app_manager', function () {
             }
         }
         function resetIndexes() {
-            $(".module").each(function (index, module) {
+            $(MODULE_SELECTOR).each(function (index, module) {
                 $(module).data('index', index);
                 $(module).children("ul.sortable-forms").first().children("li").each(function (index, form) {
                     $(form).data('index', index);

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -306,6 +306,8 @@ hqDefine('app_manager/js/app_manager', function () {
                     } else {
                         addChildModuleToParent(module, modulesByUid[newRoot]);
                     }
+                    rearrangeModules($(module));
+                    resetIndexes();
                 }
             });
         }
@@ -336,7 +338,7 @@ hqDefine('app_manager/js/app_manager', function () {
             if ($sortable.hasClass('sortable-forms')) {
                 rearrangeForms(ui, $sortable);
             } else {
-                rearrangeModules(ui, $sortable);
+                rearrangeModules(ui.item);
             }
             resetIndexes();
         }
@@ -350,18 +352,18 @@ hqDefine('app_manager/js/app_manager', function () {
                 });
 
             if (to !== from || toModuleUid !== fromModuleUid) {
-                saveRearrangement($sortable, url, from, to, fromModuleUid, toModuleUid);
+                saveRearrangement(url, from, to, fromModuleUid, toModuleUid);
             }
         }
-        function rearrangeModules(ui, $sortable) {
+        function rearrangeModules($module) {
             var url = initialPageData.reverse('rearrange', 'modules'),
-                from = ui.item.data('index'),
+                from = $module.data('index'),
                 to = _.findIndex($(".module"), function (module) {
-                    return $(module).data('uid') === ui.item.data('uid');
+                    return $(module).data('uid') === $module.data('uid');
                 });
 
             if (to !== from) {
-                saveRearrangement($sortable, url, from, to);
+                saveRearrangement(url, from, to);
             }
         }
         function resetIndexes() {
@@ -373,7 +375,7 @@ hqDefine('app_manager/js/app_manager', function () {
                 });
             });
         }
-        function saveRearrangement($sortable, url, from, to, fromModuleUid, toModuleUid) {
+        function saveRearrangement(url, from, to, fromModuleUid, toModuleUid) {
             var data = {
                 from: from,
                 to: to,

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -4,6 +4,7 @@
 
 <form class="form-horizontal save-button-form"
       action="{% url 'edit_module_attr' domain app.id module.unique_id 'all' %}"
+      data-moduleuid="{{ module.unique_id }}"
       id="module-settings-form">
     {% csrf_token %}
     <div class="save-button-holder clearfix"></div>


### PR DESCRIPTION
PRing into https://github.com/dimagi/commcare-hq/pull/23511

This makes it so when you modify a module's parent, this is immediately reflected in the sidebar.

In testing it, I also found an ordering bug that I fixed.

@czue @calellowitz buddies
@orangejenny 