### PR TITLE
Added cast of case_tags to list

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -899,7 +899,7 @@ class AdvancedFormValidator(IndexedFormBaseValidator):
         from corehq.apps.app_manager.models import AdvancedOpenCaseAction, LoadUpdateAction
 
         for action in self.form.actions.get_subcase_actions():
-            case_tags = self.form.actions.get_case_tags()
+            case_tags = list(self.form.actions.get_case_tags())
             for case_index in action.case_indices:
                 if case_index.tag not in case_tags:
                     errors.append({'type': 'missing parent tag', 'case_tag': case_index.tag})

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -898,8 +898,8 @@ class AdvancedFormValidator(IndexedFormBaseValidator):
 
         from corehq.apps.app_manager.models import AdvancedOpenCaseAction, LoadUpdateAction
 
+        case_tags = list(self.form.actions.get_case_tags())
         for action in self.form.actions.get_subcase_actions():
-            case_tags = list(self.form.actions.get_case_tags())
             for case_index in action.case_indices:
                 if case_index.tag not in case_tags:
                     errors.append({'type': 'missing parent tag', 'case_tag': case_index.tag})


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/REACH-112

Relevant: https://github.com/dimagi/commcare-hq/blob/d376be102c804b51cfe0695aef5db756e487b629/corehq/apps/app_manager/helpers/validators.py#L902-L905

Guessing this is a long-standing issue and there just aren't many apps that would trigger it: advanced modules, multiple open subcase actions, checking `case_tags` for the same tag twice.

Feature flag: advanced modules