### PR TITLE
AAA Dashboard - redirect and filtering issue

### DIFF
--- a/custom/aaa/dbaccessors.py
+++ b/custom/aaa/dbaccessors.py
@@ -262,7 +262,7 @@ class PregnantWomanQueryHelper(object):
                 woman.domain = %(domain)s AND
                 {location_where}
                 (daterange(%(start_date)s, %(end_date)s) && ANY(pregnant_ranges)) AND
-                ccs_record.add < %(start_date)s
+                (ccs_record.add < %(start_date)s or ccs_record.add is NULL)
             ) ORDER BY {sort_col}
         """.format(
             location_where=location_query,

--- a/custom/aaa/static/aaa/js/models/person.js
+++ b/custom/aaa/static/aaa/js/models/person.js
@@ -61,7 +61,7 @@ hqDefine("aaa/js/models/person", [
         self.nameLink = ko.computed(function () {
             var url = initialPageData.reverse('unified_beneficiary_details');
             url = url.replace('details_type', 'eligible_couple');
-            url = url.replace('beneficiary_id', 1);
+            url = url.replace('beneficiary_id', self.id);
             url = url + '?month=' + postData.selectedMonth() + '&year=' + postData.selectedYear();
             return '<a href="' + url + '">' + self.name + '</a>';
         });

--- a/custom/aaa/static/aaa/spec/models/person.spec.js
+++ b/custom/aaa/static/aaa/spec/models/person.spec.js
@@ -81,6 +81,7 @@ describe('Person models', function () {
             selectedYear: 2019,
         });
         var initialData = {
+            id: 1,
             name: 'test Person',
         };
         var personModel = personModels.personModel(initialData, postData);


### PR DESCRIPTION
Hi @emord 

I fixed the URL redirection from child details page to mother details page, also I checked that we don't have hardcoded ids in other redirections.

Regarding the second commit, I added to the filtering condition that ADD is NULL when we searching pregnant woman, I think this means that the woman didn't delivery the child so is still pregnant, please correct me if I'm wrong. 

TICKET: https://dimagi-dev.atlassian.net/browse/QA-485

Regards,
Łukasz