### PR TITLE
[PNA] Declare table explicitly in sqlalchemy code

### DIFF
--- a/custom/intrahealth/sqldata.py
+++ b/custom/intrahealth/sqldata.py
@@ -779,7 +779,7 @@ class SumAndAvgQueryMeta(IntraHealthQueryMeta):
                 group_by_columns + [sqlalchemy.func.sum(key_column).label('sum_col')] + [sqlalchemy.column('month')],
                 group_by=self.group_by + [sqlalchemy.column('month')],
                 whereclause=self.filter.build_expression(),
-            ).select_from(self.table_name),
+            ).select_from(sqlalchemy.table(self.table_name)),
             name='s')
 
         return select(


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-625
https://sentry.io/organizations/dimagi/issues/1030369300/?environment=pna&project=136860&query=is%3Aunresolved
I see a number of other lines of code that use `select_from.*table_name`, and they all wrap it thusly, so I think this should be a pretty safe bet.  Might be other situations where we pass raw strings in remaining, though.

@snopoke @kaapstorm 