### PR TITLE
don't call rebuild_table twice

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -181,7 +181,7 @@ class ConfigurableReportTableManagerMixin(object):
             latest_rev = config.get_db().get_rev(config._id)
             if config._rev != latest_rev:
                 raise StaleRebuildError('Tried to rebuild a stale table ({})! Ignoring...'.format(config))
-        adapter.rebuild_table()
+            adapter.rebuild_table()
         if config.is_static:
             rebuild_indicators.delay(adapter.config.get_id)
 

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -182,7 +182,7 @@ class ConfigurableReportTableManagerMixin(object):
             if config._rev != latest_rev:
                 raise StaleRebuildError('Tried to rebuild a stale table ({})! Ignoring...'.format(config))
             adapter.rebuild_table()
-        if config.is_static:
+        else:
             rebuild_indicators.delay(adapter.config.get_id)
 
 


### PR DESCRIPTION
`adapter.rebuild_table()` is called in `rebuild_indicators`: https://github.com/dimagi/commcare-hq/blob/982b386f350f5c79857b22f72d267031afb56075/corehq/apps/userreports/tasks.py#L97