### PR TITLE
Add Report Filters to Explore Case Data Report

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -33,6 +33,7 @@ breadcrumbs todo
   {% initial_page_data "report.slug" report.slug %}
   {% initial_page_data "report.columns" report.columns %}
   {% initial_page_data "report.columnFilters" report.column_filters %}
+  {% initial_page_data "report.reportFilters" report.report_filters %}
 
 <div id="case_search--model">
 

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -49,6 +49,26 @@ breadcrumbs todo
   </div>
 
   <div id="report-datagrid">
+
+    <div class="form form-horizontal well"
+         data-bind="foreach: reportFilters">
+      <div class="form-group">
+        <label class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label"
+               data-bind="text: title, attr: { for: 'filter_' + name()}"></label>
+        <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
+          <select type="text"
+                 class="form-control"
+                 data-bind="selectedOptions: value,
+                            select2: {
+                                placeholder: placeholder(),
+                                multiple: true,
+                                url: endpoint.getUrl(),
+                            },
+                            attr: { id: 'filter_' + name() }"></select>
+        </div>
+      </div>
+    </div>
+
     <table class="datagrid-headers">
       <thead>
         <tr>

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -45,7 +45,7 @@ from corehq.apps.data_interfaces.dispatcher import (
     require_can_edit_data,
 )
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.hqwebapp.decorators import use_daterangepicker
+from corehq.apps.hqwebapp.decorators import use_daterangepicker, use_select2_v4
 from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.const import SERVER_DATETIME_FORMAT
 from .dispatcher import require_form_management_privilege
@@ -122,6 +122,7 @@ class ExploreCaseDataView(BaseDomainView):
     page_title = ugettext_lazy("Explore Case Data")
 
     @use_daterangepicker
