### PR TITLE
efRefactor Case Importer

### DIFF
--- a/corehq/apps/case_importer/const.py
+++ b/corehq/apps/case_importer/const.py
@@ -14,15 +14,3 @@ MAX_CASE_IMPORTER_COLUMNS = 300
 
 class LookupErrors(object):
     NotFound, MultipleResults = list(range(2))
-
-
-class ImportErrors(object):
-    InvalidOwnerName = ugettext_noop('Invalid Owner Name')
-    InvalidOwnerId = ugettext_noop('Invalid Owner ID')
-    InvalidParentId = ugettext_noop('Invalid Parent ID')
-    InvalidDate = ugettext_noop('Invalid Date')
-    BlankExternalId = ugettext_noop('Blank External ID')
-    CaseGeneration = ugettext_noop('Case Generation Error')
-    DuplicateLocationName = ugettext_noop('Duplicated Location Name')
-    InvalidInteger = ugettext_noop('Invalid Integer')
-    ImportErrorMessage = ugettext_noop('Import Error')

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -277,7 +277,7 @@ class _CaseImportRow(object):
     def get_update_caseblock(self):
         extras = self._get_caseblock_kwargs()
         if self.uploaded_owner_id or self.uploaded_owner_name:
-            extras['owner_id'] = self._get_owner_id(),
+            extras['owner_id'] = self._get_owner_id()
         if self.case_name is not None:
             extras['case_name'] = self.case_name
         return CaseBlock(

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -150,7 +150,7 @@ class _Importer(object):
                 self.results.add_error(row_number, exceptions.ImportErrorMessage())
         else:
             self.record_form(form.form_id)
-            properties = set().union(*[set(c.dynamic_case_properties().keys()) for c in cases])
+            properties = {p for c in cases for p in c.dynamic_case_properties().keys()}
             if self.config.case_type and len(properties):
                 add_inferred_export_properties.delay(
                     'CaseImporter',

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -80,8 +80,6 @@ class _Importer(object):
         row.check_valid_external_id()
         if row.relies_on_uncreated_case(self.uncreated_external_ids):
             self.commit_caseblocks()
-            # TODO Move this into commit_caseblocks - possible bug
-            self.uncreated_external_ids = set()
 
         case, error = importer_util.lookup_case(
             self.config.search_field,
@@ -131,6 +129,7 @@ class _Importer(object):
             self._submit_caseblocks(self._caseblocks)
             self.num_chunks += 1
             self._caseblocks = []
+            self.uncreated_external_ids = set()
 
     def _submit_caseblocks(self, caseblocks):
         if caseblocks:

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -219,7 +219,7 @@ class CaseImportRow(object):
         self.owner_id = owner_id or self.user_id
 
     def set_parent_id(self, log_case_lookup):
-        for column, search_field, search_id  in [
+        for column, search_field, search_id in [
                 ('parent_id', 'case_id', self.parent_id),
                 ('parent_external_id', 'external_id', self.parent_external_id),
         ]:

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -35,7 +35,6 @@ class _Importer(object):
 
         self.created_count = 0
         self.match_count = 0
-        self.too_many_matches = 0
         self.num_chunks = 0
         self.errors = importer_util.ImportErrorDetail()
 
@@ -94,8 +93,7 @@ class _Importer(object):
             if not self.config.create_new_cases:
                 return
         elif error == LookupErrors.MultipleResults:
-            self.too_many_matches += 1
-            return
+            raise exceptions.TooManyMatches()
 
         row.set_owner_id(self.name_cache, self.id_cache)
         row.set_parent_id(self.log_case_lookup)
@@ -172,7 +170,6 @@ class _Importer(object):
         return {
             'created_count': self.created_count,
             'match_count': self.match_count,
-            'too_many_matches': self.too_many_matches,
             'errors': self.errors.as_dict(),
             'num_chunks': self.num_chunks,
         }

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -56,7 +56,7 @@ class _Importer(object):
 
     def do_import(self, spreadsheet):
         for row_num, row in enumerate(spreadsheet.iter_row_dicts(), start=1):
-            set_task_progress(self.task, row_num, spreadsheet.max_row)
+            set_task_progress(self.task, row_num - 1, spreadsheet.max_row)
             if row_num == 1:
                 continue  # skip first row (header row)
 

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -252,15 +252,10 @@ class CaseImportRow(object):
             self.extras['date_opened'] = self.date_opened
 
     def set_external_id(self, is_new_case):
-        # This can almost certainly be simplified, will worry about that later
-        if is_new_case:
-            if self.config.search_field == 'external_id':
-                self.extras['external_id'] = self.search_id
-            elif self.external_id:
-                self.extras['external_id'] = self.external_id
-        else:
-            if self.external_id:
-                self.extras['external_id'] = self.external_id
+        if is_new_case and self.config.search_field == 'external_id':
+            self.extras['external_id'] = self.search_id
+        elif self.external_id:
+            self.extras['external_id'] = self.external_id
 
     def get_create_caseblock(self):
         return CaseBlock(

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -75,36 +75,23 @@ class _Importer(object):
             self.match_count -= 1
         self.num_chunks += 1
 
-    def handle_row(self, i, row):
-        search_id = importer_util.parse_search_id(self.config, row)
-
-        fields_to_update = importer_util.populate_updated_fields(self.config, row)
+    def handle_row(self, i, raw_row):
+        search_id = importer_util.parse_search_id(self.config, raw_row)
+        fields_to_update = importer_util.populate_updated_fields(self.config, raw_row)
         if not any(fields_to_update.values()):
             # if the row was blank, just skip it, no errors
             return
 
-        if self.config.search_field == 'external_id' and not search_id:
-            # do not allow blank external id since we save this
-            raise exceptions.BlankExternalId(i + 1)
-
-        external_id = fields_to_update.pop('external_id', None)
-        parent_id = fields_to_update.pop('parent_id', None)
-        parent_external_id = fields_to_update.pop('parent_external_id', None)
-        parent_type = fields_to_update.pop('parent_type', self.config.case_type)
-        parent_ref = fields_to_update.pop('parent_ref', 'parent')
-        to_close = fields_to_update.pop('close', False)
-
-        if any(lookup_id and lookup_id in self.ids_seen
-               for lookup_id in [search_id, parent_id, parent_external_id]):
-            # clear out the queue to make sure we've processed any potential
-            # cases we want to look up
+        row = CaseImportRow(i, search_id, fields_to_update, self.config, self.domain, self.user.user_id)
+        row.check_valid_external_id()
+        if row.relies_on_unsubmitted_case(self.ids_seen):
             self.commit_caseblocks()
             # TODO Move this into commit_caseblocks - possible bug
             self.ids_seen = set()  # also clear ids_seen, since all the cases will now be in the database
 
         case, error = importer_util.lookup_case(
             self.config.search_field,
-            search_id,
+            row.search_id,
             self.domain,
             self.config.case_type
         )
@@ -120,111 +107,24 @@ class _Importer(object):
             self.too_many_matches += 1
             return
 
-        uploaded_owner_name = fields_to_update.pop('owner_name', None)
-        uploaded_owner_id = fields_to_update.pop('owner_id', None)
+        row.set_owner_id(self.name_cache, self.id_cache)
+        row.set_parent_id(self.track_load)
+        row.set_date_opened()
+        row.set_external_id(is_new_case=not case)
 
-        if uploaded_owner_name:
-            # If an owner name was provided, replace the provided
-            # uploaded_owner_id with the id of the provided group or owner
-            try:
-                uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, self.domain, self.name_cache)
-            except SQLLocation.MultipleObjectsReturned:
-                raise exceptions.DuplicateLocationName(i + 1)
-
-            if not uploaded_owner_id:
-                raise exceptions.InvalidOwnerName(i + 1, 'owner_name')
-        if uploaded_owner_id:
-            # If an owner_id mapping exists, verify it is a valid user
-            # or case sharing group
-            if importer_util.is_valid_id(uploaded_owner_id, self.domain, self.id_cache):
-                owner_id = uploaded_owner_id
-                self.id_cache[uploaded_owner_id] = True
-            else:
-                self.id_cache[uploaded_owner_id] = False
-                raise exceptions.InvalidOwnerId(i + 1, 'owner_id')
-        else:
-            # if they didn't supply an owner_id mapping, default to current
-            # user
-            owner_id = self.user.user_id
-
-        extras = {}
-        if parent_id:
-            try:
-                parent_case = CaseAccessors(self.domain).get_case(parent_id)
-                self.track_load()
-
-                if parent_case.domain == self.domain:
-                    extras['index'] = {
-                        parent_ref: (parent_case.type, parent_id)
-                    }
-            except ResourceNotFound:
-                raise exceptions.InvalidParentId(i + 1, 'parent_id')
-        elif parent_external_id:
-            parent_case, error = importer_util.lookup_case(
-                'external_id',
-                parent_external_id,
-                self.domain,
-                parent_type
-            )
-            self.track_load()
-            if parent_case:
-                extras['index'] = {
-                    parent_ref: (parent_type, parent_case.case_id)
-                }
-
-        case_name = fields_to_update.pop('name', None)
-
-        if BULK_UPLOAD_DATE_OPENED.enabled(self.domain):
-            date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
-            if date_opened:
-                extras['date_opened'] = date_opened
-
-        if not case:
-            id = uuid.uuid4().hex
-
-            if self.config.search_field == 'external_id':
-                extras['external_id'] = search_id
-            elif external_id:
-                extras['external_id'] = external_id
-
-            try:
-                caseblock = CaseBlock(
-                    create=True,
-                    case_id=id,
-                    owner_id=owner_id,
-                    user_id=self.user.user_id,
-                    case_type=self.config.case_type,
-                    case_name=case_name or '',
-                    update=fields_to_update,
-                    **extras
-                )
-                self.add_caseblock(RowAndCase(i, caseblock))
+        try:
+            if not case:
+                if row.external_id:
+                    self.ids_seen.add(row.external_id)
+                caseblock = row.get_create_caseblock()
                 self.created_count += 1
-                if external_id:
-                    self.ids_seen.add(external_id)
-            except CaseBlockError:
-                raise exceptions.CaseGeneration(i + 1)
-        else:
-            if external_id:
-                extras['external_id'] = external_id
-            if uploaded_owner_id:
-                extras['owner_id'] = owner_id
-            if to_close == 'yes':
-                extras['close'] = True
-            if case_name is not None:
-                extras['case_name'] = case_name
-
-            try:
-                caseblock = CaseBlock(
-                    create=False,
-                    case_id=case.case_id,
-                    update=fields_to_update,
-                    **extras
-                )
-                self.add_caseblock(RowAndCase(i, caseblock))
+            else:
+                caseblock = row.get_update_caseblock(case)
                 self.match_count += 1
-            except CaseBlockError:
-                raise exceptions.CaseGeneration(i + 1)
+        except CaseBlockError:
+            raise exceptions.CaseGeneration(i + 1)
+
+        self.add_caseblock(RowAndCase(i, caseblock))
 
     def add_caseblock(self, caseblock):
         self._caseblocks.append(caseblock)
@@ -287,6 +187,131 @@ class _Importer(object):
             'errors': self.errors.as_dict(),
             'num_chunks': self.num_chunks,
         }
+
+
+class CaseImportRow(object):
+    def __init__(self, i, search_id, fields_to_update, config, domain, user_id):
+        self.i = i
+        self.search_id = search_id
+        self.fields_to_update = fields_to_update
+        self.config = config
+        self.domain = domain
+        self.user_id = user_id
+
+        self.case_name = fields_to_update.pop('name', None)
+        self.external_id = fields_to_update.pop('external_id', None)
+        self.parent_id = fields_to_update.pop('parent_id', None)
+        self.parent_external_id = fields_to_update.pop('parent_external_id', None)
+        self.parent_type = fields_to_update.pop('parent_type', self.config.case_type)
+        self.parent_ref = fields_to_update.pop('parent_ref', 'parent')
+        self.to_close = fields_to_update.pop('close', False)
+        self.uploaded_owner_name = fields_to_update.pop('owner_name', None)
+        self.uploaded_owner_id = fields_to_update.pop('owner_id', None)
+        self.date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
+
+        self.owner_id = None
+        self.extras = {}
+
+    def check_valid_external_id(self):
+        if self.config.search_field == 'external_id' and not self.search_id:
+            # do not allow blank external id since we save this
+            raise exceptions.BlankExternalId(i + 1)
+
+    def relies_on_unsubmitted_case(self, ids_seen):
+        return any(lookup_id and lookup_id in ids_seen
+                   for lookup_id in [self.search_id, self.parent_id, self.parent_external_id])
+
+    def set_owner_id(self, name_cache, id_cache):
+        owner_id = self.uploaded_owner_id
+        if self.uploaded_owner_name:
+            # If an owner name was provided, use the id of the provided or
+            # owner rather than the uploaded_owner_id
+            try:
+                owner_id = importer_util.get_id_from_name(
+                    self.uploaded_owner_name, self.domain, name_cache
+                )
+            except SQLLocation.MultipleObjectsReturned:
+                raise exceptions.DuplicateLocationName(self.i + 1)
+
+            if not owner_id:
+                raise exceptions.InvalidOwnerName(self.i + 1, 'owner_name')
+
+        if owner_id:
+            # If an owner_id mapping exists, verify it is a valid user
+            # or case sharing group
+            if importer_util.is_valid_id(owner_id, self.domain, id_cache):
+                id_cache[owner_id] = True
+            else:
+                id_cache[owner_id] = False
+                raise exceptions.InvalidOwnerId(self.i + 1, 'owner_id')
+
+        # if they didn't supply an owner, default to current user
+        self.owner_id = owner_id or self.user_id
+
+    def set_parent_id(self, track_load):
+        if self.parent_id:
+            try:
+                parent_case = CaseAccessors(self.domain).get_case(self.parent_id)
+                track_load()
+                if parent_case.domain == self.domain:
+                    self.extras['index'] = {
+                        self.parent_ref: (parent_case.type, self.parent_id)
+                    }
+            except ResourceNotFound:
+                raise exceptions.InvalidParentId(self.i + 1, 'parent_id')
+        elif self.parent_external_id:
+            parent_case, error = importer_util.lookup_case(
+                'external_id',
+                self.parent_external_id,
+                self.domain,
+                self.parent_type
+            )
+            track_load()
+            if parent_case:
+                self.extras['index'] = {
+                    self.parent_ref: (self.parent_type, parent_case.case_id)
+                }
+
+    def set_date_opened(self):
+        if self.date_opened and BULK_UPLOAD_DATE_OPENED.enabled(self.domain):
+            self.extras['date_opened'] = self.date_opened
+
+    def set_external_id(self, is_new_case):
+        # This can almost certainly be simplified, will worry about that later
+        if is_new_case:
+            if self.config.search_field == 'external_id':
+                self.extras['external_id'] = self.search_id
+            elif self.external_id:
+                self.extras['external_id'] = self.external_id
+        else:
+            if self.external_id:
+                self.extras['external_id'] = self.external_id
+
+    def get_create_caseblock(self):
+        return CaseBlock(
+            create=True,
+            case_id=uuid.uuid4().hex,
+            owner_id=self.owner_id,
+            user_id=self.user_id,
+            case_type=self.config.case_type,
+            case_name=self.case_name or '',
+            update=self.fields_to_update,
+            **self.extras
+        )
+
+    def get_update_caseblock(self, case):
+        if self.uploaded_owner_id or self.uploaded_owner_name:
+            self.extras['owner_id'] = self.owner_id
+        if self.to_close == 'yes':
+            self.extras['close'] = True
+        if self.case_name is not None:
+            self.extras['case_name'] = self.case_name
+        return CaseBlock(
+            create=False,
+            case_id=case.case_id,
+            update=self.fields_to_update,
+            **self.extras
+        )
 
 
 def do_import(spreadsheet, config, domain, task=None, record_form_callback=None):

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -131,13 +131,13 @@ class _Importer(object):
                     self.user.user_id,
                     device_id=__name__ + ".do_import",
                 )
+                if form.is_error:
+                    raise Exception("Form error during case import: {}".format(form.problem))
             except Exception:
                 notify_exception(None, "Case Importer: Uncaught failure submitting caseblocks")
                 for row_number, case in caseblocks:
                     self.results.add_error(row_number, exceptions.ImportErrorMessage())
             else:
-                if form.is_error:
-                    self.results.add_error(form.problem, exceptions.ImportErrorMessage())
                 self.record_form(form.form_id)
                 properties = set().union(*[set(c.dynamic_case_properties().keys()) for c in cases])
                 if self.config.case_type and len(properties):

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -67,13 +67,7 @@ class _Importer(object):
             except exceptions.CaseRowError as error:
                 self.errors.add(error)
 
-        # TODO switch this to commit_caseblocks - possible bug, why match_count -= 1?
-        # final purge of anything left in the queue
-        try:
-            self._submit_caseblocks(self._caseblocks)
-        except exceptions.CaseRowError:
-            self.match_count -= 1
-        self.num_chunks += 1
+        self.commit_caseblocks()
 
     def handle_row(self, i, raw_row):
         search_id = importer_util.parse_search_id(self.config, raw_row)
@@ -133,12 +127,13 @@ class _Importer(object):
             self.commit_caseblocks()
 
     def commit_caseblocks(self):
-        try:
-            self._submit_caseblocks(self._caseblocks)
-        except exceptions.CaseRowError as error:
-            self.errors.add(error)
-        self.num_chunks += 1
-        self._caseblocks = []
+        if self._caseblocks:
+            try:
+                self._submit_caseblocks(self._caseblocks)
+            except exceptions.CaseRowError as error:
+                self.errors.add(error)
+            self.num_chunks += 1
+            self._caseblocks = []
 
     def _submit_caseblocks(self, caseblocks):
         if caseblocks:

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -1,0 +1,272 @@
+from __future__ import absolute_import, unicode_literals
+
+import uuid
+from collections import namedtuple
+
+from couchdbkit.exceptions import ResourceNotFound
+
+from casexml.apps.case.const import CASE_TAG_DATE_OPENED
+from casexml.apps.case.mock import CaseBlock, CaseBlockError
+from soil.progress import set_task_progress
+
+from corehq.apps.export.tasks import add_inferred_export_properties
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.users.models import CouchUser
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.toggles import BULK_UPLOAD_DATE_OPENED
+from corehq.util.datadog.utils import case_load_counter
+from corehq.util.soft_assert import soft_assert
+
+from . import util as importer_util
+from .const import ImportErrors, LookupErrors
+
+CASEBLOCK_CHUNKSIZE = 100
+RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
+
+
+def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKSIZE,
+              record_form_callback=None):
+    match_count = created_count = too_many_matches = num_chunks = 0
+    errors = importer_util.ImportErrorDetail()
+
+    user = CouchUser.get_by_user_id(config.couch_user_id, domain)
+    username = user.username
+    user_id = user._id
+
+    # keep a cache of id lookup successes to help performance
+    id_cache = {}
+    name_cache = {}
+    caseblocks = []
+    ids_seen = set()
+    track_load = case_load_counter("case_importer", domain)
+
+    def _submit_caseblocks(domain, case_type, caseblocks):
+        err = False
+        if caseblocks:
+            try:
+                form, cases = submit_case_blocks(
+                    [cb.case.as_string().decode('utf-8') for cb in caseblocks],
+                    domain,
+                    username,
+                    user_id,
+                    device_id=__name__ + ".do_import",
+                )
+
+                if form.is_error:
+                    errors.add(
+                        error=ImportErrors.ImportErrorMessage,
+                        row_number=form.problem
+                    )
+            except Exception:
+                err = True
+                for row_number, case in caseblocks:
+                    errors.add(
+                        error=ImportErrors.ImportErrorMessage,
+                        row_number=row_number
+                    )
+            else:
+                if record_form_callback:
+                    record_form_callback(form.form_id)
+                properties = set().union(*[set(c.dynamic_case_properties().keys()) for c in cases])
+                if case_type and len(properties):
+                    add_inferred_export_properties.delay(
+                        'CaseImporter',
+                        domain,
+                        case_type,
+                        properties,
+                    )
+                else:
+                    _soft_assert = soft_assert(notify_admins=True)
+                    _soft_assert(
+                        len(properties) == 0,
+                        'error adding inferred export properties in domain '
+                        '({}): {}'.format(domain, ", ".join(properties))
+                    )
+        return err
+
+    row_count = spreadsheet.max_row
+    for i, row in enumerate(spreadsheet.iter_row_dicts()):
+        if task:
+            set_task_progress(task, i, row_count)
+
+        # skip first row (header row)
+        if i == 0:
+            continue
+
+        search_id = importer_util.parse_search_id(config, row)
+
+        fields_to_update = importer_util.populate_updated_fields(config, row)
+        if not any(fields_to_update.values()):
+            # if the row was blank, just skip it, no errors
+            continue
+
+        if config.search_field == 'external_id' and not search_id:
+            # do not allow blank external id since we save this
+            errors.add(ImportErrors.BlankExternalId, i + 1)
+            continue
+
+        external_id = fields_to_update.pop('external_id', None)
+        parent_id = fields_to_update.pop('parent_id', None)
+        parent_external_id = fields_to_update.pop('parent_external_id', None)
+        parent_type = fields_to_update.pop('parent_type', config.case_type)
+        parent_ref = fields_to_update.pop('parent_ref', 'parent')
+        to_close = fields_to_update.pop('close', False)
+
+        if any([lookup_id and lookup_id in ids_seen for lookup_id in [search_id, parent_id, parent_external_id]]):
+            # clear out the queue to make sure we've processed any potential
+            # cases we want to look up
+            # note: these three lines are repeated a few places, and could be converted
+            # to a function that makes use of closures (and globals) to do the same thing,
+            # but that seems sketchier than just beeing a little RY
+            _submit_caseblocks(domain, config.case_type, caseblocks)
+            num_chunks += 1
+            caseblocks = []
+            ids_seen = set()  # also clear ids_seen, since all the cases will now be in the database
+
+        case, error = importer_util.lookup_case(
+            config.search_field,
+            search_id,
+            domain,
+            config.case_type
+        )
+        track_load()
+
+        if case:
+            if case.type != config.case_type:
+                continue
+        elif error == LookupErrors.NotFound:
+            if not config.create_new_cases:
+                continue
+        elif error == LookupErrors.MultipleResults:
+            too_many_matches += 1
+            continue
+
+        uploaded_owner_name = fields_to_update.pop('owner_name', None)
+        uploaded_owner_id = fields_to_update.pop('owner_id', None)
+
+        if uploaded_owner_name:
+            # If an owner name was provided, replace the provided
+            # uploaded_owner_id with the id of the provided group or owner
+            try:
+                uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, domain, name_cache)
+            except SQLLocation.MultipleObjectsReturned:
+                errors.add(ImportErrors.DuplicateLocationName, i + 1)
+                continue
+
+            if not uploaded_owner_id:
+                errors.add(ImportErrors.InvalidOwnerName, i + 1, 'owner_name')
+                continue
+        if uploaded_owner_id:
+            # If an owner_id mapping exists, verify it is a valid user
+            # or case sharing group
+            if importer_util.is_valid_id(uploaded_owner_id, domain, id_cache):
+                owner_id = uploaded_owner_id
+                id_cache[uploaded_owner_id] = True
+            else:
+                errors.add(ImportErrors.InvalidOwnerId, i + 1, 'owner_id')
+                id_cache[uploaded_owner_id] = False
+                continue
+        else:
+            # if they didn't supply an owner_id mapping, default to current
+            # user
+            owner_id = user_id
+
+        extras = {}
+        if parent_id:
+            try:
+                parent_case = CaseAccessors(domain).get_case(parent_id)
+                track_load()
+
+                if parent_case.domain == domain:
+                    extras['index'] = {
+                        parent_ref: (parent_case.type, parent_id)
+                    }
+            except ResourceNotFound:
+                errors.add(ImportErrors.InvalidParentId, i + 1, 'parent_id')
+                continue
+        elif parent_external_id:
+            parent_case, error = importer_util.lookup_case(
+                'external_id',
+                parent_external_id,
+                domain,
+                parent_type
+            )
+            track_load()
+            if parent_case:
+                extras['index'] = {
+                    parent_ref: (parent_type, parent_case.case_id)
+                }
+
+        case_name = fields_to_update.pop('name', None)
+
+        if BULK_UPLOAD_DATE_OPENED.enabled(domain):
+            date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
+            if date_opened:
+                extras['date_opened'] = date_opened
+
+        if not case:
+            id = uuid.uuid4().hex
+
+            if config.search_field == 'external_id':
+                extras['external_id'] = search_id
+            elif external_id:
+                extras['external_id'] = external_id
+
+            try:
+                caseblock = CaseBlock(
+                    create=True,
+                    case_id=id,
+                    owner_id=owner_id,
+                    user_id=user_id,
+                    case_type=config.case_type,
+                    case_name=case_name or '',
+                    update=fields_to_update,
+                    **extras
+                )
+                caseblocks.append(RowAndCase(i, caseblock))
+                created_count += 1
+                if external_id:
+                    ids_seen.add(external_id)
+            except CaseBlockError:
+                errors.add(ImportErrors.CaseGeneration, i + 1)
+        else:
+            if external_id:
+                extras['external_id'] = external_id
+            if uploaded_owner_id:
+                extras['owner_id'] = owner_id
+            if to_close == 'yes':
+                extras['close'] = True
+            if case_name is not None:
+                extras['case_name'] = case_name
+
+            try:
+                caseblock = CaseBlock(
+                    create=False,
+                    case_id=case.case_id,
+                    update=fields_to_update,
+                    **extras
+                )
+                caseblocks.append(RowAndCase(i, caseblock))
+                match_count += 1
+            except CaseBlockError:
+                errors.add(ImportErrors.CaseGeneration, i + 1)
+
+        # check if we've reached a reasonable chunksize
+        # and if so submit
+        if len(caseblocks) >= chunksize:
+            _submit_caseblocks(domain, config.case_type, caseblocks)
+            num_chunks += 1
+            caseblocks = []
+
+    # final purge of anything left in the queue
+    if _submit_caseblocks(domain, config.case_type, caseblocks):
+        match_count -= 1
+    num_chunks += 1
+    return {
+        'created_count': created_count,
+        'match_count': match_count,
+        'too_many_matches': too_many_matches,
+        'errors': errors.as_dict(),
+        'num_chunks': num_chunks,
+    }

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -25,248 +25,262 @@ CASEBLOCK_CHUNKSIZE = 100
 RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
 
 
