### PR TITLE
"fast" lookup table upload

### DIFF
--- a/corehq/apps/fixtures/tasks.py
+++ b/corehq/apps/fixtures/tasks.py
@@ -10,11 +10,11 @@ from corehq.apps.fixtures.upload import upload_fixture_file
 
 
 @task
-def fixture_upload_async(domain, download_id, replace):
+def fixture_upload_async(domain, download_id, replace, skip_orm):
     task = fixture_upload_async
     DownloadBase.set_progress(task, 0, 100)
     download_ref = DownloadBase.get(download_id)
-    result = upload_fixture_file(domain, download_ref.get_filename(), replace, task)
+    result = upload_fixture_file(domain, download_ref.get_filename(), replace, task, skip_orm)
     DownloadBase.set_progress(task, 100, 100)
     return {
         'messages': {

--- a/corehq/apps/fixtures/tasks.py
+++ b/corehq/apps/fixtures/tasks.py
@@ -46,6 +46,11 @@ def async_fixture_download(table_ids, domain, download_id):
 
 @task(queue='background_queue', bind=True, default_retry_delay=15 * 60)
 def delete_unneeded_fixture_data_item(self, domain, data_type_id):
+    """Deletes all fixture data items and their ownership models based on their data type.
+
+    Note that this does not bust any caches meaning that the data items could still
+    be returned to the user for some time
+    """
     item_ids = []
     try:
         for items in chunked(FixtureDataItem.by_data_type(domain, data_type_id), 1000):

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -130,7 +130,7 @@ def _run_fast_fixture_upload(domain, workbook, task=None):
             "_id": uuid.uuid4().hex,
             "doc_type": "FixtureDataType",
             "domain": domain,
-            "is_global": False,
+            "is_global": True,
             "description": None,
             "fields": [field.to_json() for field in table_def.fields],
             "copy_from": None,

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -113,6 +113,14 @@ def _run_fast_fixture_upload(domain, workbook, task=None):
     return_val = FixtureUploadResult()
 
     type_sheets = workbook.get_all_type_sheets()
+    for table_definition in type_sheets:
+        if not table_definition.is_global:
+            return_val.errors.append(
+                _("type {lookup_table_name} is not defined as global").format(
+                    lookup_table_name=table_definition.table_id
+                )
+            )
+            return return_val
     total_tables = len(type_sheets)
     return_val.number_of_fixtures = total_tables
 

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -30,7 +30,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 
 
-def upload_fixture_file(domain, filename, replace, task=None):
+def upload_fixture_file(domain, filename, replace, task=None, skip_orm=False):
     """
     should only ever be called after the same file has been validated
     using validate_fixture_file_format
@@ -38,6 +38,8 @@ def upload_fixture_file(domain, filename, replace, task=None):
     """
 
     workbook = get_workbook(filename)
+    if skip_orm is True:
+        return _run_fast_fixture_upload(domain, workbook, task=task)
     return _run_fixture_upload(domain, workbook, replace=replace, task=task)
 
 

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext as _
 
 import six
 from couchdbkit import BulkSaveError, ResourceNotFound
+from requests import HTTPError
 from six.moves import range
 
 from dimagi.utils.chunked import chunked
@@ -166,7 +167,7 @@ def _run_fast_fixture_upload(domain, workbook, task=None):
         try:
             for docs in chunked(data_item_docs_to_save, 1000):
                 FixtureDataItem.get_db().save_docs(docs)
-        except BulkSaveError:
+        except (BulkSaveError, HTTPError):
             return_val.errors.append(
                 _("Error occurred while creating {lookup_table_name}. This table was not created").format(
                     lookup_table_name=data_type['tag']
@@ -189,7 +190,7 @@ def _run_fast_fixture_upload(domain, workbook, task=None):
         # * the delete succeeds, new doc save fails meaning that there is no data type with the desired tag
         try:
             FixtureDataType.get_db().save_docs(data_type_docs)
-        except BulkSaveError:
+        except (BulkSaveError, HTTPError):
             return_val.errors.append(
                 _("Error occurred while creating {lookup_table_name}. This table was not created").format(
                     lookup_table_name=data_type['tag']

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -167,7 +167,7 @@ def _run_fast_fixture_upload(domain, workbook, task=None):
                 "_deleted": True
             })
             return_val.messages.append(
-                _("Pre-existing definition of {lookup_table_name} found").format(
+                _("Pre-existing definition of {lookup_table_name} deleted").format(
                     lookup_table_name=existing_data_type.tag
                 )
             )
@@ -177,15 +177,11 @@ def _run_fast_fixture_upload(domain, workbook, task=None):
         # through their data_type_id in real code
         FixtureDataType.get_db().save_docs(data_type_docs)
         return_val.messages.extend([
-            _("Pre-existing definition of {lookup_table_name} deleted").format(
-                lookup_table_name=existing_data_type.tag
-            ),
             _("Table {lookup_table_name} successfully uploaded").format(lookup_table_name=data_type['tag']),
         ])
 
         if existing_data_type:
             from corehq.apps.fixtures.tasks import delete_unneeded_fixture_data_item
-            existing_data_type.delete()
             # delay removing data items for the previously delete type as that requires a
             # couch view hit which introduces another opportunity for failure
             delete_unneeded_fixture_data_item.delay(domain, existing_data_type._id)

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -189,15 +189,15 @@ def _run_fast_fixture_upload(domain, workbook, task=None):
                 )
             )
             continue
-        return_val.messages.append(
-            _("Table {lookup_table_name} successfully uploaded").format(lookup_table_name=data_type['tag']),
-        )
         if existing_data_type:
             return_val.messages.append(
                 _("Pre-existing definition of {lookup_table_name} deleted").format(
                     lookup_table_name=existing_data_type.tag
                 )
             )
+        return_val.messages.append(
+            _("Table {lookup_table_name} successfully uploaded").format(lookup_table_name=data_type['tag']),
+        )
 
         if existing_data_type:
             from corehq.apps.fixtures.tasks import delete_unneeded_fixture_data_item

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1758,3 +1758,10 @@ IMPROVED_ASR_REPORT = StaticToggle(
     TAG_CUSTOM,
     [NAMESPACE_USER]
 )
+
+SKIP_ORM_FIXTURE_UPLOAD = StaticToggle(
+    'skip_orm_fixture_upload',
+    'Exposes an option in fixture api upload to skip saving through couchdbkit',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
Introduces a feature flag to skip a lot of the ORM setup in lookup table uploads. This is to enable a project that's uploading a very large excel file somewhat frequently. The trade offs are documented in the function:

https://github.com/dimagi/commcare-hq/blob/1bca5369ea01f30c7a4cfdb6687f544e061659eb/corehq/apps/fixtures/upload/run_upload.py#L105-L110

I think some of this could be introduced in the normal lookup table code to speed up normal uploads, but this feels different enough that I'm not comfortable making those changes before my PTO. 