### PR TITLE
Add validations to AAA/REACH data sources that they are extension cases

### DIFF
--- a/custom/aaa/tests/test_child_query_helper.py
+++ b/custom/aaa/tests/test_child_query_helper.py
@@ -73,6 +73,7 @@ class TestChildBeneficiarySections(TestCase):
                 'domain': cls.domain,
                 'doc_type': "CommCareCase",
                 'type': 'tasks',
+                'owner_id': '-',
             })
         pnc_adapter = cls._init_table('reach-postnatal_care')
         pnc_adapter.save({

--- a/custom/aaa/tests/test_pregnant_woman_query_helper.py
+++ b/custom/aaa/tests/test_pregnant_woman_query_helper.py
@@ -115,6 +115,7 @@ class TestPregnantWomanBeneficiarySections(TestCase):
             'domain': cls.domain,
             'doc_type': "CommCareCase",
             'type': 'person',
+            'owner_id': '-',
         })
         ccs_adapter = cls._init_table('reach-ccs_record_cases')
         ccs_adapter.save({
@@ -122,6 +123,7 @@ class TestPregnantWomanBeneficiarySections(TestCase):
             'domain': cls.domain,
             'doc_type': "CommCareCase",
             'type': 'ccs_record',
+            'owner_id': '-',
             'ifa_tablets_issued_pre': 48,
             'ifa_tablets_issued_post': 2,
         })
@@ -134,6 +136,7 @@ class TestPregnantWomanBeneficiarySections(TestCase):
                 'domain': cls.domain,
                 'doc_type': "CommCareCase",
                 'type': 'tasks',
+                'owner_id': '-',
                 "indices": [
                     {
                         "case_id": "tasks_case",

--- a/custom/aaa/ucr/data_sources/ccs_record_cases.json
+++ b/custom/aaa/ucr/data_sources/ccs_record_cases.json
@@ -23,6 +23,21 @@
       },
       "property_value": "ccs_record"
     },
+    "validations": [
+      {
+        "name": "directly_owned",
+        "error_message": "This case has an owner_id and does not default to ownership by extension",
+        "expression": {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "property_value": "-"
+        }
+      }
+    ],
     "configured_indicators": [
       {
         "column_id": "person_case_id",

--- a/custom/aaa/ucr/data_sources/child_health_cases.json
+++ b/custom/aaa/ucr/data_sources/child_health_cases.json
@@ -23,6 +23,21 @@
       "type": "boolean_expression",
       "property_value": "child_health"
     },
+    "validations": [
+      {
+        "name": "directly_owned",
+        "error_message": "This case has an owner_id and does not default to ownership by extension",
+        "expression": {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "property_value": "-"
+        }
+      }
+    ],
     "configured_indicators": [
       {
         "column_id": "person_case_id",

--- a/custom/aaa/ucr/data_sources/person_cases.json
+++ b/custom/aaa/ucr/data_sources/person_cases.json
@@ -23,6 +23,21 @@
       },
       "property_value": "person"
     },
+    "validations": [
+      {
+        "name": "directly_owned",
+        "error_message": "This case has an owner_id and does not default to ownership by extension",
+        "expression": {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "property_value": "-"
+        }
+      }
+    ],
     "configured_indicators": [
       {
         "column_id": "household_case_id",

--- a/custom/aaa/ucr/data_sources/tasks_cases.json
+++ b/custom/aaa/ucr/data_sources/tasks_cases.json
@@ -23,6 +23,21 @@
       },
       "property_value": "tasks"
     },
+    "validations": [
+      {
+        "name": "directly_owned",
+        "error_message": "This case has an owner_id and does not default to ownership by extension",
+        "expression": {
+          "type": "boolean_expression",
+          "operator": "eq",
+          "expression": {
+            "type": "property_name",
+            "property_name": "owner_id"
+          },
+          "property_value": "-"
+        }
+      }
+    ],
     "configured_indicators": [
       {
         "column_id": "parent_case_id",


### PR DESCRIPTION
All of these cases should have owner_id = '-' because there should be no legacy data in a QA domain and we use extension cases exclusively. will have to rethink this in a convergence scenario