### PR TITLE
Update suite contributors to respect build profiles

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -58,10 +58,11 @@ def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=No
     for id, value in id_strings.REGEX_DEFAULT_VALUES.items():
         yield id, value
 
+    ccz_langs = app.build_profiles[build_profile_id].langs if build_profile_id else app.langs
+    langs = [lang] + ccz_langs
     if for_default:
         # include language code names and current language
-        langs = app.build_profiles[build_profile_id].langs if build_profile_id else app.langs
-        for lc in langs:
+        for lc in ccz_langs:
             name = langcodes.get_name(lc) or lc
             if not name:
                 continue

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -39,7 +39,8 @@ def _get_custom_icon_app_locale_and_value(custom_icon_form, custom_icon_text, fo
         return id_strings.module_custom_icon_locale(module, custom_icon_form), custom_icon_text
 
 
-def _create_custom_app_strings(app, lang, for_default=False):
+def _create_custom_app_strings(app, lang, for_default=False, build_profile_id=None):
+    # build_profile_id is relevant only if for_default is true
 
     def trans(d):
         return clean_trans(d, langs)
@@ -51,7 +52,6 @@ def _create_custom_app_strings(app, lang, for_default=False):
                 text = "${0} %s" % (text,) if not (text and text[0].isdigit()) else text
         return text
 
-    langs = [lang] + app.langs
     yield id_strings.homescreen_title(), app.name
     yield id_strings.app_display_name(), app.name
 
@@ -60,7 +60,8 @@ def _create_custom_app_strings(app, lang, for_default=False):
 
     if for_default:
         # include language code names and current language
-        for lc in app.langs:
+        langs = app.build_profiles[build_profile_id].langs if build_profile_id else app.langs
+        for lc in langs:
             name = langcodes.get_name(lc) or lc
             if not name:
                 continue
@@ -112,8 +113,8 @@ def _create_custom_app_strings(app, lang, for_default=False):
             for item in module.name_enum:
                 yield id_strings.module_name_enum_variable(module, item.key_as_variable), trans(item.value)
 
-        icon = module.icon_app_string(lang, for_default=for_default)
-        audio = module.audio_app_string(lang, for_default=for_default)
+        icon = module.icon_app_string(lang, for_default=for_default, build_profile_id=build_profile_id)
+        audio = module.audio_app_string(lang, for_default=for_default, build_profile_id=build_profile_id)
         custom_icon_form, custom_icon_text = module.custom_icon_form_and_text_by_language(lang)
         if icon:
             yield id_strings.module_icon_locale(module), icon
@@ -146,8 +147,10 @@ def _create_custom_app_strings(app, lang, for_default=False):
         if hasattr(module, 'case_list'):
             if module.case_list.show:
                 yield id_strings.case_list_locale(module), trans(module.case_list.label) or "Case List"
-                icon = module.case_list.icon_app_string(lang, for_default=for_default)
-                audio = module.case_list.audio_app_string(lang, for_default=for_default)
+                icon = module.case_list.icon_app_string(lang, for_default=for_default,
+                                                        build_profile_id=build_profile_id)
+                audio = module.case_list.audio_app_string(lang, for_default=for_default,
+                                                          build_profile_id=build_profile_id)
                 if icon:
                     yield id_strings.case_list_icon_locale(module), icon
                 if audio:
@@ -170,8 +173,8 @@ def _create_custom_app_strings(app, lang, for_default=False):
                 for item in form.name_enum:
                     yield id_strings.form_name_enum_variable(form, item.key_as_variable), trans(item.value)
 
-            icon = form.icon_app_string(lang, for_default=for_default)
-            audio = form.audio_app_string(lang, for_default=for_default)
+            icon = form.icon_app_string(lang, for_default=for_default, build_profile_id=build_profile_id)
+            audio = form.audio_app_string(lang, for_default=for_default, build_profile_id=build_profile_id)
             custom_icon_form, custom_icon_text = form.custom_icon_form_and_text_by_language(lang)
             if icon:
                 yield id_strings.form_icon_locale(form), icon
@@ -188,8 +191,10 @@ def _create_custom_app_strings(app, lang, for_default=False):
                 id_strings.case_list_form_locale(module),
                 trans(module.case_list_form.label) or "Create a new Case"
             )
