### PR TITLE
Add support for unicode lookup table names in app manager suite

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -190,7 +190,7 @@ def get_all_instances_referenced_in_xpaths(domain, xpaths):
     instances = set()
     unknown_instance_ids = set()
     for xpath in xpaths:
-        instance_names = re.findall(instance_re, xpath)
+        instance_names = re.findall(instance_re, xpath, re.UNICODE)
         for instance_name in instance_names:
             try:
                 scheme, _ = instance_name.split(':', 1)

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1353,3 +1353,15 @@ class InstanceTests(SimpleTestCase, TestXmlMixin, SuiteMixin):
         # HIERARCHICAL_LOCATION_FIXTURE. In such case the domain stays on flat fixture format
         configuration_mock_obj.sync_hierarchical_fixture = False
         self.assertXmlPartialEqual(flat_fixture_format_xml, self.factory.app.create_suite(), "entry/instance")
+
+    def test_unicode_lookup_table_instance(self):
+        self.form.form_filter = "instance('item-list:província')/província/"
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <instance id='item-list:província' src='jr://fixture/item-list:província' />
+            </partial>
+            """,
+            self.factory.app.create_suite(),
+            "entry/instance"
+        )

--- a/corehq/apps/fixtures/tests/test_field_names.py
+++ b/corehq/apps/fixtures/tests/test_field_names.py
@@ -154,9 +154,17 @@ class FieldNameValidationTest(SimpleTestCase):
         bad_name = "0hello"
         self.assertTrue(is_identifier_invalid(bad_name))
 
-    def test_unicode(self):
+    def test_punctuation(self):
         bad_name = "ﾉｲ丂 ﾑ ｲ尺ﾑｱ! \_(ツ)_/¯"
         self.assertTrue(is_identifier_invalid(bad_name))
+
+    def test_alphanumeric_nonascii(self):
+        good_name = "província"
+        self.assertFalse(is_identifier_invalid(good_name))
+
+    def test_alphanumeric_unicode(self):
+        good_name = "田纳西一二三"
+        self.assertFalse(is_identifier_invalid(good_name))
 
     def test_good(self):
         good_name = "fooxmlbar0123"


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-588

We should support unicode(ish) names since https://github.com/dimagi/commcare-hq/pull/12530. 