### PR TITLE
Separate the ICDS router

### DIFF
--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -17,16 +17,7 @@ from .util import select_db_for_read
 
 DEFAULT_ENGINE_ID = 'default'
 UCR_ENGINE_ID = 'ucr'
-ICDS_UCR_ENGINE_ID = 'icds-ucr'
-ICDS_UCR_NON_DASHBOARD_ENGINE_ID = 'icds-ucr-non-dashboard'
 AAA_DB_ENGINE_ID = 'aaa-data'
-
-
-def get_icds_ucr_db_alias():
-    try:
-        return connection_manager.get_django_db_alias(ICDS_UCR_ENGINE_ID)
-    except KeyError:
-        return None
 
 
 def get_aaa_db_alias():

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -6,10 +6,8 @@ from django.db import connections
 
 from corehq.sql_db.connections import (
     AAA_DB_ENGINE_ID,
-    ICDS_UCR_ENGINE_ID,
     connection_manager,
     get_aaa_db_alias,
-    get_icds_ucr_db_alias,
 )
 
 from .config import partition_config
@@ -18,7 +16,6 @@ PROXY_APP = 'sql_proxy_accessors'
 FORM_PROCESSOR_APP = 'form_processor'
 BLOB_DB_APP = 'blobs'
 SQL_ACCESSORS_APP = 'sql_accessors'
-ICDS_REPORTS_APP = 'icds_reports'
 SCHEDULING_PARTITIONED_APP = 'scheduling_partitioned'
 WAREHOUSE_APP = 'warehouse'
 SYNCLOGS_APP = 'phone'
