### PR TITLE
Clear releases page when loading

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -309,6 +309,8 @@ hqDefine('app_manager/js/releases/releases', function () {
                 return false;
             }
             self.fetchState('pending');
+            self.savedApps.removeAll();
+            self.showLoadingSpinner(true);
             $.ajax({
                 url: self.reverse("paginate_releases"),
                 dataType: 'json',
@@ -329,6 +331,9 @@ hqDefine('app_manager/js/releases/releases', function () {
                 },
                 error: function () {
                     self.fetchState('error');
+                },
+                always: function () {
+                    self.showLoadingSpinner(false);
                 },
             });
         };


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-432
When this page takes a long time to load, it is confusing that the old results are still there when you select the dropdown. This removes all the items and shows the initial loading screen when switching pages. 
@orangejenny will let you comment as I know this was something you'd thought about before.