### PR TITLE
Change "Couch" to "Couch/SQL" in doc_in_es

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
@@ -13,7 +13,7 @@
             </form>
             <br>
             <div class="alert alert-warning">
-                Hey there!  This page is primarily for comparing documents in elasticsearch and couch.
+                Hey there!  This page is primarily for comparing documents in elasticsearch and couch/sql.
                 Are you sure you don't want
                 <a href="{% url "raw_couch" %}?id={{ doc_id }}">raw_couch</a>?
             </div>
@@ -31,14 +31,14 @@
                         <pre>{{ es_doc }}</pre>
                     </div>
                     <div class="col-xs-6">
-                        <h3>Couch Doc:</h3>
+                        <h3>Couch/SQL Doc:</h3>
                         <pre>{{ couch_info.doc|default:"NOT FOUND" }}</pre>
                     </div>
                 </div>
             {% endfor %}
             {% if not found_indices %}
                 <div class="col-xs-6">
-                    <h3>Couch Doc:</h3>
+                    <h3>Couch/SQL Doc:</h3>
                     <pre>{{ couch_info.doc|default:"NOT FOUND" }}</pre>
                 </div>
             {% endif %}


### PR DESCRIPTION
I keep getting tripped up by the label "Couch Doc" and then remember it
actually means Couch or SQL. Small change to the text should make this
clearer and match reality.

Before

<img width="545" alt="Screen Shot 2019-04-11 at 1 30 26 PM" src="https://user-images.githubusercontent.com/137212/55978526-fa25b580-5c5d-11e9-8608-7e7813c550e0.png">


After
<img width="439" alt="Screen Shot 2019-04-11 at 1 31 15 PM" src="https://user-images.githubusercontent.com/137212/55978531-fd20a600-5c5d-11e9-8f12-562e35f45ea7.png">
