### PR TITLE
Added isth-production to sync details on Datadog

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2085,6 +2085,7 @@ DATADOG_DOMAINS = {
     ("production", "malawi-fp-study"),
     ("production", "no-lean-season"),
     ("production", "rec"),
+    ("production", "isth-production"),
     ("production", "sauti-1"),
 }
 


### PR DESCRIPTION
Include isth-production in the list of project spaces that get detailed information about sync timings. They now have significant caseloads and are reporting significant restores.