### PR TITLE
exclude test states from sdd

### DIFF
--- a/custom/icds_reports/reports/service_delivery_dashboard.py
+++ b/custom/icds_reports/reports/service_delivery_dashboard.py
@@ -4,13 +4,13 @@ from datetime import date
 
 from corehq.util.quickcache import quickcache
 from custom.icds_reports.models.views import ServiceDeliveryMonthly
-from custom.icds_reports.utils import DATA_NOT_ENTERED, percent_or_not_entered
+from custom.icds_reports.utils import DATA_NOT_ENTERED, percent_or_not_entered, apply_exclude
 
 
 @quickcache([
     'start', 'length', 'order', 'reversed_order', 'location_filters', 'year', 'month', 'age_sdd'
 ], timeout=30 * 60)
-def get_service_delivery_data(start, length, order, reversed_order, location_filters, year, month, age_sdd):
+def get_service_delivery_data(domain, start, length, order, reversed_order, location_filters, year, month, age_sdd, include_test=False):
     if location_filters.get('aggregation_level') == 1:
         default_order = 'state_name'
     elif location_filters.get('aggregation_level') == 2:
@@ -31,6 +31,8 @@ def get_service_delivery_data(start, length, order, reversed_order, location_fil
         'num_awcs_conducted_vhnd', 'thr_given_21_days', 'total_thr_candidates', 'lunch_count_21_days',
         'children_3_6', 'pse_attended_21_days', 'gm_3_5', 'children_3_5'
     )
+    if not include_test:
+        data = apply_exclude(domain, data)
     data_count = data.count()
     config = {
         'data': [],

--- a/custom/icds_reports/tests/reports/test_service_delivery.py
+++ b/custom/icds_reports/tests/reports/test_service_delivery.py
@@ -10,6 +10,7 @@ class TestServiceDelivery(TestCase):
 
     def test_get_service_delivery_data_0_3(self):
         data = get_service_delivery_data(
+            'icds-cas',
             0,
             10,
             None,
@@ -90,6 +91,7 @@ class TestServiceDelivery(TestCase):
 
     def test_get_service_delivery_data_state_0_3(self):
         data = get_service_delivery_data(
+            'icds-cas',
             0,
             10,
             'district_name',
@@ -133,6 +135,7 @@ class TestServiceDelivery(TestCase):
 
     def test_get_service_delivery_data_3_6(self):
         data = get_service_delivery_data(
+            'icds-cas',
             0,
             10,
             None,
@@ -201,6 +204,7 @@ class TestServiceDelivery(TestCase):
 
     def test_get_service_delivery_data_state_3_6(self):
         data = get_service_delivery_data(
+            'icds-cas',
             0,
             10,
             'district_name',

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -355,6 +355,7 @@ class ServiceDeliveryDashboardView(BaseReportView):
         reversed_order = True if order_dir == 'desc' else False
 
         data = get_service_delivery_data(
+            domain,
             start,
             length,
             order_by_name_column,
@@ -363,6 +364,7 @@ class ServiceDeliveryDashboardView(BaseReportView):
             year,
             month,
             age_sdd,
+            include_test
         )
         return JsonResponse(data=data)
 


### PR DESCRIPTION
This properly excludes test states from the service delivery dashboard, otherwise they are visible to all users.
@Rohit25negi @emord FYI: @dmydlo 