### PR TITLE
Don't fetch cached user, we're gonna save it

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -821,7 +821,7 @@ class UserInvitationView(object):
                     invited=invitation.email, current=request.couch_user.username))
 
             if request.method == "POST":
-                couch_user = CouchUser.from_django_user(request.user)
+                couch_user = CouchUser.from_django_user(request.user, strict=True)
                 self._invite(invitation, couch_user)
                 track_workflow(request.couch_user.get_email(),
                                "Current user accepted a project invitation",


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-610
https://sentry.io/organizations/dimagi/issues/538330201/

Getting a resource conflict when adding a web user to a domain (which saves the user object).

@nickpell 