### PR TITLE
fall back to report language

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -505,7 +505,7 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
     config_ids = StringListProperty()
     send_to_owner = BooleanProperty()
     attach_excel = BooleanProperty()
-    # language is only used if some of the config_ids refer to UCRs.
+    # language is only used if some of the config_ids refer to UCRs or custom reports
     language = StringProperty()
     email_subject = StringProperty(default=DEFAULT_REPORT_NOTIF_SUBJECT)
 
@@ -636,7 +636,8 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
             for user in get_user_docs_by_username(self.all_recipient_emails)
             if 'username' in user and 'language' in user
         }
-        fallback_language = user_languages.get(self.owner_email, 'en')
+        default = self.language if self.language else 'en'
+        fallback_language = user_languages.get(self.owner_email, default)
 
         recipients = defaultdict(list)
         for email in self.all_recipient_emails:


### PR DESCRIPTION
@emord cc: @gbova 
This should resolve https://dimagi-dev.atlassian.net/browse/HI-537
It continues the current behavior of select the language of the user if the report is being sent to a commcare webuser. If the email does not belong to a user, it falls back first to a report defined language, and finally to english if that does not exist.