### PR TITLE
remove .message from exceptions for Python 3 compatibility

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -397,7 +397,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                 )
         except etree.XMLSyntaxError as error:
             return json_response(
-                {'message': _("There was an issue with your custom instances: {}").format(error.message)},
+                {'message': _("There was an issue with your custom instances: {}").format(error)},
                 status_code=400
             )
 
@@ -419,7 +419,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                 )
         except etree.XMLSyntaxError as error:
             return json_response(
-                {'message': _("There was an issue with your custom assertions: {}").format(error.message)},
+                {'message': _("There was an issue with your custom assertions: {}").format(error)},
                 status_code=400
             )
 

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -801,7 +801,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             etree.fromstring("<variables>{}</variables>".format(custom_variables['short']))
         except etree.XMLSyntaxError as error:
             return HttpResponseBadRequest(
-                "There was an issue with your custom variables: {}".format(error.message)
+                "There was an issue with your custom variables: {}".format(error)
             )
         detail.short.custom_variables = custom_variables['short']
 
@@ -810,7 +810,7 @@ def edit_module_detail_screens(request, domain, app_id, module_unique_id):
             etree.fromstring("<variables>{}</variables>".format(custom_variables['long']))
         except etree.XMLSyntaxError as error:
             return HttpResponseBadRequest(
-                "There was an issue with your custom variables: {}".format(error.message)
+                "There was an issue with your custom variables: {}".format(error)
             )
         detail.long.custom_variables = custom_variables['long']
 

--- a/corehq/apps/hqwebapp/async_handler.py
+++ b/corehq/apps/hqwebapp/async_handler.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
+
 from django.http import HttpResponse, HttpRequest
 from django.utils.functional import cached_property
+
+import six
 
 
 class AsyncHandlerMixin(object):
@@ -67,7 +70,7 @@ class BaseAsyncHandler(object):
     def _fmt_error(self, error):
         return json.dumps({
             'success': False,
-            'error': error.message,
+            'error': six.text_type(error),
         })
 
     def _fmt_success(self, data):

--- a/custom/ilsgateway/tanzania/handlers/stockout.py
+++ b/custom/ilsgateway/tanzania/handlers/stockout.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import six
+
 from corehq.util.translation import localize
 from custom.ilsgateway.tanzania.exceptions import InvalidProductCodeException
 from custom.ilsgateway.tanzania.handlers.generic_stock_report_handler import GenericStockReportHandler
@@ -36,4 +39,4 @@ class StockoutHandler(GenericStockReportHandler):
     def on_error(self, data):
         for error in data['errors']:
             if isinstance(error, InvalidProductCodeException):
-                self.respond(INVALID_PRODUCT_CODE, product_code=error.message)
+                self.respond(INVALID_PRODUCT_CODE, product_code=six.text_type(error))


### PR DESCRIPTION
Handles cases matching ```error.message```.  ```.message``` is removed in Python 3.