### PR TITLE
Use module names in list

### DIFF
--- a/corehq/apps/translations/integrations/transifex/views.py
+++ b/corehq/apps/translations/integrations/transifex/views.py
@@ -317,7 +317,7 @@ class BlacklistTranslations(BaseTranslationsView):
     @property
     def page_context(self):
         context = super(BlacklistTranslations, self).page_context
-        context['blacklisted_translations'] = TransifexBlacklist.translations_with_app_name(self.domain)
+        context['blacklisted_translations'] = TransifexBlacklist.translations_with_names(self.domain)
         context['blacklist_form'] = self.blacklist_form
         return context
 

--- a/corehq/apps/translations/models.py
+++ b/corehq/apps/translations/models.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from django.db import models
 from django.utils.functional import cached_property
 
+from corehq.util.quickcache import quickcache
 from dimagi.ext.couchdbkit import (
     Document,
     DictProperty,
@@ -14,7 +15,7 @@ from dimagi.ext.couchdbkit import (
 )
 from dimagi.utils.couch import CouchDocLockableMixIn
 
-from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
+from corehq.apps.app_manager.dbaccessors import get_app_ids_in_domain, get_app
 from corehq.motech.utils import b64_aes_decrypt
 
 
@@ -159,15 +160,43 @@ class TransifexBlacklist(models.Model):
         # app_id and module_id omitted because they are unfriendly
 
     @classmethod
-    def translations_with_app_name(cls, domain):
+    def translations_with_names(cls, domain):
         blacklisted = TransifexBlacklist.objects.filter(domain=domain).all().values()
-        app_ids_to_name = {app.id: app.name for app in get_brief_apps_in_domain(domain)}
+        apps_modules_by_id = get_apps_modules_by_id(domain)
         ret = []
         for trans in blacklisted:
             r = trans.copy()
-            r['app_name'] = app_ids_to_name.get(trans['app_id'], trans['app_id'])
+            app = apps_modules_by_id.get(trans['app_id'])
+            module = app['modules'].get(trans['module_id']) if app else None
+            r['app_name'] = app['name'] if app else trans['app_id']
+            r['module_name'] = module['name'] if module else trans['module_id']
             ret.append(r)
         return ret
+
+
+@quickcache(['domain'])
+def get_apps_modules_by_id(domain):
+    """
+    Return a dictionary of {
+        <app id>: {
+            'name': <app name>,
+            'modules': {
+                <module id>: {'name': <module name>}
+            }
+        }
+    }
+    """
+    apps = {}
+    for app_id in get_app_ids_in_domain(domain):
+        app = get_app(domain, app_id)
+        modules = {}
+        for module in app.get_modules():
+            modules[module.unique_id] = {'name': module.default_name(app)}
+        apps[app_id] = {
+            'name': app.name,
+            'modules': modules
+        }
+    return apps
 
 
 class TransifexOrganization(models.Model):

--- a/corehq/apps/translations/models.py
+++ b/corehq/apps/translations/models.py
@@ -1,22 +1,22 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 from collections import defaultdict
 
 from django.contrib import admin
 from django.db import models
 from django.utils.functional import cached_property
 
-from corehq.util.quickcache import quickcache
 from dimagi.ext.couchdbkit import (
-    Document,
     DictProperty,
+    Document,
     ListProperty,
     StringProperty,
 )
 from dimagi.utils.couch import CouchDocLockableMixIn
 
-from corehq.apps.app_manager.dbaccessors import get_app_ids_in_domain, get_app
+from corehq.apps.app_manager.dbaccessors import get_app, get_app_ids_in_domain
 from corehq.motech.utils import b64_aes_decrypt
+from corehq.util.quickcache import quickcache
 
 
 class TranslationMixin(Document):

--- a/corehq/apps/translations/templates/blacklist_translations.html
+++ b/corehq/apps/translations/templates/blacklist_translations.html
@@ -21,7 +21,7 @@
           <td>{{ translation.app_name }}</td>
           <td>
             {% if translation.module_id %}
-            <a href="{% url 'view_module' domain translation.app_id translation.module_id %}">{{ translation.module_id }}</a>
+            <a href="{% url 'view_module' domain translation.app_id translation.module_id %}">{{ translation.module_name }}</a>
             {% endif %}
           </td>
           <td>{{ translation.field_type }}</td>


### PR DESCRIPTION
Transifex blacklists for REACH and ICDS:

Showing module names is a big help for people creating blacklists, and not much more effort than getting the app name.

Before:
![image](https://user-images.githubusercontent.com/708421/57927669-0204f500-78af-11e9-85db-9c40e85114f1.png)

After:
![image](https://user-images.githubusercontent.com/708421/57927502-7ab78180-78ae-11e9-9c05-a45c7ae62adc.png)
