### PR TITLE
Start per-queue "uptime" as commcare.celery.heartbeat.blockage_ok

### DIFF
--- a/corehq/celery_monitoring/heartbeat.py
+++ b/corehq/celery_monitoring/heartbeat.py
@@ -76,7 +76,7 @@ class Heartbeat(object):
         )
         datadog_gauge(
             'commcare.celery.heartbeat.blockage_ok',
-            1 if blockage_duration <= self.threshold else 0,
+            1 if blockage_duration.total_seconds() <= self.threshold else 0,
             tags=['celery_queue:{}'.format(self.queue)]
         )
         return blockage_duration

--- a/corehq/celery_monitoring/heartbeat.py
+++ b/corehq/celery_monitoring/heartbeat.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import datetime
 
 from celery.task import periodic_task
+from django.conf import settings
 from django.core.cache import cache
 
 from corehq.util.datadog.gauges import datadog_gauge
@@ -39,6 +40,7 @@ class Heartbeat(object):
     def __init__(self, queue):
         self.queue = queue
         self._heartbeat_cache = HeartbeatCache(queue)
+        self.threshold = settings.CELERY_HEARTBEAT_THRESHOLDS[self.queue]
 
     def get_last_seen(self):
         value = self._heartbeat_cache.get()
@@ -70,6 +72,11 @@ class Heartbeat(object):
         datadog_gauge(
             'commcare.celery.heartbeat.blockage_duration',
             blockage_duration.total_seconds(),
+            tags=['celery_queue:{}'.format(self.queue)]
+        )
+        datadog_gauge(
+            'commcare.celery.heartbeat.blockage_ok',
+            1 if blockage_duration <= self.threshold else 0,
             tags=['celery_queue:{}'.format(self.queue)]
         )
         return blockage_duration

--- a/corehq/celery_monitoring/tests.py
+++ b/corehq/celery_monitoring/tests.py
@@ -36,6 +36,13 @@ def test_heartbeat():
         eq(hb.get_blockage_duration(), datetime.timedelta(minutes=10) - HEARTBEAT_FREQUENCY)
 
 
+def test_get_and_report_blockage_duration():
+    hb = Heartbeat('celery_periodic')
+    hb.mark_seen()
+    # just assert that this doesn't error
+    hb.get_and_report_blockage_duration()
+
+
 def test_time_to_start_timer():
     task_id = 'abc123'
     delay = datetime.timedelta(seconds=6)


### PR DESCRIPTION
This is a binary version of the blockage_duration metric
and reports only whether or not the blockage_duration
is under the particular threshold for each queue.

This allows us to construct individual uptime graphs per queue
and is a stronger signal for how well we're doing per queue
than blockage_duration, which has different "normal" values
for every queue.