### PR TITLE
enable authentication by using api key in place of password

### DIFF
--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -123,3 +123,22 @@ class TestOdataFeedUsingApiKey(TestOdataFeed):
     @classmethod
     def _get_correct_credentials(cls):
         return TestOdataFeedUsingApiKey._get_basic_credentials('test_user', cls.api_key.key)
+
+
+@flag_enabled('TWO_FACTOR_SUPERUSER_ROLLOUT')
+class TestOdataFeedWithTwoFactorUsingApiKey(TestOdataFeedUsingApiKey):
+
+    # Duplicated because flag on inherited method doesn't work when outer flag is used
+    @flag_enabled('ODATA')
+    def test_request_succeeded(self):
+        with trap_extra_setup(ConnectionError):
+            elasticsearch_instance = get_es_new()
+            initialize_index_and_mapping(elasticsearch_instance, CASE_INDEX_INFO)
+        self.addCleanup(self._ensure_case_index_deleted)
+
+        self.web_user.set_role(self.domain.name, 'admin')
+        self.web_user.save()
+
+        correct_credentials = self._get_correct_credentials()
+        response = self._execute_query(correct_credentials)
+        self.assertEqual(response.status_code, 200)

--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -5,6 +5,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from elasticsearch.exceptions import ConnectionError
+from tastypie.models import ApiKey
 
 from corehq.apps.accounting.models import (
     BillingAccount,
@@ -108,3 +109,17 @@ class TestOdataFeed(TestCase, OdataTestMixin):
     @staticmethod
     def _ensure_case_index_deleted():
         ensure_index_deleted(CASE_INDEX_INFO.index)
+
+
+class TestOdataFeedUsingApiKey(TestOdataFeed):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestOdataFeedUsingApiKey, cls).setUpClass()
+        cls.api_key = ApiKey.objects.get_or_create(user=cls.web_user.get_django_user())[0]
+        cls.api_key.key = cls.api_key.generate_key()
+        cls.api_key.save()
+
+    @classmethod
+    def _get_correct_credentials(cls):
+        return TestOdataFeedUsingApiKey._get_basic_credentials('test_user', cls.api_key.key)

--- a/corehq/apps/api/odata/tests/test_metadata.py
+++ b/corehq/apps/api/odata/tests/test_metadata.py
@@ -7,6 +7,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from mock import patch
+from tastypie.models import ApiKey
 
 from corehq.apps.api.odata.tests.utils import OdataTestMixin
 from corehq.apps.app_manager.tests.util import TestXmlMixin
@@ -87,3 +88,17 @@ class TestMetadataDocument(TestCase, OdataTestMixin, TestXmlMixin):
             response.content,
             self.get_xml('populated_metadata_document', override_path=PATH_TO_TEST_DATA)
         )
+
+
+class TestMetadataDocumentUsingApiKey(TestMetadataDocument):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMetadataDocumentUsingApiKey, cls).setUpClass()
+        cls.api_key = ApiKey.objects.get_or_create(user=cls.web_user.get_django_user())[0]
+        cls.api_key.key = cls.api_key.generate_key()
+        cls.api_key.save()
+
+    @classmethod
+    def _get_correct_credentials(cls):
+        return TestMetadataDocumentUsingApiKey._get_basic_credentials('test_user', cls.api_key.key)

--- a/corehq/apps/api/odata/tests/test_metadata.py
+++ b/corehq/apps/api/odata/tests/test_metadata.py
@@ -102,3 +102,36 @@ class TestMetadataDocumentUsingApiKey(TestMetadataDocument):
     @classmethod
     def _get_correct_credentials(cls):
         return TestMetadataDocumentUsingApiKey._get_basic_credentials('test_user', cls.api_key.key)
+
+
+@flag_enabled('TWO_FACTOR_SUPERUSER_ROLLOUT')
+class TestOdataFeedWithTwoFactorUsingApiKey(TestMetadataDocumentUsingApiKey):
+
+    # Duplicated because flag on inherited method doesn't work when outer flag is used
+    @flag_enabled('ODATA')
+    def test_no_case_types(self):
+        correct_credentials = self._get_correct_credentials()
+        with patch('corehq.apps.api.odata.views.get_case_type_to_properties', return_value={}):
+            response = self._execute_query(correct_credentials)
+        self.assertEqual(response.status_code, 200)
+        self.assertXmlEqual(
+            response.content,
+            self.get_xml('empty_metadata_document', override_path=PATH_TO_TEST_DATA)
+        )
+
+    @flag_enabled('ODATA')
+    def test_populated_metadata_document(self):
+        correct_credentials = self._get_correct_credentials()
+        with patch(
+            'corehq.apps.api.odata.views.get_case_type_to_properties',
+            return_value=OrderedDict([
+                ('case_type_with_no_case_properties', []),
+                ('case_type_with_case_properties', ['property_1', 'property_2']),
+            ])
+        ):
+            response = self._execute_query(correct_credentials)
+        self.assertEqual(response.status_code, 200)
+        self.assertXmlEqual(
+            response.content,
+            self.get_xml('populated_metadata_document', override_path=PATH_TO_TEST_DATA)
+        )

