### PR TITLE
Fixed build profiles dropdown in deploy modal

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -32,9 +32,13 @@ hqDefine('app_manager/js/releases/releases', function () {
             return '/a/' + self.domain() + '/apps/odk/' + self.id() + '/';
         };
         self.build_profiles = function () {
-            var profiles = [{'label': gettext('(Default)'), 'value': ''}];
-            _.each(_.sortBy(appData.build_profiles, 'name'), function (value, key) {
-                profiles.push({label: value.name, value: key});
+            var profiles = [{'label': gettext('(Default)'), 'value': ''}],
+                appProfilesList = _.map(appData.build_profiles, function (profile, key) {
+                    return _.extend(profile, {id: key});
+                });
+            appProfilesList = _.sortBy(appProfilesList, 'name');
+            _.each(appProfilesList, function (profile) {
+                profiles.push({label: profile.name, value: profile.id});
             });
             return profiles;
         };


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-560

Introduced in https://github.com/dimagi/commcare-hq/pull/23987

`appData.build_profiles` is an object, not an array.

@emord 

Feature flag: language profiles