### PR TITLE
Add packages to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,14 @@
     "abbrev": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-      "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM="
+      "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+      "dev": true
     },
     "adm-zip": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-      "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY="
+      "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.0",
@@ -23,30 +25,35 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
       "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+      "dev": true,
       "optional": true
     },
     "assert-plus": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
       "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+      "dev": true,
       "optional": true
     },
     "async": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "dev": true,
       "optional": true
     },
     "aws-sign2": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
       "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+      "dev": true,
       "optional": true
     },
     "balanced-match": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU="
+      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
+      "dev": true
     },
     "biginteger": {
       "version": "1.0.3",
@@ -57,6 +64,7 @@
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "dev": true,
       "requires": {
         "readable-stream": "1.0.34"
       }
@@ -65,6 +73,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+      "dev": true,
       "requires": {
         "hoek": "0.9.1"
       }
@@ -73,6 +82,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
       "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
+      "dev": true,
       "requires": {
         "balanced-match": "0.4.1",
         "concat-map": "0.0.1"
@@ -81,17 +91,20 @@
     "caseless": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
-      "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ="
+      "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ=",
+      "dev": true
     },
     "charenc": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.1.tgz",
-      "integrity": "sha1-AEz/n+rxAjgu0S21jdb5Ynltbog="
+      "integrity": "sha1-AEz/n+rxAjgu0S21jdb5Ynltbog=",
+      "dev": true
     },
     "combined-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "dev": true,
       "optional": true,
       "requires": {
         "delayed-stream": "0.0.5"
@@ -100,17 +113,20 @@
     "commander": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "config-chain": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
       "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
+      "dev": true,
       "requires": {
         "ini": "1.3.4",
         "proto-list": "1.2.4"
@@ -119,17 +135,20 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "crypt": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.1.tgz",
-      "integrity": "sha1-XxGyGmwF7xteeXCDZtpjdOzh5qI="
+      "integrity": "sha1-XxGyGmwF7xteeXCDZtpjdOzh5qI=",
+      "dev": true
     },
     "cryptiles": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+      "dev": true,
       "optional": true,
       "requires": {
         "boom": "0.4.2"
@@ -139,12 +158,14 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "dev": true,
       "optional": true
     },
     "debug": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
       "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+      "dev": true,
       "requires": {
         "ms": "0.6.2"
       }
@@ -153,22 +174,26 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
       "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+      "dev": true,
       "optional": true
     },
     "diff": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY="
+      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
     },
     "eslint-plugin-eslint-dimagi": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-dimagi/-/eslint-plugin-eslint-dimagi-1.0.1.tgz",
       "integrity": "sha1-X6Ih/uxto+noUWJoeNDpIXfBX1U=",
+      "dev": true,
       "requires": {
         "requireindex": "1.1.0"
       }
@@ -176,12 +201,14 @@
     "forever-agent": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+      "dev": true
     },
     "form-data": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
       "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+      "dev": true,
       "optional": true,
       "requires": {
         "async": "0.9.2",
@@ -193,6 +220,7 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
       "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.3",
         "jsonfile": "2.3.0",
@@ -204,6 +232,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
       "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
+      "dev": true,
       "requires": {
         "inflight": "1.0.4",
         "inherits": "2.0.1",
@@ -215,17 +244,20 @@
     "graceful-fs": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-      "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw="
+      "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw=",
+      "dev": true
     },
     "growl": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
-      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg="
+      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+      "dev": true
     },
     "grunt": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
       "requires": {
         "async": "0.1.22",
         "coffee-script": "1.3.3",
@@ -252,37 +284,44 @@
         "async": {
           "version": "0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
         },
         "coffee-script": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ="
+          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+          "dev": true
         },
         "colors": {
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk="
+          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+          "dev": true
         },
         "eventemitter2": {
           "version": "0.4.14",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+          "dev": true
         },
         "exit": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+          "dev": true
         },
         "findup-sync": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+          "dev": true,
           "requires": {
             "glob": "3.2.11",
             "lodash": "2.4.2"
@@ -292,6 +331,7 @@
               "version": "3.2.11",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "dev": true,
               "requires": {
                 "inherits": "2.0.1",
                 "minimatch": "0.3.0"
@@ -300,12 +340,14 @@
                 "inherits": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
                 },
                 "minimatch": {
                   "version": "0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
                   "requires": {
                     "lru-cache": "2.7.3",
                     "sigmund": "1.0.1"
@@ -314,12 +356,14 @@
                     "lru-cache": {
                       "version": "2.7.3",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
                     },
                     "sigmund": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
                     }
                   }
                 }
