### PR TITLE
Abort early if there are many blank rows

### DIFF
--- a/corehq/util/workbook_reading/adapters/xlsx.py
+++ b/corehq/util/workbook_reading/adapters/xlsx.py
@@ -66,10 +66,19 @@ class _XLSXWorksheetAdaptor(object):
         # self._worksheet.max_row is the max_row with data OR WITH FORMATTING
         # That means that if formatting is applied, that will be the xlsx row limit
         # Note that this is 1-indexed for consistency with openpyxl
+        MAX_BLANK_ROWS = 1000
+
         max_row = 1
-        for i, row in enumerate(self._worksheet.iter_rows(), 1):
-            if any(cell.value for cell in row):
+        blank_rows = 0
+        for i, row in enumerate(self._worksheet.values, 1):
+            if any(v for v in row):
                 max_row = i
+                blank_rows = 0
+            else:
+                blank_rows += 1
+            if blank_rows >= MAX_BLANK_ROWS:
+                # if this threshold is reached, assume there is no more data in the sheet
+                return max_row
         return max_row
 
     def iter_rows(self):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-525

This aborts after seeing 1000 blank rows so we don't have to loop through a whole 1,048,576 rows by 16,384 column sheet to figure out how many rows there are.

I half wanted to put in another short circuit:
```py
        XLSX_MAX_ROWS = 1048576
        if not (self._worksheet.max_row == XLSX_MAX_ROWS):
            return self._worksheet.max_row
```
since I think this only happens when there is something weird with the whole sheet, but I think this change already improves the performance enough that it would be unnoticeable. 