-def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKSIZE,
-              record_form_callback=None):
-    match_count = created_count = too_many_matches = num_chunks = 0
-    errors = importer_util.ImportErrorDetail()
+class _Importer(object):
+    def __init__(self):
+        self.created_count = 0
+        self.match_count = 0
+        self.too_many_matches = 0
+        self.num_chunks = 0
+        self.errors = importer_util.ImportErrorDetail()
 
-    user = CouchUser.get_by_user_id(config.couch_user_id, domain)
-    username = user.username
-    user_id = user._id
+    def do_import(self, spreadsheet, config, domain, task, chunksize, record_form_callback):
+        user = CouchUser.get_by_user_id(config.couch_user_id, domain)
+        username = user.username
+        user_id = user._id
 
-    # keep a cache of id lookup successes to help performance
-    id_cache = {}
-    name_cache = {}
-    caseblocks = []
-    ids_seen = set()
-    track_load = case_load_counter("case_importer", domain)
+        # keep a cache of id lookup successes to help performance
+        id_cache = {}
+        name_cache = {}
+        caseblocks = []
+        ids_seen = set()
+        track_load = case_load_counter("case_importer", domain)
 
-    def _submit_caseblocks(domain, case_type, caseblocks):
-        err = False
-        if caseblocks:
-            try:
-                form, cases = submit_case_blocks(
-                    [cb.case.as_string().decode('utf-8') for cb in caseblocks],
-                    domain,
-                    username,
-                    user_id,
-                    device_id=__name__ + ".do_import",
-                )
-
-                if form.is_error:
-                    errors.add(
-                        error=ImportErrors.ImportErrorMessage,
-                        row_number=form.problem
-                    )
-            except Exception:
-                err = True
-                for row_number, case in caseblocks:
-                    errors.add(
-                        error=ImportErrors.ImportErrorMessage,
-                        row_number=row_number
-                    )
-            else:
-                if record_form_callback:
-                    record_form_callback(form.form_id)
-                properties = set().union(*[set(c.dynamic_case_properties().keys()) for c in cases])
-                if case_type and len(properties):
-                    add_inferred_export_properties.delay(
-                        'CaseImporter',
+        def _submit_caseblocks(domain, case_type, caseblocks):
+            err = False
+            if caseblocks:
+                try:
+                    form, cases = submit_case_blocks(
+                        [cb.case.as_string().decode('utf-8') for cb in caseblocks],
                         domain,
-                        case_type,
-                        properties,
+                        username,
+                        user_id,
+                        device_id=__name__ + ".do_import",
                     )
+
+                    if form.is_error:
+                        self.errors.add(
+                            error=ImportErrors.ImportErrorMessage,
+                            row_number=form.problem
+                        )
+                except Exception:
+                    err = True
+                    for row_number, case in caseblocks:
+                        self.errors.add(
+                            error=ImportErrors.ImportErrorMessage,
+                            row_number=row_number
+                        )
                 else:
-                    _soft_assert = soft_assert(notify_admins=True)
-                    _soft_assert(
-                        len(properties) == 0,
-                        'error adding inferred export properties in domain '
-                        '({}): {}'.format(domain, ", ".join(properties))
-                    )
-        return err
+                    if record_form_callback:
+                        record_form_callback(form.form_id)
+                    properties = set().union(*[set(c.dynamic_case_properties().keys()) for c in cases])
+                    if case_type and len(properties):
+                        add_inferred_export_properties.delay(
+                            'CaseImporter',
+                            domain,
+                            case_type,
+                            properties,
+                        )
+                    else:
+                        _soft_assert = soft_assert(notify_admins=True)
+                        _soft_assert(
+                            len(properties) == 0,
+                            'error adding inferred export properties in domain '
+                            '({}): {}'.format(domain, ", ".join(properties))
+                        )
+            return err
 
-    row_count = spreadsheet.max_row
-    for i, row in enumerate(spreadsheet.iter_row_dicts()):
-        if task:
-            set_task_progress(task, i, row_count)
+        row_count = spreadsheet.max_row
+        for i, row in enumerate(spreadsheet.iter_row_dicts()):
+            if task:
+                set_task_progress(task, i, row_count)
 
-        # skip first row (header row)
-        if i == 0:
-            continue
-
-        search_id = importer_util.parse_search_id(config, row)
-
-        fields_to_update = importer_util.populate_updated_fields(config, row)
-        if not any(fields_to_update.values()):
-            # if the row was blank, just skip it, no errors
-            continue
-
-        if config.search_field == 'external_id' and not search_id:
-            # do not allow blank external id since we save this
-            errors.add(ImportErrors.BlankExternalId, i + 1)
-            continue
-
-        external_id = fields_to_update.pop('external_id', None)
-        parent_id = fields_to_update.pop('parent_id', None)
-        parent_external_id = fields_to_update.pop('parent_external_id', None)
-        parent_type = fields_to_update.pop('parent_type', config.case_type)
-        parent_ref = fields_to_update.pop('parent_ref', 'parent')
-        to_close = fields_to_update.pop('close', False)
-
-        if any([lookup_id and lookup_id in ids_seen for lookup_id in [search_id, parent_id, parent_external_id]]):
-            # clear out the queue to make sure we've processed any potential
-            # cases we want to look up
-            # note: these three lines are repeated a few places, and could be converted
-            # to a function that makes use of closures (and globals) to do the same thing,
-            # but that seems sketchier than just beeing a little RY
-            _submit_caseblocks(domain, config.case_type, caseblocks)
-            num_chunks += 1
-            caseblocks = []
-            ids_seen = set()  # also clear ids_seen, since all the cases will now be in the database
-
-        case, error = importer_util.lookup_case(
-            config.search_field,
-            search_id,
-            domain,
-            config.case_type
-        )
-        track_load()
-
-        if case:
-            if case.type != config.case_type:
-                continue
-        elif error == LookupErrors.NotFound:
-            if not config.create_new_cases:
-                continue
-        elif error == LookupErrors.MultipleResults:
-            too_many_matches += 1
-            continue
-
-        uploaded_owner_name = fields_to_update.pop('owner_name', None)
-        uploaded_owner_id = fields_to_update.pop('owner_id', None)
-
-        if uploaded_owner_name:
-            # If an owner name was provided, replace the provided
-            # uploaded_owner_id with the id of the provided group or owner
-            try:
-                uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, domain, name_cache)
-            except SQLLocation.MultipleObjectsReturned:
-                errors.add(ImportErrors.DuplicateLocationName, i + 1)
+            # skip first row (header row)
+            if i == 0:
                 continue
 
