### PR TITLE
Order location search results by length of field

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -11,6 +11,7 @@ from django_bulk_update.helper import bulk_update as bulk_update_helper
 import jsonfield
 from django.db import models, transaction
 from django.db.models import Q
+from django.db.models.functions import Length
 from django_cte import CTEQuerySet
 from memoized import memoized
 import six
@@ -333,7 +334,8 @@ class LocationManager(LocationQueriesMixin, AdjListManager):
         It matches by name or site-code
         """
         direct_matches = self._user_input_filter(domain, user_input)
-        return self.get_queryset_descendants(direct_matches, include_self=True)
+        return (self.get_queryset_descendants(direct_matches, include_self=True)
+                .order_by(Length('name')).order_by(Length('site_code')))
 
     def get_locations(self, location_ids):
         return self.filter(location_id__in=location_ids)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-521

This is a bit of a silly improvement, but I think in most cases it might actually work. 

The reason these are shown in this order is that I think postgres automatically orders `icontains` results alphabetically (and `Demo - Malawi` comes before `Malawi`). 

I'm still going to respond on the ticket that we aren't going to fix this, as the solution is for the user to do an exact match, as is indicated beneath the search box. 

![Screenshot from 2019-03-29 16-40-23](https://user-images.githubusercontent.com/146896/55261441-5c83bc80-5241-11e9-88ae-212825e39ee0.png)
