### PR TITLE
Fetch celery task id from headers instead of body

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -16,7 +16,6 @@ from xml.etree import cElementTree as ElementTree
 import six
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
-from celery.states import PENDING, REVOKED
 from django.http import HttpResponse, StreamingHttpResponse
 from django.conf import settings
 from django.utils.text import slugify
@@ -628,7 +627,7 @@ class RestoreConfig(object):
         task_id = self.async_restore_task_id_cache.get_value()
         if task_id:
             task = AsyncResult(task_id)
-            task_exists = task.status not in [PENDING, REVOKED]
+            task_exists = task.status == ASYNC_RESTORE_SENT
         else:
             task = None
             task_exists = False

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -54,7 +54,7 @@ def get_async_restore_payload(restore_config, domain=None, username=None):
 
 
 @after_task_publish.connect
-def update_celery_state(sender=None, body=None, **kwargs):
+def update_celery_state(sender=None, headers=None, **kwargs):
     """Updates the celery task progress to "SENT"
 
     When fetching an task from celery using the form AsyncResponse(task_id), if
@@ -72,7 +72,7 @@ def update_celery_state(sender=None, body=None, **kwargs):
     task = current_app.tasks.get(sender)
     backend = task.backend if task else current_app.backend
 
-    backend.store_result(body['id'], None, ASYNC_RESTORE_SENT)
+    backend.store_result(headers['id'], None, ASYNC_RESTORE_SENT)
 
 
 @periodic_task(


### PR DESCRIPTION
Celery v4.0 has a new message protocol (V2) which stores this info in the headers: http://docs.celeryproject.org/en/latest/internals/protocol.html#message-protocol-task-v2

Why was this failing silently? Celery swallows errors thrown in functions thrown from signals: 

https://github.com/celery/celery/blob/master/celery/utils/dispatch/signal.py#L287-L294

I've confirmed that this correctly updates the state of a task that hasn't yet started on the new celery backend. 

#ants-on-a-log