### PR TITLE
use forked version of celery 4.1.1 that supports recent gevent releases

### DIFF
--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
@@ -21,7 +22,6 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
-celery==4.1.1
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2
 asn1crypto==0.24.0
@@ -17,7 +18,6 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
-celery==4.1.1
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
@@ -15,7 +16,6 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-celery==4.1.1
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
@@ -19,7 +20,6 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
-celery==4.1.1
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
@@ -21,7 +22,6 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
-celery==4.1.1
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2
 asn1crypto==0.24.0
@@ -17,7 +18,6 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
-celery==4.1.1
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,9 @@ attrs~=18.1
 iso8601==0.1.12
 jsonobject==0.9.8
 jsonobject-couchdbkit~=0.9
-celery==4.1.1  # upgrade when https://github.com/celery/celery/issues/4980 is fixed
+# celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737
+# upgrade when https://github.com/celery/celery/issues/4980 is fixed
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 # required by django-digest
 decorator==4.0.11
 django~=1.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
@@ -15,7 +16,6 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-celery==4.1.1
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -5,6 +5,7 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+-e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
@@ -19,7 +20,6 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
-celery==4.1.1
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4


### PR DESCRIPTION
Includes a workaround for https://github.com/celery/celery/issues/4737

This will allow us to upgrade gevent, which is necessary for Python 3.7