### PR TITLE
Fix email regex in unsubscribe_report url for long gTLDs

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -142,7 +142,7 @@ urlpatterns = [
     url(r'^robots.txt$', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     url(r'^software-plans/$', RedirectView.as_view(url=PRICING_LINK, permanent=True), name='go_to_pricing'),
     url(r'^unsubscribe_report/(?P<scheduled_report_id>[\w-]+)/'
-        r'(?P<user_email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/(?P<scheduled_report_secret>[\w-]+)/',
+        r'(?P<user_email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/(?P<scheduled_report_secret>[\w-]+)/',
         ReportNotificationUnsubscribeView.as_view(), name=ReportNotificationUnsubscribeView.urlname),
     url(r'^phone/list_apps', list_apps, name="list_accessible_apps")
 ] + LOCAL_APP_URLS


### PR DESCRIPTION
https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#ICANN-era_generic_top-level_domains

fixes: https://sentry.io/organizations/dimagi/issues/963843881/?environment=production&referrer=alert_email&project=136860
I got an email about this because I recently touched scheduled reports, but actually I don't think this is a new bug, it's just not been hit before/recently 