### PR TITLE
Revert "Revert "CCZ integrity check for locale ids""

### DIFF
--- a/corehq/apps/app_manager/tests/test_ccz.py
+++ b/corehq/apps/app_manager/tests/test_ccz.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import itertools
+import os
+import tempfile
+import zipfile
+
+from django.test import TestCase
+from mock import patch
+
+from corehq.apps.app_manager.tests.app_factory import AppFactory
+from corehq.apps.app_manager.xform_builder import XFormBuilder
+from corehq.apps.hqmedia.models import CommCareImage
+from corehq.apps.hqmedia.tasks import check_ccz_multimedia_integrity, find_missing_locale_ids_in_ccz
+from corehq.apps.hqmedia.views import iter_media_files
+from corehq.util.test_utils import flag_enabled
+
+
+class CCZTest(TestCase):
+    def setUp(self):
+        self.domain = 'test-domain'
+        self.factory = AppFactory(build_version='2.40.0', domain=self.domain)
+        self.module, self.form = self.factory.new_basic_module('basic', 'patient')
+
+        builder = XFormBuilder(self.form.name)
+        builder.new_question(name='name', label='Name')
+        self.form.source = builder.tostring(pretty_print=True).decode('utf-8')
+
+        image_path = os.path.join('corehq', 'apps', 'hqwebapp', 'static', 'hqwebapp', 'images', 'favicon.png')
+        with open(image_path, 'rb') as f:
+            image_data = f.read()
+            self.image = CommCareImage.get_by_data(image_data)
+            self.image.attach_data(image_data, original_filename='icon.png')
+            self.image.add_domain(self.domain)
+            self.image.save()
+            self.addCleanup(self.image.delete)
+
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    def test_missing_locale_ids(self, mock):
+        files = self.factory.app.create_all_files()
+        errors = find_missing_locale_ids_in_ccz(files)
+        self.assertEqual(len(errors), 0)
+
+        default_app_strings = files['default/app_strings.txt'].splitlines()
+        files['default/app_strings.txt'] = "\n".join([line for line in default_app_strings
+                                                      if not line.startswith("forms.m0f0")])
+        errors = find_missing_locale_ids_in_ccz(files)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('forms.m0f0', errors[0])
+
+    @flag_enabled('CAUTIOUS_MULTIMEDIA')
+    def test_multimedia_integrity(self):
+        icon_path = 'jr://file/commcare/icon.png'
+        self.module.set_icon('en', icon_path)
+        self.factory.app.create_mapping(self.image, icon_path, save=False)
+
+        zip_path = self._create_multimedia_integrity_zip(
+            self.factory.app.create_media_suite(),
+            list(self.factory.app.get_media_objects()))
+        errors = check_ccz_multimedia_integrity(self.domain, zip_path)
+        self.assertEqual(len(errors), 0)
+
+        zip_path = self._create_multimedia_integrity_zip(self.factory.app.create_media_suite(), [])
+        errors = check_ccz_multimedia_integrity(self.domain, zip_path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('commcare/icon.png', errors[0])
+
+    def _create_multimedia_integrity_zip(self, media_suite, media_objects):
+        # Creates a limited zip, containing only media suite and multimedia files
+        files, errors = iter_media_files(media_objects)
+        media_suite = self.factory.app.create_media_suite()
+        files = itertools.chain(files, [('media_suite.xml', media_suite)])
+
+        dummy, zip_path = tempfile.mkstemp()
+        with open(zip_path, 'wb') as tmp:
+            with zipfile.ZipFile(tmp, "w") as z:
+                for path, data in files:
+                    z.writestr(path, data, zipfile.ZIP_STORED)
+        return zip_path

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -185,7 +185,8 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
                     if extension not in MULTIMEDIA_EXTENSIONS:
                         file_cache[path] = data
 
-        errors.extend(find_missing_locale_ids_in_ccz(file_cache))
+        if toggles.LOCALE_ID_INTEGRITY.enabled(app.domain):
+            errors.extend(find_missing_locale_ids_in_ccz(file_cache))
 
         if include_index_files and include_multimedia_files:
             errors.extend(check_ccz_multimedia_integrity(app.domain, fpath))

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -171,6 +171,7 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
             }, indent=4)
             files = itertools.chain(files, [('manifest.json', manifest)])
 
+        file_cache = {}
         with open(fpath, 'wb') as tmp:
             with zipfile.ZipFile(tmp, "w") as z:
                 progress = initial_progress
@@ -181,24 +182,13 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
                     z.writestr(path, data, file_compression)
                     progress += file_progress / file_count
                     DownloadBase.set_progress(build_application_zip, progress, 100)
+                    if extension not in MULTIMEDIA_EXTENSIONS:
+                        file_cache[path] = data
 
