### PR TITLE
Allow controlling feature flags from domain-specific page

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -89,7 +89,6 @@
     {% initial_page_data 'add_ons_layout' add_ons_layout %}
     {% registerurl 'current_app_version' domain app.id %}
     {% registerurl "new_form" domain app.id "---" %}
-    {% registerurl "toggle_app_manager_v2" %}
     {% block pre_form_content %}{% endblock %}
     {% block form-view %}{% endblock %}
     <script type="text/html" id="js-popover-template-add-item">

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -1,0 +1,39 @@
+hqDefine('domain/js/toggles', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/main',
+], function (
+    $,
+    ko,
+    _,
+    initialPageData
+) {
+
+    var Toggle = function (data) {
+        var self = {};
+        self.slug = data['slug'];
+        self.label = data['label'];
+        self.description = data['description'];
+        self.helpLink = data['help_link'];
+        self.tag = data['tag'];
+        self.tagCssClass = data['tag_css_class'];
+        self.domainEnabled = ko.observable(data['domain_enabled']);
+        self.userEnabled = ko.observable(data['user_enabled']);
+        self.url = initialPageData.reverse('edit_toggle', self.slug);
+
+        self.cssClass = ko.computed(function () {
+            if (self.domainEnabled()) {
+                return 'success';
+            } else if (self.userEnabled()) {
+                return 'info';
+            }
+        });
+
+        return self;
+    };
+
+    var allToggles = _.map(initialPageData.get('toggles'), Toggle);
+    ko.applyBindings({"toggles": allToggles}, $("#toggles-table")[0]);
+});

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -4,16 +4,24 @@ hqDefine('domain/js/toggles', [
     'underscore',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/alert_user',
+    'hqwebapp/js/assert_properties',
     'hqwebapp/js/main',
 ], function (
     $,
     ko,
     _,
     initialPageData,
-    alertUser
+    alertUser,
+    assertProperties
 ) {
 
     var Toggle = function (data) {
+        assertProperties.assert(data, [
+            'slug', 'label', 'description', 'help_link', 'tag', 'tag_css_class',
+            'tag_description', 'domain_enabled', 'user_enabled',
+            'has_domain_namespace',
+        ]);
+
         var self = {};
         self.slug = data['slug'];
         self.label = data['label'];
@@ -59,5 +67,5 @@ hqDefine('domain/js/toggles', [
     };
 
     var allToggles = _.map(initialPageData.get('toggles'), Toggle);
-    ko.applyBindings({"toggles": allToggles}, $("#toggles-table")[0]);
+    $("#toggles-table").koApplyBindings({"toggles": allToggles});
 });

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -34,6 +34,7 @@ hqDefine('domain/js/toggles', [
         self.domainEnabled = ko.observable(data['domain_enabled']);
         self.userEnabled = ko.observable(data['user_enabled']);
         self.hasDomainNamespace = data['has_domain_namespace'];
+        self.editLink = initialPageData.reverse('edit_toggle', self.slug);
 
         self.expanded = ko.observable(false);
         self.showHideDescription = function () { self.expanded(!self.expanded()); };

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -21,9 +21,13 @@ hqDefine('domain/js/toggles', [
         self.helpLink = data['help_link'];
         self.tag = data['tag'];
         self.tagCssClass = data['tag_css_class'];
+        self.tagDescription = data['tag_description'];
         self.domainEnabled = ko.observable(data['domain_enabled']);
         self.userEnabled = ko.observable(data['user_enabled']);
         self.hasDomainNamespace = data['has_domain_namespace'];
+
+        self.expanded = ko.observable(false);
+        self.showHideDescription = function () { self.expanded(!self.expanded()); };
 
         self.cssClass = ko.computed(function () {
             if (self.domainEnabled()) {

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -37,12 +37,8 @@ hqDefine('domain/js/toggles', [
         self.expanded = ko.observable(false);
         self.showHideDescription = function () { self.expanded(!self.expanded()); };
 
-        self.cssClass = ko.computed(function () {
-            if (self.domainEnabled()) {
-                return 'success';
-            } else if (self.userEnabled()) {
-                return 'info';
-            }
+        self.isEnabled = ko.computed(function () {
+            return self.domainEnabled() || self.userEnabled();
         });
 
         self.setTogglePending = ko.observable(false);

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -21,7 +21,7 @@ hqDefine('domain/js/toggles', [
         self.tagCssClass = data['tag_css_class'];
         self.domainEnabled = ko.observable(data['domain_enabled']);
         self.userEnabled = ko.observable(data['user_enabled']);
-        self.url = initialPageData.reverse('edit_toggle', self.slug);
+        self.hasDomainNamespace = data['has_domain_namespace'];
 
         self.cssClass = ko.computed(function () {
             if (self.domainEnabled()) {
@@ -30,6 +30,11 @@ hqDefine('domain/js/toggles', [
                 return 'info';
             }
         });
+
+        self.toggleEnabledState = function () {
+            var newState = !self.domainEnabled();
+            self.domainEnabled(newState);
+        };
 
         return self;
     };

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -3,12 +3,14 @@ hqDefine('domain/js/toggles', [
     'knockout',
     'underscore',
     'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/alert_user',
     'hqwebapp/js/main',
 ], function (
     $,
     ko,
     _,
-    initialPageData
+    initialPageData,
+    alertUser
 ) {
 
     var Toggle = function (data) {
@@ -31,9 +33,22 @@ hqDefine('domain/js/toggles', [
             }
         });
 
+        self.setTogglePending = ko.observable(false);
         self.toggleEnabledState = function () {
+            self.setTogglePending(true);
             var newState = !self.domainEnabled();
-            self.domainEnabled(newState);
+            $.ajax({
+                method: 'POST',
+                url: initialPageData.reverse('set_toggle', self.slug),
+                data: {
+                    item: initialPageData.get('domain'),
+                    enabled: newState,
+                    namespace: 'domain',
+                },
+                success: function () { self.domainEnabled(newState); },
+                error: function () { alertUser.alert_user("Something went wrong", 'danger'); },
+                complete: function () { self.setTogglePending(false); },
+            });
         };
 
         return self;

--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -5,6 +5,7 @@ hqDefine('domain/js/toggles', [
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/alert_user',
     'hqwebapp/js/assert_properties',
+    'hqwebapp/js/knockout_bindings.ko',  // for slideVisible
     'hqwebapp/js/main',
 ], function (
     $,

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -10,6 +10,7 @@
     {% initial_page_data 'domain' domain %}
     {% initial_page_data 'toggles' toggles %}
     {% registerurl 'set_toggle' '---' %}
+    {% registerurl 'edit_toggle' '---' %}
 
     <div class="row">
         <div class="col-sm-10">
@@ -108,9 +109,9 @@
 
                             <div class="row" data-bind="slideVisible: expanded()">
                                 <br />
-                                <p data-bind="visible: description, text: description"></p>
+                                <p data-bind="visible: description, html: description"></p>
                                 <span data-bind="visible: helpLink">
-                                    <a data-bind="attr: {href: helpLink}" target="_blank">Documentation</a>
+                                    <a data-bind="attr: {href: helpLink}">Documentation</a>
                                 </span>
                                 <hr data-bind="visible: description || helpLink" />
                                 <div>
@@ -118,6 +119,9 @@
                                                      text: tag"
                                           class="label"></span>
                                     <span data-bind="text: tagDescription">
+                                </div>
+                                <div class="text-right">
+                                    <small><a class="text-uppercase" data-bind="attr: {href: editLink}, text: slug"></a></small>
                                 </div>
                             </div>
                         </td>

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -21,20 +21,16 @@
     <div class="row">
         <div class="col-sm-10">
             <p>
-                {% blocktrans %}
-                    Features can be enabled or disabled based on feature flags or privileges. This page
-                    is intended to provide a list of what features a domain has access to.
-                {% endblocktrans %}
+                Features can be enabled or disabled based on feature flags or privileges. This page
+                is intended to provide a list of what features a domain has access to.
             </p>
             {% if use_sql_backend %}
             <div class="alert alert-warning" role="alert">
-                {% blocktrans %}
-                    NOTE: This domain is using the SCALE backend which implies the following feature flags:
-                    <ul>
-                        <li>Use new backend export infrastructure</li>  <!-- not OLD_EXPORTS -->
-                        <li>Use a SQLite backend for Touchforms</li>  <!-- TF_USES_SQLITE_BACKEND -->
-                    </ul>
-                {% endblocktrans %}
+                NOTE: This domain is using the SCALE backend which implies the following feature flags:
+                <ul>
+                    <li>Use new backend export infrastructure</li>  <!-- not OLD_EXPORTS -->
+                    <li>Use a SQLite backend for Touchforms</li>  <!-- TF_USES_SQLITE_BACKEND -->
+                </ul>
             </div>
             {% endif %}
         </div>
@@ -45,18 +41,16 @@
             <h1>Privileges</h1>
             <p>
                 {% url "domain_subscription_view" domain as software_plan_url %}
-                {% blocktrans %}
-                    Access to some features is dependent on a the software plan to which the domain
-                    is subscribed.
-                    <a href="{{ software_plan_url }}">Current Subscription</a>
-                {% endblocktrans %}
+                Access to some features is dependent on a the software plan to which the domain
+                is subscribed.
+                <a href="{{ software_plan_url }}">Current Subscription</a>
             </p>
         </div>
         <div class="col-sm-10">
             <table class="table table-striped">
                 <thead>
-                    <th>{% trans "Privilege" %}</th>
-                    <th class="checkmark-column">{% trans "Enabled for domain?" %}</th>
+                    <th>Privilege</th>
+                    <th class="checkmark-column">Enabled for domain?</th>
                 </thead>
                 <tbody>
                     {% for privilege_name, enabled_for_domain in privileges %}
@@ -81,27 +75,23 @@
             <h1>Feature Flags</h1>
             <p>
                 {% url 'toggle_list' as toggle_url %}
-                {% blocktrans %}
-                    Feature Flags turn on features for individual users or projects. They are editable only by
-                    super users, in the <a href="{{ toggle_url }}">Feature Flag edit UI</a>.
-                    In addition, some feature flags are randomly enabled by domain.
-                {% endblocktrans %}
+                Feature Flags turn on features for individual users or projects. They are editable only by
+                super users, in the <a href="{{ toggle_url }}">Feature Flag edit UI</a>.
+                In addition, some feature flags are randomly enabled by domain.
             </p>
             <p>
-                {% blocktrans %}
-                    Following are all flags enabled for this domain and/or for you.
-                    This does not include any flags set for other users in this domain.
-                {% endblocktrans %}
+                Following are all flags enabled for this domain and/or for you.
+                This does not include any flags set for other users in this domain.
             </p>
         </div>
         <div class="col-sm-10">
             <table class="table table-striped" id="toggles-table">
                 <thead>
-                    <th>{% trans "Tag" %}</th>
-                    <th>{% trans "Feature" %}</th>
-                    <th class="checkmark-column">{% trans "Enabled for domain?" %}</th>
-                    <th class="checkmark-column">{% trans "Enabled for me?" %}</th>
-                    <th>{% trans "Edit" %}</th>
+                    <th>Tag</th>
+                    <th>Feature</th>
+                    <th class="checkmark-column">Enabled for domain?</th>
+                    <th class="checkmark-column">Enabled for me?</th>
+                    <th>Edit</th>
                 </thead>
                 <tbody data-bind="foreach: toggles">
                     <tr data-bind="css: cssClass">
@@ -135,7 +125,7 @@
                         <td class="checkmark-column">
                             <i class="fa fa-check" data-bind="visible: userEnabled"></i>
                         </td>
-                        <td><a data-bind="attr: {href: url}">{% trans "change" %}</a></td>
+                        <td><a data-bind="attr: {href: url}">change</a></td>
                     </tr>
                 </tbody>
             </table>
@@ -149,8 +139,8 @@
         <div class="col-sm-10">
             <table class="table table-striped">
                 <thead>
-                    <th>{% trans "Feature" %}</th>
-                    <th class="checkmark-column">{% trans "Enabled for domain?" %}</th>
+                    <th>Feature</th>
+                    <th class="checkmark-column">Enabled for domain?</th>
                 </thead>
                 <tbody>
                     <tr class="{% if use_sql_backend %}success{% else %}info{% endif %}">

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -5,14 +5,6 @@
 
 {% requirejs_main 'domain/js/toggles' %}
 
-{% block head %}{{ block.super }}
-<style type="text/css">
-    th.checkmark-column, td.checkmark-column {
-        white-space: nowrap;
-        text-align: center;
-    }
-</style>
-{% endblock %}
 {% block page_content %}
 
     {% initial_page_data 'domain' domain %}
@@ -51,13 +43,13 @@
             <table class="table table-striped">
                 <thead>
                     <th>Privilege</th>
-                    <th class="checkmark-column">Enabled for domain?</th>
+                    <th class="text-center text-nowrap">Enabled for domain?</th>
                 </thead>
                 <tbody>
                     {% for privilege_name, enabled_for_domain in privileges %}
                     <tr class="{% if enabled_for_domain %}success{% else %}warning{% endif %}">
                         <td>{{ privilege_name }}</td>
-                        <td class="checkmark-column">
+                        <td class="text-center">
                             {% if enabled_for_domain %}
                                 <i class="fa fa-check"></i>
                             {% else %}
@@ -90,38 +82,42 @@
                 <thead>
                     <th>Tag</th>
                     <th>Feature</th>
-                    <th class="checkmark-column">Enabled for me?</th>
-                    <th class="checkmark-column">Enabled for domain?</th>
+                    <th class="text-center text-nowrap">Enabled for me?</th>
+                    <th class="text-center text-nowrap">Enabled for domain?</th>
                 </thead>
                 <tbody data-bind="foreach: toggles">
                     <tr data-bind="css: cssClass">
-                        <td><span class="label"
-                                  data-bind="css: ('label-' + tagCssClass),
-                                             text: tag"></span></td>
+                        <td>
+                            <span data-bind="css: ('label-' + tagCssClass),
+                                             text: tag"
+                                  class="label"></span>
+                        </td>
 
-                        <td data-bind="click: showHideDescription">
+                        <td class="clickable" data-bind="click: showHideDescription">
                             <span data-bind="text: label"></span>
 
                             <span data-bind="visible: helpLink">
                                 (<a data-bind="attr: {href: helpLink}" target="_blank">docs</a>)
                             </span>
 
-                            <span data-bind="visible: !!description">&#8230;</span>
+                            <span data-bind="visible: !!description">&hellip;</span>
 
                             <div data-bind="visible: expanded()" class="well">
                                 <p data-bind="text: description"></p>
-                                <div data-bind="css: ('bg-' + tagCssClass)">
-                                    <strong data-bind="text: tag"></strong>:
+                                <div>
+                                    <span data-bind="css: ('label-' + tagCssClass),
+                                                     text: tag"
+                                          class="label"></span>
                                     <span data-bind="text: tagDescription"></div>
                                 </div>
                             </div>
                         </td>
 
-                        <td class="checkmark-column">
-                            <i class="fa fa-check" data-bind="visible: userEnabled"></i>
+                        <td class="text-center">
+                            <i class="fa fa-user" data-bind="visible: userEnabled"></i>
                         </td>
 
-                        <td class="checkmark-column">
+                        <td class="text-center">
                             <div data-bind="visible: hasDomainNamespace">
                                 <i class="fa fa-spin fa-refresh" data-bind="visible: setTogglePending"></i>
                                 <button type="button"
@@ -153,16 +149,16 @@
             <table class="table table-striped">
                 <thead>
                     <th>Feature</th>
-                    <th class="checkmark-column">Enabled for domain?</th>
+                    <th class="text-center text-nowrap">Enabled for domain?</th>
                 </thead>
                 <tbody>
                     <tr class="{% if use_sql_backend %}success{% else %}info{% endif %}">
                         <td>Using new SQL/scale backend</td>
-                        <td class="checkmark-column">{% if use_sql_backend %}<i class="fa fa-check"></i>{% endif %}</td>
+                        <td class="text-center">{% if use_sql_backend %}<i class="fa fa-check"></i>{% endif %}</td>
                     </tr>
                     <tr class="{% if request|tzmigration_status == "complete" %}success{% elif enabled_for_user %}info{% endif %}">
                         <td>Using new correct timezone behavior</td>
-                        <td class="checkmark-column">{% if request|tzmigration_status == "complete" %}<i class="fa fa-check"></i>{% endif %}</td>
+                        <td class="text-center">{% if request|tzmigration_status == "complete" %}<i class="fa fa-check"></i>{% endif %}</td>
                     </tr>
                 </tbody>
             </table>

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -1,6 +1,10 @@
 {% extends "hqwebapp/base_section.html" %}
+{% load hq_shared_tags %}
 {% load i18n %}
 {% load tzmigration %}
+
+{% requirejs_main 'domain/js/toggles' %}
+
 {% block head %}{{ block.super }}
 <style type="text/css">
     th.checkmark-column, td.checkmark-column {
@@ -10,6 +14,10 @@
 </style>
 {% endblock %}
 {% block page_content %}
+
+    {% initial_page_data 'toggles' toggles %}
+    {% registerurl 'edit_toggle' '---' %}
+
     <div class="row">
         <div class="col-sm-10">
             <p>
@@ -87,7 +95,7 @@
             </p>
         </div>
         <div class="col-sm-10">
-            <table class="table table-striped">
+            <table class="table table-striped" id="toggles-table">
                 <thead>
                     <th>{% trans "Tag" %}</th>
                     <th>{% trans "Feature" %}</th>
@@ -95,37 +103,40 @@
                     <th class="checkmark-column">{% trans "Enabled for me?" %}</th>
                     <th>{% trans "Edit" %}</th>
                 </thead>
-                <tbody>
-                    {% for toggle, enabled_for_domain, enabled_for_user in flags %}
-                    <tr class="{% if enabled_for_domain %}success{% elif enabled_for_user %}info{% endif %}">
-                        <td><span class="label label-{{ toggle.tag.css_class }}">{{ toggle.tag.name }}</span></td>
-                        <td>
+                <tbody data-bind="foreach: toggles">
+                    <tr data-bind="css: cssClass">
+                        <td><span class="label"
+                                  data-bind="css: ('label-' + tagCssClass),
+                                             text: tag"></span></td>
 
-                            {% if toggle.description %}
+                        <td>
                             <a class="collapsed" data-toggle="collapse" aria-expanded="false"
-                               href="#toggleDescription-{{ toggle.slug }}">
+                               data-bind="visible: description,
+                                          attr: {href: '#toggleDescription-' + slug}">
                                 <i class="fa fa-angle-double-down"></i>
                             </a>
-                            {% endif %}
 
-                            {{ toggle.label }}
+                            <span data-bind="text: label"></span>
 
-                            {% if toggle.help_link %} (<a href="{{ toggle.help_link }}" target="_blank">docs</a>){% endif %}
+                            <span data-bind="visible: helpLink">
+                                (<a data-bind="attr: {href: helpLink}" target="_blank">docs</a>)
+                            </span>
 
-                            {% if toggle.description %}
-                            <div class="collapse" id="toggleDescription-{{ toggle.slug }}">
-                                <div class="well">
-                                    {{ toggle.description }}
-                                </div>
+                            <div class="collapse"
+                                 data-bind="visible: description,
+                                            attr: {id: 'toggleDescription-' + slug}">
+                                <div class="well" data-bind="text: description"></div>
                             </div>
-                            {% endif %}
-
                         </td>
-                        <td class="checkmark-column">{% if enabled_for_domain %}<i class="fa fa-check"></i>{% endif %}</td>
-                        <td class="checkmark-column">{% if enabled_for_user %}<i class="fa fa-check"></i>{% endif %}</td>
-                        <td><a href="{% url 'edit_toggle' toggle.slug %}">{% trans "change" %}</a></td>
+
+                        <td class="checkmark-column">
+                            <i class="fa fa-check" data-bind="visible: domainEnabled"></i>
+                        </td>
+                        <td class="checkmark-column">
+                            <i class="fa fa-check" data-bind="visible: userEnabled"></i>
+                        </td>
+                        <td><a data-bind="attr: {href: url}">{% trans "change" %}</a></td>
                     </tr>
-                    {% endfor %}
                 </tbody>
             </table>
         </div>

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -81,27 +81,32 @@
             <table class="table table-striped" id="toggles-table">
                 <thead>
                     <th>Tag</th>
+                    <th class="text-center text-nowrap"><!-- placeholder for flag icon --></th>
                     <th>Feature</th>
                     <th class="text-center text-nowrap">Enabled for me?</th>
                     <th class="text-center text-nowrap">Enabled for domain?</th>
                 </thead>
                 <tbody data-bind="foreach: toggles">
-                    <tr data-bind="css: cssClass">
+                    <tr>
                         <td>
                             <span data-bind="css: ('label-' + tagCssClass),
                                              text: tag"
                                   class="label"></span>
                         </td>
 
+                        <td>
+                            <i class="fa fa-flag" data-bind="visible: isEnabled"></i>
+                        </td>
+
                         <td class="clickable" data-bind="click: showHideDescription">
-                            <span data-bind="text: label"></span>
+                            <span data-bind="text: label,
+                                            css: {'text-muted': !isEnabled()}"></span>
 
                             <span data-bind="visible: helpLink">
                                 (<a data-bind="attr: {href: helpLink}" target="_blank">docs</a>)
                             </span>
 
                             <span data-bind="visible: !!description">&hellip;</span>
-
                             <div data-bind="visible: expanded()" class="well">
                                 <p data-bind="text: description"></p>
                                 <div>
@@ -121,13 +126,11 @@
                             <div data-bind="visible: hasDomainNamespace">
                                 <i class="fa fa-spin fa-refresh" data-bind="visible: setTogglePending"></i>
                                 <button type="button"
-                                        class="btn"
+                                        class="btn btn-default"
                                         data-bind="click: toggleEnabledState,
                                                 css: {
                                                     'active': domainEnabled,
                                                     'disabled': setTogglePending,
-                                                    'btn-primary': domainEnabled,
-                                                    'btn-default': !domainEnabled(),
                                                 },
                                                 text: domainEnabled() ? 'Enabled' : 'Not Enabled'
                                                 "></button>

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -15,7 +15,9 @@
 {% endblock %}
 {% block page_content %}
 
+    {% initial_page_data 'domain' domain %}
     {% initial_page_data 'toggles' toggles %}
+    {% registerurl 'set_toggle' '---' %}
 
     <div class="row">
         <div class="col-sm-10">
@@ -123,11 +125,13 @@
 
                         <td class="checkmark-column">
                             <div data-bind="visible: hasDomainNamespace">
+                                <i class="fa fa-spin fa-refresh" data-bind="visible: setTogglePending"></i>
                                 <button type="button"
                                         class="btn"
                                         data-bind="click: toggleEnabledState,
                                                 css: {
                                                     'active': domainEnabled,
+                                                    'disabled': setTogglePending,
                                                     'btn-primary': domainEnabled,
                                                     'btn-default': !domainEnabled(),
                                                 },

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -16,7 +16,6 @@
 {% block page_content %}
 
     {% initial_page_data 'toggles' toggles %}
-    {% registerurl 'edit_toggle' '---' %}
 
     <div class="row">
         <div class="col-sm-10">
@@ -89,9 +88,8 @@
                 <thead>
                     <th>Tag</th>
                     <th>Feature</th>
-                    <th class="checkmark-column">Enabled for domain?</th>
                     <th class="checkmark-column">Enabled for me?</th>
-                    <th>Edit</th>
+                    <th class="checkmark-column">Enabled for domain?</th>
                 </thead>
                 <tbody data-bind="foreach: toggles">
                     <tr data-bind="css: cssClass">
@@ -120,12 +118,25 @@
                         </td>
 
                         <td class="checkmark-column">
-                            <i class="fa fa-check" data-bind="visible: domainEnabled"></i>
-                        </td>
-                        <td class="checkmark-column">
                             <i class="fa fa-check" data-bind="visible: userEnabled"></i>
                         </td>
-                        <td><a data-bind="attr: {href: url}">change</a></td>
+
+                        <td class="checkmark-column">
+                            <div data-bind="visible: hasDomainNamespace">
+                                <button type="button"
+                                        class="btn"
+                                        data-bind="click: toggleEnabledState,
+                                                css: {
+                                                    'active': domainEnabled,
+                                                    'btn-primary': domainEnabled,
+                                                    'btn-default': !domainEnabled(),
+                                                },
+                                                text: domainEnabled() ? 'Enabled' : 'Not Enabled'
+                                                "></button>
+                            </div>
+                            <div data-bind="visible: !hasDomainNamespace">---</div>
+                        </td>
+
                     </tr>
                 </tbody>
             </table>

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -99,23 +99,21 @@
                                   data-bind="css: ('label-' + tagCssClass),
                                              text: tag"></span></td>
 
-                        <td>
-                            <a class="collapsed" data-toggle="collapse" aria-expanded="false"
-                               data-bind="visible: description,
-                                          attr: {href: '#toggleDescription-' + slug}">
-                                <i class="fa fa-angle-double-down"></i>
-                            </a>
-
+                        <td data-bind="click: showHideDescription">
                             <span data-bind="text: label"></span>
 
                             <span data-bind="visible: helpLink">
                                 (<a data-bind="attr: {href: helpLink}" target="_blank">docs</a>)
                             </span>
 
-                            <div class="collapse"
-                                 data-bind="visible: description,
-                                            attr: {id: 'toggleDescription-' + slug}">
-                                <div class="well" data-bind="text: description"></div>
+                            <span data-bind="visible: !!description">&#8230;</span>
+
+                            <div data-bind="visible: expanded()" class="well">
+                                <p data-bind="text: description"></p>
+                                <div data-bind="css: ('bg-' + tagCssClass)">
+                                    <strong data-bind="text: tag"></strong>:
+                                    <span data-bind="text: tagDescription"></div>
+                                </div>
                             </div>
                         </td>
 

--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -98,22 +98,26 @@
                             <i class="fa fa-flag" data-bind="visible: isEnabled"></i>
                         </td>
 
-                        <td class="clickable" data-bind="click: showHideDescription">
-                            <span data-bind="text: label,
-                                            css: {'text-muted': !isEnabled()}"></span>
+                        <td>
+                            <div class="row clickable" data-bind="click: showHideDescription">
+                                <span data-bind="text: label,
+                                                 css: {'text-muted': !isEnabled()}"></span>
 
-                            <span data-bind="visible: helpLink">
-                                (<a data-bind="attr: {href: helpLink}" target="_blank">docs</a>)
-                            </span>
+                                <span data-bind="visible: description || helpLink">&hellip;</span>
+                            </div>
 
-                            <span data-bind="visible: !!description">&hellip;</span>
-                            <div data-bind="visible: expanded()" class="well">
-                                <p data-bind="text: description"></p>
+                            <div class="row" data-bind="slideVisible: expanded()">
+                                <br />
+                                <p data-bind="visible: description, text: description"></p>
+                                <span data-bind="visible: helpLink">
+                                    <a data-bind="attr: {href: helpLink}" target="_blank">Documentation</a>
+                                </span>
+                                <hr data-bind="visible: description || helpLink" />
                                 <div>
                                     <span data-bind="css: ('label-' + tagCssClass),
                                                      text: tag"
                                           class="label"></span>
-                                    <span data-bind="text: tagDescription"></div>
+                                    <span data-bind="text: tagDescription">
                                 </div>
                             </div>
                         </td>

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -215,8 +215,7 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
     def _get_toggles(self):
 
         def _sort_key(toggle):
-            return (not toggle['domain_enabled'],
-                    not toggle['user_enabled'],
+            return (not (toggle['domain_enabled'] or toggle['user_enabled']),
                     [t.name for t in toggles.ALL_TAGS].index(toggle['tag']),
                     toggle['label'])
 

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -227,6 +227,7 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
             'help_link': toggle.help_link,
             'tag': toggle.tag.name,
             'tag_css_class': toggle.tag.css_class,
+            'has_domain_namespace': toggles.NAMESPACE_DOMAIN in toggle.namespaces,
             'domain_enabled': toggle.enabled(self.domain, namespace=toggles.NAMESPACE_DOMAIN),
             'user_enabled': toggle.enabled(self.request.couch_user.username,
                                            namespace=toggles.NAMESPACE_USER),

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -212,19 +212,26 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
     def dispatch(self, request, *args, **kwargs):
         return super(FlagsAndPrivilegesView, self).dispatch(request, *args, **kwargs)
 
-    @memoized
-    def enabled_flags(self):
-        def _sort_key(toggle_enabled_tuple):
-            toggle, domain_enabled, user_enabled = toggle_enabled_tuple
-            return (not domain_enabled,
-                    not user_enabled,
-                    toggles.ALL_TAGS.index(toggle.tag),
-                    toggle.label)
-        unsorted_toggles = [(
-            toggle,
-            toggle.enabled(self.domain, namespace=toggles.NAMESPACE_DOMAIN),
-            toggle.enabled(self.request.couch_user.username, namespace=toggles.NAMESPACE_USER)
-        ) for toggle in toggles.all_toggles()]
+    def _get_toggles(self):
+
+        def _sort_key(toggle):
+            return (not toggle['domain_enabled'],
+                    not toggle['user_enabled'],
+                    [t.name for t in toggles.ALL_TAGS].index(toggle['tag']),
+                    toggle['label'])
+
+        unsorted_toggles = [{
+            'slug': toggle.slug,
+            'label': toggle.label,
+            'description': toggle.description,
+            'help_link': toggle.help_link,
+            'tag': toggle.tag.name,
+            'tag_css_class': toggle.tag.css_class,
+            'domain_enabled': toggle.enabled(self.domain, namespace=toggles.NAMESPACE_DOMAIN),
+            'user_enabled': toggle.enabled(self.request.couch_user.username,
+                                           namespace=toggles.NAMESPACE_USER),
+        } for toggle in toggles.all_toggles()]
+
         return sorted(unsorted_toggles, key=_sort_key)
 
     def _get_privileges(self):
@@ -237,7 +244,7 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
     @property
     def page_context(self):
         return {
-            'flags': self.enabled_flags(),
+            'toggles': self._get_toggles(),
             'use_sql_backend': self.domain_object.use_sql_backend,
             'privileges': self._get_privileges(),
         }

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -226,6 +226,7 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
             'description': toggle.description,
             'help_link': toggle.help_link,
             'tag': toggle.tag.name,
+            'tag_description': toggle.tag.description,
             'tag_css_class': toggle.tag.css_class,
             'has_domain_namespace': toggles.NAMESPACE_DOMAIN in toggle.namespaces,
             'domain_enabled': toggle.enabled(self.domain, namespace=toggles.NAMESPACE_DOMAIN),

--- a/corehq/apps/hqwebapp/templates/hqwebapp/rollout_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/rollout_modal.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 
 {% with slug="app_manager_v2" name="New App Builder" %}
-{% registerurl "toggle_app_manager_v2" %}
     <!-- This will appear on page load, so don't use any animation (normally controlled by .fade) -->
     <div class="modal" id="rollout-modal" data-slug="{{ slug }}">
         <div class="modal-dialog">

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -6,7 +6,7 @@
 
 {% requirejs_main 'toggle_ui/js/edit-flag' %}
 
-{% block title %}{% trans "Edit Feature Flag: " %}{{ toggle_meta.label }}{% endblock %}
+{% block title %}{% trans "Edit Feature Flag: " %}{{ static_toggle.label }}{% endblock %}
 
 {% block stylesheets %}
     <style>
@@ -31,7 +31,7 @@
     {% initial_page_data 'last_used' last_used %}
     {% initial_page_data 'service_type' service_type %}
     {% initial_page_data 'is_random_editable' is_random_editable %}
-    {% initial_page_data 'randomness' toggle_meta.randomness %}
+    {% initial_page_data 'randomness' static_toggle.randomness %}
     <div class="row" style="margin-bottom: 50px;">
         <div class="col-sm-12">
             <span class="pull-right">
@@ -46,22 +46,22 @@
                 {% trans "Show account service type" %}
             </a>
             </span>
-            {% if toggle_meta.description %}
-                <p>{{ toggle_meta.description|safe }}</p>
+            {% if static_toggle.description %}
+                <p>{{ static_toggle.description|safe }}</p>
             {% endif %}
             <p>
-                <span class="label label-{{ toggle_meta.tag.css_class }}">{{ toggle_meta.tag.name }}</span>
+                <span class="label label-{{ static_toggle.tag.css_class }}">{{ static_toggle.tag.name }}</span>
                 {% if is_random %}
-                    <span class="label label-info">Random: {{ toggle_meta.randomness }}</span>
+                    <span class="label label-info">Random: {{ static_toggle.randomness }}</span>
                 {% endif %}
             </p>
-            <p>{{ toggle_meta.tag.description }}</p>
-            {% if toggle_meta.help_link %}
-            <p><a href="{{ toggle_meta.help_link }}" target="_blank">{% trans "More information" %}</a></p>
+            <p>{{ static_toggle.tag.description }}</p>
+            {% if static_toggle.help_link %}
+            <p><a href="{{ static_toggle.help_link }}" target="_blank">{% trans "More information" %}</a></p>
             {% endif %}
 
-            {% if toggle_meta.relevant_environments %}
-                {% if debug or server_environment in toggle_meta.relevant_environments %}
+            {% if static_toggle.relevant_environments %}
+                {% if debug or server_environment in static_toggle.relevant_environments %}
                 <div class="alert alert-warning" role="alert">
                     {% blocktrans %}
                     <strong>Please Note:</strong> This feature flag is available on this server environment, but not on others.

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -1,11 +1,17 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
-from corehq.apps.toggle_ui.views import ToggleListView, ToggleEditView, toggle_app_manager_v2
+from corehq.apps.toggle_ui.views import (
+    ToggleEditView,
+    ToggleListView,
+    set_toggle,
+    toggle_app_manager_v2,
+)
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
+    url(r'^set_toggle/(?P<toggle_slug>[\w_-]+)/$', set_toggle, name='set_toggle'),
     url(r'^toggle_app_manager_v2/$', toggle_app_manager_v2, name="toggle_app_manager_v2"),
 ]

--- a/corehq/apps/toggle_ui/urls.py
+++ b/corehq/apps/toggle_ui/urls.py
@@ -6,12 +6,10 @@ from corehq.apps.toggle_ui.views import (
     ToggleEditView,
     ToggleListView,
     set_toggle,
-    toggle_app_manager_v2,
 )
 
 urlpatterns = [
     url(r'^$', ToggleListView.as_view(), name=ToggleListView.urlname),
     url(r'^edit/(?P<toggle>[\w_-]+)/$', ToggleEditView.as_view(), name=ToggleEditView.urlname),
     url(r'^set_toggle/(?P<toggle_slug>[\w_-]+)/$', set_toggle, name='set_toggle'),
-    url(r'^toggle_app_manager_v2/$', toggle_app_manager_v2, name="toggle_app_manager_v2"),
 ]

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -322,13 +322,16 @@ def _get_most_recently_used(last_used):
 @require_superuser_or_contractor
 @require_POST
 def set_toggle(request, toggle_slug):
-    toggle = find_static_toggle(toggle_slug)
-    if not toggle:
+    static_toggle = find_static_toggle(toggle_slug)
+    if not static_toggle:
         raise Http404()
 
-    toggle.set(
-        item=request.POST['item'],
-        enabled=request.POST['enabled'] == 'true',
-        namespace=request.POST['namespace'],
-    )
+    item = request.POST['item']
+    enabled = request.POST['enabled'] == 'true'
+    namespace = request.POST['namespace']
+    static_toggle.set(item=item, enabled=enabled, namespace=namespace)
+
+    if enabled:
+        _notify_on_change(static_toggle, [item], request.user.username)
+
     return HttpResponse(json.dumps({'success': True}), content_type="application/json")

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.urls import reverse
 from django.http.response import Http404, HttpResponse
 from django.utils.decorators import method_decorator
+from django.views.decorators.http import require_POST
 from couchforms.analytics import get_last_form_submission_received
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import require_superuser_or_contractor
@@ -355,3 +356,18 @@ def _get_most_recently_used(last_used):
         'name': most_recently_used[0],
         'date': last_used[most_recently_used[0]]
     } if most_recently_used else None
+
+
+@require_superuser_or_contractor
+@require_POST
+def set_toggle(request, toggle_slug):
+    toggle = find_static_toggle(toggle_slug)
+    if not toggle:
+        raise Http404()
+
+    toggle.set(
+        item=request.POST['item'],
+        enabled=request.POST['enabled'] == 'true',
+        namespace=request.POST['namespace'],
+    )
+    return HttpResponse(json.dumps({'success': True}), content_type="application/json")

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -244,28 +244,6 @@ class ToggleEditView(ToggleBaseView):
             _assert(False, subject)
 
 
-def toggle_app_manager_v2(request):
-    slug = "app_manager_v2"
-    on_or_off = request.POST.get('on_or_off', 'on')
-    try:
-        toggle = Toggle.get(slug)
-    except ResourceNotFound:
-        toggle = Toggle(slug=slug)
-
-    enable = on_or_off == "on"
-    enabled = request.user.username in toggle.enabled_users
-    if enable != enabled:
-        changed_entries = [request.user.username]
-        if enable:
-            toggle.enabled_users.append(request.user.username)
-        else:
-            toggle.enabled_users.remove(request.user.username)
-        toggle.save()
-        _call_save_fn_and_clear_cache(slug, changed_entries, toggle.enabled_users, find_static_toggle(slug))
-
-    return HttpResponse(json.dumps({'success': True}), content_type="application/json")
-
-
 def _call_save_fn_and_clear_cache(toggle_slug, changed_entries, currently_enabled, static_toggle):
     for entry in changed_entries:
         enabled = entry in currently_enabled


### PR DESCRIPTION
https://docs.google.com/document/d/1fqVaNzp9z5fbWJSHDXuOFOc6HZHbs0H-CBnbEquyA_c/edit#

More changes following up on https://github.com/dimagi/commcare-hq/pull/23826

* Instead of a check mark under "Enabled for domain?", there's an "Enabled / Not Enabled" button letting you do something about it here!
* I decided against letting you set user-specific flags in this page, since it's particular to a domain.  Instead, I just show you a :bust_in_silhouette: where relevant
* Include the tag description with the feature flag description.
* I moved the "edit" link to the feature flag page to inside the expando
* Rather than highlighting the enabled rows (enabled either for domain or your user), this now shows a :black_flag: to the left of the flag name, and mutes the name of not-enabled flags

![image](https://user-images.githubusercontent.com/2367539/55629983-8cbbe580-5782-11e9-8313-3a08f5decab4.png)

My main focus was getting the information I wanted there in a somewhat sensible place, and allowing this page to serve as a home-base for domain-specific feature flags.

@orangejenny @nickpell @czue 

@emord FYI - I tried to keep this UI-focused, but this may have some conflicts with your migration work