### PR TITLE
make objects that include custom __eq__ but no __hash__ unhashable

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/workflow.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/workflow.py
@@ -592,6 +592,8 @@ class CommandId(object):
     def __ne__(self, other):
         return not self == other
 
+    __hash__ = None
+
     def __repr__(self):
         return 'ModuleCommand(id={})'.format(self.id)
 
@@ -661,6 +663,8 @@ class WorkflowDatumMeta(object):
 
     def __ne__(self, other):
         return not self == other
+
+    __hash__ = None
 
     def __repr__(self):
         return 'WorkflowDatumMeta(id={}, case_type={})'.format(self.id, self.case_type)

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -949,6 +949,8 @@ class CaseRuleActionResult(object):
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
+    __hash__ = None
+
     def _validate_int(self, value):
         if not isinstance(value, int):
             raise ValueError("Expected int")

--- a/corehq/ex-submodules/casexml/apps/phone/checksum.py
+++ b/corehq/ex-submodules/casexml/apps/phone/checksum.py
@@ -31,6 +31,8 @@ class CaseStateHash(object):
     
     def __ne__(self, obj):
         return not self == obj
+
+    __hash__ = None
         
 
 class Checksum(object):

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1527,6 +1527,8 @@ class CaseTransactionDetail(JsonObject):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    __hash__ = None
+
 
 class RebuildWithReason(CaseTransactionDetail):
     _type = CaseTransaction.TYPE_REBUILD_WITH_REASON


### PR DESCRIPTION
Identified by running ```python -3 manage.py runserver```.

If any objects of these classes are currently hashed, it is effectively broken (inconsistent with ```__eq__```).

@dimagi/py3 