### PR TITLE
Submit registration properties to hubspot up front

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -97,15 +97,13 @@ def _track_on_hubspot(webuser, properties):
     """
     if webuser.analytics_enabled:
         # Note: Hubspot recommends OAuth instead of api key
-        data = {}
-        if properties:
-            data = {'properties': [{'property': k, 'value': v} for k, v in properties.items()]}
-            _hubspot_post(
-                url="https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(
-                    six.moves.urllib.parse.quote(webuser.get_email())
-                ),
-                data=json.dumps(data),
-            )
+        data = {'properties': [{'property': k, 'value': v} for k, v in properties.items()]}
+        _hubspot_post(
+            url="https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(
+                six.moves.urllib.parse.quote(webuser.get_email())
+            ),
+            data=json.dumps(data),
+        )
 
 
 def _track_on_hubspot_by_email(email, properties):
@@ -234,15 +232,12 @@ def _send_form_to_hubspot(form_id, webuser, hubspot_cookie, meta, extra_fields=N
                 'firstname': webuser.first_name,
                 'lastname': webuser.last_name,
             })
+        if extra_fields:
+            data.update(extra_fields)
 
         response = _send_hubspot_form_request(url, data)
         _log_response('HS', data, response)
         response.raise_for_status()
-
-        # these must be submitted after the form to ensure
-        # the contact has been created in hubspot
-        if extra_fields:
-            update_hubspot_properties_v2(webuser, extra_fields)
 
 
 @count_by_response_code(DATADOG_HUBSPOT_SENT_FORM_METRIC)

--- a/corehq/apps/analytics/tests/test_hubspot.py
+++ b/corehq/apps/analytics/tests/test_hubspot.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.test import RequestFactory, TestCase, override_settings
+
+import mock
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+
+from ..tasks import (
+    HUBSPOT_COOKIE,
+    HUBSPOT_SIGNUP_FORM_ID,
+    track_web_user_registration_hubspot,
+)
+
+
+@override_settings(ANALYTICS_IDS={'HUBSPOT_API_ID': '1234'})
+@mock.patch('corehq.apps.analytics.tasks.requests.get', mock.MagicMock())
+@mock.patch('corehq.apps.analytics.tasks.requests.post', mock.MagicMock())
+@mock.patch('corehq.apps.analytics.tasks._send_hubspot_form_request')
+@mock.patch('corehq.apps.analytics.tasks._get_user_hubspot_id')
+@mock.patch('corehq.apps.analytics.tasks._track_on_hubspot')
+class TestSendToHubspot(TestCase):
+    domain = 'test-send-to-hubspot'
+
+    def test_registration(
+            self,
+            _track_on_hubspot,
+            _get_user_hubspot_id,
+            _send_hubspot_form_request,
+    ):
+        request = self.get_request()
+
+        # The is present in hubspot by the time this is called
+        _get_user_hubspot_id.return_value = "123abc"
+
+        buyer_props = {'buyer_persona': 'Old-Timey Prospector'}
+        track_web_user_registration_hubspot(request, self.user, buyer_props)
+
+        self.assert_signup_form_submitted(_send_hubspot_form_request)
+        self.assert_properties_sent(_track_on_hubspot, buyer_props)
+
+    def test_registration_no_user_hubspot_id(
+            self,
+            _track_on_hubspot,
+            _get_user_hubspot_id,
+            _send_hubspot_form_request,
+    ):
+        request = self.get_request()
+
+        # The user isn't present in hubspot
+        _get_user_hubspot_id.return_value = ""
+
+        buyer_props = {'buyer_persona': 'Old-Timey Prospector'}
+        track_web_user_registration_hubspot(request, self.user, buyer_props)
+
+        self.assert_signup_form_submitted(_send_hubspot_form_request)
+        # Since the user ID wasn't found,t he properties were never submitted
+        _track_on_hubspot.assert_not_called()
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSendToHubspot, cls).setUpClass()
+        cls.domain_obj = create_domain(cls.domain)
+        cls.user = WebUser.create(cls.domain, "seamus@example.com", "*****")
+        cls.user.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        cls.user.delete()
+        super(TestSendToHubspot, cls).tearDownClass()
+
+    def get_request(self):
+        request = RequestFactory().request()
+        request.couch_user = self.user
+        request.domain = self.domain
+        # The hubspot cookie must be passed from the client
+        request.COOKIES[HUBSPOT_COOKIE] = '54321'
+        return request
+
+    def assert_signup_form_submitted(self, _send_hubspot_form_request):
+        _send_hubspot_form_request.assert_called_once()
+        url, data = _send_hubspot_form_request.call_args[0]
+        self.assertIn(HUBSPOT_SIGNUP_FORM_ID, url)
+
+    def assert_properties_sent(self, _track_on_hubspot, buyer_props):
+        _track_on_hubspot.assert_called_once()
+        webuser, properties = _track_on_hubspot.call_args[0]
+        self.assertDictContainsSubset(buyer_props, properties)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-609
Reverting a few recent changes.  There was an issue with boolean property updates not appearing when submitted as part of this form update, so those properties were switched to be submitted separately: https://github.com/dimagi/commcare-hq/pull/24114
Then all properties were moved into that subsequent request, which was also moved to happen after the creation: https://github.com/dimagi/commcare-hq/pull/24146
These couple minor fixes were also reverted, since they no longer apply: https://github.com/dimagi/commcare-hq/pull/24203 https://github.com/dimagi/commcare-hq/pull/24207

I believe moving the property updates to a separate request failed due to a delay in the user being registered in hubspot - we submit the form, then immediately ping to confirm the user exists, so any delay would cause us to get a false miss.  Moving it back into the original form seems to do the trick.

The issue with the boolean properties was I believe one of encoding.  We're currently using [this API](https://developers.hubspot.com/docs/methods/forms/submit_form) which accepts a content type of `application/x-www-form-urlencoded`, so `True` doesn't do anything, but `"true"` does.  It looks like a better option for the future would be to switch to the [v3 api](https://developers.hubspot.com/docs/methods/forms/submit_form_v3) which supports JSON and does input validation and helpful error responses, but I'm punting on that now since it only supports updating properties defined in the form you're submitting, whereas the older API seems to support arbitrary property updates.

I also added tests, which I found useful in understanding how this code worked, but I could be persuaded to drop them - not sure how useful they'll be on an ongoing basis.