### PR TITLE
Drop repeat record lock

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -58,7 +58,10 @@ def check_repeaters():
 
 @task(serializer='pickle', queue=settings.CELERY_REPEAT_RECORD_QUEUE)
 def process_repeat_record(repeat_record):
-    if repeat_record.state == RECORD_FAILURE_STATE and repeat_record.overall_tries >= repeat_record.max_possible_tries:
+    if (
+        repeat_record.state == RECORD_FAILURE_STATE and
+        repeat_record.overall_tries >= repeat_record.max_possible_tries
+    ):
         repeat_record.cancel()
         repeat_record.save()
         return

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -63,7 +63,7 @@ def check_repeaters():
     try:
         with datadog_bucket_timer(
             "commcare.repeaters.check.processing",
-            buckets=_check_repeaters_buckets,
+            timing_buckets=_check_repeaters_buckets,
         ):
             for record in iterate_repeat_records(start):
                 if datetime.utcnow() > six_hours_later:

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -63,6 +63,7 @@ def check_repeaters():
     try:
         with datadog_bucket_timer(
             "commcare.repeaters.check.processing",
+            tags=[],
             timing_buckets=_check_repeaters_buckets,
         ):
             for record in iterate_repeat_records(start):

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -51,8 +51,7 @@ def check_repeaters():
             if datetime.utcnow() > six_hours_later:
                 _soft_assert(False, "I've been iterating repeat records for six hours. I quit!")
                 break
-            if acquire_redis_lock(record):
-                record.attempt_forward_now()
+            record.attempt_forward_now()
     finally:
         check_repeater_lock.release()
 
@@ -86,20 +85,6 @@ def process_repeat_record(repeat_record):
                 repeat_record.fire()
     except Exception:
         logging.exception('Failed to process repeat record: {}'.format(repeat_record._id))
-
-
-def acquire_redis_lock(record):
-    # TODO: Drop this lock at least 48 hours after PR #23580 is deployed
-    # By that time all repeat records will have next_check set in the future.
-
-    # Including _rev in the key means that the record will be unlocked
-    # for processing every time we execute a `save()` call.
-    return get_redis_lock(
-        'repeat_record_in_progress-{}_{}'.format(record._id, record._rev),
-        timeout=48 * 60 * 60,
-        name="repeat_record",
-        track_unreleased=False,
-    ).acquire()
 
 
 repeaters_overdue = datadog_gauge_task(

--- a/corehq/util/datadog/tests/test_buckets.py
+++ b/corehq/util/datadog/tests/test_buckets.py
@@ -4,12 +4,12 @@ from datetime import timedelta
 
 from testil import eq
 
-from corehq.util.datadog.utils import make_bucket_from_timedeltas, DAY_SCALE_TIME_BUCKETS
+from corehq.util.datadog.utils import make_buckets_from_timedeltas, DAY_SCALE_TIME_BUCKETS
 
 
-def test_make_bucket_from_timedeltas():
+def test_make_buckets_from_timedeltas():
     buckets = [1, 10, 60, 10 * 60, 60 * 60, 12 * 60 * 60, 24 * 60 * 60]
-    eq(make_bucket_from_timedeltas(
+    eq(make_buckets_from_timedeltas(
         timedelta(seconds=1),
         timedelta(seconds=10),
         timedelta(minutes=1),

--- a/corehq/util/datadog/utils.py
+++ b/corehq/util/datadog/utils.py
@@ -87,11 +87,11 @@ def update_datadog_metrics(metrics):
         statsd.gauge(metric, value)
 
 
-def make_bucket_from_timedeltas(*timedeltas):
+def make_buckets_from_timedeltas(*timedeltas):
     return [td.total_seconds() for td in timedeltas]
 
 
-DAY_SCALE_TIME_BUCKETS = make_bucket_from_timedeltas(
+DAY_SCALE_TIME_BUCKETS = make_buckets_from_timedeltas(
     timedelta(seconds=1),
     timedelta(seconds=10),
     timedelta(minutes=1),


### PR DESCRIPTION
...and add instrumentation so we maintain visibility of what's happening in `check_repeaters` even though it no longer acquires a lock per repeat record.

This must not be merged until at least 2 days after https://github.com/dimagi/commcare-hq/pull/23743. Otherwise it's possible some repeat records could be processed twice.

Review by commit 🐡 

@kaapstorm @Rohit25negi 