### PR TITLE
Reconcile couch/SQL (trans)action sorting and ignore xform_id list order diffs

### DIFF
--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -298,7 +298,17 @@ def _both_dates(old, new):
 
 
 def xform_ids_order(old_obj, new_obj, rule, diff):
-    """Some couch docs have the xform ID's out of order"""
+    """Some couch docs have the xform ID's out of order
+
+    `sql_case.xform_ids` is derived from transactions, which are sorted
+    by `server_date`. `couch_case.xform_ids` is based on couch actions,
+    which are not necessarily sorted by `server_date`. Therefore it is
+    likely that they will not match, even after rebuilding either side.
+
+    `reconcile_transactions` does not update `transaction.server_date`
+    and therefore SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL is not useful
+    to eliminate `sql_case.xform_ids` list order diffs.
+    """
     old_ids = set(old_obj['xform_ids'])
     new_ids = set(new_obj['xform_ids'])
     if old_ids ^ new_ids:
@@ -308,7 +318,7 @@ def xform_ids_order(old_obj, new_obj, rule, diff):
             old_value=','.join(list(old_ids - new_ids)),
             new_value=','.join(list(new_ids - old_ids)),
         )
-    raise ReplaceDiff(diff_type="list_order", path=('xform_ids', '[*]'))
+    return True
 
 
 def case_attachments(old_obj, new_obj, rule, original_diff):

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -180,9 +180,7 @@ class DiffTestCases(SimpleTestCase):
         diffs = json_diff(couch_case, sql_case, track_list_indices=False)
         self.assertEqual(2, len(diffs))
         filtered = filter_case_diffs(couch_case, sql_case, diffs + REAL_DIFFS)
