### PR TITLE
Revert to using old ajax-loader.gif

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -144,8 +144,8 @@
                     </li>
                   </ul>
                   <div class="hq-loading" data-bind="visible: $root.data_loading">
-                    <i class="fa fa-spin fa-spinner"></i>
                     {% trans "Loading" %}
+                    <img src="/static/hqwebapp/images/ajax-loader.gif" alt="loading indicator"></div>
                   <table class="table table-striped datatable table-hover">
                     <thead>
                     <tr>


### PR DESCRIPTION
@orangejenny

The case history tab is [not getting displayed](https://dimagi-dev.atlassian.net/browse/HI-618) (no JS errors) after this PR https://github.com/dimagi/commcare-hq/pull/24278/

I haven't been able to find the root case, but since this is a critical page, reverting it to make it work for now