### PR TITLE
make SelfRegistrationUserInfo unhashable because it defines a custom …

### DIFF
--- a/corehq/apps/sms/resources/v0_5.py
+++ b/corehq/apps/sms/resources/v0_5.py
@@ -47,6 +47,8 @@ class SelfRegistrationUserInfo(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    __hash__ = None
+
     def __init__(self, phone_number, custom_user_data=None):
         self.phone_number = phone_number
         self.custom_user_data = custom_user_data


### PR DESCRIPTION
… ```__eq__``` method

Missed one in https://github.com/dimagi/commcare-hq/pull/24264