### PR TITLE
Fetch all results since the scroll expires in the loop

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -63,7 +63,7 @@ EXPIRE_TIME = 60 * 60 * 24
 def update_calculated_properties():
     results = DomainES().filter(
         get_domains_to_update_es_filter()
-    ).fields(["name", "_id", "cp_last_updated"]).scroll()
+    ).fields(["name", "_id"]).run().hits
 
     all_stats = all_domain_stats()
     for r in results:


### PR DESCRIPTION
@millerdev 
https://sentry.io/organizations/dimagi/issues/421161538/?project=136860
https://dimagi-dev.atlassian.net/browse/HI-581

The scroll expires because of the time it takes to process each loop. This will avoid scrolling by saving all id,name tuples to a list. There would be around 8k items in the list. 