### PR TITLE
Explore Case Data Report pt 2 - Async Column Filters

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -116,17 +116,26 @@ breadcrumbs todo
                        data-bind="textInput: name,
                                   datagridAutocomplete: $root.editColumnController.columnNameOptions" />
               </div>
+
               <!-- ko foreach: appliedFilters -->
               <div class="row">
+                <div class="col-xs-2">
+                  <select class="form-control"
+                          data-bind="options: $root.editColumnController.filterTypeOptions,
+                                     optionsText: function (choice) {
+                                        return $root.editColumnController.filterTitleByType[choice];
+                                     },
+                                     value: $root.editColumnController.appliedFilterType"></select>
+                </div>
                 <div class="col-xs-4">
                   <select class="form-control"
-                          data-bind="options: $root.editColumnController.availableFilters,
+                          data-bind="options: $root.editColumnController.filterOptions,
                                      optionsText: 'title',
                                      value: filter,
                                      event: { change: $root.editColumnController.updateFilters },
                                      optionsCaption: 'Choose filter...'"></select>
                 </div>
-                <div class="col-xs-6">
+                <div class="col-xs-4">
                   <input type="text"
                          class="form-control"
                          data-bind="textInput: value,

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -116,6 +116,39 @@ breadcrumbs todo
                        data-bind="textInput: slug,
                                   slugAutocomplete: $root.editColumnController.slugOptions" />
               </div>
+              <!-- ko foreach: appliedFilters -->
+              <div class="row">
+                <div class="col-xs-4">
+                  <select class="form-control"
+                          data-bind="options: $root.editColumnController.availableFilters,
+                                     optionsText: 'title',
+                                     value: filter,
+                                     event: { change: $root.editColumnController.updateFilters },
+                                     optionsCaption: 'Choose filter...'"></select>
+                </div>
+                <div class="col-xs-6">
+                  <input type="text"
+                         class="form-control"
+                         data-bind="textInput: value,
+                                    event: { change: $root.editColumnController.updateFilters }" />
+                </div>
+                <div class="col-xs-2">
+                  <button type="button"
+                          class="btn btn-danger"
+                          data-bind="click: $root.editColumnController.removeFilter">
+                    <i class="fa fa-remove"></i>
+                  </button>
+
+                </div>
+              </div>
+              <!-- /ko -->
+
+              <button type="button"
+                      class="btn btn-default"
+                      data-bind="click: $root.editColumnController.addFilter" >
+                {% trans "Add Filter" %}
+              </button>
+
             </div>
           </div>
           <div class="modal-footer">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -32,6 +32,7 @@ breadcrumbs todo
   {% initial_page_data "report.endpoints" report.endpoints %}
   {% initial_page_data "report.slug" report.slug %}
   {% initial_page_data "report.columns" report.columns %}
+  {% initial_page_data "report.columnFilters" report.column_filters %}
 
 <div id="case_search--model">
 

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -76,7 +76,7 @@ breadcrumbs todo
         <tr>
           <!-- ko foreach: { data: $root.columns, as: 'column' } -->
             <td data-bind="style: { width: column.width() + 'px' }">
-              <span data-bind="text: row[column.slug()]"></span>
+              <span data-bind="text: row[column.name()]"></span>
             </td>
           <!-- /ko -->
           <td></td>
@@ -113,8 +113,8 @@ breadcrumbs todo
               <div class="form-group">
                 <input type="text"
                        class="form-control"
-                       data-bind="textInput: slug,
-                                  slugAutocomplete: $root.editColumnController.slugOptions" />
+                       data-bind="textInput: name,
+                                  datagridAutocomplete: $root.editColumnController.columnNameOptions" />
               </div>
               <!-- ko foreach: appliedFilters -->
               <div class="row">

