### PR TITLE
Removed use_select2_v4, made v4 default behavior

### DIFF
--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -42,7 +42,6 @@ from corehq.apps.domain.views.accounting import (
 )
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.decorators import (
-    use_select2_v4,
     use_jquery_ui,
     use_multiselect,
 )
@@ -163,10 +162,6 @@ class NewBillingAccountView(BillingAccountsSectionView):
     def page_url(self):
         return reverse(self.urlname)
 
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(NewBillingAccountView, self).dispatch(request, *args, **kwargs)
-
     def post(self, request, *args, **kwargs):
         if self.account_form.is_valid():
             account = self.account_form.create_account()
@@ -251,10 +246,6 @@ class ManageBillingAccountView(BillingAccountsSectionView, AsyncHandlerMixin):
     def page_url(self):
         return reverse(self.urlname, args=(self.args[0],))
 
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(ManageBillingAccountView, self).dispatch(request, *args, **kwargs)
-
     def post(self, request, *args, **kwargs):
         if self.async_response is not None:
             return self.async_response
@@ -294,7 +285,6 @@ class NewSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
         Select2BillingInfoHandler,
     ]
 
-    @use_select2_v4
     @use_jquery_ui  # for datepicker
     def dispatch(self, request, *args, **kwargs):
         return super(NewSubscriptionView, self).dispatch(request, *args, **kwargs)
@@ -368,7 +358,6 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
         Select2BillingInfoHandler,
     ]
 
-    @use_select2_v4
     @use_jquery_ui  # for datepicker
     def dispatch(self, request, *args, **kwargs):
         return super(EditSubscriptionView, self).dispatch(request, *args, **kwargs)
@@ -584,7 +573,6 @@ class EditSoftwarePlanView(AccountingSectionView, AsyncHandlerMixin):
         SoftwareProductRateAsyncHandler,
     ]
 
-    @use_select2_v4
     @use_multiselect
     def dispatch(self, request, *args, **kwargs):
         return super(EditSoftwarePlanView, self).dispatch(request, *args, **kwargs)
@@ -708,10 +696,6 @@ class TriggerInvoiceView(AccountingSectionView, AsyncHandlerMixin):
             'trigger_form': self.trigger_form,
         }
 
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(TriggerInvoiceView, self).dispatch(request, *args, **kwargs)
-
     def post(self, request, *args, **kwargs):
         if self.async_response is not None:
             return self.async_response
@@ -752,10 +736,6 @@ class TriggerCustomerInvoiceView(AccountingSectionView, AsyncHandlerMixin):
             'trigger_customer_form': self.trigger_customer_invoice_form,
         }
 
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(TriggerCustomerInvoiceView, self).dispatch(request, *args, **kwargs)
-
     def post(self, request, *args, **kwargs):
         if self.async_response is not None:
             return self.async_response
