### PR TITLE
Filter out non-AWC in ICDS AWC location UCR

### DIFF
--- a/custom/icds_reports/ucr/data_sources/awc_locations.json
+++ b/custom/icds_reports/ucr/data_sources/awc_locations.json
@@ -37,6 +37,15 @@
             "property_name": "is_archived"
           },
           "property_value": "False"
+        },
+        {
+          "operator": "eq",
+          "type": "boolean_expression",
+          "expression": {
+            "type": "property_name",
+            "property_name": "location_type"
+          },
+          "property_value": "awc"
         }
       ]
     },


### PR DESCRIPTION
This should stop all the supervisor_id is not null errors from pillows. I did something simlar in reach