### PR TITLE
in Odata feed, ignore cases with blank type

### DIFF
--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -11,6 +11,9 @@ def get_case_type_to_properties(domain):
     case_type_to_properties = defaultdict(list)
     case_types = get_case_types_for_domain_es(domain)
     for case_type in case_types:
+        if not case_type:
+            # TODO - understand why a case can have a blank case type and handle appropriately
+            continue
         case_export_schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case_type)
         for export_group_schema in case_export_schema.group_schemas[0].items:
             cleaned_case_property = export_group_schema.label.replace('_', '')

--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from collections import defaultdict
+
 from corehq.apps.export.models import CaseExportDataSchema
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
 
 
 def get_case_type_to_properties(domain):
-    case_type_to_properties = {}
+    case_type_to_properties = defaultdict(list)
     case_types = get_case_types_for_domain_es(domain)
     for case_type in case_types:
-        case_type_to_properties[case_type] = []
         case_export_schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case_type)
         for export_group_schema in case_export_schema.group_schemas[0].items:
             cleaned_case_property = export_group_schema.label.replace('_', '')


### PR DESCRIPTION
This is generating an error when Power BI attempts to process the metadata document because Power BI doesn't like blank entity types (one of the components in the Odata format):

![image001](https://user-images.githubusercontent.com/1757035/55645437-32c91900-579e-11e9-8252-5c8c6db21a12.png)

To unblock our user testing, we can just ignore this case type and address more fully after the MVP version.

fyi @djmore9 