### PR TITLE
Fix excel content error

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -125,7 +125,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     ];
 
     if (vm.haveAccessToFeatures) {
-        vm.indicators.push({id: 9, name: 'Lady Supervisor'});
+        vm.indicators.push({id: 9, name: 'LS Performance Report'});
     }
 
 

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -1018,7 +1018,7 @@ def create_lady_supervisor_excel_file(excel_data, data_type, month, aggregation_
 
     workbook = Workbook()
     worksheet = workbook.active
-    worksheet.title = "Lady Supervisor Performance"
+    worksheet.title = "LS Performance Report"
     worksheet.sheet_view.showGridLines = False
     # sheet title
     amount_of_columns = 9 - aggregation_level

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -1018,7 +1018,7 @@ def create_lady_supervisor_excel_file(excel_data, data_type, month, aggregation_
 
     workbook = Workbook()
     worksheet = workbook.active
-    worksheet.title = "Lady Supervisor Performance Report"
+    worksheet.title = "Lady Supervisor Performance"
     worksheet.sheet_view.showGridLines = False
     # sheet title
     amount_of_columns = 9 - aggregation_level


### PR DESCRIPTION
Hi @calellowitz,
I have fixed the issue where an error message is being displayed on opening excel file: “We found a problem with some content in (report). Do you want us to try to recover as much as we can? If you trust the source of this workbook, click Yes.”.
The reason is that for some versions of excel worksheet title has to be shorter than 31 characters.
Need QA: Yes
Environment: n/a
Locally Tested: Yes
Regards, Dawid