### PR TITLE
write takes unicode, strftime returns bytes

### DIFF
--- a/corehq/ex-submodules/soil/heartbeat.py
+++ b/corehq/ex-submodules/soil/heartbeat.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
 from django.conf import settings
 from datetime import datetime, timedelta
 from django.core.cache import cache
@@ -26,7 +28,8 @@ def write_file_heartbeat():
     """
     if hasattr(settings, "SOIL_HEARTBEAT_FILE"):
         with open(settings.SOIL_HEARTBEAT_FILE, 'w', encoding='utf-8') as f:
-            f.write(datetime.utcnow().strftime(DATE_FORMAT))
+            now = datetime.utcnow().strftime(DATE_FORMAT)
+            f.write(six.text_type(now))
             return True
 
 


### PR DESCRIPTION
Resolves an error I was getting locally when running Celery with a Heartbeat file.
