### PR TITLE
handle files that are not encoded in ascii

### DIFF
--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -470,7 +470,7 @@ def _upload_fixture_api(request, domain):
     with excel_file as filename:
 
         if is_async:
-            with open(filename, 'r') as f:
+            with open(filename, 'rb') as f:
                 file_ref = expose_cached_download(
                     f.read(),
                     file_extension=file_extention_from_filename(filename),


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/996868112/

Required when ```from io import open``` is included.