### PR TITLE
Add master-travis-* branches to the travis whitelist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ group: edge
 branches:
   only:
     - master
+    - master-travis-4-job
+    - master-travis-5-job-no-skip
 env:
   matrix:
     # need node installs for app_manager.XpathValidatorTest


### PR DESCRIPTION
These branches provide a base for the two possible avenues of getting back to safety after this temporary "fix" that got the master build to pass (https://github.com/dimagi/commcare-hq/pull/23887) put us in the precarious situation of skipping one of the icds_reports tests:

- master-travis-4-job: https://github.com/dimagi/commcare-hq/pull/23893
- master-travis-5-job-no-skip: https://github.com/dimagi/commcare-hq/pull/23894

From my message on slack #test-team:
> I think I have a workable proposal for how to coordinate the multiple possible paths of getting to a reliable build that doesn’t have a `@skip`ped test. Add two branches  to our travis white list, one for each of the two viable paths back to “safety”:
> 
> ```
> - master-travis-4-job
> - master-travis-5-job-no-skip
> ```
> Then, PRs that focus on getting one of these two avenues over the finish line will set the appropriate master-travis-* branch as their base, and the travis test will be run. If it furthers the goal, it can be merged into either the `master-travis-*` branch or into `master` as appropriate

When either of those branches passes and is merged, issue #23895 will be automatically closed.