### PR TITLE
fix ICDS reports tests by making order consistent across python versions

### DIFF
--- a/custom/icds_reports/reports/adhaar.py
+++ b/custom/icds_reports/reports/adhaar.py
@@ -195,16 +195,15 @@ def get_adhaar_data_chart(domain, config, loc_level, show_test=False, beta=False
         data['blue'][date_in_miliseconds]['y'] += in_month
         data['blue'][date_in_miliseconds]['all'] += valid
 
-    top_locations = sorted(
-        [
-            dict(
-                loc_name=key,
-                percent=(value['in_month'] * 100) / float(value['all'] or 1)
-            ) for key, value in six.iteritems(best_worst)
-        ],
-        key=lambda x: x['percent'],
-        reverse=True
-    )
+    all_locations = [
+        {
+            'loc_name': key,
+            'percent': (value['in_month'] * 100) / float(value['all'] or 1),
+        } for key, value in six.iteritems(best_worst)
+    ]
+    all_locations_sorted_by_name = sorted(all_locations, key=lambda x: x['loc_name'])
+    all_locations_sorted_by_percent_and_name = sorted(
+        all_locations_sorted_by_name, key=lambda x: x['percent'], reverse=True)
 
     return {
         "chart_data": [
@@ -222,8 +221,8 @@ def get_adhaar_data_chart(domain, config, loc_level, show_test=False, beta=False
                 "color": ChartColors.BLUE
             }
         ],
-        "all_locations": top_locations,
-        "top_five": top_locations[:5],
-        "bottom_five": top_locations[-5:],
+        "all_locations": all_locations_sorted_by_percent_and_name,
+        "top_five": all_locations_sorted_by_percent_and_name[:5],
+        "bottom_five": all_locations_sorted_by_percent_and_name[-5:],
         "location_type": loc_level.title() if loc_level != LocationTypes.SUPERVISOR else 'Sector'
     }

--- a/custom/icds_reports/reports/adolescent_girls.py
+++ b/custom/icds_reports/reports/adolescent_girls.py
@@ -212,11 +212,16 @@ def get_adolescent_girls_data_chart(domain, config, loc_level, show_test=False):
         data['blue'][date_in_miliseconds]['y'] += valid
         data['blue'][date_in_miliseconds]['all'] += all_adolescent
 
-    top_locations = sorted(
-        [dict(loc_name=key, value=sum(value) / len(value)) for key, value in six.iteritems(best_worst)],
-        key=lambda x: x['value'],
-        reverse=True
-    )
+    all_locations = [
+        {
+            'loc_name': key,
+            'value': sum(value) / len(value),
+        }
+        for key, value in six.iteritems(best_worst)
+    ]
+    all_locations_sorted_by_name = sorted(all_locations, key=lambda x: x['loc_name'])
+    all_locations_sorted_by_value_and_name = sorted(
+        all_locations_sorted_by_name, key=lambda x: x['value'], reverse=True)
 
     return {
         "chart_data": [
@@ -234,8 +239,8 @@ def get_adolescent_girls_data_chart(domain, config, loc_level, show_test=False):
                 "color": ChartColors.BLUE
             }
         ],
-        "all_locations": top_locations,
-        "top_five": top_locations[:5],
-        "bottom_five": top_locations[-5:],
+        "all_locations": all_locations_sorted_by_value_and_name,
+        "top_five": all_locations_sorted_by_value_and_name[:5],
+        "bottom_five": all_locations_sorted_by_value_and_name[-5:],
         "location_type": loc_level.title() if loc_level != LocationTypes.SUPERVISOR else 'Sector'
     }

