### PR TITLE
Filter out stale domain docs in GIR report calculation, avoid GIR task errors

### DIFF
--- a/corehq/apps/data_analytics/gir_generator.py
+++ b/corehq/apps/data_analytics/gir_generator.py
@@ -33,24 +33,19 @@ class GIRTableGenerator(object):
         self.monthspan_list = datespan_object_list
 
     def build_table(self):
-        def clear_duplicate(dom1_id, dom2_id):
+
+        def fetch_latest_doc(dom1_id, dom2_id):
             dom1 = Domain.get(dom1_id)
             dom2 = Domain.get(dom2_id)
             assert dom1.name == dom2.name
-            if dom1.last_modified < dom2.last_modified:
-                dom1.doc_type = 'Domain-deleted'
-                dom1.save()
-                return dom2
-            else:
-                dom2.doc_type = 'Domain-deleted'
-                dom2.save()
-                return dom1
+            return dom2 if dom1.last_modified < dom2.last_modified else dom1
+
         domains_by_name = {}
         rows = []
         # filter out duplicate domain docs
         for domain in Domain.get_all():
             if domain.name in domains_by_name:
-                latest_domain = clear_duplicate(domain.get_id, domains_by_name[domain.name].get_id)
+                latest_domain = fetch_latest_doc(domain.get_id, domains_by_name[domain.name].get_id)
                 domains_by_name[domain.name] = latest_domain
             else:
                 domains_by_name[domain.name] = domain


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-612

@proteusvacuum 

This automates the steps described [here](https://dimagi-dev.atlassian.net/browse/HI-564?focusedCommentId=18499&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18499). But may be, deleting stale domain is too much, I could just filter it out and leave it out?