### PR TITLE
Fixed case list/detail Display Text updating incorrectly

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/screen_config.js
@@ -707,7 +707,7 @@ hqDefine('app_manager/js/details/screen_config', function () {
                     if (column.original.hasAutocomplete) {
                         column.field.setOptions(self.properties);
                         column.field.val(column.original.field);
-                        column.field.fire("change");    // set field.observableVal
+                        column.field.observableVal(column.original.field);
                         module.CC_DETAIL_SCREEN.setUpAutocomplete(column.field, self.properties);
                     }
                     return column;


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-561

Introduced in https://github.com/dimagi/commcare-hq/pull/23754

Firing the change event causes the header's text to get updated, so instead directly set `observableVal`.

@emord / @dannyroberts 