### PR TITLE
Datagrid / Explore Case Data: Final Functionality Updates

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -132,10 +132,16 @@ breadcrumbs todo
                        data-bind="textInput: title" />
               </div>
               <div class="form-group">
-                <input type="text"
+                <select type="text"
                        class="form-control"
-                       data-bind="textInput: name,
-                                  datagridAutocomplete: $root.editColumnController.columnNameOptions" />
+                       data-bind="value: name,
+                                  select2: {
+                                      placeholder: 'select property',
+                                      delay: 250,
+                                      getInitialValue: getInitialNameValue,
+                                      url: $root.editColumnController.endpoint.getUrl(),
+                                      getData: $root.editColumnController.getData,
+                                  }" ></select>
               </div>
 
               <div class="form-group"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -21,7 +21,7 @@
 {% block title %}{% trans "Case Search" %}{% endblock %}
 
 {% block page_breadcrumbs %}
-breadcrumbs todo
+  breadcrumbs todo
 {% endblock %}
 
 {% block js %}{{ block.super }}
@@ -63,49 +63,49 @@ breadcrumbs todo
   {% initial_page_data "report.reportFilters" report.report_filters %}
   {% initial_page_data "report.initialReportFilters" report.initial_report_filters %}
 
-<div id="case_search--model">
+  <div id="case_search--model">
 
-  <div id="case_search--filters">
-    <div class="row">
-      <div class="col-md-6">
-        <h1>{% trans "Searching the Case Lists" %}</h1>
-      </div>
+    <div id="case_search--filters">
+      <div class="row">
+        <div class="col-md-6">
+          <h1>{% trans "Searching the Case Lists" %}</h1>
+        </div>
 
-      <div class="col-md-6">
-      </div>
-    </div>
-  </div>
-
-  <div id="report-datagrid">
-
-    <div class="form form-horizontal well"
-         data-bind="foreach: reportFilters">
-      <div class="form-group">
-        <label class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label"
-               data-bind="text: title, attr: { for: 'filter_' + name()}"></label>
-        <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
-          <select type="text"
-                 class="form-control"
-                 data-bind="selectedOptions: value,
-                            select2: {
-                                placeholder: placeholder(),
-                                multiple: true,
-                                url: endpoint.getUrl(),
-                                getInitialValue: getInitialValue,
-                            },
-                            attr: { id: 'filter_' + name() }"></select>
+        <div class="col-md-6">
         </div>
       </div>
     </div>
-    <div class="row">
-      <div data-bind="template: { name: 'datagridLimits', data: data }"
-           class="col-sm-6"></div>
-      <div data-bind="template: { name: 'datagridPages', data: data }"
-           class="col-sm-6"></div>
-    </div>
 
-    <table class="datagrid-headers">
-      <thead>
+    <div id="report-datagrid">
+
+      <div class="form form-horizontal well"
+           data-bind="foreach: reportFilters">
+        <div class="form-group">
+          <label class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label"
+                 data-bind="text: title, attr: { for: 'filter_' + name()}"></label>
+          <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
+            <select type="text"
+                    class="form-control"
+                    data-bind="selectedOptions: value,
+                               select2: {
+                                 placeholder: placeholder(),
+                                 multiple: true,
+                                 url: endpoint.getUrl(),
+                                 getInitialValue: getInitialValue,
+                               },
+                               attr: { id: 'filter_' + name() }"></select>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div data-bind="template: { name: 'datagridLimits', data: data }"
+             class="col-sm-6"></div>
+        <div data-bind="template: { name: 'datagridPages', data: data }"
+             class="col-sm-6"></div>
+      </div>
+
+      <table class="datagrid-headers">
+        <thead>
         <tr>
           <!-- ko foreach: columns -->
           <th data-bind="style: { width: width() + 'px' }">
@@ -125,163 +125,163 @@ breadcrumbs todo
             </button>
           </th>
         </tr>
-      </thead>
-    </table>
-    <table class="datagrid-rows">
-      <tbody data-bind="foreach: { data: data.rows, as: 'row' }">
+        </thead>
+      </table>
+      <table class="datagrid-rows">
+        <tbody data-bind="foreach: { data: data.rows, as: 'row' }">
         <tr>
           <!-- ko foreach: { data: $root.columns, as: 'column' } -->
-            <td data-bind="style: { width: column.width() + 'px' }">
-              <span data-bind="text: row[column.name()]"></span>
-            </td>
+          <td data-bind="style: { width: column.width() + 'px' }">
+            <span data-bind="text: row[column.name()]"></span>
+          </td>
           <!-- /ko -->
           <td></td>
         </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
 
-    <div class="modal fade"
-         data-bind="modal: editColumnController.column"
-         role="dialog">
-      <div data-bind="with: editColumnController.column"
-           class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal">
+      <div class="modal fade"
+           data-bind="modal: editColumnController.column"
+           role="dialog">
+        <div data-bind="with: editColumnController.column"
+             class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal">
                 <span aria-hidden="true">&times;</span>
                 <span class="sr-only">{% trans "Close" %}</span>
-            </button>
-            <h4 class="modal-title" data-bind="visible: $root.editColumnController.isNew">
-              {% trans "Add Column" %}
-            </h4>
-            <h4 class="modal-title" data-bind="visible: !$root.editColumnController.isNew()">
-              {% trans "Edit Column" %}
-            </h4>
-          </div>
-          <div class="modal-body">
-            <div class="form">
-              <div class="form-group">
-                <input type="text"
-                       class="form-control"
-                       placeholder="{% trans_html_attr "Title" %}"
-                       data-bind="textInput: title" />
-              </div>
-              <div class="form-group">
-                <select type="text"
-                       class="form-control"
-                       data-bind="value: name,
-                                  select2: {
-                                      placeholder: 'select property',
-                                      delay: 250,
-                                      getInitialValue: getInitialNameValue,
-                                      url: $root.editColumnController.endpoint.getUrl(),
-                                      getData: $root.editColumnController.getData,
-                                  }" ></select>
-              </div>
+              </button>
+              <h4 class="modal-title" data-bind="visible: $root.editColumnController.isNew">
+                {% trans "Add Column" %}
+              </h4>
+              <h4 class="modal-title" data-bind="visible: !$root.editColumnController.isNew()">
+                {% trans "Edit Column" %}
+              </h4>
+            </div>
+            <div class="modal-body">
+              <div class="form">
+                <div class="form-group">
+                  <input type="text"
+                         class="form-control"
+                         placeholder="{% trans_html_attr "Title" %}"
+                         data-bind="textInput: title" />
+                </div>
+                <div class="form-group">
+                  <select type="text"
+                          class="form-control"
+                          data-bind="value: name,
+                                     select2: {
+                                       placeholder: 'select property',
+                                       delay: 250,
+                                       getInitialValue: getInitialNameValue,
+                                       url: $root.editColumnController.endpoint.getUrl(),
+                                       getData: $root.editColumnController.getData,
+                                     }" ></select>
+                </div>
 
