### PR TITLE
Disable ddtrace.tracer unless 'ddtrace.contrib.django' is in INSTALLED_APPS

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2079,7 +2079,7 @@ except ImportError:
 else:
     initialize(DATADOG_API_KEY, DATADOG_APP_KEY)
 
-if UNIT_TESTING or DEBUG or SERVER_ENVIRONMENT != 'production':
+if UNIT_TESTING or DEBUG or 'ddtrace.contrib.django' not in INSTALLED_APPS:
     try:
         from ddtrace import tracer
         tracer.enabled = False


### PR DESCRIPTION
I think this may be what is causing https://sentry.io/organizations/dimagi/issues/918618547/?project=142105,
when actually celery should not be using ddtrace at all, as it is intentionally excluded from LOCAL_APPS

Nick undid https://github.com/dimagi/commcare-cloud/pull/2716 a few days later due to apparent memory issues (https://github.com/dimagi/commcare-cloud/pull/2719), and I'm trying to solve the problem in a different way.