### PR TITLE
Change used statics for generating weasyprint pdf to direct ones from…

### DIFF
--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -658,8 +658,9 @@ def create_pdf_file(pdf_context):
         pdf_page = template.render(pdf_context)
     except Exception as ex:
         pdf_page = str(ex)
-    resultFile.write(HTML(string=pdf_page, base_url=settings.STATIC_ROOT).write_pdf(
-        stylesheets=[CSS(settings.STATIC_ROOT + '/css/issnip_monthly_print_style.css'), ])
+    base_url = os.path.join(settings.FILEPATH, 'custom', 'icds_reports', 'static')
+    resultFile.write(HTML(string=pdf_page, base_url=base_url).write_pdf(
+        stylesheets=[CSS(os.path.join(base_url, 'css', 'issnip_monthly_print_style.css')), ])
     )
     # we need to reset buffer position to the beginning after creating pdf, if not read() will return empty string
     # we read this to save file in blobdb


### PR DESCRIPTION
… static directory without collecting statics
Hi @calellowitz @Rohit25negi,
I have changed the files used to generate ISSNIP monthly register reports via weasyprint to use directly files from a static directory in icds_reports rather than from collected statics directory.
These changes are related to JIRA [ICDS-493](https://dimagi-dev.atlassian.net/browse/ICDS-493) ticket.
Need QA: Yes
Environment: n/a
Locally Tested: Yes
Regards, Dawid