### PR TITLE
add migration for composite primary keys

### DIFF
--- a/custom/icds_reports/migrations/0001_squashed_0110_aww_incentive_report_monthly.py
+++ b/custom/icds_reports/migrations/0001_squashed_0110_aww_incentive_report_monthly.py
@@ -10,7 +10,7 @@ import django.db.migrations.operations.special
 import uuid
 
 from corehq.sql_db.operations import RawSQLMigration
-from custom.icds_reports.utils.migrations import get_view_migrations
+from custom.icds_reports.utils.migrations import get_view_migrations, get_composite_primary_key_migrations
 
 migrator = RawSQLMigration(('custom', 'icds_reports', 'migrations', 'sql_templates'))
 
@@ -1869,4 +1869,19 @@ class Migration(migrations.Migration):
             sql='ALTER TABLE child_health_monthly ADD COLUMN supervisor_id text',
         ),
     ]
+    # 0107_citus_composite_key
+    operations.extend(get_composite_primary_key_migrations([
+        'aggregatebirthpreparednesforms',
+        'aggregateccsrecorddeliveryforms',
+        'aggregateccsrecordpostnatalcareforms',
+        'aggregateccsrecordthrforms',
+        'aggregateccsrecordcomplementaryfeedingforms',
+        'aggregatechildhealthdailyfeedingforms',
+        'aggregatechildhealthpostnatalcareforms',
+        'aggregatechildhealththrforms',
+        'aggregatecomplementaryfeedingforms',
+        'aggregategrowthmonitoringforms',
+        'aggregateawcinfrastructureforms',
+        'dailyattendance',
+    ]))
     operations.extend(get_view_migrations())

--- a/custom/icds_reports/utils/migrations.py
+++ b/custom/icds_reports/utils/migrations.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from django.apps import apps
+from django.conf import settings
+from django.db import migrations
+
 from corehq.sql_db.operations import RawSQLMigration
 
 
@@ -23,4 +27,54 @@ def get_view_migrations():
     operations = []
     for view in sql_views:
         operations.append(migrator.get_migration(view))
+    return operations
+
+
+def _citus_composite_key_sql(model_cls):
+    pkey_name = '{}_pkey'.format(model_cls._meta.db_table)
+    fields = list(model_cls._meta.unique_together)[0]
+    columns = [model_cls._meta.get_field(field).column for field in fields]
+    index = '{}_{}_uniq'.format(model_cls._meta.db_table, '_'.join(columns))
+    sql = """
+        CREATE UNIQUE INDEX {index} on "{table}" ({cols});
+        ALTER TABLE "{table}" DROP CONSTRAINT {pkey_name};
+        ALTER TABLE "{table}" ADD CONSTRAINT {pkey_name} PRIMARY KEY USING INDEX {index};
+    """.format(
+        table=model_cls._meta.db_table,
+        pkey_name=pkey_name,
+        index=index,
+        cols=','.join(columns)
+    )
+    reverse_sql = """
+        ALTER TABLE "{table}" DROP CONSTRAINT IF EXISTS {index},
+        DROP CONSTRAINT IF EXISTS {pkey_name};
+        ALTER TABLE "{table}" ADD CONSTRAINT {pkey_name} PRIMARY KEY ({pkey});
+        DROP INDEX IF EXISTS {index};
+    """.format(
+        table=model_cls._meta.db_table,
+        pkey_name=pkey_name,
+        pkey=model_cls._meta.pk.name,
+        index=index,
+    )
+    if getattr(settings, 'UNIT_TESTING', False):
+        return sql, reverse_sql
+    else:
+        return migrations.RunSQL.noop, reverse_sql
+
+
+def get_composite_primary_key_migrations(models_to_update):
+    operations = []
+    for model_name in models_to_update:
+        model = apps.get_model('icds_reports', model_name)
+        sql, reverse_sql = _citus_composite_key_sql(model)
+        operations.append(migrations.RunSQL(
+            sql,
+            reverse_sql,
+            state_operations=[
+                migrations.AlterUniqueTogether(
+                    name=model_name,
+                    unique_together=model._meta.unique_together,
+                ),
+            ]
+        ))
     return operations


### PR DESCRIPTION
This got left out when squashing the migrations. Not sure if there was anything else.