### PR TITLE
Pass in errors to raise for large files

### DIFF
--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -9,7 +9,6 @@ from django.core.mail import send_mail, mail_admins
 from corehq.util.datadog.gauges import datadog_gauge_task
 from corehq.util.log import send_HTML_email
 from dimagi.utils.logging import notify_exception
-from dimagi.utils.django.email import LARGE_FILE_SIZE_ERROR_CODES
 import six
 
 
@@ -59,7 +58,7 @@ def send_mail_async(self, subject, message, from_email, recipient_list,
 def send_html_email_async(self, subject, recipient, html_content,
                           text_content=None, cc=None,
                           email_from=settings.DEFAULT_FROM_EMAIL,
-                          file_attachments=None, bcc=None):
+                          file_attachments=None, bcc=None, smtp_exception_skip_list=None):
     """ Call with send_HTML_email_async.delay(*args, **kwargs)
     - sends emails in the main celery queue
     - if sending fails, retry in 15 min
@@ -69,7 +68,7 @@ def send_html_email_async(self, subject, recipient, html_content,
         send_HTML_email(subject, recipient, html_content,
                         text_content=text_content, cc=cc, email_from=email_from,
                         file_attachments=file_attachments, bcc=bcc,
-                        smtp_exception_skip_list=LARGE_FILE_SIZE_ERROR_CODES)
+                        smtp_exception_skip_list=smtp_exception_skip_list)
     except Exception as e:
         from corehq.util.python_compatibility import soft_assert_type_text
         if isinstance(recipient, six.string_types):

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -9,6 +9,7 @@ from django.core.mail import send_mail, mail_admins
 from corehq.util.datadog.gauges import datadog_gauge_task
 from corehq.util.log import send_HTML_email
 from dimagi.utils.logging import notify_exception
+from dimagi.utils.django.email import LARGE_FILE_SIZE_ERROR_CODES
 import six
 
 
@@ -67,7 +68,8 @@ def send_html_email_async(self, subject, recipient, html_content,
     try:
         send_HTML_email(subject, recipient, html_content,
                         text_content=text_content, cc=cc, email_from=email_from,
-                        file_attachments=file_attachments, bcc=bcc)
+                        file_attachments=file_attachments, bcc=bcc,
+                        smtp_exception_skip_list=LARGE_FILE_SIZE_ERROR_CODES)
     except Exception as e:
         from corehq.util.python_compatibility import soft_assert_type_text
         if isinstance(recipient, six.string_types):

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -687,7 +687,8 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
                     send_html_email_async.delay(
                         title, email, body,
                         email_from=settings.DEFAULT_FROM_EMAIL,
-                        file_attachments=excel_files)
+                        file_attachments=excel_files,
+                        smtp_exception_skip_list=LARGE_FILE_SIZE_ERROR_CODES)
             except Exception as er:
                 notify_exception(
                     None,


### PR DESCRIPTION
This makes it so they end up getting rendered to excel, instead of being included in the html body of the email

@calellowitz 