### PR TITLE
compare previous media version from the version being reverted to

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4811,6 +4811,8 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
                 # Re-use the id so CommCare knows it's the same resource
                 map_item.unique_id = prev_map_item.unique_id
             # if its a linked app and the map item already has a version don't need to set it up again
+            # this avoids unnecessary re-download of media on phone
+            # https://github.com/dimagi/commcare-hq/pull/24285
             if not (icds_toggle_enabled and is_linked_app and map_item.version):
                 if (prev_map_item and prev_map_item.version
                         and prev_map_item.multimedia_id == map_item.multimedia_id):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -87,6 +87,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_app,
     get_latest_build_doc,
     get_latest_released_app_doc,
+    get_build_doc_by_version,
 )
 from corehq.apps.app_manager.util import (
     get_latest_app_release_by_location,
@@ -4220,14 +4221,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     def is_remote_app(self):
         return False
 
-    def get_version(self, version_number):
-        return self.view('app_manager/applications',
-            key=[self.domain, self.master_id, version_number],
-            include_docs=True,
-            limit=1,
-            descending=True,
-        ).first()
-
     @memoized
     def get_previous_version(self):
         return self.view('app_manager/applications',
@@ -4805,7 +4798,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         """
 
         if version_reverted_to:
-            previous_version = self.get_version(version_reverted_to)
+            previous_version = get_build_doc_by_version(self.domain, self.copy_of, version_reverted_to)
         else:
             previous_version = self.get_previous_version()
         prev_multimedia_map = previous_version.multimedia_map if previous_version else {}

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4803,17 +4803,19 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         else:
             previous_version = self.get_previous_version()
         prev_multimedia_map = previous_version.multimedia_map if previous_version else {}
-
+        is_linked_app = isinstance(self, LinkedApplication)
         for path, map_item in six.iteritems(self.multimedia_map):
             prev_map_item = prev_multimedia_map.get(path, None)
             if prev_map_item and prev_map_item.unique_id:
                 # Re-use the id so CommCare knows it's the same resource
                 map_item.unique_id = prev_map_item.unique_id
-            if (prev_map_item and prev_map_item.version
-                    and prev_map_item.multimedia_id == map_item.multimedia_id):
-                map_item.version = prev_map_item.version
-            else:
-                map_item.version = self.version
+            # if its a linked app and the map item already has a version don't need to set it up again
+            if not (is_linked_app and map_item.version):
+                if (prev_map_item and prev_map_item.version
+                        and prev_map_item.multimedia_id == map_item.multimedia_id):
+                    map_item.version = prev_map_item.version
+                else:
+                    map_item.version = self.version
 
     def ensure_module_unique_ids(self, should_save=False):
         """

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4797,7 +4797,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         Otherwise set it to the version from the last build/version reverted to.
         """
 
-        if version_reverted_to and settings.SERVER_ENVIRONMENT in ['staging', 'india']:
+        if version_reverted_to and toggles.ICDS.enabled(self.domain):
             previous_version = get_build_doc_by_version(self.domain, self.copy_of, version_reverted_to)
         else:
             previous_version = self.get_previous_version()

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4797,8 +4797,9 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         if the media is new or has changed since the last build or the build reverting to.
         Otherwise set it to the version from the last build/version reverted to.
         """
+        icds_toggle_enabled = toggles.ICDS.enabled(self.domain)
 
-        if version_reverted_to and toggles.ICDS.enabled(self.domain):
+        if version_reverted_to and icds_toggle_enabled:
             previous_version = wrap_app(get_build_doc_by_version(self.domain, self.copy_of, version_reverted_to))
         else:
             previous_version = self.get_previous_version()
@@ -4810,7 +4811,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
                 # Re-use the id so CommCare knows it's the same resource
                 map_item.unique_id = prev_map_item.unique_id
             # if its a linked app and the map item already has a version don't need to set it up again
-            if not (is_linked_app and map_item.version):
+            if not (icds_toggle_enabled and is_linked_app and map_item.version):
                 if (prev_map_item and prev_map_item.version
                         and prev_map_item.multimedia_id == map_item.multimedia_id):
                     map_item.version = prev_map_item.version

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4390,7 +4390,8 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         return settings
 
     def create_build_files(self, build_profile_id=None, version_reverted_to=None):
-        all_files = self.create_all_files(build_profile_id=build_profile_id, version_reverted_to=version_reverted_to)
+        all_files = self.create_all_files(build_profile_id=build_profile_id,
+                                          version_reverted_to=version_reverted_to)
         for filepath in all_files:
             self.lazy_put_attachment(all_files[filepath],
                                      'files/%s' % filepath)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4794,7 +4794,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         """
         Set the media version numbers for all media in the app to the current app version
         if the media is new or has changed since the last build or the build reverting to.
-        Otherwise set it to the version from the last build.
+        Otherwise set it to the version from the last build/version reverted to.
         """
 
         if version_reverted_to:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -88,6 +88,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_build_doc,
     get_latest_released_app_doc,
     get_build_doc_by_version,
+    wrap_app,
 )
 from corehq.apps.app_manager.util import (
     get_latest_app_release_by_location,
@@ -4798,7 +4799,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         """
 
         if version_reverted_to and toggles.ICDS.enabled(self.domain):
-            previous_version = get_build_doc_by_version(self.domain, self.copy_of, version_reverted_to)
+            previous_version = wrap_app(get_build_doc_by_version(self.domain, self.copy_of, version_reverted_to))
         else:
             previous_version = self.get_previous_version()
         prev_multimedia_map = previous_version.multimedia_map if previous_version else {}

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4797,7 +4797,7 @@ class Application(ApplicationBase, TranslationMixin, ApplicationMediaMixin,
         Otherwise set it to the version from the last build/version reverted to.
         """
 
-        if version_reverted_to:
+        if version_reverted_to and settings.SERVER_ENVIRONMENT in ['staging', 'india']:
             previous_version = get_build_doc_by_version(self.domain, self.copy_of, version_reverted_to)
         else:
             previous_version = self.get_previous_version()

--- a/corehq/apps/app_manager/tests/test_media_versions.py
+++ b/corehq/apps/app_manager/tests/test_media_versions.py
@@ -1,0 +1,173 @@
+# coding: utf-8
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from mock import patch
+from copy import deepcopy
+
+from django.test import SimpleTestCase
+
+from corehq.apps.app_manager.dbaccessors import wrap_app
+from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.app_manager.tests.util import parse_normalize
+from corehq.apps.hqmedia.models import CommCareImage
+from corehq.util.test_utils import flag_enabled
+
+
+class MediaVersionTest(SimpleTestCase, TestXmlMixin):
+    file_path = ('data', 'suite')
+
+    def _get_linked_app_json(self):
+        linked_app_doc = self.get_json('app')
+        linked_app_doc['doc_type'] = 'LinkedApplication'
+        return linked_app_doc
+
+    @staticmethod
+    def _get_media_resources_versions(Xml):
+        parsedXml = parse_normalize(Xml, to_string=False)
+        return {resource_node.get('id'): resource_node.get('version')
+                for resource_node in parsedXml.findall("media/resource")}
+
+    @staticmethod
+    def _add_image_media(app):
+        image_path = 'jr://file/commcare/case_list_image.jpg'
+        app.get_module(0).case_list_form.set_icon('en', image_path)
+        app.create_mapping(CommCareImage(_id='123'), image_path, save=False)
+
+    @patch('corehq.apps.app_manager.models.ApplicationBase.get_previous_version')
+    def test_version_reset_on_revert_for_master(self, previous_version_mock):
+        previous_version_mock.return_value = None
+
+        # multimedia added
+        app_v1 = wrap_app(deepcopy(self.get_json('app')))
+        self._add_image_media(app_v1)
+        app_v1.set_media_versions()
+        self.assertEqual(app_v1.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 1)
+
+        # multimedia removed
+        app_v2 = wrap_app(deepcopy(self.get_json('app')))
+        app_v2.version = 2
+        previous_version_mock.return_value = app_v1
+        app_v2.set_media_versions()
+        self.assertFalse('jr://file/commcare/case_list_image.jpg' in app_v2.multimedia_map)
+
+        # v3 is a revert to v1, multimedia added back
+        app_v3 = wrap_app(app_v1.to_json())
+        app_v3.version = 3
+        previous_version_mock.return_value = app_v2
+        app_v3.set_media_versions(version_reverted_to=1)
+
+        # version bumped to current version for media re-added in the revert but missing in previous version
+        self.assertEqual(app_v3.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 3)
+
+        # assert calls
+        self.assertEqual(previous_version_mock.call_count, 3)
+
+    @flag_enabled('ICDS')
+    @patch('corehq.apps.app_manager.models.wrap_app')
+    @patch('corehq.apps.app_manager.models.get_build_doc_by_version')
+    @patch('corehq.apps.app_manager.models.ApplicationBase.get_previous_version')
+    def test_version_not_reset_on_revert_for_master(self, previous_version_mock, build_doc_mock, wrap_app_mock):
+        previous_version_mock.return_value = None
+        build_doc_mock.return_value = 'Some Doc'
+
+        # multimedia added
+        app_v1 = wrap_app(self.get_json('app'))
+        self._add_image_media(app_v1)
+        app_v1.set_media_versions()
+        self.assertEqual(app_v1.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 1)
+
+        # multimedia removed
+        app_v2 = wrap_app(self.get_json('app'))
+        app_v2.version = 2
+        previous_version_mock.return_value = app_v1
+        app_v2.set_media_versions()
+        self.assertFalse('jr://file/commcare/case_list_image.jpg' in app_v2.multimedia_map)
+
+        # v3 is a revert to v1, multimedia added back
+        app_v3 = wrap_app(app_v1.to_json())
+        app_v3.version = 3
+        wrap_app_mock.return_value = app_v1
+        app_v3.set_media_versions(version_reverted_to=1)
+
+        # version NOT bumped for media re-added in the revert but missing in previous version
+        self.assertEqual(app_v3.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 1)
+
+        # assert calls
+        build_doc_mock.assert_called_once()
+        wrap_app_mock.assert_called_once_with('Some Doc')
+        self.assertEqual(previous_version_mock.call_count, 2)
+
+    @patch('corehq.apps.app_manager.models.wrap_app')
+    @patch('corehq.apps.app_manager.models.get_build_doc_by_version')
+    @patch('corehq.apps.app_manager.models.ApplicationBase.get_previous_version')
+    def test_version_reset_on_revert_for_linked(self, previous_version_mock, build_doc_mock, wrap_app_mock):
+        previous_version_mock.return_value = None
+
+        # multimedia added
+        linked_app_v1 = wrap_app(self._get_linked_app_json())
+        linked_app_v1.version = 100
+        self._add_image_media(linked_app_v1)
+        linked_app_v1.set_media_versions()
+        self.assertEqual(linked_app_v1.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 100)
+
+        # multimedia removed
+        linked_app_v2 = wrap_app(self._get_linked_app_json())
+        linked_app_v2.version = 200
+        previous_version_mock.return_value = linked_app_v1
+        linked_app_v2.set_media_versions()
+        self.assertFalse('jr://file/commcare/case_list_image.jpg' in linked_app_v2.multimedia_map)
+
+        # set up updated app which would act like a revert to previous version, multimedia added back
+        linked_app_v3_doc = deepcopy(linked_app_v1.to_json())
+        linked_app_v3_doc['version'] = 400
+        linked_app_v3 = wrap_app(linked_app_v3_doc)
+        previous_version_mock.return_value = linked_app_v2
+        linked_app_v3.set_media_versions()
+
+        # version bumped to current version for media re-added in the revert but missing in previous version
+        self.assertEqual(linked_app_v3.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 400)
+
+        # ensure expected calls
+        build_doc_mock.assert_not_called()
+        wrap_app_mock.assert_not_called()
+        self.assertEqual(previous_version_mock.call_count, 3)
+
+    @flag_enabled('ICDS')
+    @patch('corehq.apps.app_manager.models.wrap_app')
+    @patch('corehq.apps.app_manager.models.get_build_doc_by_version')
+    @patch('corehq.apps.app_manager.models.ApplicationBase.get_previous_version')
+    def test_version_not_reset_on_revert_for_linked(self, previous_version_mock, build_doc_mock, wrap_app_mock):
+        previous_version_mock.return_value = None
+
+        # multimedia added
+        linked_app_v1 = wrap_app(self._get_linked_app_json())
+        linked_app_v1.version = 100
+        self._add_image_media(linked_app_v1)
+        linked_app_v1.set_media_versions()
+        self.assertEqual(linked_app_v1.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 100)
+
+        linked_app_v2 = wrap_app(self._get_linked_app_json())
+        linked_app_v2.version = 200
+        previous_version_mock.return_value = linked_app_v1
+        linked_app_v2.set_media_versions()
+
+        self.assertFalse('jr://file/commcare/case_list_image.jpg' in linked_app_v2.multimedia_map)
+
+        # set up updated app which would act like a revert to previous version
+        linked_app_v3_doc = deepcopy(linked_app_v1.to_json())
+        linked_app_v3_doc['version'] = 400
+        linked_app_v3 = wrap_app(linked_app_v3_doc)
+        previous_version_mock.return_value = linked_app_v2
+        # re-set to mock a version in multimedia map received when taken from the master app
+        linked_app_v3.multimedia_map['jr://file/commcare/case_list_image.jpg'].version = 300
+        linked_app_v3.set_media_versions()
+
+        # version NOT bumped to current version for media re-added in the revert but missing in previous version
+        # by keeping the same version as in current multimedia map as pulled from master
+        self.assertEqual(linked_app_v3.multimedia_map['jr://file/commcare/case_list_image.jpg'].version, 300)
+
+        # ensure expected calls
+        build_doc_mock.assert_not_called()
+        wrap_app_mock.assert_not_called()
+        self.assertEqual(previous_version_mock.call_count, 3)

--- a/corehq/apps/app_manager/tests/test_media_versions.py
+++ b/corehq/apps/app_manager/tests/test_media_versions.py
@@ -23,10 +23,10 @@ class MediaVersionTest(SimpleTestCase, TestXmlMixin):
         return linked_app_doc
 
     @staticmethod
-    def _get_media_resources_versions(Xml):
-        parsedXml = parse_normalize(Xml, to_string=False)
+    def _get_media_resources_versions(xml):
+        parsed_xml = parse_normalize(xml, to_string=False)
         return {resource_node.get('id'): resource_node.get('version')
-                for resource_node in parsedXml.findall("media/resource")}
+                for resource_node in parsed_xml.findall("media/resource")}
 
     @staticmethod
     def _add_image_media(app):

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -362,6 +362,7 @@ def revert_to_copy(request, domain, app_id):
     copy = app.make_build(
         comment=copy_build_comment_template.format(**copy_build_comment_params),
         user_id=request.couch_user.get_id,
+        version_reverted_to=copy.version,
     )
     copy.save(increment_version=False)
     return back_to_main(request, domain, app_id=app_id)


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/ICDS-530)

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-477)

