### PR TITLE
Remove icds-test-ucr

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -19,7 +19,6 @@ DEFAULT_ENGINE_ID = 'default'
 UCR_ENGINE_ID = 'ucr'
 ICDS_UCR_ENGINE_ID = 'icds-ucr'
 ICDS_UCR_NON_DASHBOARD_ENGINE_ID = 'icds-ucr-non-dashboard'
-ICDS_TEST_UCR_ENGINE_ID = 'icds-test-ucr'
 AAA_DB_ENGINE_ID = 'aaa-data'
 
 

--- a/custom/icds_reports/sqldata/agg_awc_monthly.py
+++ b/custom/icds_reports/sqldata/agg_awc_monthly.py
@@ -17,7 +17,7 @@ from custom.utils.utils import clean_IN_filter_value
 
 class AggAWCMonthlyDataSource(ProgressReportMixIn, SqlData):
     table_name = 'agg_awc_monthly'
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     def __init__(self, config=None, loc_level='state', show_test=False, beta=False):
         super(AggAWCMonthlyDataSource, self).__init__(config)

--- a/custom/icds_reports/sqldata/agg_ccs_record_monthly.py
+++ b/custom/icds_reports/sqldata/agg_ccs_record_monthly.py
@@ -17,7 +17,7 @@ from custom.utils.utils import clean_IN_filter_value
 
 class AggCCSRecordMonthlyDataSource(ProgressReportMixIn, SqlData):
     table_name = 'agg_ccs_record_monthly'
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     def __init__(self, config=None, loc_level='state', show_test=False):
         super(AggCCSRecordMonthlyDataSource, self).__init__(config)

--- a/custom/icds_reports/sqldata/agg_child_health_monthly.py
+++ b/custom/icds_reports/sqldata/agg_child_health_monthly.py
@@ -19,7 +19,7 @@ from custom.utils.utils import clean_IN_filter_value
 
 class AggChildHealthMonthlyDataSource(ProgressReportMixIn, SqlData):
     table_name = 'agg_child_health_monthly'
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     def __init__(self, config=None, loc_level='state', show_test=False, beta=False):
         super(AggChildHealthMonthlyDataSource, self).__init__(config)

--- a/custom/icds_reports/sqldata/awc_infrastructure.py
+++ b/custom/icds_reports/sqldata/awc_infrastructure.py
@@ -12,7 +12,7 @@ from custom.utils.utils import clean_IN_filter_value
 
 
 class AWCInfrastructureUCR(SqlData):
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     def __init__(self, config):
         self.awcs = config['awc_id']

--- a/custom/icds_reports/sqldata/exports/demographics.py
+++ b/custom/icds_reports/sqldata/exports/demographics.py
@@ -13,7 +13,7 @@ from custom.icds_reports.utils import person_has_aadhaar_column, person_is_benef
 
 
 class DemographicsChildHealth(ExportableMixin, SqlData):
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     table_name = 'agg_child_health_monthly'
 
@@ -89,7 +89,7 @@ class DemographicsChildHealth(ExportableMixin, SqlData):
 
 class DemographicsAWCMonthly(ExportableMixin, SqlData):
     table_name = 'agg_awc_monthly'
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     @property
     def get_columns_by_loc_level(self):

--- a/custom/icds_reports/sqldata/vhnd_form.py
+++ b/custom/icds_reports/sqldata/vhnd_form.py
@@ -13,7 +13,7 @@ from custom.utils.utils import clean_IN_filter_value
 
 
 class VHNDFormUCR(SqlData):
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     def __init__(self, config):
         self.awcs = config['awc_id']

--- a/custom/icds_reports/utils/mixins.py
+++ b/custom/icds_reports/utils/mixins.py
@@ -36,7 +36,7 @@ FILTER_BY_LIST = {
 
 
 class ExportableMixin(object):
-    engine_id = 'icds-test-ucr'
+    engine_id = 'icds-ucr'
 
     def __init__(self, config=None, loc_level=1, show_test=False, beta=False):
         self.config = config

--- a/testsettings.py
+++ b/testsettings.py
@@ -131,7 +131,6 @@ REPORTING_DATABASES = {
     'ucr': 'default',
     'icds-ucr': 'icds-ucr',
     'icds-ucr-non-dashboard': 'icds-ucr',
-    'icds-test-ucr': 'icds-ucr',
     'aaa-data': 'default',
 }
 


### PR DESCRIPTION
arguably should be pulling a constant for the engine id, but I didn't want to pull in from `corehq.sql_db.connections`