### PR TITLE
Message Log Report feature flag

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1058,11 +1058,11 @@ USE_SMS_WITH_INACTIVE_CONTACTS = StaticToggle(
 
 SMS_LOG_CHANGES = StaticToggle(
     'sms_log_changes',
-    "Message Log Report: Test new additions",
-    TAG_CUSTOM,
+    'Message Log Report v2',
+    TAG_SOLUTIONS,
     [NAMESPACE_USER, NAMESPACE_DOMAIN],
-    description=("Include failed messages, show message status, show event. "
-                 "This feature flag exists to QA on real prod data."),
+    description=("This flag makes failed messages appear in the Message Log "
+                 "Report, and adds Status and Event columns"),
 )
 
 ENABLE_INCLUDE_SMS_GATEWAY_CHARGING = StaticToggle(

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -113,7 +113,7 @@ class TestFileMixin(object):
         return cls.get_file(name, '.xml', override_path).encode('utf-8')
 
 
-class flag_enabled(ContextDecorator):
+class flag_enabled(object):
     """
     Decorate test methods with this to mock the lookup
 
@@ -129,6 +129,11 @@ class flag_enabled(ContextDecorator):
                        new=lambda *args, **kwargs: self.enabled)
             for method_name in ['enabled', 'enabled_for_request']
         ]
+
+    def __call__(self, fn):
+        for patch in self.patches:
+            fn = patch(fn)
+        return fn
 
     def __enter__(self):
         for patch in self.patches:

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -113,7 +113,7 @@ class TestFileMixin(object):
         return cls.get_file(name, '.xml', override_path).encode('utf-8')
 
 
-def flag_enabled(toggle_class_string):
+class flag_enabled(ContextDecorator):
     """
     Decorate test methods with this to mock the lookup
 
@@ -121,17 +121,26 @@ def flag_enabled(toggle_class_string):
         def test_something_fancy(self):
             something.which_depends(on.SELF_DESTRUCT_ON_SUBMIT)
     """
-    return mock.patch(
-        '.'.join(['corehq.toggles', toggle_class_string, 'enabled']),
-        new=lambda *args, **kwargs: True,
-    )
+    enabled = True
+
+    def __init__(self, toggle_name):
+        self.patches = [
+            mock.patch('.'.join(['corehq.toggles', toggle_name, method_name]),
+                       new=lambda *args, **kwargs: self.enabled)
+            for method_name in ['enabled', 'enabled_for_request']
+        ]
+
+    def __enter__(self):
+        for patch in self.patches:
+            patch.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for patch in self.patches:
+            patch.stop()
 
 
-def flag_disabled(toggle_class_string):
-    return mock.patch(
-        '.'.join(['corehq.toggles', toggle_class_string, 'enabled']),
-        new=lambda *args, **kwargs: False,
-    )
+class flag_disabled(flag_enabled):
+    enabled = False
 
 
 class DocTestMixin(object):


### PR DESCRIPTION
Feature flag:
> **Message Log Report v2**
> This flag makes failed messages appear in the Message Log Report, and adds Status and Event columns

Mark it "Solutions" for broader use, and rename some of the variables in the code.

The plan is still to release this fully at some point and kill the feature flag, but since we don't have a definite timeline on that, this should be a better intermediate state.

@biyeun 