### PR TITLE
Updated width of bulk app translations language dropdown

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/bulk_upload_app_translations.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bulk_upload_app_translations.html
@@ -8,7 +8,7 @@
             <p>
                 {% trans "Select a language." %}
             </p>
-            <p class="form-inline">
+            <p>
                 <select class="form-control hqwebapp-select2" data-bind="value: lang">
                     <option value="">{% trans "All" %}</option>
                     {% for lang in langs %}


### PR DESCRIPTION
Small UX request from Ben: make this dropdown less cramped.

before
<img width="437" alt="Screen Shot 2019-04-25 at 11 17 22 AM" src="https://user-images.githubusercontent.com/1486591/56747645-5b648300-674c-11e9-8002-c59687e1517a.png">

after
<img width="404" alt="Screen Shot 2019-04-25 at 11 16 58 AM" src="https://user-images.githubusercontent.com/1486591/56747658-60c1cd80-674c-11e9-8cc4-65d599177a37.png">

feature flag: [bulk multimedia path management](https://www.commcarehq.org/hq/flags/edit/bulk_update_multimedia_paths/)