### PR TITLE
use AUTHENTICATION_BACKENDS for api key fallback authentication

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -163,6 +163,11 @@ INACTIVITY_TIMEOUT = 60 * 24 * 14
 SECURE_TIMEOUT = 30
 ENABLE_DRACONIAN_SECURITY_FEATURES = False
 
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'corehq.apps.domain.auth.ApiKeyFallbackBackend',
+]
+
 PASSWORD_HASHERS = (
     # this is the default list with SHA1 moved to the front
     'django.contrib.auth.hashers.SHA1PasswordHasher',


### PR DESCRIPTION
This refactor will prevent unnecessary sending the ```user_login_failed``` signal whenever the API key is used in place of the password in basic auth (ie with OData feeds for users with 2FA enabled).

In addition to being more correct, this will avoid 500s due to ResourceConflicts like:
https://sentry.io/organizations/dimagi/issues/1021058881/
https://sentry.io/organizations/dimagi/issues/1021158380/
https://sentry.io/organizations/dimagi/issues/1021241613/

Test coverage is provided by existing OData tests.