--- a/corehq/apps/api/odata/tests/test_service.py
+++ b/corehq/apps/api/odata/tests/test_service.py
@@ -102,3 +102,40 @@ class TestServiceDocumentUsingApiKey(TestServiceDocument):
     @classmethod
     def _get_correct_credentials(cls):
         return TestServiceDocumentUsingApiKey._get_basic_credentials('test_user', cls.api_key.key)
+
+
+@flag_enabled('TWO_FACTOR_SUPERUSER_ROLLOUT')
+class TestServiceDocumentWithTwoFactorUsingApiKey(TestServiceDocumentUsingApiKey):
+
+    # Duplicated because flag on inherited method doesn't work when outer flag is used
+    @flag_enabled('ODATA')
+    def test_no_case_types(self):
+        correct_credentials = self._get_correct_credentials()
+        with patch('corehq.apps.api.odata.views.get_case_types_for_domain_es', return_value=set()):
+            response = self._execute_query(correct_credentials)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            json.loads(response.content.decode('utf-8')),
+            {"@odata.context": "http://localhost:8000/a/test_domain/api/v0.5/odata/Cases/$metadata", "value": []}
+        )
+
+    # Duplicated because flag on inherited method doesn't work when outer flag is used
+    @flag_enabled('ODATA')
+    def test_with_case_types(self):
+        correct_credentials = self._get_correct_credentials()
+        with patch(
+            'corehq.apps.api.odata.views.get_case_types_for_domain_es',
+            return_value=['case_type_1', 'case_type_2'],  # return ordered iterable for deterministic test
+        ):
+            response = self._execute_query(correct_credentials)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            json.loads(response.content.decode('utf-8')),
+            {
+                "@odata.context": "http://localhost:8000/a/test_domain/api/v0.5/odata/Cases/$metadata",
+                "value": [
+                    {'kind': 'EntitySet', 'name': 'case_type_1', 'url': 'case_type_1'},
+                    {'kind': 'EntitySet', 'name': 'case_type_2', 'url': 'case_type_2'},
+                ],
+            }
+        )

--- a/corehq/apps/api/odata/tests/test_service.py
+++ b/corehq/apps/api/odata/tests/test_service.py
@@ -7,6 +7,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from mock import patch
+from tastypie.models import ApiKey
 
 from corehq.apps.api.odata.tests.utils import OdataTestMixin
 from corehq.apps.domain.models import Domain
@@ -87,3 +88,17 @@ class TestServiceDocument(TestCase, OdataTestMixin):
                 ],
             }
         )
+
+
+class TestServiceDocumentUsingApiKey(TestServiceDocument):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestServiceDocumentUsingApiKey, cls).setUpClass()
+        cls.api_key = ApiKey.objects.get_or_create(user=cls.web_user.get_django_user())[0]
+        cls.api_key.key = cls.api_key.generate_key()
+        cls.api_key.save()
+
+    @classmethod
+    def _get_correct_credentials(cls):
+        return TestServiceDocumentUsingApiKey._get_basic_credentials('test_user', cls.api_key.key)

--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -6,14 +6,14 @@ from django.views import View
 
 from corehq import toggles
 from corehq.apps.api.odata.utils import get_case_type_to_properties
-from corehq.apps.domain.decorators import api_auth
+from corehq.apps.domain.decorators import api_auth, basic_auth_or_try_api_key_auth
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
 from corehq.util.view_utils import absolute_reverse
 
 
 class ODataServiceView(View):
 
-    @method_decorator(api_auth)
+    @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(toggles.ODATA.required_decorator())
     def get(self, request, domain):
         data = {
@@ -32,7 +32,7 @@ class ODataServiceView(View):
 
 class ODataMetadataView(View):
 
-    @method_decorator(api_auth)
+    @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(toggles.ODATA.required_decorator())
     def get(self, request, domain):
         # template .items is evaluated as a dict lookup instead of a function, which messes with defaultdict

--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -6,7 +6,7 @@ from django.views import View
 
 from corehq import toggles
 from corehq.apps.api.odata.utils import get_case_type_to_properties
-from corehq.apps.domain.decorators import api_auth, basic_auth_or_try_api_key_auth
+from corehq.apps.domain.decorators import basic_auth_or_try_api_key_auth
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
 from corehq.util.view_utils import absolute_reverse
 

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -7,11 +7,12 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseForbidden
 from tastypie.authentication import Authentication
 
-from corehq.apps.domain.auth import determine_authtype_from_header
+from corehq.apps.domain.auth import determine_authtype_from_header, BASIC
 from corehq.apps.domain.decorators import (
     digest_auth,
     basic_auth,
     api_key_auth,
+    basic_auth_or_try_api_key_auth,
     login_or_digest,
     login_or_basic,
     login_or_api_key)
@@ -103,6 +104,19 @@ class RequirePermissionAuthentication(LoginAndDomainAuthentication):
             api_auth,
         ]
         return self._auth_test(request, wrappers=wrappers, **kwargs)
