### PR TITLE
Use correct parent to get question links

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
@@ -98,7 +98,7 @@
     <span data-bind="css: getDiffClass('type')">
       <i data-bind="attr: { 'class': $root.questionIcon($data), 'title': type }"></i>
       <!-- ko ifnot: $root.readOnly -->
-      <a data-bind="attr: { 'href': $parent.url + hashtagValue }, css: getDiffClass('label'), text: $root.showIds() ? value :  $root.translateQuestion($data)" target="_blank"></a>
+      <a data-bind="attr: { 'href': $parents[$parents.length - 3].url + hashtagValue }, css: getDiffClass('label'), text: $root.showIds() ? value :  $root.translateQuestion($data)" target="_blank"></a>
       <!-- /ko  -->
       <!-- ko if: $root.readOnly -->
       <span data-bind="text: $root.showIds() ? value :  $root.translateQuestion($data), css: getDiffClass('label')"></span>


### PR DESCRIPTION
The links to each question were broken because the wrong parent was being accessed now that the template is recursive. 
Introduced in https://github.com/dimagi/commcare-hq/pull/24190 

FF: app diffs