### PR TITLE
Lookup table description

### DIFF
--- a/corehq/apps/fixtures/interface.py
+++ b/corehq/apps/fixtures/interface.py
@@ -1,16 +1,19 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from couchdbkit import ResourceNotFound
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib import messages
-from django.utils.functional import cached_property
 from django.http import HttpResponseRedirect
-from corehq.apps.fixtures.views import fixtures_home, FixtureViewMixIn
-from corehq.apps.reports.generic import GenericReportView, GenericTabularReport
-from corehq.apps.reports.filters.base import BaseSingleOptionFilter
+from django.utils.functional import cached_property
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
+
+from couchdbkit import ResourceNotFound
+from memoized import memoized
+
 from corehq.apps.fixtures.dispatcher import FixtureInterfaceDispatcher
 from corehq.apps.fixtures.models import FixtureDataType, _id_from_doc
-from memoized import memoized
-from django.utils.translation import ugettext_noop, ugettext as _
+from corehq.apps.fixtures.views import FixtureViewMixIn, fixtures_home
+from corehq.apps.reports.filters.base import BaseSingleOptionFilter
+from corehq.apps.reports.generic import GenericReportView, GenericTabularReport
 
 
 class FixtureInterface(FixtureViewMixIn, GenericReportView):

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -42,8 +42,8 @@ class FixtureDataType(QuickCachedDocumentMixin, Document):
     tag = StringProperty()
     fields = SchemaListProperty(FixtureTypeField)
     item_attributes = StringListProperty()
-    description = StringProperty()  # legacy property, not used
-    copy_from = StringProperty()  # legacy property, not used
+    description = StringProperty()
+    copy_from = StringProperty()
 
     @classmethod
     def wrap(cls, obj):

