### PR TITLE
reset cancel button when reloading Report an Issue modal

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq-bug-report.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq-bug-report.js
@@ -14,6 +14,7 @@ hqDefine('hqwebapp/js/hq-bug-report', [
         var resetForm = function () {
             $hqwebappBugReportForm.find("button[type='submit']").button('reset');
             $hqwebappBugReportForm.resetForm();
+            $hqwebappBugReportCancel.enableButton();
             $hqwebappBugReportSubmit.button('reset');
             $ccFormGroup.removeClass('has-error has-feedback');
             $ccFormGroup.find(".label-danger").addClass('hide');


### PR DESCRIPTION
Product Note: Re-enable the cancel button when opening the Report an Issue modal for another bug on the same page.

https://dimagi-dev.atlassian.net/browse/HI-328