### PR TITLE
small changes to billing pop-ups

### DIFF
--- a/corehq/apps/accounting/mixins.py
+++ b/corehq/apps/accounting/mixins.py
@@ -11,6 +11,8 @@ from corehq.apps.accounting.tasks import (
     is_subscription_eligible_for_downgrade_process,
 )
 from corehq.apps.accounting.utils import months_from_date
+from corehq.apps.users.decorators import get_permission_name
+from corehq.apps.users.models import Permissions
 from corehq.util.quickcache import quickcache
 
 
@@ -54,8 +56,12 @@ class BillingModalsMixin(object):
     @property
     def main_context(self):
         main_context = super(BillingModalsMixin, self).main_context
-        main_context.update(self._downgrade_modal_context)
-        main_context.update(self._low_credits_context)
+        if self.request.couch_user and self.request.couch_user.has_permission(
+            self.domain,
+            get_permission_name(Permissions.edit_billing)
+        ):
+            main_context.update(self._downgrade_modal_context)
+            main_context.update(self._low_credits_context)
         return main_context
 
     @property

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -315,10 +315,7 @@
         {% endif %}
         {# modals #}
         {% block modals %}
-        {% comment %}
-            TODO - remove 'and False' after making updates
-        {% endcomment %}
-            {% if domain and not enterprise_mode and False %}
+            {% if domain and not enterprise_mode %}
                 {% if show_overdue_invoice_modal %}
                     {% include 'hqwebapp/downgrade_modal.html' %}
                 {% elif show_prepaid_modal %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/downgrade_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/downgrade_modal.html
@@ -5,10 +5,6 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header {% if days_until_downgrade <= 30 %}bg-danger text-danger{% endif %}">
-                <button type="button" class="close" data-dismiss="modal">
-                    <span aria-hidden="true">&times;</span>
-                    <span class="sr-only">Close</span>
-                </button>
                 <h4 class="modal-title">
                     {% blocktrans %}
                     Your invoice for {{ invoice_month }} is past due!

--- a/corehq/apps/hqwebapp/templates/hqwebapp/downgrade_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/downgrade_modal.html
@@ -13,7 +13,10 @@
             </div>
             <div class="modal-body">
                 <p>
-                    {% blocktrans %}
+                    {% blocktrans count days_until_downgrade=days_until_downgrade %}
+                    You're at risk of losing access to paid features and priority support if your invoice isn't paid in
+                    1 day.
+                    {% plural %}
                     You're at risk of losing access to paid features and priority support if your invoice isn't paid in
                     {{ days_until_downgrade }} days.
                     {% endblocktrans %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/prepaid_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/prepaid_modal.html
@@ -6,7 +6,9 @@
         <div class="modal-content">
             <div class="modal-header {% if prepaid_days_remaining <= 30 %}bg-danger text-danger{% endif %}">
                 <h4 class="modal-title">
-                    {% blocktrans %}
+                    {% blocktrans count prepaid_weeks_remaining=prepaid_weeks_remaining %}
+                    Your prepaid subscription ends in 1 week!
+                    {% plural %}
                     Your prepaid subscription ends in {{ prepaid_weeks_remaining }} weeks!
                     {% endblocktrans %}
                 </h4>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/prepaid_modal.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/prepaid_modal.html
@@ -5,10 +5,6 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header {% if prepaid_days_remaining <= 30 %}bg-danger text-danger{% endif %}">
-                <button type="button" class="close" data-dismiss="modal">
-                    <span aria-hidden="true">&times;</span>
-                    <span class="sr-only">Close</span>
-                </button>
                 <h4 class="modal-title">
                     {% blocktrans %}
                     Your prepaid subscription ends in {{ prepaid_weeks_remaining }} weeks!


### PR DESCRIPTION
Product Note: small updates to the billing pop-ups.  Removes the option to close the pop-up without snoozing and limits the pop-up to users with permissions to access the project's billing pages.

Best reviewed commit by commit.