-            if not uploaded_owner_id:
-                errors.add(ImportErrors.InvalidOwnerName, i + 1, 'owner_name')
-                continue
-        if uploaded_owner_id:
-            # If an owner_id mapping exists, verify it is a valid user
-            # or case sharing group
-            if importer_util.is_valid_id(uploaded_owner_id, domain, id_cache):
-                owner_id = uploaded_owner_id
-                id_cache[uploaded_owner_id] = True
-            else:
-                errors.add(ImportErrors.InvalidOwnerId, i + 1, 'owner_id')
-                id_cache[uploaded_owner_id] = False
-                continue
-        else:
-            # if they didn't supply an owner_id mapping, default to current
-            # user
-            owner_id = user_id
+            search_id = importer_util.parse_search_id(config, row)
 
-        extras = {}
-        if parent_id:
-            try:
-                parent_case = CaseAccessors(domain).get_case(parent_id)
-                track_load()
-
-                if parent_case.domain == domain:
-                    extras['index'] = {
-                        parent_ref: (parent_case.type, parent_id)
-                    }
-            except ResourceNotFound:
-                errors.add(ImportErrors.InvalidParentId, i + 1, 'parent_id')
+            fields_to_update = importer_util.populate_updated_fields(config, row)
+            if not any(fields_to_update.values()):
+                # if the row was blank, just skip it, no errors
                 continue
