### PR TITLE
Report celery blockage during celery check

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -135,7 +135,7 @@ def check_celery():
         if threshold:
             threshold = datetime.timedelta(seconds=threshold)
             try:
-                blockage_duration = Heartbeat(queue).get_blockage_duration()
+                blockage_duration = Heartbeat(queue).get_and_report_blockage_duration()
             except HeartbeatNeverRecorded:
                 blocked_queues.append((queue, 'as long as we can see', threshold))
             else:

--- a/corehq/celery_monitoring/heartbeat.py
+++ b/corehq/celery_monitoring/heartbeat.py
@@ -64,6 +64,15 @@ class Heartbeat(object):
         return max(datetime.datetime.utcnow() - self.get_last_seen() - HEARTBEAT_FREQUENCY,
                    datetime.timedelta(seconds=0))
 
+    def get_and_report_blockage_duration(self):
+        blockage_duration = self.get_blockage_duration()
+        datadog_gauge(
+            'commcare.celery.heartbeat.blockage_duration',
+            blockage_duration.total_seconds(),
+            tags=['celery_queue:{}'.format(self.queue)]
+        )
+        return blockage_duration
+
     @property
     def periodic_task_name(self):
         return 'heartbeat__{}'.format(self.queue)
@@ -77,11 +86,7 @@ class Heartbeat(object):
         """
         def heartbeat():
             try:
-                datadog_gauge(
-                    'commcare.celery.heartbeat.blockage_duration',
-                    self.get_blockage_duration().total_seconds(),
-                    tags=['celery_queue:{}'.format(self.queue)]
-                )
+                self.get_and_report_blockage_duration()
             except HeartbeatNeverRecorded:
                 pass
             self.mark_seen()


### PR DESCRIPTION
for more resolution. Especially when the celery check detects blockage
duration over the threshold, we want to make sure the offending peak is
recorded in datadog so we can correlate it.

Currently if there's a blockage by definition the blockage duration doesn't get reported until it's unblocked. Reporting whenever the blockage duration is regularly checked in the celery check will fill in the gaps in that data.