### PR TITLE
Markdown docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ import django
 import sys, os
 from mock import MagicMock
 import sphinx_rtd_theme
+from recommonmark.parser import CommonMarkParser
 
 sys.path.insert(0, os.path.abspath('..'))
 from ..manage import init_hq_python_path
@@ -33,6 +34,15 @@ MOCK_MODULES = ["PIL.Image", "PIL"]
 sys.modules.update((mod_name, MagicMock()) for mod_name in MOCK_MODULES)
 
 
+# Support including markdown files in the documentation
+source_parsers = {
+    '.md': CommonMarkParser,
+}
+
+# The suffix of source filenames.
+source_suffix = ['.rst', '.md']
+
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -44,9 +54,6 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinxcontrib_django
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-
-# The suffix of source filenames.
-source_suffix = '.rst'
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ Welcome to CommCareHQ's documentation!
    restore-logic
    couchdb
    celery
+   js-guide/README
 
 Tips for documenting
 --------------------

--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -6,6 +6,7 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
+alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==2.4.2
 argparse==1.4.0
@@ -27,6 +28,7 @@ click==7.0                # via pip-tools
 cloudant==2.11.0
 colorama==0.4.1           # via sniffer
 commcaretranslationchecker==0.9.3.5
+commonmark==0.8.1         # via recommonmark
 concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 coverage==4.5.1
@@ -82,6 +84,7 @@ faker==0.8.15
 fixture==1.5.11
 freezegun==0.3.11
 funcsigs==1.0.2
+future==0.17.1            # via commonmark
 gevent==1.2.2
 ghdiff==0.4
 gnureadline==6.3.8
@@ -92,6 +95,7 @@ hiredis==0.2.0
 html5lib==1.0.1
 httpagentparser==1.8.2
 idna==2.8
+imagesize==1.1.0          # via sphinx
 ipaddress==1.0.22
 ipdb==0.11
 ipython-genutils==0.2.0   # via traitlets
@@ -121,6 +125,7 @@ msgpack-python==0.5.6
 nose-exclude==0.5.0
 nose==1.3.7
 openpyxl==2.6.1
+packaging==19.0           # via sphinx
 paramiko==2.4.2           # via fabric
 pathlib2==2.3.3           # via ipython, pickleshare
 pbr==5.1.3
@@ -147,6 +152,7 @@ pygooglechart==0.4.0
 pyjwt==1.7.1
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0
+pyparsing==2.3.1          # via packaging
 pypdf2==1.26.0
 pystache==0.5.4
 python-dateutil==2.8.0
@@ -162,6 +168,7 @@ qrcode==4.0.4
 quickcache==0.5.3
 raven==6.1.0
 rcssmin==1.0.6
+recommonmark==0.5.0
 redis-py-cluster==1.3.6
 redis==2.10.6
 reportlab==3.0
@@ -177,8 +184,11 @@ simplejson==3.16.0
 six==1.12.0
 smartypants==2.0.1
 sniffer==0.4.0
+snowballstemmer==1.2.1    # via sphinx
 socketpool==0.5.3
 soupsieve==1.8
+sphinx==1.8.5             # via recommonmark
+sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlagg==0.12.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.2.18
@@ -193,7 +203,7 @@ traitlets==4.3.2          # via ipython
 transifex-client==0.12.4
 tropo-webapi-python==0.1.3
 twilio==6.5.1
-typing==3.6.6             # via django-extensions
+typing==3.6.6             # via django-extensions, sphinx
 ua-parser==0.8.0
 unidecode==0.04.20
 unittest2==1.1.0

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -20,6 +20,7 @@ cffi==1.12.2
 chardet==3.0.4
 cloudant==2.11.0
 commcaretranslationchecker==0.9.3.5
+commonmark==0.8.1         # via recommonmark
 concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.6.1
@@ -69,6 +70,7 @@ ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2
+future==0.17.1            # via commonmark
 gevent==1.2.2
 ghdiff==0.4
 greenlet==0.4.12
@@ -130,6 +132,7 @@ qrcode==4.0.4
 quickcache==0.5.3
 raven==6.1.0
 rcssmin==1.0.6
+recommonmark==0.5.0
 redis-py-cluster==1.3.6
 redis==2.10.6
 reportlab==3.0

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -16,3 +16,4 @@ modernize
 Fabric==1.14.0
 gnureadline==6.3.8
 pip-tools~=3.0
+recommonmark==0.5.0

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -16,4 +16,4 @@ modernize
 Fabric==1.14.0
 gnureadline==6.3.8
 pip-tools~=3.0
