### PR TITLE
don't rebuild all mirrored tables

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -215,7 +215,7 @@ class ConfigurableReportTableManagerMixin(object):
             return
 
         if config.is_static:
-            rebuild_indicators.delay(adapter.config.get_id, source='pillowtop')
+            rebuild_indicators.delay(adapter.config.get_id, source='pillowtop', engine_id=adapter.engine_id)
         else:
             adapter.rebuild_table(source='pillowtop')
 


### PR DESCRIPTION
This will still trigger the `_iteratively_build_table` once https://github.com/dimagi/commcare-hq/pull/24302 is merged. Probably the best approach is to build all the tables from a private release prior to merging.