### PR TITLE
disable datadog tracing in test / debug envs

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2168,6 +2168,13 @@ except ImportError:
 else:
     initialize(DATADOG_API_KEY, DATADOG_APP_KEY)
 
+if UNIT_TESTING or DEBUG:
+    try:
+        from ddtrace import tracer
+        tracer.enabled = False
+    except ImportError:
+        pass
+
 REST_FRAMEWORK = {
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%S.%fZ',
 }


### PR DESCRIPTION
I noticed in travis build's it's trying to send data to a local agent. Though it doesn't cause failure it does muddy the water with extra logging.