### PR TITLE
send extra fields as property update

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -235,12 +235,12 @@ def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=N
                 'firstname': webuser.first_name,
                 'lastname': webuser.last_name,
             })
-        if extra_fields:
-            data.update(extra_fields)
 
         response = _send_hubspot_form_request(url, data)
         _log_response('HS', data, response)
         response.raise_for_status()
+
+        update_hubspot_properties_v2(webuser, extra_fields)
 
 
 @count_by_response_code(DATADOG_HUBSPOT_SENT_FORM_METRIC)
@@ -260,6 +260,8 @@ def track_web_user_registration_hubspot(request, web_user, properties):
         return
 
     tracking_info = {
+        'created_account_in_hq': True,
+        'is_a_commcare_user': True,
         'lifecyclestage': 'lead',
     }
     env = get_instance_string()
@@ -282,13 +284,6 @@ def track_web_user_registration_hubspot(request, web_user, properties):
         HUBSPOT_SIGNUP_FORM_ID, request,
         user=web_user, extra_fields=tracking_info
     )
-
-    # For some reason the form submission will not update these, so doing it separately
-    direct_properties = {
-        'created_account_in_hq': True,
-        'is_a_commcare_user': True,
-    }
-    update_hubspot_properties_v2(web_user, direct_properties)
 
 
 @analytics_task(serializer='pickle', )

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -240,6 +240,8 @@ def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=N
         _log_response('HS', data, response)
         response.raise_for_status()
 
+        # these must be submitted after the form to ensure
+        # the contact has been created in hubspot
         update_hubspot_properties_v2(webuser, extra_fields)
 
 


### PR DESCRIPTION
@biyeun @orangejenny 
The direct update wasnt working, and I suspect it is because the contact hadn't been created yet. These need to be submitted after the form. I offlined with Mack, and nobody seems to care if the properties are part of the form submission or separate so the cleanest way seemed to be to make all extra property updates a separate call.