@@ -328,19 +372,22 @@
             "lodash": {
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
             }
           }
         },
         "getobject": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw="
+          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+          "dev": true
         },
         "glob": {
           "version": "3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true,
           "requires": {
             "graceful-fs": "1.2.3",
             "inherits": "1.0.2",
@@ -350,12 +397,14 @@
             "graceful-fs": {
               "version": "1.2.3",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+              "dev": true
             },
             "inherits": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+              "dev": true
             }
           }
         },
@@ -363,6 +412,7 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
           "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+          "dev": true,
           "requires": {
             "colors": "0.6.2",
             "grunt-legacy-log-utils": "0.1.1",
@@ -375,6 +425,7 @@
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
               "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+              "dev": true,
               "requires": {
                 "colors": "0.6.2",
                 "lodash": "2.4.2",
@@ -384,12 +435,14 @@
             "lodash": {
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
             },
             "underscore.string": {
               "version": "2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+              "dev": true
             }
           }
         },
@@ -397,6 +450,7 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
           "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+          "dev": true,
           "requires": {
             "async": "0.1.22",
             "exit": "0.1.2",
@@ -410,17 +464,20 @@
         "hooker": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
+          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+          "dev": true
         },
         "iconv-lite": {
           "version": "0.2.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+          "dev": true
         },
         "js-yaml": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+          "dev": true,
           "requires": {
             "argparse": "0.1.16",
             "esprima": "1.0.4"
@@ -430,6 +487,7 @@
               "version": "0.1.16",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+              "dev": true,
               "requires": {
                 "underscore": "1.7.0",
                 "underscore.string": "2.4.0"
@@ -438,31 +496,36 @@
                 "underscore": {
                   "version": "1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+                  "dev": true
                 },
                 "underscore.string": {
                   "version": "2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
+                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+                  "dev": true
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+              "dev": true
             }
           }
         },
         "lodash": {
           "version": "0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw="
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
           "requires": {
             "lru-cache": "2.7.3",
             "sigmund": "1.0.1"
@@ -471,12 +534,14 @@
             "lru-cache": {
               "version": "2.7.3",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+              "dev": true
             },
             "sigmund": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+              "dev": true
             }
           }
         },
@@ -484,6 +549,7 @@
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
           "requires": {
             "abbrev": "1.0.7"
           },
@@ -491,24 +557,28 @@
             "abbrev": {
               "version": "1.0.7",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM="
+              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+              "dev": true
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
         },
         "underscore.string": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk="
+          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+          "dev": true
         },
         "which": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+          "dev": true
         }
       }
     },
@@ -516,6 +586,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
+      "dev": true,
       "requires": {
         "findup-sync": "0.1.3",
         "nopt": "1.0.10",
@@ -526,6 +597,7 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+          "dev": true,
           "requires": {
             "glob": "3.2.11",
             "lodash": "2.4.2"
@@ -535,6 +607,7 @@
               "version": "3.2.11",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "dev": true,
               "requires": {
                 "inherits": "2.0.1",
                 "minimatch": "0.3.0"
@@ -543,12 +616,14 @@
                 "inherits": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
                 },
                 "minimatch": {
                   "version": "0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
                   "requires": {
                     "lru-cache": "2.7.3",
                     "sigmund": "1.0.1"
@@ -557,12 +632,14 @@
                     "lru-cache": {
                       "version": "2.7.3",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
                     },
                     "sigmund": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
                     }
                   }
                 }
@@ -571,7 +648,8 @@
             "lodash": {
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
             }
           }
         },