+    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(ExploreCaseDataView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -16,6 +16,7 @@ from django.views.decorators.http import require_http_methods
 from memoized import memoized
 
 from corehq.apps.hqwebapp.crispy import make_form_readonly
+from corehq.apps.reports.filters.controllers import EmwfOptionsController
 from dimagi.utils.web import json_response
 from soil import DownloadBase
 from soil.exceptions import TaskFailedError
@@ -225,12 +226,21 @@ class LocationsListView(BaseLocationView):
             return [to_json(user.get_sql_location(self.domain))]
 
 
-class LocationsSearchView(EmwfOptionsView):
+class LocationOptionsController(EmwfOptionsController):
+
     @property
     def data_sources(self):
         return [
             (self.get_locations_size, self.get_locations),
         ]
+
+
+class LocationsSearchView(EmwfOptionsView):
+
+    @property
+    @memoized
+    def options_controller(self):
+        return LocationOptionsController(self.request, self.domain, self.search)
 
 
 class LocationFieldsView(CustomDataModelMixin, BaseLocationView):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -59,7 +59,7 @@ class EmwfOptionsController(object):
         return len(self.get_all_static_options(query))
 
     def get_static_options(self, query, start, size):
-        return self.get_all_static_options(query)[start:start+size]
+        return self.get_all_static_options(query)[start:start + size]
 
     def group_es_query(self, query, group_type="reporting"):
         if group_type == "reporting":

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -1,0 +1,282 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import json
+
+from memoized import memoized
+
+from corehq.apps.es import UserES, GroupES, groups
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.reports.const import DEFAULT_PAGE_LIMIT
+from corehq.apps.reports.filters.case_list import CaseListFilterUtils
+from corehq.apps.reports.filters.users import EmwfUtils, UsersUtils
+from corehq.apps.reports.util import SimplifiedUserInfo
+
+
+def paginate_options(data_sources, query, start, size):
+    """
+    Returns the appropriate slice of values from the data sources
+    data_sources is a list of (count_fn, getter_fn) tuples
+        count_fn returns the total number of entries in a data source,
+        getter_fn takes in a start and size parameter and returns entries
+    """
+    # Note this is pretty confusing, check TestEmwfPagination for reference
+    options = []
+    total = 0
+    for get_size, get_objects in data_sources:
+        count = get_size(query)
+        total += count
+
+        if start > count:  # skip over this whole data source
+            start -= count
+            continue
+
+        # return a page of objects
+        objects = list(get_objects(query, start, size))
+        start = 0
+        size -= len(objects)  # how many more do we need for this page?
+        options.extend(objects)
+    return total, options
+
+
+class EmwfOptionsController(object):
+
+    def __init__(self, request, domain, search):
+        self.request = request
+        self.domain = domain
+        self.search = search
+
+    @property
+    @memoized
+    def utils(self):
+        return EmwfUtils(self.domain)
+
+    def get_all_static_options(self, query):
+        return [user_type for user_type in self.utils.static_options
+                if query.lower() in user_type[1].lower()]
+
+    def get_static_options_size(self, query):
+        return len(self.get_all_static_options(query))
+
+    def get_static_options(self, query, start, size):
+        return self.get_all_static_options(query)[start:start+size]
+
+    def group_es_query(self, query, group_type="reporting"):
+        if group_type == "reporting":
+            type_filter = groups.is_reporting()
+        elif group_type == "case_sharing":
+            type_filter = groups.is_case_sharing()
+        else:
+            raise TypeError("group_type '{}' not recognized".format(group_type))
+
+        return (GroupES()
+                .domain(self.domain)
+                .filter(type_filter)
+                .not_deleted()
+                .search_string_query(query, default_fields=["name"]))
+
+    def get_groups_size(self, query):
+        return self.group_es_query(query).count()
+
+    def get_groups(self, query, start, size):
+        groups_query = (self.group_es_query(query)
+                        .fields(['_id', 'name'])
+                        .start(start)
+                        .size(size)
+                        .sort("name.exact"))
+        return [self.utils.reporting_group_tuple(g) for g in groups_query.run().hits]
+
+    @staticmethod
+    def _get_location_specific_custom_filters(query):
+        query_sections = query.split("/")
+        # first section would be u'"parent' or u'"parent_name"', so split with " to get
+        # ['', 'parent'] or ['', 'parent_name', '']
+        parent_name_section_splits = query_sections[0].split('"')
+        parent_name = parent_name_section_splits[1]
+        try:
+            search_query = query_sections[1]
+        except IndexError:
+            # when user has entered u'"parent_name"' without trailing "/"
+            # consider it same as u'"parent_name"/'
+            search_query = "" if len(parent_name_section_splits) == 3 else None
+        return parent_name, search_query
+
+    def get_locations_query(self, query):
+        show_inactive = json.loads(self.request.GET.get('show_inactive', 'false'))
+        if show_inactive:
+            included_objects = SQLLocation.inactive_objects
+        else:
+            included_objects = SQLLocation.active_objects
+        if self.search.startswith('"'):
+            parent_name, search_query = self._get_location_specific_custom_filters(query)
+            if search_query is None:
+                # autocomplete parent names while user is looking for just the parent name
+                # and has not yet entered any child location name
+                locations = included_objects.filter(name__istartswith=parent_name, domain=self.domain)
+            else:
+                # if any parent locations with name entered then
+                #    find locations under them
+                # else just return empty queryset
+                parents = included_objects.filter(name__iexact=parent_name, domain=self.domain)
+                if parent_name and parents.count():
+                    descendants = included_objects.get_queryset_descendants(parents, include_self=True)
+                    locations = descendants.filter_by_user_input(self.domain, search_query)
+                else:
+                    return included_objects.none()
+        else:
+            locations = included_objects.filter_path_by_user_input(self.domain, query)
+        return locations.accessible_to_user(self.domain, self.request.couch_user)
+
+    def get_locations_size(self, query):
+        return self.get_locations_query(query).count()
+
+    def get_locations(self, query, start, size):
+        """
+        start: The index of the first item to be returned
+        size: The number of items to return
+        """
+        return list(map(self.utils.location_tuple,
+                        self.get_locations_query(query)[start:start + size]))
+
+    def _get_users(self, query, start, size, include_inactive=False):
+        if include_inactive:
+            user_query = self.all_user_es_query(query)
+        else:
+            user_query = self.active_user_es_query(query)
+        users = (user_query
+                 .fields(SimplifiedUserInfo.ES_FIELDS)
+                 .start(start)
+                 .size(size)
+                 .sort("username.exact"))
+        if not self.request.can_access_all_locations:
+            accessible_location_ids = SQLLocation.active_objects.accessible_location_ids(
+                self.request.domain, self.request.couch_user)
+            users = users.location(accessible_location_ids)
+        return [self.utils.user_tuple(u) for u in users.run().hits]
+
+    def active_user_es_query(self, query):
+        search_fields = ["first_name", "last_name", "base_username"]
+        return (UserES()
+                .domain(self.domain)
+                .search_string_query(query, default_fields=search_fields))
+
+    def all_user_es_query(self, query):
+        return self.active_user_es_query(query).show_inactive()
+
+    def get_all_users_size(self, query):
+        return self.all_user_es_query(query).count()
+
+    def get_active_users_size(self, query):
+        return self.active_user_es_query(query).count()
+
+    def get_all_users(self, query, start, size):
+        return self._get_users(query, start, size, include_inactive=True)
+
+    def get_active_users(self, query, start, size):
+        return self._get_users(query, start, size, include_inactive=False)
+
+    @property
+    def data_sources(self):
+        if self.request.can_access_all_locations:
+            return [
+                (self.get_static_options_size, self.get_static_options),
+                (self.get_groups_size, self.get_groups),
+                (self.get_locations_size, self.get_locations),
+                (self.get_all_users_size, self.get_all_users),
+            ]
+        else:
+            return [
+                (self.get_locations_size, self.get_locations),
+                (self.get_all_users_size, self.get_all_users),
+            ]
+
+    def get_options(self):
+        page = int(self.request.GET.get('page', 1))
+        size = int(self.request.GET.get('page_limit', DEFAULT_PAGE_LIMIT))
+        start = size * (page - 1)
+        count, options = paginate_options(
+            self.data_sources,
+            self.search,
+            start,
+            size
+        )
+        return count, [
+            {'id': entry[0], 'text': entry[1]} if len(entry) == 2 else
+            {'id': entry[0], 'text': entry[1], 'is_active': entry[2]} for entry
+            in options]
+
+
+class MobileWorkersOptionsController(EmwfOptionsController):
+
+    @property
+    @memoized
+    def utils(self):
+        return UsersUtils(self.domain)
+
+    def get_post_options(self):
+        page = int(self.request.POST.get('page', 1))
+        size = int(self.request.POST.get('page_limit', DEFAULT_PAGE_LIMIT))
+        start = size * (page - 1)
+        count, options = paginate_options(
+            self.data_sources,
+            self.search,
+            start,
+            size
+        )
+        return count, [{'id': id_, 'text': text} for id_, text in options]
+
+    @property
+    def data_sources(self):
+        return [
+            (self.get_active_users_size, self.get_active_users),
+        ]
+
+    def active_user_es_query(self, query):
+        query = super(MobileWorkersOptionsController, self).active_user_es_query(query)
+        return query.mobile_users()
+
+
+class CaseListFilterOptionsController(EmwfOptionsController):
+
+    def get_sharing_groups(self, query, start, size):
+        groups = (self.group_es_query(query, group_type="case_sharing")
+                  .fields(['_id', 'name'])
+                  .start(start)
+                  .size(size)
+                  .sort("name.exact"))
+        return list(map(self.utils.sharing_group_tuple, groups.run().hits))
+
+    @property
+    @memoized
+    def utils(self):
+        return CaseListFilterUtils(self.domain)
+
+    @property
+    # Case list shows all users, instead of just active users
+    def data_sources(self):
+        if self.request.can_access_all_locations:
+            return [
+                (self.get_static_options_size, self.get_static_options),
+                (self.get_groups_size, self.get_groups),
+                (self.get_sharing_groups_size, self.get_sharing_groups),
+                (self.get_locations_size, self.get_locations),
+                (self.get_all_users_size, self.get_all_users),
+            ]
+        else:
+            return [
+                (self.get_locations_size, self.get_locations),
+                (self.get_active_users_size, self.get_active_users),
+            ]
+
+    def get_sharing_groups_size(self, query):
+        return self.group_es_query(query, group_type="case_sharing").count()
+
+
+class LocationGroupOptionsController(EmwfOptionsController):
+
+    @property
+    def data_sources(self):
+        return [
+            (self.get_groups_size, self.get_groups),
+            (self.get_locations_size, self.get_locations),
+        ]

--- a/corehq/apps/reports/filters/location.py
+++ b/corehq/apps/reports/filters/location.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from memoized import memoized
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.reports.filters.controllers import (
+    LocationGroupOptionsController,
+)
 from .users import ExpandedMobileWorkerFilter
 from .api import EmwfOptionsView
 from django.urls import reverse
@@ -53,8 +56,6 @@ class LocationGroupFilter(ExpandedMobileWorkerFilter):
 class LocationGroupFilterOptions(EmwfOptionsView):
 
     @property
-    def data_sources(self):
-        return [
-            (self.get_groups_size, self.get_groups),
-            (self.get_locations_size, self.get_locations),
-        ]
+    @memoized
+    def options_controller(self):
+        return LocationGroupOptionsController(self.request, self.domain, self.search)

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -7,26 +7,25 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from elasticsearch import TransportError
 
-from corehq.apps.locations.dbaccessors import (
-    user_ids_at_locations, user_ids_at_locations_and_descendants
-)
-from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.standard.cases.filters import CaseSearchFilter
+from corehq.apps.reports.standard.cases.utils import (
+    query_all_project_data,
+    query_deactivated_data,
+    get_case_owners,
+    query_location_restricted_cases,
+)
 from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import PhoneTime
 from memoized import memoized
 
-from corehq.apps.es import filters, users as user_es, cases as case_es
-from corehq.apps.es.es_query import HQESQuery
-from corehq.apps.locations.dbaccessors import get_users_location_ids
+from corehq.apps.es import cases as case_es
 from corehq.apps.reports.api import ReportDataSource
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.reports.filters.select import SelectOpenCloseFilter
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
-from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.standard import ProjectReportParametersMixin
 from corehq.apps.reports.standard.inspect import ProjectInspectionReport
 from corehq.elastic import ESError
@@ -55,7 +54,6 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
                  .start(self.pagination.start))
         query.es_query['sort'] = self.get_sorting_block()
         mobile_user_and_group_slugs = self.request.GET.getlist(EMWF.slug)
