### PR TITLE
Fix skipTest usage

### DIFF
--- a/corehq/apps/userreports/tests/test_data_source_citus.py
+++ b/corehq/apps/userreports/tests/test_data_source_citus.py
@@ -39,11 +39,12 @@ class DataSourceConfigurationCitusDBTest(TestCase):
         cls.data_source.save()
         cls.adapter.build_table()
 
-    def tearDown(self):
-        self.adapter.session_helper.Session.remove()
-        self.adapter.drop_table()
-        self.data_source.delete()
-        super(DataSourceConfigurationCitusDBTest, self).tearDown()
+    @classmethod
+    def tearDownClass(cls):
+        cls.adapter.session_helper.Session.remove()
+        cls.adapter.drop_table()
+        cls.data_source.delete()
+        super(DataSourceConfigurationCitusDBTest, cls).tearDownClass()
 
     def _process_docs(self, docs):
         pillow = get_case_pillow(ucr_configs=[self.data_source])

--- a/corehq/apps/userreports/tests/test_data_source_citus.py
+++ b/corehq/apps/userreports/tests/test_data_source_citus.py
@@ -20,7 +20,6 @@ class DataSourceConfigurationCitusDBTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(DataSourceConfigurationCitusDBTest, cls).setUpClass()
         cls.data_source = get_sample_data_source()
         cls.data_source.engine_id = 'icds-ucr'
         for indicator in cls.data_source.configured_indicators:
@@ -31,10 +30,13 @@ class DataSourceConfigurationCitusDBTest(TestCase):
             distribution_column="owner"
         )
         cls.data_source.sql_settings.primary_key = ['owner', 'doc_id']
-        cls.data_source.save()
         cls.adapter = get_indicator_adapter(cls.data_source)
         if not cls.adapter.session_helper.is_citus_db:
             raise SkipTest("Test only applicable when using CitusDB: {}".format(cls.adapter.session_helper.engine))
+
+        # SkipTest must come before this setup so that the database is only setup if the test is not skipped
+        super(DataSourceConfigurationCitusDBTest, cls).setUpClass()
+        cls.data_source.save()
         cls.adapter.build_table()
 
     def tearDown(self):


### PR DESCRIPTION
If we want to skip a test it needs to be done before setUpClass is called because skipping the test in a setup does not call the teardown method. This means that if citus is not setup, then every test run after this will fail because the connection to the database was not properly torn down