### PR TITLE
use different metadata objects for different engines

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -18,7 +18,7 @@ from corehq.apps.userreports.exceptions import (
 from corehq.apps.userreports.models import AsyncIndicator
 from corehq.apps.userreports.rebuild import get_table_diffs, get_tables_rebuild_migrate, migrate_tables
 from corehq.apps.userreports.specs import EvaluationContext
-from corehq.apps.userreports.sql import metadata
+from corehq.apps.userreports.sql import get_metadata
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.sql_db.connections import connection_manager
@@ -160,7 +160,7 @@ class ConfigurableReportTableManagerMixin(object):
         for engine_id, table_map in tables_by_engine.items():
             table_names = list(table_map)
             engine = connection_manager.get_engine(engine_id)
-            diffs = get_table_diffs(engine, table_names, metadata)
+            diffs = get_table_diffs(engine, table_names, get_metadata(engine_id))
 
             tables_to_act_on = get_tables_rebuild_migrate(diffs, table_names)
             for table_name in tables_to_act_on.rebuild:

--- a/corehq/apps/userreports/sql/__init__.py
+++ b/corehq/apps/userreports/sql/__init__.py
@@ -1,2 +1,2 @@
-from .adapter import get_indicator_table, IndicatorSqlAdapter, metadata, ErrorRaisingIndicatorSqlAdapter
+from .adapter import get_indicator_table, IndicatorSqlAdapter, ErrorRaisingIndicatorSqlAdapter, get_metadata
 from .util import get_column_name

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -26,7 +26,11 @@ from corehq.util.test_utils import unit_testing_only
 logger = logging.getLogger(__name__)
 
 
-metadata = sqlalchemy.MetaData()
+engine_metadata = {}
+
+
+def get_metadata(engine_id):
+    return engine_metadata.setdefault(engine_id, sqlalchemy.MetaData())
 
 
 class IndicatorSqlAdapter(IndicatorAdapter):
@@ -47,12 +51,12 @@ class IndicatorSqlAdapter(IndicatorAdapter):
 
     @memoized
     def get_table(self):
-        return get_indicator_table(self.config)
+        return get_indicator_table(self.config, get_metadata(self.engine_id))
 
     @memoized
     def get_sqlalchemy_orm_table(self):
         table = self.get_table()
-        Base = declarative_base(metadata=metadata)
+        Base = declarative_base(metadata=get_metadata(self.engine_id))
 
         class TemporaryTableDef(Base):
             __table__ = table
@@ -137,7 +141,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
                 connection.execute('DROP TABLE "{tablename}" CASCADE'.format(tablename=table.name))
             else:
                 table.drop(connection, checkfirst=True)
-            metadata.remove(table)
+            get_metadata(self.engine_id).remove(table)
 
     @unit_testing_only
     def clear_table(self):
@@ -241,7 +245,7 @@ class ErrorRaisingIndicatorSqlAdapter(IndicatorSqlAdapter):
         super(ErrorRaisingIndicatorSqlAdapter, self).handle_exception(doc, exception)
 
 
-def get_indicator_table(indicator_config, custom_metadata=None):
+def get_indicator_table(indicator_config, metadata):
     sql_columns = [column_to_sql(col) for col in indicator_config.get_columns()]
     table_name = get_table_name(indicator_config.domain, indicator_config.table_id)
     columns_by_col_id = {col.database_column_name.decode('utf-8') for col in indicator_config.get_columns()}
@@ -262,7 +266,7 @@ def get_indicator_table(indicator_config, custom_metadata=None):
     # is that valid?
     return sqlalchemy.Table(
         table_name,
-        custom_metadata or metadata,
+        metadata,
         extend_existing=True,
         *columns_and_indices
     )
@@ -277,7 +281,6 @@ def _custom_index_name(table_name, column_ids):
 def rebuild_table(engine, table):
     with engine.begin() as connection:
         table.drop(connection, checkfirst=True)
-        metadata.remove(table)
         table.create(connection)
 
 

--- a/corehq/apps/userreports/tests/test_export.py
+++ b/corehq/apps/userreports/tests/test_export.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import datetime
+import sqlalchemy
+
 from django.test import SimpleTestCase
 
 from .test_data_source_config import get_sample_data_source
@@ -12,7 +14,7 @@ class ParameterTest(SimpleTestCase):
 
     def setUp(self):
         config = get_sample_data_source()
-        self.columns = get_indicator_table(config).columns
+        self.columns = get_indicator_table(config, sqlalchemy.MetaData()).columns
 
     def test_no_parameters(self):
         params = process_url_params({}, self.columns)


### PR DESCRIPTION
It occurred to me that having a global metadata might be fine for cases where we only have a single database but where we have multiple databases it would be better to split the metadata per DB.

Note that this splits it per `engine_id` which is not necessarily a 1-to-1 mapping with databases but has the same effect of not mixing tables from different databases in the same metadata.