### PR TITLE
Fix preg_delivery_death_list field

### DIFF
--- a/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
@@ -92,7 +92,7 @@
         "type": "dynamic_choice_list",
         "required": false,
         "slug": "owner_id",
-        "field": "owner_id",
+        "field": "awc_id",
         "choice_provider": {
           "type": "owner"
         },


### PR DESCRIPTION
I think this may have been broken during the person case v3 migration (fyi @czue).

This report uses a different query provider which makes it difficult to debug the stack trace, but I believe this will fix it. Basically owner_id == awc_id for ICDS and we removed owner_id in v3 (both were present in v2), but kept the reports interface the same. Previously (before the v3 data source) if using the filter that is changed in this PR, a query would like:

```sql
SELECT owner_id as owner_id
FROM person_case
WHERE owner_id = 'cool_guy'
```

After the migration, but before this PR it looks like:

```sql
SELECT awc_id as owner_id
FROM person_case
WHERE owner_id = 'cool_guy'
```

After this change it will look like:

```sql
SELECT awc_id as owner_id
FROM person_case
WHERE awc_id = 'cool_guy'
```

@calellowitz @snopoke FYI on errors you amy see while testing citus