### PR TITLE
Prevent Data Not Entered from being shown in number of days awc open …

### DIFF
--- a/custom/icds_reports/sqldata/exports/system_usage.py
+++ b/custom/icds_reports/sqldata/exports/system_usage.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from sqlagg.columns import SumColumn, SimpleColumn
 
 from corehq.apps.reports.sqlreport import SqlData, DatabaseColumn, AggregateColumn
-from custom.icds_reports.utils.mixins import ExportableMixin, NUM_LAUNCHED_AWCS
+from custom.icds_reports.utils.mixins import ExportableMixin, NUM_LAUNCHED_AWCS, NUM_OF_DAYS_AWC_WAS_OPEN
 from custom.icds_reports.utils import phone_number_function
 
 
@@ -39,7 +39,7 @@ class SystemUsageExport(ExportableMixin, SqlData):
         columns = self.get_columns_by_loc_level
         agg_columns = [
             DatabaseColumn(
-                'Number of days AWC was open in the given month',
+                NUM_OF_DAYS_AWC_WAS_OPEN,
                 SumColumn('awc_days_open'),
                 format_fn=lambda x: (x or 0) if self.loc_level > 4 else "Not Applicable",
                 slug='num_awc_open'

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -730,7 +730,8 @@ def prepare_excel_reports(config, aggregation_level, include_test, beta, locatio
             show_test=include_test
         ).get_excel_data(
             location,
-            system_usage_num_launched_awcs_formatting_at_awc_level=aggregation_level > 4 and beta
+            system_usage_num_launched_awcs_formatting_at_awc_level=aggregation_level > 4 and beta,
+            system_usage_num_of_days_awc_was_open_formatting=aggregation_level <= 4 and beta,
         )
     elif indicator == AWC_INFRASTRUCTURE_EXPORT:
         data_type = 'AWC_Infrastructure'

--- a/custom/icds_reports/utils/mixins.py
+++ b/custom/icds_reports/utils/mixins.py
@@ -19,6 +19,7 @@ from custom.utils.utils import clean_IN_filter_value
 import six
 
 NUM_LAUNCHED_AWCS = 'Number of launched AWCs (ever submitted at least one HH reg form)'
+NUM_OF_DAYS_AWC_WAS_OPEN = 'Number of days AWC was open in the given month'
 
 FILTER_BY_LIST = {
     'unweighed': 'Data not Entered for weight (Unweighed)',
@@ -89,7 +90,8 @@ class ExportableMixin(object):
         export_from_tables(excel_data, export_file, format)
         return export_response(export_file, format, self.title)
 
-    def get_excel_data(self, location, system_usage_num_launched_awcs_formatting_at_awc_level=False):
+    def get_excel_data(self, location, system_usage_num_launched_awcs_formatting_at_awc_level=False,
+                       system_usage_num_of_days_awc_was_open_formatting=False):
         excel_rows = []
         headers = []
         for column in self.columns:
@@ -136,6 +138,12 @@ class ExportableMixin(object):
                 else:
                     record[num_launched_awcs_column] = \
                         'Launched' if record[num_launched_awcs_column] else 'Not Launched'
+        if system_usage_num_of_days_awc_was_open_formatting and \
+                self.loc_level <= 4 and NUM_OF_DAYS_AWC_WAS_OPEN in excel_rows[0]:
+            num_of_days_awc_was_open_column = excel_rows[0].index(NUM_OF_DAYS_AWC_WAS_OPEN)
+            for record in excel_rows[1:]:
+                if record[num_of_days_awc_was_open_column] == DATA_NOT_ENTERED:
+                    record[num_of_days_awc_was_open_column] = 'Not Applicable'
         return [
             [
                 self.title,


### PR DESCRIPTION
…above awc level
Hi @Rohit25negi @calellowitz 
I have prevented Data Not Entered from being shown in the number of days AWC open above AWC level in system usage export.
This is done like that because just like for `system_usage_num_launched_awcs_formatting_at_awc_level` the formatting function isn't fired for None-s, they are just changed into `Data Not Entered`.
These changes are related to JIRA [ICDS-382](https://dimagi-dev.atlassian.net/browse/ICDS-382) ticket.
Need QA: No
Locally Tested: Yes
Regards, Dawid