--- a/corehq/apps/reports/static/reports/v2/js/context.js
+++ b/corehq/apps/reports/static/reports/v2/js/context.js
@@ -51,5 +51,8 @@ hqDefine('reports/v2/js/context', [
         getColumns: function () {
             return initialPageData.get('report.columns');
         },
+        getColumnFilters: function () {
+            return initialPageData.get('report.columnFilters');
+        },
     };
 });

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -29,20 +29,8 @@ hqDefine('reports/v2/js/datagrid', [
         self.data = options.dataModel;
         self.columns = ko.observableArray();
 
-        self.reportContext = ko.computed(function () {
-            return {
-                existingColumnNames: _.map(self.columns(), function (column) {
-                    return column.name();
-                }),
-                columnsWithFilters: _.filter(self.columns(), function (column) {
-                    return column.appliedFilters().length > 0;
-                }),
-            };
-        });
-
         self.editColumnController = columns.editColumnController({
             endpoint: options.columnEndpoint,
-            reportContext: self.reportContext,
             availableFilters: options.availableFilters,
         });
 
@@ -50,7 +38,22 @@ hqDefine('reports/v2/js/datagrid', [
             _.each(options.initialColumns, function (data) {
                 self.columns.push(columns.columnModel(data));
             });
+
+            self.reportContext = ko.computed(function () {
+                return {
+                    existingColumnNames: _.map(self.columns(), function (column) {
+                        return column.name();
+                    }),
+                    columnFilters: _.flatten(_.map(_.filter(self.columns(), function (column) {
+                        return column.appliedFilters().length > 0;
+                    }), function (column) {
+                        return column.getFilters();
+                    })),
+                };
+            });
+
             self.data.init(self.reportContext);
+            self.editColumnController.init(self.reportContext);
         };
 
         self.updateColumn = function (column) {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -34,6 +34,9 @@ hqDefine('reports/v2/js/datagrid', [
                 existingSlugs: _.map(self.columns(), function (column) {
                     return column.slug();
                 }),
+                columnsWithFilters: _.filter(self.columns(), function (column) {
+                    return column.appliedFilters().length > 0;
+                }),
             };
         });
 
@@ -44,11 +47,10 @@ hqDefine('reports/v2/js/datagrid', [
         });
 
         self.init = function () {
-            self.data.init();
-
             _.each(options.initialColumns, function (data) {
                 self.columns.push(columns.columnModel(data));
             });
+            self.data.init(self.reportContext);
         };
 
         self.updateColumn = function (column) {
@@ -63,6 +65,9 @@ hqDefine('reports/v2/js/datagrid', [
             } else {
                 self.columns.push(columns.columnModel(column.unwrap()));
             }
+            if (self.editColumnController.hasFilterUpdate()) {
+                self.data.refresh();
+            }
             self.editColumnController.unset();
         };
 
@@ -74,6 +79,10 @@ hqDefine('reports/v2/js/datagrid', [
                 }
             });
             self.columns(replacementCols);
+            if (self.editColumnController.oldColumn().availableFilters().length > 0) {
+                // refresh data if the deleted column had filters applied.
+                self.data.refresh();
+            }
             self.editColumnController.unset();
         };
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -82,7 +82,7 @@ hqDefine('reports/v2/js/datagrid', [
                 }
             });
             self.columns(replacementCols);
-            if (self.editColumnController.oldColumn().availableFilters().length > 0) {
+            if (self.editColumnController.oldColumn().appliedFilters.length > 0) {
                 // refresh data if the deleted column had filters applied.
                 self.data.refresh();
             }

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -31,8 +31,8 @@ hqDefine('reports/v2/js/datagrid', [
 
         self.reportContext = ko.computed(function () {
             return {
-                existingSlugs: _.map(self.columns(), function (column) {
-                    return column.slug();
+                existingColumnNames: _.map(self.columns(), function (column) {
+                    return column.name();
                 }),
                 columnsWithFilters: _.filter(self.columns(), function (column) {
                     return column.appliedFilters().length > 0;
@@ -41,7 +41,7 @@ hqDefine('reports/v2/js/datagrid', [
         });
 
         self.editColumnController = columns.editColumnController({
-            slugEndpoint: options.columnEndpoint,
+            endpoint: options.columnEndpoint,
             reportContext: self.reportContext,
             availableFilters: options.availableFilters,
         });
@@ -57,7 +57,7 @@ hqDefine('reports/v2/js/datagrid', [
             if (self.editColumnController.oldColumn()) {
                 var replacementCols = self.columns();
                 _.each(replacementCols, function (col, index) {
-                    if (col.slug() === self.editColumnController.oldColumn().slug()) {
+                    if (col.name() === self.editColumnController.oldColumn().name()) {
                         replacementCols[index] = columns.columnModel(column.unwrap());
                     }
                 });
@@ -74,7 +74,7 @@ hqDefine('reports/v2/js/datagrid', [
         self.deleteColumn = function () {
             var replacementCols = [];
             _.each(self.columns(), function (col) {
-                if (col.slug() !== self.editColumnController.oldColumn().slug()) {
+                if (col.name() !== self.editColumnController.oldColumn().name()) {
                     replacementCols.push(col);
                 }
             });

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -22,7 +22,7 @@ hqDefine('reports/v2/js/datagrid', [
     'use strict';
 
     var datagridController = function (options) {
-        assertProperties.assert(options, ['dataModel', 'columnEndpoint', 'initialColumns']);
+        assertProperties.assert(options, ['dataModel', 'columnEndpoint', 'initialColumns', 'availableFilters']);
 
         var self = {};
 
@@ -40,6 +40,7 @@ hqDefine('reports/v2/js/datagrid', [
         self.editColumnController = columns.editColumnController({
             slugEndpoint: options.columnEndpoint,
             reportContext: self.reportContext,
+            availableFilters: options.availableFilters,
         });
 
         self.init = function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
@@ -15,7 +15,7 @@ hqDefine('reports/v2/js/datagrid/bindingHandlers', [
 ) {
     'use strict';
 
-    ko.bindingHandlers.slugAutocomplete = {
+    ko.bindingHandlers.datagridAutocomplete = {
         init: function (element) {
             var $element = $(element);
             if (!$element.atwho) {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -36,6 +36,17 @@ hqDefine('reports/v2/js/datagrid/columns', [
             return ko.mapping.toJS(self);
         };
 
+        self.getFilters = function () {
+            return _.map(self.appliedFilters(), function (appliedFilter) {
+                return {
+                    propertyName: self.name(),
+                    filterType: appliedFilter.filter().filterType(),
+                    filterName: appliedFilter.filter().name(),
+                    filterValue: appliedFilter.value(),
+                };
+            });
+        };
+
         return self;
     };
 
@@ -43,7 +54,6 @@ hqDefine('reports/v2/js/datagrid/columns', [
         var self = {};
 
         self.endpoint = options.endpoint;
-        self.reportContext = options.reportContext;
 
         self.availableFilters = ko.observableArray(_.map(options.availableFilters, function (data) {
             return filters.columnFilterModel(data);
@@ -55,6 +65,10 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.column = ko.observable();
         self.isNew = ko.observable();
         self.hasFilterUpdate = ko.observable(false);
+
+        self.init = function (reportContextObservable) {
+            self.reportContext = reportContextObservable;
+        };
 
         self.setNew = function () {
             self.reloadOptions();
@@ -102,6 +116,10 @@ hqDefine('reports/v2/js/datagrid/columns', [
         };
 
         self.reloadOptions = function () {
+            if (!self.reportContext) {
+                throw new Error("Please call init() before calling loadOptions().");
+            }
+
             $.ajax({
                 url: self.endpoint.getUrl(),
                 method: 'post',

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -69,7 +69,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.filterOptions = ko.computed(function () {
             return _.filter(self.availableFilters(), function (filter) {
                 return filter.filterType() === self.appliedFilterType();
-            })
+            });
         });
 
         self.columnNameOptions = ko.observableArray();

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -59,6 +59,19 @@ hqDefine('reports/v2/js/datagrid/columns', [
             return filters.columnFilterModel(data);
         }));
 
+        self.defaultFilterType = options.availableFilters[0].filterType;
+        self.appliedFilterType = ko.observable();
+        self.filterTitleByType = _.object(_.map(options.availableFilters, function (data) {
+            return [data.filterType, data.filterTypeTitle];
+        }));
+        self.filterTypeOptions = ko.observableArray(_.keys(self.filterTitleByType));
+
+        self.filterOptions = ko.computed(function () {
+            return _.filter(self.availableFilters(), function (filter) {
+                return filter.filterType() === self.appliedFilterType();
+            })
+        });
+
         self.columnNameOptions = ko.observableArray();
 
         self.oldColumn = ko.observable();
@@ -82,6 +95,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
                 self.isNew(true);
                 self.hasFilterUpdate(false);
             }
+            self.updateDefaultFilterType();
         };
 
         self.set = function (existingColumn) {
@@ -90,6 +104,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
             self.column(columnModel(existingColumn.unwrap(), self.availableFilters));
             self.isNew(false);
             self.hasFilterUpdate(false);
+            self.updateDefaultFilterType();
         };
 
         self.unset = function () {
@@ -131,6 +146,10 @@ hqDefine('reports/v2/js/datagrid/columns', [
                 .done(function (data) {
                     self.columnNameOptions(data.options);
                 });
+        };
+
+        self.updateDefaultFilterType = function () {
+            self.appliedFilterType((self.column().appliedFilters().length > 0) ? self.column().appliedFilters()[0].filter().filterType() : self.defaultFilterType);
         };
 
         self.isColumnValid = ko.computed(function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -84,7 +84,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         };
 
         self.setNew = function () {
-            self.reloadOptions();
+            self.loadOptions();
             self.oldColumn(undefined);
 
             if (self.isNew() && self.column()) {
@@ -99,7 +99,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         };
 
         self.set = function (existingColumn) {
-            self.reloadOptions();
+            self.loadOptions();
             self.oldColumn(columnModel(existingColumn).unwrap());
             self.column(columnModel(existingColumn.unwrap(), self.availableFilters));
             self.isNew(false);
@@ -130,7 +130,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
             self.hasFilterUpdate(true);
         };
 
-        self.reloadOptions = function () {
+        self.loadOptions = function () {
             if (!self.reportContext) {
                 throw new Error("Please call init() before calling loadOptions().");
             }

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -15,12 +15,22 @@ hqDefine('reports/v2/js/datagrid/columns', [
 ) {
     'use strict';
 
-    var columnModel = function (data) {
+    var columnModel = function (data, availableFilters) {
         var self = {};
 
         self.title = ko.observable(data.title);
         self.slug = ko.observable(data.slug);
         self.width = ko.observable(data.width || 200);
+
+        self.appliedFilters = ko.observableArray(_.map(data.appliedFilters, function (filterData) {
+            var filterModel = filters.appliedColumnFilterModel(filterData);
+            if (availableFilters) {
+                filterModel.filter(ko.utils.arrayFirst(availableFilters(), function (item) {
+                    return item.name() === filterModel.filter().name() && item.filterType() === filterModel.filter().filterType();
+                }));
+            }
+            return filterModel;
+        }));
 
         self.unwrap = function () {
             return ko.mapping.toJS(self);
@@ -51,7 +61,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
 
             if (self.isNew() && self.column()) {
                 // keep state of existing add column progress
-                self.column(columnModel(self.column().unwrap()));
+                self.column(columnModel(self.column().unwrap(), self.availableFilters));
             } else {
                 self.column(columnModel({}));
                 self.isNew(true);
@@ -61,7 +71,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.set = function (existingColumn) {
             self.reloadOptions();
             self.oldColumn(columnModel(existingColumn).unwrap());
-            self.column(columnModel(existingColumn.unwrap()));
+            self.column(columnModel(existingColumn.unwrap(), self.availableFilters));
             self.isNew(false);
         };
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -5,9 +5,13 @@
 hqDefine('reports/v2/js/datagrid/columns', [
     'jquery',
     'knockout',
+    'underscore',
+    'reports/v2/js/datagrid/filters',
 ], function (
     $,
-    ko
+    ko,
+    _,
+    filters
 ) {
     'use strict';
 
@@ -30,6 +34,10 @@ hqDefine('reports/v2/js/datagrid/columns', [
 
         self.slugEndpoint = options.slugEndpoint;
         self.reportContext = options.reportContext;
+
+        self.availableFilters = ko.observableArray(_.map(options.availableFilters, function (data) {
+            return filters.columnFilterModel(data);
+        }));
 
         self.slugOptions = ko.observableArray();
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -42,7 +42,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
                     propertyName: self.name(),
                     filterType: appliedFilter.filter().filterType(),
                     filterName: appliedFilter.filter().name(),
-                    filterValue: appliedFilter.value(),
+                    filterValue: appliedFilter.value() || "",
                 };
             });
         };

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -19,7 +19,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         var self = {};
 
         self.title = ko.observable(data.title);
-        self.slug = ko.observable(data.slug);
+        self.name = ko.observable(data.name);
         self.width = ko.observable(data.width || 200);
 
         self.appliedFilters = ko.observableArray(_.map(data.appliedFilters, function (filterData) {
@@ -42,14 +42,14 @@ hqDefine('reports/v2/js/datagrid/columns', [
     var editColumnController = function (options) {
         var self = {};
 
-        self.slugEndpoint = options.slugEndpoint;
+        self.endpoint = options.endpoint;
         self.reportContext = options.reportContext;
 
         self.availableFilters = ko.observableArray(_.map(options.availableFilters, function (data) {
             return filters.columnFilterModel(data);
         }));
 
-        self.slugOptions = ko.observableArray();
+        self.columnNameOptions = ko.observableArray();
 
         self.oldColumn = ko.observable();
         self.column = ko.observable();
@@ -102,9 +102,8 @@ hqDefine('reports/v2/js/datagrid/columns', [
         };
 
         self.reloadOptions = function () {
-            // reload slug options
             $.ajax({
-                url: self.slugEndpoint.getUrl(),
+                url: self.endpoint.getUrl(),
                 method: 'post',
                 dataType: 'json',
                 data: {
@@ -112,13 +111,13 @@ hqDefine('reports/v2/js/datagrid/columns', [
                 },
             })
                 .done(function (data) {
-                    self.slugOptions(data.options);
+                    self.columnNameOptions(data.options);
                 });
         };
 
         self.isColumnValid = ko.computed(function () {
             if (self.column()) {
-                return !!self.column().title() && !!self.column().slug();
+                return !!self.column().title() && !!self.column().name();
             }
             return false;
         });

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -54,6 +54,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.oldColumn = ko.observable();
         self.column = ko.observable();
         self.isNew = ko.observable();
+        self.hasFilterUpdate = ko.observable(false);
 
         self.setNew = function () {
             self.reloadOptions();
@@ -65,6 +66,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
             } else {
                 self.column(columnModel({}));
                 self.isNew(true);
+                self.hasFilterUpdate(false);
             }
         };
 
@@ -73,12 +75,30 @@ hqDefine('reports/v2/js/datagrid/columns', [
             self.oldColumn(columnModel(existingColumn).unwrap());
             self.column(columnModel(existingColumn.unwrap(), self.availableFilters));
             self.isNew(false);
+            self.hasFilterUpdate(false);
         };
 
         self.unset = function () {
             self.oldColumn(undefined);
             self.column(undefined);
             self.isNew(false);
+            self.hasFilterUpdate(false);
+        };
+
+        self.addFilter = function () {
+            self.column().appliedFilters.push(filters.appliedColumnFilterModel({}));
+            self.hasFilterUpdate(true);
+        };
+
+        self.removeFilter = function (filter) {
+            self.column().appliedFilters.remove(function (listedFilter) {
+                return listedFilter === filter;
+            });
+            self.hasFilterUpdate(true);
+        };
+
+        self.updateFilters = function () {
+            self.hasFilterUpdate(true);
         };
 
         self.reloadOptions = function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
@@ -34,11 +34,11 @@ hqDefine('reports/v2/js/datagrid/data_models', [
                 dataType: 'json',
                 data: {
                     length: self.length,
-                    start: self.rows().length,
+                    start: 0, // fix with pagination
                 },
             })
                 .done(function (data) {
-                    self.rows(_.union(self.rows(), data.rows));
+                    self.rows(data.rows);
                 })
                 .fail(function () {
                     self.isLoadingError(true);

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
@@ -25,6 +25,10 @@ hqDefine('reports/v2/js/datagrid/data_models', [
         self.length = 50; // todo change number dynamically?
 
         self.loadRecords = function () {
+            if (!self.reportContext) {
+                throw new Error("Please call init() before calling loadRecords().");
+            }
+
             if (self.isDataLoading()) return;
 
             self.isDataLoading(true);
@@ -35,6 +39,7 @@ hqDefine('reports/v2/js/datagrid/data_models', [
                 data: {
                     length: self.length,
                     start: 0, // fix with pagination
+                    reportContext: JSON.stringify(self.reportContext()),
                 },
             })
                 .done(function (data) {
@@ -48,7 +53,12 @@ hqDefine('reports/v2/js/datagrid/data_models', [
                 });
         };
 
-        self.init = function () {
+        self.init = function (reportContextObservable) {
+            self.reportContext = reportContextObservable;
+            self.loadRecords();
+        };
+
+        self.refresh = function () {
             self.loadRecords();
         };
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/filters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/filters.js
@@ -17,6 +17,7 @@ hqDefine('reports/v2/js/datagrid/filters', [
         var self = {};
 
         self.filterType = ko.observable(data.filterType);
+        self.filterTypeTitle = ko.observable(data.filterTypeTitle);
         self.name = ko.observable(data.name);
         self.title = ko.observable(data.title);
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/filters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/filters.js
@@ -1,0 +1,39 @@
+/**
+ * todo add docstring
+ */
+
+hqDefine('reports/v2/js/datagrid/filters', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/assert_properties',
+], function (
+    $,
+    ko
+) {
+    'use strict';
+
+    var columnFilterModel = function (data) {
+        var self = {};
+
+        self.filterType = ko.observable(data.filterType);
+        self.name = ko.observable(data.name);
+        self.title = ko.observable(data.title);
+
+        return self;
+    };
+
+    var appliedColumnFilterModel = function (data) {
+        var self = {};
+
+        self.filter = ko.observable(columnFilterModel(data.filter || {}));
+        self.value = ko.observable(data.value);
+
+        return self;
+    };
+
+    return {
+        columnFilterModel: columnFilterModel,
+        appliedColumnFilterModel: appliedColumnFilterModel,
+    };
+});

--- a/corehq/apps/reports/static/reports/v2/js/views/explore_case_data.js
+++ b/corehq/apps/reports/static/reports/v2/js/views/explore_case_data.js
@@ -20,6 +20,7 @@ hqDefine('reports/v2/js/views/explore_case_data', [
         dataModel: datagrid.dataModels.scrollingDataModel(view.config.endpoint.datagrid),
         initialColumns: context.getColumns(),
         columnEndpoint: view.config.endpoint.case_properties,
+        availableFilters: context.getColumnFilters(),
     });
 
     view.datagridController.init();

--- a/corehq/apps/reports/v2/endpoints/datagrid.py
+++ b/corehq/apps/reports/v2/endpoints/datagrid.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import json
+
 from corehq.apps.reports.v2.models import BaseDataEndpoint
 
 
@@ -22,6 +24,10 @@ class DatagridEndpoint(BaseDataEndpoint):
     @property
     def order(self):
         return int(self.data.get('order', 1))
+
+    @property
+    def report_context(self):
+        return json.loads(self.data.get('reportContext', "{}"))
 
     def get_response(self, query, formatter):
         total = query.count()

--- a/corehq/apps/reports/v2/exceptions.py
+++ b/corehq/apps/reports/v2/exceptions.py
@@ -8,3 +8,7 @@ class ReportNotFoundError(Exception):
 
 class EndpointNotFoundError(Exception):
     pass
+
+
+class ColumnFilterNotFoundError(Exception):
+    pass

--- a/corehq/apps/reports/v2/filters/case_columns.py
+++ b/corehq/apps/reports/v2/filters/case_columns.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy
 
+from corehq.apps.es import queries
 from corehq.apps.reports.v2.models import BaseColumnFilter, FilterChoiceMeta
 
 
@@ -16,6 +17,19 @@ class TextCaseColumnFilter(BaseColumnFilter):
         FilterChoiceMeta('not_equals', ugettext_lazy('Does Not Equal')),
     ]
 
-    def get_filtered_query(self, query, config):
-        # todo
+    @classmethod
+    def get_filtered_query(cls, query, config):
+        property_name = config['propertyName']
+        filter_name = config['filterName']
+        value = config['filterValue']
+
+        clause = queries.MUST_NOT if filter_name.startswith('not_') else queries.MUST
+
+        if filter_name.endswith('contains'):
+            query = query.regexp_case_property_query(
+                property_name, ".*{}.*".format(value), clause
+            )
+        elif filter_name.endswith('equals'):
+            query = query.case_property_query(property_name, value, clause)
+
         return query

--- a/corehq/apps/reports/v2/filters/case_columns.py
+++ b/corehq/apps/reports/v2/filters/case_columns.py
@@ -31,6 +31,9 @@ class TextCaseColumnFilter(BaseColumnFilter):
             query = query.regexp_case_property_query(
                 property_name, ".*{}.*".format(value), clause
             )
+        elif value == "":
+            operator = "!=" if filter_name.startswith('not_') else "="
+            query = query.xpath_query(self.domain, "{} {} ''".format(property_name, operator))
         elif filter_name.endswith('equals'):
             query = query.case_property_query(property_name, value, clause)
 

--- a/corehq/apps/reports/v2/filters/case_columns.py
+++ b/corehq/apps/reports/v2/filters/case_columns.py
@@ -1,16 +1,19 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 from corehq.apps.reports.v2.models import BaseColumnFilter, FilterChoiceMeta
 
 
 class TextCaseColumnFilter(BaseColumnFilter):
     filter_type = 'column_text'
+    title = ugettext_lazy("Text")
     choices = [
-        FilterChoiceMeta('contains', ugettext_noop('Contains')),
-        FilterChoiceMeta('is_exactly', ugettext_noop('Is Exactly')),
+        FilterChoiceMeta('contains', ugettext_lazy('Contains')),
+        FilterChoiceMeta('equals', ugettext_lazy('Equals')),
+        FilterChoiceMeta('not_contains', ugettext_lazy('Does Not Contain')),
+        FilterChoiceMeta('not_equals', ugettext_lazy('Does Not Equal')),
     ]
 
     def get_filtered_query(self, query, config):

--- a/corehq/apps/reports/v2/filters/case_columns.py
+++ b/corehq/apps/reports/v2/filters/case_columns.py
@@ -17,8 +17,7 @@ class TextCaseColumnFilter(BaseColumnFilter):
         FilterChoiceMeta('not_equals', ugettext_lazy('Does Not Equal')),
     ]
 
-    @classmethod
-    def get_filtered_query(cls, query, config):
+    def get_filtered_query(self, query, config):
         property_name = config['propertyName']
         filter_name = config['filterName']
         value = config['filterValue']

--- a/corehq/apps/reports/v2/filters/case_columns.py
+++ b/corehq/apps/reports/v2/filters/case_columns.py
@@ -4,11 +4,14 @@ from __future__ import unicode_literals
 from django.utils.translation import ugettext_lazy
 
 from corehq.apps.es import queries
-from corehq.apps.reports.v2.models import BaseColumnFilter, FilterChoiceMeta
+from corehq.apps.reports.v2.models import (
+    BaseColumnFilter,
+    FilterChoiceMeta,
+)
 
 
 class TextCaseColumnFilter(BaseColumnFilter):
-    filter_type = 'column_text'
+    filter_type = 'case_text'
     title = ugettext_lazy("Text")
     choices = [
         FilterChoiceMeta('contains', ugettext_lazy('Contains')),

--- a/corehq/apps/reports/v2/filters/case_columns.py
+++ b/corehq/apps/reports/v2/filters/case_columns.py
@@ -38,3 +38,32 @@ class TextCaseColumnFilter(BaseColumnFilter):
             query = query.case_property_query(property_name, value, clause)
 
         return query
+
+
+class NumericCaseColumnFilter(BaseColumnFilter):
+    filter_type = 'case_numeric'
+    title = ugettext_lazy("Number")
+    choices = [
+        FilterChoiceMeta('equals', ugettext_lazy('is equal to')),
+        FilterChoiceMeta('greater_than', ugettext_lazy('is greater than')),
+        FilterChoiceMeta('less_than', ugettext_lazy('is less than')),
+        FilterChoiceMeta('not_equals', ugettext_lazy('is not equal to')),
+    ]
+
+    def get_filtered_query(self, query, config):
+        property_name = config['propertyName']
+        filter_name = config['filterName']
+        value = config['filterValue']
+
+        if value == "":
+            operator = "!=" if filter_name.startswith('not_') else "="
+            query = query.xpath_query(self.domain, "{} {} ''".format(property_name, operator))
+        elif filter_name.endswith('equals'):
+            clause = queries.MUST_NOT if filter_name.startswith('not_') else queries.MUST
+            query = query.case_property_query(property_name, value, clause)
+        elif filter_name == 'greater_than':
+            query = query.numeric_range_case_property_query(property_name, gt=value)
+        elif filter_name == 'less_than':
+            query = query.numeric_range_case_property_query(property_name, lt=value)
+
+        return query

--- a/corehq/apps/reports/v2/filters/case_columns.py
+++ b/corehq/apps/reports/v2/filters/case_columns.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_noop
+
+from corehq.apps.reports.v2.models import BaseColumnFilter, FilterChoiceMeta
+
+
+class TextCaseColumnFilter(BaseColumnFilter):
+    filter_type = 'column_text'
+    choices = [
+        FilterChoiceMeta('contains', ugettext_noop('Contains')),
+        FilterChoiceMeta('is_exactly', ugettext_noop('Is Exactly')),
+    ]
+
+    def get_filtered_query(self, query, config):
+        # todo
+        return query

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -7,7 +7,7 @@ from corehq.apps.reports.v2.exceptions import EndpointNotFoundError
 
 
 EndpointContext = namedtuple('EndpointContext', 'slug urlname')
-ColumnContext = namedtuple('ColumnContext', 'title slug width')
+ColumnContext = namedtuple('ColumnContext', 'title name width')
 FilterChoiceMeta = namedtuple('FilterOptionsMeta', 'name title')
 
 

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 
 from collections import namedtuple
 
-from corehq.apps.reports.v2.exceptions import EndpointNotFoundError
+from corehq.apps.reports.v2.exceptions import (
+    EndpointNotFoundError,
+    ColumnFilterNotFoundError,
+)
 
 
 EndpointContext = namedtuple('EndpointContext', 'slug urlname')
@@ -47,6 +50,15 @@ class BaseReport(object):
 
     def get_options_endpoint(self, endpoint_slug):
         return self._get_endpoint(endpoint_slug, self.options_endpoints)
+
+    def get_column_filter(self, filter_type):
+        name_to_class = dict([(f.filter_type, f) for f in self.column_filters])
+        try:
+            return name_to_class[filter_type]
+        except (KeyError, NameError):
+            raise ColumnFilterNotFoundError(
+                "ColumnFilter '{}' cannot be found.".format(filter_type)
+            )
 
     @property
     def context(self):

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -8,6 +8,7 @@ from corehq.apps.reports.v2.exceptions import EndpointNotFoundError
 
 EndpointContext = namedtuple('EndpointContext', 'slug urlname')
 ColumnContext = namedtuple('ColumnContext', 'title slug width')
+FilterChoiceMeta = namedtuple('FilterOptionsMeta', 'name title')
 
 
 class BaseReport(object):
@@ -19,6 +20,7 @@ class BaseReport(object):
     options_endpoints = ()
     formatters = ()
     columns = []
+    column_filters = ()
 
     def __init__(self, request, domain):
         """
@@ -59,6 +61,10 @@ class BaseReport(object):
             'slug': self.slug,
             'endpoints': [e._asdict() for e in endpoints],
             'columns': [c._asdict() for c in self.columns],
+            'column_filters': [
+                dict(filterType=f.filter_type, name=c.name, title=c.title)
+                for f in self.column_filters for c in f.choices
+            ],
         }
 
 
@@ -130,3 +136,17 @@ class BaseDataFormatter(object):
         :return: {}
         """
         raise NotImplementedError("please implement get_context")
+
+
+class BaseColumnFilter(object):
+    filter_type = None
+    choices = []
+
+    @classmethod
+    def get_filtered_query(cls, query, config):
+        """
+        Override this to return the filtered query
+        :param query:
+        :return: query
+        """
+        raise NotImplementedError("please implement get_filtered_query")

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -7,7 +7,7 @@ from corehq.apps.reports.v2.exceptions import EndpointNotFoundError
 
 
 EndpointContext = namedtuple('EndpointContext', 'slug urlname')
-ColumnContext = namedtuple('ColumnContext', 'title name width')
+ColumnMeta = namedtuple('ColumnMeta', 'title name width')
 FilterChoiceMeta = namedtuple('FilterOptionsMeta', 'name title')
 
 

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -167,7 +167,8 @@ class BaseColumnFilter(object):
     def get_filtered_query(self, query, config):
         """
         Override this to return the filtered query
-        :param query:
+        :param query: chain-able query (like ESQuery)
+        :param config: dict
         :return: query
         """
         raise NotImplementedError("please implement get_filtered_query")

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -62,7 +62,12 @@ class BaseReport(object):
             'endpoints': [e._asdict() for e in endpoints],
             'columns': [c._asdict() for c in self.columns],
             'column_filters': [
-                dict(filterType=f.filter_type, name=c.name, title=c.title)
+                dict(
+                    filterType=f.filter_type,
+                    filterTypeTitle=f.title,
+                    name=c.name,
+                    title=c.title
+                )
                 for f in self.column_filters for c in f.choices
             ],
         }
@@ -140,6 +145,7 @@ class BaseDataFormatter(object):
 
 class BaseColumnFilter(object):
     filter_type = None
+    title = None
     choices = []
 
     @classmethod

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -54,7 +54,8 @@ class BaseReport(object):
     def get_column_filter(self, filter_type):
         name_to_class = dict([(f.filter_type, f) for f in self.column_filters])
         try:
-            return name_to_class[filter_type]
+            filter_class = name_to_class[filter_type]
+            return filter_class(self.domain)
         except (KeyError, NameError):
             raise ColumnFilterNotFoundError(
                 "ColumnFilter '{}' cannot be found.".format(filter_type)
@@ -160,8 +161,10 @@ class BaseColumnFilter(object):
     title = None
     choices = []
 
-    @classmethod
-    def get_filtered_query(cls, query, config):
+    def __init__(self, domain):
+        self.domain = domain
+
+    def get_filtered_query(self, query, config):
         """
         Override this to return the filtered query
         :param query:

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -11,7 +11,7 @@ from corehq.apps.reports.v2.filters.case_columns import TextCaseColumnFilter
 from corehq.apps.reports.v2.formatters.cases import CaseDataFormatter
 from corehq.apps.reports.v2.models import (
     BaseReport,
-    ColumnContext,
+    ColumnMeta,
 )
 from corehq.apps.es import CaseSearchES
 
@@ -28,12 +28,12 @@ class ExploreCaseDataReport(BaseReport):
     )
 
     columns = [
-        ColumnContext(
+        ColumnMeta(
             title=ugettext_lazy("Case Name"),
             name='case_name',
             width=200,
         ),
-        ColumnContext(
+        ColumnMeta(
             title=ugettext_lazy("Case Type"),
             name='@case_type',
             width=200,

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -49,9 +49,8 @@ class ExploreCaseDataReport(BaseReport):
 
     def get_data_response(self, endpoint):
         query = self._get_base_query()
-
-        # todo think about filtering
-        # for f in self.get_filters():
-        #     query = f.get_filtered_query(query)
+        for config in endpoint.report_context.get('columnFilters', []):
+            column_filter = self.get_column_filter(config['filterType'])
+            query = column_filter.get_filtered_query(query, config)
 
         return endpoint.get_response(query, CaseDataFormatter)

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -7,6 +7,7 @@ from corehq.apps.reports.v2.endpoints.case_properties import (
     CasePropertiesEndpoint
 )
 from corehq.apps.reports.v2.endpoints.datagrid import DatagridEndpoint
+from corehq.apps.reports.v2.filters.case_columns import TextCaseColumnFilter
 from corehq.apps.reports.v2.formatters.cases import CaseDataFormatter
 from corehq.apps.reports.v2.models import (
     BaseReport,
@@ -38,6 +39,10 @@ class ExploreCaseDataReport(BaseReport):
             width=200,
         ),
     ]
+
+    column_filters = (
+        TextCaseColumnFilter,
+    )
 
     def _get_base_query(self):
         return CaseSearchES().domain(self.domain)

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -7,7 +7,10 @@ from corehq.apps.reports.v2.endpoints.case_properties import (
     CasePropertiesEndpoint
 )
 from corehq.apps.reports.v2.endpoints.datagrid import DatagridEndpoint
-from corehq.apps.reports.v2.filters.case_columns import TextCaseColumnFilter
+from corehq.apps.reports.v2.filters.case_columns import (
+    TextCaseColumnFilter,
+    NumericCaseColumnFilter,
+)
 from corehq.apps.reports.v2.formatters.cases import CaseDataFormatter
 from corehq.apps.reports.v2.models import (
     BaseReport,
@@ -42,6 +45,7 @@ class ExploreCaseDataReport(BaseReport):
 
     column_filters = (
         TextCaseColumnFilter,
+        NumericCaseColumnFilter,
     )
 
     def _get_base_query(self):
@@ -49,6 +53,7 @@ class ExploreCaseDataReport(BaseReport):
 
     def get_data_response(self, endpoint):
         query = self._get_base_query()
+
         for config in endpoint.report_context.get('columnFilters', []):
             column_filter = self.get_column_filter(config['filterType'])
             query = column_filter.get_filtered_query(query, config)

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -30,12 +30,12 @@ class ExploreCaseDataReport(BaseReport):
     columns = [
         ColumnContext(
             title=ugettext_lazy("Case Name"),
-            slug='case_name',
+            name='case_name',
             width=200,
         ),
         ColumnContext(
             title=ugettext_lazy("Case Type"),
-            slug='@case_type',
+            name='@case_type',
             width=200,
         ),
     ]


### PR DESCRIPTION
This is an idea PR for column filter implementation. I approached it from the paradigm that we would apply filters directly to a chain-able query object (like an `ESQuery` or `QuerySet`), rather than building out a full `xpath` expression and then running it through `CaseSearchES`'s `xpath_query`. Additionally, I needed to handle a `regex` for `contains`. 

Happy to discuss and iterate on this though! I certainly have ideas for an alternate method that builds out the xpath query, but I wanted to see how people felt about this one and get it out there for feedback as I'm about to head into interrupt.

I feel like the chain-able approach is more flexible to other query types, and perhaps more powerful. Note that we did away with `and` / `or` logic for the purposes of simplifying the UI in this test, but to support it I would also have to modify this method and treat each column as a logical group.

Note that there is still no error checking on this, or limit on the number of filters, or any UI work or thought at all outside of desired core functionality. This was done quick and dirty to keep things moving.

Here are some gifs of it in action:

![CLE-pt1](https://user-images.githubusercontent.com/716573/55516166-17d99600-5632-11e9-8046-c0b190b84e76.gif)

![CLE-pt2](https://user-images.githubusercontent.com/716573/55516167-17d99600-5632-11e9-9753-a8bcfcbbf0e3.gif)

![CLE-pt3](https://user-images.githubusercontent.com/716573/55516168-17d99600-5632-11e9-89d7-c8a1aebc54cc.gif)

![CLE-pt4](https://user-images.githubusercontent.com/716573/55516169-17d99600-5632-11e9-96ec-422d89fef428.gif)

![CLE-pt5](https://user-images.githubusercontent.com/716573/55516170-17d99600-5632-11e9-8c08-fec65d9cfcb5.gif)

![CLE-pt6](https://user-images.githubusercontent.com/716573/55516173-18722c80-5632-11e9-87d4-842b34c9decb.gif)

cc @dimagi/product and buddy @calellowitz 