--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -199,6 +199,7 @@ hqDefine("fixtures/js/lookup-manage", [
                 tag: self.tag(),
                 view_link: self.view_link(),
                 is_global: self.is_global(),
+                description: self.description(),
                 fields: (function () {
                     var fields = {},
                         i;
@@ -357,6 +358,7 @@ hqDefine("fixtures/js/lookup-manage", [
                 tag: "",
                 fields: ko.observableArray([]),
                 is_global: true,
+                description: "",
             }, self);
             dataType.editing(true);
             self.data_types.push(dataType);

--- a/corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html
+++ b/corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html
@@ -14,6 +14,12 @@
           </div>
         </div>
         <div class="form-group">
+          <label class="control-label col-sm-2">{% trans "Description" %}</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" data-bind="value: description, valueUpdate: 'afterkeydown'"/>
+          </div>
+        </div>
+        <div class="form-group">
           <label class="control-label col-sm-2">
             {% trans "Visibility" %}
           </label>

--- a/corehq/apps/fixtures/templates/fixtures/view_table.html
+++ b/corehq/apps/fixtures/templates/fixtures/view_table.html
@@ -20,6 +20,9 @@
 {% block page_content %}
   {% initial_page_data 'renderReportTables' 1 %}
   {% initial_page_data 'dataTablesOptions' data_tables_options %}
+  {% if not table_not_selected %}
+    <h4>{{ table_description }}</h4>
+  {% endif %}
 
   {% block reportcontent %}
     {% block reporttable %}

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -118,6 +118,7 @@ def update_tables(request, domain, data_type_id):
         fields_patches = fields_update["fields"]
         data_tag = fields_update["tag"]
         is_global = fields_update["is_global"]
+        description = fields_update["description"]
 
         # validate tag and fields
         validation_errors = []
@@ -146,26 +147,27 @@ def update_tables(request, domain, data_type_id):
 
         with CouchTransaction() as transaction:
             if data_type_id:
-                data_type = update_types(fields_patches, domain, data_type_id, data_tag, is_global, transaction)
-                update_items(fields_patches, domain, data_type_id, transaction)
+                data_type = _update_types(
+                    fields_patches, domain, data_type_id, data_tag, is_global, description, transaction)
+                _update_items(fields_patches, domain, data_type_id, transaction)
             else:
                 if FixtureDataType.fixture_tag_exists(domain, data_tag):
                     return HttpResponseBadRequest("DuplicateFixture")
                 else:
-                    data_type = create_types(fields_patches, domain, data_tag, is_global, transaction)
+                    data_type = _create_types(
+                        fields_patches, domain, data_tag, is_global, description, transaction)
         clear_fixture_cache(domain)
         return json_response(strip_json(data_type))
 
 
-def update_types(patches, domain, data_type_id, data_tag, is_global, transaction):
+def _update_types(patches, domain, data_type_id, data_tag, is_global, description, transaction):
     data_type = FixtureDataType.get(data_type_id)
     fields_patches = deepcopy(patches)
-    assert(data_type.doc_type == FixtureDataType._doc_type)
-    assert(data_type.domain == domain)
     old_fields = data_type.fields
     new_fixture_fields = []
-    setattr(data_type, "tag", data_tag)
-    setattr(data_type, "is_global", is_global)
+    data_type.tag = data_tag
+    data_type.is_global = is_global
+    data_type.description = description
     for old_field in old_fields:
         patch = fields_patches.pop(old_field.field_name, {})
         if not any(patch):
@@ -183,12 +185,12 @@ def update_types(patches, domain, data_type_id, data_tag, is_global, transaction
                 field_name=new_field_name,
                 properties=[]
             ))
-    setattr(data_type, "fields", new_fixture_fields)
+    data_type.fields = new_fixture_fields
     transaction.save(data_type)
     return data_type
 
 
-def update_items(fields_patches, domain, data_type_id, transaction):
+def _update_items(fields_patches, domain, data_type_id, transaction):
     data_items = FixtureDataItem.by_data_type(domain, data_type_id)
     for item in data_items:
         fields = item.fields
@@ -217,13 +219,14 @@ def update_items(fields_patches, domain, data_type_id, transaction):
     )
 
 
-def create_types(fields_patches, domain, data_tag, is_global, transaction):
+def _create_types(fields_patches, domain, data_tag, is_global, description, transaction):
     data_type = FixtureDataType(
         domain=domain,
         tag=data_tag,
         is_global=is_global,
         fields=[FixtureTypeField(field_name=field, properties=[]) for field in fields_patches],
         item_attributes=[],
+        description=description,
     )
     transaction.save(data_type)
     return data_type

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -99,8 +99,8 @@ def update_tables(request, domain, data_type_id):
         except ResourceNotFound:
             raise Http404()
 
-        assert(data_type.doc_type == FixtureDataType._doc_type)
-        assert(data_type.domain == domain)
+        if data_type.domain != domain:
+            raise Http404()
 
         if request.method == 'GET':
             return json_response(strip_json(data_type))

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -82,7 +82,7 @@ def tables(request, domain):
 
 
 @require_can_edit_fixtures
-def update_tables(request, domain, data_type_id, test_patch=None):
+def update_tables(request, domain, data_type_id):
     """
     receives a JSON-update patch like following
     {
@@ -93,8 +93,6 @@ def update_tables(request, domain, data_type_id, test_patch=None):
         "fields":{"genderr":{"update":"gender"},"grade":{}}
     }
     """
-    if test_patch is None:
-        test_patch = {}
     if data_type_id:
         try:
             data_type = FixtureDataType.get(data_type_id)
@@ -116,7 +114,7 @@ def update_tables(request, domain, data_type_id, test_patch=None):
             return HttpResponseBadRequest()
 
     if request.method == 'POST' or request.method == "PUT":
-        fields_update = test_patch or _to_kwargs(request)
+        fields_update = _to_kwargs(request)
         fields_patches = fields_update["fields"]
         data_tag = fields_update["tag"]
         is_global = fields_update["is_global"]

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js
@@ -340,7 +340,6 @@ hqDefine("hqwebapp/js/knockout_bindings.ko", [
         init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
             $(element).addClass('modal fade').modal({
                 show: false,
-                backdrop: false,
             });
             //        ko.bindingHandlers['if'].init(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext);
         },


### PR DESCRIPTION
https://app.asana.com/0/1119457610578860/1121012618797204/f

We've had a description attribute for lookup tables since https://github.com/dimagi/commcare-hq/pull/4640. It was originally used to document lookup tables that are shared on the exchange, but no reason to not have this available for all lookup tables to document it in product

![image](https://user-images.githubusercontent.com/1471773/57650796-9adafe00-7599-11e9-954c-9028fd3b5e78.png)
