### PR TITLE
Replaced some module.forms accesses with module.get_forms calls

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -519,7 +519,7 @@ class AdvancedModuleValidator(ModuleBaseValidator):
                 'module': self.get_module_info(),
             })
         if self.module.case_list_form.form_id:
-            forms = self.module.forms
+            forms = self.module.get_forms()
 
             case_tag = None
             loaded_case_types = None
@@ -599,7 +599,7 @@ class AdvancedModuleValidator(ModuleBaseValidator):
                     'module': module_info,
                 }
             if self.module.get_app().commtrack_enabled and not self.module.product_details.short.columns:
-                for form in self.module.forms:
+                for form in self.module.get_forms():
                     if self.module.case_list.show or \
                             any(action.show_product_stock for action in form.actions.load_update_cases):
                         yield {

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3076,7 +3076,7 @@ class AdvancedModule(ModuleBase):
         if self.case_list.show:
             return True
 
-        for form in self.forms:
+        for form in self.get_forms():
             if any(action.case_type == self.case_type for action in form.actions.load_update_cases):
                 return True
 

--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -29,7 +29,7 @@ def get_bulk_app_single_sheet_by_name(app, lang):
         for module_row in get_module_rows([lang], module):
             rows.append(get_list_detail_case_property_row(module_row, sheet_name))
 
-        for form in module.forms:
+        for form in module.get_forms():
             sheet_name = get_form_sheet_name(form)
             rows.append(get_name_menu_media_row(form, sheet_name, lang))
             for label_name_media in get_form_question_label_name_media([lang], form):

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -81,7 +81,7 @@ class AppTranslationsGenerator(object):
         necessary_labels = defaultdict(set)
 
         for module in self.app.modules:
-            for form in module.forms:
+            for form in module.get_forms():
                 questions = form.get_questions(self.app.langs, include_triggers=True,
                                                include_groups=True, include_translations=True)
                 for question in questions:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/REACH-115

`get_forms` and `get_modules` are defined using `IndexedSchema.Getter`, which makes sure that  [self._parent is assigned](https://github.com/dimagi/commcare-hq/blob/b0dfc4fed93fdf712132fec8d2d5b57b02223865/corehq/apps/app_manager/models.py#L291). Calling `app.modules` or `module.forms` doesn't guarantee that `_parent` is populated for those modules/forms.

Note that I don't think this code will fix the bug, just that it might prevent other instances of this error popping up. I'm guessing the cause of this particular bug is code somewhere in the CCZ build logic that accesses a form directly instead of via `get_forms` or a similar method (`get_form`, `get_form_by_unique_id`, etc all seem to go through `get_forms` at some point) but haven't found it yet.