### PR TITLE
Lost translations

### DIFF
--- a/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
+++ b/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
@@ -67,7 +67,7 @@ class TestBulkUiTranslation(SimpleTestCase):
         data = (('translations', tuple(data)),)
         temp = BytesIO()
         export_raw(headers, data, temp)
-        temp.seek(0)            # .read() is used somewhere so this needs to be at the begininng
+        temp.seek(0)  # .read() is used somewhere so this needs to be at the beginning
         return temp
 
     def test_not_upload_all_properties(self):

--- a/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
+++ b/corehq/apps/translations/tests/test_updating_app_from_trans_dict.py
@@ -3,10 +3,11 @@ from __future__ import unicode_literals
 
 from io import BytesIO
 
+import mock
 import six
 from django.test import SimpleTestCase
 
-from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.models import Application, LinkedApplication
 from corehq.apps.app_manager.ui_translations import (
     get_default_translations_for_download,
     process_ui_translation_upload,
@@ -23,6 +24,12 @@ INITIAL_TRANSLATIONS = {
     'fra': {
         'translation.always.upload': 'Swift',
         'translation.sometimes.upload': 'West',
+    }
+}
+INITIAL_LINKED_APP_TRANSLATIONS = {
+    'en': {
+        'translation.always.upload': 'Taytay',
+        'translation.sometimes.upload': 'Kanye',
     }
 }
 EXPECTED_TRANSLATIONS = {
@@ -44,6 +51,11 @@ class TestBulkUiTranslation(SimpleTestCase):
         self.app = Application.new_app("test-domain", "Test App")
         self.app.langs = ["en", "fra"]
         self.app.translations = INITIAL_TRANSLATIONS
+
+        self.linked_app = LinkedApplication.new_app('test-domain-2', 'Test Linked App')
+        self.linked_app.langs = ["en", "fra"]
+        self.linked_app.translations = INITIAL_TRANSLATIONS
+        self.linked_app.linked_app_translations = INITIAL_LINKED_APP_TRANSLATIONS
 
     def _build_translation_download_file(self, headers, data=None):
         if data is None:
@@ -92,6 +104,25 @@ class TestBulkUiTranslation(SimpleTestCase):
         update_app_translations_from_trans_dict(self.app, translations)
         self.assertDictEqual(self.app.translations['en'], EXPECTED_TRANSLATIONS['en'])
         self.assertDictEqual(self.app.translations['fra'], INITIAL_TRANSLATIONS['fra'])
+
+    @flag_enabled('PARTIAL_UI_TRANSLATIONS')
+    def test_linked_app_not_upload_all_languages_with_partial_ui_translations(self):
+        headers = (('translations', ('property', 'en')),)
+        data = (
+            ('translation.always.upload', 'Miley'),
+            ('translation.sometimes.upload', 'Kanye'),
+        )
+        f = self._build_translation_download_file(headers, data)
+
+        translations, error_properties, warnings = process_ui_translation_upload(self.linked_app, f)
+        update_app_translations_from_trans_dict(self.linked_app, translations)
+        self.assertDictEqual(self.linked_app.translations['en'], EXPECTED_TRANSLATIONS['en'])
+        self.assertDictEqual(self.linked_app.translations['fra'], INITIAL_TRANSLATIONS['fra'])
+        self.assertDictEqual(self.linked_app.linked_app_translations['en'], EXPECTED_TRANSLATIONS['en'])
+
+        with mock.patch.object(LinkedApplication, 'save'):
+            self.linked_app.reapply_overrides()
+        self.assertDictEqual(self.linked_app.translations['en'], EXPECTED_TRANSLATIONS['en'])
 
     def test_partial_property_and_language(self):
         headers = (('translations', ('property', 'en')),)

--- a/corehq/apps/translations/utils.py
+++ b/corehq/apps/translations/utils.py
@@ -23,7 +23,7 @@ def update_app_translations_from_trans_dict(app, trans_dict):
         if isinstance(app, LinkedApplication):
             for lang, trans in six.iteritems(app.translations):
                 if lang in trans_dict:
-                    app.translations[lang].update(trans_dict[lang])
+                    app.linked_app_translations[lang].update(trans_dict[lang])
 
         for lang, trans in six.iteritems(app.translations):
             if lang in trans_dict:


### PR DESCRIPTION
Context: [REACH QA](https://dimagi-dev.atlassian.net/browse/QA-473)

Feature flag: Partial UI Translations

For linked apps, when the "Partial UI Translations" feature flag is not enabled, updating UI translations updates both `linked_app_translations` and `translations` properties on the linked app.

But when the feature flag is enabled, it just updates the `translations` property twice.

The `linked_app_translations` property is used for [overwriting the master app's translations](https://github.com/dimagi/commcare-hq/blob/7ae80d002ff14137d76b57c8f4c764413f903cbf/corehq/apps/app_manager/models.py#L5582) when the linked app is pulled from master. Because `linked_app_translations` isn't being updated when the feature flag is enabled, the linked app's translations are being dropped.
