### PR TITLE
Remove warning when a case tag is blank

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -547,6 +547,7 @@ class AdvancedModuleValidator(ModuleBaseValidator):
                     for index, action in reversed(list(enumerate(non_auto_select_actions))):
                         if (
                             index > 0 and
+                            non_auto_select_actions[index - 1].case_tag and
                             non_auto_select_actions[index - 1].case_tag not in (p.tag for p in action.case_indices)
                         ):
                             errors.append({


### PR DESCRIPTION
REACH is implementing a setup where the case management looks like:

* Load a village location from the locations fixture
* Load a household case

In the case list, if the household case doesn't exist, they want to have a registration form from the case list. When adding that register from case list form, they run into this error. 

The "load a village location from the locations fixture" has a blank case tag (see https://github.com/dimagi/commcare-hq/pull/23186) because they just want a way to select a location from the case list and the case selection happens separately

Ideal fix: Implement an arbitrary session datum action so that blank case tags aren't necessary

@orangejenny Can you think of any reason why this implementation will introduce any other issues?