### PR TITLE
keep api logs for 90 days

### DIFF
--- a/corehq/apps/api/tasks.py
+++ b/corehq/apps/api/tasks.py
@@ -8,5 +8,5 @@ from tastypie.models import ApiAccess
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue='background_queue')
 def clean_api_access():
-    accessed = int(time.time()) - 30 * 24 * 3600  # only keep last 30 days
+    accessed = int(time.time()) - 90 * 24 * 3600  # only keep last 30 days
     ApiAccess.objects.filter(accessed__lt=accessed).delete()


### PR DESCRIPTION
30 days is too short for most things