### PR TITLE
Added indicator when a linked app setting isn't yet set

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5524,6 +5524,8 @@ class LinkedApplication(Application):
     linked_app_logo_refs = DictProperty()  # corresponding property: logo_refs
     linked_app_attrs = DictProperty()  # corresponds to app attributes
 
+    SUPPORTED_SETTINGS = ['target_commcare_flavor']
+
     # if `uses_master_app_form_ids` is True, the form id might match the master's form id
     # from a bug years ago. These should be fixed when mobile can handle the change
     # https://manage.dimagi.com/default.asp?283410

--- a/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/commcare_settings.js
@@ -172,6 +172,12 @@ hqDefine('app_manager/js/settings/commcare_settings', function () {
 
                 }
             });
+            setting.inheritanceMessage = ko.computed(function () {
+                if (setting.is_inherited) {
+                    return gettext("This value is inherited from the master app.");
+                }
+                return '';
+            });
             setting.computeDefault = ko.computed(function () {
                 var i, condition, _case;
                 for (i = 0; i < setting.contingent_default.length; i += 1) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/commcare_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/commcare_settings.html
@@ -57,7 +57,7 @@
               </span>
             </p>
           </div>
-          <div class="col-sm-2 control-label">
+          <div class="col-sm-4 control-label">
             <div class="pull-left">
               <span class="label label-danger" data-bind="text: $data.warning || $parents[1].warning, visible: !$data.valueIsLegal()"></span>
               <span class="label label-info" data-bind="visible: $data.preview">{% trans "Preview" %}</span>
@@ -65,6 +65,7 @@
                 <i class="fa" data-bind="css: {'fa-arrow-left': !optionOK(), 'fa-check': optionOK}"></i>
                 <span data-bind="text: disabledMessage()"></span>
               </span>
+              <span class="help-block" data-bind="text: inheritanceMessage"></span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
@emord does this seem reasonable to you?

<img width="785" alt="Screen Shot 2019-04-23 at 3 07 11 PM" src="https://user-images.githubusercontent.com/1486591/56612503-26d0ba00-65da-11e9-9f30-9cdb2bfa40be.png">

Feature flag: linked project spaces