### PR TITLE
Check app.domain_link is not None

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -302,9 +302,13 @@ def get_app_view_context(request, app):
 
 def _get_upstream_url(app, request_user):
     """Get the upstream url if the user has access"""
-    if request_user.is_superuser or (
-            not app.domain_link.is_remote
-            and request_user.is_member_of(app.domain_link.master_domain)
+    if (
+            app.domain_link and (
+                request_user.is_superuser or (
+                    not app.domain_link.is_remote
+                    and request_user.is_member_of(app.domain_link.master_domain)
+                )
+            )
     ):
         url = reverse('view_app', args=[app.domain_link.master_domain, app.master])
         if app.domain_link.is_remote:


### PR DESCRIPTION
Resolves ['NoneType' object has no attribute 'master_domain'][2].

Checks `app.domain_link` is set, as [`LinkedApplication.get_master_version()`][1] does. 

I bumped into this error by copying a linked app. If we should only allow the master version to be copied, this change might not address the problem, and we should take a different approach. But considering `LinkedApplication.get_master_version()` checks `app.domain_link`, I didn't think this change is wrong.

@esoergel, buddy @czue

  [1]: https://github.com/dimagi/commcare-hq/blob/d8436f059fe6b43204da5b1adda791d996d3e5be/corehq/apps/app_manager/models.py#L5780
  [2]: https://sentry.io/organizations/dimagi/issues/885165053/?project=136860&query=is%3Aunresolved&statsPeriod=14d&utc=true