-        user_types = EMWF.selected_user_types(mobile_user_and_group_slugs)
 
         if self.case_filter:
             query = query.filter(self.case_filter)
@@ -68,48 +66,33 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         if self.case_status:
             query = query.is_closed(self.case_status == 'closed')
 
-        if self.request.can_access_all_locations and (EMWF.show_all_data(mobile_user_and_group_slugs) or
-                                                      EMWF.no_filters_selected(mobile_user_and_group_slugs)):
+        if self.request.can_access_all_locations and (
+                EMWF.show_all_data(mobile_user_and_group_slugs)
+                or EMWF.no_filters_selected(mobile_user_and_group_slugs)
+        ):
             pass
-        elif self.request.can_access_all_locations and EMWF.show_project_data(mobile_user_and_group_slugs):
-            # Show everything but stuff we know for sure to exclude
-            ids_to_exclude = self.get_special_owner_ids(
-                admin=HQUserType.ADMIN not in user_types,
-                unknown=HQUserType.UNKNOWN not in user_types,
-                web=HQUserType.WEB not in user_types,
-                demo=HQUserType.DEMO_USER not in user_types,
-                commtrack=False,
+
+        elif (self.request.can_access_all_locations
+              and EMWF.show_project_data(mobile_user_and_group_slugs)):
+            query = query_all_project_data(
+                query, self.domain, mobile_user_and_group_slugs
             )
-            query = query.NOT(case_es.owner(ids_to_exclude))
-        elif self.request.can_access_all_locations and EMWF.show_deactivated_data(mobile_user_and_group_slugs):
-            owner_ids = (user_es.UserES()
-                         .show_only_inactive()
-                         .domain(self.domain)
-                         .get_ids())
-            query = query.OR(case_es.owner(owner_ids))
+
+        elif (self.request.can_access_all_locations
+              and EMWF.show_deactivated_data(mobile_user_and_group_slugs)):
+            query = query_deactivated_data(query, self.domain)
+
         else:  # Only show explicit matches
             query = query.owner(self.case_owners)
 
         if not self.request.can_access_all_locations:
-            query = query.OR(self.scope_filter())
+            query = query_location_restricted_cases(query, self.request)
 
         search_string = CaseSearchFilter.get_value(self.request, self.domain)
         if search_string:
             query = query.set_query({"query_string": {"query": search_string}})
 
         return query
-
-    def scope_filter(self):
-        # Filter to be applied in AND with filters for export to add scope for restricted user
-        # Restricts to cases owned by accessible locations and their respective users Or Cases
-        # Last Modified by accessible users
-        accessible_location_ids = (SQLLocation.active_objects.accessible_location_ids(
-            self.request.domain,
-            self.request.couch_user)
-        )
-        accessible_user_ids = user_ids_at_locations(accessible_location_ids)
-        accessible_ids = accessible_user_ids + list(accessible_location_ids)
-        return case_es.owner(accessible_ids)
 
     @property
     @memoized
@@ -123,29 +106,6 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
                     if original_exception.info.get('status') == 400:
                         raise BadRequestError()
             raise e
-
-    def get_special_owner_ids(self, admin, unknown, web, demo, commtrack):
-        if not any([admin, unknown, web, demo, commtrack]):
-            return []
-
-        user_filters = [filter_ for include, filter_ in [
-            (admin, user_es.admin_users()),
-            (unknown, filters.OR(user_es.unknown_users())),
-            (web, user_es.web_users()),
-            (demo, user_es.demo_users()),
-        ] if include]
-
-        owner_ids = (user_es.UserES()
-                     .domain(self.domain)
-                     .OR(*user_filters)
-                     .get_ids())
-
-        if commtrack:
-            owner_ids.append("commtrack-system")
-        if demo:
-            owner_ids.append("demo_user_group_id")
-            owner_ids.append("demo_user")
-        return owner_ids
 
     @property
     @memoized
@@ -174,72 +134,7 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         # Get user ids for each user that match the demo_user, admin,
         # Unknown Users, or All Mobile Workers filters
         mobile_user_and_group_slugs = self.request.GET.getlist(EMWF.slug)
-        special_owner_ids, selected_sharing_group_ids, selected_reporting_group_users = [], [], []
-        sharing_group_ids, location_owner_ids, assigned_user_ids_at_selected_locations = [], [], []
-        if self.request.can_access_all_locations:
-            user_types = EMWF.selected_user_types(mobile_user_and_group_slugs)
-            special_owner_ids = self.get_special_owner_ids(
-                admin=HQUserType.ADMIN in user_types,
-                unknown=HQUserType.UNKNOWN in user_types,
-                web=HQUserType.WEB in user_types,
-                demo=HQUserType.DEMO_USER in user_types,
-                commtrack=HQUserType.COMMTRACK in user_types,
-            )
-
-            # Get group ids for each group that was specified
-            selected_reporting_group_ids = EMWF.selected_reporting_group_ids(mobile_user_and_group_slugs)
-            selected_sharing_group_ids = EMWF.selected_sharing_group_ids(mobile_user_and_group_slugs)
-
-            # Get user ids for each user in specified reporting groups
-            selected_reporting_group_users = []
-            if selected_reporting_group_ids:
-                report_group_q = (HQESQuery(index="groups").domain(self.domain)
-                                  .doc_type("Group")
-                                  .filter(filters.term("_id", selected_reporting_group_ids))
-                                  .fields(["users"]))
-                user_lists = [group["users"] for group in report_group_q.run().hits]
-                selected_reporting_group_users = list(set().union(*user_lists))
-
-        # Get user ids for each user that was specifically selected
-        selected_user_ids = EMWF.selected_user_ids(mobile_user_and_group_slugs)
-
-        # Show cases owned by any selected locations, user locations, or their children
-        loc_ids = set(EMWF.selected_location_ids(mobile_user_and_group_slugs))
-
-        if loc_ids:
-            # Get users at selected locations and descendants
-            assigned_user_ids_at_selected_locations = user_ids_at_locations_and_descendants(loc_ids)
-            # Get user ids for each user in specified reporting groups
-
-        if selected_user_ids:
-            loc_ids.update(get_users_location_ids(self.domain, selected_user_ids))
-
-        location_owner_ids = []
-        if loc_ids:
-            location_owner_ids = SQLLocation.objects.get_locations_and_children_ids(loc_ids)
-
-        sharing_group_ids = []
-        if selected_reporting_group_users or selected_user_ids:
-            # Get ids for each sharing group that contains a user from selected_reporting_group_users
-            # OR a user that was specifically selected
-            sharing_group_ids = (HQESQuery(index="groups")
-                                 .domain(self.domain)
-                                 .doc_type("Group")
-                                 .term("case_sharing", True)
-                                 .term("users", (selected_reporting_group_users +
-                                                 selected_user_ids))
-                                 .get_ids())
-
-        owner_ids = list(set().union(
-            special_owner_ids,
-            selected_user_ids,
-            selected_sharing_group_ids,
-            selected_reporting_group_users,
-            sharing_group_ids,
-            location_owner_ids,
-            assigned_user_ids_at_selected_locations,
-        ))
-        return owner_ids
+        return get_case_owners(self.request, self.domain, mobile_user_and_group_slugs)
 
     def get_case(self, row):
         if '_source' in row:

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -109,7 +109,7 @@ def get_case_owners(request, domain, mobile_user_and_group_slugs):
                               .doc_type("Group")
                               .filter(
                 filters.term("_id", selected_reporting_group_ids))
-                             .fields(["users"]))
+                              .fields(["users"]))
             user_lists = [group["users"] for group in report_group_q.run().hits]
             selected_reporting_group_users = list(set().union(*user_lists))
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -109,7 +109,7 @@ def get_case_owners(request, domain, mobile_user_and_group_slugs):
                               .doc_type("Group")
                               .filter(
                 filters.term("_id", selected_reporting_group_ids))
