### PR TITLE
Fix formbuilder form title

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -54,7 +54,7 @@ hqDefine("app_manager/js/forms/form_designer", function () {
                 $('#formdesigner').removeClass('loading');
                 $('#formdesigner .fd-content-left .fd-head-text').before(
                     $('#fd-hq-edit-formname-button').html()
-                );
+                ).text(initialPageData('form_name'));
             },
         });
         VELLUM_OPTIONS.core = _.extend(VELLUM_OPTIONS.core, {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_designer.js
@@ -52,8 +52,12 @@ hqDefine("app_manager/js/forms/form_designer", function () {
             },
             formLoadedCallback: function () {
                 $('#formdesigner').removeClass('loading');
+                // This code takes control of the top-left box with the form name.
                 $('#formdesigner .fd-content-left .fd-head-text').before(
+                    // We add an edit button that opens a modal:
                     $('#fd-hq-edit-formname-button').html()
+                // and we replace the form name Vellum put there
+                // with one that's translated to the app builder's currently selected language:
                 ).text(initialPageData('form_name'));
             },
         });

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -50,7 +50,7 @@
 {% block form-view %}
     {% initial_page_data 'CKEDITOR_BASEPATH' CKEDITOR_BASEPATH|static %}
     {% initial_page_data 'days_since_created' request.couch_user.days_since_created %}
-    {% initial_page_data 'form_name' form.name|trans:app.langs %}
+    {% initial_page_data 'form_name' form.name|trans:langs %}
     {% initial_page_data 'form_comment' form.comment %}
     {% initial_page_data 'form_uses_cases' form.uses_cases %}
     {% initial_page_data 'is_registration_form' form.is_registration_form %}

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -256,7 +256,7 @@ def _get_vellum_core_context(request, domain, app, module, form, lang):
                                                'form_unique_id': form.get_unique_id()}),
         'form': form.source,
         'formId': form.get_unique_id(),
-        'formName': translate(form.name, lang, app.langs),
+        'formName': translate(form.name, app.langs[0], app.langs),
         'saveType': 'patch',
         'saveUrl': reverse('edit_form_attr',
                            args=[domain, app.id, form.get_unique_id(),

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -28,7 +28,8 @@ from corehq.apps.app_manager.views.notifications import get_facility_for_form, n
 from corehq.apps.app_manager.exceptions import AppManagerException, \
     FormNotFoundException
 
-from corehq.apps.app_manager.views.utils import back_to_main, bail, form_has_submissions
+from corehq.apps.app_manager.views.utils import back_to_main, bail, form_has_submissions, \
+    set_lang_cookie
 from corehq import toggles, privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.const import (
@@ -161,7 +162,9 @@ def _get_form_designer_view(request, domain, app, module, form):
 
     notify_form_opened(domain, request.couch_user, app.id, form.unique_id)
 
-    return render(request, "app_manager/form_designer.html", context)
+    response = render(request, "app_manager/form_designer.html", context)
+    set_lang_cookie(response, context['lang'])
+    return response
 
 
 @require_GET

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -115,6 +115,10 @@ def get_langs(request, app):
     return lang, langs
 
 
+def set_lang_cookie(response, lang):
+    response.set_cookie('lang', encode_if_unicode(lang))
+
+
 def bail(request, domain, app_id, not_found=""):
     if not_found:
         messages.error(request, 'Oops! We could not find that %s. Please try again' % not_found)

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -17,7 +17,7 @@ from corehq.apps.app_manager.views.apps import get_apps_base_context, \
 from corehq.apps.app_manager.views.forms import \
     get_form_view_context_and_template
 from corehq.apps.app_manager.views.releases import get_releases_context
-from corehq.apps.app_manager.views.utils import bail, encode_if_unicode, set_lang_cookie
+from corehq.apps.app_manager.views.utils import bail, set_lang_cookie
 from corehq.apps.hqmedia.controller import (
     MultimediaImageUploadController,
     MultimediaAudioUploadController,

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -17,7 +17,7 @@ from corehq.apps.app_manager.views.apps import get_apps_base_context, \
 from corehq.apps.app_manager.views.forms import \
     get_form_view_context_and_template
 from corehq.apps.app_manager.views.releases import get_releases_context
-from corehq.apps.app_manager.views.utils import bail, encode_if_unicode
+from corehq.apps.app_manager.views.utils import bail, encode_if_unicode, set_lang_cookie
 from corehq.apps.hqmedia.controller import (
     MultimediaImageUploadController,
     MultimediaAudioUploadController,
@@ -323,5 +323,5 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
 
     response = render(request, template, context)
 
-    response.set_cookie('lang', encode_if_unicode(lang))
+    set_lang_cookie(response, lang)
     return response


### PR DESCRIPTION
Fixes https://dimagi-dev.atlassian.net/browse/HI-539.

Turned out to be a number of independent issues together causing a very inconsistent and unpredictable experience on the form builder page that included
- the app builder language drop down
- the app builder side bar
- the form name in the top left
- the form name as it appeared in the edit form name modal
  - the behavior of submitting an edit to the form name
- less important, the form name as it appeared in the browser tab title
- the form name/`<title>` as it appeared in XML

I've chosen a set of consistent behaviors that were straightforward to implement and hopefully as intuitive as you can be in the face of two independent ways to select the display language (app builder language drop down and form builder display language selection). I'm obviously not the person to make this call, but to me this is an acceptable final state, in the absence of an overhaul.

The new state:
- app builder language dropdown is sticky—if you change it on the form builder page and then click away, the chosen language sticks. (This is the obviously-correct behavior that we see on other pages in the app builder, but there was a bug here.)
- sidebar form name still matches app builder language selection
- top-left form name still matches app builder language selection
- the form name in the edit form name modal now matches the app builder language selection
- submitting the edit form modal consistently makes the edit to the correct language (as given by the app builder language selection)
- the form XML now does _not_ change based on the selected language; it now always uses the default language.
- as before, the form builder language selection doesn't factor in to any of the above

Here's an "after" screenshot:
<img width="1039" alt="Screen Shot 2019-04-24 at 12 25 21 PM" src="https://user-images.githubusercontent.com/137212/56680116-36a8d680-668c-11e9-9fdc-50a52e2258d2.png">
