### PR TITLE
SMS Log Report Optimization

### DIFF
--- a/corehq/apps/reports/standard/message_event_display.py
+++ b/corehq/apps/reports/standard/message_event_display.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import cgi
+from collections import namedtuple
 
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -211,6 +212,9 @@ def _get_case_rule_display(domain, rule_id, content_cache):
 
     content_cache[cache_key] = result
     return result
+
+
+EventStub = namedtuple('EventStub', 'source source_id content_type form_name')
 
 
 def get_event_display(domain, event, content_cache):

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -454,7 +454,7 @@ class MessageLogReport(BaseCommConnectLogReport):
             session_event = With(
                 MessagingSubEvent.objects.filter(
                     parent__domain=self.domain,
-                    parent_id__in=queryset.values('id'),
+                    date__range=(self.datespan.startdate_utc, self.datespan.enddate_utc),
                 ).values(
                     couch_id=F("xforms_session__couch_id"),
                     source=F("parent__source"),

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -451,7 +451,7 @@ class MessageLogReport(BaseCommConnectLogReport):
     def _sort_column(self):
         col_fields = ['date', 'couch_recipient', 'phone_number', 'direction', 'text']
         sort_col = self.request_params.get('iSortCol_0')
-        if sort_col is None or sort_col < len(col_fields):
+        if sort_col is None or sort_col < 0 or sort_col >= len(col_fields):
             sort_col = 0
         return col_fields[sort_col]
 

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -568,7 +568,13 @@ class MessageLogReport(BaseCommConnectLogReport):
         """Extract event data from a message annotated via _add_sms_event_data"""
         event = None
         if message.messaging_subevent:
-            event = message.messaging_subevent.parent
+            event_obj = message.messaging_subevent.parent
+            event = EventStub(
+                source=event_obj.source,
+                source_id=event_obj.source_id,
+                content_type=event_obj.content_type,
+                form_name=event_obj.form_name,
+            )
         elif message.session_source_id is not None:
             event = EventStub(
                 source=message.session_source,

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -419,12 +419,9 @@ class MessageLogReport(BaseCommConnectLogReport):
             return data.filter(location_id__in=location_ids)
 
         def order_by_col(data_):
-            col_fields = ['date', 'couch_recipient', 'phone_number', 'direction', 'text']
-            sort_col = self.request_params.get('iSortCol_0')
-            if sort_col is not None and sort_col < len(col_fields):
-                data_ = data_.order_by(col_fields[sort_col])
-                if self.request_params.get('sSortDir_0') == 'desc':
-                    data_ = data_.reverse()
+            data_ = data_.order_by(self._sort_column)
+            if self._sort_descending:
+                data_ = data_.reverse()
             return data_
 
         queryset = SMS.objects.filter(
@@ -450,6 +447,18 @@ class MessageLogReport(BaseCommConnectLogReport):
         if self.testing_changes:
             return self._add_sms_event_data(queryset)
         return queryset
+
+    @property
+    def _sort_column(self):
+        col_fields = ['date', 'couch_recipient', 'phone_number', 'direction', 'text']
+        sort_col = self.request_params.get('iSortCol_0')
+        if sort_col is None or sort_col < len(col_fields):
+            sort_col = 0
+        return col_fields[sort_col]
+
+    @property
+    def _sort_descending(self):
+        return self.request_params.get('sSortDir_0') == 'desc'
 
     def _get_rows(self, paginate=True, contact_info=False, include_log_id=False):
         message_log_options = getattr(settings, "MESSAGE_LOG_OPTIONS", {})

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -5,7 +5,9 @@ from datetime import datetime
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Count, Q, Subquery, OuterRef
+from django.db.models import Count, Q
+from django.db.models.expressions import F
+from django.db.models.sql.constants import LOUTER
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -15,6 +17,7 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 
 import six
 from couchdbkit import ResourceNotFound
+from django_cte import With
 from memoized import memoized
 
 from casexml.apps.case.models import CommCareCase
@@ -525,22 +528,39 @@ class MessageLogReport(BaseCommConnectLogReport):
         return result
 
     def _add_sms_event_data(self, queryset):
+        """Adds information about the triggering event to a SMS queryset"""
 
-        def subquery_expression(field):
-            return Subquery(
-                MessagingSubEvent.objects.filter(
-                    parent__domain=self.domain,
-                    date__range=(self.datespan.startdate_utc, self.datespan.enddate_utc),
-                    xforms_session__couch_id=OuterRef('xforms_session_couch_id'),
-                ).values(field)
-            )
-
+        # For many SMS entries, the requisite info is easy enough to get:
         queryset = queryset.select_related('messaging_subevent', 'messaging_subevent__parent')
-        queryset = queryset.annotate(
-            session_source=subquery_expression("parent__source"),
-            session_source_id=subquery_expression("parent__source_id"),
-            session_content_type=subquery_expression("parent__content_type"),
-            session_form_name=subquery_expression("parent__form_name"),
+
+        # That connection doesn't always exist, so we sometimes have to go:
+        # SMS -> SQLXFormsSession -> MessagingSubEvent -> MessagingEvent
+        session_event = With(
+            MessagingSubEvent.objects.filter(
+                parent__domain=self.domain,
+                date__range=(self.datespan.startdate_utc, self.datespan.enddate_utc),
+            ).values(
+                couch_id=F("xforms_session__couch_id"),
+                source=F("parent__source"),
+                source_id=F("parent__source_id"),
+                session_content_type=F("parent__content_type"),
+                session_form_name=F("parent__form_name"),
+            ),
+            name="session_event"
+        )
+        queryset = session_event.join(
+            queryset.with_cte(session_event),
+            xforms_session_couch_id=session_event.col.couch_id,
+            # Use secret parameter to do LEFT OUTER JOIN
+            # WARNING: may be automatically changed to an INNER JOIN if
+            # more filters are added to the queryset after this join.
+            # See also: https://github.com/dimagi/django-cte/issues/2
+            _join_type=LOUTER,
+        ).annotate(
+            session_source=session_event.col.source,
+            session_source_id=session_event.col.source_id,
+            session_content_type=session_event.col.session_content_type,
+            session_form_name=session_event.col.session_form_name,
         )
         return queryset
 

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -547,7 +547,7 @@ class MessageLogReport(BaseCommConnectLogReport):
     def _get_events_by_xforms_session(self, messages):
         session_ids = [
             m.xforms_session_couch_id for m in messages
-            if m.xforms_session_couch_id and not m.messaging_subevent
+            if m.xforms_session_couch_id and not m.messaging_subevent_id
         ]
         subevents = (MessagingSubEvent.objects
                      .filter(parent__domain=self.domain,

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -539,6 +539,7 @@ class MessageLogReport(BaseCommConnectLogReport):
             MessagingSubEvent.objects.filter(
                 parent__domain=self.domain,
                 date__range=(self.datespan.startdate_utc, self.datespan.enddate_utc),
+                xforms_session__isnull=False,
             ).values(
                 couch_id=F("xforms_session__couch_id"),
                 source=F("parent__source"),

--- a/corehq/apps/reports/tests/test_message_log_report.py
+++ b/corehq/apps/reports/tests/test_message_log_report.py
@@ -33,6 +33,7 @@ class MessageLogReportTest(TestCase):
     def test_event_column(self):
         self.make_simple_sms('message')
         self.make_case_rule_sms('Rule 2')
+        # This sms tests this particular condition
         self.make_survey_sms('Rule 3')
 
         for report_value, rule_name in zip(

--- a/corehq/apps/reports/tests/test_message_log_report.py
+++ b/corehq/apps/reports/tests/test_message_log_report.py
@@ -78,7 +78,7 @@ class MessageLogReportTest(TestCase):
         )
         report = MessageLogReport(request, domain=self.domain)
         headers = [h.html for h in report.headers.header]
-        for row in report.rows:
+        for row in report.export_rows:
             yield dict(zip(headers, row))
 
     def make_simple_sms(self, message, error_message=None):

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -10,7 +10,6 @@ from dimagi.ext.couchdbkit import *
 from datetime import datetime, timedelta
 from django.db import models, transaction, IntegrityError, connection
 from django.http import Http404
-from django_cte import CTEManager
 from collections import namedtuple
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.models import Form
@@ -264,8 +263,6 @@ class SMSBase(UUIDGeneratorMixin, Log):
 
 
 class SMS(SMSBase):
-
-    objects = CTEManager()
 
     def to_json(self):
         from corehq.apps.sms.serializers import SMSSerializer

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -10,6 +10,7 @@ from dimagi.ext.couchdbkit import *
 from datetime import datetime, timedelta
 from django.db import models, transaction, IntegrityError, connection
 from django.http import Http404
+from django_cte import CTEManager
 from collections import namedtuple
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.models import Form
@@ -263,6 +264,8 @@ class SMSBase(UUIDGeneratorMixin, Log):
 
 
 class SMS(SMSBase):
+
+    objects = CTEManager()
 
     def to_json(self):
         from corehq.apps.sms.serializers import SMSSerializer

--- a/corehq/util/itertools.py
+++ b/corehq/util/itertools.py
@@ -4,23 +4,18 @@ from __future__ import unicode_literals
 from operator import lt, gt
 
 
-def next_or_Ellipsis(generator):
-    try:
-        return next(generator)
-    except StopIteration:
-        return Ellipsis
-
-
 def merge(generator1, generator2, key=None, reverse=False):
     """Zip two sorted generators into a sorted generator"""
     # This function can be replaced by heapq.merge in python3
+
+    END = object()
 
     def comes_before(a, b):
         comp = gt if reverse else lt
         return comp(key(a) if key else a, key(b) if key else b)
 
-    g1_item = next_or_Ellipsis(generator1)
-    g2_item = next_or_Ellipsis(generator2)
+    g1_item = next(generator1, END)
+    g2_item = next(generator2, END)
     while True:
 
         # If one generator is exhausted, dump the other one
@@ -28,8 +23,8 @@ def merge(generator1, generator2, key=None, reverse=False):
             (g1_item, g2_item, generator2),
             (g2_item, g1_item, generator1),
         ]:
-            if item == Ellipsis:
-                if other_item != Ellipsis:
+            if item == END:
+                if other_item != END:
                     yield other_item
                     for x in other_generator:
                         yield x
@@ -37,7 +32,7 @@ def merge(generator1, generator2, key=None, reverse=False):
 
         if comes_before(g1_item, g2_item):
             yield g1_item
-            g1_item = next_or_Ellipsis(generator1)
+            g1_item = next(generator1, END)
         else:
             yield g2_item
-            g2_item = next_or_Ellipsis(generator2)
+            g2_item = next(generator2, END)

--- a/corehq/util/itertools.py
+++ b/corehq/util/itertools.py
@@ -23,8 +23,8 @@ def merge(generator1, generator2, key=None, reverse=False):
             (g1_item, g2_item, generator2),
             (g2_item, g1_item, generator1),
         ]:
-            if item == END:
-                if other_item != END:
+            if item is END:
+                if other_item is not END:
                     yield other_item
                     for x in other_generator:
                         yield x

--- a/corehq/util/itertools.py
+++ b/corehq/util/itertools.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from operator import lt, gt
+
+
+def next_or_Ellipsis(generator):
+    try:
+        return next(generator)
+    except StopIteration:
+        return Ellipsis
+
+
+def merge(generator1, generator2, key=None, reverse=False):
+    """Zip two sorted generators into a sorted generator"""
+    # This function can be replaced by heapq.merge in python3
+
+    def comes_before(a, b):
+        comp = gt if reverse else lt
+        return comp(key(a) if key else a, key(b) if key else b)
+
+    g1_item = next_or_Ellipsis(generator1)
+    g2_item = next_or_Ellipsis(generator2)
+    while True:
+
+        # If one generator is exhausted, dump the other one
+        for item, other_item, other_generator in [
+            (g1_item, g2_item, generator2),
+            (g2_item, g1_item, generator1),
+        ]:
+            if item == Ellipsis:
+                if other_item != Ellipsis:
+                    yield other_item
+                    for x in other_generator:
+                        yield x
+                return
+
+        if comes_before(g1_item, g2_item):
+            yield g1_item
+            g1_item = next_or_Ellipsis(generator1)
+        else:
+            yield g2_item
+            g2_item = next_or_Ellipsis(generator2)

--- a/corehq/util/tests/test_itertools.py
+++ b/corehq/util/tests/test_itertools.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, unicode_literals
+
+from itertools import chain
+
+from ..itertools import merge
+
+
+def check_result(a, b, reverse, result):
+    actual = list(merge(chain(a), chain(b), reverse=reverse))
+    assert actual == result, "{} != {}".format(actual, result)
+
+
+def test_merge():
+    for a, b, result in [
+            ([0, 1, 2], [3, 4, 5], list(range(6))),
+            ([3, 4, 5], [0, 1, 2], list(range(6))),
+            ([0, 2, 5], [1, 3, 4], list(range(6))),
+            ([], [0, 3, 5], [0, 3, 5]),
+            ([0, 3, 5], [], [0, 3, 5]),
+            ([], [], []),
+    ]:
+        yield check_result, a, b, False, result
+
+
+def test_merge_reversed():
+    for a, b, result in [
+        ([], [], []),
+        ([4, 3, 1], [2, 0], [4, 3, 2, 1, 0]),
+    ]:
+        yield check_result, a, b, True, result


### PR DESCRIPTION
This is hidden behind a "testing" feature flag.

This is an optimization allowing this change https://github.com/dimagi/commcare-hq/pull/23982 and in particular this change https://github.com/dimagi/commcare-hq/pull/24034 to perform on a larger scale.

The problem concerns how to get SMS event data - for many SMSs, this can be obtained by a double join: SMS -> MessagingSubevent -> Event.  In some cases, however, this must go SMS -> SQLXFormsSession -> MessagingSubEvent -> MessagingEvent, and not all of those connections are simple foreign keys.  My naive, POC implementation was a db hit per row to fetch that lookup.

@millerdev agreed to assist on this - he wrote a [CTE query](https://github.com/dimagi/commcare-hq/pull/24199/commits/71f427b77540ed721b60549f2400cc7b9ed32782) to do that second type of lookup.  I also came across [a cool blog post](https://medium.com/kolonial-no-product-tech/pushing-the-orm-to-its-limits-d26d87a66d28) describing the use of subqueries in a similar context, so [I tried that approach as well](https://github.com/dimagi/commcare-hq/pull/24199/commits/eb4eab00ad01d5cd44847b91e76089df09af8c01).  Both of those returned valid results, though they were still somewhat slow.  Pulling 4 months of data on a large project (500k rows) took about 22 seconds with the CTE query and 13 seconds with subqueries.  The baselines were 4 seconds doing a relational lookup only (incomplete event data), and a little over a second with no event data.

We then decided on a two-query approach - one for SMSs with subevents, and a second for those without.  Then the related fields are pulled in only on a smaller set of data.  With additional filtering on the `WITH` clause of the CTE query, it outperformed the subquery approach on the smaller dataset, so that's the approach I used going forward.  The two separate queries are then joined, with sorting preserved.  The standard library's `heapq.merge` does this beautifully, but it doesn't support `key` or `reverse` parameters until python 3, so I made my own implementation.

Overall, it feels like I might've gone a bit too far with the optimizations on this one, though I'm not sure what the best stopping point would've been.