-        self.assertEqual(set(filtered), set([
-            FormJsonDiff(diff_type='list_order', path=('xform_ids', '[*]'), old_value=None, new_value=None)
-        ] + REAL_DIFFS))
+        self.assertEqual(filtered, REAL_DIFFS)
 
     def test_filter_case_xform_id_diffs_bad(self):
         couch_case = {

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -16,6 +16,7 @@ from couchdbkit.exceptions import ResourceNotFound
 
 from casexml.apps.case.mock import CaseBlock
 from couchforms.models import XFormInstance
+from dimagi.utils.parsing import ISO_DATETIME_FORMAT
 
 from corehq.apps.commtrack.helpers import make_product
 from corehq.apps.couch_sql_migration.couchsqlmigration import (
@@ -109,6 +110,9 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
 
     def _get_case_ids(self):
         return CaseAccessors(domain=self.domain_name).get_case_ids_in_domain()
+
+    def _get_case(self, case_id):
+        return CaseAccessors(domain=self.domain_name).get_case(case_id)
 
 
 class MigrationTestCase(BaseMigrationTestCase):
@@ -650,6 +654,28 @@ class MigrationTestCase(BaseMigrationTestCase):
         call_command('migrate_domain_from_couch_to_sql', self.domain_name, blow_away=True, no_input=True)
         self.assertFalse(Domain.get_by_name(self.domain_name).use_sql_backend)
 
+    def test_case_forms_list_order(self):
+        SERVER_DATES = [
+            datetime.strptime("2015-07-13T11:21:00.639795Z", ISO_DATETIME_FORMAT),
+            datetime.strptime("2015-07-13T11:24:27.467774Z", ISO_DATETIME_FORMAT),
+            datetime.strptime("2015-07-13T11:21:00.639795Z", ISO_DATETIME_FORMAT),
+            datetime.strptime("2017-04-27T14:23:14.683602Z", ISO_DATETIME_FORMAT),
+        ]
+        for xml, server_date in zip(LIST_ORDER_FORMS, SERVER_DATES):
+            result = submit_form_locally(xml.strip(), self.domain_name)
+            form = result.xform
+            form.received_on = server_date
+            form.save()
+
+        case = self._get_case("89da")
+        self.assertEqual(case.xform_ids, ["f1-9017", "f2-b1ce", "f3-7c38", "f4-3226"])
+
+        self._do_migration_and_assert_flags(self.domain_name)
+
+        case = self._get_case("89da")
+        self.assertEqual(set(case.xform_ids), {"f1-9017", "f2-b1ce", "f3-7c38", "f4-3226"})
+        self._compare_diffs([])
+
 
 class LedgerMigrationTests(BaseMigrationTestCase):
     def setUp(self):
@@ -830,3 +856,130 @@ class DummyObject(object):
 
     def __repr__(self):
         return "DummyObject<id={}>".format(self.id)
+
+
+LIST_ORDER_FORMS = ["""
+<?xml version="1.0" ?>
+<data
+    name="Visit"
+    uiVersion="1" version="9"
+    xmlns="http://openrosa.org/formdesigner/185A7E63-0ECD-4D9A-8357-6FD770B6F065"
+    xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+>
+    <cur_num_anc>3</cur_num_anc>
+    <health_id>Z1234</health_id>
+    <n0:case
+       case_id="89da"
+       date_modified="2015-07-13T11:23:42.485Z"
+       user_id="3fae4ea4af440efaa53441b5"
+       xmlns:n0="http://commcarehq.org/case/transaction/v2"
+    >
+        <n0:update>
+            <n0:num_anc>3</n0:num_anc>
+        </n0:update>
+    </n0:case>
+    <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
+        <n1:deviceID>cloudcare</n1:deviceID>
+        <n1:timeStart>2015-07-13T11:22:58.234Z</n1:timeStart>
+        <n1:timeEnd>2015-07-13T11:23:42.485Z</n1:timeEnd>
+        <n1:username>jeremy</n1:username>
+        <n1:userID>3fae4ea4af440efaa53441b5</n1:userID>
+        <n1:instanceID>f1-9017</n1:instanceID>
+        <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">2.0</n2:appVersion>
+    </n1:meta>
+</data>
+""", """
+<?xml version="1.0" ?>
+<data
+    name="Close"
+    uiVersion="1"
+    version="11"
+    xmlns="http://openrosa.org/formdesigner/01EB3014-71CE-4EBE-AE34-647EF70A55DE"
+    xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+>
+    <close_reason>pregnancy_ended</close_reason>
+    <health_id>Z1234</health_id>
+    <n0:case
+        case_id="89da"
+        date_modified="2015-07-13T11:24:26.614Z"
+        user_id="3fae4ea4af440efaa53441b5"
+        xmlns:n0="http://commcarehq.org/case/transaction/v2"
+    >
+        <n0:close/>
+    </n0:case>
+    <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
+        <n1:deviceID>cloudcare</n1:deviceID>
+        <n1:timeStart>2015-07-13T11:24:03.544Z</n1:timeStart>
+        <n1:timeEnd>2015-07-13T11:24:26.614Z</n1:timeEnd>
+        <n1:username>jeremy</n1:username>
+        <n1:userID>3fae4ea4af440efaa53441b5</n1:userID>
+        <n1:instanceID>f2-b1ce</n1:instanceID>
+        <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">2.0</n2:appVersion>
+    </n1:meta>
+</data>
+""", """
+<?xml version="1.0" ?>
+<data
+    name="Register
+    Pregnancy"
+    uiVersion="1"
+    version="11"
+    xmlns="http://openrosa.org/formdesigner/882FC273-E436-4BA1-B8CC-9CA526FFF8C2"
+    xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+>
+    <health_id>Z1234</health_id>
+    <first_name>Xeenax</first_name>
+    <age>27</age>
+    <n0:case
+        case_id="89da"
+        date_modified="2015-08-04T18:25:56.656Z"
+        user_id="3fae4ea4af440efaa53441b5"
+        xmlns:n0="http://commcarehq.org/case/transaction/v2"
+    >
+        <n0:create>
+            <n0:case_name>Xeenax</n0:case_name>
+            <n0:owner_id>3fae4ea4af440efaa53441b5</n0:owner_id>
+            <n0:case_type>pregnancy</n0:case_type>
+        </n0:create>
+        <n0:update>
+            <n0:age>27</n0:age>
+        </n0:update>
+    </n0:case>
+    <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
+        <n1:deviceID>cloudcare</n1:deviceID>
+        <n1:timeStart>2015-07-13T11:20:11.381Z</n1:timeStart>
+        <n1:timeEnd>2015-08-04T18:25:56.656Z</n1:timeEnd>
+        <n1:username>jeremy</n1:username>
+        <n1:userID>3fae4ea4af440efaa53441b5</n1:userID>
+        <n1:instanceID>f3-7c38</n1:instanceID>
+        <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">2.0</n2:appVersion>
+    </n1:meta>
+</data>
+""", """
+<?xml version="1.0" ?>
+<system
+    uiVersion="1"
+    version="1"
+    xmlns="http://commcarehq.org/case"
+    xmlns:orx="http://openrosa.org/jr/xforms"
+>
+    <orx:meta xmlns:cc="http://commcarehq.org/xforms">
+        <orx:deviceID/>
+        <orx:timeStart>2017-04-27T14:23:14.628725Z</orx:timeStart>
+        <orx:timeEnd>2017-04-27T14:23:14.628725Z</orx:timeEnd>
+        <orx:username>jwacksman@dimagi.com</orx:username>
+        <orx:userID>743501c499f5f9e9843ffabc1919cea2</orx:userID>
+        <orx:instanceID>f4-3226</orx:instanceID>
+        <cc:appVersion/>
+    </orx:meta>
+    <case
+        case_id="89da"
+        date_modified="2017-04-27T14:23:14.143507Z"
+        xmlns="http://commcarehq.org/case/transaction/v2"
+    >
+        <update>
+            <health_id>Z12340</health_id>
+        </update>
+    </case>
+</system>
+"""]

--- a/corehq/ex-submodules/casexml/apps/case/const.py
+++ b/corehq/ex-submodules/casexml/apps/case/const.py
@@ -1,5 +1,7 @@
 # how cases/referrals are tagged in the xform/couch
+from __future__ import absolute_import
 from __future__ import unicode_literals
+
 from datetime import timedelta
 
 CASE_TAG = "case"

--- a/corehq/ex-submodules/casexml/apps/case/const.py
+++ b/corehq/ex-submodules/casexml/apps/case/const.py
@@ -1,5 +1,7 @@
 # how cases/referrals are tagged in the xform/couch
 from __future__ import unicode_literals
+from datetime import timedelta
+
 CASE_TAG = "case"
 REFERRAL_TAG = "referral"
 
@@ -47,3 +49,5 @@ DEFAULT_CASE_INDEX_IDENTIFIERS = {CASE_INDEX_CHILD: 'parent', CASE_INDEX_EXTENSI
 UNOWNED_EXTENSION_OWNER_ID = '-'
 
 ARCHIVED_CASE_OWNER_ID = '_archive_'
+
+SIGNIFICANT_TIME = timedelta(hours=12)

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -404,7 +404,7 @@ class CouchCaseUpdateStrategy(UpdateStrategy):
 def _action_sort_key_function(case):
 
     def action_cmp(first_action, second_action):
-        # if the forms aren't submitted by the same user, just default to server dates
+        # compare server dates if the forms aren't submitted by the same user
         if first_action.user_id != second_action.user_id:
             return cmp(first_action.server_date, second_action.server_date)
 
@@ -429,7 +429,6 @@ def _action_sort_key_function(case):
 
     def sort_key(action):
         # if the user is the same you should compare with the special logic below
-        # if the user is not the same you should compare just using received_on
         return (
             action.date,
             form_index(action.xform_id),

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -406,15 +406,15 @@ def _action_sort_key_function(case):
         # if the forms aren't submitted by the same user, just default to server dates
         if first_action.user_id != second_action.user_id:
             return cmp(first_action.server_date, second_action.server_date)
-        else:
-            if first_action.xform_id and first_action.xform_id == second_action.xform_id:
-                # short circuit if they are from the same form
-                return cmp(
-                    _type_sort(first_action.action_type),
-                    _type_sort(second_action.action_type)
-                )
 
-            return cmp(_sortkey(first_action), _sortkey(second_action))
+        if first_action.xform_id and first_action.xform_id == second_action.xform_id:
+            # short circuit if they are from the same form
+            return cmp(
+                _type_sort(first_action.action_type),
+                _type_sort(second_action.action_type)
+            )
+
+        return cmp(_sortkey(first_action), _sortkey(second_action))
 
     def _sortkey(action):
         if not action.server_date or not action.date:

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -1,27 +1,36 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import copy
-from functools import cmp_to_key
 import logging
-from PIL import Image
-from io import BytesIO
-from couchdbkit import BadValueError
 import sys
 from datetime import date, datetime
+from functools import cmp_to_key
+from io import BytesIO
+
+from django.utils.translation import ugettext as _
+
+import six
+from couchdbkit import BadValueError
+from ddtrace import tracer
+from PIL import Image
+
 from casexml.apps.case import const
 from casexml.apps.case.const import CASE_ACTION_COMMTRACK
-from casexml.apps.case.exceptions import ReconciliationError, MissingServerDate, UsesReferrals
+from casexml.apps.case.exceptions import (
+    MissingServerDate,
+    ReconciliationError,
+    UsesReferrals,
+)
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import primary_actions
 from casexml.apps.case.xml.parser import KNOWN_PROPERTIES
-from django.utils.translation import ugettext as _
+from couchforms.models import XFormInstance
+from dimagi.ext.couchdbkit import StringProperty
+from dimagi.utils.logging import notify_exception
+
 from corehq.form_processor.update_strategy_base import UpdateStrategy
 from corehq.util.datadog.gauges import datadog_counter
-from couchforms.models import XFormInstance
-from ddtrace import tracer
-from dimagi.utils.logging import notify_exception
-from dimagi.ext.couchdbkit import StringProperty
-import six
 
 
 def coerce_to_datetime(v):

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -30,6 +30,7 @@ from dimagi.ext.couchdbkit import StringProperty
 from dimagi.utils.logging import notify_exception
 
 from corehq.form_processor.update_strategy_base import UpdateStrategy
+from corehq.util import cmp
 from corehq.util.datadog.gauges import datadog_counter
 
 

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -402,7 +402,7 @@ class CouchCaseUpdateStrategy(UpdateStrategy):
 
 
 def _action_sort_key_function(case):
-    def _action_cmp(first_action, second_action):
+    def action_cmp(first_action, second_action):
         # if the forms aren't submitted by the same user, just default to server dates
         if first_action.user_id != second_action.user_id:
             return cmp(first_action.server_date, second_action.server_date)
@@ -410,17 +410,17 @@ def _action_sort_key_function(case):
         if first_action.xform_id and first_action.xform_id == second_action.xform_id:
             # short circuit if they are from the same form
             return cmp(
-                _type_sort(first_action.action_type),
-                _type_sort(second_action.action_type)
+                type_index(first_action.action_type),
+                type_index(second_action.action_type)
             )
 
-        return cmp(_sortkey(first_action), _sortkey(second_action))
+        return cmp(sort_key(first_action), sort_key(second_action))
 
-    def _type_sort(action_type):
+    def type_index(action_type):
         """Consistent ordering for action types"""
         return const.CASE_ACTIONS.index(action_type)
 
-    def _sortkey(action):
+    def sort_key(action):
         if not action.server_date or not action.date:
             raise MissingServerDate()
 
@@ -432,7 +432,7 @@ def _action_sort_key_function(case):
             action.server_date.date(),
             action.date,
             form_index(action.xform_id),
-            _type_sort(action.action_type),
+            type_index(action.action_type),
         )
 
     class cache(object):
@@ -443,4 +443,4 @@ def _action_sort_key_function(case):
             cache.ids = {form_id: i for i, form_id in enumerate(case.xform_ids)}
         return cache.ids.get(form_id, sys.maxsize)
 
-    return cmp_to_key(_action_cmp)
+    return cmp_to_key(action_cmp)

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -416,6 +416,10 @@ def _action_sort_key_function(case):
 
         return cmp(_sortkey(first_action), _sortkey(second_action))
 
+    def _type_sort(action_type):
+        """Consistent ordering for action types"""
+        return const.CASE_ACTIONS.index(action_type)
+
     def _sortkey(action):
         if not action.server_date or not action.date:
             raise MissingServerDate()
@@ -440,10 +444,3 @@ def _action_sort_key_function(case):
         return cache.ids.get(form_id, sys.maxsize)
 
     return cmp_to_key(_action_cmp)
-
-
-def _type_sort(action_type):
-    """
-    Consistent ordering for action types
-    """
-    return const.CASE_ACTIONS.index(action_type)

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -414,22 +414,22 @@ def _action_sort_key_function(case):
                     _type_sort(second_action.action_type)
                 )
 
-            def _sortkey(action):
-                if not action.server_date or not action.date:
-                    raise MissingServerDate()
-
-                # if the user is the same you should compare with the special logic below
-                # if the user is not the same you should compare just using received_on
-                return (
-                    # this is sneaky - it's designed to use just the date for the
-                    # server time in case the phone submits two forms quickly out of order
-                    action.server_date.date(),
-                    action.date,
-                    form_index(action.xform_id),
-                    _type_sort(action.action_type),
-                )
-
             return cmp(_sortkey(first_action), _sortkey(second_action))
+
+    def _sortkey(action):
+        if not action.server_date or not action.date:
+            raise MissingServerDate()
+
+        # if the user is the same you should compare with the special logic below
+        # if the user is not the same you should compare just using received_on
+        return (
+            # this is sneaky - it's designed to use just the date for the
+            # server time in case the phone submits two forms quickly out of order
+            action.server_date.date(),
+            action.date,
+            form_index(action.xform_id),
+            _type_sort(action.action_type),
+        )
 
     class cache(object):
         ids = None

--- a/corehq/form_processor/backends/couch/update_strategy.py
+++ b/corehq/form_processor/backends/couch/update_strategy.py
@@ -415,7 +415,8 @@ def _action_sort_key_function(case):
                 type_index(second_action.action_type)
             )
 
-        if not (first_action.server_date and second_action.server_date):
+        if not (first_action.server_date and second_action.server_date
+                and first_action.date and second_action.date):
             raise MissingServerDate()
 
         if abs(first_action.server_date - second_action.server_date) > const.SIGNIFICANT_TIME:

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -392,15 +392,15 @@ def _transaction_sort_key_function(case):
         if abs(first_transaction.server_date - second_transaction.server_date) > fudge_factor:
             return cmp(first_transaction.server_date, second_transaction.server_date)
 
-        def _sortkey(transaction):
-            # if the user is the same you should compare with the special logic below
-            return (
-                transaction.client_date,
-                form_index(transaction.form_id),
-                _type_sort(transaction.type),
-            )
-
         return cmp(_sortkey(first_transaction), _sortkey(second_transaction))
+
+    def _sortkey(transaction):
+        # if the user is the same you should compare with the special logic below
+        return (
+            transaction.client_date,
+            form_index(transaction.form_id),
+            _type_sort(transaction.type),
+        )
 
     class cache(object):
         ids = None

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -373,7 +373,7 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
 def _transaction_sort_key_function(case):
 
     def transaction_cmp(first_transaction, second_transaction):
-        # if the forms aren't submitted by the same user, just default to server dates
+        # compare server dates if the forms aren't submitted by the same user
         if first_transaction.user_id != second_transaction.user_id:
             return cmp(first_transaction.server_date, second_transaction.server_date)
 

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import datetime
 import logging
 import sys
 from functools import cmp_to_key

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -371,7 +371,6 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
 
 
 def _transaction_sort_key_function(case):
-    fudge_factor = datetime.timedelta(hours=12)
 
     def transaction_cmp(first_transaction, second_transaction):
         # if the forms aren't submitted by the same user, just default to server dates
@@ -388,8 +387,7 @@ def _transaction_sort_key_function(case):
         if not (first_transaction.server_date and second_transaction.server_date):
             raise MissingServerDate()
 
-        # checks if the dates received are within a particular range
-        if abs(first_transaction.server_date - second_transaction.server_date) > fudge_factor:
+        if abs(first_transaction.server_date - second_transaction.server_date) > const.SIGNIFICANT_TIME:
             return cmp(first_transaction.server_date, second_transaction.server_date)
 
         return cmp(sort_key(first_transaction), sort_key(second_transaction))

--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -394,6 +394,13 @@ def _transaction_sort_key_function(case):
 
         return cmp(_sortkey(first_transaction), _sortkey(second_transaction))
 
+    def _type_sort(action_type):
+        """Consistent ordering for action types"""
+        for idx, type_action in enumerate(CaseTransaction.FORM_TYPE_ACTIONS_ORDER):
+            if action_type & type_action == action_type:
+                return idx
+        return len(CaseTransaction.FORM_TYPE_ACTIONS_ORDER)
+
     def _sortkey(transaction):
         # if the user is the same you should compare with the special logic below
         return (
@@ -411,13 +418,3 @@ def _transaction_sort_key_function(case):
         return cache.ids.get(form_id, sys.maxsize)
 
     return cmp_to_key(_transaction_cmp)
-
-
-def _type_sort(action_type):
-    """
-    Consistent ordering for action types
-    """
-    for idx, type_action in enumerate(CaseTransaction.FORM_TYPE_ACTIONS_ORDER):
-        if action_type & type_action == action_type:
-            return idx
-    return len(CaseTransaction.FORM_TYPE_ACTIONS_ORDER)

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1495,6 +1495,14 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
 
     def __str__(self):
         return (
+            "{self.form_id}: "
+            "{self.client_date} "
+            "({self.server_date}) "
+            "{self.readable_type}"
+        ).format(self=self)
+
+    def __repr__(self):
+        return (
             "CaseTransaction("
             "case_id='{self.case_id}', "
             "form_id='{self.form_id}', "

--- a/corehq/util/__init__.py
+++ b/corehq/util/__init__.py
@@ -27,3 +27,11 @@ def eval_lazy(value):
     if isinstance(value, Promise):
         value = value._proxy____cast()
     return value
+
+
+def cmp(a, b):
+    """Comparison function for Python 3
+
+    https://stackoverflow.com/a/22490617/10840
+    """
+    return (a > b) - (a < b)


### PR DESCRIPTION
The most important discovery here is reflected in b4d34e6d22d5f2b2790710a347c244047f95ae24 comments:

`sql_case.xform_ids` is derived from transactions, which are sorted by `server_date`. `couch_case.xform_ids` is based on couch actions, which are not necessarily sorted by `server_date`. Therefore it is likely that they will not match, even after rebuilding either side.

`reconcile_transactions` does not update `transaction.server_date` and therefore `SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL` is not useful to eliminate `sql_case.xform_ids` list order diffs.

All commits except for https://github.com/dimagi/commcare-hq/commit/6905b7ba2c5224196e4aaff40e7ae6244677eb71 and https://github.com/dimagi/commcare-hq/commit/b4d34e6d22d5f2b2790710a347c244047f95ae24 are refactoring. https://github.com/dimagi/commcare-hq/commit/6905b7ba2c5224196e4aaff40e7ae6244677eb71 changes couch action sorting to be more logical and mirror the SQL sorting algorithm.

Review by commit 🐠 

@snopoke cc @sravfeyn 