### PR TITLE
Make BlobStream implement RawIOBase and simplify test

### DIFF
--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -3,14 +3,11 @@ from __future__ import unicode_literals
 import os
 import weakref
 from contextlib import contextmanager
-from io import UnsupportedOperation
+from io import RawIOBase, UnsupportedOperation
 
 from corehq.blobs.exceptions import NotFound
 from corehq.blobs.interface import AbstractBlobDB
-from corehq.blobs.util import (
-    check_safe_key,
-    ClosingContextProxy,
-)
+from corehq.blobs.util import check_safe_key
 from corehq.util.datadog.gauges import datadog_counter, datadog_bucket_timer
 from dimagi.utils.logging import notify_exception
 
@@ -143,23 +140,41 @@ class S3BlobDB(AbstractBlobDB):
         return self.db.Bucket(self.s3_bucket_name)
 
 
-class BlobStream(ClosingContextProxy):
+class BlobStream(RawIOBase):
 
     def __init__(self, stream, blob_db, blob_key):
-        super(BlobStream, self).__init__(stream)
+        self._obj = stream
         self._blob_db = weakref.ref(blob_db)
         self.blob_key = blob_key
 
+    def readable(self):
+        return True
+
+    def read(self, *args, **kw):
+        return self._obj.read(*args, **kw)
+
+    read1 = read
+
+    def write(self, *args, **kw):
+        raise IOError
+
+    def tell(self):
+        return self._obj._amount_read
+
     def seek(self, offset, from_what=os.SEEK_SET):
-        try:
-            return super(BlobStream, self).seek(offset, from_what)
-        except AttributeError:
-            pass
         if from_what != os.SEEK_SET:
             raise ValueError("seek mode not supported")
-        if offset != self._amount_read:
-            name = type(self._obj).__name__
-            raise ValueError("%s.seek not supported" % name)
+        pos = self.tell()
+        if offset != pos:
+            raise ValueError("seek not supported")
+        return pos
+
+    def close(self):
+        self._obj.close()
+        return super(BlobStream, self).close()
+
+    def __getattr__(self, name):
+        return getattr(self._obj, name)
 
     @property
     def blob_db(self):

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -13,9 +13,10 @@ from django.test import TestCase
 
 import corehq.blobs.mixin as mod
 from corehq.blobs import CODES
-from corehq.blobs.s3db import ClosingContextProxy, maybe_not_found
+from corehq.blobs.s3db import maybe_not_found
 from corehq.blobs.tests.util import (TemporaryFilesystemBlobDB,
     TemporaryMigratingBlobDB, TemporaryS3BlobDB)
+from corehq.blobs.util import ClosingContextProxy
 from corehq.util.test_utils import generate_cases, trap_extra_setup
 from dimagi.ext.couchdbkit import Document
 from mock import patch

--- a/custom/icds_reports/tests/test_cas_data_export.py
+++ b/custom/icds_reports/tests/test_cas_data_export.py
@@ -21,12 +21,9 @@ class TestLocationView(CSVTestCase):
 
     def _get_data_from_blobdb(self, indicator, state_id, month):
         sync, _ = get_cas_data_blob_file(indicator, state_id, month)
-        with sync.get_file_from_blobdb() as streaming_body:
-            # Workaround botocore.response.StreamingBody has no 'readable' attribute
-            fileobj = io.BytesIO(streaming_body.read())
-        # TextIOWrapper uses universal newline mode by default
-        csv_file = io.TextIOWrapper(fileobj, encoding='utf-8')
-        csv_data = list(csv.reader(csv_file))
+        with sync.get_file_from_blobdb() as fileobj:
+            csv_file = io.TextIOWrapper(fileobj, encoding='utf-8')
+            csv_data = list(csv.reader(csv_file))
         headers = csv_data[0]
         rows = csv_data[1:]
         for row_count, row in enumerate(rows):


### PR DESCRIPTION
Reading text from a blob stream seems like something we should have the capability to do easily, and without hacky workarounds like buffering in BytesIO.

This is cleanup of https://github.com/dimagi/commcare-hq/pull/23897

@calellowitz 