### PR TITLE
Upgrade to Pillow 6.0

### DIFF
--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -136,7 +136,7 @@ pdfrw==0.4
 pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
-pillow==5.4.1
+pillow==6.0.0
 pip-tools==3.6.0
 ply==3.11
 polib==1.1.0

--- a/requirements-python3_6/docs-requirements.txt
+++ b/requirements-python3_6/docs-requirements.txt
@@ -107,7 +107,7 @@ packaging==19.0           # via sphinx
 pbr==5.1.3
 pdfrw==0.4
 phonenumberslite==8.10.10
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11
 polib==1.1.0
 psycogreen==1.0.1

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -113,7 +113,7 @@ pdfrw==0.4
 pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11
 polib==1.1.0
 prompt-toolkit==1.0.16    # via ipython

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -101,7 +101,7 @@ openpyxl==2.6.2
 pbr==5.1.3                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.10
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -111,7 +111,7 @@ openpyxl==2.6.2
 pbr==5.1.3
 pdfrw==0.4
 phonenumberslite==8.10.10
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11
 polib==1.1.0
 psycogreen==1.0.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -137,7 +137,7 @@ pdfrw==0.4
 pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
-pillow==5.4.1
+pillow==6.0.0
 pip-tools==3.6.0
 ply==3.11
 polib==1.1.0

--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -108,7 +108,7 @@ packaging==19.0           # via sphinx
 pbr==5.1.3
 pdfrw==0.4
 phonenumberslite==8.10.10
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11
 polib==1.1.0
 psycogreen==1.0.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -114,7 +114,7 @@ pdfrw==0.4
 pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11
 polib==1.1.0
 prompt-toolkit==1.0.16    # via ipython

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -25,7 +25,7 @@ kafka-python==1.4.4
 kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 mock==2.0.0
-Pillow~=5.2
+Pillow~=6.0
 phonenumberslite~=8.8
 psycopg2~=2.7.7
 psycogreen~=1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -102,7 +102,7 @@ openpyxl==2.6.2
 pbr==5.1.3                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.10
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -112,7 +112,7 @@ openpyxl==2.6.2
 pbr==5.1.3
 pdfrw==0.4
 phonenumberslite==8.10.10
-pillow==5.4.1
+pillow==6.0.0
 ply==3.11
 polib==1.1.0
 psycogreen==1.0.1


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/releasenotes/6.0.0.html#id1

Backwards incompatible changes
- Python 3.4 dropped
- Removed deprecated PIL.OleFileIO
- Removed deprecated ImageOps functions (we only use `fit` which is not
  deprecated)
- Removed deprecated VERSION