### PR TITLE
use default name

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -231,7 +231,7 @@ class BaseEditConfigReportView(BaseUserConfigReportsView):
                             "app_url": app_url,
                             "app_name": app.name,
                             "module_url": module_url,
-                            "module_name": module.name['en']
+                            "module_name": module.default_name()
                         })
         return to_ret
 


### PR DESCRIPTION
@emord @sravfeyn cc: @gbova 
https://dimagi-dev.atlassian.net/browse/HI-594
This was broken for apps with no english module name. This switches to using the default language instead.