### PR TITLE
fix query used in wire invoice creation

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -267,7 +267,7 @@ class DomainWireInvoiceFactory(object):
             invoices = CustomerInvoice.objects.filter(account=self.account)
         else:
             invoices = Invoice.objects.filter(
-                subscription__subscriber__domain=self.domain,
+                subscription__subscriber__domain=self.domain.name,
                 is_hidden=False,
                 date_paid__exact=None
             ).order_by('-date_start')


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-410

Based on the timelines of the existing code and the sentry error, I'm guessing something changed when ```@six.python_2_unicode_compatible``` was added to classes that stopped ```self.domain``` from being evaluated by the django orm as ```str(self.domain)```.