-                              .fields(["users"]))
+                             .fields(["users"]))
             user_lists = [group["users"] for group in report_group_q.run().hits]
             selected_reporting_group_users = list(set().union(*user_lists))
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -105,11 +105,12 @@ def get_case_owners(request, domain, mobile_user_and_group_slugs):
         # Get user ids for each user in specified reporting groups
         selected_reporting_group_users = []
         if selected_reporting_group_ids:
-            report_group_q = (HQESQuery(index="groups").domain(domain)
-                              .doc_type("Group")
-                              .filter(
-                filters.term("_id", selected_reporting_group_ids))
-                              .fields(["users"]))
+            report_group_q = (
+                HQESQuery(index="groups").domain(domain).doc_type("Group").filter(
+                    filters.term(
+                        "_id", selected_reporting_group_ids
+                    )).fields(["users"])
+            )
             user_lists = [group["users"] for group in report_group_q.run().hits]
             selected_reporting_group_users = list(set().union(*user_lists))
 

--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -1,0 +1,172 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from corehq.apps.locations.dbaccessors import (
+    user_ids_at_locations,
+    user_ids_at_locations_and_descendants,
+    get_users_location_ids,
+)
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.reports.models import HQUserType
+from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
+from corehq.apps.es import filters, users as user_es, cases as case_es
+from corehq.apps.es.es_query import HQESQuery
+
+
+def _get_special_owner_ids(domain, admin, unknown, web, demo, commtrack):
+    if not any([admin, unknown, web, demo, commtrack]):
+        return []
+
+    user_filters = [filter_ for include, filter_ in [
+        (admin, user_es.admin_users()),
+        (unknown, filters.OR(user_es.unknown_users())),
+        (web, user_es.web_users()),
+        (demo, user_es.demo_users()),
+    ] if include]
+
+    owner_ids = (user_es.UserES()
+                 .domain(domain)
+                 .OR(*user_filters)
+                 .get_ids())
+
+    if commtrack:
+        owner_ids.append("commtrack-system")
+    if demo:
+        owner_ids.append("demo_user_group_id")
+        owner_ids.append("demo_user")
+    return owner_ids
+
+
+def query_all_project_data(query, domain, mobile_user_and_group_slugs):
+    # Show everything but stuff we know for sure to exclude
+    user_types = EMWF.selected_user_types(mobile_user_and_group_slugs)
+    ids_to_exclude = _get_special_owner_ids(
+        domain=domain,
+        admin=HQUserType.ADMIN not in user_types,
+        unknown=HQUserType.UNKNOWN not in user_types,
+        web=HQUserType.WEB not in user_types,
+        demo=HQUserType.DEMO_USER not in user_types,
+        commtrack=False,
+    )
+    return query.NOT(case_es.owner(ids_to_exclude))
+
+
+def query_deactivated_data(query, domain):
+    owner_ids = (user_es.UserES()
+                 .show_only_inactive()
+                 .domain(domain)
+                 .get_ids())
+    return query.OR(case_es.owner(owner_ids))
+
+
+def get_case_owners(request, domain, mobile_user_and_group_slugs):
+    """
+    For unrestricted user
+    :return:
+    user ids for selected user types
+    for selected reporting group ids, returns user_ids belonging to these groups
+        also finds the sharing groups which has any user from the above reporting group
+    selected sharing group ids
+    selected user ids
+        also finds the sharing groups which has any user from the above selected users
+        ids and descendants ids of assigned locations to these users
+    ids and descendants ids of selected locations
+        assigned users at selected locations and their descendants
+
+    For restricted user
+    :return:
+    selected user ids
+        also finds the sharing groups which has any user from the above selected users
+        ids and descendants ids of assigned locations to these users
+    ids and descendants ids of selected locations
+        assigned users at selected locations and their descendants
+    """
+    special_owner_ids, selected_sharing_group_ids, selected_reporting_group_users = [], [], []
+    sharing_group_ids, location_owner_ids, assigned_user_ids_at_selected_locations = [], [], []
+
+    if request.can_access_all_locations:
+        user_types = EMWF.selected_user_types(mobile_user_and_group_slugs)
+
+        special_owner_ids = _get_special_owner_ids(
+            domain=domain,
+            admin=HQUserType.ADMIN in user_types,
+            unknown=HQUserType.UNKNOWN in user_types,
+            web=HQUserType.WEB in user_types,
+            demo=HQUserType.DEMO_USER in user_types,
+            commtrack=HQUserType.COMMTRACK in user_types,
+        )
+
+        # Get group ids for each group that was specified
+        selected_reporting_group_ids = EMWF.selected_reporting_group_ids(
+            mobile_user_and_group_slugs)
+        selected_sharing_group_ids = EMWF.selected_sharing_group_ids(
+            mobile_user_and_group_slugs)
+
+        # Get user ids for each user in specified reporting groups
+        selected_reporting_group_users = []
+        if selected_reporting_group_ids:
+            report_group_q = (HQESQuery(index="groups").domain(domain)
+                              .doc_type("Group")
+                              .filter(
+                filters.term("_id", selected_reporting_group_ids))
+                              .fields(["users"]))
+            user_lists = [group["users"] for group in report_group_q.run().hits]
+            selected_reporting_group_users = list(set().union(*user_lists))
+
+    # Get user ids for each user that was specifically selected
+    selected_user_ids = EMWF.selected_user_ids(mobile_user_and_group_slugs)
+
+    # Show cases owned by any selected locations, user locations, or their children
+    loc_ids = set(EMWF.selected_location_ids(mobile_user_and_group_slugs))
+
+    if loc_ids:
+        # Get users at selected locations and descendants
+        assigned_user_ids_at_selected_locations = user_ids_at_locations_and_descendants(
+            loc_ids)
+        # Get user ids for each user in specified reporting groups
+
+    if selected_user_ids:
+        loc_ids.update(get_users_location_ids(domain, selected_user_ids))
+
+    location_owner_ids = []
+    if loc_ids:
+        location_owner_ids = SQLLocation.objects.get_locations_and_children_ids(
+            loc_ids)
+
+    sharing_group_ids = []
+    if selected_reporting_group_users or selected_user_ids:
+        # Get ids for each sharing group that contains a user from
+        # selected_reporting_group_users OR a user that was specifically selected
+        sharing_group_ids = (HQESQuery(index="groups")
+                             .domain(domain)
+                             .doc_type("Group")
+                             .term("case_sharing", True)
+                             .term("users", (selected_reporting_group_users +
+                                             selected_user_ids))
+                             .get_ids())
+
+    owner_ids = list(set().union(
+        special_owner_ids,
+        selected_user_ids,
+        selected_sharing_group_ids,
+        selected_reporting_group_users,
+        sharing_group_ids,
+        location_owner_ids,
+        assigned_user_ids_at_selected_locations,
+    ))
+    return owner_ids
+
+
+def _get_location_accessible_ids(request):
+    accessible_location_ids = (SQLLocation.active_objects.accessible_location_ids(
+        request.domain,
+        request.couch_user
+    ))
+    accessible_user_ids = user_ids_at_locations(accessible_location_ids)
+    accessible_ids = accessible_user_ids + list(accessible_location_ids)
+    return accessible_ids
+
+
+def query_location_restricted_cases(query, request):
+    accessible_ids = _get_location_accessible_ids(request)
+    return query.OR(case_es.owner(accessible_ids))

