### PR TITLE
Increase the number of send attempts

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -560,7 +560,7 @@ class RepeatRecord(Document):
     payload_id = StringProperty()
 
     overall_tries = IntegerProperty(default=0)
-    max_possible_tries = IntegerProperty(default=3)
+    max_possible_tries = IntegerProperty(default=5)
 
     attempts = ListProperty(RepeatRecordAttempt)
 
@@ -665,11 +665,12 @@ class RepeatRecord(Document):
         window = timedelta(minutes=0)
         if self.last_checked:
             window = now - self.last_checked
-            window += (window // 2)  # window *= 1.5
+            window *= 3
         if window < MIN_RETRY_WAIT:
             window = MIN_RETRY_WAIT
         elif window > MAX_RETRY_WAIT:
             window = MAX_RETRY_WAIT
+        # Retries will typically be after 1h, 3h, 9h, 27h, 81h -- 5d 3h total
 
         return RepeatRecordAttempt(
             cancelled=False,

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -293,12 +293,10 @@ class RepeaterTest(BaseRepeaterTest):
     @run_with_all_backends
     def test_automatic_cancel_repeat_record(self):
         repeat_record = self.case_repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
-        repeat_record.overall_tries = 1
+        self.assertEqual(1, repeat_record.overall_tries)
         with patch('corehq.motech.repeaters.models.simple_post', side_effect=Exception('Boom!')):
-            repeat_record.fire()
-        self.assertEqual(2, repeat_record.overall_tries)
-        with patch('corehq.motech.repeaters.models.simple_post', side_effect=Exception('Boom!')):
-            repeat_record.fire()
+            for __ in range(repeat_record.max_possible_tries - repeat_record.overall_tries):
+                repeat_record.fire()
         self.assertEqual(True, repeat_record.cancelled)
         repeat_record.requeue()
         self.assertEqual(0, repeat_record.overall_tries)


### PR DESCRIPTION
Currently, if a remote service is offline for more than about 5 hours, the payloads of forms submitted during that time could be cancelled, and not resent when the service is back online.

This change increases the number of send attempts from 3 to 5, and increases the interval between attempts, so that the last send attempt is 5 days after the first attempt, instead of 4 hours and 45 minutes after the first attempt.

This should reduce the need for human intervention when sending payloads to services with intermittent/unreliable connectivity.
