### PR TITLE
Refactor: Comments, docstrings, and comprehensions

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -19,7 +19,6 @@ from corehq import toggles
 
 
 def non_empty_only(dct):
-    return dict([(key, value) for key, value in dct.items() if value])
     return {key: value for key, value in dct.items() if value}
 
 

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -20,6 +20,7 @@ from corehq import toggles
 
 def non_empty_only(dct):
     return dict([(key, value) for key, value in dct.items() if value])
+    return {key: value for key, value in dct.items() if value}
 
 
 def convert_to_two_letter_code(lc):
@@ -313,21 +314,21 @@ class SimpleAppStrings(AppStringsBase):
 
 
 class SelectKnownAppStrings(AppStringsBase):
+    """
+    Like DumpKnownAppStrings, but instead of returning all default
+    translations, only returns those used by the app.
+
+    This is the default behaviour.
+    """
 
     def get_app_translation_keys(self, app):
-        return set.union(set(), *(
-            set(t.keys()) for t in app.translations.values()
-        ))
+        return {k for t in app.translations.values() for k in t.keys()}
 
     def app_strings_parts(self, app, lang, for_default=False, build_profile_id=None):
-        yield self.create_custom_app_strings(app, lang,
-                                             for_default=for_default,
-                                             build_profile_id=build_profile_id)
+        yield self.create_custom_app_strings(app, lang, for_default=for_default, build_profile_id=build_profile_id)
         commcare_version = app.build_version.vstring if app.build_version else None
         cc_trans = self.get_default_translations(lang, commcare_version)
-        yield dict((key, cc_trans[key])
-                   for key in self.get_app_translation_keys(app)
-                   if key in cc_trans)
+        yield {key: cc_trans[key] for key in self.get_app_translation_keys(app) if key in cc_trans}
         yield non_empty_only(app.translations.get(lang, {}))
 
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5580,6 +5580,7 @@ class LinkedApplication(Application):
             raise ActionNotPermitted
 
     def reapply_overrides(self):
+        # Used by app_manager.views.utils.update_linked_app()
         self.translations.update(self.linked_app_translations)
         self.logo_refs.update(self.linked_app_logo_refs)
         for attribute, value in self.linked_app_attrs.items():

--- a/corehq/apps/app_manager/tests/test_app_strings.py
+++ b/corehq/apps/app_manager/tests/test_app_strings.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+from __future__ import absolute_import, unicode_literals
+
+from testil import eq
+
+from corehq.apps.app_manager import app_strings
+from corehq.apps.app_manager.models import Application
+
+
+def get_app():
+    app = Application.new_app("test-domain", "Test App")
+    app.langs = ["en", "rus"]
+    app.set_translation("en", "hello", "Hello")
+    app.set_translation("rus", "hello", "привет")
+    app.set_translation("en", "goodbye", "Goodbye")
+    app.set_translation("rus", "goodbye", "до свидания")
+    app.set_translation("en", "all_yr_base", "ALL YOUR BASE ARE BELONG TO US")
+    app.set_translation("rus", "all_yr_base", "ВСЯ ВАША БАЗА ОТНОСИТСЯ К НАМ")  # Well, that's what Google says
+    return app
+
+
+def test_get_app_translation_keys():
+    app = get_app()
+    select_known = app_strings.CHOICES["select-known"]
+    keys = select_known.get_app_translation_keys(app)
+    eq(keys, {"hello", "goodbye", "all_yr_base"})
+
+
+def test_non_empty_only():
+    things = {
+        "none": None,
+        "zero": 0,
+        "empty": "",
+        "empty_too": [],
+        "also_empty": {},
+        "all_of_the_things": [None, 0, "", [], {}],
+    }
+    non_empty_things = app_strings.non_empty_only(things)
+    eq(non_empty_things, {"all_of_the_things": [None, 0, "", [], {}]})

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -712,13 +712,15 @@ def edit_app_ui_translations(request, domain, app_id):
     translations.pop('modules.m0', None)
 
     app.set_translations(lang, translations)
-    response = {}
-    app.save(response)
-    return json_response(response)
+    app.save(response_json={})  # Updates the app version without updating app properties
+    return json_response({})
 
 
 @require_GET
 def get_app_ui_translations(request, domain):
+    """
+    Retrieves translations from all domains
+    """
     params = json_request(request.GET)
     lang = params.get('lang', 'en')
     key = params.get('key', None)

--- a/corehq/apps/translations/models.py
+++ b/corehq/apps/translations/models.py
@@ -22,10 +22,6 @@ from corehq.util.quickcache import quickcache
 class TranslationMixin(Document):
     translations = DictProperty()
 
-    # TODO: Unused? Kill
-    def init(self, lang):
-        self.translations[lang] = Translation.get_translations(lang, one=True)
-
     def set_translation(self, lang, key, value):
         if lang not in self.translations:
             self.translations[lang] = {}

--- a/corehq/apps/translations/models.py
+++ b/corehq/apps/translations/models.py
@@ -22,6 +22,7 @@ from corehq.util.quickcache import quickcache
 class TranslationMixin(Document):
     translations = DictProperty()
 
+    # TODO: Unused? Kill
     def init(self, lang):
         self.translations[lang] = Translation.get_translations(lang, one=True)
 


### PR DESCRIPTION
While trying to wrap my head around how app_strings.txt and UI translation downloads work, I wrote some comments, a TODO, and tried to simplify a couple of comprehensions.

Marking "do not merge" because I haven't used these changes yet, and I'd like to resolve that TODO.

@dannyroberts, it looks like you wrote that `init` method back in 2011. I can't find any reference to it in the codebase, but I thought I should ping you first before removing it.
