### PR TITLE
Followup soil error handling

### DIFF
--- a/corehq/apps/hqmedia/exceptions.py
+++ b/corehq/apps/hqmedia/exceptions.py
@@ -1,2 +1,6 @@
 class BadMediaFileException(Exception):
     pass
+
+
+class ApplicationBuildException(Exception):
+    pass

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -12,7 +12,6 @@ from wsgiref.util import FileWrapper
 from django.conf import settings
 from django.utils.translation import ugettext as _
 
-from celery import states
 from celery.task import task
 from celery.utils.log import get_task_logger
 
@@ -23,6 +22,7 @@ from soil.util import expose_cached_download, expose_file_download
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.hqmedia.cache import BulkMultimediaStatusCache
+from corehq.apps.hqmedia.exceptions import ApplicationBuildException
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.util.files import file_extention_from_filename
 
@@ -205,7 +205,7 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
             os.remove(fpath)
             # Add SOIL_ERROR_SEPARATOR first so that even with one error, soil assumes that this
             # was originally a list
-            raise Exception(SOIL_ERROR_SEPARATOR + SOIL_ERROR_SEPARATOR.join(errors))
+            raise ApplicationBuildException(SOIL_ERROR_SEPARATOR + SOIL_ERROR_SEPARATOR.join(errors))
     else:
         DownloadBase.set_progress(build_application_zip, initial_progress + file_progress, 100)
 

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -17,6 +17,7 @@ from celery.task import task
 from celery.utils.log import get_task_logger
 
 from soil import DownloadBase
+from soil.progress import SOIL_ERROR_SEPARATOR
 from soil.util import expose_cached_download, expose_file_download
 
 from corehq import toggles
@@ -202,7 +203,9 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
 
         if errors:
             os.remove(fpath)
-            raise Exception('\t' + '\t'.join(errors))
+            # Add SOIL_ERROR_SEPARATOR first so that even with one error, soil assumes that this
+            # was originally a list
+            raise Exception(SOIL_ERROR_SEPARATOR + SOIL_ERROR_SEPARATOR.join(errors))
     else:
         DownloadBase.set_progress(build_application_zip, initial_progress + file_progress, 100)
 

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -22,7 +22,6 @@ from soil.util import expose_cached_download, expose_file_download
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.hqmedia.cache import BulkMultimediaStatusCache
-from corehq.apps.hqmedia.exceptions import ApplicationBuildException
 from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.util.files import file_extention_from_filename
 
@@ -202,6 +201,7 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
                             errors += [_('Media file missing from CCZ: {}').format(r) for r in missing]
 
         if errors:
+            from corehq.apps.hqmedia.exceptions import ApplicationBuildException
             os.remove(fpath)
             # Add SOIL_ERROR_SEPARATOR first so that even with one error, soil assumes that this
             # was originally a list

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -9,8 +9,6 @@ from django.db import IntegrityError
 import six
 from celery.result import GroupResult
 
-from soil.exceptions import TaskFailedError
-
 TaskProgress = namedtuple('TaskProgress',
                           ['current', 'total', 'percent', 'error', 'error_message'])
 

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import absolute_import, division, unicode_literals
 
 import logging
@@ -11,6 +12,8 @@ from celery.result import GroupResult
 
 TaskProgress = namedtuple('TaskProgress',
                           ['current', 'total', 'percent', 'error', 'error_message'])
+
+SOIL_ERROR_SEPARATOR = "🐜🥜🌲"
 
 
 class STATES(object):
@@ -125,8 +128,8 @@ def get_task_status(task, is_multiple_download_task=False):
             context_result = result and result.get('messages')
         elif result and isinstance(result, Exception):
             context_error = six.text_type(result)
-            if '\t' in context_error:
-                context_error = [err for err in context_error.split('\t') if err]
+            if SOIL_ERROR_SEPARATOR in context_error:
+                context_error = [err for err in context_error.split(SOIL_ERROR_SEPARATOR) if err]
         elif result and result.get('errors'):
             failed = True
             context_error = result.get('errors')


### PR DESCRIPTION
following up https://github.com/dimagi/commcare-hq/pull/24251/

One idea was following https://github.com/dimagi/commcare-hq/pull/24082/files#diff-7faddaabdab973bc0a58f1fa0dff728cR87 and creating new soil exceptions and then switching on what the exception name is, but that didn't seem less hacky and would still involve some inspection and conversion of strings to not strings.

I don't have any other bright ideas at the moment don't involve digging more into the libraries and potentially PRing there. 