### PR TITLE
Fix search releases page

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -125,7 +125,10 @@ def paginate_releases(request, domain, app_id):
             app_es = app_es.is_released()
         if query:
             app_es = app_es.add_query(build_comment(query), queries.SHOULD)
-            app_es = app_es.add_query(version(query), queries.SHOULD)
+            try:
+                app_es = app_es.add_query(version(int(query)), queries.SHOULD)
+            except ValueError:
+                pass
 
         results = app_es.exclude_source().run()
         total_apps = results.total

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_search_box.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_search_box.html
@@ -1,6 +1,6 @@
 <script type="text/html" id="ko-search-box-template">
     <div class="ko-search-box">
-        <form class="input-group">
+        <form class="input-group" data-bind="submit: clickAction">
             <input type="text" class="form-control"
                    data-bind="value: value, valueUpdate: 'afterkeydown', attr: {placeholder: placeholder}, event: {keypress: keypressAction}"  />
             <span class="input-group-btn">


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-498

Fixes 2 issues:
- Hitting <enter> in a search box just reloaded all pages with that widget without performing a search
- If you searched for a string on the releases page, elasticsearch would complain that it wasn't a number. 