### PR TITLE
Web user reports project access

### DIFF
--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -153,7 +153,7 @@ class EnterpriseWebUserReport(EnterpriseReport):
                     self.format_date(user.last_login),
                 ]
                 + self.domain_properties(domain_obj)
-                + [user.domains_accessed[domain_obj.name] if domain_obj.name in user.domains_accessed else ""])
+                + [user.domains_accessed.get(domain_obj.name, "")])
         return rows
 
     def total_for_domain(self, domain_obj):

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -137,19 +137,23 @@ class EnterpriseWebUserReport(EnterpriseReport):
     @property
     def headers(self):
         headers = super(EnterpriseWebUserReport, self).headers
-        return [_('Name'), _('Email Address'), _('Role'), _('Last Login [UTC]')] + headers
+        return [_('Name'), _('Email Address'), _('Role'), _('Last Login [UTC]')] + headers + \
+               [_("Last Access Date [UTC]")]
 
     def rows_for_domain(self, domain_obj):
         rows = []
         for user in get_all_user_rows(domain_obj.name, include_web_users=True, include_mobile_users=False,
                                       include_inactive=False, include_docs=True):
             user = CouchUser.wrap_correctly(user['doc'])
-            rows.append([
-                user.full_name,
-                user.username,
-                user.role_label(domain_obj.name),
-                self.format_date(user.last_login),
-            ] + self.domain_properties(domain_obj))
+            rows.append(
+                [
+                    user.full_name,
+                    user.username,
+                    user.role_label(domain_obj.name),
+                    self.format_date(user.last_login),
+                ]
+                + self.domain_properties(domain_obj)
+                + [user.domains_accessed[domain_obj.name] if domain_obj.name in user.domains_accessed else ""])
         return rows
 
     def total_for_domain(self, domain_obj):

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -145,6 +145,10 @@ class EnterpriseWebUserReport(EnterpriseReport):
         for user in get_all_user_rows(domain_obj.name, include_web_users=True, include_mobile_users=False,
                                       include_inactive=False, include_docs=True):
             user = CouchUser.wrap_correctly(user['doc'])
+            domain_membership = user.get_domain_membership(domain_obj.name)
+            last_accessed_domain = None
+            if domain_membership:
+                last_accessed_domain = domain_membership.last_accessed
             rows.append(
                 [
                     user.full_name,
@@ -153,7 +157,7 @@ class EnterpriseWebUserReport(EnterpriseReport):
                     self.format_date(user.last_login),
                 ]
                 + self.domain_properties(domain_obj)
-                + [user.get_domain_membership(domain_obj.name).last_accessed])
+                + [last_accessed_domain])
         return rows
 
     def total_for_domain(self, domain_obj):

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -153,7 +153,7 @@ class EnterpriseWebUserReport(EnterpriseReport):
                     self.format_date(user.last_login),
                 ]
                 + self.domain_properties(domain_obj)
-                + [user.domains_accessed.get(domain_obj.name, "")])
+                + [user.get_domain_membership(domain_obj.name).last_accessed])
         return rows
 
     def total_for_domain(self, domain_obj):

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -11,7 +11,7 @@ from dimagi.utils.dates import DateSpan
 
 from couchforms.analytics import get_last_form_submission_received
 from corehq.apps.accounting.exceptions import EnterpriseReportError
-from corehq.apps.accounting.models import BillingAccount, DefaultProductPlan, Subscription
+from corehq.apps.accounting.models import BillingAccount, Subscription
 from corehq.apps.accounting.utils import get_default_domain_url
 from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
 from corehq.apps.domain.models import Domain

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -72,7 +72,7 @@ def update_linked_app_and_notify_task(domain, app_id, user_id, email):
     update_linked_app_and_notify(domain, app_id, user_id, email)
 
 
