### PR TITLE
replace instances of deprecated ex.message with six.text_type(e)

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -228,8 +228,8 @@ class ESView(View):
         try:
             raw_post = request.body
             raw_query = json.loads(raw_post)
-        except Exception as ex:
-            content_response = dict(message="Error parsing query request", exception=ex.message)
+        except Exception as e:
+            content_response = dict(message="Error parsing query request", exception=six.text_type(e))
             response = HttpResponse(status=406, content=json.dumps(content_response))
             return response
 

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import json
 from functools import wraps
 
+import six
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseForbidden
 from tastypie.authentication import Authentication
@@ -25,9 +26,9 @@ def api_auth(view_func):
     def _inner(req, domain, *args, **kwargs):
         try:
             return view_func(req, domain, *args, **kwargs)
-        except Http404 as ex:
-            if ex.message:
-                return HttpResponse(json.dumps({"error": ex.message}),
+        except Http404 as e:
+            if six.text_type(e):
+                return HttpResponse(json.dumps({"error": six.text_type(e)}),
                                 content_type="application/json",
                                 status=404)
             return HttpResponse(json.dumps({"error": "not authorized"}),

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -394,9 +394,9 @@ class GroupResource(v0_4.GroupResource):
             try:
 
                 self.obj_create(bundle=bundle, **self.remove_api_resource_names(kwargs))
-            except AssertionError as ex:
+            except AssertionError as e:
                 status = http.HttpBadRequest
-                bundle.data['_id'] = ex.message
+                bundle.data['_id'] = six.text_type(e)
             bundles_seen.append(bundle)
 
         to_be_serialized = [bundle.data['_id'] for bundle in bundles_seen]
@@ -420,8 +420,8 @@ class GroupResource(v0_4.GroupResource):
                 updated_bundle = self.full_dehydrate(updated_bundle)
                 updated_bundle = self.alter_detail_data_to_serialize(request, updated_bundle)
                 return self.create_response(request, updated_bundle, response_class=http.HttpCreated, location=location)
-        except AssertionError as ex:
-            bundle.data['error_message'] = ex.message
+        except AssertionError as e:
+            bundle.data['error_message'] = six.text_type(e)
             return self.create_response(request, bundle, response_class=http.HttpBadRequest)
 
     def _update(self, bundle):

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -616,8 +616,8 @@ class EntriesHelper(object):
                             "Module with ID %s has no product details configuration" % module_id
                         )
                     return target
-                except ModuleNotFoundException as ex:
-                    raise ParentModuleReferenceError(ex.message)
+                except ModuleNotFoundException as e:
+                    raise ParentModuleReferenceError(six.text_type(e))
             else:
                 if case_type == module.case_type:
                     return module

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
 from collections import namedtuple, defaultdict
 from six.moves import zip_longest
 


### PR DESCRIPTION
```Exception.message``` is removed in python 3.  This PR handles missed instances of ```ex.message```.