### PR TITLE
don't fire post save on delete

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1186,9 +1186,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             user.delete()
         except User.DoesNotExist:
             pass
-        super(CouchUser, self).delete() # Call the "real" delete() method.
-        from .signals import couch_user_post_save
-        couch_user_post_save.send_robust(sender='couch_user', couch_user=self)
+        super(CouchUser, self).delete()  # Call the "real" delete() method.
 
     def delete_phone_number(self, phone_number):
         for i in range(0, len(self.phone_numbers)):


### PR DESCRIPTION
Firing this signal during test teardown was causing the following error:
```
cloudant.error.CloudantDocumentException: A document id is required to fetch document contents. Add an _id key and value to the document and re-try.
```

After a doc is deleted the '_id' and '_rev' fields
are cleared making it useless in the signal handlers.

Since we never truly delete users in reality there's
no need to add a separate signal for deletion.