### PR TITLE
Use generator for Worker Activity report in email

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -37,7 +37,7 @@ def get_last_submission_time_for_users(domain, user_ids, datespan):
         return string_to_datetime(date).date() if date else None
 
     query = (
-        FormES()
+        FormES(es_instance_alias='export')
         .domain(domain)
         .user_id(user_ids)
         .completed(gte=datespan.startdate.date(), lte=datespan.enddate.date())

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -32,12 +32,12 @@ from six.moves import map
 PagedResult = namedtuple('PagedResult', 'total hits')
 
 
-def get_last_submission_time_for_users(domain, user_ids, datespan):
+def get_last_submission_time_for_users(domain, user_ids, datespan, es_instance_alias=ES_DEFAULT_INSTANCE):
     def convert_to_date(date):
         return string_to_datetime(date).date() if date else None
 
     query = (
-        FormES(es_instance_alias='export')
+        FormES(es_instance_alias=es_instance_alias)
         .domain(domain)
         .user_id(user_ids)
         .completed(gte=datespan.startdate.date(), lte=datespan.enddate.date())

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -1005,7 +1005,7 @@ class GenericTabularReport(GenericReportView):
             return [_unformat_val(val) for val in row]
 
         table = headers.as_export_table
-        rows = [_unformat_row(row) for row in self.export_rows]
+        rows = (_unformat_row(row) for row in self.export_rows)
         table.extend(rows)
         if self.total_row:
             table.append(_unformat_row(self.total_row))

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -828,6 +828,7 @@ class GenericTabularReport(GenericReportView):
     use_datatables = True
     charts_per_row = 1
     bad_request_error_text = None
+    exporting_as_excel = False
 
     # Sets bSort in the datatables instance to true/false (config.dataTables.bootstrap.js)
     sortable = True
@@ -1005,6 +1006,7 @@ class GenericTabularReport(GenericReportView):
             return [_unformat_val(val) for val in row]
 
         table = headers.as_export_table
+        self.exporting_as_excel = True
         rows = (_unformat_row(row) for row in self.export_rows)
         table.extend(rows)
         if self.total_row:

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -10,6 +10,7 @@ import json
 import logging
 from six.moves.urllib.parse import urlencode
 
+from corehq.elastic import ESError
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.http import Http404
@@ -575,6 +576,8 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
                 },
                 None,
             )
+        except ESError:
+            raise ESError
         except Exception:
             notify_exception(None, "Error generating report: {}".format(self.report_slug), details={
                 'domain': self.domain,

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -576,16 +576,6 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
                 },
                 None,
             )
-        except ESError:
-            raise ESError
-        except Exception:
-            notify_exception(None, "Error generating report: {}".format(self.report_slug), details={
-                'domain': self.domain,
-                'user': self.owner.username,
-                'report': self.report_slug,
-                'report config': self.get_id
-            })
-            return ReportContent(_("An error occurred while generating this report."), None)
 
     @property
     def is_active(self):

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1800,7 +1800,6 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
 
     @property
     def get_all_rows(self):
-        # Note, you can get rid of user_generator() if this works.
         user_query = EMWF.user_es_query(
             self.domain, self.request.GET.getlist(EMWF.slug), self.request.couch_user
         )
@@ -1809,6 +1808,8 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         user_list = [user for user in formatted_user_generator]
         formatted_data = self._report_data(users_to_iterate=user_list, user_ids=[a.user_id for a in user_list])
         formatted_rows = self._rows_by_user(formatted_data, user_list)
+
+        self.total_row = self._total_row(formatted_rows, formatted_data)
 
         return formatted_rows
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1350,6 +1350,7 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
 
     fix_left_col = True
     emailable = True
+    exportable_all = True
 
     NO_FORMS_TEXT = ugettext_noop('None')
 
@@ -1667,10 +1668,10 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             ])
         return rows
 
-    def _rows_by_user(self, report_data):
+    def _rows_by_user(self, report_data, users):
         rows = []
         last_form_by_user = self.es_last_submissions()
