### PR TITLE
Set a timeout of 3 days for cached celery time to start info

### DIFF
--- a/corehq/celery.py
+++ b/corehq/celery.py
@@ -33,7 +33,8 @@ except AppRegistryNotReady:
 def celery_add_time_sent(headers=None, body=None, **kwargs):
     info = headers if 'task' in headers else body
     task_id = info['id']
-    cache.set('task.{}.time_sent'.format(task_id), datetime.datetime.utcnow())
+    cache.set('task.{}.time_sent'.format(task_id), datetime.datetime.utcnow(),
+              timeout=3 * 24 * 60 * 60)
 
 
 @task_prerun.connect


### PR DESCRIPTION
I think the default timeout must be five minutes because as soon as the time to start metric got close to 300s, it cut out and those tasks started reporting time to start unavailable instead:
<img width="1259" alt="Screen Shot 2019-03-29 at 9 08 24 PM" src="https://user-images.githubusercontent.com/137212/55269912-ad59dc00-5266-11e9-86f1-47f519abb217.png">
