### PR TITLE
Add management command update_es_settings

### DIFF
--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -61,8 +61,6 @@ ES_ENV_SETTINGS = {
         },
     },
 }
-if settings.ES_SETTINGS is not None:
-    ES_ENV_SETTINGS.update({settings.SERVER_ENVIRONMENT: settings.ES_SETTINGS})
 
 ES_META = {
     # Default settings for all indexes on ElasticSearch
@@ -116,8 +114,13 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
         meta_settings.update(
             ES_META.get(settings.SERVER_ENVIRONMENT, {}).get(self.alias, {})
         )
+
+        overrides = copy(ES_ENV_SETTINGS)
+        if settings.ES_SETTINGS is not None:
+            overrides.update({settings.SERVER_ENVIRONMENT: settings.ES_SETTINGS})
+
         for alias in ['default', self.alias]:
-            for key, value in ES_ENV_SETTINGS.get(settings.SERVER_ENVIRONMENT, {}).get(alias, {}).items():
+            for key, value in overrides.get(settings.SERVER_ENVIRONMENT, {}).get(alias, {}).items():
                 if value is REMOVE_SETTING:
                     del meta_settings['settings'][key]
                 else:

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -55,18 +55,6 @@ ANALYZERS = {
 REMOVE_SETTING = None
 
 ES_ENV_SETTINGS = {
-    'production': {
-        'xforms': {
-            "number_of_replicas": REMOVE_SETTING,
-        },
-        'hqcases': {
-            "number_of_replicas": REMOVE_SETTING,
-        },
-        'hqusers': {
-            "number_of_replicas": 1,
-        },
-    },
-
     'icds': {
         'hqusers': {
             "number_of_replicas": 1,

--- a/corehq/ex-submodules/pillowtop/management/commands/update_es_settings.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/update_es_settings.py
@@ -1,0 +1,65 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.core.management.base import BaseCommand, CommandError
+
+from corehq.elastic import get_es_new
+from corehq.pillows.utils import get_all_expected_es_indices
+from six.moves import input
+
+
+class Command(BaseCommand):
+    help = "Update dynamic settings for existing elasticsearch indices."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput',
+            action='store_true',
+            dest='noinput',
+            default=False,
+            help='Skip important confirmation warnings.'
+        )
+
+    def handle(self, **options):
+        noinput = options.pop('noinput')
+        es_indices = list(get_all_expected_es_indices())
+
+        to_update = []
+        es = get_es_new()
+
+        for index_info in es_indices:
+            old_settings = es.indices.get_settings(index=index_info.index)
+            old_number_of_replicas = int(
+                old_settings[index_info.index]['settings']['index']['number_of_replicas']
+            )
+            new_number_of_replicas = index_info.meta['settings']['number_of_replicas']
+
+            if old_number_of_replicas != new_number_of_replicas:
+                print("{} [{}]:\n  Number of replicas changing from {!r} to {!r}".format(
+                    index_info.alias, index_info.index, old_number_of_replicas, new_number_of_replicas))
+                to_update.append((index_info, {
+                    'number_of_replicas': new_number_of_replicas,
+                }))
+
+        if not to_update:
+            print("There is nothing to update.")
+            return
+        if (noinput or _confirm(
+                "Confirm that you want to update all the settings above?")):
+            for index_info, settings in to_update:
+                    mapping_res = es.indices.put_settings(index=index_info.index, body=settings)
+                    if mapping_res.get('acknowledged', False):
+                        print("{} [{}]:\n  Index settings successfully updated".format(
+                            index_info.alias, index_info.index))
+                    else:
+                        print(mapping_res)
+
+
+def _confirm(message):
+    if input(
+            '{} [y/n]'.format(message)
+    ).lower() == 'y':
+        return True
+    else:
+        raise CommandError('abort')

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -20,7 +20,20 @@ class ProdIndexManagementTest(SimpleTestCase):
         settings.PILLOWTOPS = cls._PILLOWTOPS
         super(ProdIndexManagementTest, cls).tearDownClass()
 
-    @override_settings(SERVER_ENVIRONMENT='production')
+    @override_settings(SERVER_ENVIRONMENT='production', ES_SETTINGS={
+        "default": {"number_of_replicas": 1},
+        "case_search": {},
+        "hqapps": {},
+        "hqcases": {},
+        "hqdomains": {},
+        "hqgroups": {},
+        "hqusers": {},
+        "ledgers": {},
+        "report_cases": {},
+        "report_xforms": {},
+        "smslogs": {},
+        "xforms": {},
+    })
     def test_prod_config(self):
         found_prod_indices = [info.to_json() for info in get_all_expected_es_indices()]
         for info in found_prod_indices:
@@ -50,7 +63,7 @@ EXPECTED_PROD_INDICES = [
         "type": "case",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -78,7 +91,7 @@ EXPECTED_PROD_INDICES = [
         "type": "app",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -97,6 +110,7 @@ EXPECTED_PROD_INDICES = [
         "type": "case",
         "meta": {
             "settings": {
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -124,7 +138,7 @@ EXPECTED_PROD_INDICES = [
         "type": "hqdomain",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -147,7 +161,7 @@ EXPECTED_PROD_INDICES = [
         "type": "group",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -195,7 +209,7 @@ EXPECTED_PROD_INDICES = [
         "type": "ledger",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -223,7 +237,7 @@ EXPECTED_PROD_INDICES = [
         "type": "report_case",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -251,7 +265,7 @@ EXPECTED_PROD_INDICES = [
         "type": "report_xform",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -279,7 +293,7 @@ EXPECTED_PROD_INDICES = [
         "type": "sms",
         "meta": {
             "settings": {
-                "number_of_replicas": 0,
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {
@@ -307,6 +321,7 @@ EXPECTED_PROD_INDICES = [
         "type": "xform",
         "meta": {
             "settings": {
+                "number_of_replicas": 1,
                 "analysis": {
                     "analyzer": {
                         "default": {


### PR DESCRIPTION
currently only rolls out the number_of_replicas setting.

This will make it easier to keep envs' ES settings in sync with what we specify in localsettings.py. Currently what we specify in localsettings.py is only used upon index _creation_, but doesn't get automatically pushed out on deploy.