-        elif parent_external_id:
-            parent_case, error = importer_util.lookup_case(
-                'external_id',
-                parent_external_id,
+
+            if config.search_field == 'external_id' and not search_id:
+                # do not allow blank external id since we save this
+                self.errors.add(ImportErrors.BlankExternalId, i + 1)
+                continue
+
+            external_id = fields_to_update.pop('external_id', None)
+            parent_id = fields_to_update.pop('parent_id', None)
+            parent_external_id = fields_to_update.pop('parent_external_id', None)
+            parent_type = fields_to_update.pop('parent_type', config.case_type)
+            parent_ref = fields_to_update.pop('parent_ref', 'parent')
+            to_close = fields_to_update.pop('close', False)
+
+            if any([lookup_id and lookup_id in ids_seen for lookup_id in [search_id, parent_id, parent_external_id]]):
+                # clear out the queue to make sure we've processed any potential
+                # cases we want to look up
+                # note: these three lines are repeated a few places, and could be converted
+                # to a function that makes use of closures (and globals) to do the same thing,
+                # but that seems sketchier than just beeing a little RY
+                _submit_caseblocks(domain, config.case_type, caseblocks)
+                self.num_chunks += 1
+                caseblocks = []
+                ids_seen = set()  # also clear ids_seen, since all the cases will now be in the database
+
+            case, error = importer_util.lookup_case(
+                config.search_field,
+                search_id,
                 domain,
-                parent_type
+                config.case_type
             )
             track_load()
-            if parent_case:
-                extras['index'] = {
-                    parent_ref: (parent_type, parent_case.case_id)
-                }
 
-        case_name = fields_to_update.pop('name', None)
+            if case:
+                if case.type != config.case_type:
+                    continue
+            elif error == LookupErrors.NotFound:
+                if not config.create_new_cases:
+                    continue
+            elif error == LookupErrors.MultipleResults:
+                self.too_many_matches += 1
+                continue
 
-        if BULK_UPLOAD_DATE_OPENED.enabled(domain):
-            date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
-            if date_opened:
-                extras['date_opened'] = date_opened
+            uploaded_owner_name = fields_to_update.pop('owner_name', None)
+            uploaded_owner_id = fields_to_update.pop('owner_id', None)
 
-        if not case:
-            id = uuid.uuid4().hex
+            if uploaded_owner_name:
+                # If an owner name was provided, replace the provided
+                # uploaded_owner_id with the id of the provided group or owner
+                try:
+                    uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, domain, name_cache)
+                except SQLLocation.MultipleObjectsReturned:
+                    self.errors.add(ImportErrors.DuplicateLocationName, i + 1)
+                    continue
 
-            if config.search_field == 'external_id':
-                extras['external_id'] = search_id
-            elif external_id:
-                extras['external_id'] = external_id
-
-            try:
-                caseblock = CaseBlock(
-                    create=True,
-                    case_id=id,
-                    owner_id=owner_id,
-                    user_id=user_id,
-                    case_type=config.case_type,
-                    case_name=case_name or '',
-                    update=fields_to_update,
-                    **extras
-                )
-                caseblocks.append(RowAndCase(i, caseblock))
-                created_count += 1
-                if external_id:
-                    ids_seen.add(external_id)
-            except CaseBlockError:
-                errors.add(ImportErrors.CaseGeneration, i + 1)
-        else:
-            if external_id:
-                extras['external_id'] = external_id
+                if not uploaded_owner_id:
+                    self.errors.add(ImportErrors.InvalidOwnerName, i + 1, 'owner_name')
+                    continue
             if uploaded_owner_id:
-                extras['owner_id'] = owner_id
-            if to_close == 'yes':
-                extras['close'] = True
-            if case_name is not None:
-                extras['case_name'] = case_name
+                # If an owner_id mapping exists, verify it is a valid user
+                # or case sharing group
+                if importer_util.is_valid_id(uploaded_owner_id, domain, id_cache):
+                    owner_id = uploaded_owner_id
+                    id_cache[uploaded_owner_id] = True
+                else:
+                    self.errors.add(ImportErrors.InvalidOwnerId, i + 1, 'owner_id')
+                    id_cache[uploaded_owner_id] = False
+                    continue
+            else:
+                # if they didn't supply an owner_id mapping, default to current
+                # user
+                owner_id = user_id
 