@@ -60,10 +57,7 @@ def allow_migrate(db, app_label):
 
     :return: Must return a boolean value, not None.
     """
-    if app_label == ICDS_REPORTS_APP:
-        db_alias = get_icds_ucr_db_alias()
-        return bool(db_alias and db_alias == db)
-    elif app_label == AAA_APP:
+    if app_label == AAA_APP:
         db_alias = get_aaa_db_alias()
         return bool(db_alias and db_alias == db)
     elif app_label == SYNCLOGS_APP:
@@ -101,11 +95,6 @@ def db_for_read_write(model, write=True):
         return settings.WAREHOUSE_DATABASE_ALIAS
     elif app_label == SYNCLOGS_APP:
         return settings.SYNCLOGS_SQL_DB_ALIAS
-    elif app_label == ICDS_REPORTS_APP:
-        engine_id = ICDS_UCR_ENGINE_ID
-        if not write:
-            engine_id = connection_manager.get_load_balanced_read_db_alias(ICDS_UCR_ENGINE_ID)
-        return connection_manager.get_django_db_alias(engine_id)
     elif app_label == AAA_APP:
         engine_id = AAA_DB_ENGINE_ID
         if not write:

--- a/corehq/sql_db/tests/test_routers.py
+++ b/corehq/sql_db/tests/test_routers.py
@@ -59,7 +59,7 @@ class AllowMigrateTest(SimpleTestCase):
         self.assertIs(False, allow_migrate('default', SYNCLOGS_APP))
         self.assertIs(True, allow_migrate('synclogs', SYNCLOGS_APP))
 
-    @patch('corehq.sql_db.routers.get_icds_ucr_db_alias')
+    @patch('custom.icds_reports.router.get_icds_ucr_db_alias')
     def test_icds_db(self, mock):
         mock.return_value = None
         self.assertIs(False, allow_migrate('default', ICDS_REPORTS_APP))

--- a/custom/icds_reports/const.py
+++ b/custom/icds_reports/const.py
@@ -118,3 +118,6 @@ VALID_LEVELS_FOR_DUMP = [
     '2',  # district
     '3',  # block
 ]
+
+ICDS_UCR_ENGINE_ID = 'icds-ucr'
+ICDS_UCR_NON_DASHBOARD_ENGINE_ID = 'icds-ucr-non-dashboard'

--- a/custom/icds_reports/management/commands/imbalanced_indicator.py
+++ b/custom/icds_reports/management/commands/imbalanced_indicator.py
@@ -7,7 +7,7 @@ import six
 from django.core.management.base import BaseCommand
 from django.db import connections
 
-from corehq.sql_db.connections import get_icds_ucr_db_alias
+from custom.icds_reports.router import get_icds_ucr_db_alias
 
 
 class Command(BaseCommand):

--- a/custom/icds_reports/management/commands/update_agg_awc_num_awc_infra_last_update.py
+++ b/custom/icds_reports/management/commands/update_agg_awc_num_awc_infra_last_update.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 
 from django.db import connections, transaction
 
-from corehq.sql_db.connections import get_icds_ucr_db_alias
+from custom.icds_reports.router import get_icds_ucr_db_alias
 from io import open
 
 

--- a/custom/icds_reports/management/commands/update_child_health_monthly.py
+++ b/custom/icds_reports/management/commands/update_child_health_monthly.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 
 from django.db import connections, transaction
 
-from corehq.sql_db.connections import get_icds_ucr_db_alias
+from custom.icds_reports.router import get_icds_ucr_db_alias
 from io import open
 
 

--- a/custom/icds_reports/models/aggregate.py
+++ b/custom/icds_reports/models/aggregate.py
@@ -3,44 +3,53 @@ from __future__ import absolute_import, unicode_literals
 from contextlib import contextmanager
 from datetime import date
 
-from corehq.form_processor.utils.sql import fetchall_as_namedtuple
-from corehq.sql_db.routers import db_for_read_write
-from custom.icds_reports.const import (AGG_CCS_RECORD_BP_TABLE,
-    AGG_CCS_RECORD_CF_TABLE, AGG_CCS_RECORD_DELIVERY_TABLE,
-    AGG_CCS_RECORD_PNC_TABLE, AGG_CCS_RECORD_THR_TABLE,
-    AGG_CHILD_HEALTH_PNC_TABLE, AGG_CHILD_HEALTH_THR_TABLE,
-    AGG_COMP_FEEDING_TABLE, AGG_DAILY_FEEDING_TABLE,
-    AGG_GROWTH_MONITORING_TABLE, AGG_INFRASTRUCTURE_TABLE, AWW_INCENTIVE_TABLE,
-                                       AGG_LS_AWC_VISIT_TABLE, AGG_LS_VHND_TABLE,
-                                       AGG_LS_BENEFICIARY_TABLE)
 from django.db import connections, models, transaction
 
+from corehq.form_processor.utils.sql import fetchall_as_namedtuple
+from custom.icds_reports.const import (
+    AGG_CCS_RECORD_BP_TABLE,
+    AGG_CCS_RECORD_CF_TABLE,
+    AGG_CCS_RECORD_DELIVERY_TABLE,
+    AGG_CCS_RECORD_PNC_TABLE,
+    AGG_CCS_RECORD_THR_TABLE,
+    AGG_CHILD_HEALTH_PNC_TABLE,
+    AGG_CHILD_HEALTH_THR_TABLE,
+    AGG_COMP_FEEDING_TABLE,
+    AGG_DAILY_FEEDING_TABLE,
+    AGG_GROWTH_MONITORING_TABLE,
+    AGG_INFRASTRUCTURE_TABLE,
+    AGG_LS_AWC_VISIT_TABLE,
+    AGG_LS_BENEFICIARY_TABLE,
+    AGG_LS_VHND_TABLE,
+    AWW_INCENTIVE_TABLE,
+)
+from custom.icds_reports.router import db_for_read_write
 from custom.icds_reports.utils.aggregation_helpers.monolith import (
+    AggAwcDailyAggregationHelper,
+    AggAwcHelper,
     AggCcsRecordAggregationHelper,
     AggChildHealthAggregationHelper,
+    AggLsHelper,
     AwcInfrastructureAggregationHelper,
     AwwIncentiveAggregationHelper,
-    LSAwcMgtFormAggHelper,
-    LSBeneficiaryFormAggHelper,
-    LSVhndFormAggHelper,
-    AggLsHelper,
     BirthPreparednessFormsAggregationHelper,
     CcsRecordMonthlyAggregationHelper,
     ChildHealthMonthlyAggregationHelper,
     ComplementaryFormsAggregationHelper,
     ComplementaryFormsCcsRecordAggregationHelper,
+    DailyAttendanceAggregationHelper,
     DailyFeedingFormsChildHealthAggregationHelper,
     DeliveryFormsAggregationHelper,
     GrowthMonitoringFormsAggregationHelper,
     InactiveAwwsAggregationHelper,
+    LocationAggregationHelper,
+    LSAwcMgtFormAggHelper,
+    LSBeneficiaryFormAggHelper,
+    LSVhndFormAggHelper,
     PostnatalCareFormsCcsRecordAggregationHelper,
     PostnatalCareFormsChildHealthAggregationHelper,
-    THRFormsChildHealthAggregationHelper,
     THRFormsCcsRecordAggregationHelper,
-    AggAwcHelper,
-    AggAwcDailyAggregationHelper,
-    LocationAggregationHelper,
-    DailyAttendanceAggregationHelper
+    THRFormsChildHealthAggregationHelper,
 )
 
 

--- a/custom/icds_reports/router.py
+++ b/custom/icds_reports/router.py
@@ -20,11 +20,7 @@ class ICDSReportsRouter(object):
             # defer to other routers
             return None
 
-        db_alias = get_icds_ucr_db_alias()
-        if db_alias == db:
-            return True
-
-        return False
+        return db == get_icds_ucr_db_alias()
 
     def allow_relation(self, obj1, obj2, **hints):
         app1, app2 = obj1._meta.app_label, obj2._meta.app_label

--- a/custom/icds_reports/router.py
+++ b/custom/icds_reports/router.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from corehq.sql_db.connections import (
-    ICDS_UCR_ENGINE_ID,
-    connection_manager,
-    get_icds_ucr_db_alias,
-)
+from corehq.sql_db.connections import connection_manager
+from custom.icds_reports.const import ICDS_UCR_ENGINE_ID
 
 ICDS_REPORTS_APP = 'icds_reports'
 
@@ -44,3 +41,10 @@ def db_for_read_write(model, write=True):
         if not write:
             engine_id = connection_manager.get_load_balanced_read_db_alias(ICDS_UCR_ENGINE_ID)
         return connection_manager.get_django_db_alias(engine_id)
+
+
+def get_icds_ucr_db_alias():
+    try:
+        return connection_manager.get_django_db_alias(ICDS_UCR_ENGINE_ID)
+    except KeyError:
+        return None

--- a/custom/icds_reports/router.py
+++ b/custom/icds_reports/router.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, unicode_literals
+
+from corehq.sql_db.connections import (
+    ICDS_UCR_ENGINE_ID,
+    connection_manager,
+    get_icds_ucr_db_alias,
+)
+
+ICDS_REPORTS_APP = 'icds_reports'
+
+
+class ICDSReportsRouter(object):
+
+    def db_for_read(self, model, **hints):
+        return db_for_read_write(model, write=False)
+
+    def db_for_write(self, model, **hints):
+        return db_for_read_write(model, write=True)
+
+    def allow_migrate(self, db, app_label, model=None, **hints):
+        if app_label != ICDS_REPORTS_APP:
+            return False
+
+        db_alias = get_icds_ucr_db_alias()
+        return bool(db_alias and db_alias == db)
+
+    def allow_relation(self, obj1, obj2, **hints):
+        app1, app2 = obj1._meta.app_label, obj2._meta.app_label
+        if app1 == ICDS_REPORTS_APP or app2 == ICDS_REPORTS_APP:
+            return app1 == app2
+        return None
+
+
+def db_for_read_write(model, write=True):
+    """
+    :param model: Django model being queried
+    :param write: Default to True since the DB for writes can also handle reads
+    :return: Django DB alias to use for query
+    """
+    app_label = model._meta.app_label
+
+    if app_label == ICDS_REPORTS_APP:
+        engine_id = ICDS_UCR_ENGINE_ID
+        if not write:
+            engine_id = connection_manager.get_load_balanced_read_db_alias(ICDS_UCR_ENGINE_ID)
+        return connection_manager.get_django_db_alias(engine_id)

--- a/custom/icds_reports/router.py
+++ b/custom/icds_reports/router.py
@@ -15,11 +15,16 @@ class ICDSReportsRouter(object):
         return db_for_read_write(model, write=True)
 
     def allow_migrate(self, db, app_label, model=None, **hints):
-        if app_label != ICDS_REPORTS_APP:
-            return False
+        is_icds_app = (app_label == ICDS_REPORTS_APP)
+        if not is_icds_app:
+            # defer to other routers
+            return None
 
         db_alias = get_icds_ucr_db_alias()
-        return bool(db_alias and db_alias == db)
+        if db_alias == db:
+            return True
+
+        return False
 
     def allow_relation(self, obj1, obj2, **hints):
         app1, app2 = obj1._meta.app_label, obj2._meta.app_label

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -46,7 +46,6 @@ from corehq.const import SERVER_DATE_FORMAT
 from corehq.form_processor.change_publishers import publish_case_saved
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.sql_db.connections import get_icds_ucr_db_alias
-from corehq.sql_db.routers import db_for_read_write
 from corehq.util.datadog.utils import case_load_counter, create_datadog_event
 from corehq.util.decorators import serial_task
 from corehq.util.log import send_HTML_email
@@ -102,6 +101,7 @@ from custom.icds_reports.reports.incentive import IncentiveReport
 from custom.icds_reports.reports.issnip_monthly_register import (
     ISSNIPMonthlyReport,
 )
+from custom.icds_reports.router import db_for_read_write
 from custom.icds_reports.sqldata.exports.awc_infrastructure import (
     AWCInfrastructureExport,
 )

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -45,7 +45,6 @@ from corehq.apps.users.dbaccessors.all_commcare_users import (
 from corehq.const import SERVER_DATE_FORMAT
 from corehq.form_processor.change_publishers import publish_case_saved
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.sql_db.connections import get_icds_ucr_db_alias
 from corehq.util.datadog.utils import case_load_counter, create_datadog_event
 from corehq.util.decorators import serial_task
 from corehq.util.log import send_HTML_email
@@ -101,7 +100,7 @@ from custom.icds_reports.reports.incentive import IncentiveReport
 from custom.icds_reports.reports.issnip_monthly_register import (
     ISSNIPMonthlyReport,
 )
-from custom.icds_reports.router import db_for_read_write
+from custom.icds_reports.router import db_for_read_write, get_icds_ucr_db_alias
 from custom.icds_reports.sqldata.exports.awc_infrastructure import (
     AWCInfrastructureExport,
 )

--- a/custom/icds_reports/tests/__init__.py
+++ b/custom/icds_reports/tests/__init__.py
@@ -19,7 +19,8 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.userreports.models import StaticDataSourceConfiguration
 from corehq.apps.userreports.util import get_indicator_adapter, get_table_name
-from corehq.sql_db.connections import connection_manager, ICDS_UCR_ENGINE_ID
+from corehq.sql_db.connections import connection_manager
+from custom.icds_reports.const import ICDS_UCR_ENGINE_ID
 from custom.icds_reports.tasks import (
     move_ucr_data_into_aggregation_tables,
     build_incentive_report,

--- a/settings.py
+++ b/settings.py
@@ -1274,6 +1274,8 @@ if helper.is_testing():
 
 
 DATABASE_ROUTERS = globals().get('DATABASE_ROUTERS', [])
+if 'custom.icds_reports.router.ICDSReportsRouter' not in DATABASE_ROUTERS:
+    DATABASE_ROUTERS.append('custom.icds_reports.router.ICDSReportsRouter')
 if 'corehq.sql_db.routers.MultiDBRouter' not in DATABASE_ROUTERS:
     DATABASE_ROUTERS.append('corehq.sql_db.routers.MultiDBRouter')
 


### PR DESCRIPTION
I've been looking at the database code recently and thought about doing this. Thoughts on this change? I think it would simplify the router and we could do similar changes for AAA and warehouse/synclogs databases (if we wanted to)