### PR TITLE
Fix dashboard pagination alignment

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/ko_pagination.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/ko_pagination.html
@@ -2,7 +2,7 @@
 <!-- used by corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js -->
 <script type="text/html" id="ko-pagination-template">
     <div data-bind="css: {row: !inlinePageListOnly}">
-        <div class="col-sm-5" data-bind="if: !inlinePageListOnly">
+        <div class="col-sm-5" data-bind="visible: !inlinePageListOnly, if: !inlinePageListOnly">
             <div class="form-inline pagination-text">
                 <span data-bind="text: itemsText"></span>
                 <span>


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/23711 affected the alignment of pagination on the dashboard:
<img width="297" alt="Screen Shot 2019-03-22 at 11 04 25 AM" src="https://user-images.githubusercontent.com/1486591/54836494-50708b80-4c92-11e9-9a06-b159f7576d2d.png">

Fixed:
<img width="295" alt="Screen Shot 2019-03-22 at 11 04 34 AM" src="https://user-images.githubusercontent.com/1486591/54836499-55353f80-4c92-11e9-9d9d-a67334241e3a.png">

@gbova 