### PR TITLE
Add indication of previous build comments

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -350,13 +350,16 @@ def revert_to_copy(request, domain, app_id):
         request,
         "Successfully reverted to version %s, now at version %s" % (copy.version, app.version)
     )
+    copy_build_comment_template = "Reverted to version {old_version}"
+    copy_build_comment_params = {
+        "old_version": copy.version,
+        "original_comment": copy.build_comment,
+    }
     if copy.build_comment:
-        new_build_comment = "Reverted to version {old_version}\n\n{original_comment}".format(
-            old_version=copy.version, original_comment=copy.build_comment)
-    else:
-        new_build_comment = "Reverted to version {old_version}".format(old_version=copy.version)
+        copy_build_comment_template += "\n\nPrevious build comments:\n{original_comment}"
+
     copy = app.make_build(
-        comment=new_build_comment,
+        comment=copy_build_comment_template.format(**copy_build_comment_params),
         user_id=request.couch_user.get_id,
     )
     copy.save(increment_version=False)

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -348,15 +348,20 @@ def revert_to_copy(request, domain, app_id):
     app.save()
     messages.success(
         request,
-        "Successfully reverted to version %s, now at version %s" % (copy.version, app.version)
+        _("Successfully reverted to version %(old_version)s, now at version %(new_version)s") % {
+            'old_version': copy.version,
+            'new_version': app.version,
+        }
     )
-    copy_build_comment_template = "Reverted to version {old_version}"
     copy_build_comment_params = {
         "old_version": copy.version,
         "original_comment": copy.build_comment,
     }
     if copy.build_comment:
-        copy_build_comment_template += "\n\nPrevious build comments:\n{original_comment}"
+        copy_build_comment_template = _(
+            "Reverted to version {old_version}\n\nPrevious build comments:\n{original_comment}")
+    else:
+        copy_build_comment_template = _("Reverted to version {old_version}")
 
     copy = app.make_build(
         comment=copy_build_comment_template.format(**copy_build_comment_params),


### PR DESCRIPTION
@orangejenny Following up on the comment questions. This was suggested by Priyanka and Nick Nestle

Product Note: When reverting an app, the build includes a comment of the format:

```
Reverted to version #XYZ

Previous build comments:
My super cool build
```