-            try:
-                caseblock = CaseBlock(
-                    create=False,
-                    case_id=case.case_id,
-                    update=fields_to_update,
-                    **extras
+            extras = {}
+            if parent_id:
+                try:
+                    parent_case = CaseAccessors(domain).get_case(parent_id)
+                    track_load()
+
+                    if parent_case.domain == domain:
+                        extras['index'] = {
+                            parent_ref: (parent_case.type, parent_id)
+                        }
+                except ResourceNotFound:
+                    self.errors.add(ImportErrors.InvalidParentId, i + 1, 'parent_id')
+                    continue
+            elif parent_external_id:
+                parent_case, error = importer_util.lookup_case(
+                    'external_id',
+                    parent_external_id,
+                    domain,
+                    parent_type
                 )
-                caseblocks.append(RowAndCase(i, caseblock))
-                match_count += 1
-            except CaseBlockError:
-                errors.add(ImportErrors.CaseGeneration, i + 1)
+                track_load()
+                if parent_case:
+                    extras['index'] = {
+                        parent_ref: (parent_type, parent_case.case_id)
+                    }
 
-        # check if we've reached a reasonable chunksize
-        # and if so submit
-        if len(caseblocks) >= chunksize:
-            _submit_caseblocks(domain, config.case_type, caseblocks)
-            num_chunks += 1
-            caseblocks = []
+            case_name = fields_to_update.pop('name', None)
 
-    # final purge of anything left in the queue
-    if _submit_caseblocks(domain, config.case_type, caseblocks):
-        match_count -= 1
-    num_chunks += 1
-    return {
-        'created_count': created_count,
-        'match_count': match_count,
-        'too_many_matches': too_many_matches,
-        'errors': errors.as_dict(),
-        'num_chunks': num_chunks,
-    }
+            if BULK_UPLOAD_DATE_OPENED.enabled(domain):
+                date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
+                if date_opened:
+                    extras['date_opened'] = date_opened
+
+            if not case:
+                id = uuid.uuid4().hex
+
+                if config.search_field == 'external_id':
+                    extras['external_id'] = search_id
+                elif external_id:
+                    extras['external_id'] = external_id
+
+                try:
+                    caseblock = CaseBlock(
+                        create=True,
+                        case_id=id,
+                        owner_id=owner_id,
+                        user_id=user_id,
+                        case_type=config.case_type,
+                        case_name=case_name or '',
+                        update=fields_to_update,
+                        **extras
+                    )
+                    caseblocks.append(RowAndCase(i, caseblock))
+                    self.created_count += 1
+                    if external_id:
+                        ids_seen.add(external_id)
+                except CaseBlockError:
+                    self.errors.add(ImportErrors.CaseGeneration, i + 1)
+            else:
+                if external_id:
+                    extras['external_id'] = external_id
+                if uploaded_owner_id:
+                    extras['owner_id'] = owner_id
+                if to_close == 'yes':
+                    extras['close'] = True
+                if case_name is not None:
+                    extras['case_name'] = case_name
+
+                try:
+                    caseblock = CaseBlock(
+                        create=False,
+                        case_id=case.case_id,
+                        update=fields_to_update,
+                        **extras
+                    )
+                    caseblocks.append(RowAndCase(i, caseblock))
+                    self.match_count += 1
+                except CaseBlockError:
+                    self.errors.add(ImportErrors.CaseGeneration, i + 1)
+
+            # check if we've reached a reasonable chunksize
+            # and if so submit
+            if len(caseblocks) >= chunksize:
+                _submit_caseblocks(domain, config.case_type, caseblocks)
+                self.num_chunks += 1
+                caseblocks = []
+
+        # final purge of anything left in the queue
+        if _submit_caseblocks(domain, config.case_type, caseblocks):
+            self.match_count -= 1
+        self.num_chunks += 1
+
+    @property
+    def outcome(self):
+        return {
+            'created_count': self.created_count,
+            'match_count': self.match_count,
+            'too_many_matches': self.too_many_matches,
+            'errors': self.errors.as_dict(),
+            'num_chunks': self.num_chunks,
+        }
+
+
+def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKSIZE,
+              record_form_callback=None):
+    importer = _Importer()
+    importer.do_import(spreadsheet, config, domain, task, chunksize, record_form_callback)
+    return importer.outcome

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -86,10 +86,7 @@ class _Importer(object):
         )
         self.log_case_lookup()
 
-        if case:
-            if case.type != self.config.case_type:
-                return  # TODO Add error message about skipped row
-        elif error == LookupErrors.NotFound:
+        if error == LookupErrors.NotFound:
             if not self.config.create_new_cases:
                 return
         elif error == LookupErrors.MultipleResults:

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -33,7 +33,7 @@ class _Importer(object):
         self.num_chunks = 0
         self.errors = importer_util.ImportErrorDetail()
 
-    def do_import(self, spreadsheet, config, domain, task, chunksize, record_form_callback):
+    def do_import(self, spreadsheet, config, domain, task, record_form_callback):
         user = CouchUser.get_by_user_id(config.couch_user_id, domain)
         username = user.username
         user_id = user._id
@@ -258,7 +258,7 @@ class _Importer(object):
 
             # check if we've reached a reasonable chunksize
             # and if so submit
-            if len(caseblocks) >= chunksize:
+            if len(caseblocks) >= CASEBLOCK_CHUNKSIZE:
                 _submit_caseblocks(domain, config.case_type, caseblocks)
                 self.num_chunks += 1
                 caseblocks = []
@@ -279,8 +279,7 @@ class _Importer(object):
         }
 
 
-def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKSIZE,
-              record_form_callback=None):
+def do_import(spreadsheet, config, domain, task=None, record_form_callback=None):
     importer = _Importer()
-    importer.do_import(spreadsheet, config, domain, task, chunksize, record_form_callback)
+    importer.do_import(spreadsheet, config, domain, task, record_form_callback)
     return importer.outcome

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -119,3 +119,11 @@ class ImportErrorMessage(CaseRowError):
     message = ugettext_lazy(
         "Problems in importing cases. Please check the Excel file."
     )
+
+
+class TooManyMatches(CaseRowError):
+    title = ugettext_noop('Too Many Matches')
+    message = ugettext_lazy(
+        "These rows matched more than one case at the same time - this means "
+        "that there are cases in your system with the same external ID."
+    )

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from django.utils.translation import ugettext_lazy, ugettext_noop
 import xlrd
 
 
@@ -35,3 +36,87 @@ class ImporterExcelFileEncrypted(ImporterExcelError):
 class InvalidCustomFieldNameException(ImporterError):
     """Raised when a custom field name is reserved (e.g. "type")"""
     pass
+
+
+class CaseRowError(Exception):
+    """Base Error class for failures associated with an individual upload row"""
+    title = ""
+    message = ""
+
+    def __init__(self, row_number, column_name=None):
+        self.row_number = row_number
+        self.column_name = column_name
+        super(CaseRowError, self).__init__(self.message)
+
+
+class InvalidOwnerName(CaseRowError):
+    title = ugettext_noop('Invalid Owner Name')
+    message = ugettext_lazy(
+        "Owner name was used in the mapping but there were errors when "
+        "uploading because of these values."
+    )
+
+
+class InvalidOwnerId(CaseRowError):
+    title = ugettext_noop('Invalid Owner ID')
+    message = ugettext_lazy(
+        "Owner ID was used in the mapping but there were errors when "
+        "uploading because of these values. Make sure the values in this "
+        "column are ID's for users or case sharing groups or locations."
+    )
+
+
+class InvalidParentId(CaseRowError):
+    title = ugettext_noop('Invalid Parent ID')
+    message = ugettext_lazy(
+        "An invalid or unknown parent case was specified for the "
+        "uploaded case."
+    )
+
+
+class InvalidDate(CaseRowError):
+    title = ugettext_noop('Invalid Date')
+    message = ugettext_lazy(
+        "Date fields were specified that caused an error during "
+        "conversion. This is likely caused by a value from Excel having "
+        "the wrong type or not being formatted properly."
+    )
+
+
+class BlankExternalId(CaseRowError):
+    title = ugettext_noop('Blank External ID')
+    message = ugettext_lazy(
+        "Blank external ids were found in these rows causing as error "
+        "when importing cases."
+    )
+
+
+class CaseGeneration(CaseRowError):
+    title = ugettext_noop('Case Generation Error')
+    message = ugettext_lazy(
+        "These rows failed to generate cases for unknown reasons"
+    )
+
+
+class DuplicateLocationName(CaseRowError):
+    title = ugettext_noop('Duplicated Location Name')
+    message = ugettext_lazy(
+        "Owner ID was used in the mapping, but there were errors when "
+        "uploading because of these values. There are multiple locations "
+        "with this same name, try using site-code instead."
+    )
+
+
+class InvalidInteger(CaseRowError):
+    title = ugettext_noop('Invalid Integer')
+    message = ugettext_lazy(
+        "Integer values were specified, but the values in Excel were not "
+        "all integers"
+    )
+
+
+class ImportErrorMessage(CaseRowError):
+    title = ugettext_noop('Import Error')
+    message = ugettext_lazy(
+        "Problems in importing cases. Please check the Excel file."
+    )

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -43,8 +43,7 @@ class CaseRowError(Exception):
     title = ""
     message = ""
 
-    def __init__(self, row_number, column_name=None):
-        self.row_number = row_number
+    def __init__(self, column_name=None):
         self.column_name = column_name
         super(CaseRowError, self).__init__(self.message)
 

--- a/corehq/apps/case_importer/management/commands/import_cases.py
+++ b/corehq/apps/case_importer/management/commands/import_cases.py
@@ -5,7 +5,7 @@ import json
 from datetime import datetime
 from django.core.management import BaseCommand, CommandError
 from dimagi.utils.web import json_handler
-from corehq.apps.case_importer.tasks import do_import
+from corehq.apps.case_importer.do_import import do_import
 from corehq.apps.case_importer.util import ImporterConfig, get_spreadsheet
 from corehq.apps.users.models import WebUser
 from io import open

--- a/corehq/apps/case_importer/migrations/0013_make_duplicates_errors.py
+++ b/corehq/apps/case_importer/migrations/0013_make_duplicates_errors.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations
+
+import six
+
+from corehq.apps.case_importer.exceptions import TooManyMatches
+from corehq.apps.case_importer.models import CaseUploadRecord
+from corehq.apps.case_importer.tracking.task_status import (
+    TaskStatusResultError,
+)
+
+
+def iterator(queryset):
+    chunk_size = 1000
+    total = queryset.count()
+    for start in range(0, total, chunk_size):
+        end = start + chunk_size
+        for record in queryset[start:end]:
+            yield record
+
+
+def migrate_record_duplicates(apps, schema_editor):
+    for record in iterator(CaseUploadRecord.objects.all()):
+        result = record.task_status_json['result']
+        if result and 'too_many_matches' in result:
+            if result.pop('too_many_matches', 0):
+                result['errors'].append(
+                    TaskStatusResultError(
+                        title=TooManyMatches.title,
+                        description=six.text_type(TooManyMatches.message),
+                        rows=[],
+                    ).to_json()
+                )
+            record.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_importer', '0012_auto_20190405_1747'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_record_duplicates),
+    ]

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -1,37 +1,23 @@
 from __future__ import absolute_import, unicode_literals
 
-import uuid
-from collections import namedtuple
-
 from celery import states
 from celery.exceptions import Ignore
 from celery.schedules import crontab
 from celery.task import task
-from couchdbkit.exceptions import ResourceNotFound
 