@@ -793,10 +773,6 @@ class TriggerBookkeeperEmailView(AccountingSectionView):
         return {
             'trigger_email_form': self.trigger_email_form,
         }
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(TriggerBookkeeperEmailView, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         if self.trigger_email_form.is_valid():

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -41,7 +41,6 @@
   {% endcompress %}
 
   {% include 'hqwebapp/includes/atwho.html' %}
-  <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
   <script src="{% static 'bootstrap3-typeahead/bootstrap3-typeahead.min.js' %}"></script>
   <script src="{% static 'hqwebapp/js/bootstrap-multi-typeahead.js' %}"></script>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/apps_stylesheets.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/apps_stylesheets.html
@@ -2,10 +2,9 @@
 {% load hq_shared_tags %}
 
 {% compress css %}
-  {# Explicitly include these because app manager doesn't really do class-based views, can't use the decorators #}
+  {# Explicitly include this because app manager doesn't do class-based views, so it doesn't use @use_jquery_ui #}
   <link type="text/css" rel="stylesheet" media="screen" href="{% static 'jquery-ui/themes/redmond/jquery-ui.min.css' %}"/>
 {% endcompress %}
-<link type="text/css" rel="stylesheet" media="all" href="{% static 'select2/dist/css/select2.min.css' %}" />
 
 {% if less_debug %}
   <link type="text/less"

--- a/corehq/apps/app_manager/templates/app_manager/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/source_files.html
@@ -60,8 +60,3 @@
   </table>
   {% block post_files %}{% endblock %}
 {% endblock page_content %}
-
-
-{% block stylesheets %}{{ block.super }}
-  <link type="text/css" rel="stylesheet" media="all" href="{% static 'select2/dist/css/select2.min.css' %}" />
-{% endblock %}

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -140,7 +140,6 @@ def excel_config(request, domain):
         'slug': base.ImportCases.slug,
     }
     context.update(_case_importer_breadcrumb_context(_('Case Options'), domain))
-    request.use_select2_v4 = True
     return render(request, "case_importer/excel_config.html", context)
 
 

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -45,7 +45,7 @@ from corehq.apps.data_interfaces.dispatcher import (
     require_can_edit_data,
 )
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.hqwebapp.decorators import use_daterangepicker, use_select2_v4
+from corehq.apps.hqwebapp.decorators import use_daterangepicker
 from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.const import SERVER_DATETIME_FORMAT
 from .dispatcher import require_form_management_privilege
@@ -122,7 +122,6 @@ class ExploreCaseDataView(BaseDomainView):
     page_title = ugettext_lazy("Explore Case Data")
 
     @use_daterangepicker
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(ExploreCaseDataView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -24,10 +24,7 @@ from corehq.const import USER_DATE_FORMAT
 from corehq.apps.accounting.async_handlers import Select2BillingInfoHandler
 from corehq.apps.accounting.invoicing import DomainWireInvoiceFactory
 from corehq.apps.hqwebapp.tasks import send_mail_async
-from corehq.apps.hqwebapp.decorators import (
-    use_jquery_ui,
-    use_select2_v4,
-)
+from corehq.apps.hqwebapp.decorators import use_jquery_ui
 from corehq.apps.accounting.exceptions import (
     NewSubscriptionError,
     PaymentRequestError,
@@ -357,7 +354,6 @@ class EditExistingBillingAccountView(DomainAccountingSettings, AsyncHandlerMixin
         return EditBillingAccountInfoForm(self.account, self.domain, self.request.couch_user.username,
                                           is_ops_user=is_ops_user)
 
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         if self.account is None:
             raise Http404()
@@ -1257,10 +1253,6 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
         Select2BillingInfoHandler,
     ]
 
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(ConfirmBillingAccountInfoView, self).dispatch(request, *args, **kwargs)
-
     @property
     def steps(self):
         last_steps = super(ConfirmBillingAccountInfoView, self).steps
@@ -1459,7 +1451,6 @@ class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin
         Select2BillingInfoHandler,
     ]
 
-    @use_select2_v4
     @method_decorator(require_POST)
     def dispatch(self, request, *args, **kwargs):
         return super(ConfirmSubscriptionRenewalView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/domain/views/pro_bono.py
+++ b/corehq/apps/domain/views/pro_bono.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy
 
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.domain.forms import ProBonoForm
 from corehq.apps.domain.views.accounting import DomainAccountingSettings, DomainSubscriptionView
 from corehq.apps.hqwebapp.views import BasePageView
@@ -50,10 +49,6 @@ class ProBonoStaticView(ProBonoMixin, BasePageView):
     urlname = 'pro_bono_static'
     use_domain_field = True
 
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(ProBonoStaticView, self).dispatch(request, *args, **kwargs)
-
     @property
     def requesting_domain(self):
         return self.pro_bono_form.cleaned_data['domain']
@@ -63,10 +58,6 @@ class ProBonoView(ProBonoMixin, DomainAccountingSettings):
     template_name = 'domain/pro_bono/domain.html'
     urlname = 'pro_bono'
     use_domain_field = False
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(ProBonoView, self).dispatch(request, *args, **kwargs)
 
     @property
     def requesting_domain(self):

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -18,7 +18,6 @@ from corehq.apps.app_manager.models import AppReleaseByLocation
 from corehq.apps.domain.forms import ManageAppReleasesForm
 from corehq.apps.domain.views import BaseProjectSettingsView
 from corehq.apps.domain.decorators import login_and_domain_required
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.locations.models import SQLLocation
 
 
@@ -27,10 +26,6 @@ class ManageReleases(BaseProjectSettingsView):
     template_name = 'domain/manage_releases.html'
     urlname = 'manage_releases'
     page_title = ugettext_lazy("Manage Releases")
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(ManageReleases, self).dispatch(request, *args, **kwargs)
 
     @cached_property
     def manage_releases_form(self):

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -26,7 +26,6 @@ from corehq.apps.case_search.models import (
     disable_case_search,
 )
 from corehq.apps.locations.permissions import location_safe
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import NAMESPACE_DOMAIN
 from custom.openclinica.forms import OpenClinicaSettingsForm
@@ -116,7 +115,6 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
     page_title = ugettext_lazy("Basic")
 
     @method_decorator(domain_admin_required)
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/domain/views/sms.py
+++ b/corehq/apps/domain/views/sms.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy
 
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.smsbillables.async_handlers import (
     SMSRatesAsyncHandler,
@@ -22,7 +21,6 @@ class PublicSMSRatesView(BasePageView, AsyncHandlerMixin):
     template_name = 'domain/admin/global_sms_rates.html'
     async_handlers = [PublicSMSRatesAsyncHandler]
 
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(PublicSMSRatesView, self).dispatch(request, *args, **kwargs)
 
@@ -49,7 +47,6 @@ class SMSRatesView(BaseAdminProjectSettingsView, AsyncHandlerMixin):
         SMSRatesSelect2AsyncHandler,
     ]
 
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(SMSRatesView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -21,7 +21,7 @@ from soil.util import get_download_context, process_email_request
 from corehq.apps.analytics.tasks import send_hubspot_form, HUBSPOT_DOWNLOADED_EXPORT_FORM_ID, track_workflow
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.models import Domain
-from corehq.apps.hqwebapp.decorators import use_select2, use_daterangepicker
+from corehq.apps.hqwebapp.decorators import use_select2_legacy, use_daterangepicker
 from corehq.apps.hqwebapp.views import HQJSONResponseMixin
 from corehq.apps.hqwebapp.widgets import DateRangePickerWidget
 from corehq.apps.locations.permissions import location_safe
@@ -130,7 +130,7 @@ class BaseDownloadExportView(HQJSONResponseMixin, BaseProjectDataView):
     export_filter_class = None
 
     @use_daterangepicker
-    @use_select2
+    @use_select2_legacy
     @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):
         self.permissions = ExportsPermissionsManager(self.form_or_case, request.domain, request.couch_user)

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -27,7 +27,7 @@ from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.app_manager.fields import ApplicationDataRMIHelper
 from corehq.apps.domain.decorators import login_and_domain_required, api_auth
 from corehq.apps.domain.models import Domain
-from corehq.apps.hqwebapp.decorators import use_select2
+from corehq.apps.hqwebapp.decorators import use_select2_legacy
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import location_safe, location_restricted_response
 from corehq.apps.reports.views import should_update_export
@@ -463,7 +463,7 @@ class BaseExportListView(BaseProjectDataView):
         for use in third-party data analysis tools.
     ''')
 
-    @use_select2
+    @use_select2_legacy
     @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):
         self.permissions = ExportsPermissionsManager(self.form_or_case, request.domain, request.couch_user)

--- a/corehq/apps/hqcase/views.py
+++ b/corehq/apps/hqcase/views.py
@@ -10,7 +10,6 @@ from django.views.generic import TemplateView
 from corehq.apps.domain.decorators import require_superuser_or_contractor
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
 from corehq.apps.hqcase.tasks import delete_exploded_case_task, explode_case_task
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.form_processor.utils import should_use_sql_backend
 from soil import DownloadBase
 
@@ -20,7 +19,6 @@ class ExplodeCasesView(BaseProjectSettingsView, TemplateView):
     template_name = "hqcase/explode_cases.html"
     page_title = "Explode Cases"
 
-    @use_select2_v4
     @method_decorator(require_superuser_or_contractor)
     def dispatch(self, *args, **kwargs):
         return super(ExplodeCasesView, self).dispatch(*args, **kwargs)

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -56,7 +56,6 @@ from corehq.apps.hqmedia.tasks import (
     process_bulk_upload_zip,
     build_application_zip,
 )
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
@@ -308,10 +307,6 @@ class MultimediaTranslationsCoverageView(BaseMultimediaTemplateView):
     urlname = "multimedia_translations_coverage"
     template_name = "hqmedia/translations_coverage.html"
     page_title = ugettext_noop("Translations Coverage")
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(MultimediaTranslationsCoverageView, self).dispatch(request, *args, **kwargs)
 
     @property
     def parent_pages(self):

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -20,24 +20,6 @@ def use_select2(view_func):
     return _wrapped
 
 
-def use_select2_v4(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the 4.0 Version of select2 js library at
-    the base template. (4.0 is still in testing phase)
-
-    Example:
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_select2_v4 = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
-
-
 def use_angular_js(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the angularjs library at the base template

--- a/corehq/apps/hqwebapp/decorators.py
+++ b/corehq/apps/hqwebapp/decorators.py
@@ -3,19 +3,19 @@ from __future__ import unicode_literals
 from functools import wraps
 
 
-def use_select2(view_func):
+def use_select2_legacy(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the select2 js library at the base template.
 
     Example:
 
-    @use_select2
+    @use_select2_legacy
     def dispatch(self, request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
     @wraps(view_func)
     def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_select2 = True
+        request.use_select2_legacy = True
         return view_func(class_based_view, request, *args, **kwargs)
     return _wrapped
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -70,7 +70,7 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_select2_v4 %}
+    {% if not request.use_select2 %}
       {% compress css %}
         <link type="text/css"
               rel="stylesheet"
@@ -476,7 +476,7 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_select2_v4 and not requirejs_main %}
+    {% if not request.use_select2 and not requirejs_main %}
       {% compress js %}
         <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
       {% endcompress %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -57,7 +57,7 @@
     {% block csrf_token_block %}
       <input id="csrfTokenContainer" type="hidden" value="{{ csrf_token }}">
     {% endblock %}
-    {% if request.use_select2 %}
+    {% if request.use_select2_legacy %}
       {% compress css %}
         <link type="text/css"
               rel="stylesheet"
@@ -70,7 +70,7 @@
       {% endcompress %}
     {% endif %}
 
-    {% if not request.use_select2 %}
+    {% if not request.use_select2_legacy %}
       {% compress css %}
         <link type="text/css"
               rel="stylesheet"
@@ -470,13 +470,13 @@
       {% endcompress %}
     {% endif %}
 
-    {% if request.use_select2 and not requirejs_main %}
+    {% if request.use_select2_legacy and not requirejs_main %}
       {% compress js %}
         <script src="{% static 'select2-3.5.2-legacy/select2.js' %}"></script>
       {% endcompress %}
     {% endif %}
 
-    {% if not request.use_select2 and not requirejs_main %}
+    {% if not request.use_select2_legacy and not requirejs_main %}
       {% compress js %}
         <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
       {% endcompress %}

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -28,7 +28,7 @@ from corehq.apps.consumption.shortcuts import get_default_monthly_consumption
 from corehq.apps.custom_data_fields.edit_model import CustomDataModelMixin
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_multiselect, use_select2_v4
+from corehq.apps.hqwebapp.decorators import use_jquery_ui, use_multiselect
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.hqwebapp.views import no_permissions
 from corehq.apps.products.models import Product, SQLProduct
@@ -185,7 +185,6 @@ class LocationsListView(BaseLocationView):
     template_name = 'locations/manage/locations.html'
 
     @use_jquery_ui
-    @use_select2_v4
     @method_decorator(check_pending_locations_import())
     @method_decorator(require_can_edit_or_view_locations)
     def dispatch(self, request, *args, **kwargs):
@@ -272,7 +271,6 @@ class LocationTypesView(BaseDomainView):
         return reverse(LocationsListView.urlname, args=[self.domain])
 
     @use_jquery_ui
-    @use_select2_v4
     @method_decorator(can_edit_location_types)
     @method_decorator(require_can_edit_locations)
     @method_decorator(check_pending_locations_import())
@@ -602,7 +600,6 @@ class NewLocationView(BaseEditLocationView):
     page_title = ugettext_noop("New Location")
 
     @use_multiselect
-    @use_select2_v4
     @method_decorator(require_can_edit_locations)
     @method_decorator(check_pending_locations_import(redirect=True))
     def dispatch(self, request, *args, **kwargs):
@@ -681,7 +678,6 @@ class EditLocationView(BaseEditLocationView):
     creates_new_location = False
 
     @use_multiselect
-    @use_select2_v4
     @method_decorator(check_pending_locations_import(redirect=True))
     @method_decorator(can_edit_or_view_location)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/products/views.py
+++ b/corehq/apps/products/views.py
@@ -29,7 +29,6 @@ from corehq.apps.programs.models import Program
 from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 from corehq.apps.custom_data_fields.edit_entity import CustomDataEditor
 from corehq.apps.custom_data_fields.edit_model import CustomDataModelMixin
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.domain.decorators import (
     domain_admin_required,
@@ -215,10 +214,6 @@ class NewProductView(BaseCommTrackManageView):
     urlname = 'commtrack_product_new'
     page_title = ugettext_noop("New Product")
     template_name = 'products/manage/product.html'
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(NewProductView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -24,7 +24,7 @@ from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
     use_jquery_ui,
     use_datatables,
-    use_select2,
+    use_select2_legacy,
     use_daterangepicker,
     use_nvd3,
 )
@@ -754,7 +754,7 @@ class GenericReportView(object):
 
     @use_nvd3
     @use_jquery_ui
-    @use_select2
+    @use_select2_legacy
     @use_datatables
     @use_daterangepicker
     def decorator_dispatcher(self, request, *args, **kwargs):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -143,7 +143,6 @@ from corehq.apps.saved_reports.tasks import send_delayed_report, send_email_repo
 from corehq.form_processor.utils.xform import resave_form
 from corehq.apps.hqcase.utils import resave_case
 from corehq.apps.hqwebapp.decorators import (
-    use_select2_v4,
     use_datatables,
     use_multiselect,
     use_jquery_ui
@@ -531,7 +530,6 @@ class ScheduledReportsView(BaseProjectReportSectionView):
     template_name = 'reports/edit_scheduled_report.html'
 
     @use_multiselect
-    @use_select2_v4
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(ScheduledReportsView, self).dispatch(request, *args, **kwargs)
@@ -932,7 +930,6 @@ class CaseDataView(BaseProjectReportSectionView):
     http_method_names = ['get']
 
     @method_decorator(require_case_view_permission)
-    @use_select2_v4
     @use_datatables
     def dispatch(self, request, *args, **kwargs):
         if not self.case_instance:
@@ -1624,7 +1621,6 @@ class FormDataView(BaseProjectReportSectionView):
     http_method_names = ['get']
 
     @method_decorator(require_form_view_permission)
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(FormDataView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -39,7 +39,6 @@ from corehq.apps.domain.decorators import (
     two_factor_exempt,
 )
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.hqwebapp.utils import sign, update_session_language
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.settings.forms import (
@@ -126,7 +125,6 @@ class MyAccountSettingsView(BaseMyAccountView):
     api_key = None
     template_name = 'settings/edit_my_account.html'
 
-    @use_select2_v4
     @two_factor_exempt
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -37,7 +37,6 @@ from corehq.apps.sms.dbaccessors import get_forwarding_rules_for_domain
 from corehq.apps.hqwebapp.decorators import (
     use_timepicker,
     use_typeahead,
-    use_select2_v4,
     use_jquery_ui,
     use_datatables,
 )
@@ -1052,7 +1051,6 @@ class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView)
     strict_domain_fetching = True
 
     @method_decorator(domain_admin_required)
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(DomainSmsGatewayListView, self).dispatch(request, *args, **kwargs)
 
@@ -1431,7 +1429,6 @@ class GlobalSmsGatewayListView(CRUDPaginatedViewMixin, BaseAdminSectionView):
     urlname = 'list_global_backends'
     page_title = ugettext_noop("SMS Connectivity")
 
-    @use_select2_v4
     @method_decorator(require_superuser)
     def dispatch(self, request, *args, **kwargs):
         return super(GlobalSmsGatewayListView, self).dispatch(request, *args, **kwargs)
@@ -1703,7 +1700,6 @@ class SMSLanguagesView(BaseMessagingSectionView):
     page_title = ugettext_noop("Languages")
 
     @use_jquery_ui
-    @use_select2_v4
     @method_decorator(domain_admin_required)
     def dispatch(self, *args, **kwargs):
         return super(SMSLanguagesView, self).dispatch(*args, **kwargs)
@@ -2007,7 +2003,6 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
 
     @method_decorator(domain_admin_required)
     @use_timepicker
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(SMSSettingsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/translations/integrations/transifex/views.py
+++ b/corehq/apps/translations/integrations/transifex/views.py
@@ -26,7 +26,6 @@ from openpyxl import Workbook
 
 from corehq import toggles
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.translations.forms import (
     AddTransifexBlacklistForm,
@@ -213,7 +212,6 @@ class PullResource(BaseTranslationsView):
     template_name = 'pull_resource.html'
     section_name = ugettext_noop("Translations")
 
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(PullResource, self).dispatch(request, *args, **kwargs)
 
@@ -336,7 +334,6 @@ class AppTranslations(BaseTranslationsView):
     template_name = 'app_translations.html'
     section_name = ugettext_lazy("Translations")
 
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(AppTranslations, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -13,7 +13,7 @@ from corehq.apps.reports.util import DatatablesParams
 from corehq.apps.reports_core.filters import Choice, PreFilter
 from corehq.apps.hqwebapp.crispy import CSS_ACTION_CLASS
 from corehq.apps.hqwebapp.decorators import (
-    use_select2,
+    use_select2_legacy,
     use_daterangepicker,
     use_jquery_ui,
     use_nvd3,
@@ -141,7 +141,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             return self._domain
         return super(ConfigurableReportView, self).domain
 
-    @use_select2
+    @use_select2_legacy
     @use_daterangepicker
     @use_jquery_ui
     @use_datatables

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -58,7 +58,7 @@ from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.hqwebapp.decorators import (
-    use_select2,
+    use_select2_legacy,
     use_daterangepicker,
     use_datatables,
     use_jquery_ui,
@@ -279,7 +279,7 @@ class ReportBuilderView(BaseDomainView):
 
     @method_decorator(require_permission(Permissions.edit_data))
     @cls_to_view_login_and_domain
-    @use_select2
+    @use_select2_legacy
     @use_daterangepicker
     @use_datatables
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -52,7 +52,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.es import AppES
 from corehq.apps.es.queries import search_string_query
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.hqwebapp.utils import send_confirmation_email
 from corehq.apps.hqwebapp.views import BasePageView, logout
 from corehq.apps.locations.permissions import (
@@ -211,10 +210,6 @@ class DefaultProjectUserSettingsView(BaseUserSettingsView):
 
 
 class BaseEditUserView(BaseUserSettingsView):
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(BaseEditUserView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized
@@ -954,10 +949,6 @@ class InviteWebUserView(BaseManageWebUserView):
     template_name = "users/invite_web_user.html"
     urlname = 'invite_web_user'
     page_title = ugettext_lazy("Invite Web User to Project")
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(InviteWebUserView, self).dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -8,10 +8,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_noop
 
 from corehq.apps.reports.filters.api import MobileWorkersOptionsView
-from corehq.apps.hqwebapp.decorators import (
-    use_multiselect,
-    use_select2_v4,
-)
+from corehq.apps.hqwebapp.decorators import use_multiselect
 from django_prbac.utils import has_privilege
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -129,7 +126,6 @@ class BaseGroupsView(BaseUserSettingsView):
 
     @method_decorator(require_can_edit_or_view_groups)
     @use_multiselect
-    @use_select2_v4
     def dispatch(self, request, *args, **kwargs):
         return super(BaseGroupsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -59,7 +59,6 @@ from corehq.apps.ota.utils import turn_off_demo_mode, demo_restore_date_created
 from corehq.apps.sms.models import SelfRegistrationInvitation
 from corehq.apps.sms.verify import initiate_sms_verification_workflow
 from corehq.apps.hqwebapp.decorators import (
-    use_select2_v4,
     use_angular_js,
     use_multiselect,
 )
@@ -136,7 +135,6 @@ class EditCommCareUserView(BaseEditUserView):
         else:
             return "users/edit_commcare_user.html"
 
-    @use_select2_v4
     @use_multiselect
     @method_decorator(require_can_edit_or_view_commcare_users)
     def dispatch(self, request, *args, **kwargs):
@@ -345,7 +343,6 @@ class ConfirmBillingAccountForExtraUsersView(BaseUserSettingsView, AsyncHandlerM
             'billing_info_form': self.billing_info_form,
         }
 
-    @use_select2_v4
     @method_decorator(domain_admin_required)
     def dispatch(self, request, *args, **kwargs):
         if self.account.date_confirmed_extra_charges is not None:
@@ -576,7 +573,6 @@ class MobileWorkerListView(HQJSONResponseMixin, BaseUserSettingsView):
     urlname = 'mobile_workers'
     page_title = ugettext_noop("Mobile Workers")
 
-    @use_select2_v4
     @use_angular_js
     @method_decorator(require_can_edit_or_view_commcare_users)
     def dispatch(self, *args, **kwargs):

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -26,7 +26,7 @@ from corehq.apps.sms.models import QueuedSMS, SMS, INCOMING, OUTGOING, Messaging
 from corehq.apps.sms.tasks import time_within_windows, OutboundDailyCounter
 from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
-from corehq.apps.hqwebapp.decorators import use_datatables, use_select2_v4, use_jquery_ui, use_timepicker, use_nvd3
+from corehq.apps.hqwebapp.decorators import use_datatables, use_jquery_ui, use_timepicker, use_nvd3
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
@@ -419,7 +419,6 @@ class CreateScheduleView(BaseMessagingSectionView, AsyncHandlerMixin):
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
     @use_jquery_ui
     @use_timepicker
-    @use_select2_v4
     def dispatch(self, *args, **kwargs):
         return super(CreateScheduleView, self).dispatch(*args, **kwargs)
 
@@ -791,7 +790,6 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
     @use_jquery_ui
     @use_timepicker
-    @use_select2_v4
     def dispatch(self, *args, **kwargs):
         return super(CreateConditionalAlertView, self).dispatch(*args, **kwargs)
 

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -20,7 +20,6 @@ from dimagi.utils.post import simple_post
 from corehq import toggles
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.domain.views.settings import BaseAdminProjectSettingsView, BaseProjectSettingsView
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.users.decorators import require_can_edit_web_users, require_permission
 from corehq.apps.users.models import Permissions
 
@@ -197,10 +196,6 @@ class AddFormRepeaterView(AddRepeaterView):
 class AddCaseRepeaterView(AddRepeaterView):
     urlname = 'add_case_repeater'
     repeater_form_class = CaseRepeaterForm
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(AddCaseRepeaterView, self).dispatch(request, *args, **kwargs)
 
     @property
     def page_url(self):

--- a/custom/ewsghana/views.py
+++ b/custom/ewsghana/views.py
@@ -17,7 +17,6 @@ from corehq.apps.domain.decorators import (
     login_and_domain_required,
 )
 from corehq.apps.domain.views.base import BaseDomainView
-from corehq.apps.hqwebapp.decorators import use_select2_v4
 from corehq.apps.locations.permissions import locations_access_required, location_safe
 from corehq.apps.products.models import Product
 from corehq.apps.locations.models import SQLLocation
@@ -139,10 +138,6 @@ class InputStockView(BaseDomainView):
 @location_safe
 class EWSUserExtensionView(BaseCommTrackManageView):
     template_name = 'ewsghana/user_extension.html'
-
-    @use_select2_v4
-    def dispatch(self, request, *args, **kwargs):
-        return super(EWSUserExtensionView, self).dispatch(request, *args, **kwargs)
 
     @property
     def page_context(self):

--- a/custom/ilsgateway/tanzania/reports/dashboard_report.py
+++ b/custom/ilsgateway/tanzania/reports/dashboard_report.py
@@ -1,7 +1,12 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from corehq.apps.hqwebapp.decorators import use_daterangepicker, use_datatables, use_select2, use_jquery_ui, \
-    use_nvd3
+from corehq.apps.hqwebapp.decorators import (
+    use_daterangepicker,
+    use_datatables,
+    use_select2_legacy,
+    use_jquery_ui,
+    use_nvd3,
+)
 from custom.ilsgateway.filters import (
     ProgramFilter,
     B3ILSDateFilter,
@@ -26,7 +31,7 @@ class DashboardReport(MultiReport):
     @use_datatables
     @use_daterangepicker
     @use_jquery_ui
-    @use_select2
+    @use_select2_legacy
     @use_nvd3
     def decorator_dispatcher(self, request, *args, **kwargs):
         pass

--- a/docs/js-guide/migrating.md
+++ b/docs/js-guide/migrating.md
@@ -155,7 +155,7 @@ makes it harder to bundle and share code across pages effectively.
 | Version        |  4.0.0                             | 3.5.2                             |
 | Docs           | https://select2.org/               | http://select2.github.io/select2/ |
 | JS module      | `select2/dist/js/select2.full.min` | `select2-3.5.2-legacy/select2`    |
-| View decorator | `@use_select2_v4`                  | `@use_select2`                    |
+| View decorator | none                               | `@use_select2`                    |
 
 This is a fairly complicated migration both because the old and new version differ in multiple significant ways and because of how code is shared in HQ.
 

--- a/docs/js-guide/migrating.md
+++ b/docs/js-guide/migrating.md
@@ -155,7 +155,7 @@ makes it harder to bundle and share code across pages effectively.
 | Version        |  4.0.0                             | 3.5.2                             |
 | Docs           | https://select2.org/               | http://select2.github.io/select2/ |
 | JS module      | `select2/dist/js/select2.full.min` | `select2-3.5.2-legacy/select2`    |
-| View decorator | none                               | `@use_select2`                    |
+| View decorator | none                               | `@use_select2_legacy`             |
 
 This is a fairly complicated migration both because the old and new version differ in multiple significant ways and because of how code is shared in HQ.
 
@@ -163,9 +163,9 @@ This is a fairly complicated migration both because the old and new version diff
 
 Migrating one select2 widget typically leads to migrating a number of other dependent ones. There are a couple of ways to pick a starting point:
 
-- Pick a view that uses the `use_select2` decorator
+- Pick a view that uses the `use_select2_legacy` decorator
 - Pick a javascript module that directly depends on `select2-3.5.2-legacy/select2`
-- Pick a page that includes a script tag for `select2-3.5.2-legacy/select2.js` (rare, because most pages use the `@use_select2` decorator rather than including a script tag)
+- Pick a page that includes a script tag for `select2-3.5.2-legacy/select2.js` (rare, because most pages use the `@use_select2_legacy` decorator rather than including a script tag)
 - Browse the [requirejs bundle configuration](https://www.commcarehq.org/static/build.txt) to find modules that indirectly depend on `select2-3.5.2-legacy/select2`
 - Javascript modules that don't yet declare dependencies but that call the `.select2()` function
 - Pages that use a select2-dependent knockout binding like `select2`, `autocompleteSelect2`, or `questionsSelect`


### PR DESCRIPTION
Cherry-picked from the final select2 migration branch, which needs a fair amount more work, but this particular commit is prone to merge conflicts and is safe to release on its own.

It removes the `use_select2_v4` decorator, leaves the old `use_select2` decorator in place, and includes select2 new select2 on *all* pages except those that specifically require the old version.

Sanity tested a couple of pages locally: old version, requirejs new version, non-requirejs new version.