### PR TITLE
re-fetch doc from DB on conflict

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -266,6 +266,7 @@ def download_file(request, domain, app_id, path):
         except ResourceConflict:
             if is_retry:
                 raise
+            request.app = Application.get(request.app.get_id)
             create_build_files_if_necessary_handling_conflicts(True)
 
     try:


### PR DESCRIPTION
I'm not sure why we might get conflicts here but adding this line does seem like the correct approach to handling it. I'm not sure how this would ever have worked before.