-from casexml.apps.case.const import CASE_TAG_DATE_OPENED
-from casexml.apps.case.mock import CaseBlock, CaseBlockError
-from corehq.apps.case_importer import util as importer_util
-from corehq.apps.case_importer.const import ImportErrors, LookupErrors
-from corehq.apps.case_importer.exceptions import ImporterError
-from corehq.apps.case_importer.tracking.analytics import get_case_upload_files_total_bytes
-from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
-from corehq.apps.case_importer.util import get_importer_error_message
-from corehq.apps.export.tasks import add_inferred_export_properties
-from corehq.apps.hqadmin.tasks import AbnormalUsageAlert, send_abnormal_usage_alert
-from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.apps.locations.models import SQLLocation
-from corehq.apps.users.models import CouchUser
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.toggles import BULK_UPLOAD_DATE_OPENED
+from soil.progress import update_task_state
+
+from corehq.apps.hqadmin.tasks import (
+    AbnormalUsageAlert,
+    send_abnormal_usage_alert,
+)
 from corehq.util.datadog.gauges import datadog_gauge_task
-from corehq.util.datadog.utils import case_load_counter
-from corehq.util.soft_assert import soft_assert
-from soil.progress import set_task_progress, update_task_state
 
-CASEBLOCK_CHUNKSIZE = 100
-
-RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
+from .do_import import do_import
+from .exceptions import ImporterError
+from .tracking.analytics import get_case_upload_files_total_bytes
+from .tracking.case_upload_tracker import CaseUpload
+from .util import get_importer_error_message
 
 
 @task(serializer='pickle', queue='case_import_queue')
@@ -65,253 +51,6 @@ def bulk_import_async(config, domain, excel_id):
 def store_task_result(upload_id):
     case_upload = CaseUpload.get(upload_id)
     case_upload.store_task_result()
-
-
-def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKSIZE,
-              record_form_callback=None):
-    match_count = created_count = too_many_matches = num_chunks = 0
-    errors = importer_util.ImportErrorDetail()
-
-    user = CouchUser.get_by_user_id(config.couch_user_id, domain)
-    username = user.username
-    user_id = user._id
-
-    # keep a cache of id lookup successes to help performance
-    id_cache = {}
-    name_cache = {}
-    caseblocks = []
-    ids_seen = set()
-    track_load = case_load_counter("case_importer", domain)
-
-    def _submit_caseblocks(domain, case_type, caseblocks):
-        err = False
-        if caseblocks:
-            try:
-                form, cases = submit_case_blocks(
-                    [cb.case.as_string().decode('utf-8') for cb in caseblocks],
-                    domain,
-                    username,
-                    user_id,
-                    device_id=__name__ + ".do_import",
-                )
-
-                if form.is_error:
-                    errors.add(
-                        error=ImportErrors.ImportErrorMessage,
-                        row_number=form.problem
-                    )
-            except Exception:
-                err = True
-                for row_number, case in caseblocks:
-                    errors.add(
-                        error=ImportErrors.ImportErrorMessage,
-                        row_number=row_number
-                    )
-            else:
-                if record_form_callback:
-                    record_form_callback(form.form_id)
-                properties = set().union(*[set(c.dynamic_case_properties().keys()) for c in cases])
-                if case_type and len(properties):
-                    add_inferred_export_properties.delay(
-                        'CaseImporter',
-                        domain,
-                        case_type,
-                        properties,
-                    )
-                else:
-                    _soft_assert = soft_assert(notify_admins=True)
-                    _soft_assert(
-                        len(properties) == 0,
-                        'error adding inferred export properties in domain '
-                        '({}): {}'.format(domain, ", ".join(properties))
-                    )
-        return err
-
-    row_count = spreadsheet.max_row
-    for i, row in enumerate(spreadsheet.iter_row_dicts()):
-        if task:
-            set_task_progress(task, i, row_count)
-
-        # skip first row (header row)
-        if i == 0:
-            continue
-
-        search_id = importer_util.parse_search_id(config, row)
-
-        fields_to_update = importer_util.populate_updated_fields(config, row)
-        if not any(fields_to_update.values()):
-            # if the row was blank, just skip it, no errors
-            continue
-
-        if config.search_field == 'external_id' and not search_id:
-            # do not allow blank external id since we save this
-            errors.add(ImportErrors.BlankExternalId, i + 1)
-            continue
-
-        external_id = fields_to_update.pop('external_id', None)
-        parent_id = fields_to_update.pop('parent_id', None)
-        parent_external_id = fields_to_update.pop('parent_external_id', None)
-        parent_type = fields_to_update.pop('parent_type', config.case_type)
-        parent_ref = fields_to_update.pop('parent_ref', 'parent')
-        to_close = fields_to_update.pop('close', False)
-
-        if any([lookup_id and lookup_id in ids_seen for lookup_id in [search_id, parent_id, parent_external_id]]):
-            # clear out the queue to make sure we've processed any potential
-            # cases we want to look up
-            # note: these three lines are repeated a few places, and could be converted
-            # to a function that makes use of closures (and globals) to do the same thing,
-            # but that seems sketchier than just beeing a little RY
-            _submit_caseblocks(domain, config.case_type, caseblocks)
-            num_chunks += 1
-            caseblocks = []
-            ids_seen = set()  # also clear ids_seen, since all the cases will now be in the database
-
-        case, error = importer_util.lookup_case(
-            config.search_field,
-            search_id,
-            domain,
-            config.case_type
-        )
-        track_load()
-
-        if case:
-            if case.type != config.case_type:
-                continue
-        elif error == LookupErrors.NotFound:
-            if not config.create_new_cases:
-                continue
-        elif error == LookupErrors.MultipleResults:
-            too_many_matches += 1
-            continue
-
-        uploaded_owner_name = fields_to_update.pop('owner_name', None)
-        uploaded_owner_id = fields_to_update.pop('owner_id', None)
-
-        if uploaded_owner_name:
-            # If an owner name was provided, replace the provided
-            # uploaded_owner_id with the id of the provided group or owner
-            try:
-                uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, domain, name_cache)
-            except SQLLocation.MultipleObjectsReturned:
-                errors.add(ImportErrors.DuplicateLocationName, i + 1)
-                continue
-
-            if not uploaded_owner_id:
-                errors.add(ImportErrors.InvalidOwnerName, i + 1, 'owner_name')
-                continue
-        if uploaded_owner_id:
-            # If an owner_id mapping exists, verify it is a valid user
-            # or case sharing group
-            if importer_util.is_valid_id(uploaded_owner_id, domain, id_cache):
-                owner_id = uploaded_owner_id
-                id_cache[uploaded_owner_id] = True
-            else:
-                errors.add(ImportErrors.InvalidOwnerId, i + 1, 'owner_id')
-                id_cache[uploaded_owner_id] = False
-                continue
-        else:
-            # if they didn't supply an owner_id mapping, default to current
-            # user
-            owner_id = user_id
-
-        extras = {}
-        if parent_id:
-            try:
-                parent_case = CaseAccessors(domain).get_case(parent_id)
-                track_load()
-
-                if parent_case.domain == domain:
-                    extras['index'] = {
-                        parent_ref: (parent_case.type, parent_id)
-                    }
-            except ResourceNotFound:
-                errors.add(ImportErrors.InvalidParentId, i + 1, 'parent_id')
-                continue
-        elif parent_external_id:
-            parent_case, error = importer_util.lookup_case(
-                'external_id',
-                parent_external_id,
-                domain,
-                parent_type
-            )
-            track_load()
-            if parent_case:
-                extras['index'] = {
-                    parent_ref: (parent_type, parent_case.case_id)
-                }
-
-        case_name = fields_to_update.pop('name', None)
-
-        if BULK_UPLOAD_DATE_OPENED.enabled(domain):
-            date_opened = fields_to_update.pop(CASE_TAG_DATE_OPENED, None)
-            if date_opened:
-                extras['date_opened'] = date_opened
-
-        if not case:
-            id = uuid.uuid4().hex
-
-            if config.search_field == 'external_id':
-                extras['external_id'] = search_id
-            elif external_id:
-                extras['external_id'] = external_id
-
-            try:
-                caseblock = CaseBlock(
-                    create=True,
-                    case_id=id,
-                    owner_id=owner_id,
-                    user_id=user_id,
-                    case_type=config.case_type,
-                    case_name=case_name or '',
-                    update=fields_to_update,
-                    **extras
-                )
-                caseblocks.append(RowAndCase(i, caseblock))
-                created_count += 1
-                if external_id:
-                    ids_seen.add(external_id)
-            except CaseBlockError:
-                errors.add(ImportErrors.CaseGeneration, i + 1)
-        else:
-            if external_id:
-                extras['external_id'] = external_id
-            if uploaded_owner_id:
-                extras['owner_id'] = owner_id
-            if to_close == 'yes':
-                extras['close'] = True
-            if case_name is not None:
-                extras['case_name'] = case_name
-
-            try:
-                caseblock = CaseBlock(
-                    create=False,
-                    case_id=case.case_id,
-                    update=fields_to_update,
-                    **extras
-                )
-                caseblocks.append(RowAndCase(i, caseblock))
-                match_count += 1
-            except CaseBlockError:
-                errors.add(ImportErrors.CaseGeneration, i + 1)
-
-        # check if we've reached a reasonable chunksize
-        # and if so submit
-        if len(caseblocks) >= chunksize:
-            _submit_caseblocks(domain, config.case_type, caseblocks)
-            num_chunks += 1
-            caseblocks = []
-
-    # final purge of anything left in the queue
-    if _submit_caseblocks(domain, config.case_type, caseblocks):
-        match_count -= 1
-    num_chunks += 1
-    return {
-        'created_count': created_count,
-        'match_count': match_count,
-        'too_many_matches': too_many_matches,
-        'errors': errors.as_dict(),
-        'num_chunks': num_chunks,
-    }
 
 
 def _alert_on_result(result, domain):

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -29,8 +29,6 @@ from corehq.util.datadog.utils import case_load_counter
 from corehq.util.soft_assert import soft_assert
 from soil.progress import set_task_progress, update_task_state
 
-POOL_SIZE = 10
-PRIME_VIEW_FREQUENCY = 500
 CASEBLOCK_CHUNKSIZE = 100
 
 RowAndCase = namedtuple('RowAndCase', ['row', 'case'])

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -25,16 +25,6 @@
     {% trans "No cases were created or updated during this import." %}
   </p>
   <!--/ko-->