@@ -579,6 +657,7 @@
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
           "requires": {
             "abbrev": "1.0.7"
           },
@@ -586,14 +665,16 @@
             "abbrev": {
               "version": "1.0.7",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM="
+              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+              "dev": true
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-          "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ="
+          "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
+          "dev": true
         }
       }
     },
@@ -601,6 +682,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
       "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
+      "dev": true,
       "requires": {
         "async": "0.2.10",
         "gaze": "0.5.2",
@@ -611,12 +693,14 @@
         "async": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
         },
         "gaze": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
           "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+          "dev": true,
           "requires": {
             "globule": "0.1.0"
           },
@@ -625,6 +709,7 @@
               "version": "0.1.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+              "dev": true,
               "requires": {
                 "glob": "3.1.21",
                 "lodash": "1.0.2",
@@ -635,6 +720,7 @@
                   "version": "3.1.21",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+                  "dev": true,
                   "requires": {
                     "graceful-fs": "1.2.3",
                     "inherits": "1.0.2",
@@ -644,24 +730,28 @@
                     "graceful-fs": {
                       "version": "1.2.3",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+                      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+                      "dev": true
                     },
                     "inherits": {
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                      "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+                      "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+                      "dev": true
                     }
                   }
                 },
                 "lodash": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                  "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+                  "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+                  "dev": true
                 },
                 "minimatch": {
                   "version": "0.2.14",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                  "dev": true,
                   "requires": {
                     "lru-cache": "2.7.3",
                     "sigmund": "1.0.1"
@@ -670,12 +760,14 @@
                     "lru-cache": {
                       "version": "2.7.3",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
                     },
                     "sigmund": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
                     }
                   }
                 }
@@ -686,12 +778,14 @@
         "lodash": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
         },
         "tiny-lr-fork": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
           "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
+          "dev": true,
           "requires": {
             "debug": "0.7.4",
             "faye-websocket": "0.4.4",
@@ -702,17 +796,20 @@
             "debug": {
               "version": "0.7.4",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
             },
             "faye-websocket": {
               "version": "0.4.4",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
-              "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w="
+              "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
+              "dev": true
             },
             "noptify": {
               "version": "0.0.3",
               "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
+              "dev": true,
               "requires": {
                 "nopt": "2.0.0"
               },
@@ -721,6 +818,7 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
+                  "dev": true,
                   "requires": {
                     "abbrev": "1.0.7"
                   },
@@ -728,7 +826,8 @@
                     "abbrev": {
                       "version": "1.0.7",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                      "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM="
+                      "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+                      "dev": true
                     }
                   }
                 }
@@ -737,7 +836,8 @@
             "qs": {
               "version": "0.5.6",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-              "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q="
+              "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
+              "dev": true
             }
           }
         }
@@ -747,6 +847,7 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/grunt-mocha/-/grunt-mocha-0.4.15.tgz",
       "integrity": "sha1-r1hHEvRn+yohawwEhjBh2kg44SM=",
