### PR TITLE
ignore restrictions in case specific target mentioned

### DIFF
--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -61,7 +61,7 @@ def safe_cached_download(f):
         domain = args[0] if len(args) > 0 else kwargs["domain"]
         app_id = args[1] if len(args) > 1 else kwargs["app_id"]
         latest = True if request.GET.get('latest') == 'true' else False
-        # target it used update to latest build/saved state/release of the app
+        # target is used update to latest build/saved state/release of the app
         target = request.GET.get('target') or None
 
         # make endpoints that call the user fail hard

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -61,7 +61,7 @@ def safe_cached_download(f):
         domain = args[0] if len(args) > 0 else kwargs["domain"]
         app_id = args[1] if len(args) > 1 else kwargs["app_id"]
         latest = True if request.GET.get('latest') == 'true' else False
-        # target it used update to latest build or latest saved app
+        # target it used update to latest build/saved state/release of the app
         target = request.GET.get('target') or None
 
         # make endpoints that call the user fail hard

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -61,6 +61,7 @@ def safe_cached_download(f):
         domain = args[0] if len(args) > 0 else kwargs["domain"]
         app_id = args[1] if len(args) > 1 else kwargs["app_id"]
         latest = True if request.GET.get('latest') == 'true' else False
+        # target it used update to latest build or latest saved app
         target = request.GET.get('target') or None
 
         # make endpoints that call the user fail hard
@@ -71,8 +72,9 @@ def safe_cached_download(f):
             request.GET.pop('username')
 
         latest_enabled_build = None
-        if latest and request.GET.get('profile') and toggles.RELEASE_BUILDS_PER_PROFILE.enabled(domain):
-            latest_enabled_build = get_latest_enabled_build_for_profile(domain, request.GET.get('profile'))
+        if latest and not target:
+            if request.GET.get('profile') and toggles.RELEASE_BUILDS_PER_PROFILE.enabled(domain):
+                latest_enabled_build = get_latest_enabled_build_for_profile(domain, request.GET.get('profile'))
         try:
             if latest_enabled_build:
                 request.app = latest_enabled_build


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/ICDS-480?focusedCommentId=18209&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18209)

This PR skips restrictions in case there is a request to update directly to a specific state of the app(saved, released, built). 
Confirmed with mobile team that when the normal updates happen from the app, where we should be checking for restrictions,  this parameter is completely skipped.
This parameter is set only via developer options.
Behind : Feature Flag: `release_builds_per_profile`