### PR TITLE
Make get_case_ids_from_form return stock transaction case ids too

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -56,7 +56,6 @@ from corehq.form_processor.models import (
     XFormInstanceSQL,
     XFormOperationSQL,
 )
-from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
 from corehq.form_processor.submission_post import CaseStockProcessingResult
 from corehq.form_processor.utils import adjust_datetimes, should_use_sql_backend
 from corehq.form_processor.utils.general import (
@@ -202,7 +201,7 @@ class CouchSqlDomainMigrator(object):
         self._log_main_forms_processed_count()
 
     def _try_to_process_form(self, wrapped_form, pool):
-        case_ids = _get_case_ids(wrapped_form)
+        case_ids = get_case_ids_from_form(wrapped_form)
         if self.queues.try_obj(case_ids, wrapped_form):
             pool.spawn(self._migrate_form_and_associated_models_async, wrapped_form)
         elif self.queues.full:
@@ -815,12 +814,6 @@ def _get_case_and_ledger_updates(domain, sql_form):
         case_models=cases,
         stock_result=stock_result,
     )
-
-
-def _get_case_ids(xform):
-    case_ids = get_case_ids_from_form(xform)
-    case_ids.update(get_case_ids_from_stock_transactions(xform))
-    return case_ids
 
 
 def _save_migrated_models(sql_form, case_stock_result=None):

--- a/corehq/ex-submodules/casexml/apps/case/signals.py
+++ b/corehq/ex-submodules/casexml/apps/case/signals.py
@@ -9,10 +9,9 @@ from couchforms.signals import xform_archived, xform_unarchived
 def rebuild_form_cases(sender, xform, *args, **kwargs):
     from casexml.apps.case.xform import get_case_ids_from_form
     from casexml.apps.case.cleanup import rebuild_case_from_forms
-    from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
 
     domain = xform.domain
-    case_ids = get_case_ids_from_form(xform) | get_case_ids_from_stock_transactions(xform)
+    case_ids = get_case_ids_from_form(xform)
     detail = FormArchiveRebuild(form_id=xform.form_id, archived=xform.is_archived)
     for case_id in case_ids:
         rebuild_case_from_forms(domain, case_id, detail)

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -412,7 +412,10 @@ def _update_order_index(update):
 
 
 def get_case_ids_from_form(xform):
-    return set(cu.id for cu in get_case_updates(xform))
+    from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
+    case_ids = set(cu.id for cu in get_case_updates(xform))
+    case_ids.update(get_case_ids_from_stock_transactions(xform))
+    return case_ids
 
 
 def cases_referenced_by_xform(xform):

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from collections import namedtuple
-import logging
 from itertools import groupby
 
 import itertools
-from couchdbkit import ResourceNotFound
 from django.db.models import Q
 from casexml.apps.case.const import UNOWNED_EXTENSION_OWNER_ID, CASE_INDEX_EXTENSION
 from casexml.apps.case.signals import cases_received
@@ -18,9 +16,7 @@ from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.soft_assert import soft_assert
 from couchforms.models import XFormInstance
-from casexml.apps.case.exceptions import (
-    NoDomainProvided,
-    InvalidCaseIndex, IllegalCaseId)
+from casexml.apps.case.exceptions import InvalidCaseIndex, IllegalCaseId
 from django.conf import settings
 
 from casexml.apps.case import const
@@ -425,7 +421,6 @@ def cases_referenced_by_xform(xform):
     representation of an XFormInstance
     """
     assert xform.domain, "Form is missing 'domain'"
-    from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
     case_ids = get_case_ids_from_form(xform)
     case_accessor = CaseAccessors(xform.domain)
     return list(case_accessor.get_cases(list(case_ids)))

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -412,9 +412,16 @@ def _update_order_index(update):
 
 
 def get_case_ids_from_form(xform):
-    from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
+    from corehq.form_processor.parsers.ledgers.form import (
+        get_case_ids_from_stock_transactions,
+        MissingFormXml,
+    )
     case_ids = set(cu.id for cu in get_case_updates(xform))
-    case_ids.update(get_case_ids_from_stock_transactions(xform))
+    if xform:
+        try:
+            case_ids.update(get_case_ids_from_stock_transactions(xform))
+        except MissingFormXml:
+            pass
     return case_ids
 
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -590,9 +590,8 @@ class FormAccessorSQL(AbstractFormAccessor):
     @transaction.atomic
     def _archive_unarchive_form(form, user_id, archive):
         from casexml.apps.case.xform import get_case_ids_from_form
-        from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
         form_id = form.form_id
-        case_ids = list(get_case_ids_from_form(form) | get_case_ids_from_stock_transactions(form))
+        case_ids = list(get_case_ids_from_form(form))
         with get_cursor(XFormInstanceSQL) as cursor:
             cursor.execute('SELECT archive_unarchive_form(%s, %s, %s)', [form_id, user_id, archive])
             cursor.execute('SELECT revoke_restore_case_transactions_for_form(%s, %s, %s)',

--- a/corehq/form_processor/change_publishers.py
+++ b/corehq/form_processor/change_publishers.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from casexml.apps.case.xform import get_case_ids_from_form
 from corehq.apps.change_feed import data_sources, topics
 from corehq.apps.change_feed.producer import producer
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.signals import sql_case_post_save
 from pillowtop.feed.interface import ChangeMeta
 
@@ -106,9 +104,3 @@ def change_meta_from_ledger_v1(stock_state, deleted=False):
         domain=stock_state.domain,
         is_deletion=deleted,
     )
-
-
-def get_cases_from_form(domain, form):
-    from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
-    case_ids = get_case_ids_from_form(form) | get_case_ids_from_stock_transactions(form)
-    return CaseAccessors(domain).get_cases(list(case_ids))

--- a/corehq/form_processor/parsers/ledgers/form.py
+++ b/corehq/form_processor/parsers/ledgers/form.py
@@ -127,6 +127,9 @@ def get_all_stock_report_helpers_from_form(xform):
     them to StockReportHelper objects.
     """
     form_xml = xform.get_xml_element()
