### PR TITLE
Adjust rebuild_export time buckets

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -10,7 +10,6 @@ import datetime
 
 from couchdbkit import ResourceConflict
 
-from corehq.apps.couch_sql_migration.couchsqlmigration import TIMING_BUCKETS
 from dimagi.utils.logging import notify_exception
 from soil import DownloadBase
 
@@ -22,7 +21,7 @@ from corehq.elastic import iter_es_docs_from_query
 from corehq.toggles import PAGINATED_EXPORTS
 from corehq.util.files import safe_filename, TransientTempfile
 from corehq.util.datadog.gauges import datadog_histogram, datadog_track_errors
-from corehq.util.datadog.utils import load_counter
+from corehq.util.datadog.utils import load_counter, DAY_SCALE_TIME_BUCKETS
 from corehq.apps.export.esaccessors import (
     get_form_export_base_query,
     get_case_export_base_query,
@@ -467,7 +466,7 @@ def _get_base_query(export_instance):
         )
 
 
-@datadog_track_errors('rebuild_export', duration_buckets=TIMING_BUCKETS)
+@datadog_track_errors('rebuild_export', duration_buckets=DAY_SCALE_TIME_BUCKETS)
 def rebuild_export(export_instance, progress_tracker):
     """
     Rebuild the given daily saved ExportInstance

--- a/corehq/util/datadog/tests/test_buckets.py
+++ b/corehq/util/datadog/tests/test_buckets.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 from datetime import timedelta
 
 from corehq.util.datadog.utils import make_bucket_from_timedeltas, DAY_SCALE_TIME_BUCKETS

--- a/corehq/util/datadog/tests/test_buckets.py
+++ b/corehq/util/datadog/tests/test_buckets.py
@@ -2,12 +2,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from datetime import timedelta
 
+from testil import eq
+
 from corehq.util.datadog.utils import make_bucket_from_timedeltas, DAY_SCALE_TIME_BUCKETS
 
 
 def test_make_bucket_from_timedeltas():
     buckets = [1, 10, 60, 10 * 60, 60 * 60, 12 * 60 * 60, 24 * 60 * 60]
-    assert make_bucket_from_timedeltas(
+    eq(make_bucket_from_timedeltas(
         timedelta(seconds=1),
         timedelta(seconds=10),
         timedelta(minutes=1),
@@ -15,5 +17,5 @@ def test_make_bucket_from_timedeltas():
         timedelta(hours=1),
         timedelta(hours=12),
         timedelta(hours=24),
-    ) == buckets
-    assert DAY_SCALE_TIME_BUCKETS == buckets
+    ), buckets)
+    eq(DAY_SCALE_TIME_BUCKETS, buckets)

--- a/corehq/util/datadog/tests/test_buckets.py
+++ b/corehq/util/datadog/tests/test_buckets.py
@@ -1,0 +1,17 @@
+from datetime import timedelta
+
+from corehq.util.datadog.utils import make_bucket_from_timedeltas, DAY_SCALE_TIME_BUCKETS
+
+
+def test_make_bucket_from_timedeltas():
+    buckets = [1, 10, 60, 10 * 60, 60 * 60, 12 * 60 * 60, 24 * 60 * 60]
+    assert make_bucket_from_timedeltas(
+        timedelta(seconds=1),
+        timedelta(seconds=10),
+        timedelta(minutes=1),
+        timedelta(minutes=10),
+        timedelta(hours=1),
+        timedelta(hours=12),
+        timedelta(hours=24),
+    ) == buckets
+    assert DAY_SCALE_TIME_BUCKETS == buckets

--- a/corehq/util/datadog/utils.py
+++ b/corehq/util/datadog/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import re
+from datetime import timedelta
 from functools import wraps
 
 from datadog import api
@@ -84,6 +85,21 @@ def get_url_group(url):
 def update_datadog_metrics(metrics):
     for metric, value in metrics.items():
         statsd.gauge(metric, value)
+
+
+def make_bucket_from_timedeltas(*timedeltas):
+    return [td.total_seconds() for td in timedeltas]
+
+
+DAY_SCALE_TIME_BUCKETS = make_bucket_from_timedeltas(
+    timedelta(seconds=1),
+    timedelta(seconds=10),
+    timedelta(minutes=1),
+    timedelta(minutes=10),
+    timedelta(hours=1),
+    timedelta(hours=12),
+    timedelta(hours=24),
+)
 
 
 def bucket_value(value, buckets, unit=''):


### PR DESCRIPTION
- Limit to 7 buckets for better datadog graphs
- Put in a shared place for reuse (DAY_SCALE_TIME_BUCKETS)

I've found the current buckets to be too granular to be helpful, and it datadog only has about 8 colors, so it was wrapping around which is visually confusing. These buckets were chosen to be very roughly logarithmic (10x, 6x, 10x, 6x, 12x) to be able to cover a day scale nicely, plus I threw 24h at the end because that's an important threshold for something that happens daily.