-@task(queue=settings.CELERY_MAIN_QUEUE)
+@task
 def load_appcues_template_app(domain, username, app_slug):
     from corehq.apps.app_manager.views.apps import load_app_from_slug
     load_app_from_slug(domain, username, app_slug)

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -17,7 +17,8 @@ from corehq.apps.callcenter.utils import (
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.signals import commcare_domain_post_save
-from corehq.apps.users.models import CommCareUser, format_username
+from corehq.apps.users.util import format_username
+from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.bulkupload import create_or_update_users_and_groups
 from django.test import TestCase, SimpleTestCase, override_settings
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -53,6 +53,7 @@ from .exceptions import InactiveTransferDomainException, NameUnavailableExceptio
 
 from corehq.apps.app_manager.const import AMPLIFIES_NO, AMPLIFIES_NOT_SET, AMPLIFIES_YES
 
+from .project_access.models import SuperuserProjectEntryRecord  # noqa
 from functools import reduce
 from six import unichr
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -53,7 +53,6 @@ from .exceptions import InactiveTransferDomainException, NameUnavailableExceptio
 
 from corehq.apps.app_manager.const import AMPLIFIES_NO, AMPLIFIES_NOT_SET, AMPLIFIES_YES
 
-from .project_access.models import SuperuserProjectEntryRecord  # noqa
 from functools import reduce
 from six import unichr
 

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -27,5 +27,5 @@ class ProjectAccessMiddleware(MiddlewareMixin):
     def record_web_user_entry(user, domain):
         membership = user.get_domain_membership(domain)
         yesterday = (datetime.today() - timedelta(hours=24)).date()
-        if membership and (not membership.last_accessed or membership.last_accessed < yesterday):
+        if membership and (not membership.last_accessed or membership.last_accessed <= yesterday):
             update_domain_date.delay(user.user_id, domain)

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -13,7 +13,7 @@ class ProjectAccessMiddleware(MiddlewareMixin):
             return self.record_entry(request.domain, request.couch_user.username)
         if getattr(request, 'couch_user', None) and request.couch_user.is_web_user() \
                 and hasattr(request, 'domain'):
-            update_domain_date(request.couch_user, request.domain)
+            update_domain_date.delay(request.couch_user, request.domain)
 
     @quickcache(['domain', 'username'], timeout=ENTRY_RECORD_FREQUENCY.seconds)
     def record_entry(self, domain, username):

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.utils.deprecation import MiddlewareMixin
 from corehq.apps.domain.project_access.models import SuperuserProjectEntryRecord, ENTRY_RECORD_FREQUENCY
 from corehq.util.quickcache import quickcache
+from corehq.apps.users.tasks import update_domain_date
 
 
 class ProjectAccessMiddleware(MiddlewareMixin):
@@ -12,7 +13,7 @@ class ProjectAccessMiddleware(MiddlewareMixin):
             return self.record_entry(request.domain, request.couch_user.username)
         if getattr(request, 'couch_user', None) and request.couch_user.is_web_user() \
                 and hasattr(request, 'domain'):
-            request.couch_user.update_domain_date(request.domain)
+            update_domain_date(request.couch_user, request.domain)
 
     @quickcache(['domain', 'username'], timeout=ENTRY_RECORD_FREQUENCY.seconds)
     def record_entry(self, domain, username):

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -28,4 +28,4 @@ class ProjectAccessMiddleware(MiddlewareMixin):
         membership = user.get_domain_membership(domain)
         yesterday = (datetime.today() - timedelta(hours=24)).date()
         if membership and (not membership.last_accessed or membership.last_accessed < yesterday):
-            update_domain_date.delay(user, domain)
+            update_domain_date.delay(user.user_id, domain)

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -12,13 +12,13 @@ class ProjectAccessMiddleware(MiddlewareMixin):
     def process_view(self, request, view_func, view_args, view_kwargs):
         if getattr(request, 'couch_user', None) and request.couch_user.is_superuser \
                 and hasattr(request, 'domain'):
-            return self.record_entry(request.domain, request.couch_user.username)
+            self.record_superuser_entry(request.domain, request.couch_user.username)
         if getattr(request, 'couch_user', None) and request.couch_user.is_web_user() \
                 and hasattr(request, 'domain'):
             self.record_web_user_entry(request.couch_user, request.domain)
 
     @quickcache(['domain', 'username'], timeout=ENTRY_RECORD_FREQUENCY.seconds)
-    def record_entry(self, domain, username):
+    def record_superuser_entry(self, domain, username):
         if not SuperuserProjectEntryRecord.entry_recently_recorded(username, domain):
             SuperuserProjectEntryRecord.record_entry(username, domain)
         return None

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -10,6 +10,9 @@ class ProjectAccessMiddleware(MiddlewareMixin):
         if getattr(request, 'couch_user', None) and request.couch_user.is_superuser \
                 and hasattr(request, 'domain'):
             return self.record_entry(request.domain, request.couch_user.username)
+        if getattr(request, 'couch_user', None) and request.couch_user.is_web_user() \
+                and not request.couch_user.is_superuser and hasattr(request, 'domain'):
+            request.couch_user.update_domain_date(request.domain)
 
     @quickcache(['domain', 'username'], timeout=ENTRY_RECORD_FREQUENCY.seconds)
     def record_entry(self, domain, username):

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -25,6 +25,7 @@ class ProjectAccessMiddleware(MiddlewareMixin):
 
     @staticmethod
     def record_web_user_entry(user, domain):
-        yesterday = datetime.today() - timedelta(hours=24)
-        if domain not in user.domains_accessed or user.domains_accessed[domain] < yesterday:
+        membership = user.get_domain_membership(domain)
+        yesterday = (datetime.today() - timedelta(hours=24)).date()
+        if membership and (not membership.last_accessed or membership.last_accessed < yesterday):
             update_domain_date.delay(user, domain)

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -11,7 +11,7 @@ class ProjectAccessMiddleware(MiddlewareMixin):
                 and hasattr(request, 'domain'):
             return self.record_entry(request.domain, request.couch_user.username)
         if getattr(request, 'couch_user', None) and request.couch_user.is_web_user() \
-                and not request.couch_user.is_superuser and hasattr(request, 'domain'):
+                and hasattr(request, 'domain'):
             request.couch_user.update_domain_date(request.domain)
 
     @quickcache(['domain', 'username'], timeout=ENTRY_RECORD_FREQUENCY.seconds)

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -28,3 +28,4 @@ class ProjectAccessMiddleware(MiddlewareMixin):
         membership = user.get_domain_membership(domain)
         yesterday = (datetime.today() - timedelta(hours=24)).date()
         if membership and (not membership.last_accessed or membership.last_accessed <= yesterday):
+            update_domain_date.delay(user.user_id, domain)

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -28,4 +28,3 @@ class ProjectAccessMiddleware(MiddlewareMixin):
         membership = user.get_domain_membership(domain)
         yesterday = (datetime.today() - timedelta(hours=24)).date()
         if membership and (not membership.last_accessed or membership.last_accessed <= yesterday):
-            update_domain_date.delay(user.user_id, domain)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import inspect
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 import logging
 import re
@@ -2340,6 +2340,7 @@ def get_fixture_statuses(user_id):
 class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     program_id = StringProperty()
     last_password_set = DateTimeProperty(default=datetime(year=1900, month=1, day=1))
+    domains_accessed = DictProperty()
 
     fcm_device_token = StringProperty()
     # this property is used to mark users who signed up from internal invitations
@@ -2520,6 +2521,12 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     def get_location(self, domain):
         return self.get_sql_location(domain)
+
+    def update_domain_date(self, domain):
+        yesterday = datetime.today() - timedelta(hours=24)
+        if domain not in self.domains_accessed or self.domains_accessed[domain] < yesterday:
+            self.domains_accessed[domain] = datetime.today()
+            self.save()
 
 
 class FakeUser(WebUser):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -475,6 +475,7 @@ class DomainMembership(Membership):
     location_id = StringProperty()
     assigned_location_ids = StringListProperty()
     program_id = StringProperty()
+    last_accessed = DateProperty()
 
     @property
     def permissions(self):
@@ -2337,7 +2338,6 @@ def get_fixture_statuses(user_id):
 class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     program_id = StringProperty()
     last_password_set = DateTimeProperty(default=datetime(year=1900, month=1, day=1))
-    domains_accessed = DictProperty()
 
     fcm_device_token = StringProperty()
     # this property is used to mark users who signed up from internal invitations

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import inspect
-from datetime import datetime, timedelta
+from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import logging
 import re
@@ -22,7 +21,6 @@ from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.sql_db.routers import db_for_read_write
 from corehq.util.python_compatibility import soft_assert_type_text
-from corehq.util.soft_assert import soft_assert
 from dimagi.ext.couchdbkit import (
     StringProperty,
     IntegerProperty,
@@ -61,7 +59,6 @@ from corehq.apps.users.util import (
     user_display_string,
     user_location_data,
     username_to_user_id,
-    format_username,
     filter_by_app
 )
 from corehq.apps.users.tasks import tag_forms_as_deleted_rebuild_associated_cases, \
@@ -73,7 +70,7 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 from dimagi.utils.dates import force_to_datetime
 from xml.etree import cElementTree as ElementTree
 
-from couchdbkit.exceptions import ResourceConflict, NoResultFound, BadValueError
+from couchdbkit.exceptions import ResourceConflict, BadValueError
 
 from dimagi.utils.web import get_site_domain
 import six

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2338,7 +2338,6 @@ def get_fixture_statuses(user_id):
 class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     program_id = StringProperty()
     last_password_set = DateTimeProperty(default=datetime(year=1900, month=1, day=1))
-    domains_accessed = DictProperty()
 
     fcm_device_token = StringProperty()
     # this property is used to mark users who signed up from internal invitations

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2338,6 +2338,7 @@ def get_fixture_statuses(user_id):
 class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     program_id = StringProperty()
     last_password_set = DateTimeProperty(default=datetime(year=1900, month=1, day=1))
+    domains_accessed = DictProperty()
 
     fcm_device_token = StringProperty()
     # this property is used to mark users who signed up from internal invitations
@@ -2518,6 +2519,12 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     def get_location(self, domain):
         return self.get_sql_location(domain)
+
+    def update_domain_date(self, domain):
+        yesterday = datetime.today() - timedelta(hours=24)
+        if domain not in self.domains_accessed or self.domains_accessed[domain] < yesterday:
+            self.domains_accessed[domain] = datetime.today()
+            self.save()
 
 
 class FakeUser(WebUser):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2522,12 +2522,6 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     def get_location(self, domain):
         return self.get_sql_location(domain)
 
-    def update_domain_date(self, domain):
-        yesterday = datetime.today() - timedelta(hours=24)
-        if domain not in self.domains_accessed or self.domains_accessed[domain] < yesterday:
-            self.domains_accessed[domain] = datetime.today()
-            self.save()
-
 
 class FakeUser(WebUser):
     """

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2520,12 +2520,6 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
     def get_location(self, domain):
         return self.get_sql_location(domain)
 
-    def update_domain_date(self, domain):
-        yesterday = datetime.today() - timedelta(hours=24)
-        if domain not in self.domains_accessed or self.domains_accessed[domain] < yesterday:
-            self.domains_accessed[domain] = datetime.today()
-            self.save()
-
 
 class FakeUser(WebUser):
     """

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -295,5 +295,6 @@ def remove_unused_custom_fields_from_users_task(domain):
 
 @task()
 def update_domain_date(user, domain):
-    user.domains_accessed[domain] = datetime.today()
+    domain_membership = user.get_domain_membership(domain)
+    domain_membership.last_accessed = datetime.today().date()
     user.save()

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import six
 from celery.exceptions import MaxRetriesExceededError
@@ -299,4 +299,3 @@ def update_domain_date(user_id, domain):
     user = WebUser.get_by_user_id(user_id, domain)
     domain_membership = user.get_domain_membership(domain)
     domain_membership.last_accessed = datetime.today().date()
-    user.save()

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import six
 from celery.exceptions import MaxRetriesExceededError
@@ -8,6 +8,7 @@ from celery.schedules import crontab
 from celery.task import task
 from celery.task.base import periodic_task
 from celery.utils.log import get_task_logger
+from django.conf import settings
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -297,4 +297,7 @@ def update_domain_date(user_id, domain):
     from corehq.apps.users.models import WebUser
     user = WebUser.get_by_user_id(user_id, domain)
     domain_membership = user.get_domain_membership(domain)
-    domain_membership.last_accessed = datetime.today().date()
+    if domain_membership:
+        domain_membership.last_accessed = datetime.today().date()
+    else:
+        logger.error("DomainMembership does not exist for user %s in domain %s" % (user.name, domain))

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -8,7 +8,6 @@ from celery.schedules import crontab
 from celery.task import task
 from celery.task.base import periodic_task
 from celery.utils.log import get_task_logger
-from django.conf import settings
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -299,5 +299,6 @@ def update_domain_date(user_id, domain):
     domain_membership = user.get_domain_membership(domain)
     if domain_membership:
         domain_membership.last_accessed = datetime.today().date()
+        user.save()
     else:
         logger.error("DomainMembership does not exist for user %s in domain %s" % (user.name, domain))

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -293,7 +293,9 @@ def remove_unused_custom_fields_from_users_task(domain):
 
 
 @task()
-def update_domain_date(user, domain):
+def update_domain_date(user_id, domain):
+    from corehq.apps.users.models import WebUser
+    user = WebUser.get_by_user_id(user_id, domain)
     domain_membership = user.get_domain_membership(domain)
     domain_membership.last_accessed = datetime.today().date()
     user.save()

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import six
 from celery.exceptions import MaxRetriesExceededError
@@ -293,9 +293,7 @@ def remove_unused_custom_fields_from_users_task(domain):
     remove_unused_custom_fields_from_users(domain)
 
 
-@task(queue=settings.CELERY_MAIN_QUEUE)
+@task()
 def update_domain_date(user, domain):
-    yesterday = datetime.today() - timedelta(hours=24)
-    if domain not in user.domains_accessed or user.domains_accessed[domain] < yesterday:
-        user.domains_accessed[domain] = datetime.today()
-        user.save()
+    user.domains_accessed[domain] = datetime.today()
+    user.save()


### PR DESCRIPTION
Background:
We renewed CRS’s contract, and it’s based on how many web users they have (now we’re charging them for all web users over 1500). Now, they want to deactivate web users that haven’t been active for a while; if a web users hasn't been active on a project space for 6 months, they want to remove that web user’s access to that project space. In the Web Users report on the Enterprise Dashboard, we have a column called “Last login", which is a timestamp for the last time a web user logged into CommCare (so this is too general for their needs)

This PR adds tracking for when a web user accesses a domain, and adds a new column, `Last Access Date [UTC]`, to the ED report.