### PR TITLE
Add survey SMS event displays to SMS log report

### DIFF
--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -489,8 +489,18 @@ class MessageLogReport(BaseCommConnectLogReport):
             ] if val != Ellipsis]
 
     def _get_message_event_display(self, message, content_cache):
+        event = None
         if message.messaging_subevent:
             event = message.messaging_subevent.parent
+        elif message.xforms_session_couch_id:
+            try:
+                subevent = (MessagingSubEvent.objects
+                            .get(parent__domain=self.domain,
+                                 xforms_session__couch_id=message.xforms_session_couch_id))
+                event = subevent.parent
+            except MessagingSubEvent.DoesNotExist:
+                pass
+        if event:
             return get_event_display(self.domain, event, content_cache)
         return "-"
 

--- a/corehq/apps/reports/tests/test_message_log_report.py
+++ b/corehq/apps/reports/tests/test_message_log_report.py
@@ -111,7 +111,8 @@ class MessageLogReportTest(TestCase):
         self.addCleanup(sms.delete)
 
     def make_survey_sms(self, rule_name):
-        # It appears that in production, many SMSs don't have a direct link to the triggering event - the connection is roundabout via the xforms_session
+        # It appears that in production, many SMSs don't have a direct link to the
+        # triggering event - the connection is roundabout via the xforms_session
         rule = AutomaticUpdateRule.objects.create(domain=self.domain, name=rule_name)
         xforms_session = SQLXFormsSession.objects.create(
             domain=self.domain,

--- a/corehq/apps/reports/tests/test_message_log_report.py
+++ b/corehq/apps/reports/tests/test_message_log_report.py
@@ -12,6 +12,7 @@ from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.reports.standard.sms import MessageLogReport
 from corehq.apps.sms.models import OUTGOING, SMS, MessagingEvent
+from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.users.models import WebUser
 from corehq.util.test_utils import flag_enabled
 
@@ -31,10 +32,11 @@ class MessageLogReportTest(TestCase):
     def test_event_column(self):
         self.make_simple_sms('message')
         self.make_case_rule_sms('Rule 2')
+        self.make_survey_sms('Rule 3')
 
         for report_value, rule_name in zip(
             self.get_report_column('Event'),
-            ['-', 'Rule 2'],
+            ['-', 'Rule 2', 'Rule 3'],
         ):
             # The cell value should be a link to the rule
             self.assertIn(rule_name, report_value)
@@ -104,5 +106,38 @@ class MessageLogReportTest(TestCase):
             text='this is a message',
             messaging_subevent=subevent,
         )
+        self.addCleanup(rule.delete)
+        self.addCleanup(event.delete)  # cascades to subevent
+        self.addCleanup(sms.delete)
+
+    def make_survey_sms(self, rule_name):
+        # It appears that in production, many SMSs don't have a direct link to the triggering event - the connection is roundabout via the xforms_session
+        rule = AutomaticUpdateRule.objects.create(domain=self.domain, name=rule_name)
+        xforms_session = SQLXFormsSession.objects.create(
+            domain=self.domain,
+            couch_id=uuid.uuid4().hex,
+            start_time=datetime.utcnow(),
+            modified_time=datetime.utcnow(),
+            current_action_due=datetime.utcnow(),
+            expire_after=3,
+        )
+        event = MessagingEvent.objects.create(
+            domain=self.domain,
+            date=datetime.utcnow(),
+            source=MessagingEvent.SOURCE_CASE_RULE,
+            source_id=rule.pk,
+        )
+        subevent = event.create_subevent_for_single_sms()
+        subevent.xforms_session = xforms_session
+        subevent.save()
+        sms = SMS.objects.create(
+            domain=self.domain,
+            date=datetime.utcnow(),
+            direction=OUTGOING,
+            text='this is a message',
+            xforms_session_couch_id=xforms_session.couch_id,
+        )
+        self.addCleanup(rule.delete)
+        self.addCleanup(xforms_session.delete)
         self.addCleanup(event.delete)  # cascades to subevent
         self.addCleanup(sms.delete)


### PR DESCRIPTION
This is still in testing and isn't being rolled out to all users yet - it's behind a per-user feature flag so I can try it out on real data.

SMSs have a connection to the triggering event by `sms.messaging_subevent.event`, however, it turns out that survey SMSs _don't_ maintain this direct connection.  This looks to be by design, as when you navigate to the SMSs themselves, the linkage is: Message History report lists `events`, click on that, it takes you to the `message_event_detail` page, which redirects to the `survey_detail` page if there's only one `messaging_subevent` with one survey.  This page operates on the `xforms_session` of the subevent, and all SMSs with a corresponding `xforms_session_couch_id` are fetched.

To get event data on those sorts of SMSs then, I made this change here, which should be pretty clear in the context of the above explanation.

I'm a bit nervous about the performance implications of this per-row lookup, so I'll solicit feedback from architecture review.  This PR needn't be blocked by that review though, since these changes only take effect for feature-flagged users.

@nickpell @millerdev 