-            icon = module.case_list_form.icon_app_string(lang, for_default=for_default)
-            audio = module.case_list_form.audio_app_string(lang, for_default=for_default)
+            icon = module.case_list_form.icon_app_string(lang, for_default=for_default,
+                                                         build_profile_id=build_profile_id)
+            audio = module.case_list_form.audio_app_string(lang, for_default=for_default,
+                                                           build_profile_id=build_profile_id)
             if icon:
                 yield id_strings.case_list_form_icon_locale(module), icon
             if audio:
@@ -208,19 +213,21 @@ class AppStringsBase(object):
             translations[id] = value
         return translations
 
-    def create_custom_app_strings(self, app, lang, for_default=False):
-        custom = dict(_create_custom_app_strings(app, lang, for_default=for_default))
+    def create_custom_app_strings(self, app, lang, for_default=False, build_profile_id=None):
+        custom = dict(_create_custom_app_strings(app, lang, for_default=for_default,
+                                                 build_profile_id=build_profile_id))
         if not for_default:
             custom = non_empty_only(custom)
         return custom
 
-    def create_app_strings(self, app, lang, for_default=False):
+    def create_app_strings(self, app, lang, for_default=False, build_profile_id=None):
+        # build_profile_id is relevant only if for_default is true
         messages = {}
-        for part in self.app_strings_parts(app, lang, for_default=for_default):
+        for part in self.app_strings_parts(app, lang, for_default=for_default, build_profile_id=build_profile_id):
             messages.update(part)
         return commcare_translations.dumps(messages)
 
-    def app_strings_parts(self, app, lang, for_default=False):
+    def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
         raise NotImplementedError()
 
     def create_default_app_strings(self, app, build_profile_id=None):
@@ -231,7 +238,7 @@ class AppStringsBase(object):
             if lc == "default":
                 continue
             new_messages = commcare_translations.loads(
-                self.create_app_strings(app, lc, for_default=True)
+                self.create_app_strings(app, lc, for_default=True, build_profile_id=build_profile_id)
             )
 
             for key, val in new_messages.items():
@@ -288,18 +295,18 @@ class AppStringsBase(object):
 
 class DumpKnownAppStrings(AppStringsBase):
 
-    def app_strings_parts(self, app, lang, for_default=False):
+    def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
         commcare_version = app.build_version.vstring if app.build_version else None
 
-        yield self.create_custom_app_strings(app, lang, for_default=for_default)
+        yield self.create_custom_app_strings(app, lang, for_default=for_default, build_profile_id=build_profile_id)
         yield self.get_default_translations(lang, commcare_version)
         yield non_empty_only(app.translations.get(lang, {}))
 
 
 class SimpleAppStrings(AppStringsBase):
 
-    def app_strings_parts(self, app, lang, for_default=False):
-        yield self.create_custom_app_strings(app, lang, for_default=for_default)
+    def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
+        yield self.create_custom_app_strings(app, lang, for_default=for_default, build_profile_id=build_profile_id)
         if not for_default:
             yield non_empty_only(app.translations.get(lang, {}))
 
@@ -311,9 +318,10 @@ class SelectKnownAppStrings(AppStringsBase):
             set(t.keys()) for t in app.translations.values()
         ))
 
