### PR TITLE
Skip queues without a blockage threshold for blockage_ok metric

### DIFF
--- a/corehq/celery_monitoring/heartbeat.py
+++ b/corehq/celery_monitoring/heartbeat.py
@@ -74,11 +74,12 @@ class Heartbeat(object):
             blockage_duration.total_seconds(),
             tags=['celery_queue:{}'.format(self.queue)]
         )
-        datadog_gauge(
-            'commcare.celery.heartbeat.blockage_ok',
-            1 if blockage_duration.total_seconds() <= self.threshold else 0,
-            tags=['celery_queue:{}'.format(self.queue)]
-        )
+        if self.threshold:
+            datadog_gauge(
+                'commcare.celery.heartbeat.blockage_ok',
+                1 if blockage_duration.total_seconds() <= self.threshold else 0,
+                tags=['celery_queue:{}'.format(self.queue)]
+            )
         return blockage_duration
 
     @property


### PR DESCRIPTION
currently appearing as 0 which makes it look like something is down,
but that is just because of the accident than in python
```
>>> 5 <= None
False
```