### PR TITLE
Minor raw_docs tweaks

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
@@ -1,4 +1,4 @@
-hqDefine('hqadmin/js/raw_couch_main', [
+hqDefine('hqadmin/js/raw_doc', [
     'jquery',
     'hqwebapp/js/initial_page_data',
     "hqwebapp/js/base_ace",
@@ -11,11 +11,9 @@ hqDefine('hqadmin/js/raw_couch_main', [
 
         var viewModel = {'allDatabases': allDatabase};
         $("#doc-form").koApplyBindings(viewModel);
-        var $element = $("#couch-document");
 
-
-        baseAce.initAceEditor($element.get(0), 'ace/mode/json', {}, ($element.length ? JSON.stringify($element.data('doc'), null, 4) : null));
-
-
+        var $element = $("#doc-element"),
+            doc = ($element.length ? JSON.stringify($element.data('doc'), null, 4) : null);
+        baseAce.initAceEditor($element.get(0), 'ace/mode/json', {}, doc);
     });
 });

--- a/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/doc_in_es.html
@@ -15,7 +15,7 @@
       <div class="alert alert-warning">
         Hey there!  This page is primarily for comparing documents in elasticsearch and couch/sql.
         Are you sure you don't want
-        <a href="{% url "raw_couch" %}?id={{ doc_id }}">raw_couch</a>?
+        <a href="{% url "raw_doc" %}?id={{ doc_id }}">raw_doc</a>?
       </div>
     </div>
     {% if doc_id %}

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
@@ -39,7 +39,7 @@
                 <tr>
                   <td><span class="label label-{{ db.status }}">{{ db.result }}</span></td>
                   {% if db.result == "found"  %}
-                    <td><a href="{% url "raw_couch" %}?id={{ doc_id }}&db_name={{ db.dbname }}">
+                    <td><a href="{% url "raw_doc" %}?id={{ doc_id }}&db_name={{ db.dbname }}">
                       {{ db.dbname }}
                     </a></td>
                   {% else %}
@@ -62,7 +62,7 @@
                  title="Open in HQ" />
           </a>
           <a href="{% url 'doc_in_es' %}?id={{ doc_id }}" target="_blank" title="Search in ES"><i class="fa fa-search"></i></a>
-          <a href="{% url "raw_couch" %}?id={{ doc_id }}&db_name={{ selected_db }}&raw=true" title="Load raw json doc"><i class="fa fa-code"></i></a>
+          <a href="{% url "raw_doc" %}?id={{ doc_id }}&db_name={{ selected_db }}&raw=true" title="Load raw json doc"><i class="fa fa-code"></i></a>
           <div>
             <h3>Raw Doc:</h3>
             <pre id="couch-document" data-doc="{% html_attr doc %}"></pre>

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_couch.html
@@ -55,6 +55,7 @@
           <h3>Doc {{ doc_id }}</h3>
           <p>Doc type: {{ doc_type }}</p>
           <p>Database or table: {{ dbname }}</p>
+          <p>Domain: {{ domain }}</p>
           <a href="{% url 'global_quick_find' %}?q={{ doc_id }}">
             <img src="{% static 'hqwebapp/images/commcare-flower.png' %}"
                  alt="CommCare" witdth="14px" height="14px"

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
@@ -1,7 +1,7 @@
 {% extends "hqwebapp/base.html" %}
 {% load hq_shared_tags %}
 
-{% block title %}Doc {{ doc_id }}{% endblock %}
+{% block title %}Doc {{ doc_id }} ({{ doc_type }}){% endblock %}
 
 {% block js %}{{ block.super }}
   {% requirejs_main 'hqadmin/js/raw_doc' %}

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
@@ -4,7 +4,7 @@
 {% block title %}Doc {{ doc_id }}{% endblock %}
 
 {% block js %}{{ block.super }}
-  {% requirejs_main 'hqadmin/js/raw_couch_main' %}
+  {% requirejs_main 'hqadmin/js/raw_doc' %}
 {% endblock %}
 
 
@@ -65,7 +65,7 @@
           <a href="{% url "raw_doc" %}?id={{ doc_id }}&db_name={{ selected_db }}&raw=true" title="Load raw json doc"><i class="fa fa-code"></i></a>
           <div>
             <h3>Raw Doc:</h3>
-            <pre id="couch-document" data-doc="{% html_attr doc %}"></pre>
+            <pre id="doc-element" data-doc="{% html_attr doc %}"></pre>
           </div>
         </div>
       </div>

--- a/corehq/apps/hqadmin/templates/hqadmin/system_info.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/system_info.html
@@ -53,7 +53,7 @@
                   </div>
                 </li>
                 <li>
-                  <a href="{% url "raw_couch" %}">Look for a doc in couch</a>
+                  <a href="{% url "raw_doc" %}">Look for a doc in the db</a>
                 </li>
               </ul>
             </td>

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -17,7 +17,7 @@
       <dl>
         <dt>{% trans "ID" %}</dt>
         <dd>{{ web_user.get_id }}
-          <small><a href="{% url 'raw_couch' %}?id={{ web_user.get_id }}">{% trans "couch doc" %}</a></small> |
+          <small><a href="{% url 'raw_doc' %}?id={{ web_user.get_id }}">{% trans "couch doc" %}</a></small> |
           <small><a href="{% url 'doc_in_es' %}?id={{ web_user.get_id }}">{% trans "elasticsearch lookup" %}</a></small>
         </dd>
       </dl>

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -1,17 +1,15 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import include, url
+
+from corehq.apps.api.urls import admin_urlpatterns as admin_api_urlpatterns
 from corehq.apps.domain.decorators import require_superuser
 from corehq.apps.domain.utils import new_domain_re
-from corehq.apps.hqadmin.views.data import (
-    doc_in_es,
-    raw_couch,
-    raw_doc,
-)
+from corehq.apps.hqadmin.views.data import doc_in_es, raw_doc
 from corehq.apps.hqadmin.views.operations import (
     CallcenterUCRCheck,
-    mass_email,
     ReprocessMessagingCaseUpdatesView,
+    mass_email,
 )
 from corehq.apps.hqadmin.views.reports import (
     DimagisphereView,
@@ -30,7 +28,6 @@ from corehq.apps.hqadmin.views.system import (
     pillow_operation_api,
     system_ajax,
 )
-from corehq.apps.hqadmin.views.utils import default
 from corehq.apps.hqadmin.views.users import (
     AdminRestoreView,
     AppBuildTimingsView,
@@ -41,10 +38,8 @@ from corehq.apps.hqadmin.views.users import (
     WebUserDataView,
     web_user_lookup,
 )
-
+from corehq.apps.hqadmin.views.utils import default
 from corehq.apps.reports.dispatcher import AdminReportDispatcher
-
-from corehq.apps.api.urls import admin_urlpatterns as admin_api_urlpatterns
 
 urlpatterns = [
     url(r'^$', default, name="default_admin_report"),
@@ -73,7 +68,7 @@ urlpatterns = [
     url(r'^disable_two_factor/$', DisableTwoFactorView.as_view(), name=DisableTwoFactorView.urlname),
     url(r'^disable_account/$', DisableUserView.as_view(), name=DisableUserView.urlname),
     url(r'^doc_in_es/$', doc_in_es, name='doc_in_es'),
-    url(r'^raw_couch/$', raw_couch, name='raw_couch'),
+    url(r'^raw_couch/$', raw_doc, name='raw_couch'),
     url(r'^raw_doc/$', raw_doc, name='raw_doc'),
     url(r'^api/', include(admin_api_urlpatterns)),
     url(r'^callcenter_ucr_check/$', CallcenterUCRCheck.as_view(), name=CallcenterUCRCheck.urlname),

--- a/corehq/apps/hqadmin/views/__init__.py
+++ b/corehq/apps/hqadmin/views/__init__.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from corehq.apps.hqadmin.views.data import (
     doc_in_es,
     get_db_from_db_name,
-    raw_couch,
     raw_doc,
 )
 from corehq.apps.hqadmin.views.operations import (

--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -140,12 +140,6 @@ def doc_in_es(request):
 
 
 @require_superuser
-def raw_couch(request):
-    get_params = dict(six.iteritems(request.GET))
-    return HttpResponseRedirect(reverse("raw_doc", params=get_params))
-
-
-@require_superuser
 def raw_doc(request):
     doc_id = request.GET.get("id")
     db_name = request.GET.get("db_name", None)

--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -156,4 +156,4 @@ def raw_doc(request):
 
     other_couch_dbs = sorted([_f for _f in couch_config.all_dbs_by_slug if _f])
     context['all_databases'] = ['commcarehq'] + other_couch_dbs + list(_SQL_DBS)
-    return render(request, "hqadmin/raw_couch.html", context)
+    return render(request, "hqadmin/raw_doc.html", context)

--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -100,6 +100,7 @@ def _lookup_id_in_database(doc_id, db_name=None):
             response.update({
                 "doc": json.dumps(doc, indent=4, sort_keys=True, cls=CommCareJSONEncoder),
                 "doc_type": doc.get('doc_type', getattr(db, 'doc_type', 'Unknown')),
+                "domain": doc.get('domain', 'Unknown'),
                 "dbname": db.dbname,
             })
 

--- a/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
+++ b/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
@@ -40,7 +40,7 @@
           <a class="btn btn-mini" href="{% url "global_quick_find" %}?q={{ error.doc_id }}" target="_blank">
             <i class="icon-search"></i> {% trans "Search HQ" %}
           </a>
-          <a class="btn btn-mini" href="{% url "raw_couch" %}?id={{ error.doc_id }}" target="_blank">
+          <a class="btn btn-mini" href="{% url "raw_doc" %}?id={{ error.doc_id }}" target="_blank">
             <i class="icon-file"></i> {% trans "Raw doc" %}
           </a>
         </td>

--- a/corehq/apps/hqpillow_retry/views.py
+++ b/corehq/apps/hqpillow_retry/views.py
@@ -155,7 +155,7 @@ class PillowErrorsReport(GenericTabularReport, DatespanMixin, GetParamsMixin):
             search_url=reverse("global_quick_find"),
             doc_id=error.doc_id,
             search_title=_("Search HQ for this document: %(doc_id)s") % {'doc_id': error.doc_id},
-            raw_url=reverse("raw_couch"),
+            raw_url=reverse("raw_doc"),
             raw_title=_("Open the raw document: %(doc_id)s") % {'doc_id': error.doc_id},
             error_url=reverse(EditPillowError.urlname),
             error_id=error.id,

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1094,7 +1094,7 @@ def quick_find(request):
             messages.info(request, _("We've redirected you to the %s matching your query") % doc_info.type_display)
             return HttpResponseRedirect(doc_info.link)
         elif redirect and request.couch_user.is_superuser:
-            return HttpResponseRedirect('{}?id={}'.format(reverse('raw_couch'), doc.get('_id')))
+            return HttpResponseRedirect('{}?id={}'.format(reverse('raw_doc'), doc.get('_id')))
         else:
             return json_response(doc_info)
 

--- a/corehq/ex-submodules/auditcare/templates/auditcare/audit_views.html
+++ b/corehq/ex-submodules/auditcare/templates/auditcare/audit_views.html
@@ -22,7 +22,7 @@
       {% for v in audit_views %}
         <tr>
           <td>
-            <a href="{% url 'raw_couch' %}?id={{ v.id }}">View
+            <a href="{% url 'raw_doc' %}?id={{ v.id }}">View
             </a>
           </td>
           <td>

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1938,8 +1938,8 @@ class AdminTab(UITab):
             from corehq.apps.hqadmin.views.users import AuthenticateAs
             from corehq.apps.notifications.views import ManageNotificationView
             data_operations = [
-                {'title': _('View raw couch documents'),
-                 'url': reverse('raw_couch')},
+                {'title': _('View raw documents'),
+                 'url': reverse('raw_doc')},
                 {'title': _('View documents in ES'),
                  'url': reverse('doc_in_es')},
             ]


### PR DESCRIPTION
* Add domain to the meta data at the top of the raw docs page
* Add doc type to the page title
* Stop linking to `raw_couch` and redirecting to `raw_doc`
* Remove all references to `raw_couch` except for the URL

@kaapstorm 