### PR TITLE
Add early return when inserting into InvalidUCRData

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -279,6 +279,7 @@ class ErrorRaisingIndicatorSqlAdapter(IndicatorSqlAdapter):
                     validation_name='not_null_violation',
                     validation_text='A column in this doc violates an is_nullable constraint'
                 )
+                return
 
         super(ErrorRaisingIndicatorSqlAdapter, self).handle_exception(doc, exception)
 


### PR DESCRIPTION
If you don't return it goes to [super's handle_exception](https://github.com/dimagi/commcare-hq/blob/b67d44b36806bfd5eeb88642dc1e3a636051f7ed/corehq/apps/userreports/adapter.py#L50-L68) which still notifies us in sentry. Inserting inot invalidUCRData table should be considered handling the error and not need a `notify_exception`