### PR TITLE
Allow us to turn on sms log changes for a domain

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1081,7 +1081,7 @@ SMS_LOG_CHANGES = StaticToggle(
     'sms_log_changes',
     "Message Log Report: Test new additions",
     TAG_CUSTOM,
-    [NAMESPACE_USER],
+    [NAMESPACE_USER, NAMESPACE_DOMAIN],
     description=("Include failed messages, show message status, show event. "
                  "This feature flag exists to QA on real prod data."),
 )


### PR DESCRIPTION
Feature flag: "Message Log Report: Test new additions" - this is a testing/one-off feature flag, not yet applicable to the broader team.

I'm gonna leave this as a feature flag for a bit longer, and a partner will begin using it as such, so this PR enables turning it on for a domain.  The plan is still to release this behavior (killing the feature flag) in the next couple weeks.

@sravfeyn @djmore9 @nickpell 
Please merge once ready, I'll be offline next week, and I think we'd like to enable this as soon as it's available.