--- a/corehq/apps/reports/static/reports/v2/js/context.js
+++ b/corehq/apps/reports/static/reports/v2/js/context.js
@@ -54,5 +54,14 @@ hqDefine('reports/v2/js/context', [
         getColumnFilters: function () {
             return initialPageData.get('report.columnFilters');
         },
+        getReportFilters: function () {
+            var filterData = initialPageData.get('report.reportFilters'),
+                config = reportConfig();
+            filterData = _.map(filterData, function (data) {
+                data.endpoint = config.endpoint[data.endpointSlug];
+                return data;
+            });
+            return filterData;
+        },
     };
 });

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -22,7 +22,7 @@ hqDefine('reports/v2/js/datagrid', [
     'use strict';
 
     var datagridController = function (options) {
-        assertProperties.assert(options, ['dataModel', 'columnEndpoint', 'initialColumns', 'availableFilters']);
+        assertProperties.assert(options, ['dataModel', 'columnEndpoint', 'initialColumns', 'columnFilters', 'reportFilters']);
 
         var self = {};
 
@@ -31,7 +31,7 @@ hqDefine('reports/v2/js/datagrid', [
 
         self.editColumnController = columns.editColumnController({
             endpoint: options.columnEndpoint,
-            availableFilters: options.availableFilters,
+            availableFilters: options.columnFilters,
         });
 
         self.init = function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -9,6 +9,7 @@ hqDefine('reports/v2/js/datagrid', [
     'hqwebapp/js/assert_properties',
     'reports/v2/js/datagrid/data_models',
     'reports/v2/js/datagrid/columns',
+    'reports/v2/js/datagrid/reportFilters',
     'reports/v2/js/datagrid/bindingHandlers',  // for custom ko bindingHandlers
     'hqwebapp/js/knockout_bindings.ko',  // for modal bindings
 ], function (
@@ -17,7 +18,8 @@ hqDefine('reports/v2/js/datagrid', [
     _,
     assertProperties,
     dataModels,
-    columns
+    columns,
+    reportFilters
 ) {
     'use strict';
 
@@ -27,6 +29,13 @@ hqDefine('reports/v2/js/datagrid', [
         var self = {};
 
         self.data = options.dataModel;
+        self.reportFilters = ko.observableArray(_.map(options.reportFilters, function (data) {
+            var newFilter = reportFilters.reportFilter(data);
+            newFilter.value.subscribe(function () {
+                self.data.refresh();
+            });
+            return newFilter;
+        }));
         self.columns = ko.observableArray();
 
         self.editColumnController = columns.editColumnController({
@@ -47,6 +56,9 @@ hqDefine('reports/v2/js/datagrid', [
                     }),
                     columns: _.map(self.columns(), function (column) {
                         return column.context();
+                    }),
+                    reportFilters: _.map(self.reportFilters(), function (reportFilter) {
+                        return reportFilter.context();
                     }),
                 };
             });

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
@@ -5,16 +5,77 @@
 hqDefine('reports/v2/js/datagrid/bindingHandlers', [
     'jquery',
     'knockout',
+    'underscore',
     'hqwebapp/js/atwho',
     'atjs',
     'caretjs',
     'bootstrap-daterangepicker/daterangepicker',
+    "select2/dist/js/select2.full.min",
 ], function (
     $,
     ko,
+    _,
     atwho
 ) {
     'use strict';
+
+    ko.bindingHandlers.select2 = {
+        init: function (element, valueAccessor, allBindings) {
+            var options = ko.utils.unwrapObservable(valueAccessor()),
+                ajax = {};
+
+            if (options.url) {
+                ajax = {
+                    delay: 150,
+                    url: options.url,
+                    dataType: 'json',
+                    type: 'post',
+                    data: function (params) {
+                        var data = {
+                            search: params.term,
+                            page: params.page || 1
+                        };
+                        if (_.isFunction(options.getData)) {
+                            data = options.getData(data);
+                        }
+                        return data;
+                    },
+                    processResults: function (data) {
+                        if (_.isFunction(options.processResults)) {
+                            data = options.processResults(data);
+                        }
+                        return data;
+                    },
+                    error: function () {
+                        if (_.isFunction(options.handleError)) {
+                            options.handleError();
+                        }
+                    },
+                };
+            }
+
+            $(element).select2({
+                minimumInputLength: 0,
+                allowClear: true,
+                multiple: !!options.multiple,
+                placeholder: options.placeholder || gettext("Search..."), // some placeholder required for allowClear
+                width: options.width || '100%',
+                ajax: ajax,
+                templateResult: function (result) {
+                    if (_.isFunction(options.templateResult)) {
+                        return options.templateResult(result);
+                    }
+                    return result.text;
+                },
+                templateSelection: function (selection) {
+                    if (_.isFunction(options.templateSelection)) {
+                        return options.templateSelection(selection);
+                    }
+                    return selection.text;
+                },
+            });
+        },
+    };
 
     ko.bindingHandlers.datagridAutocomplete = {
         init: function (element) {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
@@ -20,7 +20,7 @@ hqDefine('reports/v2/js/datagrid/bindingHandlers', [
     'use strict';
 
     ko.bindingHandlers.select2 = {
-        init: function (element, valueAccessor, allBindings) {
+        init: function (element, valueAccessor) {
             var options = ko.utils.unwrapObservable(valueAccessor()),
                 ajax = {};
 
@@ -33,7 +33,7 @@ hqDefine('reports/v2/js/datagrid/bindingHandlers', [
                     data: function (params) {
                         var data = {
                             search: params.term,
-                            page: params.page || 1
+                            page: params.page || 1,
                         };
                         if (_.isFunction(options.getData)) {
                             data = options.getData(data);

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columnFilters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columnFilters.js
@@ -1,4 +1,4 @@
-hqDefine('reports/v2/js/datagrid/filters', [
+hqDefine('reports/v2/js/datagrid/columnFilters', [
     'jquery',
     'knockout',
 ], function (

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -6,12 +6,12 @@ hqDefine('reports/v2/js/datagrid/columns', [
     'jquery',
     'knockout',
     'underscore',
-    'reports/v2/js/datagrid/filters',
+    'reports/v2/js/datagrid/columnFilters',
 ], function (
     $,
     ko,
     _,
-    filters
+    columnFilters
 ) {
     'use strict';
 
@@ -25,7 +25,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.clause = ko.observable(data.clause || 'all');
 
         self.appliedFilters = ko.observableArray(_.map(data.appliedFilters, function (filterData) {
-            return filters.appliedColumnFilter(filterData);
+            return columnFilters.appliedColumnFilter(filterData);
         }));
 
         self.showClause = ko.computed(function () {
@@ -69,7 +69,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         self.hasFilterUpdate = ko.observable(false);
 
         self.availableFilters = ko.observableArray(_.map(options.availableFilters, function (data) {
-            return filters.columnFilter(data);
+            return columnFilters.columnFilter(data);
         }));
 
         self.availableFilterNames = ko.computed(function () {
@@ -153,7 +153,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         };
 
         self.addFilter = function () {
-            self.column().appliedFilters.push(filters.appliedColumnFilter({
+            self.column().appliedFilters.push(columnFilters.appliedColumnFilter({
                 filterName: self.selectedFilter().name(),
                 choiceName: self.selectedFilter().choices()[0].name(),
             }));

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/reportFilters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/reportFilters.js
@@ -1,0 +1,36 @@
+hqDefine('reports/v2/js/datagrid/reportFilters', [
+    'jquery',
+    'knockout',
+], function (
+    $,
+    ko
+) {
+    'use strict';
+
+    var reportFilter = function (data) {
+        var self = {};
+
+        self.title = ko.observable(data.title);
+        self.name = ko.observable(data.name);
+        self.value = ko.observableArray();
+        self.defaultValue = ko.observable(data.defaultValue);
+        self.placeholder = ko.computed(function () {
+            return gettext("Select") + " " + self.title() + "...";
+        });
+
+        self.endpoint = data.endpoint;
+
+        self.context = ko.computed(function () {
+            return {
+                name: self.name(),
+                value: self.value(),
+            };
+        });
+
+        return self;
+    };
+
+    return {
+        reportFilter: reportFilter,
+    };
+});

--- a/corehq/apps/reports/static/reports/v2/js/views/explore_case_data.js
+++ b/corehq/apps/reports/static/reports/v2/js/views/explore_case_data.js
@@ -20,7 +20,8 @@ hqDefine('reports/v2/js/views/explore_case_data', [
         dataModel: datagrid.dataModels.scrollingDataModel(view.config.endpoint.datagrid),
         initialColumns: context.getColumns(),
         columnEndpoint: view.config.endpoint.case_properties,
-        availableFilters: context.getColumnFilters(),
+        columnFilters: context.getColumnFilters(),
+        reportFilters: context.getReportFilters(),
     });
 
     view.datagridController.init();

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -5,7 +5,7 @@ from mock import patch
 from django.test.client import RequestFactory
 
 from corehq.apps.locations.models import LocationType
-from corehq.apps.reports.filters.api import paginate_options
+from corehq.apps.reports.filters.controllers import paginate_options
 from corehq.apps.reports.filters.case_list import CaseListFilter
 from corehq.apps.reports.filters.forms import FormsByApplicationFilterParams, FormsByApplicationFilter, \
     PARAM_SLUG_STATUS, PARAM_VALUE_STATUS_ACTIVE, PARAM_SLUG_APP_ID, PARAM_SLUG_MODULE

--- a/corehq/apps/reports/v2/endpoints/case_owner.py
+++ b/corehq/apps/reports/v2/endpoints/case_owner.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from corehq.apps.reports.filters.controllers import (
+    CaseListFilterOptionsController,
+)
+from corehq.apps.reports.v2.models import BaseOptionsEndpoint
+
+
+class CaseOwnerEndpoint(BaseOptionsEndpoint):
+    slug = "case_owner"
+
+    @property
+    def search(self):
+        return self.data.get('search', '')
+
+    @property
+    def page(self):
+        return self.data.get('page', 1)
+
+    def get_response(self):
+        options_controller = CaseListFilterOptionsController(
+            self.request, self.domain, self.search
+        )
+        has_more, results = options_controller.get_options(show_more=True)
+        return {
+            'results': results,
+            'pagination': {
+                'more': has_more,
+            }
+        }

--- a/corehq/apps/reports/v2/endpoints/case_properties.py
+++ b/corehq/apps/reports/v2/endpoints/case_properties.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import json
 from memoized import memoized
 
 from corehq.apps.case_search.const import (
@@ -16,11 +15,6 @@ from corehq.apps.reports.v2.models import BaseOptionsEndpoint
 
 class CasePropertiesEndpoint(BaseOptionsEndpoint):
     slug = "case_properties"
-
-    @property
-    @memoized
-    def report_context(self):
-        return json.loads(self.data.get('reportContext', "{}"))
 
     @property
     @memoized

--- a/corehq/apps/reports/v2/endpoints/datagrid.py
+++ b/corehq/apps/reports/v2/endpoints/datagrid.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import json
-
 from corehq.apps.reports.v2.models import BaseDataEndpoint
 
 
@@ -24,10 +22,6 @@ class DatagridEndpoint(BaseDataEndpoint):
     @property
     def order(self):
         return int(self.data.get('order', 1))
-
-    @property
-    def report_context(self):
-        return json.loads(self.data.get('reportContext', "{}"))
 
     def get_response(self, query, formatter):
         total = query.count()

--- a/corehq/apps/reports/v2/exceptions.py
+++ b/corehq/apps/reports/v2/exceptions.py
@@ -12,3 +12,7 @@ class EndpointNotFoundError(Exception):
 
 class ColumnFilterNotFound(Exception):
     pass
+
+
+class ReportFilterNotFound(Exception):
+    pass

--- a/corehq/apps/reports/v2/filters/case_report.py
+++ b/corehq/apps/reports/v2/filters/case_report.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy
+
+from corehq.apps.reports.standard.cases.utils import (
+    query_all_project_data,
+    query_deactivated_data,
+    get_case_owners,
+)
+from corehq.apps.reports.v2.endpoints.case_owner import CaseOwnerEndpoint
+from corehq.apps.reports.v2.models import BaseReportFilter
+from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
+
+
+class Widget(object):
+    SELECT2_MULTIPLE = 'select2_multiple'
+
+
+class CaseOwnerReportFilter(BaseReportFilter):
+    title = ugettext_lazy("Case Owner(s)")
+    name = 'report_case_owner'
+    endpoint_slug = CaseOwnerEndpoint.slug
+    widget = Widget.SELECT2_MULTIPLE
+
+    @classmethod
+    def get_context(cls):
+        return {
+            'title': cls.title,
+            'name': cls.name,
+            'endpointSlug': cls.endpoint_slug,
+            'widget': cls.widget,
+        }
+
+    def get_filtered_query(self, query):
+        if self.request.can_access_all_locations and (
+            EMWF.show_all_data(self.value)
+            or EMWF.no_filters_selected(self.value)
+        ):
+            return query
+
+        if self.request.can_access_all_locations and EMWF.show_project_data(self.value):
+            return query_all_project_data(query, self.domain, self.value)
+
+        if self.request.can_access_all_locations and EMWF.show_deactivated_data(self.value):
+            return query_deactivated_data(query, self.domain)
+
+        # otherwise only return explicit matches
+        case_owners = get_case_owners(self.request, self.domain, self.value)
+        return query.owner(case_owners)
+

--- a/corehq/apps/reports/v2/filters/case_report.py
+++ b/corehq/apps/reports/v2/filters/case_report.py
@@ -48,4 +48,3 @@ class CaseOwnerReportFilter(BaseReportFilter):
         # otherwise only return explicit matches
         case_owners = get_case_owners(self.request, self.domain, self.value)
         return query.owner(case_owners)
-

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -2,9 +2,12 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import six
+import json
 
 from collections import namedtuple
 from abc import ABCMeta, abstractmethod
+
+from memoized import memoized
 
 from corehq.apps.reports.v2.exceptions import EndpointNotFoundError
 
@@ -105,6 +108,11 @@ class BaseEndpoint(object):
     @property
     def data(self):
         return self.request.POST
+
+    @property
+    @memoized
+    def report_context(self):
+        return json.loads(self.data.get('reportContext', "{}"))
 
 
 class BaseOptionsEndpoint(BaseEndpoint):

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -9,8 +9,10 @@ from abc import ABCMeta, abstractmethod
 
 from memoized import memoized
 
-from corehq.apps.reports.v2.exceptions import EndpointNotFoundError
-
+from corehq.apps.reports.v2.exceptions import (
+    EndpointNotFoundError,
+    ReportFilterNotFound,
+)
 
 EndpointContext = namedtuple('EndpointContext', 'slug urlname')
 ColumnMeta = namedtuple('ColumnMeta', 'title name width')
@@ -26,6 +28,7 @@ class BaseReport(object):
     formatters = ()
     columns = []
     column_filters = []
+    report_filters = []
 
     def __init__(self, request, domain):
         """
@@ -53,6 +56,17 @@ class BaseReport(object):
     def get_options_endpoint(self, endpoint_slug):
         return self._get_endpoint(endpoint_slug, self.options_endpoints)
 
+    def get_report_filter(self, context):
+        filter_name = context['name']
+        name_to_class = {f.name: f for f in self.report_filters}
+        try:
+            filter_class = name_to_class[filter_name]
+            return filter_class(self.request, self.domain, context)
+        except (KeyError, NameError):
+            raise ReportFilterNotFound(
+                "Could not find the report filter '{}'".format(filter_name)
+            )
+
     @property
     def context(self):
         endpoints = []
@@ -67,6 +81,7 @@ class BaseReport(object):
             'endpoints': [e._asdict() for e in endpoints],
             'columns': [c._asdict() for c in self.columns],
             'column_filters': [c.get_context() for c in self.column_filters],
+            'report_filters': [r.get_context() for r in self.report_filters],
         }
 
 
@@ -155,3 +170,21 @@ class BaseFilter(six.with_metaclass(ABCMeta)):
         :return: {}
         """
         raise NotImplementedError("please implement get_context")
+
+
+class BaseReportFilter(BaseFilter):
+    name = None
+
+    def __init__(self, request, domain, context):
+        self.request = request
+        self.domain = domain
+        self.value = context['value']
+
+    @abstractmethod
+    def get_filtered_query(self, query):
+        """
+        Returns a filtered query object/
+        :param query:
+        :return: query object
+        """
+        raise NotImplementedError("please implement get_filtered_query")


### PR DESCRIPTION
This adds the Case Owner(s) report filter to the Explore Case Data Report
- note that I had to detangle some of the functionality from existing reports / filters views to make this work. 
- I took the core `select2` paginated data source out of `ExpandedMobileWorkerFilter` and turned it into something a little more reusable in `corehq.apps.reports.filters.controllers`
- I took out the querying logic based on the `ExpandedMobileWorkerFilter` from the `CaseListMixin` `build_query()` method into its own reusable utility functions decoupled from the view mixin in `corehq.apps.reports.standard.cases.utils`

I tested my mini refactor pretty extensively locally. The existing reports using the `Case Owner(s)` filter and derivatives (`Mobile Worker(s)`, etc) were working as expected.

Here's a little gif of this functionality working
![CLE-pt8](https://user-images.githubusercontent.com/716573/57082352-d999ca00-6cf6-11e9-943f-0bdc7ff82879.gif)

@orangejenny I have plans to replace the `atwho` widget for the case property box in the add/edit column popup with the `select2 v4` widget in the next PR. just wanted to keep this PR contained
