### PR TITLE
Sort Django modules separately

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,5 @@ multi_line_output=3
 include_trailing_comma=true
 
 known_django=django
-sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_exsubmodules=auditcare,casexml,couchexport,couchforms,dimagi,fluff,phonelog,pillow_retry,pillowtop,soil,toggle
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,EXSUBMODULES,FIRSTPARTY,LOCALFOLDER

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,7 @@
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
 [settings]
 multi_line_output=3
 include_trailing_comma=true
+
+known_django=django
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
from https://github.com/dimagi/commcare-hq/pull/23863
`isort` is wicked configurable, I'm impressed!  Just took this config for a test drive and this is one thing that stood out.

Another one is that it does group `__future__` imports on one line, although I'm actually fine with that, not sure why we have the convention that they're on their own line.

Lastly, I'm considering adding:
```
known_dimagi=dimagi,memoized,quickcache,jsonobject,...
```
So we can group those in between 3rd party and 1st party, though I'd be interested in feedback on that point.