### PR TITLE
Fix form problem created by swap_duplicate_xforms 

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -26,6 +26,9 @@ from django.db.utils import IntegrityError
 from django_redis import get_redis_connection
 from gevent.pool import Pool
 
+from corehq.apps.cleanup.management.commands.swap_duplicate_xforms import (
+    PROBLEM_TEMPLATE_START,
+)
 from corehq.apps.couch_sql_migration.diff import (
     filter_case_diffs,
     filter_form_diffs,
@@ -70,7 +73,7 @@ from corehq.util.log import with_progress_bar
 from corehq.util.pagination import PaginationEventHandler
 from corehq.util.timer import TimingContext
 from couchforms.models import XFormInstance, all_known_formlike_doc_types
-from couchforms.models import doc_types as form_doc_types
+from couchforms.models import XFormOperation, doc_types as form_doc_types
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.undo import DELETED_SUFFIX
@@ -160,9 +163,12 @@ class CouchSqlDomainMigrator(object):
         for change in self._with_progress(['XFormInstance'], changes):
             log.debug('Processing doc: {}({})'.format('XFormInstance', change.id))
             form = change.get_document()
-            if form.get('problem', None):
-                self.errors_with_normal_doc_type.append(change.id)
-                continue
+            if form.get('problem'):
+                if six.text_type(form['problem']).startswith(PROBLEM_TEMPLATE_START):
+                    form = _fix_replacement_form_problem_in_couch(form)
+                else:
+                    self.errors_with_normal_doc_type.append(change.id)
+                    continue
             try:
                 wrapped_form = XFormInstance.wrap(form)
                 form_received = wrapped_form.received_on
@@ -702,6 +708,37 @@ def _migrate_couch_attachments_to_blob_db(couch_form):
                     content_type=meta.get("content_type"),
                 )
         assert not set(couch_form._attachments) - set(couch_form.blobs), couch_form
+
+
+def _fix_replacement_form_problem_in_couch(doc):
+    """Fix replacement form created by swap_duplicate_xforms
+
+    The replacement form was incorrectly created with "problem" text,
+    which causes it to be counted as an error form, and that messes up
+    the diff counts at the end of this migration.
+
+    NOTE the replacement form's _id does not match instanceID in its
+    form.xml. That issue is not resolved here.
+
+    See:
+    - corehq/apps/cleanup/management/commands/swap_duplicate_xforms.py
+    - couchforms/_design/views/all_submissions_by_domain/map.js
+    """
+    problem = doc["problem"]
+    assert problem.startswith(PROBLEM_TEMPLATE_START), doc
+    assert doc["doc_type"] == "XFormInstance", doc
+    deprecated_id = problem[len(PROBLEM_TEMPLATE_START):].split(" on ", 1)[0]
+    form = XFormInstance.wrap(doc)
+    form.deprecated_form_id = deprecated_id
+    form.history.append(XFormOperation(
+        user="system",
+        date=datetime.utcnow(),
+        operation="Resolved bad duplicate form during couch-to-sql "
+        "migration. Original problem: %s" % problem,
+    ))
+    form.problem = None
+    form.save()
+    return form.to_json()
 
 
 def _migrate_case_attachments(couch_case, sql_case):

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -18,6 +18,10 @@ from casexml.apps.case.mock import CaseBlock
 from couchforms.models import XFormInstance
 from dimagi.utils.parsing import ISO_DATETIME_FORMAT
 
