### PR TITLE
Update demo mode submissions to presume noauth

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -61,7 +61,7 @@ def determine_authtype_from_request(request, default=DIGEST):
     headers found in the request.
     """
 
-    # Fixes behavior for mobile versions between 2.39.0 and 
+    # Fixes behavior for mobile versions between 2.39.0 and
     # 2.46.0, which did not explicitly request noauth when
     # submitting in demo mode.
     if request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -62,7 +62,7 @@ def determine_authtype_from_request(request, default=DIGEST):
     """
     if request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:
         return NOAUTH
-    
+
     """
     Guess the auth type, based on the (phone's) user agent or the
     headers found in the request.

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -57,16 +57,16 @@ def determine_authtype_from_header(request, default=DIGEST):
 
 def determine_authtype_from_request(request, default=DIGEST):
     """
-    There's a bug on mobile where demo submissions weren't always
-    sending noauth headers, but that should be the default.
-    """
-    if request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:
-        return NOAUTH
-
-    """
     Guess the auth type, based on the (phone's) user agent or the
     headers found in the request.
     """
+
+    # Fixes behavior for mobile versions between 2.39.0 and 
+    # 2.46.0, which did not explicitly request noauth when
+    # submitting in demo mode.
+    if request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:
+        return NOAUTH
+
     user_agent = request.META.get('HTTP_USER_AGENT')
     if is_probably_j2me(user_agent):
         return DIGEST

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -11,10 +11,8 @@ from django.http import (
 )
 from casexml.apps.case.xform import get_case_updates, is_device_report
 from corehq.apps.domain.auth import (
-    determine_authtype_from_request, 
-    BASIC,
-    DIGEST,
-    NOAUTH
+    determine_authtype_from_request,
+    BASIC, DIGEST, NOAUTH
 )
 from corehq.apps.domain.decorators import (
     check_domain_migration, login_or_digest_ex, login_or_basic_ex,

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -10,7 +10,12 @@ from django.http import (
     HttpResponseForbidden,
 )
 from casexml.apps.case.xform import get_case_updates, is_device_report
-from corehq.apps.domain.auth import determine_authtype_from_request, BASIC
+from corehq.apps.domain.auth import (
+    determine_authtype_from_request, 
+    BASIC,
+    DIGEST,
+    NOAUTH
+)
 from corehq.apps.domain.decorators import (
     check_domain_migration, login_or_digest_ex, login_or_basic_ex,
     two_factor_exempt,
@@ -294,9 +299,9 @@ def _secure_post_basic(request, domain, app_id=None):
 @check_domain_migration
 def secure_post(request, domain, app_id=None):
     authtype_map = {
-        'digest': _secure_post_digest,
-        'basic': _secure_post_basic,
-        'noauth': _noauth_post,
+        DIGEST: _secure_post_digest,
+        BASIC: _secure_post_basic,
+        NOAUTH: _noauth_post,
     }
 
     if request.GET.get('authtype'):


### PR DESCRIPTION
Fix/workaround for:
https://dimagi-dev.atlassian.net/browse/ICDS-488

caused by
https://dimagi-dev.atlassian.net/browse/ICDS-454

Makes "demo" mode submissions (which won't be processed anyway) default to noauth submissions, which is the default phone behavior anyway (or is supposed to be).