### PR TITLE
Formplayer inactivity timeout

### DIFF
--- a/corehq/apps/hqadmin/utils.py
+++ b/corehq/apps/hqadmin/utils.py
@@ -120,8 +120,7 @@ def parse_celery_workers(celery_workers):
     return expect_running, expect_stopped
 
 
-def get_django_user_from_session_key(session_key):
-    session = _get_session(session_key)
+def get_django_user_from_session(session):
     if not session:
         return None
 
@@ -137,7 +136,7 @@ def get_django_user_from_session_key(session_key):
             return None
 
 
-def _get_session(session_key):
+def get_session(session_key):
     engine = import_module(settings.SESSION_ENGINE)
     session = engine.SessionStore(session_key)
     try:

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -56,6 +56,7 @@ class SessionDetailsView(View):
         secure_session = session.get('secure_session')
         timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
         session.set_expiry(timeout * 60)
+        session.save()
 
         return JsonResponse({
             'username': user.username,

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -1,13 +1,15 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import json
-from django.http import HttpResponseBadRequest, Http404, JsonResponse
+
+from django.conf import settings
+from django.http import Http404, HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from corehq.apps.domain.auth import formplayer_auth
-from corehq.apps.hqadmin.utils import get_django_user_from_session_key
+from corehq.apps.hqadmin.utils import get_django_user_from_session, get_session
 from corehq.apps.users.models import CouchUser
 
 
@@ -41,13 +43,19 @@ class SessionDetailsView(View):
         if not session_id:
             return HttpResponseBadRequest()
 
-        user = get_django_user_from_session_key(session_id)
+        session = get_session(session_id)
+        user = get_django_user_from_session(session)
         if user:
             couch_user = CouchUser.get_by_username(user.username)
             if not couch_user:
                 raise Http404
         else:
             raise Http404
+
+        # reset the session's expiry if there's some formplayer activity
+        secure_session = session.get('secure_session')
+        timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
+        session.set_expiry(timeout * 60)
 
         return JsonResponse({
             'username': user.username,

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -142,10 +142,12 @@ class TimeoutMiddleware(MiddlewareMixin):
                 django_logout(request, template_name=settings.BASE_TEMPLATE)
                 # this must be after logout so it is attached to the new session
                 request.session['secure_session'] = True
+                request.session.set_expiry(settings.SECURE_TIMEOUT * 60)
                 return HttpResponseRedirect(reverse('login') + '?next=' + request.path)
             else:
                 request.session['secure_session'] = True
                 request.session['last_request'] = json_format_datetime(now)
+                request.session.set_expiry(settings.SECURE_TIMEOUT * 60)
                 return
         else:
             last_request = request.session.get('last_request')
@@ -154,6 +156,7 @@ class TimeoutMiddleware(MiddlewareMixin):
                 django_logout(request, template_name=settings.BASE_TEMPLATE)
                 return HttpResponseRedirect(reverse('login') + '?next=' + request.path)
             request.session['last_request'] = json_format_datetime(now)
+            request.session.set_expiry(timeout * 60)
 
 
 def always_allow_browser_caching(fn):

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -117,10 +117,9 @@ class TimeoutMiddleware(MiddlewareMixin):
     def _session_expired(timeout, activity, time):
         if activity is None:
             return False
-        if time - string_to_utc_datetime(activity) > datetime.timedelta(minutes=timeout):
-            return True
-        else:
-            return False
+
+        time_since_activity = time - string_to_utc_datetime(activity)
+        return time_since_activity > datetime.timedelta(minutes=timeout)
 
     @staticmethod
     def _user_requires_secure_session(couch_user):
@@ -132,31 +131,30 @@ class TimeoutMiddleware(MiddlewareMixin):
             return
 
         secure_session = request.session.get('secure_session')
+        timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
         domain = getattr(request, "domain", None)
         now = datetime.datetime.utcnow()
 
-        if not secure_session and (
-                (domain and Domain.is_secure_session_required(domain)) or
-                self._user_requires_secure_session(request.couch_user)):
-            if self._session_expired(settings.SECURE_TIMEOUT, request.user.last_login, now):
+        # figure out if we want to switch to secure_sessions
+        change_to_secure_session = (
+            not secure_session
+            and (
+                (domain and Domain.is_secure_session_required(domain))
+                or self._user_requires_secure_session(request.couch_user)))
+
+        if change_to_secure_session:
+            timeout = settings.SECURE_TIMEOUT
+            # force re-authentication if the user has been logged in longer than the secure timeout
+            if self._session_expired(timeout, request.user.last_login, now):
                 django_logout(request, template_name=settings.BASE_TEMPLATE)
                 # this must be after logout so it is attached to the new session
                 request.session['secure_session'] = True
-                request.session.set_expiry(settings.SECURE_TIMEOUT * 60)
+                request.session.set_expiry(timeout * 60)
                 return HttpResponseRedirect(reverse('login') + '?next=' + request.path)
-            else:
-                request.session['secure_session'] = True
-                request.session['last_request'] = json_format_datetime(now)
-                request.session.set_expiry(settings.SECURE_TIMEOUT * 60)
-                return
-        else:
-            last_request = request.session.get('last_request')
-            timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
-            if self._session_expired(timeout, last_request, now):
-                django_logout(request, template_name=settings.BASE_TEMPLATE)
-                return HttpResponseRedirect(reverse('login') + '?next=' + request.path)
-            request.session['last_request'] = json_format_datetime(now)
-            request.session.set_expiry(timeout * 60)
+
+            request.session['secure_session'] = True
+
+        request.session.set_expiry(timeout * 60)
 
 
 def always_allow_browser_caching(fn):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-511

product note: This will enforce the "shorten inactivity timeout" for web apps users

The main change here is that I removed `last_request` and used [Django's `set_expiry`](https://docs.djangoproject.com/en/1.11/topics/http/sessions/#django.contrib.sessions.backends.base.SessionBase.set_expiry) which will handle the expiration timeout for us in `SessionMiddleware`.

The original timeout middleware was implemented in https://github.com/dimagi/commcare-hq/pull/9496 Its not clear why `set_expiry` was not used.

todo:

- [x] put on staging for testing
- [x] add test to https://github.com/dimagi/commcare-hq/blob/08f746fbc4f0f1dc91413301d5f3ed9061967f8f/corehq/apps/hqwebapp/session_details_endpoint/tests.py#L15 (once i figure out some local failures)