### PR TITLE
Include errored SMSs in Message Log Report

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1077,6 +1077,13 @@ USE_SMS_WITH_INACTIVE_CONTACTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+INCLUDE_SMS_ERRORS = StaticToggle(
+    'include_sms_errors',
+    "Include failed messages in Message Log Report",
+    TAG_CUSTOM,
+    [NAMESPACE_USER]
+)
+
 ENABLE_INCLUDE_SMS_GATEWAY_CHARGING = StaticToggle(
     'enable_include_sms_gateway_charging',
     'Enable include SMS gateway charging',


### PR DESCRIPTION
It looks like errored messages are (inadvertently?) hidden from the message log report.  I've been looking in to coming up with a way to share that information with an external partner, and it appears that this may be all it takes.

Behind a `INCLUDE_SMS_ERRORS` feature flag for now so I can test it on real data.

@nickpell @millerdev 