### PR TITLE
define __ne__ as the opposite of __eq__ to make behavior consistent across Python versions

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -641,6 +641,9 @@ class SoftwareProductRate(models.Model):
                 return False
         return True
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def new_rate(cls, product_name, monthly_fee, save=True):
         rate = SoftwareProductRate(name=product_name, monthly_fee=monthly_fee)
@@ -704,6 +707,9 @@ class FeatureRate(models.Model):
             if not getattr(self, field) == getattr(other, field):
                 return False
         return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     @classmethod
     def new_rate(cls, feature_name, feature_type,
@@ -1124,6 +1130,9 @@ class Subscription(models.Model):
             and other.subscriber.pk == self.subscriber.pk
             and other.account.pk == self.account.pk
         )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def save(self, *args, **kwargs):
         """

--- a/corehq/apps/aggregate_ucrs/aggregations.py
+++ b/corehq/apps/aggregate_ucrs/aggregations.py
@@ -63,6 +63,9 @@ class TimePeriodAggregationWindow(object):
     def __eq__(self, other):
         return isinstance(other, TimePeriodAggregationWindow) and self._period == other._period
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash((type(self), self.start))
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -276,6 +276,9 @@ class IndexedSchema(DocumentSchema):
             and (self._parent == other._parent)
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     class Getter(object):
 
         def __init__(self, attr):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -344,6 +344,9 @@ class Instance(IdNode, OrderedXmlObject):
     def __eq__(self, other):
         return self.src == other.src and self.id == other.id
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash((self.src, self.id))
 

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -268,6 +268,9 @@ class ItextNodeGroup(object):
 
         return True
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return ''.join(["{0}{1}".format(n.lang, n.rendered_values) for n in self.nodes.values()]).__hash__()
 

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -272,7 +272,7 @@ class ItextNodeGroup(object):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return ''.join(["{0}{1}".format(n.lang, n.rendered_values) for n in self.nodes.values()]).__hash__()
+        return hash(''.join(["{0}{1}".format(n.lang, n.rendered_values) for n in self.nodes.values()]))
 
     def __repr__(self):
         return "{0}, {1}".format(self.id, self.nodes)

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -949,6 +949,9 @@ class CaseRuleActionResult(object):
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     __hash__ = None
 
     def _validate_int(self, value):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -150,6 +150,9 @@ class PathNode(DocumentSchema):
     def __eq__(self, other):
         return self.__key() == other.__key()
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash(self.__key())
 
@@ -194,6 +197,9 @@ class ExportItem(DocumentSchema, ReadablePathMixin):
 
     def __eq__(self, other):
         return self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -209,6 +209,9 @@ class Permissions(DocumentSchema):
                 return False
         return True
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def max(cls):
         return Permissions(
@@ -933,6 +936,9 @@ class DeviceIdLastUsed(DocumentSchema):
 
     def __eq__(self, other):
         return all(getattr(self, p) == getattr(other, p) for p in self.properties())
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class LastSubmission(DocumentSchema):

--- a/corehq/ex-submodules/dimagi/ext/tests/test_schema.py
+++ b/corehq/ex-submodules/dimagi/ext/tests/test_schema.py
@@ -17,6 +17,9 @@ class Ham(DocumentSchema):
     def __eq__(self, other):
         return self.doc_type == other.doc_type and self.eggs == other.eggs
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash(self.eggs)
 

--- a/corehq/ex-submodules/fluff/indicators.py
+++ b/corehq/ex-submodules/fluff/indicators.py
@@ -276,6 +276,9 @@ class IndicatorDocument(six.with_metaclass(IndicatorDocumentMeta, schema.Documen
                 def __eq__(x, y):
                     return x.__key() == y.__key()
 
+                def __ne__(self, other):
+                    return not self.__eq__(other)
+
                 def __hash__(self):
                     return hash(self.__key())
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1236,6 +1236,9 @@ class CommCareCaseIndexSQL(PartitionedModel, models.Model, SaveStateMixin):
             self.relationship_id == other.relationship_id,
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash((self.case_id, self.identifier, self.referenced_id, self.relationship_id))
 

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -37,6 +37,9 @@ class Dhis2Repeater(FormRepeater):
             self.get_id == other.get_id
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash(self.get_id)
 

--- a/corehq/motech/openmrs/jsonpath.py
+++ b/corehq/motech/openmrs/jsonpath.py
@@ -39,6 +39,9 @@ class Cmp(JSONPath):
             other.operand == self.operand
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash(str(self))
 
@@ -68,6 +71,9 @@ class WhereNot(JSONPath):
 
     def __eq__(self, other):
         return isinstance(other, WhereNot) and other.left == self.left and other.right == self.right
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __hash__(self):
         return hash(str(self))

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -73,6 +73,9 @@ class OpenmrsRepeater(CaseRepeater):
             self.get_id == other.get_id
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def wrap(cls, data):
         if 'atom_feed_last_polled_at' in data:


### PR DESCRIPTION
Python 2:
https://docs.python.org/2/reference/datamodel.html#object.__ne

"There are no implied relationships among the comparison operators. The truth of `x==y` does not imply that `x!=y` is false. Accordingly, when defining `__eq__()`, one should also define `__ne__()` so that the operators will behave as expected."

Python 3:
https://docs.python.org/3/reference/datamodel.html#object.__ne

"By default, `__ne__()` delegates to `__eq__()` and inverts the result unless it is NotImplemented. There are no other implied relationships among the comparison operators, for example, the truth of (`x<y or x==y`) does not imply `x<=y`."