### PR TITLE
Added lazy migration to remove media_language_map

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4666,6 +4666,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
     @classmethod
     def wrap(cls, data):
         data.pop('commtrack_enabled', None)  # Remove me after migrating apps
+        data.pop('media_language_map', None)
         data['modules'] = [module for module in data.get('modules', [])
                            if module.get('doc_type') != 'CareplanModule']
         self = super(Application, cls).wrap(data)


### PR DESCRIPTION
This property has been unused since https://github.com/dimagi/commcare-hq/pull/23149 and it's quite large on ICDS's apps.

I created a real migration in https://github.com/dimagi/commcare-hq/pull/23150 but have run into problems running it. In the meantime, ICDS started hitting a [payload size error](https://sentry.io/organizations/dimagi/issues/1005600806) when pulling the app. Hoping that this PR will resolve that problem.