### PR TITLE
fix warning when updating transifex

### DIFF
--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -839,7 +839,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
             msgs.append((
                 messages.error,
                 _("You must provide at least one translation"
-                  " for the label '%s' in sheet '%s'") % (label, sheet.worksheet.title)
+                  " for the label '{0}' in sheet '{1}'") % (label, sheet.worksheet.title)
             ))
     # Update the translations
     for lang in app.langs:

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -839,7 +839,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
             msgs.append((
                 messages.error,
                 _("You must provide at least one translation"
-                  " for the label '{0}' in sheet '{1}'") % (label, sheet.worksheet.title)
+                  " for the label '{0}' in sheet '{1}'").format(label, sheet.worksheet.title)
             ))
     # Update the translations
     for lang in app.langs:


### PR DESCRIPTION
Fixes
```
./corehq/apps/translations/app_translations.py:841: warning: 'msgid' format string with unnamed arguments cannot be properly localized:
                                                             The translator cannot reorder the arguments.
                                                             Please consider using a format string with named arguments,
                                                             and a mapping instead of a tuple for the arguments.
```