+
+
+class RequirePermissionAuthenticationForOdata(RequirePermissionAuthentication):
+
+    def __init__(self, *args, **kwargs):
+        super(RequirePermissionAuthenticationForOdata, self).__init__(*args, **kwargs)
+        self.decorator_map = {
+            'basic': basic_auth_or_try_api_key_auth,
+            'api_key': api_key_auth,
+        }
+
+    def _get_auth_decorator(self, request):
+        return self.decorator_map[determine_authtype_from_header(request, default=BASIC)]
 
 
 class DomainAdminAuthentication(LoginAndDomainAuthentication):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -26,7 +26,8 @@ from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.api.odata.serializers import ODataCommCareCaseSerializer
 from corehq.apps.api.odata.views import add_odata_headers
-from corehq.apps.api.resources.auth import RequirePermissionAuthentication, AdminAuthentication
+from corehq.apps.api.resources.auth import RequirePermissionAuthentication, AdminAuthentication, \
+    RequirePermissionAuthenticationForOdata
 from corehq.apps.api.resources.meta import CustomResourceMeta
 from corehq.apps.api.util import get_obj
 from corehq.apps.app_manager.models import Application
@@ -924,6 +925,7 @@ class ODataCommCareCaseResource(v0_4.CommCareCaseResource):
         return add_odata_headers(response)
 
     class Meta(v0_4.CommCareCaseResource.Meta):
+        authentication = RequirePermissionAuthenticationForOdata(Permissions.edit_data)
         resource_name = 'odata/{}'.format(ODATA_CASE_RESOURCE_NAME)
         serializer = ODataCommCareCaseSerializer()
         max_limit = 10000  # This is for experimental purposes only.  TODO: set to a better value soon after testing

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -158,6 +158,7 @@ def basic_or_api_key(realm=''):
                     # try api key auth
                     try:
                         user = User.objects.get(username=username, api_key__key=password)
+                        request.skip_two_factor_check = True
                     except (User.DoesNotExist, User.MultipleObjectsReturned):
                         pass
                 if user is not None and user.is_active:

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -305,7 +305,12 @@ def two_factor_check(view_func, api_key):
         def _inner(request, domain, *args, **kwargs):
             domain_obj = Domain.get_by_name(domain)
             couch_user = _ensure_request_couch_user(request)
-            if not api_key and domain_obj and _two_factor_required(view_func, domain_obj, couch_user):
+            if (
+                not api_key and
+                not getattr(request, 'skip_two_factor_check', False) and
+                domain_obj and
+                _two_factor_required(view_func, domain_obj, couch_user)
+            ):
                 token = request.META.get('HTTP_X_COMMCAREHQ_OTP')
                 if not token and 'otp' in request.GET:
                     with mutable_querydict(request.GET):

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -27,7 +27,7 @@ from corehq.apps.domain.auth import (
     determine_authtype_from_request, basicauth,
     BASIC, DIGEST, API_KEY,
     get_username_and_password_from_request, FORMPLAYER,
-    formplayer_auth, formplayer_as_user_auth)
+    formplayer_auth, formplayer_as_user_auth, basic_or_api_key)
 
 from tastypie.authentication import ApiKeyAuthentication
 from tastypie.http import HttpUnauthorized
@@ -205,6 +205,10 @@ def login_or_basic_ex(allow_cc_users=False, allow_sessions=True):
     return _login_or_challenge(basicauth(), allow_cc_users=allow_cc_users, allow_sessions=allow_sessions)
 
 
+def login_or_basic_or_api_key_ex(allow_cc_users=False, allow_sessions=True):
+    return _login_or_challenge(basic_or_api_key(), allow_cc_users=allow_cc_users, allow_sessions=allow_sessions)
+
+
 def login_or_digest_ex(allow_cc_users=False, allow_sessions=True):
     return _login_or_challenge(httpdigest, allow_cc_users=allow_cc_users, allow_sessions=allow_sessions)
 
@@ -291,6 +295,8 @@ login_or_api_key = login_or_api_key_ex()
 digest_auth = login_or_digest_ex(allow_sessions=False)
 basic_auth = login_or_basic_ex(allow_sessions=False)
 api_key_auth = login_or_api_key_ex(allow_sessions=False)
+
+basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 
 
 def two_factor_check(view_func, api_key):


### PR DESCRIPTION
Product Note: Allows users with two factor authentication to use Tableau/PowerBI Odata feeds by authenticating using their API key instead of their password.

Flag: https://www.commcarehq.org/hq/flags/edit/odata/