-    def app_strings_parts(self, app, lang, for_default=False):
+    def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
         yield self.create_custom_app_strings(app, lang,
-                                             for_default=for_default)
+                                             for_default=for_default,
+                                             build_profile_id=build_profile_id)
         commcare_version = app.build_version.vstring if app.build_version else None
         cc_trans = self.get_default_translations(lang, commcare_version)
         yield dict((key, cc_trans[key])

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1430,7 +1430,7 @@ class NavMenuItemMediaMixin(DocumentSchema):
     def get_app(self):
         raise NotImplementedError
 
-    def _get_media_by_language(self, media_attr, lang, strict=False):
+    def _get_media_by_language(self, media_attr, lang, strict=False, build_profile_id=None):
         """
         Return media-path for given language if one exists, else 1st path in the
         sorted lang->media-path list
@@ -1440,7 +1440,9 @@ class NavMenuItemMediaMixin(DocumentSchema):
             lang: language code
         **kwargs:
             strict: whether to return None if media-path is not set for lang or
-            to return first path in sorted lang->media-path list
+                to return first path in sorted lang->media-path list
+            build_profile_id: If this is provided and strict is False, only return
+                media in one of the profile's languages
         """
         assert media_attr in ('media_image', 'media_audio')
         app = self.get_app()
@@ -1458,7 +1460,8 @@ class NavMenuItemMediaMixin(DocumentSchema):
             # if the queried lang key doesn't exist,
             # return the first in the sorted list
             for lang, item in sorted(media_dict.items()):
-                return item
+                if not build_profile_id or lang in app.build_profiles[build_profile_id].langs:
+                    return item
 
     @property
     def default_media_image(self):
@@ -1484,11 +1487,11 @@ class NavMenuItemMediaMixin(DocumentSchema):
             _assert = soft_assert(['jschweers' + '@' + 'dimagi.com'])
             _assert(False, 'Called default_media_image on app with localized media: {}'.format(url))
 
-    def icon_by_language(self, lang, strict=False):
-        return self._get_media_by_language('media_image', lang, strict=strict)
+    def icon_by_language(self, lang, strict=False, build_profile_id=None):
+        return self._get_media_by_language('media_image', lang, strict=strict, build_profile_id=build_profile_id)
 
-    def audio_by_language(self, lang, strict=False):
-        return self._get_media_by_language('media_audio', lang, strict=strict)
+    def audio_by_language(self, lang, strict=False, build_profile_id=None):
+        return self._get_media_by_language('media_audio', lang, strict=strict, build_profile_id=build_profile_id)
 
     def custom_icon_form_and_text_by_language(self, lang):
         custom_icon = self.custom_icon
@@ -1550,7 +1553,7 @@ class NavMenuItemMediaMixin(DocumentSchema):
     def all_audio_paths(self, lang=None):
         return self._all_media_paths('media_audio', lang=lang)
 
-    def icon_app_string(self, lang, for_default=False): # TODO: for_default should take a lang, not a bool
+    def icon_app_string(self, lang, for_default=False, build_profile_id=None):
         """
         Return lang/app_strings.txt translation for given lang
         if a path exists for the lang
@@ -1563,9 +1566,9 @@ class NavMenuItemMediaMixin(DocumentSchema):
             return self.icon_by_language(lang, strict=True)
 
         if for_default:
-            return self.icon_by_language(lang, strict=False)
+            return self.icon_by_language(lang, strict=False, build_profile_id=build_profile_id)
 
-    def audio_app_string(self, lang, for_default=False):    # TODO: for_default should take a lang, not a bool
+    def audio_app_string(self, lang, for_default=False, build_profile_id=None):
         """
             see note on self.icon_app_string
         """
@@ -1574,7 +1577,7 @@ class NavMenuItemMediaMixin(DocumentSchema):
             return self.audio_by_language(lang, strict=True)
 
         if for_default:
-            return self.audio_by_language(lang, strict=False)
+            return self.audio_by_language(lang, strict=False, build_profile_id=build_profile_id)
 
     @property
     def custom_icon(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1534,13 +1534,15 @@ class NavMenuItemMediaMixin(DocumentSchema):
                 valid_media_paths.add(value)
         return valid_media_paths
 
-    def uses_image(self):
+    def uses_image(self, build_profile_id=None):
         app = self.get_app()
-        return bool(self.icon_app_string(app.langs[0], for_default=True))
+        langs = app.build_profiles[build_profile_id].langs if build_profile_id else app.langs
+        return any([self.icon_app_string(lang) for lang in langs])
 
-    def uses_audio(self):
+    def uses_audio(self, build_profile_id=None):
         app = self.get_app()
-        return bool(self.audio_app_string(app.langs[0], for_default=True))
+        langs = app.build_profiles[build_profile_id].langs if build_profile_id else app.langs
+        return any([self.audio_app_string(lang) for lang in langs])
 
     def all_image_paths(self, lang=None):
         return self._all_media_paths('media_image', lang=lang)
@@ -1548,7 +1550,7 @@ class NavMenuItemMediaMixin(DocumentSchema):
     def all_audio_paths(self, lang=None):
         return self._all_media_paths('media_audio', lang=lang)
 
-    def icon_app_string(self, lang, for_default=False):
+    def icon_app_string(self, lang, for_default=False): # TODO: for_default should take a lang, not a bool
         """
         Return lang/app_strings.txt translation for given lang
         if a path exists for the lang
@@ -1563,7 +1565,7 @@ class NavMenuItemMediaMixin(DocumentSchema):
         if for_default:
             return self.icon_by_language(lang, strict=False)
 
-    def audio_app_string(self, lang, for_default=False):
+    def audio_app_string(self, lang, for_default=False):    # TODO: for_default should take a lang, not a bool
         """
             see note on self.icon_app_string
         """
@@ -3556,7 +3558,7 @@ class ReportModule(ModuleBase):
         from corehq.apps.app_manager.suite_xml.features.mobile_ucr import ReportModuleSuiteHelper
         return ReportModuleSuiteHelper(self).get_custom_entries()
 
-    def get_menus(self, supports_module_filter=False):
+    def get_menus(self, supports_module_filter=False, build_profile_id=None):
         from corehq.apps.app_manager.suite_xml.utils import get_module_enum_text, get_module_locale_id
         kwargs = {}
         if supports_module_filter:
@@ -3566,8 +3568,8 @@ class ReportModule(ModuleBase):
             id=id_strings.menu_id(self),
             menu_locale_id=get_module_locale_id(self),
             menu_enum_text=get_module_enum_text(self),
-            media_image=self.uses_image(),
-            media_audio=self.uses_audio(),
+            media_image=self.uses_image(build_profile_id=build_profile_id),
+            media_audio=self.uses_audio(build_profile_id=build_profile_id),
             image_locale_id=id_strings.module_icon_locale(self),
             audio_locale_id=id_strings.module_audio_locale(self),
             **kwargs

--- a/corehq/apps/app_manager/suite_xml/contributors.py
+++ b/corehq/apps/app_manager/suite_xml/contributors.py
@@ -4,12 +4,13 @@ import six
 
 
 class BaseSuiteContributor(six.with_metaclass(ABCMeta, object)):
-    def __init__(self, suite, app, modules):
+    def __init__(self, suite, app, modules, build_profile_id=None):
         from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
         self.suite = suite
         self.app = app
         self.modules = modules
-        self.entries_helper = EntriesHelper(app, modules)
+        self.build_profile_id = build_profile_id
+        self.entries_helper = EntriesHelper(app, modules, build_profile_id=self.build_profile_id)
 
 
 class SectionContributor(six.with_metaclass(ABCMeta, BaseSuiteContributor)):

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -59,8 +59,8 @@ class SuiteGenerator(object):
             ])
 
         # by module
