### PR TITLE
make test_awc_reports compatible with python 3

### DIFF
--- a/custom/icds_reports/reports/awc_reports.py
+++ b/custom/icds_reports/reports/awc_reports.py
@@ -25,7 +25,8 @@ from custom.icds_reports.utils import apply_exclude, percent_diff, get_value, pe
     wasting_severe_column, stunting_moderate_column, stunting_severe_column, current_month_stunting_column, \
     current_month_wasting_column, hfa_recorded_in_month_column, wfh_recorded_in_month_column, \
     chosen_filters_to_labels, default_age_interval, get_anemic_status, get_symptoms, get_counseling, \
-    get_tt_dates, is_anemic, format_decimal, DATA_NOT_ENTERED, get_delivery_nature
+    get_tt_dates, is_anemic, format_decimal, DATA_NOT_ENTERED, get_delivery_nature, get_color_with_green_positive,\
+    get_color_with_red_positive
 from custom.icds_reports.const import MapColors
 import six
 
@@ -460,12 +461,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'valid_weighed'
                     ),
-                    'color': 'red' if percent_diff(
+                    'color': get_color_with_red_positive(percent_diff(
                         'underweight',
                         this_month_data,
                         prev_month_data,
                         'valid_weighed'
-                    ) > 0 else 'green',
+                    )),
                     'value': get_value(this_month_data, 'underweight'),
                     'all': get_value(this_month_data, 'valid_weighed'),
                     'format': 'percent_and_div',
@@ -480,12 +481,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'weighed_and_height_measured_in_month'
                     ),
-                    'color': 'red' if percent_diff(
+                    'color': get_color_with_red_positive(percent_diff(
                         'wasting',
                         this_month_data,
                         prev_month_data,
                         'weighed_and_height_measured_in_month'
-                    ) > 0 else 'green',
+                    )),
                     'value': get_value(this_month_data, 'wasting'),
                     'all': get_value(this_month_data, 'weighed_and_height_measured_in_month'),
                     'format': 'percent_and_div',
@@ -502,12 +503,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'height_measured_in_month'
                     ),
-                    'color': 'red' if percent_diff(
+                    'color': get_color_with_red_positive(percent_diff(
                         'stunting',
                         this_month_data,
                         prev_month_data,
                         'height_measured_in_month'
-                    ) > 0 else 'green',
+                    )),
                     'value': get_value(this_month_data, 'stunting'),
                     'all': get_value(this_month_data, 'height_measured_in_month'),
                     'format': 'percent_and_div',
@@ -525,12 +526,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data_we,
                         'wer_eli'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'wer_weight',
                         this_month_data_we,
                         prev_month_data_we,
                         'wer_eli'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(this_month_data_we, 'wer_weight'),
                     'all': get_value(this_month_data_we, 'wer_eli'),
                     'format': 'percent_and_div',
@@ -550,12 +551,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'weighed_and_born_in_month'
                     ),
-                    'color': 'red' if percent_diff(
+                    'color': get_color_with_red_positive(percent_diff(
                         'low_birth',
                         this_month_data,
                         prev_month_data,
                         'weighed_and_born_in_month'
-                    ) > 0 else 'green',
+                    )),
                     'value': get_value(this_month_data, 'low_birth'),
                     'all': get_value(this_month_data, 'weighed_and_born_in_month'),
                     'format': 'percent_and_div',
@@ -570,12 +571,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'born'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'birth',
                         this_month_data,
                         prev_month_data,
                         'born'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(this_month_data, 'birth'),
                     'all': get_value(this_month_data, 'born'),
                     'format': 'percent_and_div',
@@ -592,12 +593,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'ebf'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'month_ebf',
                         this_month_data,
                         prev_month_data,
                         'ebf'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(this_month_data, 'month_ebf'),
                     'all': get_value(this_month_data, 'ebf'),
                     'format': 'percent_and_div',
@@ -612,12 +613,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'cf'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'month_cf',
                         this_month_data,
                         prev_month_data,
                         'cf'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(this_month_data, 'month_cf'),
                     'all': get_value(this_month_data, 'cf'),
                     'format': 'percent_and_div',