-
-  <!--ko if: result.too_many_matches > 0-->
-  <p>
-    {% blocktrans with too_many_matches='result.too_many_matches' %}
-      <strong data-bind="text: {{ too_many_matches }}"></strong> rows matched more
-      than one case at the same time - this means that there are cases
-      in your system with the same external ID.
-    {% endblocktrans %}
-  </p>
-  <!--/ko-->
 </div>
 <!--ko if: !_.isEmpty(result.errors)-->
 <div class="alert alert-warning">

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -10,7 +10,8 @@ from mock import patch
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases
 from corehq.apps.case_importer.const import ImportErrors
-from corehq.apps.case_importer.tasks import bulk_import_async, do_import
+from corehq.apps.case_importer.do_import import do_import
+from corehq.apps.case_importer.tasks import bulk_import_async
 from corehq.apps.case_importer.util import ImporterConfig, WorksheetWrapper
 from corehq.apps.commtrack.tests.util import make_loc
 from corehq.apps.domain.shortcuts import create_domain

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -9,7 +9,7 @@ from mock import patch
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure
 from casexml.apps.case.tests.util import delete_all_cases
-from corehq.apps.case_importer.const import ImportErrors
+from corehq.apps.case_importer import exceptions
 from corehq.apps.case_importer.do_import import do_import
 from corehq.apps.case_importer.tasks import bulk_import_async
 from corehq.apps.case_importer.util import ImporterConfig, WorksheetWrapper
@@ -359,7 +359,7 @@ class ImporterTest(TestCase):
         res = do_import(file_missing, config, self.domain)
         error_column_name = 'parent_id'
         self.assertEqual(rows,
-                         len(res['errors'][ImportErrors.InvalidParentId][error_column_name]['rows']),
+                         len(res['errors'][exceptions.InvalidParentId.title][error_column_name]['rows']),
                          "All cases should have missing parent")
 
     def import_mock_file(self, rows):
@@ -397,12 +397,12 @@ class ImporterTest(TestCase):
         self.assertEqual(cases['location-owner-code'].owner_id, location.group_id)
         self.assertEqual(cases['location-owner-name'].owner_id, location.group_id)
 
-        error_message = ImportErrors.DuplicateLocationName
+        error_message = exceptions.DuplicateLocationName.title
         error_column_name = None
         self.assertIn(error_message, res['errors'])
         self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [5])
 
-        error_message = ImportErrors.InvalidOwnerId
+        error_message = exceptions.InvalidOwnerId.title
         self.assertIn(error_message, res['errors'])
         error_column_name = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [6])

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -284,6 +284,7 @@ class ImporterTest(TestCase):
         self.assertEqual(0, res['match_count'])
         self.assertEqual(0, len(get_case_ids_in_domain(self.domain)))
 
+    @patch('corehq.apps.case_importer.do_import.CASEBLOCK_CHUNKSIZE', 2)
     def testBasicChunking(self):
         config = self._config(['case_id', 'age', 'sex', 'location'])
         file = make_worksheet_wrapper(
@@ -294,7 +295,7 @@ class ImporterTest(TestCase):
             ['case_id-3', 'age-3', 'sex-3', 'location-3'],
             ['case_id-4', 'age-4', 'sex-4', 'location-4'],
         )
-        res = do_import(file, config, self.domain, chunksize=2)
+        res = do_import(file, config, self.domain)
         # 5 cases in chunks of 2 = 3 chunks
         self.assertEqual(3, res['num_chunks'])
         self.assertEqual(5, res['created_count'])

--- a/corehq/apps/case_importer/tests/test_owner.py
+++ b/corehq/apps/case_importer/tests/test_owner.py
@@ -1,24 +1,24 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.test import SimpleTestCase
-from corehq.apps.case_importer.util import is_valid_owner
+from corehq.apps.case_importer.do_import import _is_valid_owner
 from corehq.apps.users.models import CommCareUser, DomainMembership, WebUser
 
 
-class ImporterUtilsTest(SimpleTestCase):
+class TestIsValidOwner(SimpleTestCase):
 
     def test_user_owner_match(self):
-        self.assertTrue(is_valid_owner(_mk_user(domain='match'), 'match'))
+        self.assertTrue(_is_valid_owner(_mk_user(domain='match'), 'match'))
 
     def test_user_owner_nomatch(self):
-        self.assertFalse(is_valid_owner(_mk_user(domain='match'), 'nomatch'))
+        self.assertFalse(_is_valid_owner(_mk_user(domain='match'), 'nomatch'))
 
     def test_web_user_owner_match(self):
-        self.assertTrue(is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'match'))
-        self.assertTrue(is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'match2'))
+        self.assertTrue(_is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'match'))
+        self.assertTrue(_is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'match2'))
 
     def test_web_user_owner_nomatch(self):
-        self.assertFalse(is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'nomatch'))
+        self.assertFalse(_is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'nomatch'))
 
 
 def _mk_user(domain):

--- a/corehq/apps/case_importer/tracking/task_status.py
+++ b/corehq/apps/case_importer/tracking/task_status.py
@@ -23,7 +23,6 @@ class TaskStatusProgress(jsonobject.StrictJsonObject):
 class TaskStatusResult(jsonobject.StrictJsonObject):
     match_count = jsonobject.IntegerProperty()
     created_count = jsonobject.IntegerProperty()
-    too_many_matches = jsonobject.IntegerProperty()
     num_chunks = jsonobject.IntegerProperty()
     errors = jsonobject.ListProperty(lambda: TaskStatusResultError)
 
@@ -43,7 +42,6 @@ def normalize_task_status_result(result):
         return TaskStatusResult(
             match_count=result['match_count'],
             created_count=result['created_count'],
-            too_many_matches=result['too_many_matches'],
             num_chunks=result['num_chunks'],
             errors=normalize_task_status_result_errors(result),
         )

--- a/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
@@ -6,7 +6,7 @@ from django.forms import model_to_dict
 from django.test import TestCase
 import mock
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
-from corehq.apps.case_importer.tasks import do_import
+from corehq.apps.case_importer.do_import import do_import
 from corehq.apps.case_importer.tests.test_importer import make_worksheet_wrapper
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.tracking.dbaccessors import get_case_upload_records, \

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -206,7 +206,7 @@ class ImportResults(object):
         self._results[row_num] = self.UPDATED
 
     def to_json(self):