+      "dev": true,
       "requires": {
         "grunt-lib-phantomjs": "0.7.1",
         "lodash": "3.10.1",
@@ -757,6 +858,7 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
           "requires": {
             "graceful-fs": "2.0.3",
             "inherits": "2.0.1",
@@ -766,12 +868,14 @@
         "graceful-fs": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+          "dev": true
         },
         "grunt-lib-phantomjs": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.7.1.tgz",
           "integrity": "sha1-pJasEEvI6ELiaJN0nVTEkFR16Pw=",
+          "dev": true,
           "requires": {
             "eventemitter2": "0.4.14",
             "phantomjs": "1.9.19",
@@ -782,12 +886,14 @@
             "eventemitter2": {
               "version": "0.4.14",
               "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-              "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+              "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+              "dev": true
             },
             "phantomjs": {
               "version": "1.9.19",
               "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.19.tgz",
               "integrity": "sha1-p/LO9eunND4acpzpkiqVptChHAc=",
+              "dev": true,
               "requires": {
                 "adm-zip": "0.4.4",
                 "fs-extra": "0.23.1",
@@ -803,12 +909,14 @@
             "semver": {
               "version": "4.3.6",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+              "dev": true
             },
             "temporary": {
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
               "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
+              "dev": true,
               "requires": {
                 "package": "1.0.1"
               },
@@ -816,7 +924,8 @@
                 "package": {
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
-                  "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw="
+                  "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
+                  "dev": true
                 }
               }
             }
@@ -825,12 +934,14 @@
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
           "requires": {
             "lru-cache": "2.7.3",
             "sigmund": "1.0.1"
@@ -840,6 +951,7 @@
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -848,6 +960,7 @@
           "version": "1.21.5",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
           "integrity": "sha1-fFiwkXTfl25DSiOx6NY5hz/FKek=",
+          "dev": true,
           "requires": {
             "commander": "2.3.0",
             "debug": "2.0.0",
@@ -865,6 +978,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
       "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+      "dev": true,
       "optional": true,
       "requires": {
         "boom": "0.4.2",
@@ -876,12 +990,14 @@
     "hoek": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+      "dev": true
     },
     "http-signature": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
       "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "dev": true,
       "optional": true,
       "requires": {
         "asn1": "0.1.11",
@@ -893,6 +1009,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
       "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+      "dev": true,
       "requires": {
         "once": "1.3.3",
         "wrappy": "1.0.1"
@@ -901,27 +1018,32 @@
     "inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz",
-      "integrity": "sha1-9cbAUdc/hvEbTuFCZ8wQKfziYdA="
+      "integrity": "sha1-9cbAUdc/hvEbTuFCZ8wQKfziYdA=",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "jade": {
       "version": "0.26.3",
       "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
       "requires": {
         "commander": "0.6.1",
         "mkdirp": "0.3.0"
@@ -930,12 +1052,14 @@
         "commander": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
         },
         "mkdirp": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
         }
       }
     },
@@ -948,27 +1072,32 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsonfile": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.0.tgz",
-      "integrity": "sha1-/5wgtnuWBchS4J8pmFn0jxMMGew="
+      "integrity": "sha1-/5wgtnuWBchS4J8pmFn0jxMMGew=",
+      "dev": true
     },
     "kew": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz",
-      "integrity": "sha1-2pdITxsGUCFG88YM7AWsYBLNmT8="
+      "integrity": "sha1-2pdITxsGUCFG88YM7AWsYBLNmT8=",
+      "dev": true
     },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
     },
     "md5": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.0.0.tgz",
       "integrity": "sha1-deOS4OvVqbiNx8t6k4dRN7h8ijM=",
+      "dev": true,
       "requires": {
         "charenc": "0.0.1",
         "crypt": "0.0.1",
@@ -979,17 +1108,20 @@
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
       "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+      "dev": true,
       "optional": true
     },
     "mime-types": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-      "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+      "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
       "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.4"
       }
@@ -997,12 +1129,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -1011,6 +1145,7 @@
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
       "integrity": "sha1-FRdo3Sh161G8gpXpgAAm6fK7OY8=",
+      "dev": true,
       "requires": {
         "commander": "2.3.0",
         "debug": "2.2.0",
@@ -1026,12 +1161,14 @@
         "commander": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
         },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
           "requires": {
             "ms": "0.7.1"
           },
@@ -1039,24 +1176,28 @@
             "ms": {
               "version": "0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+              "dev": true
             }
           }
         },
         "diff": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
         },
         "glob": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
           "requires": {
             "graceful-fs": "2.0.3",
             "inherits": "2.0.1",
@@ -1066,17 +1207,20 @@
             "graceful-fs": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-              "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+              "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+              "dev": true
             },
             "inherits": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
             },
             "minimatch": {
               "version": "0.2.14",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+              "dev": true,
               "requires": {
                 "lru-cache": "2.7.3",
                 "sigmund": "1.0.1"
@@ -1085,12 +1229,14 @@
                 "lru-cache": {
                   "version": "2.7.3",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "dev": true
                 },
                 "sigmund": {
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "dev": true
                 }
               }
             }
