### PR TITLE
Add blob expiration API

### DIFF
--- a/corehq/blobs/atomic.py
+++ b/corehq/blobs/atomic.py
@@ -46,6 +46,9 @@ class AtomicBlobs(object):
         self.deletes.append(key)
         return None  # result is unknown
 
+    def expire(self, *args, **kw):
+        self.metadb.expire(*args, **kw)
+
     def copy_blob(self, *args, **kw):
         raise NotImplementedError
 

--- a/corehq/blobs/interface.py
+++ b/corehq/blobs/interface.py
@@ -102,6 +102,13 @@ class AbstractBlobDB(six.with_metaclass(ABCMeta, object)):
         """
         raise NotImplementedError
 
+    def expire(self, *args, **kw):
+        """Set blob expiration
+
+        See `metadata.MetaDB.expire` for more details
+        """
+        self.metadb.expire(*args, **kw)
+
     @abstractmethod
     def copy_blob(self, content, key):
         """Copy blob from other blob database

--- a/corehq/blobs/metadata.py
+++ b/corehq/blobs/metadata.py
@@ -120,6 +120,24 @@ class MetaDB(object):
         datadog_counter('commcare.blobs.deleted.count', value=len(metas))
         datadog_counter('commcare.blobs.deleted.bytes', value=deleted_bytes)
 
+    def expire(self, parent_id, key, minutes=60):
+        """Set blob expiration to some minutes from now
+
+        :param parent_id: Parent identifier used for sharding.
+        :param key: Blob key.
+        :param minutes: Optional number of minutes from now that
+        the blob will be set to expire. The default is 60.
+        """
+        try:
+            meta = self.get(parent_id=parent_id, key=key)
+        except BlobMeta.DoesNotExist:
+            return
+        if meta.expires_on is None:
+            datadog_counter('commcare.temp_blobs.count')
+            datadog_counter('commcare.temp_blobs.bytes_added', value=meta.content_length)
+        meta.expires_on = _utcnow() + timedelta(minutes=minutes)
+        meta.save()
+
     def get(self, **kw):
         """Get metadata for a single blob
 

--- a/corehq/blobs/migratingdb.py
+++ b/corehq/blobs/migratingdb.py
@@ -46,5 +46,8 @@ class MigratingBlobDB(object):
         old_result = self.old_db.bulk_delete(*args, **kw)
         return new_result or old_result
 
+    def expire(self, *args, **kw):
+        self.metadb.expire(*args, **kw)
+
     def copy_blob(self, *args, **kw):
         self.new_db.copy_blob(*args, **kw)

--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -1,17 +1,21 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
+
 import os
 from datetime import datetime, timedelta
 from io import BytesIO, open
 from os.path import isdir, join
 from shutil import rmtree
 from tempfile import mkdtemp
+
 from django.test import TestCase
+from mock import patch
 
 import corehq.blobs.fsdb as mod
 from corehq.blobs import CODES
 from corehq.blobs.metadata import MetaDB
-from corehq.blobs.tests.util import new_meta
+from corehq.blobs.tasks import delete_expired_blobs
+from corehq.blobs.tests.util import new_meta, temporary_blob_db
 from corehq.util.test_utils import generate_cases, patch_datadog
 
 
@@ -115,6 +119,31 @@ class _BlobDBTests(object):
         self.db.put(BytesIO(b"bang"), meta=meta)
         with self.db.get(key=meta.key) as fh:
             self.assertEqual(fh.read(), b"bang")
+
+    def test_expire(self):
+        now = datetime.utcnow()
+        meta = self.db.put(
+            BytesIO(b"content"),
+            domain="test",
+            parent_id="test",
+            type_code=CODES.tempfile,
+        )
+        with self.db.get(key=meta.key) as fh:
+            self.assertEqual(fh.read(), b"content")
+        self.db.expire("test", meta.key)
+
+        future_date = now + timedelta(minutes=120)
+        with temporary_blob_db(self.db), \
+                patch('corehq.blobs.tasks._utcnow', return_value=future_date):
+            delete_expired_blobs()
+
+        with self.assertRaises(mod.NotFound):
+            self.db.get(key=meta.key)
+
+    def test_expire_missing_blob(self):
+        self.db.expire("test", "abc")  # should not raise error
+        with self.assertRaises(mod.NotFound):
+            self.db.get(key="abc")
 
 
 @generate_cases([


### PR DESCRIPTION
Make it easy to set an expiration date on a permanent blob. This makes it easy to handle the scenario where a new blob is replacing an existing (now old) blob, and the old blob should be scheduled for deletion at a time in the near future.

@mkangia cc @sravfeyn 