### PR TITLE
Add notify_error when non-dimagi superuser added

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -60,8 +60,9 @@ def check_non_dimagi_superusers():
         (Q(is_staff=True) | Q(is_superuser=True)) & ~Q(username__endswith='@dimagi.com')
     ).values_list('username', flat=True)))
     if non_dimagis_superuser:
-        _soft_assert_superusers(
-            False, "{non_dimagis} have superuser privileges".format(non_dimagis=non_dimagis_superuser))
+        message = "{non_dimagis} have superuser privileges".format(non_dimagis=non_dimagis_superuser)
+        _soft_assert_superusers(False, message)
+        notify_error(message=message)
 
 
 @task(serializer='pickle', queue="email_queue")


### PR DESCRIPTION
notify_error will send this to sentry which means we'd get alerted in slack. probably better than the soft asserts that everyone auto-archives