### PR TITLE
Catch and reraise dates errors

### DIFF
--- a/corehq/util/workbook_reading/__init__.py
+++ b/corehq/util/workbook_reading/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from corehq.util.workbook_reading.exceptions import (
+    CellValueError,
     SpreadsheetFileError,
     SpreadsheetFileExtError,
     SpreadsheetFileInvalidError,

--- a/corehq/util/workbook_reading/exceptions.py
+++ b/corehq/util/workbook_reading/exceptions.py
@@ -16,3 +16,7 @@ class SpreadsheetFileNotFound(SpreadsheetFileError, IOError):
 
 class SpreadsheetFileEncrypted(SpreadsheetFileError):
     pass
+
+
+class CellValueError(Exception):
+    pass


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-567
Apparently xls allows nonsensical or ambiguous dates.  The xlrd [docs](https://xlrd.readthedocs.io/en/latest/dates.html) put it well:

> **Dates in Excel spreadsheets**
> In reality, there are no such things. What you have are floating point numbers and pious hope.

xlrd detects these nonsensical values and raises an error.  Catching them like this should make it a little easier to see what's going on.

I also looked in to catching this error in the case import code and presenting it to the user as an error, but ended up punting on that for a few reasons:

* This is very rare
* If I switch from a for loop to a while loop with `next()` calls inside a try/except, the iterator will stop working once the exception is hit, so the remaining rows won't be processed
* Returning anything other than a usable value changes this API, and all usages would need to account for that.  This seems like more than I want to bite off.

Other options I considered were:

* Just return `None`, like we do for an empty cell.
* Force the value to be a date - this is what other spreadsheet programs do, and what I'm tempted by if this issue recurs.  For instance, `xlrd.xldate_as_datetime` does manage to spit out a datetime when confronted by this particular issue, but it's not meant to be used like that (it doesn't support dateless times)

In short, this is where I've landed, but I'm open to second opinions.