### PR TITLE
avoid and fix form="default" in form label translations

### DIFF
--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -725,25 +725,20 @@ def update_form_translations(sheet, rows, missing_cols, app):
         return msgs
 
     def find_itext_node(xform):
-        try:
-            # find the bucket node that holds all translations.
-            # it has a bunch of nodes, one for each lang, which then
-            # has translations for all labels as a child node, example
-            # <itext>
-            #   <translation lang="en" default="">
-            #     <text id="name-label">
-            #       <value>Name2</value>
-            #       <value form="image">image_path</value>
-            #     </text>
-            #   </translation>
-            # </itext>
-            return xform.itext_node
-        except XFormException:
-            return None
+        # find the bucket node that holds all translations.
+        # it has a bunch of nodes, one for each lang, which then
+        # has translations for all labels as a child node, example
+        # <itext>
+        #   <translation lang="en" default="">
+        #     <text id="name-label">
+        #       <value>Name2</value>
+        #       <value form="image">image_path</value>
+        #     </text>
+        #   </translation>
+        # </itext>
+        return xform.itext_node
 
     itext = find_itext_node(xform)
-    if not itext:
-        return msgs
 
     # Make language nodes for each language if they don't yet exist
     #

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -806,7 +806,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
                 if 'form' not in n.attrib or n.get('form') == 'default'
             )
         except StopIteration:
-            return WrappedNode(None)
+            return None
 
     def had_markdown(text_node_):
         """
@@ -822,7 +822,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
         builder that the value isn't Markdown.
         """
         value_node_ = get_value_node(text_node_)
-        if not value_node_.exists():
+        if value_node_ is None:
             return False
         old_trans = etree.tostring(value_node_.xml, method="text", encoding="unicode").strip()
         return _looks_like_markdown(old_trans) and not had_markdown(text_node_)

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -745,18 +745,15 @@ def update_form_translations(sheet, rows, missing_cols, app):
     # Currently operating under the assumption that every xForm has at least
     # one translation element, that each translation element has a text node
     # for each question and that each text node has a value node under it
-    template_translation_el = None
+
     # Get a translation element to be used as a template for new elements, starting with default
-    trans_el = itext.find("./{f}translation[@lang='%s']" % app.default_language)
-    if trans_el.exists():
-        template_translation_el = trans_el
-        if not template_translation_el:
-            for lang in app.langs:
-                trans_el = itext.find("./{f}translation[@lang='%s']" % lang)
-                if trans_el.exists():
-                    template_translation_el = trans_el
-                    break
-    assert(template_translation_el is not None)
+    template_translation_el = itext.find("./{f}translation[@lang='%s']" % app.default_language)
+    if not template_translation_el.exists():
+        for lang in app.langs:
+            template_translation_el = itext.find("./{f}translation[@lang='%s']" % lang)
+            if template_translation_el.exists():
+                break
+    assert template_translation_el.exists()
     # Add missing translation elements
     for lang in app.langs:
         trans_el = itext.find("./{f}translation[@lang='%s']" % lang)

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -746,11 +746,15 @@ def update_form_translations(sheet, rows, missing_cols, app):
     # one translation element, that each translation element has a text node
     # for each question and that each text node has a value node under it
     template_translation_el = None
-    # Get a translation element to be used as a template for new elements
-    for lang in app.langs:
-        trans_el = itext.find("./{f}translation[@lang='%s']" % lang)
-        if trans_el.exists():
-            template_translation_el = trans_el
+    # Get a translation element to be used as a template for new elements, starting with default
+    trans_el = itext.find("./{f}translation[@lang='%s']" % app.default_language)
+    if trans_el.exists():
+        template_translation_el = trans_el
+        if not template_translation_el:
+            for lang in app.langs:
+                trans_el = itext.find("./{f}translation[@lang='%s']" % lang)
+                if trans_el.exists():
+                    template_translation_el = trans_el
     assert(template_translation_el is not None)
     # Add missing translation elements
     for lang in app.langs:

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -918,7 +918,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
                     _update_translation_node(
                         new_translation,
                         get_value_node(text_node),
-                        {'form': 'default'},
+                        {},
                         delete_node=(not keep_value_node)
                     )
                 else:

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -823,6 +823,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
             return empty_form_attr_value_nodes[0]
         if default_form_attr_value_nodes:
             return sanitize_invalid_value_node(default_form_attr_value_nodes[0])
+        return WrappedNode(None)
 
     def had_markdown(text_node_):
         """
@@ -838,7 +839,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
         builder that the value isn't Markdown.
         """
         value_node_ = get_value_node(text_node_)
-        if value_node_ is None:
+        if not value_node_.exists():
             return False
         old_trans = etree.tostring(value_node_.xml, method="text", encoding="unicode").strip()
         return _looks_like_markdown(old_trans) and not had_markdown(text_node_)

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -724,9 +724,25 @@ def update_form_translations(sheet, rows, missing_cols, app):
         # Tell the user this?
         return msgs
 
-    try:
-        itext = xform.itext_node
-    except XFormException:
+    def find_itext_node(xform):
+        try:
+            # find the bucket node that holds all translations.
+            # it has a bunch of nodes, one for each lang, which then
+            # has translations for all labels as a child node, example
+            # <itext>
+            #   <translation lang="en" default="">
+            #     <text id="name-label">
+            #       <value>Name2</value>
+            #       <value form="image">image_path</value>
+            #     </text>
+            #   </translation>
+            # </itext>
+            return xform.itext_node
+        except XFormException:
+            return None
+
+    itext = find_itext_node(xform)
+    if not itext:
         return msgs
 
     # Make language nodes for each language if they don't yet exist

--- a/corehq/apps/translations/app_translations.py
+++ b/corehq/apps/translations/app_translations.py
@@ -755,6 +755,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
                 trans_el = itext.find("./{f}translation[@lang='%s']" % lang)
                 if trans_el.exists():
                     template_translation_el = trans_el
+                    break
     assert(template_translation_el is not None)
     # Add missing translation elements
     for lang in app.langs:


### PR DESCRIPTION
[Sentry Error](https://sentry.io/organizations/dimagi/issues/979888908/events/33674cd9cb7041e689b1e02834fe4842/)

We have seen it [before](http://manage.dimagi.com/default.asp?236239#BugEvent.1214824)

This PR:
1. Does minor improvements
2. Does not set the incorrect value by default for text node
3. Revisit logic to catch bad cases and fix invalid entries 

Pinging everyone on review who i feel have context.
Buddy @czue 

[Jira ticket for tracking](https://dimagi-dev.atlassian.net/browse/ICDS-487)