-              <div class="form-group"
-                   data-bind="visible: showClause">
-                {% trans "Match" %}
-                <select data-bind="value: clause,
+                <div class="form-group"
+                     data-bind="visible: showClause">
+                  {% trans "Match" %}
+                  <select data-bind="value: clause,
                                    event: { change: $root.editColumnController.updateFilter }"
-                        class="form-control">
-                  <option value="all">
-                    {% trans "all of the" %}
-                  </option>
-                  <option value="any">
-                    {% trans "any of the" %}
-                  </option>
-                </select>
-                {% trans "following conditions:" %}
+                          class="form-control">
+                    <option value="all">
+                      {% trans "all of the" %}
+                    </option>
+                    <option value="any">
+                      {% trans "any of the" %}
+                    </option>
+                  </select>
+                  {% trans "following conditions:" %}
+                </div>
+
+                <!-- ko foreach: appliedFilters -->
+                <div class="row">
+                  <div class="col-xs-2">
+                    <!-- ko if: $index() == 0 -->
+                    <select class="form-control"
+                            data-bind="options: $root.editColumnController.availableFilterNames,
+                                       optionsText: function (val) {
+                                         return $root.editColumnController.filterTitleByName[val];
+                                       },
+                                       value: filterName,
+                                       event: { change: $root.editColumnController.updateFilterName }"></select>
+                    <!-- /ko -->
+                  </div>
+                  <div class="col-xs-4">
+                    <select class="form-control"
+                            data-bind="options: $root.editColumnController.availableChoiceNames,
+                                       optionsText: function (val) {
+                                         return $root.editColumnController.choiceTitleByName()[val];
+                                       },
+                                       value: choiceName,
+                                       event: { change: $root.editColumnController.updateFilter }"></select>
+                  </div>
+                  <div class="col-xs-4">
+                    <input type="text"
+                           class="form-control"
+                           data-bind="textInput: value,
+                                      visible: $root.editColumnController.isFilterText,
+                                      event: { change: $root.editColumnController.updateFilter }" />
+
+                    <input type="number"
+                           class="form-control"
+                           data-bind="textInput: value,
+                                      visible: $root.editColumnController.isFilterNumeric,
+                                      event: { change: $root.editColumnController.updateFilter }" />
+
+                    <input type="text"
+                           class="form-control"
+                           data-bind="value: value,
+                                      visible: $root.editColumnController.isFilterDate,
+                                      singleDatePicker: $root.editColumnController.isFilterDate,
+                                      event: { change: $root.editColumnController.updateFilter }" />
+                  </div>
+                  <div class="col-xs-2">
+                    <button type="button"
+                            class="btn btn-danger"
+                            data-bind="click: $root.editColumnController.removeFilter">
+                      <i class="fa fa-remove"></i>
+                    </button>
+
+                  </div>
+                </div>
+                <!-- /ko -->
+                <button type="button"
+                        class="btn btn-default"
+                        data-bind="click: $root.editColumnController.addFilter,
+                                   visible: showAddFilter" >
+                  {% trans "Add Filter" %}
+                </button>
               </div>
-
-              <!-- ko foreach: appliedFilters -->
-              <div class="row">
-                <div class="col-xs-2">
-                  <!-- ko if: $index() == 0 -->
-                  <select class="form-control"
-                          data-bind="options: $root.editColumnController.availableFilterNames,
-                                     optionsText: function (val) {
-                                        return $root.editColumnController.filterTitleByName[val];
-                                     },
-                                     value: filterName,
-                                     event: { change: $root.editColumnController.updateFilterName }"></select>
-                  <!-- /ko -->
-                </div>
-                <div class="col-xs-4">
-                  <select class="form-control"
-                          data-bind="options: $root.editColumnController.availableChoiceNames,
-                                     optionsText: function (val) {
-                                        return $root.editColumnController.choiceTitleByName()[val];
-                                     },
-                                     value: choiceName,
-                                     event: { change: $root.editColumnController.updateFilter }"></select>
-                </div>
-                <div class="col-xs-4">
-                  <input type="text"
-                         class="form-control"
-                         data-bind="textInput: value,
-                                    visible: $root.editColumnController.isFilterText,
-                                    event: { change: $root.editColumnController.updateFilter }" />
-
-                  <input type="number"
-                         class="form-control"
-                         data-bind="textInput: value,
-                                    visible: $root.editColumnController.isFilterNumeric,
-                                    event: { change: $root.editColumnController.updateFilter }" />
-
-                  <input type="text"
-                         class="form-control"
-                         data-bind="value: value,
-                                    visible: $root.editColumnController.isFilterDate,
-                                    singleDatePicker: $root.editColumnController.isFilterDate,
-                                    event: { change: $root.editColumnController.updateFilter }" />
-                </div>
-                <div class="col-xs-2">
-                  <button type="button"
-                          class="btn btn-danger"
-                          data-bind="click: $root.editColumnController.removeFilter">
-                    <i class="fa fa-remove"></i>
-                  </button>
-
-                 </div>
-              </div>
-              <!-- /ko -->
+            </div>
+            <div class="modal-footer">
+              <button type="button"
+                      data-bind="visible: !$root.editColumnController.isNew(),
+                                 click: $root.deleteColumn"
+                      class="btn btn-danger pull-left">
+                <i class="fa fa-trash"></i>
+                {% trans "Delete" %}
+              </button>
               <button type="button"
                       class="btn btn-default"
-                      data-bind="click: $root.editColumnController.addFilter,
-                                 visible: showAddFilter" >
-                {% trans "Add Filter" %}
-              </button>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button"
-                    data-bind="visible: !$root.editColumnController.isNew(),
-                               click: $root.deleteColumn"
-                    class="btn btn-danger pull-left">
-              <i class="fa fa-trash"></i>
-              {% trans "Delete" %}
-            </button>
-            <button type="button"
-                    class="btn btn-default"
-                    data-dismiss="modal">{% trans "Cancel" %}</button>
-            <button class="btn btn-primary"
-                    data-bind="click: $root.updateColumn,
-                               disable: $root.editColumnController.isSaveDisabled">
+                      data-dismiss="modal">{% trans "Cancel" %}</button>
+              <button class="btn btn-primary"
+                      data-bind="click: $root.updateColumn,
+                                 disable: $root.editColumnController.isSaveDisabled">
               <span data-bind="visible: $root.editColumnController.isNew">
                 {% trans "Add" %}
               </span>
