### PR TITLE
Removed hotfixes from output of last_deploy.sh

### DIFF
--- a/scripts/last_deploy.sh
+++ b/scripts/last_deploy.sh
@@ -11,5 +11,5 @@ else
 fi
 
 for i in ${ENVS[@]}; do
-    git tag | grep deploy | grep ${i} | tail -n 1
+    git tag | grep deploy | grep ${i} | grep -v hot_fix | tail -n 1
 done


### PR DESCRIPTION
Output was 
```
(hq) jschweers ~/Documents/commcare-hq (master) $ scripts/last_deploy.sh
2019-05-28_16.08-staging-deploy
2019-05-28_21.34-production-deploy
hot_fix_2019-05-06_19.01-india-deploy
2019-05-27_19.28-swiss-deploy
2019-05-28_17.14-icds-deploy
2019-05-21_19.28-pna-deploy
```

This removes the hot_fix line.