-        entries = EntriesContributor(self.suite, self.app, self.modules)
-        menus = MenuContributor(self.suite, self.app, self.modules)
+        entries = EntriesContributor(self.suite, self.app, self.modules, self.build_profile_id)
+        menus = MenuContributor(self.suite, self.app, self.modules, self.build_profile_id)
         remote_requests = RemoteRequestContributor(self.suite, self.app, self.modules)
 
         if any(module.is_training_module for module in self.modules):

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -50,10 +50,6 @@ from io import open
 class DetailContributor(SectionContributor):
     section_name = 'details'
 
-    def __init__(self, suite, app, modules, build_profile_id=None):
-        super(DetailContributor, self).__init__(suite, app, modules)
-        self.build_profile_id = build_profile_id
-
     def get_section_elements(self):
         def include_sort(detail_type, detail):
             return detail_type.endswith('short') or detail.sort_nodeset_columns_for_detail()
@@ -242,8 +238,8 @@ class DetailContributor(SectionContributor):
             case_list_form = module.case_list_form
             action = LocalizedAction(
                 menu_locale_id=id_strings.case_list_form_locale(module),
-                media_image=case_list_form.uses_image(),
-                media_audio=case_list_form.uses_audio(),
+                media_image=case_list_form.uses_image(build_profile_id=self.build_profile_id),
+                media_audio=case_list_form.uses_audio(build_profile_id=self.build_profile_id),
                 image_locale_id=id_strings.case_list_form_icon_locale(module),
                 audio_locale_id=id_strings.case_list_form_audio_locale(module),
                 stack=Stack(),

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -49,17 +49,17 @@ class FormDatumMeta(namedtuple('FormDatumMeta', 'datum case_type requires_select
 
 
 class EntriesContributor(SuiteContributorByModule):
-
     def get_module_contributions(self, module):
         return self.entries_helper.entry_for_module(module)
 
 
 class EntriesHelper(object):
 
-    def __init__(self, app, modules=None):
+    def __init__(self, app, modules=None, build_profile_id=None):
         from corehq.apps.app_manager.suite_xml.sections.details import DetailsHelper
         self.app = app
         self.modules = modules or list(app.get_modules())
+        self.build_profile_id = build_profile_id
         self.details_helper = DetailsHelper(self.app, self.modules)
 
     def get_datums_meta_for_form_generic(self, form, module=None):
@@ -140,8 +140,8 @@ class EntriesHelper(object):
                     id=id_strings.form_command(form, module),
                     menu_locale_id=get_form_locale_id(form),
                     menu_enum_text=get_form_enum_text(form),
-                    media_image=form.uses_image(),
-                    media_audio=form.uses_audio(),
+                    media_image=form.uses_image(build_profile_id=self.build_profile_id),
+                    media_audio=form.uses_audio(build_profile_id=self.build_profile_id),
                     image_locale_id=id_strings.form_icon_locale(form),
                     audio_locale_id=id_strings.form_audio_locale(form),
                     custom_icon_locale_id=(id_strings.form_custom_icon_locale(form, form_custom_icon.form)
@@ -191,8 +191,8 @@ class EntriesHelper(object):
                 e.command = LocalizedCommand(
                     id=id_strings.case_list_command(module),
                     menu_locale_id=id_strings.case_list_locale(module),
-                    media_image=module.case_list.uses_image(),
-                    media_audio=module.case_list.uses_audio(),
+                    media_image=module.case_list.uses_image(build_profile_id=self.build_profile_id),
+                    media_audio=module.case_list.uses_audio(build_profile_id=self.build_profile_id),
                     image_locale_id=id_strings.case_list_icon_locale(module),
                     audio_locale_id=id_strings.case_list_audio_locale(module),
                 )

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -83,7 +83,8 @@ class MenuContributor(SuiteContributorByModule):
 
         menus = []
         if hasattr(module, 'get_menus'):
-            for menu in module.get_menus(supports_module_filter=supports_module_filter):
+            for menu in module.get_menus(supports_module_filter=supports_module_filter,
+                                         build_profile_id=self.build_profile_id):
                 menus.append(menu)
         else:
             from corehq.apps.app_manager.models import ShadowModule
@@ -123,8 +124,8 @@ class MenuContributor(SuiteContributorByModule):
                         menu_kwargs.update({
                             'menu_locale_id': get_module_locale_id(module),
                             'menu_enum_text': get_module_enum_text(module),
-                            'media_image': module.uses_image(),
-                            'media_audio': module.uses_audio(),
+                            'media_image': module.uses_image(build_profile_id=self.build_profile_id),
+                            'media_audio': module.uses_audio(build_profile_id=self.build_profile_id),
                             'image_locale_id': id_strings.module_icon_locale(module),
                             'audio_locale_id': id_strings.module_audio_locale(module),
                             'custom_icon_locale_id': (

--- a/corehq/apps/app_manager/suite_xml/sections/resources.py
+++ b/corehq/apps/app_manager/suite_xml/sections/resources.py
@@ -14,10 +14,6 @@ from corehq.apps.app_manager.util import languages_mapping
 class FormResourceContributor(SectionContributor):
     section_name = 'xform_resources'
 
-    def __init__(self, suite, app, modules, build_profile_id=None):
-        super(FormResourceContributor, self).__init__(suite, app, modules)
-        self.build_profile_id = build_profile_id
-
     def get_section_elements(self):
         from corehq.apps.app_manager.models import ShadowForm
         for form_stuff in self.app.get_forms(bare=False):
@@ -56,10 +52,6 @@ class FormResourceContributor(SectionContributor):
 class LocaleResourceContributor(SectionContributor):
     section_name = 'locale_resources'
 
-    def __init__(self, suite, app, modules, build_profile_id=None):
-        super(LocaleResourceContributor, self).__init__(suite, app, modules)
-        self.build_profile_id = build_profile_id
-
     def get_section_elements(self):
         langs = self.app.get_build_langs(self.build_profile_id)
         for lang in ["default"] + langs:
@@ -83,10 +75,6 @@ class LocaleResourceContributor(SectionContributor):
 
 class PracticeUserRestoreContributor(SectionContributor):
     section_name = 'practice_user_restore_resources'
-
-    def __init__(self, suite, app, modules, build_profile_id=None):
-        super(PracticeUserRestoreContributor, self).__init__(suite, app, modules)
-        self.build_profile_id = build_profile_id
 
     def get_section_elements(self):
         user = self.app.get_practice_user(self.build_profile_id)

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -521,8 +521,6 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         self.assertIn('modules.m0.icon', locale_ids['en'])
         self.assertIn('modules.m0.audio', locale_ids['en'])
 
-        # TODO: the assertNotIn statements fail because create_default_app_strings calls create_app_strings
-        # with for_default=True instead of passing along the build profile id
         self.assertIn('modules.m0', locale_ids['hin'])
         self.assertNotIn('modules.m0.icon', locale_ids['hin'])
         self.assertNotIn('modules.m0.audio', locale_ids['hin'])

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -474,6 +474,59 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
             "./entry/command[@id='m0-f0']/"
         )
 
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    def test_suite_media_with_app_profile(self, *args):
+        # Test that suite includes only media relevant to the profile
+
+        app = Application.new_app('domain', "my app")
+        module = app.add_module(Module.new_module("Module 1", None))
+        form = app.new_form(0, "Form 1", None)
+        app.build_spec = BuildSpec.from_string('2.21.0/latest')
+        app.build_profiles = OrderedDict({
+            'en': BuildProfile(langs=['en'], name='en-profile'),
+            'hin': BuildProfile(langs=['hin'], name='hin-profile'),
+            'all': BuildProfile(langs=['en', 'hin'], name='all-profile'),
+        })
+        app.langs = ['en', 'hin']
+
+        image_path = 'jr://file/commcare/module0_en.png'
+        audio_path = 'jr://file/commcare/module0_en.mp3'
+        app.get_module(0).set_icon('en', image_path)
+        app.get_module(0).set_audio('en', audio_path)
+
+        # Generate suites and default app strings for each profile
+        suites = {}
+        locale_ids = {}
+        for build_profile_id in app.build_profiles.keys():
+            suites[build_profile_id] = app.create_suite(build_profile_id=build_profile_id)
+            default_app_strings = app.create_app_strings('default', build_profile_id)
+            locale_ids[build_profile_id] = {line.split('=')[0] for line in default_app_strings.splitlines()}
+
+        # Suite should have only the relevant images
+        media_xml = self.makeXML("modules.m0", "modules.m0.icon", "modules.m0.audio")
+        self.assertXmlPartialEqual(media_xml, suites['all'], "././menu[@id='m0']/display")
+
+        no_media_xml = self.XML_without_media("modules.m0")
+        self.assertXmlPartialEqual(media_xml, suites['en'], "././menu[@id='m0']/display")
+
+        no_media_xml = self.XML_without_media("modules.m0")
+        self.assertXmlPartialEqual(no_media_xml, suites['hin'], "././menu[@id='m0']/text")
+
+        # Default app strings should have only the relevant locales
+        self.assertIn('modules.m0', locale_ids['all'])
+        self.assertIn('modules.m0.icon', locale_ids['all'])
+        self.assertIn('modules.m0.audio', locale_ids['all'])
+
+        self.assertIn('modules.m0', locale_ids['en'])
+        self.assertIn('modules.m0.icon', locale_ids['en'])
+        self.assertIn('modules.m0.audio', locale_ids['en'])
+
+        # TODO: the assertNotIn statements fail because create_default_app_strings calls create_app_strings
+        # with for_default=True instead of passing along the build profile id
+        self.assertIn('modules.m0', locale_ids['hin'])
+        self.assertNotIn('modules.m0.icon', locale_ids['hin'])
+        self.assertNotIn('modules.m0.audio', locale_ids['hin'])
+
     def _assert_app_strings_available(self, app, lang):
         et = etree.XML(app.create_suite())
         locale_elems = et.findall(".//locale/[@id]")

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -479,8 +479,8 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
         # Test that suite includes only media relevant to the profile
 
         app = Application.new_app('domain', "my app")
-        module = app.add_module(Module.new_module("Module 1", None))
-        form = app.new_form(0, "Form 1", None)
+        app.add_module(Module.new_module("Module 1", None))
+        app.new_form(0, "Form 1", None)
         app.build_spec = BuildSpec.from_string('2.21.0/latest')
         app.build_profiles = OrderedDict({
             'en': BuildProfile(langs=['en'], name='en-profile'),

--- a/corehq/apps/app_manager/tests/test_translations.py
+++ b/corehq/apps/app_manager/tests/test_translations.py
@@ -4,18 +4,19 @@ from __future__ import unicode_literals
 
 import os
 
+from collections import OrderedDict
 import commcare_translations
 from django.test import TestCase
 from lxml import etree
 
-from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.models import Application, BuildProfile
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import SuiteMixin
 from corehq.apps.translations.app_translations.upload_form import BulkAppTranslationFormUpdater
 
 
 class AppManagerTranslationsTest(TestCase, SuiteMixin):
     root = os.path.dirname(__file__)
-    file_path = ('data', 'suite')
 
     def test_escape_output_value(self):
         test_cases = [
@@ -36,14 +37,73 @@ class AppManagerTranslationsTest(TestCase, SuiteMixin):
             self.assertEqual(expected_output, etree.tostring(escaped_input).decode('utf-8'))
 
     def test_language_names(self):
-        app_json = self.get_json('app')
-        app_json['langs'] = ['en', 'fra', 'hin', 'pol']
-        app_json['domain'] = 'test'
-        app = Application.wrap(app_json)
-        app.create_suite()
-        app_strings = app.create_app_strings('default')
+        factory = AppFactory(build_version='2.40.0')
+        factory.app.langs = ['en', 'fra', 'hin', 'pol']
+        factory.app.create_suite()
+        app_strings = factory.app.create_app_strings('default')
         app_strings_dict = commcare_translations.loads(app_strings)
         self.assertEqual(app_strings_dict['en'], 'English')
         self.assertEqual(app_strings_dict['fra'], 'Français')
         self.assertEqual(app_strings_dict['hin'], 'हिंदी')
         self.assertEqual(app_strings_dict['pol'], 'polski')
+
+    def _generate_app_strings(self, app, lang, build_profile_id=None):
+        content = app.create_app_strings(lang, build_profile_id)
+        return {
+            line[:line.find('=')]: line[line.find('=') + 1:]
+            for line in content.splitlines()
+        }
+
+    def test_app_strings(self):
+        factory = AppFactory(build_version='2.40.0')
+        factory.app.langs = ['en', 'es']
+        module, form = factory.new_basic_module('my_module', 'cases')
+        module.name = {
+            'en': 'Fascination Street',
+            'es': 'Calle de Fascinación',
+        }
+        form.name = {
+            'en': 'Prayers for Rain',
+            'es': 'Oraciones por la Lluvia',
+        }
+
+        en_strings = self._generate_app_strings(factory.app, 'en')
+        self.assertEqual(en_strings['modules.m0'], module.name['en'])
+        self.assertEqual(en_strings['forms.m0f0'], form.name['en'])
+
+        es_strings = self._generate_app_strings(factory.app, 'es')
+        self.assertEqual(es_strings['modules.m0'], module.name['es'])
+        self.assertEqual(es_strings['forms.m0f0'], form.name['es'])
+
+        default_strings = self._generate_app_strings(factory.app, 'default')
+        self.assertEqual(default_strings['modules.m0'], module.name['en'])
+        self.assertEqual(default_strings['forms.m0f0'], form.name['en'])
+
+    def test_default_app_strings_with_build_profiles(self):
+        factory = AppFactory(build_version='2.40.0')
+        factory.app.langs = ['en', 'es']
+        factory.app.build_profiles = OrderedDict({
+            'en': BuildProfile(langs=['en'], name='en-profile'),
+            'es': BuildProfile(langs=['es'], name='es-profile'),
+        })
+        module, form = factory.new_basic_module('my_module', 'cases')
+        module.name = {
+            'en': 'Alive',
+            'es': 'Viva',
+        }
+        form.name = {
+            'en': 'Human',
+            'es': 'Humana',
+        }
+
+        all_default_strings = self._generate_app_strings(factory.app, 'default')
+        self.assertEqual(all_default_strings['modules.m0'], module.name['en'])
+        self.assertEqual(all_default_strings['forms.m0f0'], form.name['en'])
+
+        en_default_strings = self._generate_app_strings(factory.app, 'default', build_profile_id='en')
+        self.assertEqual(en_default_strings['modules.m0'], module.name['en'])
+        self.assertEqual(en_default_strings['forms.m0f0'], form.name['en'])
+
+        es_default_strings = self._generate_app_strings(factory.app, 'default', build_profile_id='es')
+        self.assertEqual(es_default_strings['modules.m0'], module.name['es'])
+        self.assertEqual(es_default_strings['forms.m0f0'], form.name['es'])

--- a/corehq/apps/app_manager/tests/test_translations.py
+++ b/corehq/apps/app_manager/tests/test_translations.py
@@ -9,7 +9,7 @@ import commcare_translations
 from django.test import TestCase
 from lxml import etree
 
-from corehq.apps.app_manager.models import Application, BuildProfile
+from corehq.apps.app_manager.models import BuildProfile
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.app_manager.tests.util import SuiteMixin
 from corehq.apps.translations.app_translations.upload_form import BulkAppTranslationFormUpdater


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-507

Looks like a substantial part of suite generation ignores the build profile id, which is probably fine most of the time, but it can be a problem when a menu's image/audio is present for some languages in the app but not for any of the languages in the build profile. Then the suite references the multimedia, but the app strings files, which do pay attention to the build profile, don't have a translation for it and the app errors at run time.

Opening for review and tests; I'm planning to add more tests and also think some more about how understandable the "for_default" logic is. Open to suggestions.

Feature flag (or privilege? I forget how access to these is controlled): build profiles