+from corehq.apps.cleanup.management.commands.swap_duplicate_xforms import (
+    BAD_FORM_PROBLEM_TEMPLATE,
+    FIXED_FORM_PROBLEM_TEMPLATE,
+)
 from corehq.apps.commtrack.helpers import make_product
 from corehq.apps.couch_sql_migration.couchsqlmigration import (
     MigrationRestricted,
@@ -677,6 +681,37 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assertEqual(set(case.xform_ids), {"f1-9017", "f2-b1ce", "f3-7c38", "f4-3226"})
         self._compare_diffs([])
 
+    def test_normal_form_with_problem_and_case_updates(self):
+        bad_form = submit_form_locally(TEST_FORM, self.domain_name).xform
+        assert bad_form._id == "test-form", bad_form
+
+        form = XFormInstance.wrap(bad_form.to_json())
+        form._id = "new-form"
+        form._rev = None
+        form.problem = FIXED_FORM_PROBLEM_TEMPLATE.format(
+            id_="test-form", datetime_="a day long ago")
+        assert len(form.external_blobs) == 1, form.external_blobs
+        form.external_blobs.pop("form.xml")
+        with bad_form.fetch_attachment("form.xml", stream=True) as xml:
+            form.put_attachment(xml, "form.xml", content_type="text/xml")
+        form.save()
+
+        bad_form.doc_type = "XFormDuplicate"
+        bad_form.problem = BAD_FORM_PROBLEM_TEMPLATE.format("new-form", "a day long ago")
+        bad_form.save()
+
+        case = self._get_case("test-case")
+        self.assertEqual(case.xform_ids, ["test-form"])
+
+        self._do_migration_and_assert_flags(self.domain_name)
+
+        case = self._get_case("test-case")
+        self.assertEqual(case.xform_ids, ["new-form"])
+        self._compare_diffs([])
+        form = FormAccessors(self.domain_name).get_form('new-form')
+        self.assertEqual(form.deprecated_form_id, "test-form")
+        self.assertIsNone(form.problem)
+
 
 class LedgerMigrationTests(BaseMigrationTestCase):
     def setUp(self):
@@ -857,6 +892,45 @@ class DummyObject(object):
 
     def __repr__(self):
         return "DummyObject<id={}>".format(self.id)
+
+
+TEST_FORM = """
+<?xml version="1.0" ?>
+<data
+    name="Registration"
+    uiVersion="1"
+    version="11"
+    xmlns="http://openrosa.org/formdesigner/test-form"
+    xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+>
+    <first_name>Xeenax</first_name>
+    <age>27</age>
+    <n0:case
+        case_id="test-case"
+        date_modified="2015-08-04T18:25:56.656Z"
+        user_id="3fae4ea4af440efaa53441b5"
+        xmlns:n0="http://commcarehq.org/case/transaction/v2"
+    >
+        <n0:create>
+            <n0:case_name>Xeenax</n0:case_name>
+            <n0:owner_id>3fae4ea4af440efaa53441b5</n0:owner_id>
+            <n0:case_type>testing</n0:case_type>
+        </n0:create>
+        <n0:update>
+            <n0:age>27</n0:age>
+        </n0:update>
+    </n0:case>
+    <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
+        <n1:deviceID>cloudcare</n1:deviceID>
+        <n1:timeStart>2015-07-13T11:20:11.381Z</n1:timeStart>
+        <n1:timeEnd>2015-08-04T18:25:56.656Z</n1:timeEnd>
+        <n1:username>jeremy</n1:username>
+        <n1:userID>3fae4ea4af440efaa53441b5</n1:userID>
+        <n1:instanceID>test-form</n1:instanceID>
+        <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">2.0</n2:appVersion>
+    </n1:meta>
+</data>
+""".strip()
 
 
 LIST_ORDER_FORMS = ["""

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -165,7 +165,7 @@ class XFormInstance(DeferredBlobMixin, SafeSaveDocument,
                     )
             return db.get(docid, rev=rev, wrapper=cls.wrap, **extras)
         except ResourceNotFound:
-            raise XFormNotFound
+            raise XFormNotFound(docid)
 
     @property
     def form_id(self):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -368,7 +368,7 @@ class FormAccessorSQL(AbstractFormAccessor):
         try:
             return XFormInstanceSQL.objects.partitioned_get(form_id)
         except XFormInstanceSQL.DoesNotExist:
-            raise XFormNotFound
+            raise XFormNotFound(form_id)
 
     @staticmethod
     def get_forms(form_ids, ordered=False):
@@ -1271,7 +1271,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
             try:
                 return xform_map[form_id]
             except KeyError:
-                raise XFormNotFound
+                raise XFormNotFound(form_id)
 
         for case_transaction in transactions:
             if case_transaction.form_id:


### PR DESCRIPTION
Review by commit 🐠 

Also includes an unrelated change to fix something I have always found annoying: `XFormNotFound` is now raised with the form id as the message, which makes debugging easier. Please flag if there was an intentional reason that it was done that way originally.

@dannyroberts @snopoke cc @mkangia 