### PR TITLE
filter configs where domain doesn't exist

### DIFF
--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -101,12 +101,12 @@ def get_docs_in_domain_by_class(domain, doc_class):
 
 
 def get_domain_ids_by_names(names):
-    return [result['id'] for result in Domain.view(
+    return {result['key']: result['id'] for result in Domain.view(
         "domain/domains",
         keys=names,
         reduce=False,
         include_docs=False
-    )]
+    )}
 
 
 def iter_domains():

--- a/corehq/apps/domain/tests/test_dbaccessors.py
+++ b/corehq/apps/domain/tests/test_dbaccessors.py
@@ -147,13 +147,10 @@ class DBAccessorsTest(TestCase):
             return domain._id
 
         names = ['b', 'a', 'c']
-        expected_ids = [_create_domain(name) for name in names]
+        expected_ids = {name: _create_domain(name) for name in names}
 
         ids = get_domain_ids_by_names(names)
         self.assertEqual(ids, expected_ids)
-
-        ids = get_domain_ids_by_names(names[:-1])
-        self.assertEqual(ids, expected_ids[:-1])
 
     def test_count_downloads_for_all_snapshots(self):
         counts = [5, 12, 10]

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -69,11 +69,11 @@ def _filter_by_hash(configs, ucr_division):
 
 def _filter_missing_domains(configs):
     """Return a list of configs whose domain exists on this environment"""
-    domain_names = [config.domain for config in configs]
-    ids_by_name = get_domain_ids_by_names(domain_names)
+    domain_names = [config.domain for config in configs if config.is_static]
+    existing_domains = list(get_domain_ids_by_names(domain_names))
     return [
         config for config in configs
-        if config.domain in ids_by_name
+        if not config.is_static or config.domain in existing_domains
     ]
 
 

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -10,6 +10,7 @@ import six
 
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, KafkaCheckpointEventHandler
 from corehq.apps.change_feed.topics import LOCATION as LOCATION_TOPIC
+from corehq.apps.domain.dbaccessors import get_domain_ids_by_names
 from corehq.apps.userreports.const import KAFKA_TOPICS
 from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvider, StaticDataSourceProvider
 from corehq.apps.userreports.exceptions import (
@@ -66,6 +67,16 @@ def _filter_by_hash(configs, ucr_division):
     return filtered_configs
 
 
+def _filter_missing_domains(configs):
+    """Return a list of configs whose domain exists on this environment"""
+    domain_names = [config.domain for config in configs]
+    ids_by_name = get_domain_ids_by_names(domain_names)
+    return [
+        config for config in configs
+        if config.domain in ids_by_name
+    ]
+
+
 class ConfigurableReportTableManagerMixin(object):
 
     def __init__(self, data_source_providers, ucr_division=None,
@@ -107,6 +118,8 @@ class ConfigurableReportTableManagerMixin(object):
             configs = [config for config in configs if config.table_id in self.include_ucrs]
         elif self.ucr_division:
             configs = _filter_by_hash(configs, self.ucr_division)
+
+        configs = _filter_missing_domains(configs)
 
         return configs
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -24,13 +24,21 @@ from corehq.apps.userreports.pillow import REBUILD_CHECK_INTERVAL, \
     ConfigurableReportPillowProcessor
 from corehq.apps.userreports.tasks import rebuild_indicators, queue_async_indicators
 from corehq.apps.userreports.tests.utils import get_sample_data_source, get_sample_doc_and_indicators, \
-    doc_to_change, get_data_source_with_related_doc_type
+    doc_to_change, get_data_source_with_related_doc_type, skip_domain_filter_patch
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.pillows.case import get_case_pillow
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.test_utils import softer_assert
 from pillow_retry.models import PillowError
+
+
+def setup_module():
+    skip_domain_filter_patch.start()
+
+
+def teardown_module():
+    skip_domain_filter_patch.stop()
 
 
 def _get_pillow(configs, processor_chunk_size=0):

--- a/corehq/apps/userreports/tests/test_rebuild_migrate.py
+++ b/corehq/apps/userreports/tests/test_rebuild_migrate.py
@@ -5,9 +5,17 @@ import mock
 from django.test import TestCase
 from sqlalchemy.engine import reflection
 
-from corehq.apps.userreports.tests.utils import get_sample_data_source
+from corehq.apps.userreports.tests.utils import get_sample_data_source, skip_domain_filter_patch
 from corehq.apps.userreports.util import get_indicator_adapter, get_table_name
 from corehq.pillows.case import get_case_pillow
+
+
+def setup_module():
+    skip_domain_filter_patch.start()
+
+
+def teardown_module():
+    skip_domain_filter_patch.stop()
 
 
 class RebuildTableTest(TestCase):

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -167,3 +167,12 @@ def load_data_from_db(table_name):
                 elif value is None:
                     row[idx] = ''
             yield dict(zip(columns, row))
+
+
+def mock_filter_missing_domains(configs):
+    return configs
+
+
+skip_domain_filter_patch = patch(
+    'corehq.apps.userreports.pillow._filter_missing_domains', mock_filter_missing_domains
+)


### PR DESCRIPTION
This will prevent creating tables for static UCR configs where `config.domain` does not exist on the environment.