### PR TITLE
Chunk fixture delete

### DIFF
--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -1,31 +1,47 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 from datetime import datetime
 from xml.etree import cElementTree as ElementTree
-from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
+
 from django.db import models
+
+import six
+from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
+from memoized import memoized
+
+from dimagi.ext.couchdbkit import (
+    BooleanProperty,
+    DictProperty,
+    Document,
+    DocumentSchema,
+    IntegerProperty,
+    SchemaListProperty,
+    StringListProperty,
+    StringProperty,
+)
+from dimagi.utils.couch.bulk import CouchTransaction
+
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.fixtures.dbaccessors import (
-    get_owner_ids_by_type,
     get_fixture_data_types_in_domain,
-    get_fixture_items_for_data_types
+    get_fixture_items_for_data_types,
+    get_owner_ids_by_type,
 )
-from corehq.apps.fixtures.exceptions import FixtureException, FixtureTypeCheckError
+from corehq.apps.fixtures.exceptions import (
+    FixtureException,
+    FixtureTypeCheckError,
+    FixtureVersionError,
+)
 from corehq.apps.fixtures.utils import (
     clean_fixture_field_name,
     get_fields_without_attributes,
     remove_deleted_ownerships,
 )
-from corehq.apps.users.models import CommCareUser
-from corehq.apps.fixtures.exceptions import FixtureVersionError
-from dimagi.ext.couchdbkit import Document, DocumentSchema, DictProperty, StringProperty, StringListProperty, SchemaListProperty, IntegerProperty, BooleanProperty
 from corehq.apps.groups.models import Group
+from corehq.apps.locations.models import SQLLocation
+from corehq.apps.users.models import CommCareUser
 from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.xml_utils import serialize
-from dimagi.utils.couch.bulk import CouchTransaction
-from memoized import memoized
-from corehq.apps.locations.models import SQLLocation
-import six
 
 FIXTURE_BUCKET = 'domain-fixtures'
 

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -19,6 +19,7 @@ from dimagi.ext.couchdbkit import (
     StringListProperty,
     StringProperty,
 )
+from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.bulk import CouchTransaction
 
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
@@ -114,7 +115,8 @@ class FixtureDataType(QuickCachedDocumentMixin, Document):
         for item in FixtureDataItem.by_data_type(self.domain, self.get_id):
             transaction.delete(item)
             item_ids.append(item.get_id)
-        transaction.delete_all(FixtureOwnership.for_all_item_ids(item_ids, self.domain))
+        for item_id_chunk in chunked(item_ids, 1000):
+            transaction.delete_all(FixtureOwnership.for_all_item_ids(item_id_chunk, self.domain))
         transaction.delete(self)
 
     @classmethod

--- a/corehq/ex-submodules/dimagi/utils/couch/bulk.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/bulk.py
@@ -86,7 +86,8 @@ class CouchTransaction(object):
 
     def commit(self):
         for cls, docs in self.docs_to_delete.items():
-            cls.bulk_delete(docs)
+            for chunk in chunked(docs, 1000):
+                cls.bulk_delete(chunk)
 
         for cls, doc_map in self.docs_to_save.items():
             docs = list(doc_map.values())


### PR DESCRIPTION
Inddex has lookup tables with ~52,000 items. The `CouchTransaction` class tries to send all of these docs back to couch to delete them. Fun!

Short of totally rewriting the lookup table code, this chunks the lookup that causes [this](https://sentry.io/organizations/dimagi/issues/912264885/?project=136860&query=is%3Aunresolved).

Then chunks the actual delete operation might solve [this](https://sentry.io/organizations/dimagi/issues/1038860778/?project=136860&query=is%3Aunresolved+lookup_table&statsPeriod=14d).

https://dimagi-dev.atlassian.net/browse/HI-650