-              <span data-bind="visible:!$root.editColumnController.isNew()">
+                <span data-bind="visible:!$root.editColumnController.isNew()">
                 {% trans "Update" %}
               </span>
-            </button>
+              </button>
+            </div>
           </div>
         </div>
       </div>
+
     </div>
 
   </div>
-
-</div>
 {% endblock %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -34,6 +34,7 @@ breadcrumbs todo
   {% initial_page_data "report.columns" report.columns %}
   {% initial_page_data "report.columnFilters" report.column_filters %}
   {% initial_page_data "report.reportFilters" report.report_filters %}
+  {% initial_page_data "report.initialReportFilters" report.initial_report_filters %}
 
 <div id="case_search--model">
 
@@ -63,6 +64,7 @@ breadcrumbs todo
                                 placeholder: placeholder(),
                                 multiple: true,
                                 url: endpoint.getUrl(),
+                                getInitialValue: getInitialValue,
                             },
                             attr: { id: 'filter_' + name() }"></select>
         </div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -24,6 +24,33 @@
 breadcrumbs todo
 {% endblock %}
 
+{% block js %}{{ block.super }}
+  <script type="text/html" id="datagridPages">
+    <a href="#" data-bind="click: previousPage, visible: showPrevious">
+      <i class="fa fa-angle-double-left"></i>
+      {% trans "Previous" %}
+    </a>
+    <ul class="datagrid-pages datagrid-number-nav"
+        data-bind="foreach: pages">
+      <li data-bind="css: {'current': isCurrent}">
+        <a href="#" data-bind="text: number, click: $root.data.changePage"></a>
+      </li>
+    </ul>
+    <a href="#" data-bind="click: nextPage, visible: showNext">
+      {% trans "Next" %}
+      <i class="fa fa-angle-double-right"></i>
+    </a>
+  </script>
+
+  <script type="text/html" id="datagridLimits">
+    <ul class="datagrid-limits datagrid-number-nav"
+        data-bind="foreach: limits">
+      <li data-bind="css: {'current': isCurrent}">
+        <a href="#" data-bind="text: number, click: $root.data.changeLimit"></a>
+      </li>
+    </ul>
+  </script>
+{% endblock %}
 
 {% block page_content %}
   {% registerurl "endpoint_options" domain report.slug '---' %}
@@ -69,6 +96,12 @@ breadcrumbs todo
                             attr: { id: 'filter_' + name() }"></select>
         </div>
       </div>
+    </div>
+    <div class="row">
+      <div data-bind="template: { name: 'datagridLimits', data: data }"
+           class="col-sm-6"></div>
+      <div data-bind="template: { name: 'datagridPages', data: data }"
+           class="col-sm-6"></div>
     </div>
 
     <table class="datagrid-headers">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -24,34 +24,6 @@
   breadcrumbs todo
 {% endblock %}
 
-{% block js %}{{ block.super }}
-  <script type="text/html" id="datagridPages">
-    <a href="#" data-bind="click: previousPage, visible: showPrevious">
-      <i class="fa fa-angle-double-left"></i>
-      {% trans "Previous" %}
-    </a>
-    <ul class="datagrid-pages datagrid-number-nav"
-        data-bind="foreach: pages">
-      <li data-bind="css: {'current': isCurrent}">
-        <a href="#" data-bind="text: number, click: $root.data.changePage"></a>
-      </li>
-    </ul>
-    <a href="#" data-bind="click: nextPage, visible: showNext">
-      {% trans "Next" %}
-      <i class="fa fa-angle-double-right"></i>
-    </a>
-  </script>
-
-  <script type="text/html" id="datagridLimits">
-    <ul class="datagrid-limits datagrid-number-nav"
-        data-bind="foreach: limits">
-      <li data-bind="css: {'current': isCurrent}">
-        <a href="#" data-bind="text: number, click: $root.data.changeLimit"></a>
-      </li>
-    </ul>
-  </script>
-{% endblock %}
-
 {% block page_content %}
   {% registerurl "endpoint_options" domain report.slug '---' %}
   {% registerurl "endpoint_data" domain report.slug '---' %}
@@ -97,12 +69,6 @@
           </div>
         </div>
       </div>
-      <div class="row">
-        <div data-bind="template: { name: 'datagridLimits', data: data }"
-             class="col-sm-6"></div>
-        <div data-bind="template: { name: 'datagridPages', data: data }"
-             class="col-sm-6"></div>
-      </div>
 
       <table class="datagrid-headers">
         <thead>
@@ -139,6 +105,14 @@
         </tr>
         </tbody>
       </table>
