### PR TITLE
Add modules properly

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5465,8 +5465,8 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
                 else:
                     orphaned_modules.append(module)
 
-        self.modules = [m for modules in modules_by_parent_id.values() for m in modules]
-        self.modules += orphaned_modules
+        normal_modules = [m for modules in modules_by_parent_id.values() for m in modules]
+        self.modules = normal_modules + orphaned_modules
 
     def scrub_source(self, source):
         source = update_form_unique_ids(source)


### PR DESCRIPTION
The old version of this set the modules as expected, but the ones added via the += didn't persist on save.  Really bizzare bug - I'm guessing it comes from jsonobject overriding the assignment operator or `__iadd__` or something.

@orangejenny 
@czue @calellowitz buddies