-        counts = Counter(self._results.values())
+        counts = Counter(six.itervalues(self._results))
         return {
             'created_count': counts.get(self.CREATED, 0),
             'match_count': counts.get(self.UPDATED, 0),

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -7,7 +7,8 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from couchdbkit import NoResultFound
 
-from corehq.apps.case_importer.const import LookupErrors, ImportErrors
+from corehq.apps.case_importer.const import LookupErrors
+from corehq.apps.case_importer import exceptions
 from corehq.apps.groups.models import Group
 from corehq.apps.case_importer.exceptions import (
     ImporterExcelFileEncrypted,
@@ -172,62 +173,24 @@ def convert_custom_fields_to_struct(config):
 
 class ImportErrorDetail(object):
 
-    ERROR_MSG = {
-        ImportErrors.InvalidOwnerId: _(
-            "Owner ID was used in the mapping but there were errors when "
-            "uploading because of these values. Make sure the values in this "
-            "column are ID's for users or case sharing groups or locations."
-        ),
-        ImportErrors.InvalidOwnerName: _(
-            "Owner name was used in the mapping but there were errors when "
-            "uploading because of these values."
-        ),
-        ImportErrors.InvalidDate: _(
-            "Date fields were specified that caused an error during "
-            "conversion. This is likely caused by a value from Excel having "
-            "the wrong type or not being formatted properly."
-        ),
-        ImportErrors.BlankExternalId: _(
-            "Blank external ids were found in these rows causing as error "
-            "when importing cases."
-        ),
-        ImportErrors.CaseGeneration: _(
-            "These rows failed to generate cases for unknown reasons"
-        ),
-        ImportErrors.InvalidParentId: _(
-            "An invalid or unknown parent case was specified for the "
-            "uploaded case."
-        ),
-        ImportErrors.DuplicateLocationName: _(
-            "Owner ID was used in the mapping, but there were errors when "
-            "uploading because of these values. There are multiple locations "
-            "with this same name, try using site-code instead."
-        ),
-        ImportErrors.InvalidInteger: _(
-            "Integer values were specified, but the values in Excel were not "
-            "all integers"
-        ),
-        ImportErrors.ImportErrorMessage: _(
-            "Problems in importing cases. Please check the Excel file."
-        )
-    }
-
     def __init__(self, *args, **kwargs):
         self.errors = defaultdict(dict)
 
-    def add(self, error, row_number, column_name=None):
-        self.errors[error].setdefault(column_name, {})
-        self.errors[error][column_name]['error'] = _(error)
+    def add(self, error):
+        key = error.title
+        column_name = error.column_name
+        self.errors[key].setdefault(column_name, {})
+        self.errors[key][column_name]['error'] = _(error.title)
 
         try:
-            self.errors[error][column_name]['description'] = self.ERROR_MSG[error]
+            self.errors[key][column_name]['description'] = error.message
         except KeyError:
-            self.errors[error][column_name]['description'] = self.ERROR_MSG[ImportErrors.CaseGeneration]
+            self.errors[key][column_name]['description'] = exceptions.CaseGeneration.message
 
-        if 'rows' not in self.errors[error][column_name]:
-            self.errors[error][column_name]['rows'] = []
+        if 'rows' not in self.errors[key][column_name]:
+            self.errors[key][column_name]['rows'] = []
 
-        self.errors[error][column_name]['rows'].append(row_number)
+        self.errors[key][column_name]['rows'].append(error.row_number)
 
     def as_dict(self):
         return dict(self.errors)

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -1,34 +1,30 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from contextlib import contextmanager
+from __future__ import absolute_import, unicode_literals
+
 import json
-from collections import defaultdict, namedtuple, OrderedDict, Counter
+from collections import OrderedDict, namedtuple
+from contextlib import contextmanager
+
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
-from couchdbkit import NoResultFound
 
-from corehq.apps.case_importer.const import LookupErrors
-from corehq.apps.case_importer import exceptions
-from corehq.apps.groups.models import Group
-from corehq.apps.case_importer.exceptions import (
-    ImporterExcelFileEncrypted,
-    ImporterExcelError,
-    ImporterFileNotFound,
-    ImporterRefError,
-    InvalidCustomFieldNameException,
-)
-from corehq.apps.users.cases import get_wrapped_owner
-from corehq.apps.users.models import CouchUser
-from corehq.apps.users.util import format_username
-from corehq.apps.locations.models import SQLLocation
-from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.util.python_compatibility import soft_assert_type_text
-from corehq.util.workbook_reading import open_any_workbook, Workbook, \
-    SpreadsheetFileEncrypted, SpreadsheetFileNotFound, SpreadsheetFileInvalidError
-from couchexport.export import SCALAR_NEVER_WAS
 import six
 
+from corehq.apps.case_importer.const import LookupErrors
+from corehq.apps.case_importer.exceptions import (
+    ImporterExcelError,
+    ImporterExcelFileEncrypted,
+    ImporterFileNotFound,
+    ImporterRefError,
+)
+from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.workbook_reading import (
+    SpreadsheetFileEncrypted,
+    SpreadsheetFileInvalidError,
+    SpreadsheetFileNotFound,
+    Workbook,
+    open_any_workbook,
+)
 
 # Don't allow users to change the case type by accident using a custom field. But do allow users to change
 # owner_id, external_id, etc. (See also custom_data_fields.models.RESERVED_WORDS)
@@ -143,105 +139,6 @@ class WorksheetWrapper(object):
             }
 
 
-def convert_custom_fields_to_struct(config):
-    excel_fields = config.excel_fields
-    case_fields = config.case_fields
-    custom_fields = config.custom_fields
-
-    field_map = {}
-    for i, field in enumerate(excel_fields):
-        if field:
-            field_map[field] = {}
-
-            if case_fields[i]:
-                field_map[field]['field_name'] = case_fields[i]
-            elif custom_fields[i]:
-                # if we have configured this field for external_id populate external_id instead
-                # of the default property name from the column
-                if config.search_field == EXTERNAL_ID and field == config.search_column:
-                    field_map[field]['field_name'] = EXTERNAL_ID
-                else:
-                    field_map[field]['field_name'] = custom_fields[i]
-    # hack: make sure the external_id column ends up in the field_map if the user
-    # didn't explicitly put it there
-    if config.search_column not in field_map and config.search_field == EXTERNAL_ID:
-        field_map[config.search_column] = {
-            'field_name': EXTERNAL_ID
-        }
-    return field_map
-
-
-class ImportResults(object):
-    CREATED = 'created'
-    UPDATED = 'updated'
-    FAILED = 'failed'
-
-    def __init__(self):
-        self._results = {}
-        self._errors = defaultdict(dict)
-        self.num_chunks = 0
-
-    def add_error(self, row_num, error):
-        self._results[row_num] = self.FAILED
-
-        key = error.title
-        column_name = error.column_name
-        self._errors[key].setdefault(column_name, {})
-        self._errors[key][column_name]['error'] = _(error.title)
-
-        try:
-            self._errors[key][column_name]['description'] = error.message
-        except KeyError:
-            self._errors[key][column_name]['description'] = exceptions.CaseGeneration.message
-
-        if 'rows' not in self._errors[key][column_name]:
-            self._errors[key][column_name]['rows'] = []
-
-        self._errors[key][column_name]['rows'].append(row_num)
-
-    def add_created(self, row_num):
-        self._results[row_num] = self.CREATED
-
-    def add_updated(self, row_num):
-        self._results[row_num] = self.UPDATED
-
-    def to_json(self):
-        counts = Counter(six.itervalues(self._results))
-        return {
-            'created_count': counts.get(self.CREATED, 0),
-            'match_count': counts.get(self.UPDATED, 0),
-            'errors': dict(self._errors),
-            'num_chunks': self.num_chunks,
-        }
-
-
-def convert_field_value(value):
-    # coerce to string unless it's a unicode string then we want that
-    if isinstance(value, six.text_type):
-        return value
-    else:
-        return str(value)
-
-
-def parse_search_id(config, row):
-    """ Find and convert the search id in an Excel row """
-
-    # Find index of user specified search column
-    search_column = config.search_column
-    search_id = row[search_column] or ''
-
-    try:
-        # if the spreadsheet gives a number, strip any decimals off
-        # float(x) is more lenient in conversion from string so both
-        # are used
-        search_id = int(float(search_id))
-    except (ValueError, TypeError, OverflowError):
-        # if it's not a number that's okay too
-        pass
-
-    return convert_field_value(search_id)
-
-
 def lookup_case(search_field, search_id, domain, case_type):
     """
     Attempt to find the case in CouchDB by the provided search_field and search_id.
@@ -274,43 +171,6 @@ def lookup_case(search_field, search_id, domain, case_type):
         return (None, LookupErrors.NotFound)
 
 
-def populate_updated_fields(config, row):
-    """
-    Returns a dict map of fields that were marked to be updated
-    due to the import. This can be then used to pass to the CaseBlock
-    to trigger updates.
-    """
-    field_map = convert_custom_fields_to_struct(config)
-    fields_to_update = {}
-    for key in field_map:
-        try:
-            update_value = row[key]
-        except Exception:
-            continue
-
-        if 'field_name' in field_map[key]:
-            update_field_name = field_map[key]['field_name'].strip()
-        else:
-            # nothing was selected so don't add this value
-            continue
-
-        if update_field_name in RESERVED_FIELDS:
-            raise InvalidCustomFieldNameException(_('Field name "{}" is reserved').format(update_field_name))
-
-        if isinstance(update_value, six.string_types) and update_value.strip() == SCALAR_NEVER_WAS:
-            soft_assert_type_text(update_value)
-            # If we find any instances of blanks ('---'), convert them to an
-            # actual blank value without performing any data type validation.
-            # This is to be consistent with how the case export works.
-            update_value = ''
-        elif update_value is not None:
-            update_value = convert_field_value(update_value)
-
-        fields_to_update[update_field_name] = update_value
-
-    return fields_to_update
-
-
 def open_spreadsheet_download_ref(filename):
     """
     open a spreadsheet download ref just to test there are no errors opening it
@@ -330,66 +190,6 @@ def get_spreadsheet(filename):
         raise ImporterFileNotFound(six.text_type(e))
     except SpreadsheetFileInvalidError as e:
         raise ImporterExcelError(six.text_type(e))
-
-
-def is_valid_location_owner(owner, domain):
-    if isinstance(owner, SQLLocation):
-        return owner.domain == domain and owner.location_type.shares_cases
-    else:
-        return False
-
-
-def is_valid_id(uploaded_id, domain, cache):
-    if uploaded_id in cache:
-        return cache[uploaded_id]
-
-    owner = get_wrapped_owner(uploaded_id)
-    return is_valid_owner(owner, domain)
-
-
-def is_valid_owner(owner, domain):
-    return (
-        (isinstance(owner, CouchUser) and owner.is_member_of(domain)) or
-        (isinstance(owner, Group) and owner.case_sharing and owner.is_member_of(domain)) or
-        is_valid_location_owner(owner, domain)
-    )
-
-
-def get_id_from_name(name, domain, cache):
-    '''
-    :param name: A username, group name, or location name/site_code
-    :param domain:
-    :param cache:
-    :return: Looks for the given name and returns the corresponding id if the
-    user or group exists and None otherwise. Searches for user first, then
-    group, then location
-    '''
-    if name in cache:
-        return cache[name]
-
-    def get_from_user(name):
-        try:
-            name_as_address = name
-            if '@' not in name_as_address:
-                name_as_address = format_username(name, domain)
-            user = CouchUser.get_by_username(name_as_address)
-            return getattr(user, 'couch_id', None)
-        except NoResultFound:
-            return None
-
-    def get_from_group(name):
-        group = Group.by_name(domain, name, one=True)
-        return getattr(group, 'get_id', None)
-
-    def get_from_location(name):
-        try:
-            return SQLLocation.objects.get_from_user_input(domain, name).location_id
-        except SQLLocation.DoesNotExist:
-            return None
-
-    id = get_from_user(name) or get_from_group(name) or get_from_location(name)
-    cache[name] = id
-    return id
 
 
 def get_importer_error_message(e):

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -176,7 +176,7 @@ class ImportErrorDetail(object):
     def __init__(self, *args, **kwargs):
         self.errors = defaultdict(dict)
 
-    def add(self, error):
+    def add(self, error, row_num):
         key = error.title
         column_name = error.column_name
         self.errors[key].setdefault(column_name, {})
@@ -190,7 +190,7 @@ class ImportErrorDetail(object):
         if 'rows' not in self.errors[key][column_name]:
             self.errors[key][column_name]['rows'] = []
 
-        self.errors[key][column_name]['rows'].append(error.row_number)
+        self.errors[key][column_name]['rows'].append(row_num)
 
     def as_dict(self):
         return dict(self.errors)


### PR DESCRIPTION
I'd definitely go commit-by-commit, which should be pretty straightforward to follow.  

My main goal here was to make this code more comprehensible.  I did find a number bugs and odd quirks in behavior in the process, which I addressed.  It should be clear when behavior is intentionally changed.

### Fixes

* Make `too_many_matches` a normal error like any other, so it is more meaningful to the user.  It'll also show which rows have too many matches
* Add error message when parent lookup by external ID fails
* Fix flawed logic that would sometimes result in cases referencing parents that hadn't yet been uploaded (which would fail)
* Log unknown failures (we're currently silencing them, so some bugs are really hard to understand)
* Fix weird "-1 rows were matched and updated" thing
* Keep track of status per row.   This used to log rows to each error category, and I inverted that.  This means the task results should be much more reliable.  Currently, you see this:
![image](https://user-images.githubusercontent.com/2367539/57950910-9888e480-78b6-11e9-8416-72346ab5508a.png)
Those rows are all logged as successful, then they later fail during the "commit" stage, but we don't un-mark them successful, so you get contradictory messages.

@kaapstorm 