+    if form_xml is None:
+        # HACK should be raised by xform.get_xml_element()
+        raise MissingFormXml(xform.form_id)
     commtrack_node_names = ('{%s}balance' % COMMTRACK_REPORT_XMLNS,
                             '{%s}transfer' % COMMTRACK_REPORT_XMLNS)
 
@@ -312,3 +315,7 @@ def _coerce_to_list(obj_or_list):
         return obj_or_list
     else:
         return [obj_or_list]
+
+
+class MissingFormXml(Exception):
+    pass

--- a/corehq/form_processor/parsers/ledgers/form.py
+++ b/corehq/form_processor/parsers/ledgers/form.py
@@ -84,9 +84,10 @@ def get_stock_actions(xform):
     if is_device_report(xform):
         return _empty_actions()
 
+    stock_report_helpers = list(get_all_stock_report_helpers_from_form(xform))
     transaction_helpers = [
         transaction_helper
-        for stock_report_helper in get_all_stock_report_helpers_from_form(xform)
+        for stock_report_helper in stock_report_helpers
         for transaction_helper in stock_report_helper.transactions
     ]
     if not transaction_helpers:

--- a/corehq/form_processor/parsers/ledgers/form.py
+++ b/corehq/form_processor/parsers/ledgers/form.py
@@ -54,20 +54,17 @@ LedgerInstruction = namedtuple(
 
 
 def get_case_ids_from_stock_transactions(xform):
-    stock_report_helpers = list(get_all_stock_report_helpers_from_form(xform))
-    case_ids = {
+    return {
         transaction_helper.case_id
-        for stock_report_helper in stock_report_helpers
+        for stock_report_helper in get_all_stock_report_helpers_from_form(xform)
         for transaction_helper in stock_report_helper.transactions
     }
-    return case_ids
 
 
 def get_ledger_references_from_stock_transactions(xform):
-    stock_report_helpers = list(get_all_stock_report_helpers_from_form(xform))
     return {
         UniqueLedgerReference(tx_helper.case_id, tx_helper.section_id, tx_helper.product_id)
-        for stock_report_helper in stock_report_helpers
+        for stock_report_helper in get_all_stock_report_helpers_from_form(xform)
         for tx_helper in stock_report_helper.transactions
     }
 
@@ -87,10 +84,9 @@ def get_stock_actions(xform):
     if is_device_report(xform):
         return _empty_actions()
 
-    stock_report_helpers = list(get_all_stock_report_helpers_from_form(xform))
     transaction_helpers = [
         transaction_helper
-        for stock_report_helper in stock_report_helpers
+        for stock_report_helper in get_all_stock_report_helpers_from_form(xform)
         for transaction_helper in stock_report_helper.transactions
     ]
     if not transaction_helpers:

--- a/corehq/form_processor/parsers/ledgers/form.py
+++ b/corehq/form_processor/parsers/ledgers/form.py
@@ -126,6 +126,9 @@ def get_all_stock_report_helpers_from_form(xform):
     Given an instance of an AbstractXFormInstance, extract the ledger actions and convert
     them to StockReportHelper objects.
     """
+    if xform.get_xml_element is None:
+        # ESXFormInstance (has a weird API)
+        raise MissingFormXml(xform.form_id)
     form_xml = xform.get_xml_element()
     if form_xml is None:
         # HACK should be raised by xform.get_xml_element()


### PR DESCRIPTION
There were a few places where `get_case_ids_from_stock_transactions` was not called:

Please review these. I'm not sure if it is important for them to exclude case ids from stock transactions:
- [`cases_referenced_by_xform`](https://github.com/dimagi/commcare-hq/blob/482a3b535d3145bbbb28e49c54f0bf06c9ce2661/corehq/ex-submodules/casexml/apps/case/xform.py#L427)
- user tasks: [`tag_forms_as_deleted_rebuild_associated_cases`](https://github.com/dimagi/commcare-hq/blob/482a3b535d3145bbbb28e49c54f0bf06c9ce2661/corehq/apps/users/tasks.py#L120), [`_get_forms_to_modify`](https://github.com/dimagi/commcare-hq/blob/482a3b535d3145bbbb28e49c54f0bf06c9ce2661/corehq/apps/users/tasks.py#L148)

Management commands (probably fine to include stock transaction case ids):
- [purge_forms_and_cases.py](https://github.com/dimagi/commcare-hq/blob/482a3b535d3145bbbb28e49c54f0bf06c9ce2661/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py#L89)
- [republish_forms_rebuild_cases.py](https://github.com/dimagi/commcare-hq/blob/482a3b535d3145bbbb28e49c54f0bf06c9ce2661/corehq/apps/cleanup/management/commands/republish_forms_rebuild_cases.py#L58)

Edit: I don't think it changes the validity of this PR, but noting there that getting case ids involved in stock transactions requires parsing form XML rather than simply traversing JSON. This is because of the way namespaced ledger elements are encoded in the XML; the namespacing is lost when the XML is converted to JSON.

@snopoke @mkangia 