### PR TITLE
acknowledge existing task for all statuses except PENDING and REVOKED

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -16,6 +16,7 @@ from xml.etree import cElementTree as ElementTree
 import six
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
+from celery.states import PENDING, REVOKED
 from django.http import HttpResponse, StreamingHttpResponse
 from django.conf import settings
 from django.utils.text import slugify
@@ -627,7 +628,7 @@ class RestoreConfig(object):
         task_id = self.async_restore_task_id_cache.get_value()
         if task_id:
             task = AsyncResult(task_id)
-            task_exists = task.status == ASYNC_RESTORE_SENT
+            task_exists = task.status not in [PENDING, REVOKED]
         else:
             task = None
             task_exists = False


### PR DESCRIPTION
Accept statuses SENT and those in http://docs.celeryproject.org/en/latest/reference/celery.states.html except for PENDING and REVOKED.

Hoping that this will stop the issues that arise when the queue is backlogged.