### PR TITLE
Remove broken/useless fab symlink

### DIFF
--- a/fab
+++ b/fab
@@ -1,1 +1,0 @@
-deployment/commcare-hq-deploy/fab


### PR DESCRIPTION
This caused minor annoyance today as it blocked a `grep -R` from working due to a bad symlink. But more to the point it's broken and pointless