### PR TITLE
service delivery for not launched awc and no valid indicator value

### DIFF
--- a/custom/icds_reports/reports/service_delivery_dashboard.py
+++ b/custom/icds_reports/reports/service_delivery_dashboard.py
@@ -65,6 +65,7 @@ def get_service_delivery_data(start, length, order, reversed_order, location_fil
             )
         else:
             return dict(
+                num_launched_awcs=get_value_or_data_not_entered(row_data, 'num_launched_awcs'),
                 state_name=get_value_or_data_not_entered(row_data, 'state_name'),
                 district_name=get_value_or_data_not_entered(row_data, 'district_name'),
                 block_name=get_value_or_data_not_entered(row_data, 'block_name'),

--- a/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
+++ b/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
@@ -1,6 +1,6 @@
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function ServiceDeliveryDashboardController($scope, $http, $location, $routeParams, $log, DTOptionsBuilder, DTColumnBuilder, $compile, storageService, userLocationId, haveAccessToAllLocations) {
+function ServiceDeliveryDashboardController($scope, $http, $location, $routeParams, $log, DTOptionsBuilder, DTColumnBuilder, $compile, storageService, userLocationId, haveAccessToAllLocations,haveAccessToFeatures) {
     var vm = this;
     vm.data = {};
     vm.label = "Service Delivery Dashboard";
@@ -33,28 +33,28 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
         .withDOM('ltipr');
 
     vm.setDtColumns = function () {
-        var locationLevelName = 'State';
+         vm.locationLevelName = 'State';
         var locationLevelNameField = 'state_name';
         if (vm.dataAggregationLevel === 1) {
-            locationLevelName = 'State';
+            vm.locationLevelName = 'State';
             locationLevelNameField = 'state_name';
         } else if (vm.dataAggregationLevel === 2) {
-            locationLevelName = 'District';
+            vm.locationLevelName = 'District';
             locationLevelNameField = 'district_name';
         } else if (vm.dataAggregationLevel === 3) {
-            locationLevelName = 'Block';
+            vm.locationLevelName = 'Block';
             locationLevelNameField = 'block_name';
         } else if (vm.dataAggregationLevel === 4) {
-            locationLevelName = 'Sector';
+            vm.locationLevelName = 'Sector';
             locationLevelNameField = 'supervisor_name';
         } else {
-            locationLevelName = 'AWC';
+            vm.locationLevelName = 'AWC';
             locationLevelNameField = 'awc_name';
         }
         vm.dtColumns = [DTColumnBuilder.newColumn(
             locationLevelNameField
         ).withTitle(
-            locationLevelName
+            vm.locationLevelName
         ).renderWith(simpleRender(
             locationLevelNameField
         )).withClass('medium-col')];
@@ -141,6 +141,11 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
     }
     function simpleRender(indicator) {
         return function simpleRenderer(data, type, full) {
+
+            if (haveAccessToFeatures && ['state_name', 'district_name', 'block_name', 'supervisor_name', 'awc_name', 'num_launched_awcs'].indexOf(indicator) === -1 && full['num_launched_awcs'] === 0) {
+                return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+            }
+
             return '<div>' + (
                 full[indicator] !== vm.dataNotEntered ? full[indicator] : vm.dataNotEntered
             ) + '</div>';
@@ -148,27 +153,56 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
     }
     function simpleYesNoRender(indicator) {
         return function simpleRenderer(data, type, full) {
-            return '<div>' + (
+
+            if (haveAccessToFeatures &&  full['num_launched_awcs'] === 0) {
+                return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+
+            }
+            return  '<div>' + (
                 full[indicator] !== vm.dataNotEntered ? (full[indicator] ? 'Yes' : 'No') : vm.dataNotEntered
             ) + '</div>';
         };
     }
     function renderHomeVisits(data, type, full) {
+        if (haveAccessToFeatures &&  full['num_launched_awcs'] === 0) {
+            return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+
+        }
         return renderPercentageAndPartials(full.home_visits, full.valid_visits, full.expected_visits);
     }
     function renderGrowthMonitoring03(data, type, full) {
+        if (haveAccessToFeatures &&  full['num_launched_awcs'] === 0) {
+            return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+
+        }
         return renderPercentageAndPartials(full.gm, full.gm_0_3, full.children_0_3);
     }
     function renderTakeHomeRation(data, type, full) {
+        if (haveAccessToFeatures && full['num_launched_awcs'] === 0) {
+            return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+
+        }
         return renderPercentageAndPartials(full.thr, full.thr_given_21_days, full.total_thr_candidates);
     }
     function renderSupplementaryNutrition(data, type, full) {
+        if (haveAccessToFeatures &&  full['num_launched_awcs'] === 0) {
+            return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+
+        }
         return renderPercentageAndPartials(full.sn, full.lunch_count_21_days, full.children_3_6);
     }
     function renderPreSchoolEducation(data, type, full) {
+        if (haveAccessToFeatures &&  full['num_launched_awcs'] === 0) {
+            return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+
+        }
         return renderPercentageAndPartials(full.pse, full.pse_attended_21_days, full.children_3_6);
     }
     function renderGrowthMonitoring36(data, type, full) {
+        if (haveAccessToFeatures &&  full['num_launched_awcs'] === 0) {
+            return '<div>' + vm.locationLevelName + ' Not Launched</div>';
+
+        }
         return renderPercentageAndPartials(full.gm, full.gm_3_5, full.children_3_5);
     }
 
@@ -231,7 +265,7 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
     vm.getData();
 }
 
-ServiceDeliveryDashboardController.$inject = ['$scope', '$http', '$location', '$routeParams', '$log', 'DTOptionsBuilder', 'DTColumnBuilder', '$compile', 'storageService', 'userLocationId', 'haveAccessToAllLocations'];
+ServiceDeliveryDashboardController.$inject = ['$scope', '$http', '$location', '$routeParams', '$log', 'DTOptionsBuilder', 'DTColumnBuilder', '$compile', 'storageService', 'userLocationId', 'haveAccessToAllLocations','haveAccessToFeatures'];
 
 window.angular.module('icdsApp').directive('serviceDeliveryDashboard', function () {
     return {

--- a/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
+++ b/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
@@ -33,7 +33,7 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
         .withDOM('ltipr');
 
     vm.setDtColumns = function () {
-         var locationLevelName = 'State';
+        var locationLevelName = 'State';
         var locationLevelNameField = 'state_name';
         if (vm.dataAggregationLevel === 1) {
             locationLevelName = 'State';
@@ -55,33 +55,32 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
             locationLevelNameField
         ).withTitle(
             locationLevelName
-        ).renderWith(simpleRender(
-            locationLevelNameField
-        )).withClass('medium-col')];
+        ).renderWith(renderCellValue('raw', locationLevelNameField)
+        ).withClass('medium-col')];
         if (vm.dataAgeSDD === '0_3') {
             if (vm.dataAggregationLevel <= 4) {
                 vm.dtColumns = vm.dtColumns.concat([
-                    DTColumnBuilder.newColumn('num_launched_awcs').withTitle(renderNumLaunchedAwcsTooltip()).renderWith(simpleRender('num_launched_awcs')).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('home_visits').withTitle(renderHomeVisitsTooltip()).renderWith(renderHomeVisits).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('gm').withTitle(renderGrowthMonitoringTooltip()).renderWith(renderGrowthMonitoring03).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('num_awcs_conducted_cbe').withTitle(renderCommunityBasedEventsTooltip()).renderWith(simpleRender('num_awcs_conducted_cbe')).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('num_awcs_conducted_vhnd').withTitle(renderVHSNDTooltip()).renderWith(simpleRender('num_awcs_conducted_vhnd')).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('thr').withTitle(renderTakeHomeRationTooltip()).renderWith(renderTakeHomeRation).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('num_launched_awcs').withTitle(renderNumLaunchedAwcsTooltip()).renderWith(renderCellValue('raw','num_launched_awcs')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('home_visits').withTitle(renderHomeVisitsTooltip()).renderWith(renderCellValue('percentage', 'homeVisits')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('gm').withTitle(renderGrowthMonitoringTooltip()).renderWith(renderCellValue('percentage', 'gm03')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('num_awcs_conducted_cbe').withTitle(renderCommunityBasedEventsTooltip()).renderWith(renderCellValue('raw','num_awcs_conducted_cbe')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('num_awcs_conducted_vhnd').withTitle(renderVHSNDTooltip()).renderWith(renderCellValue('raw','num_awcs_conducted_vhnd')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('thr').withTitle(renderTakeHomeRationTooltip()).renderWith(renderCellValue('percentage','thr')).withClass('medium-col'),
                 ]);
             } else {
                 vm.dtColumns = vm.dtColumns.concat([
-                    DTColumnBuilder.newColumn('home_visits').withTitle(renderHomeVisitsTooltip()).renderWith(renderHomeVisits).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('gm').withTitle(renderGrowthMonitoringTooltip()).renderWith(renderGrowthMonitoring03).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('num_awcs_conducted_cbe').withTitle(renderCommunityBasedEventsTooltipAWC()).renderWith(simpleYesNoRender('num_awcs_conducted_cbe')).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('num_awcs_conducted_vhnd').withTitle(renderVHSNDTooltipAWC()).renderWith(simpleYesNoRender('num_awcs_conducted_vhnd')).withClass('medium-col'),
-                    DTColumnBuilder.newColumn('thr').withTitle(renderTakeHomeRationTooltip()).renderWith(renderTakeHomeRation).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('home_visits').withTitle(renderHomeVisitsTooltip()).renderWith(renderCellValue('percentage', 'homeVisits')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('gm').withTitle(renderGrowthMonitoringTooltip()).renderWith(renderCellValue('percentage', 'gm03')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('num_awcs_conducted_cbe').withTitle(renderCommunityBasedEventsTooltipAWC()).renderWith(renderCellValue('BooleanRaw','num_awcs_conducted_cbe')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('num_awcs_conducted_vhnd').withTitle(renderVHSNDTooltipAWC()).renderWith(renderCellValue('BooleanRaw','num_awcs_conducted_vhnd')).withClass('medium-col'),
+                    DTColumnBuilder.newColumn('thr').withTitle(renderTakeHomeRationTooltip()).renderWith(renderCellValue('percentage','thr')).withClass('medium-col'),
                 ]);
             }
         } else {
             vm.dtColumns = vm.dtColumns.concat([
-                DTColumnBuilder.newColumn('sn').withTitle(renderSupplementaryNutritionTooltip()).renderWith(renderSupplementaryNutrition).withClass('medium-col'),
-                DTColumnBuilder.newColumn('pse').withTitle(renderPreSchoolEducationTooltip()).renderWith(renderPreSchoolEducation).withClass('medium-col'),
-                DTColumnBuilder.newColumn('gm').withTitle(renderGrowthMonitoring36Tooltip()).renderWith(renderGrowthMonitoring36).withClass('medium-col'),
+                DTColumnBuilder.newColumn('sn').withTitle(renderSupplementaryNutritionTooltip()).renderWith(renderCellValue('percentage','supNutrition')).withClass('medium-col'),
+                DTColumnBuilder.newColumn('pse').withTitle(renderPreSchoolEducationTooltip()).renderWith(renderCellValue('percentage','pse')).withClass('medium-col'),
+                DTColumnBuilder.newColumn('gm').withTitle(renderGrowthMonitoring36Tooltip()).renderWith(renderCellValue('percentage','gm36')).withClass('medium-col'),
             ]);
         }
     };
@@ -134,7 +133,7 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
     }
 
     function renderPercentageAndPartials(percentage, nominator, denominator, indicator) {
-        if (isZeroNullUnassignedOrDataNotEntered(denominator) && haveAccessToFeatures) {
+        if (haveAccessToFeatures && isZeroNullUnassignedOrDataNotEntered(denominator)) {
             return '<div> No expected ' + indicator + ' </div>';
         }
         else {
@@ -151,72 +150,44 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
     }
 
 
-    function simpleRender(indicator) {
-        return function simpleRenderer(data, type, full) {
+    function renderCellValue(CellType, indicator) {
+
+        return function (data, type, full) {
 
             if (haveAccessToFeatures && ['state_name', 'district_name', 'block_name', 'supervisor_name', 'awc_name', 'num_launched_awcs'].indexOf(indicator) === -1 && isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
                 return '<div>Not Launched</div>';
             }
 
-            return '<div>' + (
-                full[indicator] !== vm.dataNotEntered ? full[indicator] : vm.dataNotEntered
-            ) + '</div>';
-        };
-    }
-    function simpleYesNoRender(indicator) {
-        return function simpleRenderer(data, type, full) {
+            switch (CellType) {
+                case "raw": return simpleRender(full, indicator, 'raw');
+                case "booleanRaw": return simpleRender(full, indicator, 'booleanRaw');
+                case "percentage":
+                    switch (indicator) {
+                        case "homeVisits": return renderPercentageAndPartials(full.home_visits, full.valid_visits, full.expected_visits, 'Home visits');
+                        case "gm03": return  renderPercentageAndPartials(full.gm, full.gm_0_3, full.children_0_3, 'Weight measurement');
+                        case "gm36": return renderPercentageAndPartials(full.gm, full.gm_3_5, full.children_3_5, 'Weight measurement');
+                        case "thr": return renderPercentageAndPartials(full.thr, full.thr_given_21_days, full.total_thr_candidates, 'THR');
+                        case "pse": return renderPercentageAndPartials(full.pse, full.pse_attended_21_days, full.children_3_6, 'beneficiaries');
+                        case "supNutrition": return renderPercentageAndPartials(full.sn, full.lunch_count_21_days, full.children_3_6, 'beneficiaries');
 
-            if (haveAccessToFeatures &&  isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
-                return '<div>Not Launched</div>';
-
+                    }
+                    break;
             }
-            return  '<div>' + (
-                full[indicator] !== vm.dataNotEntered ? (full[indicator] ? 'Yes' : 'No') : vm.dataNotEntered
-            ) + '</div>';
+
         };
-    }
-    function renderHomeVisits(data, type, full) {
-        if (haveAccessToFeatures &&  isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
-            return '<div>Not Launched</div>';
 
-        }
-        return renderPercentageAndPartials(full.home_visits, full.valid_visits, full.expected_visits, 'Home visits');
     }
-    function renderGrowthMonitoring03(data, type, full) {
-        if (haveAccessToFeatures &&  isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
-            return '<div>Not Launched</div>';
 
+    function simpleRender(full, indicator, outputType) {
+        var output;
+        if (outputType === 'raw') {
+            output = full[indicator] !== vm.dataNotEntered ? full[indicator] : vm.dataNotEntered;
+        } else if (outputType === 'booleanRaw') {
+            output = full[indicator] !== vm.dataNotEntered ? (full[indicator] ? 'Yes' : 'No') : vm.dataNotEntered;
         }
-        return renderPercentageAndPartials(full.gm, full.gm_0_3, full.children_0_3, 'Weight measurement');
+        return '<div>' + output + '</div>';
     }
-    function renderTakeHomeRation(data, type, full) {
-        if (haveAccessToFeatures && isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
-            return '<div>Not Launched</div>';
 
-        }
-        return renderPercentageAndPartials(full.thr, full.thr_given_21_days, full.total_thr_candidates, 'THR');
-    }
-    function renderSupplementaryNutrition(data, type, full) {
-        if (haveAccessToFeatures &&  isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
-            return '<div>Not Launched</div>';
-
-        }
-        return renderPercentageAndPartials(full.sn, full.lunch_count_21_days, full.children_3_6, 'beneficiaries');
-    }
-    function renderPreSchoolEducation(data, type, full) {
-        if (haveAccessToFeatures &&  isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
-            return '<div>Not Launched</div>';
-
-        }
-        return renderPercentageAndPartials(full.pse, full.pse_attended_21_days, full.children_3_6, 'beneficiaries');
-    }
-    function renderGrowthMonitoring36(data, type, full) {
-        if (haveAccessToFeatures &&  isZeroNullUnassignedOrDataNotEntered(full['num_launched_awcs'])) {
-            return '<div>Not Launched</div>';
-
-        }
-        return renderPercentageAndPartials(full.gm, full.gm_3_5, full.children_3_5, 'Weight measurement');
-    }
 
     if (Object.keys($location.search()).length === 0) {
         $location.search(storageService.getKey('search'));

--- a/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
+++ b/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
@@ -1,6 +1,6 @@
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function ServiceDeliveryDashboardController($scope, $http, $location, $routeParams, $log, DTOptionsBuilder, DTColumnBuilder, $compile, storageService, userLocationId, haveAccessToAllLocations,haveAccessToFeatures) {
+function ServiceDeliveryDashboardController($scope, $http, $location, $routeParams, $log, DTOptionsBuilder, DTColumnBuilder, $compile, storageService, userLocationId, haveAccessToAllLocations, haveAccessToFeatures) {
     var vm = this;
     vm.data = {};
     vm.label = "Service Delivery Dashboard";
@@ -215,7 +215,7 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
             return '<div>Not Launched</div>';
 
         }
-        return renderPercentageAndPartials(full.gm, full.gm_3_5, full.children_3_5,'Weight measurement');
+        return renderPercentageAndPartials(full.gm, full.gm_3_5, full.children_3_5, 'Weight measurement');
     }
 
     if (Object.keys($location.search()).length === 0) {
@@ -277,7 +277,7 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
     vm.getData();
 }
 
-ServiceDeliveryDashboardController.$inject = ['$scope', '$http', '$location', '$routeParams', '$log', 'DTOptionsBuilder', 'DTColumnBuilder', '$compile', 'storageService', 'userLocationId', 'haveAccessToAllLocations','haveAccessToFeatures'];
+ServiceDeliveryDashboardController.$inject = ['$scope', '$http', '$location', '$routeParams', '$log', 'DTOptionsBuilder', 'DTColumnBuilder', '$compile', 'storageService', 'userLocationId', 'haveAccessToAllLocations', 'haveAccessToFeatures'];
 
 window.angular.module('icdsApp').directive('serviceDeliveryDashboard', function () {
     return {

--- a/custom/icds_reports/tests/reports/test_service_delivery.py
+++ b/custom/icds_reports/tests/reports/test_service_delivery.py
@@ -162,7 +162,8 @@ class TestServiceDelivery(TestCase):
                     'gm': '70.48 %',
                     'supervisor_name': 'Data Not Entered',
                     'pse_attended_21_days': 7,
-                    'awc_name': 'Data Not Entered'
+                    'awc_name': 'Data Not Entered',
+                    'num_launched_awcs': 9
                 },
                 {
                     'gm_3_5': 240,
@@ -177,7 +178,8 @@ class TestServiceDelivery(TestCase):
                     'gm': '69.97 %',
                     'supervisor_name': 'Data Not Entered',
                     'pse_attended_21_days': 60,
-                    'awc_name': 'Data Not Entered'
+                    'awc_name': 'Data Not Entered',
+                    'num_launched_awcs': 11
                 },
                 {
                     'gm_3_5': 0,
@@ -192,7 +194,8 @@ class TestServiceDelivery(TestCase):
                     'gm': '0.00 %',
                     'supervisor_name': 'Data Not Entered',
                     'pse_attended_21_days': 0,
-                    'awc_name': 'Data Not Entered'
+                    'awc_name': 'Data Not Entered',
+                    'num_launched_awcs': 1,
                 }
             ],
             'ageSDD': '3_6',
@@ -231,7 +234,8 @@ class TestServiceDelivery(TestCase):
                     'gm': '70.48 %',
                     'supervisor_name': 'Data Not Entered',
                     'pse_attended_21_days': 7,
-                    'awc_name': 'Data Not Entered'
+                    'awc_name': 'Data Not Entered',
+                    'num_launched_awcs': 9
                 }
             ],
             'ageSDD': '3_6',


### PR DESCRIPTION
This Change is under Feature Flag,
This changes following:
-> For the location which has 0 awc launched will show 'not launched' for all indicators
-> For indicators where denominator is not have a value show "no expected <indicator>"

It Has been tested locally

@calellowitz 