-        for user in self.users_to_iterate:
+        for user in users:
             owner_ids = set([user["user_id"].lower(), user["location_id"]] + user["group_ids"])
             active_cases = sum([int(report_data.active_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
             total_cases = sum([int(report_data.total_cases_by_owner.get(owner_id, 0)) for owner_id in owner_ids])
@@ -1737,12 +1738,12 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
             avg_datespan.startdate = datetime.datetime(1900, 1, 1)
         return avg_datespan
 
-    def _report_data(self):
+    def _report_data(self, users_to_iterate, user_ids):
         export = self.rendered_as == 'export'
         avg_datespan = self.avg_datespan
 
-        case_owners = _get_owner_ids_from_users(self.users_to_iterate)
-        user_ids = self.user_ids
+        case_owners = _get_owner_ids_from_users(users_to_iterate)
+        user_ids = user_ids
 
         return WorkerActivityReportData(
             avg_submissions_by_user=get_submission_counts_by_user(
@@ -1798,14 +1799,28 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         return total_row
 
     @property
+    def get_all_rows(self):
+        # Note, you can get rid of user_generator() if this works.
+        user_query = EMWF.user_es_query(
+            self.domain, self.request.GET.getlist(EMWF.slug), self.request.couch_user
+        )
+        paginated_user_query = util.get_paginated_user_query(user_query)
+        formatted_user_generator = (util._report_user_dict(single_user) for single_user in paginated_user_query)
+        user_list = [user for user in formatted_user_generator]
+        formatted_data = self._report_data(users_to_iterate=user_list, user_ids=[a.user_id for a in user_list])
+        formatted_rows = self._rows_by_user(formatted_data, user_list)
+
+        return formatted_rows
+
+    @property
     def rows(self):
-        report_data = self._report_data()
+        report_data = self._report_data(self.users_to_iterate, self.user_ids)
 
         rows = []
         if self.view_by_groups:
             rows = self._rows_by_group(report_data)
         else:
-            rows = self._rows_by_user(report_data)
+            rows = self._rows_by_user(report_data, self.users_to_iterate)
 
         self.total_row = self._total_row(rows, report_data)
         return rows

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -16,6 +16,7 @@ from memoized import memoized
 from pygooglechart import ScatterChart
 
 from corehq import toggles
+from corehq.elastic import ES_DEFAULT_INSTANCE
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.es import cases as case_es, filters
 from corehq.apps.es.aggregations import FilterAggregation, MissingAggregation, TermsAggregation
@@ -1485,7 +1486,11 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         """
         Creates a dict of userid => date of last submission
         """
-        return get_last_submission_time_for_users(self.domain, self.user_ids, self.datespan)
+        if self.exporting_as_excel:
+            es_instance_alias = 'export'
+        else:
+            es_instance_alias = ES_DEFAULT_INSTANCE
+        return get_last_submission_time_for_users(self.domain, self.user_ids, self.datespan, es_instance_alias=es_instance_alias)
 
     @staticmethod
     def _dates_for_linked_reports(datespan, case_list=False):

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -46,7 +46,7 @@ from corehq.apps.es.domains import DomainES
 from corehq.elastic import (
     stream_es_query,
     send_to_elasticsearch,
-    get_es_new, ES_META)
+    get_es_new, ES_META, ESError)
 from corehq.pillows.mappings.app_mapping import APP_INDEX
 from corehq.util.view_utils import absolute_reverse
 
@@ -274,7 +274,7 @@ def send_email_report(self, recipient_emails, domain, report_slug, report_type,
                             smtp_exception_skip_list=[LARGE_FILE_SIZE_ERROR_CODE])
 
     except Exception as er:
-        if getattr(er, 'smtp_code', None) == LARGE_FILE_SIZE_ERROR_CODE:
+        if getattr(er, 'smtp_code', None) == LARGE_FILE_SIZE_ERROR_CODE or type(er) == ESError:
             # If the smtp server rejects the email because of its large size.
             # Then sends the report download link in the email.
             report_state = {

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -261,13 +261,13 @@ def send_email_report(self, recipient_emails, domain, report_slug, report_type,
 
     subject = cleaned_data['subject'] or _("Email report from CommCare HQ")
 
-    content = _render_report_configs(
-        mock_request, [config], domain, user_id, couch_user, True, lang=couch_user.language,
-        notes=cleaned_data['notes'], once=once
-    )[0]
-    body = render_full_report_notification(None, content).content
-
     try:
+        content = _render_report_configs(
+            mock_request, [config], domain, user_id, couch_user, True, lang=couch_user.language,
+            notes=cleaned_data['notes'], once=once
+        )[0]
+        body = render_full_report_notification(None, content).content
+
         for recipient in recipient_emails:
             send_HTML_email(subject, recipient,
                             body, email_from=settings.DEFAULT_FROM_EMAIL,

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -292,6 +292,7 @@ def send_email_report(self, recipient_emails, domain, report_slug, report_type,
 def export_all_rows_task(ReportClass, report_state, recipient_list=None):
     report = object.__new__(ReportClass)
     report.__setstate__(report_state)
+    report.rendered_as = 'export'
 
     # need to set request
     setattr(report.request, 'REQUEST', {})

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -248,6 +248,11 @@ def _report_user_dict(user):
         return info
 
 
+def get_paginated_user_query(user_es_query):
+    users_query = user_es_query.fields(SimplifiedUserInfo.ES_FIELDS).scroll()
+    return users_query
+
+
 def get_simplified_users(user_es_query):
     """
     Accepts an instance of UserES and returns SimplifiedUserInfo dicts for the


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/705279448066644/1108792991464102/f)

The issue is that the report used to pull the entire table from ES and keep it in memory, format it, and then write it to excel, which would raise an ES error because the table is too large for ICDS. This uses all generators instead of ever saving the whole table in memory.

@calellowitz 
fyi @sravfeyn @esoergel  