-        # Integrity check that all media files present in media_suite.xml were added to the zip
-        if include_multimedia_files and include_index_files and toggles.CAUTIOUS_MULTIMEDIA.enabled(app.domain):
-            with open(fpath, 'rb') as tmp:
-                with zipfile.ZipFile(tmp, "r") as z:
-                    media_suites = [f for f in z.namelist() if re.search(r'\bmedia_suite.xml\b', f)]
-                    if len(media_suites) != 1:
-                        message = _('Could not identify media_suite.xml in CCZ')
-                        errors.append(message)
-                    else:
-                        with z.open(media_suites[0]) as media_suite:
-                            from corehq.apps.app_manager.xform import parse_xml
-                            parsed = parse_xml(media_suite.read())
-                            resources = {node.text for node in
-                                         parsed.findall("media/resource/location[@authority='local']")}
-                            names = z.namelist()
-                            missing = [r for r in resources if re.sub(r'^\.\/', '', r) not in names]
-                            errors += [_('Media file missing from CCZ: {}').format(r) for r in missing]
+        errors.extend(find_missing_locale_ids_in_ccz(file_cache))
+
+        if include_index_files and include_multimedia_files:
+            errors.extend(check_ccz_multimedia_integrity(app.domain, fpath))
 
         if errors:
             os.remove(fpath)
@@ -226,3 +216,53 @@ def build_application_zip(include_multimedia_files, include_index_files, app,
         )
 
     DownloadBase.set_progress(build_application_zip, 100, 100)
+
+
+def find_missing_locale_ids_in_ccz(file_cache):
+    errors = [
+        _("Could not find {file_path} in CCZ").format(file_path)
+        for file_path in ('default/app_strings.txt', 'suite.xml') if file_path not in file_cache]
+    if errors:
+        return errors
+
+    # Each line of an app_strings.txt file is of the format "name.of.key=value of key"
+    # decode is necessary because Application._make_language_files calls .encode('utf-8')
+    app_strings_ids = {
+        line.decode("utf-8").split('=')[0]
+        for line in file_cache['default/app_strings.txt'].splitlines()
+    }
+
+    from corehq.apps.app_manager.xform import parse_xml
+    parsed = parse_xml(file_cache['suite.xml'])
+    suite_ids = {locale.get("id") for locale in parsed.iter("locale")}
+
+    return [
+        _("Locale ID {id} present in suite.xml but not in default app strings.").format(id=id)
+        for id in (suite_ids - app_strings_ids) if id
+    ]
+
+
+# Check that all media files present in media_suite.xml were added to the zip
+def check_ccz_multimedia_integrity(domain, fpath):
+    if not toggles.CAUTIOUS_MULTIMEDIA.enabled(domain):
+        return []
+
+    errors = []
+
+    with open(fpath, 'rb') as tmp:
+        with zipfile.ZipFile(tmp, "r") as z:
+            media_suites = [f for f in z.namelist() if re.search(r'\bmedia_suite.xml\b', f)]
+            if len(media_suites) != 1:
+                message = _('Could not find media_suite.xml in CCZ')
+                errors.append(message)
+            else:
+                with z.open(media_suites[0]) as media_suite:
+                    from corehq.apps.app_manager.xform import parse_xml
+                    parsed = parse_xml(media_suite.read())
+                    resources = {node.text for node in
+                                 parsed.findall("media/resource/location[@authority='local']")}
+                    names = z.namelist()
+                    missing = [r for r in resources if re.sub(r'^\.\/', '', r) not in names]
+                    errors += [_('Media file missing from CCZ: {}').format(r) for r in missing]
+
+    return errors

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -921,7 +921,6 @@ def iter_index_files(app, build_profile_id=None, download_targeted_version=False
             if build_profile_id is not None:
                 name = name.replace(build_profile_id + '/', '')
             if name not in skip_files:
-                # TODO: make RemoteApp.create_all_files not return media files
                 extension = os.path.splitext(name)[1]
                 data = _encode_if_unicode(f) if extension in text_extensions else f
                 yield (_get_name(name), data)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1281,6 +1281,13 @@ CAUTIOUS_MULTIMEDIA = StaticToggle(
     always_enabled={'icds', 'icds-cas'},
 )
 
+LOCALE_ID_INTEGRITY = StaticToggle(
+    'locale_id_integrity',
+    'Verify all locale ids in suite are present in app strings before allowing CCZ download',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)
+
 BULK_UPDATE_MULTIMEDIA_PATHS = StaticToggle(
     'bulk_update_multimedia_paths',
     'Bulk multimedia path management',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-553

Re-applies https://github.com/dimagi/commcare-hq/pull/24200

Putting behind a flag both so ICDS can wait to enable it until the "missing" strings are added to CCUI translations, and also so it doesn't affect other projects that use case tiles.