### PR TITLE
Remove hard set width and height options for chart in AWC launched se…

### DIFF
--- a/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
+++ b/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
@@ -44,8 +44,6 @@ function MapOrSectorController($location, storageService, locationsService) {
 
         chart: {
             type: 'multiBarHorizontalChart',
-            width: 1400,
-            height: 550,
             margin: {
                 bottom: 40,
                 left: 100,


### PR DESCRIPTION
…ctor view
Hi @calellowitz @Rohit25negi 
I have fixed the distorted chart in AWC launched sector view by removing the width and height options, that leads to chart filling the space while still respecting margins rather than to either stretch or cramp the chart.
These changes are related to JIRA [ICDS-353](https://dimagi-dev.atlassian.net/browse/ICDS-353) ticket.
Need QA: Yes
Locally Tested: Yes
Regards, Dawid