### PR TITLE
document couch transaction

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/bulk.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/bulk.py
@@ -17,6 +17,16 @@ class BulkFetchException(Exception):
 
 class CouchTransaction(object):
     """
+    Do not use this class. There is no such thing as a transaction in CouchDB.
+    This class can fail during delete, leaving only some rows deleted.
+    This class can fail after delete and before saves, leaving everything deleted.
+    This class can fail during save, leaving some rows saved, some not.
+    This class can fail after save but before post commit actions, leaving your code in an uncertain state.
+    There is no cleanup behavior here other than throwing an exception in any of these.
+    The exception does not give you enough information to recover.
+
+    https://docs.couchdb.org/en/stable/api/database/bulk-api.html?highlight=_bulk_docs#api-db-bulk-docs-semantics
+
     Helper for saving up a bunch of saves and deletes of couch docs
     and then committing them all at once with a few bulk operations
 

--- a/corehq/ex-submodules/dimagi/utils/couch/bulk.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/bulk.py
@@ -117,27 +117,3 @@ def get_docs(db, keys, **query_params):
         raise
     except (HTTPError, JSONDecodeError) as e:
         raise BulkFetchException(e)
-
-
-def wrapped_docs(cls, keys):
-    docs = get_docs(cls.get_db(), keys)
-    for doc in docs:
-        yield cls.wrap(doc)
-
-
-def soft_delete_docs(all_docs, cls, doc_type=None):
-    """
-    Adds the '-Deleted' suffix to all the docs passed in.
-    docs - the docs to soft delete, should be dictionary (json) and not objects
-    cls - the class of the docs
-    doc_type - doc type of the docs, defaults to cls.__name__
-    """
-    doc_type = doc_type or cls.__name__
-    for docs in chunked(all_docs, 50):
-        docs_to_save = []
-        for doc in docs:
-            if doc.get('doc_type', '') != doc_type:
-                continue
-            doc['doc_type'] += DELETED_SUFFIX
-            docs_to_save.append(doc)
-        cls.get_db().bulk_save(docs_to_save)

--- a/docs/couchdb.rst
+++ b/docs/couchdb.rst
@@ -39,7 +39,7 @@ Takeaways:
    (after excluding the ones that haven't changed and don't need to be saved!)
    using ``MyClass.get_db().bulk_save(docs)``.
    If you're writing application code that touches a number of related docs
-   in a number of different places, and you want to bulk save them,
+   in a number of different places, you want to bulk save them, and you understand the warning in its docstring,
    you can use ``dimagi.utils.couch.bulk.CouchTransaction``.
    Note that this isn't good for saving thousands of documents,
    because it doesn't do any chunking.


### PR DESCRIPTION
Luckily this is only used in lookup table uploads. unluckily several users have  had lookup tables that were deleted https://dimagi-dev.atlassian.net/browse/HI-558