### PR TITLE
Add ucr tables to domain delete operations

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -15,6 +15,7 @@ from corehq.apps.custom_data_fields.dbaccessors import get_by_domain_and_type
 from corehq.apps.domain.utils import silence_during_tests
 from corehq.apps.locations.views import LocationFieldsView
 from corehq.apps.products.views import ProductFieldsView
+from corehq.apps.userreports.dbaccessors import delete_all_ucr_tables_for_domain
 from corehq.apps.users.views.mobile import UserFieldsView
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
@@ -236,6 +237,7 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('motech', 'RequestLog', 'domain'),
     ModelDeletion('couchforms', 'UnfinishedSubmissionStub', 'domain'),
     CustomDeletion('custom_data_fields', _delete_custom_data_fields),
+    CustomDeletion('ucr', delete_all_ucr_tables_for_domain),
 ]
 
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -963,11 +963,12 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 assert isinstance(response, list)
                 dynamic_deletion_operations.extend(response)
 
-        # delete all associated objects
+        # delete SQL models first because UCR tables are indexed by configs in couch
+        apply_deletion_operations(self.name, dynamic_deletion_operations)
+
+        # delete couch docs
         for db, related_doc_ids in get_all_doc_ids_for_domain_grouped_by_db(self.name):
             iter_bulk_delete(db, related_doc_ids, chunksize=500)
-
-        apply_deletion_operations(self.name, dynamic_deletion_operations)
 
     def all_media(self, from_apps=None):  # todo add documentation or refactor
         from corehq.apps.hqmedia.models import CommCareMultimedia

--- a/corehq/apps/userreports/dbaccessors.py
+++ b/corehq/apps/userreports/dbaccessors.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import re
+
 from corehq.apps.domain.dbaccessors import get_docs_in_domain_by_class
 from corehq.apps.domain.models import Domain
+from corehq.apps.userreports.util import get_legacy_table_name, get_table_name
 from corehq.dbaccessors.couchapps.all_docs import delete_all_docs_by_doc_type
+from corehq.sql_db.connections import connection_manager, UCR_ENGINE_ID
 from corehq.util.test_utils import unit_testing_only
 
 
@@ -65,3 +70,30 @@ def get_all_report_configs():
 def delete_all_report_configs():
     from corehq.apps.userreports.models import ReportConfiguration
     delete_all_docs_by_doc_type(ReportConfiguration.get_db(), ('ReportConfiguration',))
+
+
+def get_all_table_names_for_domain(domain):
+    engine = connection_manager.get_engine(UCR_ENGINE_ID)
+    with engine.begin() as connection:
+        possible_matches = connection.execute("select tablename from pg_tables where tablename ~ %s", domain)
+    # DO NOT assume just because the domain is in the table name
+    # that the table is in the domain
+    all_table_names_for_domain = []
+    for table_name, in possible_matches:
+        match = re.match(r'^(config_report|ucr)_(.*)_([0-9a-f]{0,29})_([0-9a-f]{8})$', table_name)
+        if match:
+            prefix, table_domain, table_big_hash, table_little_hash = match.groups()
+            if prefix == 'ucr':
+                table_name_check = get_table_name(domain, table_big_hash)
+            else:
+                table_name_check = get_legacy_table_name(domain, table_big_hash)
+            if table_name == table_name_check:
+                all_table_names_for_domain.append(table_name)
+    return all_table_names_for_domain
+
+
+def delete_all_ucr_tables_for_domain(domain):
+    engine = connection_manager.get_engine(UCR_ENGINE_ID)
+    with engine.begin() as connection:
+        for table_name in get_all_table_names_for_domain(domain):
+            connection.execute('DROP TABLE "{}"'.format(table_name))

--- a/corehq/apps/userreports/dbaccessors.py
+++ b/corehq/apps/userreports/dbaccessors.py
@@ -1,13 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import re
-
 from corehq.apps.domain.dbaccessors import get_docs_in_domain_by_class
 from corehq.apps.domain.models import Domain
-from corehq.apps.userreports.util import get_legacy_table_name, get_table_name
+from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.dbaccessors.couchapps.all_docs import delete_all_docs_by_doc_type
-from corehq.sql_db.connections import connection_manager, UCR_ENGINE_ID
 from corehq.util.test_utils import unit_testing_only
 
 
@@ -72,28 +69,13 @@ def delete_all_report_configs():
     delete_all_docs_by_doc_type(ReportConfiguration.get_db(), ('ReportConfiguration',))
 
 
-def get_all_table_names_for_domain(domain):
-    engine = connection_manager.get_engine(UCR_ENGINE_ID)
-    with engine.begin() as connection:
-        possible_matches = connection.execute("select tablename from pg_tables where tablename ~ %s", domain)
-    # DO NOT assume just because the domain is in the table name
-    # that the table is in the domain
-    all_table_names_for_domain = []
-    for table_name, in possible_matches:
-        match = re.match(r'^(config_report|ucr)_(.*)_([0-9a-f]{0,29})_([0-9a-f]{8})$', table_name)
-        if match:
-            prefix, table_domain, table_big_hash, table_little_hash = match.groups()
-            if prefix == 'ucr':
-                table_name_check = get_table_name(domain, table_big_hash)
-            else:
-                table_name_check = get_legacy_table_name(domain, table_big_hash)
-            if table_name == table_name_check:
-                all_table_names_for_domain.append(table_name)
-    return all_table_names_for_domain
-
-
 def delete_all_ucr_tables_for_domain(domain):
-    engine = connection_manager.get_engine(UCR_ENGINE_ID)
-    with engine.begin() as connection:
-        for table_name in get_all_table_names_for_domain(domain):
-            connection.execute('DROP TABLE "{}"'.format(table_name))
+    """
+    For a given domain, delete all the known UCR data source tables
+
+    This only deletes "known" data sources for the domain.
+    To identify "orphaned" tables, see the prune_old_datasources management command.
+    """
+    for config in get_datasources_for_domain(domain):
+        adapter = get_indicator_adapter(config)
+        adapter.drop_table()


### PR DESCRIPTION
I think this is a safe way to do this. First, pull all tables in the ucr db that
have the domain name in them, just as a way to filter down to a very small set
to pull into memory. Then, for each one, pull out the table prefix and table id,
reconstruct the expected table name from those, and only keep the ones
where the original table name matches the expected table name.

I think I can assert that this will _never_ match a table in the wrong domain.
For a very long domain name, however, this may _miss_ some tables in the domain,
specficially if the table name was trucated so that the full table id is not present
in the table name. Then I think short of some sort of brute force search,
there is no simple way to show that a table belongs to a domain.

Ran the `delete_all_ucr_tables_for_domain` function directly already for https://dimagi-dev.atlassian.net/browse/HI-553