### PR TITLE
Icds reports tabular reports location filter disabled filter

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -125,7 +125,12 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         {id: 9, name: 'LS Performance Report'},
     ];
 
-    var ALL_OPTION = {name: 'All', location_id: 'all'};
+    var ALL_OPTION = {
+        name: 'All',
+        location_id: 'all',
+        "user_have_access": false,
+        "user_have_access_to_parent": true,
+    };
     var NATIONAL_OPTION = {name: 'National', location_id: 'all'};
 
     var locationsCache = {};

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -128,8 +128,8 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     var ALL_OPTION = {
         name: 'All',
         location_id: 'all',
-        "user_have_access": false,
-        "user_have_access_to_parent": true,
+        "user_have_access": 0,
+        "user_have_access_to_parent": 1,
     };
     var NATIONAL_OPTION = {name: 'National', location_id: 'all'};
 
@@ -281,14 +281,12 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         }
         var notDisabledLocationsForLevel = 0;
         window.angular.forEach(vm.getLocationsForLevel(level), function(location) {
-            if (location.location_id && location.location_id !== 'all' && (
-                location.user_have_access || location.user_have_access_to_parent)
-            ) {
+            if (location.user_have_access || location.user_have_access_to_parent) {
                 notDisabledLocationsForLevel += 1;
             }
         });
 
-        return notDisabledLocationsForLevel === 0;
+        return notDisabledLocationsForLevel <= 1;
     };
 
     vm.onSelectForISSNIP = function ($item, level) {

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -276,12 +276,14 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         }
         var notDisabledLocationsForLevel = 0;
         window.angular.forEach(vm.getLocationsForLevel(level), function(location) {
-            if (location.user_have_access || location.user_have_access_to_parent) {
+            if (location.location_id && location.location_id !== 'all' && (
+                location.user_have_access || location.user_have_access_to_parent)
+            ) {
                 notDisabledLocationsForLevel += 1;
             }
         });
 
-        return notDisabledLocationsForLevel <= 1;
+        return notDisabledLocationsForLevel === 0;
     };
 
     vm.onSelectForISSNIP = function ($item, level) {

--- a/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
@@ -72,13 +72,11 @@ function LocationModalController($uibModalInstance, $location, locationsService,
         }
         var notDisabledLocationsForLevel = 0;
         window.angular.forEach(vm.getLocationsForLevel(level), function(location) {
-            if (location.location_id && location.location_id !== 'all' && (
-                location.user_have_access || location.user_have_access_to_parent)
-            ) {
+            if (location.user_have_access || location.user_have_access_to_parent) {
                 notDisabledLocationsForLevel += 1;
             }
         });
-        return notDisabledLocationsForLevel === 0;
+        return notDisabledLocationsForLevel <= 1;
     };
 
     vm.onSelect = function($item, level) {
@@ -176,8 +174,8 @@ function LocationFilterController($rootScope, $scope, $location, $uibModal, loca
     var ALL_OPTION = {
         name: 'All',
         location_id: 'all',
-        "user_have_access": false,
-        "user_have_access_to_parent": true,
+        "user_have_access": 0,
+        "user_have_access_to_parent": 1,
     };
 
     var initHierarchy = function() {

--- a/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
@@ -176,8 +176,8 @@ function LocationFilterController($rootScope, $scope, $location, $uibModal, loca
     var ALL_OPTION = {
         name: 'All',
         location_id: 'all',
-        "user_have_access": 0,
-        "user_have_access_to_parent": 1,
+        "user_have_access": false,
+        "user_have_access_to_parent": true,
     };
 
     var initHierarchy = function() {

--- a/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
@@ -72,11 +72,13 @@ function LocationModalController($uibModalInstance, $location, locationsService,
         }
         var notDisabledLocationsForLevel = 0;
         window.angular.forEach(vm.getLocationsForLevel(level), function(location) {
-            if (location.user_have_access || location.user_have_access_to_parent) {
+            if (location.location_id && location.location_id !== 'all' && (
+                location.user_have_access || location.user_have_access_to_parent)
+            ) {
                 notDisabledLocationsForLevel += 1;
             }
         });
-        return notDisabledLocationsForLevel <= 1;
+        return notDisabledLocationsForLevel === 0;
     };
 
     vm.onSelect = function($item, level) {


### PR DESCRIPTION
Hi @calellowitz,
I have fixed the location filter issue for Chandigarh in tabular reports page.
The reason is that `location` `All` object might not have `user_have_access` and `user_have_access_to_parent` properties.
Right now the certain location filter level drop-down is going to be disabled only when there is no option to choose (there isn't access to any location at that level).
The difference between location filter on the other pages and on tabular reports page was due to the difference in `ALL_OPTION` constant.
These changes are related to JIRA [ICDS-456](https://dimagi-dev.atlassian.net/browse/ICDS-456) ticket.
Need QA: No
Environment: n/a
Locally Tested: Yes
Regards, Dawid