### PR TITLE
allow flexibility in widget js to use a different id

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/widgets_v4.js
+++ b/corehq/apps/app_manager/static/app_manager/js/widgets_v4.js
@@ -11,8 +11,8 @@ hqDefine("app_manager/js/widgets_v4", [
 ) {
     var initVersionDropdown = function ($select, options) {
         options = options || {};
-        assertProperties.assert(options, [], ['url', 'width']);
-
+        assertProperties.assert(options, [], ['url', 'width', 'idValue']);
+        var idValue = options.idValue || 'id';
         $select.select2({
             ajax: {
                 url: options.url || initialPageData.reverse('paginate_releases'),
@@ -28,7 +28,7 @@ hqDefine("app_manager/js/widgets_v4", [
                     return {
                         results: _.map(data.apps, function (build) {
                             return {
-                                id: build.id,
+                                id: build[idValue],
                                 text: build.version + ": " + (build.build_comment || gettext("no comment")),
                             };
                         }),

--- a/corehq/apps/translations/static/translations/js/app_translations.js
+++ b/corehq/apps/translations/static/translations/js/app_translations.js
@@ -19,6 +19,7 @@ hqDefine("translations/js/app_translations", [
                     return initialPageData.reverse("paginate_releases", appId);
                 },
                 width: '100%',
+                idValue: 'version',
             });
         });
 


### PR DESCRIPTION
introduced [here](https://github.com/dimagi/commcare-hq/pull/23521/files#diff-b6bc312ea20c7f6e9bb4d0604be7bc35)

the form expects to share version number instead of build id. So added that option in js