### PR TITLE
Fix soil for new django-celery-results

### DIFF
--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -1,29 +1,31 @@
 from __future__ import absolute_import, division, unicode_literals
-from io import open
+
+import itertools
+import json
 import os
+import re
 import tempfile
+import zipfile
+from io import open
 from wsgiref.util import FileWrapper
+
+from django.conf import settings
+from django.utils.translation import ugettext as _
+
 from celery import states
 from celery.exceptions import Ignore
 from celery.task import task
 from celery.utils.log import get_task_logger
-from django.conf import settings
-import itertools
-import json
-import re
-import zipfile
+
+from soil import DownloadBase
+from soil.progress import update_task_state
+from soil.util import expose_cached_download, expose_file_download
+
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.hqmedia.cache import BulkMultimediaStatusCache
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.util.files import file_extention_from_filename
-from dimagi.utils.logging import notify_exception
-from corehq.util.soft_assert import soft_assert
-from soil import DownloadBase
-from django.utils.translation import ugettext as _
-
-from soil.progress import update_task_state
-from soil.util import expose_file_download, expose_cached_download
 
 logging = get_task_logger(__name__)
 

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -17,7 +17,6 @@ from celery.task import task
 from celery.utils.log import get_task_logger
 
 from soil import DownloadBase
-from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, expose_file_download
 
 from corehq import toggles
@@ -203,7 +202,7 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
 
         if errors:
             os.remove(fpath)
-            raise TaskFailedError(errors=errors)
+            raise Exception('\t' + '\t'.join(errors))
     else:
         DownloadBase.set_progress(build_application_zip, initial_progress + file_progress, 100)
 


### PR DESCRIPTION
introduced in celery upgrade https://github.com/dimagi/commcare-hq/pull/23627/

this is also a related fix https://github.com/dimagi/commcare-hq/pull/24082/files#diff-7faddaabdab973bc0a58f1fa0dff728cR87

django-celery-results forces the resutl for failed tasks into an exception, so we need to throw a real exception instead of ignore. This is also going to affect the case importer and readthedcos needs to be updated as well.

@orangejenny Mostly posting this so it unblocks any testing you have for https://dimagi-dev.atlassian.net/browse/ICDS-507 this is pretty hacky and i need to redo this, though its probably mergeable if its high prio for you.