### PR TITLE
enable dynamic ucr comparison ratio

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 
 from __future__ import unicode_literals
+
+import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta
 import logging
-import random
 
 from django.conf import settings
 from lxml.builder import E
@@ -17,9 +18,9 @@ from corehq.apps.app_manager.const import (
     MOBILE_UCR_MIGRATING_TO_2,
     MOBILE_UCR_VERSION_2,
 )
-from corehq.apps.app_manager.models import ReportModule
 from corehq.apps.app_manager.suite_xml.features.mobile_ucr import is_valid_mobile_select_filter_type
 from corehq.apps.userreports.reports.filters.factory import ReportFilterFactory
+from corehq.toggles import COMPARE_UCR_REPORTS, NAMESPACE_OTHER
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.xml_utils import serialize
@@ -33,8 +34,6 @@ from corehq.apps.app_manager.dbaccessors import (
 )
 from six.moves import zip
 from six.moves import map
-
-UCR_COMPARISONS_THRESHOLD = 1000
 
 
 def _should_sync(restore_state):
@@ -206,7 +205,7 @@ class ReportFixturesProvider(BaseReportFixturesProvider):
             defer_filters, filter_options_by_field, restore_user._couch_user)
 
         if (report_config.report_id in settings.UCR_COMPARISONS and
-                random.randint(0, UCR_COMPARISONS_THRESHOLD) == UCR_COMPARISONS_THRESHOLD):
+                COMPARE_UCR_REPORTS.enabled(uuid.uuid4().hex, NAMESPACE_OTHER)):
             compare_ucr_dbs.delay(domain, report_config.report_id, filter_values)
 
         report_elem = E.report(id=report_config.uuid, report_id=report_config.report_id)
@@ -383,7 +382,7 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
         report_filter_elem.append(filters_elem)
 
         if (report_config.report_id in settings.UCR_COMPARISONS and
-                random.randint(0, UCR_COMPARISONS_THRESHOLD) == UCR_COMPARISONS_THRESHOLD):
+                COMPARE_UCR_REPORTS.enabled(uuid.uuid4().hex, NAMESPACE_OTHER)):
             compare_ucr_dbs.delay(domain, report_config.report_id, filter_values)
 
         report_elem = E.fixture(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1508,6 +1508,15 @@ ICDS_COMPARE_QUERIES_AGAINST_CITUS = DynamicallyPredictablyRandomToggle(
     namespaces=[NAMESPACE_OTHER],
 )
 
+COMPARE_UCR_REPORTS = DynamicallyPredictablyRandomToggle(
+    'compare_ucr_reports',
+    'Compare UCR reports against other reports or against other databases. '
+    'Reports for comparison must be listed in settings.UCR_COMPARISONS.',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_OTHER],
+    default_randomness=0.001  # 1 in 1000
+)
+
 MOBILE_LOGIN_LOCKOUT = StaticToggle(
     'mobile_user_login_lockout',
     "On too many wrong password attempts, lock out mobile users",


### PR DESCRIPTION
This will make it easier to adjust per env and also for short periods while testing.