### PR TITLE
Alert and handle if feed page no longer exists

### DIFF
--- a/corehq/motech/openmrs/exceptions.py
+++ b/corehq/motech/openmrs/exceptions.py
@@ -6,3 +6,7 @@ class OpenmrsConfigurationError(Exception):
     OpenMRS is configured in a non-standard or unexpected way.
     """
     pass
+
+
+class OpenmrsFeedDoesNotExist(Exception):
+    pass


### PR DESCRIPTION
Importing from a particular OpenMRS Atom feed is failing because a partner changed the IP address of a Repeater to the address of a different server. As a result, Atom feed status is wrong, and continues to poll a page that does not (yet) exist.

This change sends an alert, because the error should never happen, and resets the Atom feed status to treat the feed as newly-added. Historical changes are not imported from newly-added feeds, but changes from that time onwards will be.

Feature Flag: OpenMRS