+
+      <pagination data-apply-bindings="false"
+                  params="goToPage: $root.data.goToPage,
+                          pageSlug: 'p',
+                          limitSlug: 'l',
+                          slug: 'datagrid',
+                          perPage: $root.data.limit,
+                          totalItems: $root.data.totalRecords"></pagination>
 
       <div class="modal fade"
            data-bind="modal: editColumnController.column"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -171,7 +171,7 @@
                           class="form-control"
                           data-bind="value: name,
                                      select2: {
-                                       placeholder: 'select property',
+                                       placeholder: '{% trans_html_attr "Select Property" %}',
                                        delay: 250,
                                        getInitialValue: getInitialNameValue,
                                        url: $root.editColumnController.endpoint.getUrl(),

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -81,9 +81,9 @@
       <div class="form form-horizontal well"
            data-bind="foreach: reportFilters">
         <div class="form-group">
-          <label class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label"
+          <label class="{% css_label_class %} control-label"
                  data-bind="text: title, attr: { for: 'filter_' + name()}"></label>
-          <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6">
+          <div class="{% css_field_class %}">
             <select type="text"
                     class="form-control"
                     data-bind="selectedOptions: value,

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -30,7 +30,17 @@ hqDefine('hqwebapp/js/components/pagination', [
         viewModel: function (params) {
             var self = {};
 
-            self.currentPage = ko.observable(params.currentPage || 1);
+            // load initial values based on GET parameters
+            self.initialValues = {};
+            self._url = new URL(window.location.href);
+            if (params.pageSlug) {
+                self.initialValues.page = parseInt(self._url.searchParams.get(params.pageSlug));
+            }
+            if (params.limitSlug) {
+                self.initialValues.limit = parseInt(self._url.searchParams.get(params.limitSlug));
+            }
+
+            self.currentPage = ko.observable(self.initialValues.page || self.currentPage || 1);
 
             self.totalItems = params.totalItems;
             self.totalItems.subscribe(function (newValue) {
@@ -42,7 +52,7 @@ hqDefine('hqwebapp/js/components/pagination', [
             self.perPage = ko.isObservable(params.perPage) ? params.perPage : ko.observable(params.perPage);
             if (!self.inlinePageListOnly) {
                 self.perPageCookieName = 'ko-pagination-' + self.slug;
-                self.perPage($.cookie(self.perPageCookieName) || self.perPage());
+                self.perPage(self.initialValues.limit || $.cookie(self.perPageCookieName) || self.perPage());
                 self.perPage.subscribe(function (newValue) {
                     self.goToPage(1);
                     if (self.slug) {
@@ -69,7 +79,9 @@ hqDefine('hqwebapp/js/components/pagination', [
                 self.goToPage(Math.max(self.currentPage() - 1, 1), e);
             };
             self.goToPage = function (page, e) {
-                self.currentPage(page);
+                // make sure that the first goToPage that's called does not override the initialValues from GET
+                self.currentPage(self.initialValues.page || page);
+                self.initialValues.page = undefined;
                 params.goToPage(self.currentPage());
                 if (e) {
                     e.stopPropagation();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/requirejs_config.js
@@ -12,8 +12,6 @@ requirejs.config({
         "datatables.bootstrap": "datatables-bootstrap3/BS3/assets/js/datatables",
         "datatables.scroller": "datatables-scroller/js/dataTables.scroller",
         "datatables.colReorder": "datatables-colreorder/js/dataTables.colReorder",
-        "atjs": "At.js/dist/js/jquery.atwho.min",
-        "caretjs": "Caret.js/dist/jquery.caret.min",
     },
     shim: {
         "ace-builds/src-min-noconflict/ace": { exports: "ace" },

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datagrid.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datagrid.less
@@ -12,4 +12,20 @@ for the new reporting grids (tables).
 
 }
 
+.datagrid-number-nav {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+
+  li {
+    padding: 0;
+    margin: 0;
+    display: inline-block;
+
+    &.current {
+      font-weight: bold;
+    }
+  }
+}
 

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -205,6 +205,14 @@ class EmwfOptionsController(object):
         return int(self.request.GET.get('page_limit', DEFAULT_PAGE_LIMIT))
 
     def get_options(self, show_more=False):
+        """
+        If `show_more` = True, then the result returns a tuple where the first
+        value is a boolean of whether more additional pages are still available
+        (used by Select 2 V4). Otherwise the first value in the tuple returned
+        is the total.
+        :param show_more: (optional)
+        :return: (int) count or (bool) has_more, (list) results
+        """
         start = self.size * (self.page - 1)
         count, options = paginate_options(
             self.data_sources,

--- a/corehq/apps/reports/static/reports/v2/js/context.js
+++ b/corehq/apps/reports/static/reports/v2/js/context.js
@@ -56,8 +56,10 @@ hqDefine('reports/v2/js/context', [
         },
         getReportFilters: function () {
             var filterData = initialPageData.get('report.reportFilters'),
+                initialData = initialPageData.get('report.initialReportFilters'),
                 config = reportConfig();
             filterData = _.map(filterData, function (data) {
+                data.value = initialData[data.name];
                 data.endpoint = config.endpoint[data.endpointSlug];
                 return data;
             });

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -24,7 +24,13 @@ hqDefine('reports/v2/js/datagrid', [
     'use strict';
 
     var datagridController = function (options) {
-        assertProperties.assert(options, ['dataModel', 'columnEndpoint', 'initialColumns', 'columnFilters', 'reportFilters']);
+        assertProperties.assert(options, [
+            'dataModel',
+            'columnEndpoint',
+            'initialColumns',
+            'columnFilters',
+            'reportFilters',
+        ]);
 
         var self = {};
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid.js
@@ -9,8 +9,8 @@ hqDefine('reports/v2/js/datagrid', [
     'hqwebapp/js/assert_properties',
     'reports/v2/js/datagrid/data_models',
     'reports/v2/js/datagrid/columns',
-    'reports/v2/js/datagrid/reportFilters',
-    'reports/v2/js/datagrid/bindingHandlers',  // for custom ko bindingHandlers
+    'reports/v2/js/datagrid/report_filters',
+    'reports/v2/js/datagrid/binding_handlers',  // for custom ko bindingHandlers
     'hqwebapp/js/knockout_bindings.ko',  // for modal bindings
 ], function (
     $,

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/bindingHandlers.js
@@ -6,27 +6,28 @@ hqDefine('reports/v2/js/datagrid/bindingHandlers', [
     'jquery',
     'knockout',
     'underscore',
-    'hqwebapp/js/atwho',
-    'atjs',
-    'caretjs',
     'bootstrap-daterangepicker/daterangepicker',
     "select2/dist/js/select2.full.min",
 ], function (
     $,
     ko,
-    _,
-    atwho
+    _
 ) {
     'use strict';
 
     ko.bindingHandlers.select2 = {
         init: function (element, valueAccessor) {
-            var options = ko.utils.unwrapObservable(valueAccessor()),
+            var $select = $(element),
+                options = ko.utils.unwrapObservable(valueAccessor()),
                 ajax = {};
+
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                $select.select2('destroy');
+            });
 
             if (options.url) {
                 ajax = {
-                    delay: 150,
+                    delay: options.delay || 150,
                     url: options.url,
                     dataType: 'json',
                     type: 'post',
@@ -54,16 +55,23 @@ hqDefine('reports/v2/js/datagrid/bindingHandlers', [
                 };
             }
 
-            $(element).select2({
+            $select.select2({
                 minimumInputLength: 0,
                 allowClear: true,
                 multiple: !!options.multiple,
                 placeholder: options.placeholder || gettext("Search..."), // some placeholder required for allowClear
                 width: options.width || '100%',
+                data: options.data,
                 ajax: ajax,
                 templateResult: function (result) {
                     if (_.isFunction(options.templateResult)) {
                         return options.templateResult(result);
+                    }
+                    if (result.labelText) {
+                        var $label = $('<span class="label pull-right"></span>')
+                                     .addClass(result.labelStyle)
+                                     .text(result.labelText);
+                        return $('<span>' + result.text + '</span>').append($label);
                     }
                     return result.text;
                 },
@@ -74,41 +82,21 @@ hqDefine('reports/v2/js/datagrid/bindingHandlers', [
                     return selection.text;
                 },
             });
-        },
-    };
 
-    ko.bindingHandlers.datagridAutocomplete = {
-        init: function (element) {
-            var $element = $(element);
-            if (!$element.atwho) {
-                throw new Error("The typeahead binding requires Atwho.js and Caret.js");
+            if (_.isFunction(options.getInitialValue) && (_.isObject(options.getInitialValue()) || _.isArray(options.getInitialValue()))) {
+                // https://select2.org/programmatic-control/add-select-clear-items#preselecting-options-in-an-remotely-sourced-ajax-select2
+                var initialValue = options.getInitialValue();
+                if (!_.isArray(options.getInitialValue())) {
+                    initialValue = [initialValue];
+                }
+                _.each(initialValue, function (valObj) {
+                    var option = new Option(valObj.text, valObj.id, true, true);
+                    $select.append(option);
+                });
+                $select.trigger('change');
+                $select.trigger({type: 'select2:select', params: {data: initialValue}});
             }
 
-            atwho.init($element, {
-                atwhoOptions: {
-                    displayTpl: function (item) {
-                        if (item.case_type) {
-                            return '<li><span class="label label-default pull-right">${case_type}</span> ${name}</li>';
-                        } else if (item.meta_type) {
-                            return '<li><span class="label label-primary pull-right">${meta_type}</span> ${name}</li>';
-                        }
-                        return '<li>${name}</li>';
-                    },
-                },
-                afterInsert: function () {
-                    $element.trigger('textchange');
-                },
-            });
-
-            $element.on("textchange", function () {
-                if ($element.val()) {
-                    $element.change();
-                }
-            });
-        },
-
-        update: function (element, valueAccessor) {
-            $(element).atwho('load', '', ko.utils.unwrapObservable(valueAccessor()));
         },
     };
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/binding_handlers.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/binding_handlers.js
@@ -2,7 +2,7 @@
  * todo add docstring
  */
 
-hqDefine('reports/v2/js/datagrid/bindingHandlers', [
+hqDefine('reports/v2/js/datagrid/binding_handlers', [
     'jquery',
     'knockout',
     'underscore',

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/column_filters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/column_filters.js
@@ -1,4 +1,4 @@
-hqDefine('reports/v2/js/datagrid/columnFilters', [
+hqDefine('reports/v2/js/datagrid/column_filters', [
     'jquery',
     'knockout',
 ], function (

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -6,7 +6,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
     'jquery',
     'knockout',
     'underscore',
-    'reports/v2/js/datagrid/columnFilters',
+    'reports/v2/js/datagrid/column_filters',
 ], function (
     $,
     ko,

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -54,6 +54,14 @@ hqDefine('reports/v2/js/datagrid/columns', [
             };
         });
 
+        self.getInitialNameValue = function () {
+            if (!data.name) return null;
+            return {
+                id: data.name,
+                text: data.name,
+            };
+        };
+
         return self;
     };
 
@@ -124,7 +132,6 @@ hqDefine('reports/v2/js/datagrid/columns', [
         };
 
         self.setNew = function () {
-            self.loadOptions();
             self.oldColumn(undefined);
 
             if (self.isNew() && self.column()) {
@@ -138,7 +145,6 @@ hqDefine('reports/v2/js/datagrid/columns', [
         };
 
         self.set = function (existingColumn) {
-            self.loadOptions();
             self.oldColumn(columnModel(existingColumn).unwrap());
             self.column(columnModel(existingColumn.unwrap()));
             self.isNew(false);
@@ -181,22 +187,11 @@ hqDefine('reports/v2/js/datagrid/columns', [
             self.hasFilterUpdate(true);
         };
 
-        self.loadOptions = function () {
-            if (!self.reportContext) {
-                throw new Error("Please call init() before calling loadOptions().");
+        self.getData = function (data) {
+            if (self.reportContext) {
+                data.reportContext = JSON.stringify(self.reportContext());
             }
-
-            $.ajax({
-                url: self.endpoint.getUrl(),
-                method: 'post',
-                dataType: 'json',
-                data: {
-                    reportContext: JSON.stringify(self.reportContext()),
-                },
-            })
-                .done(function (data) {
-                    self.columnNameOptions(data.options);
-                });
+            return data;
         };
 
         self.isColumnValid = ko.computed(function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
@@ -13,6 +13,17 @@ hqDefine('reports/v2/js/datagrid/data_models', [
 ) {
     'use strict';
 
+    var _numberOption = function (number, current) {
+        var self = {};
+
+        self.number = ko.observable(number);
+        self.isCurrent = ko.computed(function () {
+            return self.number() === current;
+        });
+
+        return self;
+    };
+
     var scrollingDataModel = function (endpoint) {
         var self = {};
 
@@ -22,7 +33,68 @@ hqDefine('reports/v2/js/datagrid/data_models', [
         self.isLoadingError = ko.observable(false);
 
         self.rows = ko.observableArray([]);
-        self.length = 50; // todo change number dynamically?
+        self.limit = ko.observable(10);
+        self.currentPage = ko.observable(1);
+        self.totalPages = ko.observable(1);
+        self.totalRecords = ko.observable(1);
+
+        self.pages = ko.computed(function () {
+            return _.map(_.range(1, self.totalPages() + 1), function (pageNum) {
+               return _numberOption(pageNum, self.currentPage());
+            });
+        });
+
+        self.limits = ko.computed(function() {
+            return _.map([10, 25, 50, 100], function (limitNum) {
+                return _numberOption(limitNum, self.limit());
+            });
+        });
+
+        self.changePage = function (page) {
+            self.currentPage(page.number());
+            self.loadRecords();
+        };
+
+        self.changeLimit = function (limit) {
+            self.limit(limit.number());
+            self.currentPage(1);
+            self.loadRecords();
+        };
+
+        self._pushState = function () {
+            var stateInfo = {
+                    page: self.currentPage(),
+                    limit: self.limit(),
+                },
+                url = '?p=' + self.currentPage() + "&l=" + self.limit();
+            window.history.pushState(stateInfo, self.pageTitle, url);
+        };
+
+        self._loadState = function () {
+            var history = window.history.state;
+            if (_.isObject(history)) {
+                self.currentPage(history.page || 1);
+                self.limit(history.limit || 10);
+            }
+        };
+
+        self.showNext = ko.computed(function () {
+           return self.currentPage() < self.totalPages();
+        });
+
+        self.showPrevious = ko.computed(function () {
+            return self.currentPage() > 1;
+        });
+
+        self.nextPage = function () {
+           self.currentPage(Math.min(self.totalPages(), self.currentPage() + 1));
+           self.loadRecords();
+        };
+
+        self.previousPage = function () {
+            self.currentPage(Math.max(self.currentPage() - 1, 1));
+            self.loadRecords();
+        };
 
         self.loadRecords = function () {
             if (!self.reportContext) {
@@ -37,13 +109,16 @@ hqDefine('reports/v2/js/datagrid/data_models', [
                 method: 'post',
                 dataType: 'json',
                 data: {
-                    length: self.length,
-                    start: 0, // fix with pagination
+                    limit: self.limit(),
+                    page: self.currentPage(),
                     reportContext: JSON.stringify(self.reportContext()),
                 },
             })
                 .done(function (data) {
                     self.rows(data.rows);
+                    self.totalPages(data.totalPages);
+                    self.totalRecords(data.totalRecords);
+                    self._pushState();
                 })
                 .fail(function () {
                     self.isLoadingError(true);
@@ -55,6 +130,8 @@ hqDefine('reports/v2/js/datagrid/data_models', [
 
         self.init = function (reportContextObservable) {
             self.reportContext = reportContextObservable;
+            self.pageTitle = $(document).find("title").text();
+            self._loadState();
             self.loadRecords();
         };
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
@@ -6,23 +6,13 @@ hqDefine('reports/v2/js/datagrid/data_models', [
     'jquery',
     'knockout',
     'underscore',
+    'hqwebapp/js/components.ko',  // pagination widget
 ], function (
     $,
     ko,
     _
 ) {
     'use strict';
-
-    var _numberOption = function (number, current) {
-        var self = {};
-
-        self.number = ko.observable(number);
-        self.isCurrent = ko.computed(function () {
-            return self.number() === current;
-        });
-
-        return self;
-    };
 
     var scrollingDataModel = function (endpoint) {
         var self = {};
@@ -33,32 +23,25 @@ hqDefine('reports/v2/js/datagrid/data_models', [
         self.isLoadingError = ko.observable(false);
 
         self.rows = ko.observableArray([]);
-        self.limit = ko.observable(10);
-        self.currentPage = ko.observable(1);
-        self.totalPages = ko.observable(1);
+
+        self.limit = ko.observable(undefined);
+        self.hasLimitBeenModified = ko.observable(false);
+
+        self.currentPage = ko.observable(undefined);
         self.totalRecords = ko.observable(1);
 
-        self.pages = ko.computed(function () {
-            return _.map(_.range(1, self.totalPages() + 1), function (pageNum) {
-                return _numberOption(pageNum, self.currentPage());
-            });
+        self.limit.subscribe(function () {
+            // needed to stay in sync with pagination widget
+            // to prevent unnecessary reloads of data
+            self.hasLimitBeenModified(true);
         });
 
-        self.limits = ko.computed(function () {
-            return _.map([10, 25, 50, 100], function (limitNum) {
-                return _numberOption(limitNum, self.limit());
-            });
-        });
-
-        self.changePage = function (page) {
-            self.currentPage(page.number());
-            self.loadRecords();
-        };
-
-        self.changeLimit = function (limit) {
-            self.limit(limit.number());
-            self.currentPage(1);
-            self.loadRecords();
+        self.goToPage = function (page) {
+            if (page !== self.currentPage() || self.hasLimitBeenModified()) {
+                self.currentPage(page);
+                self.hasLimitBeenModified(false);
+                self.loadRecords();
+            }
         };
 
         self._pushState = function () {
@@ -70,38 +53,16 @@ hqDefine('reports/v2/js/datagrid/data_models', [
             window.history.pushState(stateInfo, self.pageTitle, url);
         };
 
-        self._loadState = function () {
-            var history = window.history.state;
-            if (_.isObject(history)) {
-                self.currentPage(history.page || 1);
-                self.limit(history.limit || 10);
-            }
-        };
-
-        self.showNext = ko.computed(function () {
-            return self.currentPage() < self.totalPages();
-        });
-
-        self.showPrevious = ko.computed(function () {
-            return self.currentPage() > 1;
-        });
-
-        self.nextPage = function () {
-            self.currentPage(Math.min(self.totalPages(), self.currentPage() + 1));
-            self.loadRecords();
-        };
-
-        self.previousPage = function () {
-            self.currentPage(Math.max(self.currentPage() - 1, 1));
-            self.loadRecords();
-        };
-
         self.loadRecords = function () {
             if (!self.reportContext) {
                 throw new Error("Please call init() before calling loadRecords().");
             }
 
             if (self.isDataLoading()) return;
+
+            // wait for pagination widget to kick in
+            if (self.currentPage() === undefined) return;
+            if (self.limit() === undefined) return;
 
             self.isDataLoading(true);
             $.ajax({
@@ -116,7 +77,6 @@ hqDefine('reports/v2/js/datagrid/data_models', [
             })
                 .done(function (data) {
                     self.rows(data.rows);
-                    self.totalPages(data.totalPages);
                     self.totalRecords(data.totalRecords);
                     self._pushState();
                 })
@@ -131,8 +91,11 @@ hqDefine('reports/v2/js/datagrid/data_models', [
         self.init = function (reportContextObservable) {
             self.reportContext = reportContextObservable;
             self.pageTitle = $(document).find("title").text();
-            self._loadState();
-            self.loadRecords();
+
+            var _url = new URL(window.location.href);
+            self.currentPage(_url.searchParams.get('p') || self.currentPage());
+            self.limit(_url.searchParams.get('l') || self.limit());
+
         };
 
         self.refresh = function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/data_models.js
@@ -40,11 +40,11 @@ hqDefine('reports/v2/js/datagrid/data_models', [
 
         self.pages = ko.computed(function () {
             return _.map(_.range(1, self.totalPages() + 1), function (pageNum) {
-               return _numberOption(pageNum, self.currentPage());
+                return _numberOption(pageNum, self.currentPage());
             });
         });
 
-        self.limits = ko.computed(function() {
+        self.limits = ko.computed(function () {
             return _.map([10, 25, 50, 100], function (limitNum) {
                 return _numberOption(limitNum, self.limit());
             });
@@ -79,7 +79,7 @@ hqDefine('reports/v2/js/datagrid/data_models', [
         };
 
         self.showNext = ko.computed(function () {
-           return self.currentPage() < self.totalPages();
+            return self.currentPage() < self.totalPages();
         });
 
         self.showPrevious = ko.computed(function () {
@@ -87,8 +87,8 @@ hqDefine('reports/v2/js/datagrid/data_models', [
         });
 
         self.nextPage = function () {
-           self.currentPage(Math.min(self.totalPages(), self.currentPage() + 1));
-           self.loadRecords();
+            self.currentPage(Math.min(self.totalPages(), self.currentPage() + 1));
+            self.loadRecords();
         };
 
         self.previousPage = function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/report_filters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/report_filters.js
@@ -27,6 +27,10 @@ hqDefine('reports/v2/js/datagrid/report_filters', [
             };
         });
 
+        self.getInitialValue = function () {
+            return data.value;
+        };
+
         return self;
     };
 

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/report_filters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/report_filters.js
@@ -15,7 +15,7 @@ hqDefine('reports/v2/js/datagrid/report_filters', [
         self.value = ko.observableArray();
         self.defaultValue = ko.observable(data.defaultValue);
         self.placeholder = ko.computed(function () {
-            return gettext("Select") + " " + self.title() + "...";
+            return _.template(gettext("Select <%= title %>..."))({ title: self.title() });
         });
 
         self.endpoint = data.endpoint;

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/report_filters.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/report_filters.js
@@ -1,4 +1,4 @@
-hqDefine('reports/v2/js/datagrid/reportFilters', [
+hqDefine('reports/v2/js/datagrid/report_filters', [
     'jquery',
     'knockout',
 ], function (

--- a/corehq/apps/reports/v2/endpoints/case_properties.py
+++ b/corehq/apps/reports/v2/endpoints/case_properties.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 from memoized import memoized
 
+from django.utils.translation import ugettext as _
+
 from corehq.apps.case_search.const import (
     SPECIAL_CASE_PROPERTIES,
     CASE_COMPUTED_METADATA,
@@ -11,6 +13,8 @@ from corehq.apps.reports.standard.cases.filters import (
     get_flattened_case_properties,
 )
 from corehq.apps.reports.v2.models import BaseOptionsEndpoint
+
+DEFAULT_RESULTS_LIMIT = 10
 
 
 class CasePropertiesEndpoint(BaseOptionsEndpoint):
@@ -26,6 +30,18 @@ class CasePropertiesEndpoint(BaseOptionsEndpoint):
         return ['name'] + self.existing_slugs
 
     @property
+    def search(self):
+        return self.data.get('search', '')
+
+    @property
+    def page(self):
+        return int(self.data.get('page', 1))
+
+    @property
+    def limit(self):
+        return int(self.data.get('limit', DEFAULT_RESULTS_LIMIT))
+
+    @property
     @memoized
     def case_properties(self):
         case_properties = get_flattened_case_properties(
@@ -37,16 +53,66 @@ class CasePropertiesEndpoint(BaseOptionsEndpoint):
         ]
         return case_properties + special_properties
 
+    @staticmethod
+    def _fmt_select2(prop):
+        prop['text'] = prop['name']
+        prop['id'] = prop['name']
+        prop['labelStyle'] = ('label-default' if prop['case_type']
+                              else 'label-primary')
+        prop['labelText'] = prop['case_type'] or prop['meta_type']
+        return prop
+
+
     @property
-    def filtered_case_properties(self):
+    @memoized
+    def matching_case_properties(self):
+        exact = []
+        starts = []
+        ends = []
+        other = []
 
-        def _filter_property(prop):
-            # todo future filters based on case_types, etc.
-            return prop['name'] not in self.excluded_slugs
+        for prop in self.case_properties:
+            if prop['name'] in self.excluded_slugs:
+                continue
 
-        return [prop for prop in self.case_properties if _filter_property(prop)]
+            if not self.search:
+                exact.append(self._fmt_select2(prop))
+
+            elif prop['name'] == self.search:
+                exact.append(self._fmt_select2(prop))
+
+            elif prop['name'].startswith(self.search):
+                starts.append(self._fmt_select2(prop))
+
+            elif prop['name'].endswith(self.search):
+                ends.append(self._fmt_select2(prop))
+
+            elif self.search in prop['name']:
+                other.append(self._fmt_select2(prop))
+
+        if len(exact) == 0 and self.search:
+            exact.append({
+                'text': self.search,
+                'id': self.search,
+                'labelStyle': 'label-info',
+                'labelText': '({})'.format(_("custom")),
+            })
+
+        return exact + starts + ends + other
 
     def get_response(self):
+        #  todo more intelligent caching of results
+
+        total = len(self.matching_case_properties)
+        start = (self.page - 1) * self.limit
+        stop = min(self.page * self.limit, total)
+        has_more = total > stop
+
+        matching_page = self.matching_case_properties[start:stop]
+
         return {
-            'options': self.filtered_case_properties,
+            'results': matching_page,
+            'pagination': {
+                'more': has_more,
+            },
         }

--- a/corehq/apps/reports/v2/endpoints/datagrid.py
+++ b/corehq/apps/reports/v2/endpoints/datagrid.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from __future__ import division
 
 import math
 

--- a/corehq/apps/reports/v2/endpoints/datagrid.py
+++ b/corehq/apps/reports/v2/endpoints/datagrid.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from __future__ import division
-
-import math
 
 from corehq.apps.reports.v2.models import BaseDataEndpoint
 
@@ -25,7 +22,6 @@ class DatagridEndpoint(BaseDataEndpoint):
     def get_response(self, query, formatter):
         total = query.count()
         start = min((self.page - 1) * self.limit, total)
-        total_pages = int(math.ceil(float(total) / float(self.limit)))
 
         query = query.size(self.limit).start(start)
         results = [formatter(self.request, self.domain, r).get_context()
@@ -33,5 +29,4 @@ class DatagridEndpoint(BaseDataEndpoint):
         return {
             "rows": results,
             "totalRecords": total,
-            "totalPages": total_pages,
         }

--- a/corehq/apps/reports/v2/endpoints/datagrid.py
+++ b/corehq/apps/reports/v2/endpoints/datagrid.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import math
+
 from corehq.apps.reports.v2.models import BaseDataEndpoint
 
 
@@ -12,24 +14,23 @@ class DatagridEndpoint(BaseDataEndpoint):
         return int(self.data.get('draw', 1))
 
     @property
-    def start(self):
-        return int(self.data.get('start', 0))
+    def page(self):
+        return int(self.data.get('page', 1))
 
     @property
-    def length(self):
-        return int(self.data.get('length', 1))
-
-    @property
-    def order(self):
-        return int(self.data.get('order', 1))
+    def limit(self):
+        return int(self.data.get('limit', 10))
 
     def get_response(self, query, formatter):
         total = query.count()
-        query = query.size(self.length).start(self.start)
+        start = min((self.page - 1) * self.limit, total)
+        total_pages = int(math.ceil(float(total) / float(self.limit)))
+
+        query = query.size(self.limit).start(start)
         results = [formatter(self.request, self.domain, r).get_context()
                    for r in query.run().raw['hits'].get('hits', [])]
         return {
             "rows": results,
-            "recordsTotal": total,
-            "recordsFiltered": total,
+            "totalRecords": total,
+            "totalPages": total_pages,
         }

--- a/corehq/apps/reports/v2/filters/case_report.py
+++ b/corehq/apps/reports/v2/filters/case_report.py
@@ -13,15 +13,10 @@ from corehq.apps.reports.v2.models import BaseReportFilter
 from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 
 
-class Widget(object):
-    SELECT2_MULTIPLE = 'select2_multiple'
-
-
 class CaseOwnerReportFilter(BaseReportFilter):
     title = ugettext_lazy("Case Owner(s)")
     name = 'report_case_owner'
     endpoint_slug = CaseOwnerEndpoint.slug
-    widget = Widget.SELECT2_MULTIPLE
 
     @classmethod
     def get_context(cls):
@@ -29,7 +24,6 @@ class CaseOwnerReportFilter(BaseReportFilter):
             'title': cls.title,
             'name': cls.name,
             'endpointSlug': cls.endpoint_slug,
-            'widget': cls.widget,
         }
 
     def get_filtered_query(self, query):

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -9,6 +9,8 @@ from abc import ABCMeta, abstractmethod
 
 from memoized import memoized
 
+from django.utils.translation import ugettext as _
+
 from corehq.apps.reports.v2.exceptions import (
     EndpointNotFoundError,
     ReportFilterNotFound,
@@ -47,7 +49,7 @@ class BaseReport(object):
             return endpoint_class(self.request, self.domain)
         except (KeyError, NameError):
             raise EndpointNotFoundError(
-                "The report endpoint for {}/{} cannot be found.".format(
+                _("The report endpoint for {}/{} cannot be found.").format(
                     self.slug, endpoint_slug
                 )
             )

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -66,7 +66,7 @@ class BaseReport(object):
             return filter_class(self.request, self.domain, context)
         except (KeyError, NameError):
             raise ReportFilterNotFound(
-                "Could not find the report filter '{}'".format(filter_name)
+                _("Could not find the report filter '{}'").format(filter_name)
             )
 
     @property

--- a/corehq/apps/reports/v2/models.py
+++ b/corehq/apps/reports/v2/models.py
@@ -16,6 +16,7 @@ from corehq.apps.reports.v2.exceptions import (
 
 EndpointContext = namedtuple('EndpointContext', 'slug urlname')
 ColumnMeta = namedtuple('ColumnMeta', 'title name width')
+ReportFilterData = namedtuple('ReportFilterData', 'name value')
 
 
 class BaseReport(object):
@@ -29,6 +30,7 @@ class BaseReport(object):
     columns = []
     column_filters = []
     report_filters = []
+    initial_report_filters = []  # list of ReportFilterData
 
     def __init__(self, request, domain):
         """
@@ -82,6 +84,8 @@ class BaseReport(object):
             'columns': [c._asdict() for c in self.columns],
             'column_filters': [c.get_context() for c in self.column_filters],
             'report_filters': [r.get_context() for r in self.report_filters],
+            'initial_report_filters': {r.name: r.value
+                                       for r in self.initial_report_filters},
         }
 
 

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy
 
+from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
 from corehq.apps.reports.standard.cases.utils import query_location_restricted_cases
 from corehq.apps.reports.v2.endpoints.case_owner import CaseOwnerEndpoint
 from corehq.apps.reports.v2.endpoints.case_properties import (
@@ -75,7 +76,7 @@ class ExploreCaseDataReport(BaseReport):
     def _get_base_query(self):
         return (CaseSearchES()
                 .domain(self.domain)
-                .NOT(case_es.case_type("user-owner-mapping-case")))
+                .NOT(case_es.case_type(USER_LOCATION_OWNER_MAP_TYPE)))
 
     def get_data_response(self, endpoint):
         query = self._get_base_query()

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -20,6 +20,7 @@ from corehq.apps.reports.v2.formatters.cases import CaseDataFormatter
 from corehq.apps.reports.v2.models import (
     BaseReport,
     ColumnMeta,
+    ReportFilterData,
 )
 from corehq.apps.es import CaseSearchES, cases as case_es
 
@@ -57,6 +58,18 @@ class ExploreCaseDataReport(BaseReport):
 
     report_filters = [
         CaseOwnerReportFilter,
+    ]
+
+    initial_report_filters = [
+        ReportFilterData(
+            name=CaseOwnerReportFilter.name,
+            value=[
+                {
+                    'text': "[{}]".format(ugettext_lazy("Project Data")),
+                    'id': 'project_data',
+                },
+            ],
+        ),
     ]
 
     def _get_base_query(self):


### PR DESCRIPTION
here are the remaining functionality updates before I start work on the design : )

- replaces `atwho` widget with `select2 v4` widget on column `name` selector
- responds to @orangejenny's feedback in https://github.com/dimagi/commcare-hq/pull/24204
- some minor code cleanup
- adds pagination and limit selection with ability to link to a specific page & limit from the `pushState` history.
- adds ability to specify default value in report filters

![pt1-select2](https://user-images.githubusercontent.com/716573/57466496-129ae700-7281-11e9-80bb-98ba6388512d.gif)
![pt2-pagination](https://user-images.githubusercontent.com/716573/57466497-129ae700-7281-11e9-90d3-7ff2e406b336.gif)
![pt3-pagination state](https://user-images.githubusercontent.com/716573/57466498-129ae700-7281-11e9-8930-2a43b28c217c.gif)



