### PR TITLE
don't revoke pending export

### DIFF
--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -112,16 +112,10 @@ def rebuild_saved_export(export_instance_id, manual=False):
     """
     download_data = _get_saved_export_download_data(export_instance_id)
     status = get_task_status(download_data.task)
-    if manual:
-        if status.missing():
-            # cancel pending task before kicking off a new one
-            if download_data.task:
-                download_data.task.revoke()
-        if status.not_started() or status.started():
-            return  # noop - make the user wait before starting a new one
-    else:
-        if status.not_started() or status.started():
-            return  # noop - one's already on the way
+    if manual and status.missing() and download_data.task:
+        download_data.task.revoke()
+    if status.not_started() or status.started():
+        return
 
     # associate task with the export instance
     download_data.set_task(

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -113,11 +113,11 @@ def rebuild_saved_export(export_instance_id, manual=False):
     download_data = _get_saved_export_download_data(export_instance_id)
     status = get_task_status(download_data.task)
     if manual:
-        if status.not_started() or status.missing():
+        if status.missing():
             # cancel pending task before kicking off a new one
             if download_data.task:
                 download_data.task.revoke()
-        if status.started():
+        if status.not_started() or status.started():
             return  # noop - make the user wait before starting a new one
     else:
         if status.not_started() or status.started():


### PR DESCRIPTION
Related to https://github.com/dimagi/commcare-hq/pull/23751

I've noticed that when saved_export_queue workers go down there's usually a task that's been revoked immediately before.  This change will avoid revoking a task with the ```not_started``` status.