-recommonmark==0.5.0
+recommonmark

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -6,6 +6,7 @@
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
+alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==2.4.2
 argparse==1.4.0
@@ -27,6 +28,7 @@ click==7.0                # via pip-tools
 cloudant==2.11.0
 colorama==0.4.1           # via sniffer
 commcaretranslationchecker==0.9.3.5
+commonmark==0.8.1         # via recommonmark
 concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 coverage==4.5.1
@@ -82,6 +84,7 @@ faker==0.8.15
 fixture==1.5.11
 freezegun==0.3.11
 funcsigs==1.0.2
+future==0.17.1            # via commonmark
 futures==3.2.0
 gevent==1.2.2
 ghdiff==0.4
@@ -93,6 +96,7 @@ hiredis==0.2.0
 html5lib==1.0.1
 httpagentparser==1.8.2
 idna==2.8
+imagesize==1.1.0          # via sphinx
 ipaddress==1.0.22
 ipdb==0.11
 ipython-genutils==0.2.0   # via traitlets
@@ -122,6 +126,7 @@ msgpack-python==0.5.6
 nose-exclude==0.5.0
 nose==1.3.7
 openpyxl==2.6.1
+packaging==19.0           # via sphinx
 paramiko==2.4.2           # via fabric
 pathlib2==2.3.3           # via ipython, pickleshare
 pbr==5.1.3
@@ -148,6 +153,7 @@ pygooglechart==0.4.0
 pyjwt==1.7.1
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0
+pyparsing==2.3.1          # via packaging
 pypdf2==1.26.0
 pystache==0.5.4
 python-dateutil==2.8.0
@@ -163,6 +169,7 @@ qrcode==4.0.4
 quickcache==0.5.3
 raven==6.1.0
 rcssmin==1.0.6
+recommonmark==0.5.0
 redis-py-cluster==1.3.6
 redis==2.10.6
 reportlab==3.0
@@ -178,8 +185,11 @@ simplejson==3.16.0
 six==1.12.0
 smartypants==2.0.1
 sniffer==0.4.0
+snowballstemmer==1.2.1    # via sphinx
 socketpool==0.5.3
 soupsieve==1.8
+sphinx==1.8.5             # via recommonmark
+sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlagg==0.12.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.2.18
@@ -194,7 +204,7 @@ traitlets==4.3.2          # via ipython
 transifex-client==0.12.4
 tropo-webapi-python==0.1.3
 twilio==6.5.1
-typing==3.6.6             # via django-extensions
+typing==3.6.6             # via django-extensions, sphinx
 ua-parser==0.8.0
 unidecode==0.04.20
 unittest2==1.1.0

--- a/requirements/docs-requirements.in
+++ b/requirements/docs-requirements.in
@@ -5,4 +5,4 @@ sphinx-rtd-theme~=0.3
 docutils==0.14
 django-extensions==1.7.7
 sphinxcontrib-django~=0.3
-recommonmark==0.5.0
+recommonmark

--- a/requirements/docs-requirements.in
+++ b/requirements/docs-requirements.in
@@ -5,3 +5,4 @@ sphinx-rtd-theme~=0.3
 docutils==0.14
 django-extensions==1.7.7
 sphinxcontrib-django~=0.3
+recommonmark==0.5.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -20,6 +20,7 @@ cffi==1.12.2
 chardet==3.0.4
 cloudant==2.11.0
 commcaretranslationchecker==0.9.3.5
+commonmark==0.8.1         # via recommonmark
 concurrent-log-handler==0.9.12
 contextlib2==0.5.5
 cryptography==2.6.1
@@ -69,6 +70,7 @@ ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2
+future==0.17.1            # via commonmark
 futures==3.2.0
 gevent==1.2.2
 ghdiff==0.4
@@ -131,6 +133,7 @@ qrcode==4.0.4
 quickcache==0.5.3
 raven==6.1.0
 rcssmin==1.0.6
+recommonmark==0.5.0
 redis-py-cluster==1.3.6
 redis==2.10.6
 reportlab==3.0


### PR DESCRIPTION
Add markdown support to our readthedocs docs.  I do think we should use rst first and foremost, but I'd rather have docs in one place, and this seems to be a barrier, so this can be a transition plan.

@czue @calellowitz @orangejenny 

![image](https://user-images.githubusercontent.com/2367539/55188064-d7c96d80-5170-11e9-8b7e-6baf7d7dea95.png)
