### PR TITLE
Revert "Revert "upgrade gevent and greenlet""

### DIFF
--- a/requirements-python3_6/dev-requirements.txt
+++ b/requirements-python3_6/dev-requirements.txt
@@ -86,11 +86,11 @@ fixture==1.5.11
 freezegun==0.3.11
 funcsigs==1.0.2
 future==0.17.1            # via commonmark
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
 gnureadline==6.3.8
 graphviz==0.7
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1

--- a/requirements-python3_6/prod-requirements.txt
+++ b/requirements-python3_6/prod-requirements.txt
@@ -75,9 +75,9 @@ eventlet==0.24.1          # via errand-boy
 faker==0.8.15
 flower==0.9.2
 funcsigs==1.0.2
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1

--- a/requirements-python3_6/requirements.txt
+++ b/requirements-python3_6/requirements.txt
@@ -70,9 +70,9 @@ ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2           # via mock
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint

--- a/requirements-python3_6/test-requirements.txt
+++ b/requirements-python3_6/test-requirements.txt
@@ -77,9 +77,9 @@ fakecouch==0.0.15
 faker==0.8.15
 freezegun==0.3.11
 funcsigs==1.0.2
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -87,11 +87,11 @@ freezegun==0.3.11
 funcsigs==1.0.2
 future==0.17.1            # via commonmark
 futures==3.2.0
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
 gnureadline==6.3.8
 graphviz==0.7
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -76,9 +76,9 @@ faker==0.8.15
 flower==0.9.2
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -46,8 +46,8 @@ Unidecode==0.04.20
 xlrd==1.0.0
 simplejson~=3.11
 sh==1.09
-gevent==1.2.2
-greenlet==0.4.12
+gevent==1.4.0
+greenlet==0.4.15
 openpyxl~=2.6
 six~=1.11
 socketpool==0.5.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -71,9 +71,9 @@ eulxml==1.1.3
 faker==0.8.15
 funcsigs==1.0.2           # via mock
 futures==3.2.0            # via s3transfer, tinys3
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -78,9 +78,9 @@ faker==0.8.15
 freezegun==0.3.11
 funcsigs==1.0.2
 futures==3.2.0
-gevent==1.2.2
+gevent==1.4.0
 ghdiff==0.4
-greenlet==0.4.12
+greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0
 html5lib==1.0.1


### PR DESCRIPTION
Reverts dimagi/commcare-hq#24353

Celery has been forked to support newer versions of gevent.