### PR TITLE
POC for removing pickle from celery tasks

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -67,7 +67,7 @@ from corehq.apps.app_manager.dbaccessors import get_all_apps
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqmedia.models import ApplicationMediaMixin
 from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.apps.users.models import FakeUser, WebUser, CommCareUser
+from corehq.apps.users.models import FakeUser, WebUser, CommCareUser, CouchUser
 from corehq.const import (
     SERVER_DATE_FORMAT,
     SERVER_DATETIME_FORMAT_NO_SEC,
@@ -1006,6 +1006,12 @@ def send_prepaid_credits_export():
 
 @task(serializer='pickle', queue="email_queue")
 def email_enterprise_report(domain, slug, couch_user):
+    email_enterprise_report_json_args(domain, slug, couch_user.get_id)
+
+
+@task(queue='email_queue')
+def email_enterprise_report_json_args(domain, slug, couch_user_id):
+    couch_user = CouchUser.get_by_user_id(couch_user_id)
     account = BillingAccount.get_account_by_domain(domain)
     report = EnterpriseReport.create(slug, account.id, couch_user)
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -1004,9 +1004,9 @@ def send_prepaid_credits_export():
     )
 
 
-@task(serializer='pickle', queue="email_queue")
-def email_enterprise_report(domain, slug, couch_user):
-    email_enterprise_report_json_args(domain, slug, couch_user.get_id)
+@task(queue='email_queue')
+def email_enterprise_report(domain, slug, couch_user_id):
+    email_enterprise_report_json_args(domain, slug, couch_user_id)
 
 
 @task(queue='email_queue')

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -1006,11 +1006,6 @@ def send_prepaid_credits_export():
 
 @task(queue='email_queue')
 def email_enterprise_report(domain, slug, couch_user_id):
-    email_enterprise_report_json_args(domain, slug, couch_user_id)
-
-
-@task(queue='email_queue')
-def email_enterprise_report_json_args(domain, slug, couch_user_id):
     couch_user = CouchUser.get_by_user_id(couch_user_id)
     account = BillingAccount.get_account_by_domain(domain)
     report = EnterpriseReport.create(slug, account.id, couch_user)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -95,7 +95,7 @@ from corehq.apps.accounting.models import (
     Invoice, WireInvoice, CustomerInvoice, BillingAccount, CreditLine, Subscription, CustomerBillingRecord,
     SoftwarePlanVersion, SoftwarePlan, CreditAdjustment, DefaultProductPlan, StripePaymentMethod, InvoicePdf
 )
-from corehq.apps.accounting.tasks import email_enterprise_report
+from corehq.apps.accounting.tasks import email_enterprise_report_json_args
 from corehq.apps.accounting.utils import (
     fmt_feature_rate_dict, fmt_product_rate_dict,
     has_subscription_already_ended,
@@ -1265,7 +1265,7 @@ def enterprise_dashboard_download(request, domain, slug, export_hash):
 def enterprise_dashboard_email(request, domain, slug):
     account = _get_account_or_404(request, domain)
     report = EnterpriseReport.create(slug, account.id, request.couch_user)
-    email_enterprise_report.delay(domain, slug, request.couch_user)
+    email_enterprise_report_json_args.delay(domain, slug, request.couch_user.get_id)
     message = _("Generating {title} report, will email to {email} when complete.").format(**{
         'title': report.title,
         'email': request.couch_user.username,

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -95,7 +95,7 @@ from corehq.apps.accounting.models import (
     Invoice, WireInvoice, CustomerInvoice, BillingAccount, CreditLine, Subscription, CustomerBillingRecord,
     SoftwarePlanVersion, SoftwarePlan, CreditAdjustment, DefaultProductPlan, StripePaymentMethod, InvoicePdf
 )
-from corehq.apps.accounting.tasks import email_enterprise_report_json_args
+from corehq.apps.accounting.tasks import email_enterprise_report
 from corehq.apps.accounting.utils import (
     fmt_feature_rate_dict, fmt_product_rate_dict,
     has_subscription_already_ended,
@@ -1265,7 +1265,7 @@ def enterprise_dashboard_download(request, domain, slug, export_hash):
 def enterprise_dashboard_email(request, domain, slug):
     account = _get_account_or_404(request, domain)
     report = EnterpriseReport.create(slug, account.id, request.couch_user)
-    email_enterprise_report_json_args.delay(domain, slug, request.couch_user.get_id)
+    email_enterprise_report.delay(domain, slug, request.couch_user.get_id)
     message = _("Generating {title} report, will email to {email} when complete.").format(**{
         'title': report.title,
         'email': request.couch_user.username,


### PR DESCRIPTION
My plan is to roll this out in 3 distinct stages (see commit-by-commit):

1. A. Create a new function that does not use the pickle serializer.  All future queued tasks should use this function.
    B. Wait enough time for all of the queued tasks using pickle to be processed.  At this point, the Python 3 migration is unblocked.
2. A.  If we think the new celery task is named better than the old task, then delete the old task and declare victory!  (This is a great opportunity to rename functions that have bad names.)  If we want to revert the task to the previous name, then
    B.  Update the original function's signature to use the non-pickled arguments, and remove the pickle serializer.  All future queued tasks should use the original function.
    C.  Wait enough time for all of the intermediate function's tasks to get processed.
3.  Delete the intermediate function.

Let me know if there are any holes/inefficiencies in this plan.  I'd like to iron them out before I execute these steps on the 100+ celery tasks that use pickle.

@dimagi/py3 