--- a/custom/icds_reports/reports/adult_weight_scale.py
+++ b/custom/icds_reports/reports/adult_weight_scale.py
@@ -125,16 +125,16 @@ def get_adult_weight_scale_data_chart(domain, config, loc_level, show_test=False
         data['blue'][date_in_miliseconds]['all'] += (valid or 0)
         data['blue'][date_in_miliseconds]['in_month'] += in_month
 
-    top_locations = sorted(
-        [
-            dict(
-                loc_name=key,
-                percent=(value['in_month'] * 100) / float(value['all'] or 1)
-            ) for key, value in six.iteritems(best_worst)
-        ],
-        key=lambda x: x['percent'],
-        reverse=True
-    )
+    all_locations = [
+        {
+            'loc_name': key,
+            'percent': (value['in_month'] * 100) / float(value['all'] or 1)
+        }
+        for key, value in six.iteritems(best_worst)
+    ]
+    all_locations_sorted_by_name = sorted(all_locations, key=lambda x: x['loc_name'])
+    all_locations_sorted_by_percent_and_name = sorted(
+        all_locations_sorted_by_name, key=lambda x: x['percent'], reverse=True)
 
     return {
         "chart_data": [
@@ -152,9 +152,9 @@ def get_adult_weight_scale_data_chart(domain, config, loc_level, show_test=False
                 "color": ChartColors.BLUE
             }
         ],
-        "all_locations": top_locations,
-        "top_five": top_locations[:5],
-        "bottom_five": top_locations[-5:],
+        "all_locations": all_locations_sorted_by_percent_and_name,
+        "top_five": all_locations_sorted_by_percent_and_name[:5],
+        "bottom_five": all_locations_sorted_by_percent_and_name[-5:],
         "location_type": loc_level.title() if loc_level != LocationTypes.SUPERVISOR else 'Sector'
     }
 

--- a/custom/icds_reports/tests/reports/test_adhaar.py
+++ b/custom/icds_reports/tests/reports/test_adhaar.py
@@ -199,18 +199,18 @@ class TestAdhaar(TestCase):
             {
                 "location_type": "State",
                 "bottom_five": [
+                    {'loc_name': 'st3', 'percent': 0.0},
                     {'loc_name': 'st4', 'percent': 0.0},
                     {'loc_name': 'st5', 'percent': 0.0},
                     {'loc_name': 'st6', 'percent': 0.0},
                     {'loc_name': 'st7', 'percent': 0.0},
-                    {'loc_name': 'st3', 'percent': 0.0}
                 ],
                 "top_five": [
                     {'loc_name': 'st1', 'percent': 24.774193548387096},
                     {'loc_name': 'st2', 'percent': 18.48739495798319},
+                    {'loc_name': 'st3', 'percent': 0.0},
                     {'loc_name': 'st4', 'percent': 0.0},
                     {'loc_name': 'st5', 'percent': 0.0},
-                    {'loc_name': 'st6', 'percent': 0.0}
                 ],
                 "chart_data": [
                     {
@@ -245,11 +245,11 @@ class TestAdhaar(TestCase):
                 "all_locations": [
                     {'loc_name': 'st1', 'percent': 24.774193548387096},
                     {'loc_name': 'st2', 'percent': 18.48739495798319},
+                    {'loc_name': 'st3', 'percent': 0.0},
                     {'loc_name': 'st4', 'percent': 0.0},
                     {'loc_name': 'st5', 'percent': 0.0},
                     {'loc_name': 'st6', 'percent': 0.0},
                     {'loc_name': 'st7', 'percent': 0.0},
-                    {'loc_name': 'st3', 'percent': 0.0}
                 ]
             }
         )

--- a/custom/icds_reports/tests/reports/test_adolescent_girls.py
+++ b/custom/icds_reports/tests/reports/test_adolescent_girls.py
@@ -131,18 +131,18 @@ class TestAdolescentGirls(TestCase):
             {
                 "location_type": "State",
                 "bottom_five": [
+                    {'loc_name': 'st3', 'value': 0.0},
                     {'loc_name': 'st4', 'value': 0.0},
                     {'loc_name': 'st5', 'value': 0.0},
                     {'loc_name': 'st6', 'value': 0.0},
                     {'loc_name': 'st7', 'value': 0.0},
-                    {'loc_name': 'st3', 'value': 0.0}
                 ],
                 "top_five": [
                     {'loc_name': 'st1', 'value': 17.0},
                     {'loc_name': 'st2', 'value': 17.0},
+                    {'loc_name': 'st3', 'value': 0.0},
                     {'loc_name': 'st4', 'value': 0.0},
                     {'loc_name': 'st5', 'value': 0.0},
-                    {'loc_name': 'st6', 'value': 0.0}
                 ],
                 "chart_data": [
                     {
@@ -161,11 +161,11 @@ class TestAdolescentGirls(TestCase):
                 "all_locations": [
                     {'loc_name': 'st1', 'value': 17.0},
                     {'loc_name': 'st2', 'value': 17.0},
+                    {'loc_name': 'st3', 'value': 0.0},
                     {'loc_name': 'st4', 'value': 0.0},
                     {'loc_name': 'st5', 'value': 0.0},
                     {'loc_name': 'st6', 'value': 0.0},
                     {'loc_name': 'st7', 'value': 0.0},
-                    {'loc_name': 'st3', 'value': 0.0}
                 ]
             }
         )

--- a/custom/icds_reports/tests/reports/test_adult_weight_scale.py
+++ b/custom/icds_reports/tests/reports/test_adult_weight_scale.py
@@ -232,26 +232,26 @@ class TestAdultWeightScale(TestCase):
                 "top_five": [
                     {'loc_name': 'st2', 'percent': 30.76923076923077},
                     {'loc_name': 'st1', 'percent': 29.41176470588235},
+                    {'loc_name': 'st3', 'percent': 0.0},
                     {'loc_name': 'st4', 'percent': 0.0},
                     {'loc_name': 'st5', 'percent': 0.0},
-                    {'loc_name': 'st6', 'percent': 0.0}
                 ],
                 "location_type": "State",
                 "all_locations": [
                     {'loc_name': 'st2', 'percent': 30.76923076923077},
                     {'loc_name': 'st1', 'percent': 29.41176470588235},
+                    {'loc_name': 'st3', 'percent': 0.0},
                     {'loc_name': 'st4', 'percent': 0.0},
                     {'loc_name': 'st5', 'percent': 0.0},
                     {'loc_name': 'st6', 'percent': 0.0},
                     {'loc_name': 'st7', 'percent': 0.0},
-                    {'loc_name': 'st3', 'percent': 0.0}
                 ],
                 "bottom_five": [
+                    {'loc_name': 'st3', 'percent': 0.0},
                     {'loc_name': 'st4', 'percent': 0.0},
                     {'loc_name': 'st5', 'percent': 0.0},
                     {'loc_name': 'st6', 'percent': 0.0},
                     {'loc_name': 'st7', 'percent': 0.0},
-                    {'loc_name': 'st3', 'percent': 0.0}
                 ]
             }
         )


### PR DESCRIPTION
🐡 

Required because ```six.iteritems(best_worst)``` of dict ```best_worst``` has a different iteration order in Python 2 vs Python 3.  Takes advantage of python sorting being a stable-sort.