### PR TITLE
Add Async option to fixtures api

### DIFF
--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -8,9 +8,12 @@ from corehq.apps.fixtures.views import (
     UploadItemLists, FixtureUploadStatusView,
     upload_fixture_api, fixture_metadata, tables, download_item_lists,
     download_file, update_tables, fixture_upload_job_poll,
+    fixture_api_upload_status,
 )
 
 urlpatterns = [
+    url(r'^fixapi/status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
+        fixture_api_upload_status, name='fixture_api_status'),
     url(r'^fixapi/', upload_fixture_api),
     url(r'^metadata/$', fixture_metadata, name='fixture_metadata'),
     url(r'^$', RedirectView.as_view(url='edit_lookup_tables', permanent=True), name='edit_lookup_tables'),

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -428,7 +428,8 @@ def upload_fixture_api(request, domain, **kwargs):
 def fixture_api_upload_status(request, domain, download_id, **kwargs):
     """
         Use following curl-command to test.
-        > curl -v --digest http://127.0.0.1:8000/a/gsid/fixtures/fixapi/status/<download_id>/ -u user@domain.com:password
+        > curl -v --digest http://127.0.0.1:8000/a/gsid/fixtures/fixapi/status/<download_id>/
+               -u user@domain.com:password
     """
     try:
         context = get_download_context(download_id, require_result=True)

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -424,7 +424,7 @@ def upload_fixture_api(request, domain, **kwargs):
 
 def _upload_fixture_api(request, domain):
     try:
-        excel_file, replace = _get_fixture_upload_args_from_request(request, domain)
+        excel_file, replace, is_async = _get_fixture_upload_args_from_request(request, domain)
     except FixtureAPIRequestError as e:
         return UploadFixtureAPIResponse('fail', six.text_type(e))
 
@@ -471,6 +471,8 @@ def _get_fixture_upload_args_from_request(request, domain):
             replace = True
         elif replace.lower() == "false":
             replace = False
+        is_async = request.POST["async"]
+        is_async = is_async.lower() == "true"
     except Exception:
         raise FixtureAPIRequestError(
             "Invalid post request."
@@ -481,7 +483,7 @@ def _get_fixture_upload_args_from_request(request, domain):
             "User {} doesn't have permission to upload fixtures"
             .format(request.couch_user.username))
 
-    return _excel_upload_file(upload_file), replace
+    return _excel_upload_file(upload_file), replace, is_async
 
 
 @login_and_domain_required


### PR DESCRIPTION
For HI-542. Adds an async option to the fixtures API so that an upload doesn't fail if the connection breaks. To use it pass `-F "async=true"` 