### PR TITLE
Handle repeat index for nested repeat groups

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -432,7 +432,7 @@ WebFormSession.prototype.newRepeat = function (repeat) {
 
 WebFormSession.prototype.deleteRepeat = function (repetition) {
     var juncture = getIx(repetition.parent);
-    var rep_ix = +(repetition.rel_ix().replace('_', ':').split(":").slice(-1)[0]);
+    var rep_ix = +(repetition.rel_ix().replace(/_/g, ':').split(":").slice(-1)[0]);
     this.serverRequest(
         {
             'action': Formplayer.Const.DELETE_REPEAT,


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-575
This fixes a bug inside web apps / live preview which blocked users from deleting elements from repeat groups that are nested inside other repeat groups.

The replace statement only applied to the first `_` in the string - it needed a global replace