### PR TITLE
CAS exports allow to download the report for a certain month at 15th …

### DIFF
--- a/custom/icds_reports/static/js/directives/cas-export/cas-export.directive.js
+++ b/custom/icds_reports/static/js/directives/cas-export/cas-export.directive.js
@@ -16,7 +16,9 @@ function CasExportController($window, $location, locationHierarchy, locationsSer
     });
     var now = moment();
     if (now.date() <= 15) {
-        now.subtract(1, 'months')
+        now.subtract(2, 'months');
+    } else {
+        now.subtract(1, 'months');
     }
 
     vm.selectedMonth = now.month() + 1;
@@ -31,7 +33,7 @@ function CasExportController($window, $location, locationHierarchy, locationsSer
 
     if (vm.selectedYear === new Date().getFullYear()) {
         vm.months = _.filter(vm.monthsCopy, function (month) {
-            return month.id < new Date().getMonth() + 1 || (month.id === new Date().getMonth() + 1 && moment().date() > 15);
+            return month.id < new Date().getMonth() || (month.id === new Date().getMonth() && moment().date() > 15);
         });
     } else if (vm.selectedYear === 2017) {
         vm.months = _.filter(vm.monthsCopy, function (month) {
@@ -74,6 +76,8 @@ function CasExportController($window, $location, locationHierarchy, locationsSer
 
     vm.onSelectYear = function (year) {
         var latest = new Date();
+        var offset = latest.getDate() < 15 ? 2 : 1;
+        latest.setMonth(latest.getMonth() - offset);
         if (year.id > latest.getFullYear()) {
             vm.years =  _.filter(vm.yearsCopy, function (y) {
                 return y.id <= latest.getFullYear();

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -1878,8 +1878,8 @@ class CasDataExportAPIView(View):
 
         query_month = date(year, month, 1)
         today = date.today()
-        current_month = today - relativedelta(months=1) if today.day <= 15 else today
-        if query_month > current_month:
+        available_month = today - relativedelta(months=2) if today.day <= 15 else today - relativedelta(months=1)
+        if query_month > available_month:
             return JsonResponse(self.message('invalid_month'), status=400)
 
         selected_date = date(year, month, 1).strftime('%Y-%m-%d')


### PR DESCRIPTION
…day of the next month
Hi @calellowitz @Rohit25negi,
I have changed the filter limitations for CAS exports. Right now you will be able to download the report for eg March starting from 15th April.
First change addresses the chosen month after getting on the page. Second available months to choose from after getting on the page. And the third one months available after changing year.
These changes are related to JIRA [ICDS-464](https://dimagi-dev.atlassian.net/browse/ICDS-464) ticket.
Need QA: No
Environment: n/a
Locally Tested: Yes
Regards, Dawid