### PR TITLE
Couch -> SQL forms & cases ignore rules

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -77,7 +77,7 @@ from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from pillowtop.reindexer.change_providers.couch import CouchDomainDocTypeChangeProvider
 
-log = logging.getLogger('main_couch_sql_datamigration')
+log = logging.getLogger(__name__)
 
 CASE_DOC_TYPES = ['CommCareCase', 'CommCareCase-Deleted', ]
 

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -3,27 +3,29 @@ from __future__ import unicode_literals
 
 from corehq.apps.tzmigration.timezonemigration import is_datetime_string, FormJsonDiff, json_diff, MISSING
 
+from .diffrule import Ignore
 
-PARTIAL_DIFFS = {
+
+IGNORE_RULES = {
     'XFormInstance*': [
-        {'path': ('_rev',)},  # couch only
-        {'path': ('migrating_blobs_from_couch',)},  # couch only
-        {'path': ('#export_tag',)},  # couch only
-        {'path': ('computed_',)},  # couch only
-        {'path': ('state',)},  # SQL only
-        {'path': ('computed_modified_on_',)},  # couch only
-        {'path': ('deprecated_form_id',), 'old_value': MISSING, 'new_value': None},  # SQL always has this
-        {'path': ('path',)},  # couch only
-        {'path': ('user_id',)},  # couch only
-        {'path': ('external_blobs',)},  # couch only
-        {'diff_type': 'type', 'path': ('openrosa_headers', 'HTTP_X_OPENROSA_VERSION')},
-        {'path': ('problem',), 'old_value': MISSING, 'new_value': None},
-        {'path': ('problem',), 'old_value': '', 'new_value': None},
-        {'path': ('orig_id',), 'old_value': MISSING, 'new_value': None},
-        {'path': ('edited_on',), 'old_value': MISSING, 'new_value': None},
-        {'path': ('repeats',), 'new_value': MISSING},  # report records save in form
-        {'path': ('form_migrated_from_undefined_xmlns',), 'new_value': MISSING},
-        {'diff_type': 'missing', 'old_value': None, 'new_value': MISSING},
+        Ignore(path='_rev'),  # couch only
+        Ignore(path='migrating_blobs_from_couch'),  # couch only
+        Ignore(path='#export_tag'),  # couch only
+        Ignore(path='computed_'),  # couch only
+        Ignore(path='state'),  # SQL only
+        Ignore(path='computed_modified_on_'),  # couch only
+        Ignore(path='deprecated_form_id', old=MISSING, new=None),  # SQL always has this
+        Ignore(path='path'),  # couch only
+        Ignore(path='user_id'),  # couch only
+        Ignore(path='external_blobs'),  # couch only
+        Ignore(type='type', path=('openrosa_headers', 'HTTP_X_OPENROSA_VERSION')),
+        Ignore(path='problem', old=MISSING, new=None),
+        Ignore(path='problem', old='', new=None),
+        Ignore(path='orig_id', old=MISSING, new=None),
+        Ignore(path='edited_on', old=MISSING, new=None),
+        Ignore(path='repeats', old=MISSING),  # report records save in form
+        Ignore(path='form_migrated_from_undefined_xmlns', new=MISSING),
+        Ignore(type='missing', old=None, new=MISSING),
     ],
     'XFormInstance': [],
     'XFormInstance-Deleted': [],
@@ -33,78 +35,70 @@ PARTIAL_DIFFS = {
     'XFormDuplicate': [],
     'XFormDeprecated': [],
     'CommCareCase*': [
-        {'path': ('_rev',)},  # couch only
-        {'path': ('initial_processing_complete',)},  # couch only
-        {'path': ('actions', '[*]')},  # ignore case actions
-        {'path': ('id',)},  # SQL only
-        {'path': ('@xmlns',)},  # legacy
-        {'path': ('_attachments',)},  # couch only
-        {'path': ('external_blobs',)},  # couch only
-        {'path': ('#export_tag',)},  # couch only
-        {'path': ('computed_',)},  # couch only
-        {'path': ('version',)},  # couch only
-        {'path': ('deleted',)},  # SQL only
-        {'path': ('export_tag',)},  # couch only
-        {'path': ('computed_modified_on_',)},  # couch only
-        {'path': ('case_id',)},  # legacy
-        {'path': ('@case_id',)},  # legacy
-        {'path': ('case_json',)},  # SQL only
-        {'path': ('modified_by',)},  # SQL only
+        Ignore(path='_rev'),  # couch only
+        Ignore(path='initial_processing_complete'),  # couch only
+        Ignore(path=('actions', '[*]')),  # ignore case actions
+        Ignore(path='id'),  # SQL only
+        Ignore(path='@xmlns'),  # legacy
+        Ignore(path='_attachments'),  # couch only
+        Ignore(path='external_blobs'),  # couch only
+        Ignore(path='#export_tag'),  # couch only
+        Ignore(path='computed_'),  # couch only
+        Ignore(path='version'),  # couch only
+        Ignore(path='deleted'),  # SQL only
+        Ignore(path='export_tag'),  # couch only
+        Ignore(path='computed_modified_on_'),  # couch only
+        Ignore(path='case_id'),  # legacy
+        Ignore(path='@case_id'),  # legacy
+        Ignore(path='case_json'),  # SQL only
+        Ignore(path='modified_by'),  # SQL only
         # legacy bug left cases with no owner_id
-        {'diff_type': 'diff', 'path': ('owner_id',), 'old_value': ''},
-        {'diff_type': 'type', 'path': ('owner_id',), 'old_value': None},
-        {'diff_type': 'type', 'path': ('user_id',), 'old_value': None},
-        {'diff_type': 'type', 'path': ('opened_on',), 'old_value': None},
-        {'diff_type': 'type', 'path': ('opened_by',), 'old_value': MISSING},
+        Ignore('diff', 'owner_id', old=''),
+        Ignore('type', 'owner_id', old=None),
+        Ignore('type', 'user_id', old=None),
+        Ignore('type', 'opened_on', old=None),
+        Ignore('type', 'opened_by', old=MISSING),
         # form has case block with no actions
-        {'diff_type': 'set_mismatch', 'path': ('xform_ids', '[*]'), 'old_value': ''},
-        {'diff_type': 'missing', 'path': ('case_attachments',), 'old_value': MISSING, 'new_value': {}},
-        {'diff_type': 'missing', 'old_value': None, 'new_value': MISSING},
+        Ignore('set_mismatch', ('xform_ids', '[*]'), old=''),
+        Ignore('missing', 'case_attachments', old=MISSING, new={}),
+        Ignore('missing', old=None, new=MISSING),
     ],
     'CommCareCase': [
         # couch case was deleted and then restored - SQL case won't have deletion properties
-        {'diff_type': 'missing', 'path': ('-deletion_id',), 'new_value': MISSING},
-        {'diff_type': 'missing', 'path': ('-deletion_date',), 'new_value': MISSING},
+        Ignore('missing', '-deletion_id', new=MISSING),
+        Ignore('missing', '-deletion_date', new=MISSING),
     ],
     'CommCareCase-Deleted': [
-        {'diff_type': 'missing', 'path': ('-deletion_id',), 'old_value': MISSING, 'new_value': None},
-        {
-            'diff_type': 'complex', 'path': ('-deletion_id', 'deletion_id'),
-            'old_value': MISSING, 'new_value': None
-        },
-        {'diff_type': 'missing', 'path': ('-deletion_date',), 'old_value': MISSING, 'new_value': None},
+        Ignore('missing', '-deletion_id', old=MISSING, new=None),
+        Ignore('complex', ('-deletion_id', 'deletion_id'), old=MISSING, new=None),
+        Ignore('missing', '-deletion_date', old=MISSING, new=None),
     ],
     'CommCareCaseIndex': [
         # SQL JSON has case_id field in indices which couch JSON doesn't
-        {'path': ('indices', '[*]', 'case_id')},
+        Ignore(path=('indices', '[*]', 'case_id')),
         # SQL indices don't have doc_type
-        {
-            'diff_type': 'missing', 'path': ('indices', '[*]', 'doc_type'),
-            'old_value': 'CommCareCaseIndex', 'new_value': MISSING
-        },
+        Ignore('missing', ('indices', '[*]', 'doc_type'), old='CommCareCaseIndex', new=MISSING),
         # defaulted on SQL
-        {
-            'diff_type': 'missing', 'path': ('indices', '[*]', 'relationship'),
-            'old_value': MISSING, 'new_value': 'child'
-        },
+        Ignore('missing', ('indices', '[*]', 'relationship'), old=MISSING, new='child'),
     ],
     'LedgerValue': [
-        {'path': ('_id',)},  # couch only
+        Ignore(path='_id'),  # couch only
     ],
     'case_attachment': [
-        {'path': ('doc_type',)},  # couch only
-        {'path': ('attachment_properties',)},  # couch only
-        {'path': ('attachment_from',)},  # couch only
-        {'path': ('attachment_src',)},  # couch only
-        {'path': ('content_type',)},  # couch only
-        {'path': ('server_mime',)},  # couch only
-        {'path': ('attachment_name',)},  # couch only
-        {'path': ('server_md5',)},  # couch only
+        Ignore(path='_id'),  # couch only
+        Ignore(path='attachment_properties'),  # couch only
+        Ignore(path='attachment_from'),  # couch only
+        Ignore(path='attachment_src'),  # couch only
+        Ignore(path='content_type'),  # couch only
+        Ignore(path='server_mime'),  # couch only
+        Ignore(path='attachment_name'),  # couch only
+        Ignore(path='server_md5'),  # couch only
     ]
 }
 
 
 FORM_IGNORED_DIFFS = (
+    Ignore('missing', ('history', '[*]', 'doc_type'), old='XFormOperation', new=MISSING),
     FormJsonDiff(
         diff_type='missing', path=('history', '[*]', 'doc_type'),
         old_value='XFormOperation', new_value=MISSING
@@ -149,8 +143,8 @@ RENAMED_FIELDS = {
 def filter_form_diffs(couch_form, sql_form, diffs):
     doc_type = couch_form['doc_type']
     filtered = _filter_exact_matches(diffs, FORM_IGNORED_DIFFS)
-    partial_diffs = PARTIAL_DIFFS[doc_type] + PARTIAL_DIFFS['XFormInstance*']
-    filtered = _filter_partial_matches(filtered, partial_diffs)
+    partial_diffs = IGNORE_RULES[doc_type] + IGNORE_RULES['XFormInstance*']
+    filtered = _filter_ignored(couch_form, sql_form, filtered, partial_diffs)
     filtered = _filter_text_xmlns(filtered)
     filtered = _filter_date_diffs(filtered)
     filtered = _filter_renamed_fields(filtered, couch_form, sql_form)
@@ -167,8 +161,8 @@ def _filter_text_xmlns(diffs):
 def filter_case_diffs(couch_case, sql_case, diffs, forms_that_touch_cases_without_actions=None):
     doc_type = couch_case['doc_type']
     filtered_diffs = _filter_exact_matches(diffs, CASE_IGNORED_DIFFS)
-    partial_filters = PARTIAL_DIFFS[doc_type] + PARTIAL_DIFFS['CommCareCase*'] + PARTIAL_DIFFS['CommCareCaseIndex']
-    filtered_diffs = _filter_partial_matches(filtered_diffs, partial_filters)
+    partial_filters = IGNORE_RULES[doc_type] + IGNORE_RULES['CommCareCase*'] + IGNORE_RULES['CommCareCaseIndex']
+    filtered_diffs = _filter_ignored(couch_case, sql_case, filtered_diffs, partial_filters)
     filtered_diffs = _filter_date_diffs(filtered_diffs)
     filtered_diffs = _filter_user_case_diffs(couch_case, sql_case, filtered_diffs)
     filtered_diffs = _filter_xform_id_diffs(couch_case, sql_case, filtered_diffs)
@@ -205,7 +199,7 @@ def _filter_forms_touch_case(diffs, forms_that_touch_cases_without_actions):
 
 
 def filter_ledger_diffs(diffs):
-    return _filter_partial_matches(diffs, PARTIAL_DIFFS['LedgerValue'])
+    return _filter_ignored(None, None, diffs, IGNORE_RULES['LedgerValue'])
 
 
 def _filter_exact_matches(diffs, diffs_to_ignore):
@@ -222,19 +216,14 @@ def _filter_exact_matches(diffs, diffs_to_ignore):
     return filtered
 
 
-def _filter_partial_matches(diffs, partial_diffs_to_exclude):
-    """Filter out diffs that match a subset of attributes
-    :type partial_diffs_to_exclude: dict([(attr, value)...])
-    """
-    def _partial_match(diff):
-        for partial in partial_diffs_to_exclude:
-            if all(getattr(diff, attr) == val for attr, val in partial.items()):
-                return True
-        return False
+def _filter_ignored(couch_obj, sql_obj, diffs, ignore_rules):
+    """Filter out diffs that match ignore rules
 
+    :type ignore_rules: [Ignore(...), ...]
+    """
     return [
         diff for diff in diffs
-        if not _partial_match(diff)
+        if not any(rule.matches(diff, couch_obj, sql_obj) for rule in ignore_rules)
     ]
 
 
@@ -339,7 +328,8 @@ def _filter_case_attachment_diffs(couch_case, sql_case, diffs):
                 ))
             else:
                 att_diffs = json_diff(couch_att, sql_att)
-                filtered = _filter_partial_matches(att_diffs, PARTIAL_DIFFS['case_attachment'])
+                filtered = _filter_ignored(
+                    couch_att, sql_att, att_diffs, IGNORE_RULES['case_attachment'])
                 filtered = _filter_renamed_fields(filtered, couch_att, sql_att, 'case_attachment')
                 for diff in filtered:
                     diff_dict = diff._asdict()
@@ -373,7 +363,12 @@ def _filter_case_index_diffs(couch_case, sql_case, diffs):
             diff_dict['path'] = tuple(['indices'] + list(diff.path))
             new_index_diffs.append(FormJsonDiff(**diff_dict))
 
-        new_index_diffs = _filter_partial_matches(new_index_diffs, PARTIAL_DIFFS['CommCareCaseIndex'])
+        new_index_diffs = _filter_ignored(
+            couch_case,
+            sql_case,
+            new_index_diffs,
+            IGNORE_RULES['CommCareCaseIndex'],
+        )
         remaining_diffs.extend(new_index_diffs)
         return remaining_diffs
     else:

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -40,6 +40,11 @@ def case_index_order(old_obj, new_obj, rule, diff):
     return _diff_case_index_order(old_obj, new_obj, diff)
 
 
+def is_supply_point(old_obj, new_obj, rule, diff):
+    from corehq.apps.commtrack.const import COMMTRACK_SUPPLY_POINT_XMLNS
+    return old_obj["xmlns"] == COMMTRACK_SUPPLY_POINT_XMLNS
+
+
 IGNORE_RULES = {
     'XFormInstance*': [
         Ignore(path='_rev'),  # couch only
@@ -69,6 +74,7 @@ IGNORE_RULES = {
         Ignore('type', 'xmlns', old=None, new=''),
         Ignore('type', 'initial_processing_complete', old=None, new=True),
         Ignore('missing', 'backend_id', old=MISSING, new='sql'),
+        Ignore('missing', 'location_id', new=MISSING, check=is_supply_point),
 
         Ignore('diff', check=has_date_values),
         Ignore(check=is_text_xmlns),

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -26,6 +26,16 @@ IGNORE_RULES = {
         Ignore(path='repeats', old=MISSING),  # report records save in form
         Ignore(path='form_migrated_from_undefined_xmlns', new=MISSING),
         Ignore(type='missing', old=None, new=MISSING),
+
+        # FORM_IGNORED_DIFFS
+        Ignore('missing', ('history', '[*]', 'doc_type'), old='XFormOperation', new=MISSING),
+        Ignore('diff', 'doc_type', old='HQSubmission', new='XFormInstance'),
+        Ignore('missing', 'deleted_on', old=MISSING, new=None),
+        Ignore('missing', 'location_', old=[], new=MISSING),
+        Ignore('missing', ('form', 'case', '#text'), old='', new=MISSING),
+        Ignore('type', 'xmlns', old=None, new=''),
+        Ignore('type', 'initial_processing_complete', old=None, new=True),
+        Ignore('missing', 'backend_id', old=MISSING, new='sql'),
     ],
     'XFormInstance': [],
     'XFormInstance-Deleted': [],
@@ -97,24 +107,6 @@ IGNORE_RULES = {
 }
 
 
-FORM_IGNORED_DIFFS = (
-    Ignore('missing', ('history', '[*]', 'doc_type'), old='XFormOperation', new=MISSING),
-    FormJsonDiff(
-        diff_type='missing', path=('history', '[*]', 'doc_type'),
-        old_value='XFormOperation', new_value=MISSING
-    ),
-    FormJsonDiff(
-        diff_type='diff', path=('doc_type',),
-        old_value='HQSubmission', new_value='XFormInstance'
-    ),
-    FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=MISSING, new_value=None),
-    FormJsonDiff(diff_type='missing', path=('location_',), old_value=[], new_value=MISSING),
-    FormJsonDiff(diff_type='missing', path=('form', 'case', '#text'), old_value='', new_value=MISSING),
-    FormJsonDiff(diff_type='type', path=('xmlns',), old_value=None, new_value=''),
-    FormJsonDiff(diff_type='type', path=('initial_processing_complete',), old_value=None, new_value=True),
-    FormJsonDiff(diff_type='missing', path=('backend_id',), old_value=MISSING, new_value='sql'),
-)
-
 CASE_IGNORED_DIFFS = (
     FormJsonDiff(diff_type='type', path=('name',), old_value='', new_value=None),
     FormJsonDiff(diff_type='type', path=('closed_by',), old_value='', new_value=None),
@@ -142,9 +134,8 @@ RENAMED_FIELDS = {
 
 def filter_form_diffs(couch_form, sql_form, diffs):
     doc_type = couch_form['doc_type']
-    filtered = _filter_exact_matches(diffs, FORM_IGNORED_DIFFS)
-    partial_diffs = IGNORE_RULES[doc_type] + IGNORE_RULES['XFormInstance*']
-    filtered = _filter_ignored(couch_form, sql_form, filtered, partial_diffs)
+    ignore_rules = IGNORE_RULES[doc_type] + IGNORE_RULES['XFormInstance*']
+    filtered = _filter_ignored(couch_form, sql_form, diffs, ignore_rules)
     filtered = _filter_text_xmlns(filtered)
     filtered = _filter_date_diffs(filtered)
     filtered = _filter_renamed_fields(filtered, couch_form, sql_form)

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from corehq.apps.tzmigration.timezonemigration import is_datetime_string, FormJsonDiff, json_diff
+
+from corehq.apps.tzmigration.timezonemigration import is_datetime_string, FormJsonDiff, json_diff, MISSING
+
 
 PARTIAL_DIFFS = {
     'XFormInstance*': [
@@ -10,18 +12,18 @@ PARTIAL_DIFFS = {
         {'path': ('computed_',)},  # couch only
         {'path': ('state',)},  # SQL only
         {'path': ('computed_modified_on_',)},  # couch only
-        {'path': ('deprecated_form_id',), 'old_value': Ellipsis, 'new_value': None},  # SQL always has this
+        {'path': ('deprecated_form_id',), 'old_value': MISSING, 'new_value': None},  # SQL always has this
         {'path': ('path',)},  # couch only
         {'path': ('user_id',)},  # couch only
         {'path': ('external_blobs',)},  # couch only
         {'diff_type': 'type', 'path': ('openrosa_headers', 'HTTP_X_OPENROSA_VERSION')},
-        {'path': ('problem',), 'old_value': Ellipsis, 'new_value': None},
+        {'path': ('problem',), 'old_value': MISSING, 'new_value': None},
         {'path': ('problem',), 'old_value': '', 'new_value': None},
-        {'path': ('orig_id',), 'old_value': Ellipsis, 'new_value': None},
-        {'path': ('edited_on',), 'old_value': Ellipsis, 'new_value': None},
-        {'path': ('repeats',), 'new_value': Ellipsis},  # report records save in form
-        {'path': ('form_migrated_from_undefined_xmlns',), 'new_value': Ellipsis},
-        {'diff_type': 'missing', 'old_value': None, 'new_value': Ellipsis},
+        {'path': ('orig_id',), 'old_value': MISSING, 'new_value': None},
+        {'path': ('edited_on',), 'old_value': MISSING, 'new_value': None},
+        {'path': ('repeats',), 'new_value': MISSING},  # report records save in form
+        {'path': ('form_migrated_from_undefined_xmlns',), 'new_value': MISSING},
+        {'diff_type': 'missing', 'old_value': None, 'new_value': MISSING},
     ],
     'XFormInstance': [],
     'XFormInstance-Deleted': [],
@@ -53,24 +55,24 @@ PARTIAL_DIFFS = {
         {'diff_type': 'type', 'path': ('owner_id',), 'old_value': None},
         {'diff_type': 'type', 'path': ('user_id',), 'old_value': None},
         {'diff_type': 'type', 'path': ('opened_on',), 'old_value': None},
-        {'diff_type': 'type', 'path': ('opened_by',), 'old_value': Ellipsis},
+        {'diff_type': 'type', 'path': ('opened_by',), 'old_value': MISSING},
         # form has case block with no actions
         {'diff_type': 'set_mismatch', 'path': ('xform_ids', '[*]'), 'old_value': ''},
-        {'diff_type': 'missing', 'path': ('case_attachments',), 'old_value': Ellipsis, 'new_value': {}},
-        {'diff_type': 'missing', 'old_value': None, 'new_value': Ellipsis},
+        {'diff_type': 'missing', 'path': ('case_attachments',), 'old_value': MISSING, 'new_value': {}},
+        {'diff_type': 'missing', 'old_value': None, 'new_value': MISSING},
     ],
     'CommCareCase': [
         # couch case was deleted and then restored - SQL case won't have deletion properties
-        {'diff_type': 'missing', 'path': ('-deletion_id',), 'new_value': Ellipsis},
-        {'diff_type': 'missing', 'path': ('-deletion_date',), 'new_value': Ellipsis},
+        {'diff_type': 'missing', 'path': ('-deletion_id',), 'new_value': MISSING},
+        {'diff_type': 'missing', 'path': ('-deletion_date',), 'new_value': MISSING},
     ],
     'CommCareCase-Deleted': [
-        {'diff_type': 'missing', 'path': ('-deletion_id',), 'old_value': Ellipsis, 'new_value': None},
+        {'diff_type': 'missing', 'path': ('-deletion_id',), 'old_value': MISSING, 'new_value': None},
         {
             'diff_type': 'complex', 'path': ('-deletion_id', 'deletion_id'),
-            'old_value': Ellipsis, 'new_value': None
+            'old_value': MISSING, 'new_value': None
         },
-        {'diff_type': 'missing', 'path': ('-deletion_date',), 'old_value': Ellipsis, 'new_value': None},
+        {'diff_type': 'missing', 'path': ('-deletion_date',), 'old_value': MISSING, 'new_value': None},
     ],
     'CommCareCaseIndex': [
         # SQL JSON has case_id field in indices which couch JSON doesn't
@@ -78,12 +80,12 @@ PARTIAL_DIFFS = {
         # SQL indices don't have doc_type
         {
             'diff_type': 'missing', 'path': ('indices', '[*]', 'doc_type'),
-            'old_value': 'CommCareCaseIndex', 'new_value': Ellipsis
+            'old_value': 'CommCareCaseIndex', 'new_value': MISSING
         },
         # defaulted on SQL
         {
             'diff_type': 'missing', 'path': ('indices', '[*]', 'relationship'),
-            'old_value': Ellipsis, 'new_value': 'child'
+            'old_value': MISSING, 'new_value': 'child'
         },
     ],
     'LedgerValue': [
@@ -105,33 +107,33 @@ PARTIAL_DIFFS = {
 FORM_IGNORED_DIFFS = (
     FormJsonDiff(
         diff_type='missing', path=('history', '[*]', 'doc_type'),
-        old_value='XFormOperation', new_value=Ellipsis
+        old_value='XFormOperation', new_value=MISSING
     ),
     FormJsonDiff(
         diff_type='diff', path=('doc_type',),
         old_value='HQSubmission', new_value='XFormInstance'
     ),
-    FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=Ellipsis, new_value=None),
-    FormJsonDiff(diff_type='missing', path=('location_',), old_value=[], new_value=Ellipsis),
-    FormJsonDiff(diff_type='missing', path=('form', 'case', '#text'), old_value='', new_value=Ellipsis),
+    FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=MISSING, new_value=None),
+    FormJsonDiff(diff_type='missing', path=('location_',), old_value=[], new_value=MISSING),
+    FormJsonDiff(diff_type='missing', path=('form', 'case', '#text'), old_value='', new_value=MISSING),
     FormJsonDiff(diff_type='type', path=('xmlns',), old_value=None, new_value=''),
     FormJsonDiff(diff_type='type', path=('initial_processing_complete',), old_value=None, new_value=True),
-    FormJsonDiff(diff_type='missing', path=('backend_id',), old_value=Ellipsis, new_value='sql'),
+    FormJsonDiff(diff_type='missing', path=('backend_id',), old_value=MISSING, new_value='sql'),
 )
 
 CASE_IGNORED_DIFFS = (
     FormJsonDiff(diff_type='type', path=('name',), old_value='', new_value=None),
     FormJsonDiff(diff_type='type', path=('closed_by',), old_value='', new_value=None),
-    FormJsonDiff(diff_type='missing', path=('location_id',), old_value=Ellipsis, new_value=None),
-    FormJsonDiff(diff_type='missing', path=('referrals',), old_value=[], new_value=Ellipsis),
-    FormJsonDiff(diff_type='missing', path=('location_',), old_value=[], new_value=Ellipsis),
+    FormJsonDiff(diff_type='missing', path=('location_id',), old_value=MISSING, new_value=None),
+    FormJsonDiff(diff_type='missing', path=('referrals',), old_value=[], new_value=MISSING),
+    FormJsonDiff(diff_type='missing', path=('location_',), old_value=[], new_value=MISSING),
     FormJsonDiff(diff_type='type', path=('type',), old_value=None, new_value=''),
     # this happens for cases where the creation form has been archived but the case still has other forms
     FormJsonDiff(diff_type='type', path=('owner_id',), old_value=None, new_value=''),
-    FormJsonDiff(diff_type='missing', path=('closed_by',), old_value=Ellipsis, new_value=None),
+    FormJsonDiff(diff_type='missing', path=('closed_by',), old_value=MISSING, new_value=None),
     FormJsonDiff(diff_type='type', path=('external_id',), old_value='', new_value=None),
-    FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=Ellipsis, new_value=None),
-    FormJsonDiff(diff_type='missing', path=('backend_id',), old_value=Ellipsis, new_value='sql'),
+    FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=MISSING, new_value=None),
+    FormJsonDiff(diff_type='missing', path=('backend_id',), old_value=MISSING, new_value='sql'),
 )
 
 RENAMED_FIELDS = {
@@ -158,7 +160,7 @@ def filter_form_diffs(couch_form, sql_form, diffs):
 def _filter_text_xmlns(diffs):
     return [
         diff for diff in diffs
-        if not (diff.path[-1] in ('#text', '@xmlns') and diff.old_value in ('', Ellipsis))
+        if not (diff.path[-1] in ('#text', '@xmlns') and diff.old_value in ('', MISSING))
     ]
 
 
@@ -253,11 +255,11 @@ def _check_renamed_fields(filtered_diffs, couch_doc, sql_doc, couch_field_name, 
         if diff.path[0] != sql_field_name and diff.path[0] != couch_field_name
     ]
     if len(remaining_diffs) != len(filtered_diffs):
-        sql_field = sql_doc.get(sql_field_name, Ellipsis)
-        couch_field = couch_doc.get(couch_field_name, Ellipsis)
+        sql_field = sql_doc.get(sql_field_name, MISSING)
+        couch_field = couch_doc.get(couch_field_name, MISSING)
         if sql_field != couch_field \
                 and not _both_dates(couch_field, sql_field) \
-                and not (couch_field == Ellipsis and sql_field == ''):
+                and not (couch_field is MISSING and sql_field == ''):
             remaining_diffs.append(FormJsonDiff(
                 diff_type='complex', path=(couch_field_name, sql_field_name),
                 old_value=couch_field, new_value=sql_field
@@ -287,7 +289,7 @@ def _filter_user_case_diffs(couch_case, sql_case, diffs):
         if diff.path[0] not in ('external_id', 'hq_user_id')
     ]
     hq_user_id_couch = couch_case['hq_user_id']
-    hq_user_id_sql = sql_case.get('external_id', Ellipsis)
+    hq_user_id_sql = sql_case.get('external_id', MISSING)
     if hq_user_id_sql != hq_user_id_couch:
         filtered_diffs.append(FormJsonDiff(
             diff_type='complex', path=('hq_user_id', 'external_id'),
@@ -329,8 +331,8 @@ def _filter_case_attachment_diffs(couch_case, sql_case, diffs):
         sql_attachments = sql_case.get('case_attachments', {})
 
         for name, couch_att in couch_attachments.items():
-            sql_att = sql_attachments.get(name, Ellipsis)
-            if sql_att == Ellipsis:
+            sql_att = sql_attachments.get(name, MISSING)
+            if sql_att is MISSING:
                 remaining_diffs.append(FormJsonDiff(
                     diff_type='missing', path=('case_attachments', name),
                     old_value=couch_att, new_value=sql_att

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -11,7 +11,6 @@ from corehq.apps.tzmigration.timezonemigration import is_datetime_string, FormJs
 from .diffrule import Ignore
 
 
-
 load_ignore_rules = memoized(lambda: {
     'XFormInstance*': [
         Ignore(path='_rev'),  # couch only

--- a/corehq/apps/couch_sql_migration/diffrule.py
+++ b/corehq/apps/couch_sql_migration/diffrule.py
@@ -16,6 +16,8 @@ class AnyType(object):
     def __repr__(self):
         return "ANY"
 
+    __hash__ = None
+
 
 ANY = AnyType()
 

--- a/corehq/apps/couch_sql_migration/diffrule.py
+++ b/corehq/apps/couch_sql_migration/diffrule.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import attr
+import six
+
+
+class AnyType(object):
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+    def __repr__(self):
+        return "ANY"
+
+
+ANY = AnyType()
+
+
+@attr.s
+class Ignore(object):
+    """Ignore rule
+
+    The `MISSING` constant referenced here is defined in
+    `corehq.apps.tzmigration.timezonemigration`.
+
+    :param type: Diff type to match (string or `ANY`).
+    :param path: Diff path to match (string, tuple, or `ANY`). A string
+    is shorthand for a single-element path. Stand-alone `ANY` matches
+    all paths. Each element in a tuple must be a string or `ANY`. `ANY`
+    within a tuple acts as wildcard matching a single element in the
+    same position.
+    :param old: Old value, `ANY` or `MISSING`.
+    :param new: New value, `ANY` or `MISSING`.
+    :param check: A predicate function accepting four arguments
+    `(old_obj, new_obj, ignore_rule, diff_object)` and returning a bool.
+    The default predicate returns true, which means diffs having all
+    other matching comparisons are ignored by default.
+    """
+
+    def _convert_path(value):
+        if isinstance(value, six.text_type):
+            return (value,)
+        if value is ANY:
+            return value
+        assert all(isinstance(v, six.text_type) or v is ANY for v in value), \
+            "invalid path: {}".format(value)
+        assert isinstance(value, tuple) or value is ANY, repr(value)
+        return value
+
+    type = attr.ib(default=ANY)
+    path = attr.ib(default=ANY, converter=_convert_path)
+    old = attr.ib(default=ANY)
+    new = attr.ib(default=ANY)
+    check = attr.ib(default=lambda old_obj, new_obj, rule, diff: True)
+
+    def matches(self, diff, old_obj, new_obj):
+        """Determine if the given diff can be ignored
+
+        Match any diff having a matching `diff_type`, `path`, `old_value`,
+        `new_value`, and for which this rule's check predicate returns true.
+
+        :param diff: `FormJsonDiff` object.
+        :param old_obj: Old object (JSON-encodable).
+        :param new_obj: New object (JSON-encodable).
+        :returns: True if the diff can be ignored otherwise false.
+        """
+        return (
+            self.type == diff.diff_type and
+            self.path == diff.path and
+            self.old == diff.old_value and
+            self.new == diff.new_value and
+            self.check(old_obj, new_obj, self, diff)
+        )

--- a/corehq/apps/couch_sql_migration/tests/test_diffrule.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffrule.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from testil import assert_raises
+
 from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, MISSING
 
 from ..diffrule import ANY, Ignore
@@ -94,3 +96,12 @@ def test_multi_element_path_rules():
 
     yield no_match, Ignore("diff", (ANY,), old=1, new=2)
     yield no_match, Ignore("diff", (ANY, ANY, ANY), old=1, new=2)
+
+
+def test_any_not_hashable():
+    def test(path):
+        with assert_raises(TypeError):
+            {}[path] = None
+
+    yield test, ANY
+    yield test, ("path", ANY)

--- a/corehq/apps/couch_sql_migration/tests/test_diffrule.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffrule.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, MISSING
+
+from ..diffrule import ANY, Ignore
+
+
+def test_rules():
+    diff = FormJsonDiff("diff", ("node",), "old", "new")
+    old_obj = {"node": "old", "flag": True}
+    new_obj = {"node": "new", "is_val": True}
+
+    def match(rule):
+        assert rule.matches(diff, old_obj, new_obj), (rule, diff)
+
+    def no_match(rule):
+        assert not rule.matches(diff, old_obj, new_obj), (rule, diff)
+
+    yield match, Ignore("diff", ("node",), old="old", new="new")
+    yield match, Ignore("diff", "node", old="old", new="new")
+    yield match, Ignore(ANY, "node", old="old", new="new")
+    yield match, Ignore("diff", ANY, old="old", new="new")
+    yield match, Ignore("diff", (ANY,), old="old", new="new")
+    yield match, Ignore("diff", "node", old=ANY, new="new")
+    yield match, Ignore("diff", "node", old="old", new=ANY)
+    yield match, Ignore("diff", "node", old="old")
+    yield match, Ignore("diff", "node")
+    yield match, Ignore("diff")
+    yield match, Ignore(type="diff")
+    yield match, Ignore(path="node")
+    yield match, Ignore(old="old")
+    yield match, Ignore(new="new")
+    yield match, Ignore()
+
+    yield no_match, Ignore(type="miss")
+    yield no_match, Ignore(path=("key",))
+    yield no_match, Ignore(path="key")
+    yield no_match, Ignore(old=1)
+    yield no_match, Ignore(new=2)
+    yield no_match, Ignore(old=MISSING)
+    yield no_match, Ignore(new=MISSING)
+
+    def is_flagged(old, new, rule, diff_):
+        assert old is old_obj, old
+        assert new is new_obj, new
+        assert rule is check_rule, rule
+        assert diff_ is diff, diff_
+        return old["flag"]
+
+    check_rule = Ignore("diff", "node", old="old", new="new", check=is_flagged)
+    yield match, check_rule
+
+    def nope(old_obj, new_obj, rule, diff):
+        return False
+
+    yield no_match, Ignore("diff", "node", old="old", new="new", check=nope)
+
+
+def test_missing_rules():
+    old_obj = {"flag": True}
+    new_obj = {"is_val": True}
+
+    def match(rule, diff):
+        assert rule.matches(diff, old_obj, new_obj), (rule, diff)
+
+    yield (
+        match,
+        Ignore("diff", "flag", old=True, new=MISSING),
+        FormJsonDiff("diff", ("flag",), True, MISSING),
+    )
+
+    yield (
+        match,
+        Ignore("diff", "is_val", old=MISSING, new=True),
+        FormJsonDiff("diff", ("is_val",), MISSING, True),
+    )
+
+
+def test_multi_element_path_rules():
+    diff = FormJsonDiff("diff", ("data", "num"), 1, 2)
+    old_obj = {"data": {"num": 1}}
+    new_obj = {"data": {"num": 2}}
+
+    def match(rule):
+        assert rule.matches(diff, old_obj, new_obj), (rule, diff)
+
+    def no_match(rule):
+        assert not rule.matches(diff, old_obj, new_obj), (rule, diff)
+
+    yield match, Ignore("diff", (ANY, "num"), old=1, new=2)
+    yield match, Ignore("diff", ("data", ANY), old=1, new=2)
+    yield match, Ignore("diff", ANY, old=1, new=2)
+
+    yield no_match, Ignore("diff", (ANY,), old=1, new=2)
+    yield no_match, Ignore("diff", (ANY, ANY, ANY), old=1, new=2)

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -39,7 +39,7 @@ REAL_DIFFS = [
 ]
 
 
-def _get_partial_diffs(doc_type):
+def _make_ignored_diffs(doc_type):
     diff_defaults = dict(diff_type='type', path=None, old_value=0, new_value=1)
     return [FormJsonDiff(**_diff_args(rule, diff_defaults)) for rule in IGNORE_RULES[doc_type]]
 
@@ -65,11 +65,11 @@ class DiffTestCases(SimpleTestCase):
         self.assertEqual(filtered, expected)
 
     def test_filter_form_diffs(self):
-        partial_diffs = _get_partial_diffs('XFormInstance')
+        ignored_diffs = _make_ignored_diffs('XFormInstance')
 
         self._test_form_diff_filter(
             {'doc_type': 'XFormInstance'}, {'doc_type': 'XFormInstance'},
-            list(FORM_IGNORED_DIFFS) + partial_diffs + DATE_DIFFS + REAL_DIFFS,
+            list(FORM_IGNORED_DIFFS) + ignored_diffs + DATE_DIFFS + REAL_DIFFS,
             REAL_DIFFS
         )
 
@@ -122,8 +122,8 @@ class DiffTestCases(SimpleTestCase):
 
     def test_filter_case_diffs(self):
         couch_case = {'doc_type': 'CommCareCase'}
-        partial_diffs = _get_partial_diffs('CommCareCase')
-        diffs = list(CASE_IGNORED_DIFFS) + partial_diffs + DATE_DIFFS + REAL_DIFFS
+        ignored_diffs = _make_ignored_diffs('CommCareCase')
+        diffs = list(CASE_IGNORED_DIFFS) + ignored_diffs + DATE_DIFFS + REAL_DIFFS
         filtered = filter_case_diffs(couch_case, {}, diffs)
         self.assertEqual(filtered, REAL_DIFFS)
 
@@ -225,8 +225,8 @@ class DiffTestCases(SimpleTestCase):
         ])
 
     def test_filter_ledger_diffs(self):
-        partial_diffs = _get_partial_diffs('LedgerValue')
-        filtered = filter_ledger_diffs(partial_diffs + REAL_DIFFS)
+        ignored_diffs = _make_ignored_diffs('LedgerValue')
+        filtered = filter_ledger_diffs(ignored_diffs + REAL_DIFFS)
         self.assertEqual(filtered, REAL_DIFFS)
 
     def test_filter_combo_fields(self):

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -33,6 +33,13 @@ DELETION_DIFFS = [
     FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=MISSING, new_value='123'),
 ]
 
+TEXT_XMLNS_DIFFS = [
+    FormJsonDiff(diff_type='missing', path=('path', 'to', '#text'), old_value='', new_value="text?"),
+    FormJsonDiff(diff_type='missing', path=('path', 'to', '@xmlns'), old_value='', new_value="xml"),
+    FormJsonDiff(diff_type='missing', path=('#text',), old_value=MISSING, new_value="text?"),
+    FormJsonDiff(diff_type='missing', path=('@xmlns',), old_value=MISSING, new_value="xml"),
+]
+
 REAL_DIFFS = [
     FormJsonDiff(diff_type='diff', path=('name',), old_value='Form1', new_value='Form2'),
     FormJsonDiff(diff_type='missing', path=('random_field',), old_value='legacy value', new_value=MISSING),
@@ -128,6 +135,13 @@ class DiffTestCases(SimpleTestCase):
             'deleted_on': '123',
         }
         self._test_form_diff_filter(couch_doc, sql_doc, DELETION_DIFFS + REAL_DIFFS)
+
+    def test_filter_text_xmlns_fields(self):
+        self._test_form_diff_filter(
+            {'doc_type': 'XFormInstance'},
+            {'doc_type': 'XFormInstance'},
+            TEXT_XMLNS_DIFFS + REAL_DIFFS,
+        )
 
     def test_filter_case_deletion_fields(self):
         couch_case = {

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase
 
 from corehq.apps.couch_sql_migration.diff import (
     filter_form_diffs, IGNORE_RULES,
-    filter_case_diffs, CASE_IGNORED_DIFFS, filter_ledger_diffs
+    filter_case_diffs, filter_ledger_diffs
 )
 from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, json_diff, MISSING
 from corehq.util.test_utils import softer_assert
@@ -128,8 +128,7 @@ class DiffTestCases(SimpleTestCase):
 
     def test_filter_case_diffs(self):
         couch_case = {'doc_type': 'CommCareCase'}
-        ignored_diffs = _make_ignored_diffs('CommCareCase')
-        diffs = list(CASE_IGNORED_DIFFS) + ignored_diffs + DATE_DIFFS + REAL_DIFFS
+        diffs = _make_ignored_diffs('CommCareCase') + DATE_DIFFS + REAL_DIFFS
         filtered = filter_case_diffs(couch_case, {}, diffs)
         self.assertEqual(filtered, REAL_DIFFS)
 

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -6,8 +6,10 @@ from attr import fields_dict
 from django.test import SimpleTestCase
 
 from corehq.apps.couch_sql_migration.diff import (
-    filter_form_diffs, IGNORE_RULES,
-    filter_case_diffs, filter_ledger_diffs
+    filter_case_diffs,
+    filter_form_diffs,
+    filter_ledger_diffs,
+    load_ignore_rules,
 )
 from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, json_diff, MISSING
 from corehq.util.test_utils import softer_assert
@@ -52,7 +54,7 @@ def _make_ignored_diffs(doc_type):
     diffs = [
         FormJsonDiff(**_diff_args(rule, diff_defaults))
         for type in [doc_type, doc_type + "*"]
-        for rule in IGNORE_RULES.get(type, [])
+        for rule in load_ignore_rules().get(type, [])
         if not _has_check(rule)
     ]
     assert diffs, "expected diffs for %s" % doc_type

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -379,3 +379,43 @@ class DiffTestCases(SimpleTestCase):
         diffs = json_diff(couch_case, sql_case, track_list_indices=False)
         filtered_diffs = filter_case_diffs(couch_case, sql_case, diffs)
         self.assertEqual(expected_diffs, filtered_diffs)
+
+    def test_case_attachments(self):
+        couch_case = {
+            'doc_type': 'CommCareCase',
+            'case_attachments': {
+                'xyz': {
+                    '_id': 'ignored',
+                    'attachment_properties': 'ignored',
+                    'attachment_from': 'ignored',
+                    'attachment_src': 'ignored',
+                    'content_type': 'ignored-couch',
+                    'server_mime': 'ignored',
+                    'attachment_name': 'ignored',
+                    'server_md5': 'ignored',
+                    'identifier': 'xyz',
+                    'attachment_size': 123,
+                    'properties': 'value',
+                    'unexpected': 'value',
+                },
+            },
+        }
+        sql_case = {
+            'doc_type': 'CommCareCase',
+            'case_attachments': {
+                'xyz': {
+                    'name': 'xyz',
+                    'content_length': 123,
+                    'content_type': 'ignored-sql',
+                    # for testing only, not an expected transformation
+                    'properties': 'eulav',
+                },
+            },
+        }
+
+        diffs = json_diff(couch_case, sql_case, track_list_indices=False)
+        filtered = filter_case_diffs(couch_case, sql_case, diffs)
+        self.assertEqual(filtered, [
+            FormJsonDiff('missing', ('case_attachments', 'xyz', 'unexpected'), 'value', MISSING),
+            FormJsonDiff('diff', ('case_attachments', 'xyz', 'properties'), 'value', 'eulav'),
+        ])

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -66,17 +66,16 @@ def _diff_args(ignore_rule, diff_defaults):
 @softer_assert()
 class DiffTestCases(SimpleTestCase):
 
-    def _test_form_diff_filter(self, couch_form, sql_form, diffs, expected):
+    def _test_form_diff_filter(self, couch_form, sql_form, diffs, expected=REAL_DIFFS):
         filtered = filter_form_diffs(couch_form, sql_form, diffs)
         self.assertEqual(filtered, expected)
 
     def test_filter_form_diffs(self):
         ignored_diffs = _make_ignored_diffs('XFormInstance')
-
         self._test_form_diff_filter(
-            {'doc_type': 'XFormInstance'}, {'doc_type': 'XFormInstance'},
+            {'doc_type': 'XFormInstance'},
+            {'doc_type': 'XFormInstance'},
             ignored_diffs + DATE_DIFFS + REAL_DIFFS,
-            REAL_DIFFS
         )
 
     def test_filter_form_rename_fields_good(self):
@@ -89,11 +88,8 @@ class DiffTestCases(SimpleTestCase):
             'edited_on': 'abc',
         }
         diffs = json_diff(couch_form, sql_form, track_list_indices=False)
-        self._test_form_diff_filter(
-            couch_form, sql_form,
-            diffs + REAL_DIFFS,
-            REAL_DIFFS
-        )
+        assert len(diffs) == 2, diffs
+        self._test_form_diff_filter(couch_form, sql_form, diffs + REAL_DIFFS)
 
     def test_filter_form_rename_fields_bad(self):
         couch_form = {

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from django.test import SimpleTestCase
 
 from corehq.apps.couch_sql_migration.diff import (
-    filter_form_diffs, FORM_IGNORED_DIFFS, IGNORE_RULES,
+    filter_form_diffs, IGNORE_RULES,
     filter_case_diffs, CASE_IGNORED_DIFFS, filter_ledger_diffs
 )
 from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, json_diff, MISSING
@@ -75,7 +75,7 @@ class DiffTestCases(SimpleTestCase):
 
         self._test_form_diff_filter(
             {'doc_type': 'XFormInstance'}, {'doc_type': 'XFormInstance'},
-            list(FORM_IGNORED_DIFFS) + ignored_diffs + DATE_DIFFS + REAL_DIFFS,
+            ignored_diffs + DATE_DIFFS + REAL_DIFFS,
             REAL_DIFFS
         )
 

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -319,7 +319,12 @@ class DiffTestCases(SimpleTestCase):
         sql_case['indices'][0]['relationship'] = 'extension'
 
         expected_diffs = [
-            FormJsonDiff(diff_type='diff', path=('indices', '[*]', 'relationship'), old_value='child', new_value='extension')
+            FormJsonDiff(
+                diff_type='diff',
+                path=('indices', '[*]', 'relationship'),
+                old_value='child',
+                new_value='extension',
+            )
         ]
         diffs = json_diff(couch_case, sql_case, track_list_indices=False)
         filtered_diffs = filter_case_diffs(couch_case, sql_case, diffs)

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from copy import deepcopy
 
+from attr import fields_dict
 from django.test import SimpleTestCase
 
 from corehq.apps.couch_sql_migration.diff import (
@@ -45,14 +46,14 @@ def _make_ignored_diffs(doc_type):
         FormJsonDiff(**_diff_args(rule, diff_defaults))
         for type in [doc_type, doc_type + "*"]
         for rule in IGNORE_RULES.get(type, [])
-        if not _is_check_any(rule)
+        if not _has_check(rule)
     ]
     assert diffs, "expected diffs for %s" % doc_type
     return diffs
 
 
-def _is_check_any(rule):
-    return all(getattr(rule, attr) is ANY for attr in ["type", "path", "old", "new"])
+def _has_check(rule):
+    return rule.check is not fields_dict(type(rule))["check"].default
 
 
 def _diff_args(ignore_rule, diff_defaults):

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -196,9 +196,9 @@ class DiffTestCases(SimpleTestCase):
             FormJsonDiff(diff_type='diff', path=('xform_ids', '[*]'), old_value='456', new_value='abc')
         ]
 
-        expected_diffs = REAL_DIFFS + [
+        expected_diffs = [
             FormJsonDiff(diff_type='set_mismatch', path=('xform_ids', '[*]'), old_value='456', new_value='abc')
-        ]
+        ] + REAL_DIFFS
         filtered = filter_case_diffs(couch_case, sql_case, diffs + REAL_DIFFS)
         self.assertEqual(filtered, expected_diffs)
 

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -8,8 +8,9 @@ from corehq.apps.couch_sql_migration.diff import (
     filter_form_diffs, FORM_IGNORED_DIFFS, PARTIAL_DIFFS,
     filter_case_diffs, CASE_IGNORED_DIFFS, filter_ledger_diffs
 )
-from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, json_diff
+from corehq.apps.tzmigration.timezonemigration import FormJsonDiff, json_diff, MISSING
 from corehq.util.test_utils import softer_assert
+
 
 DATE_DIFFS = [
     FormJsonDiff(
@@ -23,15 +24,15 @@ DATE_DIFFS = [
 ]
 
 DELETION_DIFFS = [
-    FormJsonDiff(diff_type='missing', path=('-deletion_id',), old_value='abc', new_value=Ellipsis),
-    FormJsonDiff(diff_type='missing', path=('deletion_id',), old_value=Ellipsis, new_value='abc'),
-    FormJsonDiff(diff_type='missing', path=('-deletion_date',), old_value='123', new_value=Ellipsis),
-    FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=Ellipsis, new_value='123'),
+    FormJsonDiff(diff_type='missing', path=('-deletion_id',), old_value='abc', new_value=MISSING),
+    FormJsonDiff(diff_type='missing', path=('deletion_id',), old_value=MISSING, new_value='abc'),
+    FormJsonDiff(diff_type='missing', path=('-deletion_date',), old_value='123', new_value=MISSING),
+    FormJsonDiff(diff_type='missing', path=('deleted_on',), old_value=MISSING, new_value='123'),
 ]
 
 REAL_DIFFS = [
     FormJsonDiff(diff_type='diff', path=('name',), old_value='Form1', new_value='Form2'),
-    FormJsonDiff(diff_type='missing', path=('random_field',), old_value='legacy value', new_value=Ellipsis),
+    FormJsonDiff(diff_type='missing', path=('random_field',), old_value='legacy value', new_value=MISSING),
     FormJsonDiff(diff_type='type', path=('timeStart',), old_value='2016-04-01T15:39:42Z', new_value='not a date'),
 ]
 
@@ -206,7 +207,7 @@ class DiffTestCases(SimpleTestCase):
         self.assertEqual(filtered, [
             FormJsonDiff(
                 diff_type='complex', path=('hq_user_id', 'external_id'),
-                old_value='123', new_value=Ellipsis
+                old_value='123', new_value=MISSING
             )
         ])
 

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -41,7 +41,13 @@ REAL_DIFFS = [
 
 def _make_ignored_diffs(doc_type):
     diff_defaults = dict(diff_type='type', path=None, old_value=0, new_value=1)
-    return [FormJsonDiff(**_diff_args(rule, diff_defaults)) for rule in IGNORE_RULES[doc_type]]
+    diffs = [
+        FormJsonDiff(**_diff_args(rule, diff_defaults))
+        for type in [doc_type, doc_type + "*"]
+        for rule in IGNORE_RULES.get(type, [])
+    ]
+    assert diffs, "expected diffs for %s" % doc_type
+    return diffs
 
 
 def _diff_args(ignore_rule, diff_defaults):

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -419,3 +419,21 @@ class DiffTestCases(SimpleTestCase):
             FormJsonDiff('missing', ('case_attachments', 'xyz', 'unexpected'), 'value', MISSING),
             FormJsonDiff('diff', ('case_attachments', 'xyz', 'properties'), 'value', 'eulav'),
         ])
+
+    def test_form_with_obsolete_location_id(self):
+        couch_doc = {
+            "doc_type": "XFormInstance",
+            "location_id": "deadbeef",
+            "xmlns": "http://commtrack.org/supply_point",
+        }
+        sql_doc = {
+            "doc_type": "XFormInstance",
+            "xmlns": "http://commtrack.org/supply_point",
+        }
+        diffs = [
+            FormJsonDiff(
+                diff_type='missing', path=('location_id',),
+                old_value='deadbeef', new_value=MISSING
+            )
+        ]
+        self._test_form_diff_filter(couch_doc, sql_doc, REAL_DIFFS + diffs)

--- a/corehq/apps/tzmigration/timezonemigration.py
+++ b/corehq/apps/tzmigration/timezonemigration.py
@@ -45,34 +45,34 @@ def _json_diff(obj1, obj2, path, track_list_indices=True):
 
     if obj1 == obj2:
         return
-    elif Ellipsis in (obj1, obj2):
+    elif MISSING in (obj1, obj2):
         yield FormJsonDiff('missing', path, obj1, obj2)
     elif type(obj1) != type(obj2):
         yield FormJsonDiff('type', path, obj1, obj2)
     elif isinstance(obj1, dict):
         keys = set(obj1.keys()) | set(obj2.keys())
 
-        def value_or_ellipsis(obj, key):
-            return obj.get(key, Ellipsis)
+        def value_or_missing(obj, key):
+            return obj.get(key, MISSING)
 
         for key in keys:
-            for result in _json_diff(value_or_ellipsis(obj1, key),
-                                     value_or_ellipsis(obj2, key),
+            for result in _json_diff(value_or_missing(obj1, key),
+                                     value_or_missing(obj2, key),
                                      path=path + (key,),
                                      track_list_indices=track_list_indices):
                 yield result
     elif isinstance(obj1, list):
 
-        def value_or_ellipsis(obj, i):
+        def value_or_missing(obj, i):
             try:
                 return obj[i]
             except IndexError:
-                return Ellipsis
+                return MISSING
 
         for i in range(max(len(obj1), len(obj2))):
             list_index = i if track_list_indices else '[*]'
-            for result in _json_diff(value_or_ellipsis(obj1, i),
-                                     value_or_ellipsis(obj2, i),
+            for result in _json_diff(value_or_missing(obj1, i),
+                                     value_or_missing(obj2, i),
                                      path=path + (list_index,),
                                      track_list_indices=track_list_indices):
                 yield result
@@ -209,3 +209,12 @@ def is_datetime_string(string):
         return False
     else:
         return True
+
+
+class MissingType(object):
+
+    def __repr__(self):
+        return "MISSING"
+
+
+MISSING = MissingType()


### PR DESCRIPTION
Mostly refactoring the diff ignoring system in the Couch to SQL migration app to make the ignore rules more readable and easier to add bits of custom ignore logic without duplication. All ignore rule conversions done in this PR are tested, and new tests have been added for rules that did not previously have them.

There is one commit with a new ignore rule: e3c9bbfff3c16ea2e4395e3a2c7a4f09a0ce1109

Review by commit 🐠 