### PR TITLE
Invoice by user history

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -483,8 +483,6 @@ class LineItemFactory(object):
     @property
     @memoized
     def subscribed_domains(self):
-        if self.subscription.subscriber.domain is None:
-            raise LineItemError("No domain could be obtained as the subscriber.")
         if self.subscription.account.is_customer_billing_account:
             return list(self.subscription.account.subscription_set.filter(
                 Q(date_end__isnull=True) | Q(date_end__gt=self.invoice.date_start),

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -638,13 +638,8 @@ class UserLineItemFactory(FeatureLineItemFactory):
         return non_prorated_unit_cost
 
     @property
+    @memoized
     def quantity(self):
-        if self.invoice.is_customer_invoice and self.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY:
-            return self.num_excess_users_over_period
-        return self.num_excess_users
-
-    @property
-    def num_excess_users_over_period(self):
         # Iterate through all months in the invoice date range to aggregate total users into one line item
         dates = self.all_month_ends_in_invoice()
         excess_users = 0
@@ -655,7 +650,7 @@ class UserLineItemFactory(FeatureLineItemFactory):
                     history = DomainUserHistory.objects.get(domain=domain, record_date=date)
                     total_users += history.num_users
                 except DomainUserHistory.DoesNotExist:
-                    total_users += 0
+                    raise
             excess_users += max(total_users - self.rate.monthly_limit, 0)
         return excess_users
 
@@ -668,28 +663,11 @@ class UserLineItemFactory(FeatureLineItemFactory):
         return dates
 
     @property
-    def num_excess_users(self):
-        if self.rate.monthly_limit == UNLIMITED_FEATURE_USAGE:
-            return 0
-        else:
-            return max(self.num_users - self.rate.monthly_limit, 0)
-
-    @property
-    @memoized
-    def num_users(self):
-        total_users = 0
-        for domain in self.subscribed_domains:
-            total_users += CommCareUser.total_by_domain(domain, is_active=True)
-        return total_users
-
-    @property
     def unit_description(self):
-        non_monthly_invoice = self.invoice.is_customer_invoice and \
-            self.invoice.account.invoicing_plan != InvoicingPlan.MONTHLY
-        if self.num_excess_users > 0 or (non_monthly_invoice and self.num_excess_users_over_period > 0):
+        if self.quantity > 0:
             return ungettext(
-                "Per User fee exceeding monthly limit of %(monthly_limit)s user.",
-                "Per User fee exceeding monthly limit of %(monthly_limit)s users.",
+                "Per User fee exceeding limit of %(monthly_limit)s user.",
+                "Per User fee exceeding limit of %(monthly_limit)s users.",
                 self.rate.monthly_limit
             ) % {
                 'monthly_limit': self.rate.monthly_limit,

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -1033,10 +1033,11 @@ def email_enterprise_report(domain, slug, couch_user):
 
 
 @periodic_task(run_every=crontab(hour=1, minute=0, day_of_month='1'), acks_late=True)
-def calculate_users_in_all_domains():
+def calculate_users_in_all_domains(today=None):
+    today = today or datetime.date.today()
     for domain in Domain.get_all_names():
         num_users = CommCareUser.total_by_domain(domain)
-        record_date = datetime.date.today() - relativedelta(days=1)
+        record_date = today - relativedelta(days=1)
         DomainUserHistory.objects.create(
             domain=domain,
             num_users=num_users,

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -79,6 +79,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         """
         # invoice date is 2 months before the end of the subscription (this is arbitrary)
         invoice_date = utils.months_from_date(cls.subscription.date_start, cls.subscription_length - 2)
+        tasks.calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
     @mock.patch.object(StripePaymentMethod, 'customer')

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -130,6 +130,7 @@ class TestCreditLines(BaseInvoiceTestCase):
         """
         for month_num in range(2, 5):
             invoice_date = utils.months_from_date(self.subscription.date_start, month_num)
+            tasks.calculate_users_in_all_domains(invoice_date)
             tasks.generate_invoices(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')
 
@@ -230,6 +231,7 @@ class TestCreditLines(BaseInvoiceTestCase):
     def _test_final_invoice_balance(self):
         for month_num in range(2, 5):
             invoice_date = utils.months_from_date(self.subscription.date_start, month_num)
+            tasks.calculate_users_in_all_domains(invoice_date)
             tasks.generate_invoices(invoice_date)
             invoice = self.subscription.invoice_set.latest('date_end')
 

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -628,11 +628,6 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
         )
         self.sms_date = utils.months_from_date(self.invoice_date, -1)
 
-    def tearDown(self):
-        for user_history in DomainUserHistory.objects.all():
-            user_history.delete()
-        super(TestQuarterlyInvoicing, self).tearDown()
-
     def initialize_domain_user_history_objects(self):
         record_dates = []
         month_end = self.subscription.date_end

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 from decimal import Decimal
 import random
 from datetime import date
+
+from dateutil import relativedelta
 from mock import Mock
 
 from django.test import TestCase
@@ -11,6 +13,7 @@ from django.test import TestCase
 from dimagi.utils.dates import add_months_to_date
 
 from corehq.apps.accounting.invoicing import LineItemFactory
+from corehq.apps.accounting.tasks import calculate_users_in_all_domains
 from corehq.apps.domain.models import Domain
 from corehq.util.dates import get_previous_month_date_range
 
@@ -134,6 +137,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
     def test_multiple_subscription_invoice(self):
         invoice_date = utils.months_from_date(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
@@ -154,6 +158,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
         Two subscriptions of the same plan only create one product line item and one set of feature line items
         """
         invoice_date = utils.months_from_date(self.sub2.date_end, 1)
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
@@ -171,6 +176,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
         """
         Test that an invoice is not created if its subscriptions didn't start in the previous month.
         """
+        calculate_users_in_all_domains(self.subscription.date_start)
         tasks.generate_invoices(self.subscription.date_start)
         self.assertEqual(CustomerInvoice.objects.count(), 0)
 
@@ -179,6 +185,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
         No invoices should be generated for the months after the end date of the subscriptions.
         """
         invoice_date = utils.months_from_date(self.sub2.date_end, 2)
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 0)
 
@@ -196,6 +203,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
     def test_product_line_items(self):
         invoice_date = utils.months_from_date(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
 
@@ -213,6 +221,10 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         self.account.invoicing_plan = InvoicingPlan.QUARTERLY
         self.account.save()
         invoice_date = utils.months_from_date(self.subscription.date_start, 14)
+        for months_before_invoice_date in range(3):
+            user_date = date(invoice_date.year, invoice_date.month, 1)
+            user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
+            calculate_users_in_all_domains(user_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
@@ -230,6 +242,10 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         self.account.invoicing_plan = InvoicingPlan.YEARLY
         self.account.save()
         invoice_date = utils.months_from_date(self.subscription.date_start, 14)
+        for months_before_invoice_date in range(12):
+            user_date = date(invoice_date.year, invoice_date.month, 1)
+            user_date -= relativedelta.relativedelta(months=months_before_invoice_date)
+            calculate_users_in_all_domains(user_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
@@ -247,6 +263,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         self.subscription.do_not_invoice = True
 
         invoice_date = utils.months_from_date(self.sub2.date_end, 1)
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
@@ -272,6 +289,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         )
         invoice_date = utils.months_from_date(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
@@ -291,6 +309,7 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
         )
         invoice_date = utils.months_from_date(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
@@ -317,6 +336,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
         num_users_advanced = random.randint(0, self.advanced_rate.monthly_limit)
         generator.arbitrary_commcare_users_for_domain(self.domain2.name, num_users_advanced)
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
 
@@ -340,6 +360,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
         num_users_advanced = self.advanced_rate.monthly_limit + 1
         generator.arbitrary_commcare_users_for_domain(self.domain2.name, num_users_advanced)
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
 
@@ -374,6 +395,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
             account=self.account,
         )
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
@@ -399,6 +421,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
             subscription=self.sub2
         )
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
@@ -420,6 +443,7 @@ class TestUserLineItem(BaseCustomerInvoiceCase):
 
         invoice_date = utils.months_from_date(self.subscription.date_start,
                                               random.randint(2, self.subscription_length))
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
@@ -517,6 +541,7 @@ class TestSmsLineItem(BaseCustomerInvoiceCase):
             subscription=self.sub2,
         )
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
@@ -538,6 +563,7 @@ class TestSmsLineItem(BaseCustomerInvoiceCase):
             subscription=self.subscription
         )
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
@@ -559,12 +585,14 @@ class TestSmsLineItem(BaseCustomerInvoiceCase):
             account=self.account,
         )
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
         self.assertEqual(invoice.balance, Decimal('1507.7500'))
 
     def _create_sms_line_items(self):
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
@@ -625,6 +653,13 @@ class TestQuarterlyInvoicing(BaseCustomerInvoiceCase):
             DomainUserHistory.objects.create(
                 domain=self.domain2,
                 num_users=num_users,
+                record_date=record_date
+            )
+
+        for record_date in record_dates:
+            DomainUserHistory.objects.create(
+                domain=self.domain3,
+                num_users=0,
                 record_date=record_date
             )
 

--- a/corehq/apps/accounting/tests/test_forms.py
+++ b/corehq/apps/accounting/tests/test_forms.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from dateutil.relativedelta import relativedelta
 import random
 
-from corehq.apps.accounting.tasks import generate_invoices
+from corehq.apps.accounting.tasks import calculate_users_in_all_domains, generate_invoices
 from corehq.apps.accounting.forms import AdjustBalanceForm
 from corehq.apps.accounting.models import (
     CreditAdjustmentReason,
@@ -27,7 +27,9 @@ class TestAdjustBalanceForm(BaseInvoiceTestCase):
 
     def setUp(self):
         super(TestAdjustBalanceForm, self).setUp()
-        generate_invoices(self.subscription.date_start + relativedelta(months=1))
+        invoice_date = self.subscription.date_start + relativedelta(months=1)
+        calculate_users_in_all_domains(datetime.date(invoice_date.year, invoice_date.month, 1))
+        generate_invoices(invoice_date)
         self.invoice = Invoice.objects.first()
 
     def tearDown(self):
@@ -121,7 +123,9 @@ class TestAdjustBalanceFormForCustomerAccount(BaseInvoiceTestCase):
 
     def setUp(self):
         super(TestAdjustBalanceFormForCustomerAccount, self).setUp()
-        generate_invoices(self.subscription.date_start + relativedelta(months=1))
+        invoice_date = self.subscription.date_start + relativedelta(months=1)
+        calculate_users_in_all_domains(datetime.date(invoice_date.year, invoice_date.month, 1))
+        generate_invoices(invoice_date)
         self.invoice = CustomerInvoice.objects.first()
 
     def tearDown(self):

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -30,6 +30,7 @@ from corehq.apps.accounting.models import (
     SubscriptionAdjustment,
     SubscriptionType,
 )
+from corehq.apps.accounting.tasks import calculate_users_in_all_domains
 from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 from corehq.apps.sms.models import INCOMING, OUTGOING
@@ -104,6 +105,7 @@ class TestInvoice(BaseInvoiceTestCase):
 
     def test_subscription_invoice(self):
         invoice_date = utils.months_from_date(self.subscription.date_start, random.randint(2, self.subscription_length))
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
         self.assertEqual(self.subscription.invoice_set.count(), 1)
         self.assertEqual(self.subscription.subscriber.domain, self.domain.name)
@@ -150,6 +152,8 @@ class TestInvoice(BaseInvoiceTestCase):
         billing_contact = generator.arbitrary_contact_info(account, self.dimagi_user)
         account.date_confirmed_extra_charges = datetime.date.today()
         account.save()
+        today = datetime.date.today()
+        calculate_users_in_all_domains(datetime.date(today.year, today.month, 1))
         tasks.generate_invoices()
         subscriber = Subscriber.objects.get(domain=domain.name)
         invoices = Invoice.objects.filter(subscription__subscriber=subscriber)
@@ -166,6 +170,7 @@ class TestInvoice(BaseInvoiceTestCase):
     def test_date_due_not_set_small_invoice(self):
         """Date Due doesn't get set if the invoice is small"""
         invoice_date_small = utils.months_from_date(self.subscription.date_start, 1)
+        calculate_users_in_all_domains(invoice_date_small)
         tasks.generate_invoices(invoice_date_small)
         small_invoice = self.subscription.invoice_set.first()
 
@@ -177,6 +182,7 @@ class TestInvoice(BaseInvoiceTestCase):
         self.subscription.plan_version = generator.subscribable_plan_version(SoftwarePlanEdition.ADVANCED)
         self.subscription.save()
         invoice_date_large = utils.months_from_date(self.subscription.date_start, 3)
+        calculate_users_in_all_domains(invoice_date_large)
         tasks.generate_invoices(invoice_date_large)
         large_invoice = self.subscription.invoice_set.last()
 
@@ -187,6 +193,7 @@ class TestInvoice(BaseInvoiceTestCase):
         """Date due always gets set for autopay """
         self.subscription.account.update_autopay_user(self.billing_contact, self.domain)
         invoice_date_autopay = utils.months_from_date(self.subscription.date_start, 1)
+        calculate_users_in_all_domains(invoice_date_autopay)
         tasks.generate_invoices(invoice_date_autopay)
 
         autopay_invoice = self.subscription.invoice_set.last()
@@ -214,6 +221,7 @@ class TestContractedInvoices(BaseInvoiceTestCase):
 
         expected_recipient = ["accounts@example.com"]
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
 
         self.assertEqual(Invoice.objects.count(), 1)
@@ -226,6 +234,7 @@ class TestContractedInvoices(BaseInvoiceTestCase):
         """
         expected_template = BillingRecord.INVOICE_CONTRACTED_HTML_TEMPLATE
 
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
 
         self.assertEqual(BillingRecord.objects.count(), 1)
@@ -254,6 +263,7 @@ class TestProductLineItem(BaseInvoiceTestCase):
         - subtotal = monthly fee
         """
         invoice_date = utils.months_from_date(self.subscription.date_start, random.randint(2, self.subscription_length))
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
         invoice = self.subscription.invoice_set.latest('date_created')
 
@@ -348,6 +358,7 @@ class TestUserLineItem(BaseInvoiceTestCase):
         num_inactive = num_users()
         generator.arbitrary_commcare_users_for_domain(self.domain.name, num_inactive, is_active=False)
 
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
         invoice = self.subscription.invoice_set.latest('date_created')
         user_line_item = invoice.lineitem_set.get_feature_by_type(FeatureType.USER).get()
@@ -379,6 +390,7 @@ class TestUserLineItem(BaseInvoiceTestCase):
         num_inactive = num_users()
         generator.arbitrary_commcare_users_for_domain(self.domain.name, num_inactive, is_active=False)
 
+        calculate_users_in_all_domains(datetime.date(invoice_date.year, invoice_date.month, 1))
         tasks.generate_invoices(invoice_date)
         invoice = self.subscription.invoice_set.latest('date_created')
         user_line_item = invoice.lineitem_set.get_feature_by_type(FeatureType.USER).get()
@@ -409,10 +421,12 @@ class TestUserLineItem(BaseInvoiceTestCase):
 
         account = BillingAccount.get_or_create_account_by_domain(
             domain, created_by=self.dimagi_user)[0]
-        billing_contact = generator.arbitrary_contact_info(account, self.dimagi_user)
-        account.date_confirmed_extra_charges = datetime.date.today()
+        generator.arbitrary_contact_info(account, self.dimagi_user)
+        today = datetime.date.today()
+        account.date_confirmed_extra_charges = today
         account.save()
 
+        calculate_users_in_all_domains(datetime.date(today.year, today.month, 1))
         tasks.generate_invoices()
         subscriber = Subscriber.objects.get(domain=domain.name)
         invoice = Invoice.objects.filter(subscription__subscriber=subscriber).get()
@@ -562,6 +576,7 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         self.assertEqual(sms_line_item.total, sms_cost)
 
     def _create_sms_line_item(self):
+        calculate_users_in_all_domains(self.invoice_date)
         tasks.generate_invoices(self.invoice_date)
         invoice = self.subscription.invoice_set.latest('date_created')
         return invoice.lineitem_set.get_feature_by_type(FeatureType.SMS).get()
@@ -598,6 +613,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
         self._setup_implementation_subscription_with_dimagi_contact()
 
         invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -609,6 +625,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
         self._setup_implementation_subscription_without_dimagi_contact()
 
         invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -620,6 +637,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
         self._setup_product_subscription()
 
         invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 2)
@@ -644,6 +662,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
         self._setup_product_subscription_with_admin_user()
 
         invoice_date = utils.months_from_date(self.subscription.date_start, 1)
+        calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.assertEqual(len(mail.outbox), 1)
@@ -685,6 +704,7 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
         web_user.save()
 
     def _test_specified_recipients(self):
+        calculate_users_in_all_domains(datetime.date(self.subscription.date_start.year, self.subscription.date_start.month + 1, 1))
         DomainInvoiceFactory(
             self.subscription.date_start,
             utils.months_from_date(self.subscription.date_start, 1) - datetime.timedelta(days=1),

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -704,7 +704,8 @@ class TestInvoiceRecipients(BaseInvoiceTestCase):
         web_user.save()
 
     def _test_specified_recipients(self):
-        calculate_users_in_all_domains(datetime.date(self.subscription.date_start.year, self.subscription.date_start.month + 1, 1))
+        calculate_users_in_all_domains(
+            datetime.date(self.subscription.date_start.year, self.subscription.date_start.month + 1, 1))
         DomainInvoiceFactory(
             self.subscription.date_start,
             utils.months_from_date(self.subscription.date_start, 1) - datetime.timedelta(days=1),

--- a/corehq/apps/accounting/tests/test_wire_invoice.py
+++ b/corehq/apps/accounting/tests/test_wire_invoice.py
@@ -13,9 +13,11 @@ class TestWireInvoice(BaseInvoiceTestCase):
     def setUp(self):
         super(TestWireInvoice, self).setUp()
         invoice_date = utils.months_from_date(self.subscription.date_start, 2)
+        tasks.calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         invoice_date = utils.months_from_date(self.subscription.date_start, 3)
+        tasks.calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.invoices = Invoice.objects.all()
@@ -44,9 +46,11 @@ class TestCustomerAccountWireInvoice(BaseInvoiceTestCase):
         self.account.save()
 
         invoice_date = utils.months_from_date(self.subscription.date_start, 2)
+        tasks.calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         invoice_date = utils.months_from_date(self.subscription.date_start, 3)
+        tasks.calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
         self.invoices = CustomerInvoice.objects.all()

--- a/corehq/apps/accounting/tests/test_wire_invoice.py
+++ b/corehq/apps/accounting/tests/test_wire_invoice.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
+
 from decimal import Decimal
 from django.core import mail
 
 from corehq.apps.accounting.tests.test_invoicing import BaseInvoiceTestCase
 from corehq.apps.accounting import utils, tasks
 from corehq.apps.accounting.invoicing import DomainWireInvoiceFactory
-from corehq.apps.accounting.models import Invoice, CustomerInvoice
+from corehq.apps.accounting.models import Invoice
 
 
 class TestWireInvoice(BaseInvoiceTestCase):
@@ -21,11 +22,10 @@ class TestWireInvoice(BaseInvoiceTestCase):
         tasks.generate_invoices(invoice_date)
 
         self.invoices = Invoice.objects.all()
-        self.domain_name = self.invoices[0].get_domain()
 
     def test_factory(self):
         factory = DomainWireInvoiceFactory(
-            self.domain_name,
+            self.domain.name,
             contact_emails=[self.dimagi_user],
         )
         balance = Decimal(100)
@@ -53,12 +53,9 @@ class TestCustomerAccountWireInvoice(BaseInvoiceTestCase):
         tasks.calculate_users_in_all_domains(invoice_date)
         tasks.generate_invoices(invoice_date)
 
-        self.invoices = CustomerInvoice.objects.all()
-        self.domain_name = self.invoices.first().subscriptions.first().subscriber.domain
-
     def test_factory(self):
         factory = DomainWireInvoiceFactory(
-            self.domain_name,
+            self.domain.name,
             contact_emails=[self.dimagi_user],
             account=self.account
         )


### PR DESCRIPTION
This simplifies the invoicing code and makes it deterministic based on the DomainUserHistory, instead of whatever the number of users is at the time the invoice is generated.

This applies to customer and non-customer invoices.

@djmore9 