### PR TITLE
hide new billing pop-ups until addressing feedback [ci skip]

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -315,7 +315,10 @@
         {% endif %}
         {# modals #}
         {% block modals %}
-            {% if domain and not enterprise_mode %}
+        {% comment %}
+            TODO - remove 'and False' after making updates
+        {% endcomment %}
+            {% if domain and not enterprise_mode and False %}
                 {% if show_overdue_invoice_modal %}
                     {% include 'hqwebapp/downgrade_modal.html' %}
                 {% elif show_prepaid_modal %}


### PR DESCRIPTION
There's been a few updates requested for the billing pop-ups, to make them less intrusive.  Since it will take some time to get a proper PR and to wait for tests to pass, this is a quick-fix to hide the pop-ups in today's deploy until we are ready to reveal them again.

@esoergel new code buddy