### PR TITLE
Reordered bulk app translation headers for form sheets

### DIFF
--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -394,7 +394,7 @@ def get_bulk_app_sheet_headers(app, exclude_module=None, exclude_form=None):
             sheet_name = get_form_sheet_name(form)
             headers.append([
                 sheet_name,
-                ["label"] + languages_list + audio_lang_list + image_lang_list + video_lang_list
+                ["label"] + languages_list + image_lang_list + audio_lang_list + video_lang_list
             ])
     return headers
 

--- a/corehq/apps/translations/tests/test_bulk_app_translation.py
+++ b/corehq/apps/translations/tests/test_bulk_app_translation.py
@@ -580,7 +580,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
         (MODULES_AND_FORMS_SHEET_NAME, ('Type', 'sheet_name', 'default_en', 'icon_filepath_en',
                                         'audio_filepath_en', 'unique_id')),
         ('module1', ('case_property', 'list_or_detail', 'default_en')),
-        ('module1_form1', ('label', 'default_en', 'audio_en', 'image_en', 'video_en'))
+        ('module1_form1', ('label', 'default_en', 'image_en', 'audio_en', 'video_en'))
     )
 
     excel_data = (
@@ -624,7 +624,7 @@ class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
             ['Modules_and_forms', ['Type', 'sheet_name', 'default_en',
              'icon_filepath_en', 'audio_filepath_en', 'unique_id']],
             ['module1', ['case_property', 'list_or_detail', 'default_en']],
-            ['module1_form1', ['label', 'default_en', 'audio_en', 'image_en', 'video_en']]
+            ['module1_form1', ['label', 'default_en', 'image_en', 'audio_en', 'video_en']]
         ])
 
         self.assertEqual(get_bulk_multimedia_sheet_headers('fra'),


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-431

Introduced in https://github.com/dimagi/commcare-hq/pull/23391/commits/7bead92ca59105dd391949f39fa4953f6ec7d0c6 : I should have also made this change but missed it. I updated tests in that commit but suspect I didn't run them and instead did test updates later, when I thought everything was working and just updated test data so that tests would pass. Which is not the way to update tests.

@mkangia / @gbova 