@@ -642,12 +643,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_data,
                         'eligible'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'immunized',
                         this_month_data,
                         prev_month_data,
                         'eligible'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(this_month_data, 'immunized'),
                     'all': get_value(this_month_data, 'eligible'),
                     'format': 'percent_and_div',
@@ -662,12 +663,12 @@ def get_awc_reports_maternal_child(domain, config, month, prev_month, show_test=
                         prev_month_institutional_delivery_data,
                         'delivered_in_month_sum'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'institutional_delivery_in_month_sum',
                         this_month_institutional_delivery_data,
                         prev_month_institutional_delivery_data,
                         'delivered_in_month_sum'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(
                         this_month_institutional_delivery_data,
                         'institutional_delivery_in_month_sum'
@@ -770,10 +771,10 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                         data,
                         prev_data,
                     ),
-                    'color': 'green' if percent_increase(
+                    'color': get_color_with_green_positive(percent_increase(
                         'household',
                         data,
-                        prev_data) > 0 else 'red',
+                        prev_data)),
                     'value': get_value(data, 'household'),
                     'all': '',
                     'format': 'number',
@@ -791,12 +792,12 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                         prev_data,
                         'all_persons'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'person_aadhaar',
                         data,
                         prev_data,
                         'all_persons'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(data, 'person_aadhaar'),
                     'all': get_value(data, 'all_persons'),
                     'format': 'percent_and_div',
@@ -808,10 +809,10 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                     'label': _('Percent children (0-6 years) enrolled for Anganwadi Services'),
                     'help_text': percent_children_enrolled_help_text(),
                     'percent': percent_diff('child_health', data, prev_data, 'child_health_all'),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'child_health_all',
                         data,
-                        prev_data, 'child_health_all') > 0 else 'red',
+                        prev_data, 'child_health_all')),
                     'value': get_value(data, 'child_health'),
                     'all': get_value(data, 'child_health_all'),
                     'format': 'percent_and_div',
@@ -822,12 +823,12 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                     'help_text': _('Of the total number of pregnant women, the percentage of pregnant '
                                    'women enrolled for Anganwadi Services'),
                     'percent': percent_diff('ccs_pregnant', data, prev_data, 'ccs_pregnant_all'),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'ccs_pregnant',
                         data,
                         prev_data,
                         'ccs_pregnant_all'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(data, 'ccs_pregnant'),
                     'all': get_value(data, 'ccs_pregnant_all'),
                     'format': 'percent_and_div',
@@ -841,12 +842,12 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                     'help_text': _('Of the total number of lactating women, the percentage of '
                                    'lactating women enrolled for Anganwadi Services'),
                     'percent': percent_diff('css_lactating', data, prev_data, 'css_lactating_all'),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'css_lactating',
                         data,
                         prev_data,
                         'css_lactating_all'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(data, 'css_lactating'),
                     'all': get_value(data, 'css_lactating_all'),
                     'format': 'percent_and_div',
@@ -864,12 +865,12 @@ def get_awc_report_demographics(domain, config, now_date, month, show_test=False
                         prev_data,
                         'person_adolescent_all'
                     ),
-                    'color': 'green' if percent_diff(
+                    'color': get_color_with_green_positive(percent_diff(
                         'person_adolescent',
                         data,
                         prev_data,
                         'person_adolescent_all'
-                    ) > 0 else 'red',
+                    )),
                     'value': get_value(data, 'person_adolescent'),
                     'all': get_value(data, 'person_adolescent_all'),
                     'format': 'percent_and_div',

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -603,7 +603,8 @@ def email_dashboad_team(aggregation_date):
     if six.PY2 and isinstance(aggregation_date, bytes):
         aggregation_date = aggregation_date.decode('utf-8')
     # temporary soft assert to verify it's completing
