### PR TITLE
Management command for scripting to start Celery

### DIFF
--- a/corehq/util/management/commands/celery_is_eager.py
+++ b/corehq/util/management/commands/celery_is_eager.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from __future__ import print_function
 
 from django.conf import settings
 from django.core.management.base import BaseCommand

--- a/corehq/util/management/commands/celery_is_eager.py
+++ b/corehq/util/management/commands/celery_is_eager.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Prints "true" if settings.CELERY_TASK_ALWAYS_EAGER is truthy, else "false".'
+
+    def handle(self, **options):
+        always_eager = getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False)
+        print('true' if always_eager else 'false')


### PR DESCRIPTION
I don't know how we feel about adding utility management commands. I'm sure we wouldn't want an arbitrary number of them. But I wrote this for starting Celery when I need it, and I thought I'd share.

I use tmux to run Django locally. A snippet of my script goes something like
```bash

    tmux new-session -s cchq -n runserver \
            './manage.py runserver_plus 0.0.0.0:8000' \; \
        detach
    if [ `./manage.py celery_is_eager` != "true" ]
    then
        tmux attach-session -t cchq \; \
            new-window -n worker \
                'celery -A corehq worker -l info' \; \
            detach
    fi
```