@@ -1099,12 +1245,14 @@
         "growl": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
-          "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg="
+          "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+          "dev": true
         },
         "jade": {
           "version": "0.26.3",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+          "dev": true,
           "requires": {
             "commander": "0.6.1",
             "mkdirp": "0.3.0"
@@ -1113,12 +1261,14 @@
             "commander": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-              "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+              "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+              "dev": true
             },
             "mkdirp": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-              "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+              "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+              "dev": true
             }
           }
         },
@@ -1126,6 +1276,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           },
@@ -1133,31 +1284,36 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
             }
           }
         },
         "supports-color": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+          "dev": true
         }
       }
     },
     "ms": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+      "dev": true
     },
     "node-uuid": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-      "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
+      "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
       "requires": {
         "abbrev": "1.0.7"
       }
@@ -1166,6 +1322,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
       "integrity": "sha1-ombH5cVmlet/VcrzpacyjyRRDa4=",
+      "dev": true,
       "requires": {
         "config-chain": "1.1.10",
         "inherits": "2.0.1",
@@ -1182,12 +1339,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
       "integrity": "sha1-8ilW8x6nFRqCHl8vsywRPK2Ln2k=",
+      "dev": true,
       "optional": true
     },
     "once": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.1"
       }
@@ -1195,17 +1354,20 @@
     "os-homedir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
+      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-      "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
+      "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+      "dev": true
     },
     "osenv": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
       "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+      "dev": true,
       "requires": {
         "os-homedir": "1.0.1",
         "os-tmpdir": "1.0.1"
@@ -1214,27 +1376,32 @@
     "path-is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+      "dev": true
     },
     "progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
     },
     "qs": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-      "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
+      "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g=",
+      "dev": true
     },
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.1",
@@ -1246,6 +1413,7 @@
       "version": "2.42.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
       "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
+      "dev": true,
       "requires": {
         "aws-sign2": "0.5.0",
         "bl": "0.9.5",
@@ -1268,6 +1436,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
       "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
+      "dev": true,
       "requires": {
         "throttleit": "0.0.2"
       }
@@ -1275,12 +1444,14 @@
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
     },
     "rimraf": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
       "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
+      "dev": true,
       "requires": {
         "glob": "7.0.3"
       }
@@ -1288,17 +1459,20 @@
     "semver": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+      "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
     },
     "sntp": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+      "dev": true,
       "optional": true,
       "requires": {
         "hoek": "0.9.1"
@@ -1315,29 +1489,34 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true,
       "optional": true
     },
     "throttleit": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
       "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
+      "dev": true,
       "optional": true
     },
     "tunnel-agent": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-      "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4="
+      "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+      "dev": true
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -1365,17 +1544,20 @@
     "uid-number": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4="
+      "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4=",
+      "dev": true
     },
     "which": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
+      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+      "dev": true
     },
     "yargs": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "repository": "https://github.com/dimagi/commcare-hq",
   "description": "CommcareHQ Javascript tests",
   "dependencies": {
+    "js-xpath": "dimagi/js-xpath#v0.0.2-rc1",
+    "uglifyjs": "^2.4.10"
+  },
+  "devDependencies": {
     "eslint-plugin-eslint-dimagi": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha": "^0.4.13",
-    "js-xpath": "dimagi/js-xpath#v0.0.2-rc1",
-    "mocha": "^2.3.3",
-    "uglifyjs": "^2.4.10"
+    "mocha": "^2.3.3"
   }
 }


### PR DESCRIPTION
I'm getting annoyed by being told about "vulnerabilities" when i push to get when they don't affect prod sites. I'm hoping that github will ignore dev dependencies but at least I will be able to more confidentally dismiss those alerts since they don't affect us if they aren't installed in production.

I think that I could also move uglifyjs to dev dependencies as we install it globally https://github.com/dimagi/commcare-cloud/blob/33cb8038279ce9ab39c4a91c92e853ab86aca850/src/commcare_cloud/ansible/roles/nodejs/tasks/main.yml#L32 but I don't want to debug that now.

Guessing @orangejenny will be interested since its JS ?