### PR TITLE
Fix "Info no longer available" on large uploads

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -33,11 +33,8 @@
             <!--ko if: task_status().state == $root.states.FAILED-->
             <span class="label label-danger">{% trans "Failed" %}</span>
             <!--/ko-->
-            <!--ko if: task_status().state == $root.states.MISSING-->
+            <!--ko if: task_status().state == $root.states.MISSING || task_status().state == $root.states.NOT_STARTED -->
             {% trans "Waiting to start" %}
-            <!--/ko-->
-            <!--ko if: task_status().state == $root.states.NOT_STARTED-->
-            {% trans "Info no longer available" %}
             <!--/ko-->
             <!--ko if: task_status().state == $root.states.STARTED-->
             <div class="progress">

--- a/corehq/apps/case_importer/tracking/task_status.py
+++ b/corehq/apps/case_importer/tracking/task_status.py
@@ -13,7 +13,7 @@ class TaskStatus(jsonobject.StrictJsonObject):
     result = jsonobject.ObjectProperty(lambda: TaskStatusResult)
 
     def is_finished(self):
-        return self.state not in (STATES.missing, STATES.started)
+        return self.state in (STATES.success, STATES.failed)
 
 
 class TaskStatusProgress(jsonobject.StrictJsonObject):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-502

I think the new version of celery might be more proactive about returning "not started" (status = 'pending'). Something weird is happening with async restore too, which I think might be caused by this.

"Pending" was listed as a "finished" state previously, so whenever a large import was created, it was saving this state to the model, (https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/case_importer/tracking/views.py#L36-L37), and for some reason in the view "not started" was showing as "Info no longer available".

I think there's maybe a chore to go and clean up recent uploads that have this "Info no longer available" state, if that information is still available from celery, otherwise they will currently be listed as "Waiting to start" even though some of them will have been completed. Will have to think about what to do there.

