### PR TITLE
Updated multimedia_map_for_build to not always remove unused multimedia

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5635,7 +5635,7 @@ def import_app(app_id_or_source, domain, source_properties=None, request=None):
 
     try:
         if not app.is_remote_app():
-            for path, media in app.get_media_objects():
+            for path, media in app.get_media_objects(remove_unused=True):
                 if domain not in media.valid_domains:
                     media.valid_domains.append(domain)
                     media.save()

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -114,8 +114,8 @@ class MediaSuiteGenerator(object):
     @property
     def media_resources(self):
         PREFIX = 'jr://file/'
-        for path, m in sorted(list(self.app.multimedia_map_for_build(build_profile=self.build_profile).items()),
-                              key=lambda item: item[0]):
+        multimedia_map = self.app.multimedia_map_for_build(build_profile=self.build_profile, remove_unused=True)
+        for path, m in sorted(list(multimedia_map.items()), key=lambda item: item[0]):
             unchanged_path = path
             if path.startswith(PREFIX):
                 path = path[len(PREFIX):]

--- a/corehq/apps/app_manager/tests/test_ccz.py
+++ b/corehq/apps/app_manager/tests/test_ccz.py
@@ -59,7 +59,7 @@ class CCZTest(TestCase):
 
         zip_path = self._create_multimedia_integrity_zip(
             self.factory.app.create_media_suite(),
-            list(self.factory.app.get_media_objects()))
+            list(self.factory.app.get_media_objects(remove_unused=True)))
         errors = check_ccz_multimedia_integrity(self.domain, zip_path)
         self.assertEqual(len(errors), 0)
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -970,7 +970,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         for db, related_doc_ids in get_all_doc_ids_for_domain_grouped_by_db(self.name):
             iter_bulk_delete(db, related_doc_ids, chunksize=500)
 
-    def all_media(self, from_apps=None):  # todo add documentation or refactor
+    def all_media(self, from_apps=None):
         from corehq.apps.hqmedia.models import CommCareMultimedia
         dom_with_media = self if not self.is_snapshot else self.copied_from
 
@@ -988,7 +988,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
             for app in apps:
                 if app.doc_type != 'Application':
                     continue
-                for _, m in app.get_media_objects():
+                for _, m in app.get_media_objects(remove_unused=True):
                     if m.get_id not in media_ids:
                         media.append(m)
                         media_ids.add(m.get_id)

--- a/corehq/apps/hqmedia/management/commands/set_media_file_domains.py
+++ b/corehq/apps/hqmedia/management/commands/set_media_file_domains.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
                     try:
                         if app.is_remote_app():
                             continue
-                        for _, m in app.get_media_objects():
+                        for _, m in app.get_media_objects(remove_unused=True):
                             if app.domain not in m.valid_domains:
                                 m.valid_domains.append(app.domain)
                                 self.stdout.write("adding domain %s to media file %s" % (app.domain, m._id))

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -767,8 +767,8 @@ class ApplicationMediaMixin(Document, MediaMixin):
                     self.media_form_errors = True
         return media
 
-    def multimedia_map_for_build(self, build_profile=None):
-        if self.multimedia_map:
+    def multimedia_map_for_build(self, build_profile=None, remove_unused=False):
+        if self.multimedia_map and remove_unused:
             self.remove_unused_mappings()
         else:
             self.multimedia_map = {}
@@ -907,7 +907,7 @@ class ApplicationMediaMixin(Document, MediaMixin):
                 updated_doc = self.get(self._id)
                 updated_doc.create_mapping(multimedia, form_path)
 
-    def get_media_objects(self, build_profile_id=None):
+    def get_media_objects(self, build_profile_id=None, remove_unused=False):
         """
             Gets all the media objects stored in the multimedia map.
             If passed a profile, will only get those that are used
@@ -920,7 +920,8 @@ class ApplicationMediaMixin(Document, MediaMixin):
         # preload all the docs to avoid excessive couch queries.
         # these will all be needed in memory anyway so this is ok.
         build_profile = self.build_profiles[build_profile_id] if build_profile_id else None
-        multimedia_map_for_build = self.multimedia_map_for_build(build_profile=build_profile)
+        multimedia_map_for_build = self.multimedia_map_for_build(build_profile=build_profile,
+                                                                 remove_unused=remove_unused)
         expected_ids = [map_item.multimedia_id for map_item in multimedia_map_for_build.values()]
         raw_docs = dict((d["_id"], d) for d in iter_docs(CommCareMultimedia.get_db(), expected_ids))
         for path, map_item in multimedia_map_for_build.items():
@@ -946,7 +947,7 @@ class ApplicationMediaMixin(Document, MediaMixin):
 
     def get_object_map(self):
         object_map = {}
-        for path, media_obj in self.get_media_objects():
+        for path, media_obj in self.get_media_objects(remove_unused=False):
             object_map[path] = media_obj.get_media_info(path)
         return object_map
 
@@ -973,7 +974,7 @@ class ApplicationMediaMixin(Document, MediaMixin):
             Prepares the multimedia in the application for exchanging across domains.
         """
         self.remove_unused_mappings()
-        for path, media in self.get_media_objects():
+        for path, media in self.get_media_objects(remove_unused=True):
             if not media or (not media.is_shared and self.domain not in media.owners):
                 del self.multimedia_map[path]
 

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -740,7 +740,7 @@ def iter_app_files(app, include_multimedia_files, include_index_files, build_pro
     index_file_count = 0
     multimedia_file_count = 0
     if include_multimedia_files:
-        media_objects = list(app.get_media_objects(build_profile_id=build_profile_id))
+        media_objects = list(app.get_media_objects(build_profile_id=build_profile_id, remove_unused=True))
         multimedia_file_count = len(media_objects)
         file_iterator, errors = iter_media_files(media_objects)
     if include_index_files:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-640

On the ticket, @esoergel says

> It also seems inappropriate that `view_generic` is ... attempting to modify the app.

Which I agree with. This adds a `remove_unused` flag to `multimedia_map_for_build`, allows it to remain true for most usages, but sets it false for `get_object_map`, which is called from most app manager views.

Unused multimedia might get trimmed slightly less often, but it'll still be removed on every build, which I think is sufficient. Maybe this'll even speed up app manager a bit for apps with a lot of multimedia.