### PR TITLE
speedup get_case_type_to_properties

### DIFF
--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from collections import defaultdict
 
-from corehq.apps.export.models import CaseExportDataSchema
+from corehq.apps.export.dbaccessors import get_latest_case_export_schema
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
 
 
@@ -14,7 +14,7 @@ def get_case_type_to_properties(domain):
         if not case_type:
             # TODO - understand why a case can have a blank case type and handle appropriately
             continue
-        case_export_schema = CaseExportDataSchema.generate_schema_from_builds(domain, None, case_type)
+        case_export_schema = get_latest_case_export_schema(domain, case_type)
         for export_group_schema in case_export_schema.group_schemas[0].items:
             cleaned_case_property = export_group_schema.label.replace('_', '')
             case_type_to_properties[case_type].append(cleaned_case_property)

--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from collections import defaultdict
 
 from corehq.apps.export.dbaccessors import get_latest_case_export_schema
+from corehq.apps.export.models import CaseExportDataSchema
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
 
 
@@ -14,7 +15,10 @@ def get_case_type_to_properties(domain):
         if not case_type:
             # TODO - understand why a case can have a blank case type and handle appropriately
             continue
-        case_export_schema = get_latest_case_export_schema(domain, case_type)
+        case_export_schema = (
+            get_latest_case_export_schema(domain, case_type)
+            or CaseExportDataSchema.generate_schema_from_builds(domain, None, case_type)
+        )
         for export_group_schema in case_export_schema.group_schemas[0].items:
             cleaned_case_property = export_group_schema.label.replace('_', '')
             case_type_to_properties[case_type].append(cleaned_case_property)


### PR DESCRIPTION
Using ```get_latest_case_export_schema``` with a fallback to ```CaseExportDataSchema.generate_schema_from_builds``` significantly speeds up get_case_type_to_properties for domains with lots of case types and case properties. 