-    _dashboard_team_soft_assert(False, "Aggregation completed on {}".format(settings.SERVER_ENVIRONMENT))
+    if not settings.UNIT_TESTING:
+        _dashboard_team_soft_assert(False, "Aggregation completed on {}".format(settings.SERVER_ENVIRONMENT))
     celery_task_logger.info("Aggregation has completed")
     icds_data_validation.delay(aggregation_date)
 

--- a/custom/icds_reports/tests/reports/test_awc_reports.py
+++ b/custom/icds_reports/tests/reports/test_awc_reports.py
@@ -1044,8 +1044,8 @@ class TestAWCReport(TestCase):
         for kpi in data['kpi']:
             for el in kpi:
                 del el['help_text']
-        self.assertEqual(
-            list(data.keys()),
+        self.assertItemsEqual(
+            data,
             ["images", "kpi", "charts", "map"]
         )
 
@@ -1700,8 +1700,8 @@ class TestAWCReport(TestCase):
         )
 
     def test_awc_reports_demographics_monthly_keys(self):
-        self.assertEqual(
-            list(get_awc_report_demographics(
+        self.assertItemsEqual(
+            get_awc_report_demographics(
                 'icds-cas',
                 {
                     'state_id': 'st1',
@@ -1712,7 +1712,7 @@ class TestAWCReport(TestCase):
                 },
                 (2017, 6, 1),
                 (2017, 5, 1),
-            ).keys()),
+            ),
             ['kpi', 'chart']
         )
 
@@ -1941,8 +1941,8 @@ class TestAWCReport(TestCase):
         )
 
     def test_awc_reports_demographics_daily_keys(self):
-        self.assertEqual(
-            list(get_awc_report_demographics(
+        self.assertItemsEqual(
+            get_awc_report_demographics(
                 'icds-cas',
                 {
                     'state_id': 'st1',
@@ -1953,7 +1953,7 @@ class TestAWCReport(TestCase):
                 },
                 (2017, 5, 29),
                 (2017, 5, 1),
-            ).keys()),
+            ),
             ['kpi', 'chart']
         )
 
@@ -2182,8 +2182,8 @@ class TestAWCReport(TestCase):
         )
 
     def test_awc_reports_demographics_daily_if_aggregation_script_fail_keys(self):
-        self.assertEqual(
-            list(get_awc_report_demographics(
+        self.assertItemsEqual(
+            get_awc_report_demographics(
                 'icds-cas',
                 {
                     'state_id': 'st1',
@@ -2194,7 +2194,7 @@ class TestAWCReport(TestCase):
                 },
                 (2017, 5, 30),
                 (2017, 5, 1),
-            ).keys()),
+            ),
             ['kpi', 'chart']
         )
 
@@ -2482,12 +2482,9 @@ class TestAWCReport(TestCase):
 
     def test_awc_report_beneficiary_keys(self):
         data = get_awc_report_beneficiary(0, 10, 1, 'dob', {'awc_id': 'a18'}, (2017, 5, 1), (2017, 3, 1), False)
-        self.assertJSONEqual(
-            json.dumps(list(data.keys()), cls=DjangoJSONEncoder),
-            json.dumps(
-                ['draw', 'last_month', 'recordsTotal', 'months', 'recordsFiltered', 'data'],
-                cls=DjangoJSONEncoder
-            )
+        self.assertItemsEqual(
+            data,
+            ['draw', 'last_month', 'recordsTotal', 'months', 'recordsFiltered', 'data']
         )
 
     def test_awc_report_pregnant_first_record(self):

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -323,6 +323,17 @@ def get_color_with_green_positive(val):
         return 'green'
 
 
+def get_color_with_red_positive(val):
+    if isinstance(val, (int, float)):
+        if val > 0:
+            return 'red'
+        else:
+            return 'green'
+    else:
+        assert val == PREVIOUS_PERIOD_ZERO_DATA, val
+        return 'red'
+
+
 def get_value(data, prop):
     return (data[0][prop] or 0) if data else 0
 


### PR DESCRIPTION
Adds a new helper function ```get_color_with_red_positive```.

Also skips the "aggregation completed" soft assert during unit testing for ease of using ```REUSE_DB=1```.