### PR TITLE
[ICDS] - Rename column in lady supervisor export

### DIFF
--- a/custom/icds_reports/sqldata/exports/lady_supervisor.py
+++ b/custom/icds_reports/sqldata/exports/lady_supervisor.py
@@ -20,7 +20,7 @@ class LadySupervisorExport(ExportableMixin, IcdsSqlData):
             DatabaseColumn('District', SimpleColumn('district_name'), slug='district_name'),
             DatabaseColumn('Block', SimpleColumn('block_name'), slug='block_name'),
             DatabaseColumn('Sector Name', SimpleColumn('supervisor_name'), slug='supervisor_name'),
-            DatabaseColumn('Name of Lady Supervisor', SimpleColumn('supervisor_site_code'),
+            DatabaseColumn('Lady Supervisor User ID', SimpleColumn('supervisor_site_code'),
                            slug='supervisor_site_code'),
             DatabaseColumn('Total No. of AWCs visited', SimpleColumn('awc_visits'), slug='awc_visits'),
             DatabaseColumn(

--- a/custom/icds_reports/tests/test_export_data.py
+++ b/custom/icds_reports/tests/test_export_data.py
@@ -2022,7 +2022,7 @@ class TestExportData(TestCase):
                         'District',
                         'Block',
                         'Sector Name',
-                        'Name of Lady Supervisor',
+                        'Lady Supervisor User ID',
                         'Total No. of AWCs visited',
                         'Total No. of Beneficiaries Visited',
                         'Total No. of VHNDs observed'
@@ -2096,8 +2096,8 @@ class TestExportData(TestCase):
             ]
         ]
         self.assertListEqual(
-            data,
-            expected
+            expected,
+            data
         )
 
     def test_aww_performance_export(self):


### PR DESCRIPTION
Hi @calellowitz @Rohit25negi 

I changed the label for a column in the lady supervisor export from Name of Lady Supervisor to Lady Supervisor User ID.

TICKET: https://dimagi-dev.atlassian.net/browse/ICDS-567

QA: no
Environment: ICDS
locally tested: yes

Please let me know if you have any question.