Getting this idea out as a PR for feedback/thoughts/review. Not very well versed with multimedia/linkedApp in HQ so pinging people with better context for review.

This PR uses the app version being reverted to, when setting media versions in case of a revert.

Current state where we use the last version.
Using the last version, causes the media being added back after a revert to be treated as new media. Consider this app version life cycle
1. Version 1 
2. Version 2 (Media added, media-version 2)
3. Reverted to version 1, now version 3 (No media)
4. Reverted to version 2 (Media is again present but since it was not present in the previous version i.e version 3, media's version number is updated to 4 since [this](https://github.com/dimagi/commcare-hq/blob/2145165a26374ec186354fb6bf7e7dcbe12e786f/corehq/apps/app_manager/models.py#L4813) returns None and now the mobile thinks of it as a new media and tries to refetch it)

When the app is pulled by the linked app, it does the same thing again.

After this PR
on step 4, *when revert is done* we would take previous media versions from version 2 and there wont be any change in media versions in app version 4.

For linked app,
the update to multimedia version is skipped since its already done by the master app, so it does not redo the work done by master app and reset versions in that process.

I tested this once on my system for a simple app + linked app with a couple of media.

Currently this is being flagged in ICDS project but i believe this would be a general problem.
Putting this behind icds feature flag for now.

Should we be doing the same for set_form_versions?

i think better to review all at once, can view by commit to get a sense of series of changes done
review buddy @millerdev 

Note:
Phone logic as of date to decide which media to download
1. check the previous version mapped to the [id](https://github.com/dimagi/commcare-hq/blob/572e1d40b3fad07bd5a5d519a7cc454187ec0d78/corehq/apps/app_manager/id_strings.py#L340) of the resource, can be seen in media_suite.xml file. (The phone app keeps a mapping of version for each id downloaded, generated/updated when it installs/updates an app)
2. If the version has now increased, re-download
3. if the version is the same or less, do nothing