### PR TITLE
Rn program summary performance

### DIFF
--- a/custom/icds_reports/reports/cas_reach_data.py
+++ b/custom/icds_reports/reports/cas_reach_data.py
@@ -54,7 +54,6 @@ def get_cas_reach_data(domain, now_date, config, show_test=False):
     del config['prev_month']
 
     awc_this_month_data = get_data_for_awc_monthly(current_month, config)
-    awc_prev_month_data = get_data_for_awc_monthly(previous_month, config)
 
     current_month_selected = (current_month.year == now_date.year and current_month.month == now_date.month)
 
@@ -83,6 +82,7 @@ def get_cas_reach_data(domain, now_date, config, show_test=False):
             'redirect': 'icds_cas_reach/awc_daily_status',
         }
     else:
+        awc_prev_month_data = get_data_for_awc_monthly(previous_month, config)
         monthly_attendance_percent = percent_increase('awc_num_open', awc_this_month_data, awc_prev_month_data)
         number_of_awc_open_yesterday = {
             'help_text': _("Total Number of AWCs open for at least one day in month"),


### PR DESCRIPTION
This Pr is to gather the feedback about whether this change will contribute to reduce the response time of each dashboard request on program summary. I have tested it from Shell. It looks way faster when db tables are used instead of views.

This change is based on the following understanding and observations:
1. It takes more time to query from these views in comparison if we query the table. Because these views are form with join with awc_location table which itself is  big one
2. On pages like program summary. It does not add  additional benefit to query to these views as these views only provide 'name' info on top of the tables.

Only Concern I feel, is Using views is more safer to prevent accidental modification to Tables though Code. But which i think should not be a concern because these code change go through code reviews.
If that still looks a problem. Probably we can create another view just with data from just these table. But that will still reduce performance because that will still be query under query.

@calellowitz  @emord  how do you feel about it.

If we all feel good About it. I can apply these changes to other similar pages also.
