### PR TITLE
Allow partial uploads to include new languages

### DIFF
--- a/corehq/apps/translations/utils.py
+++ b/corehq/apps/translations/utils.py
@@ -23,7 +23,10 @@ def update_app_translations_from_trans_dict(app, trans_dict):
         if isinstance(app, LinkedApplication):
             for lang, trans in six.iteritems(app.translations):
                 if lang in trans_dict:
-                    app.linked_app_translations[lang].update(trans_dict[lang])
+                    if lang in app.linked_app_translations:
+                        app.linked_app_translations[lang].update(trans_dict[lang])
+                    else:
+                        app.linked_app_translations[lang] = trans_dict[lang]
 
         for lang, trans in six.iteritems(app.translations):
             if lang in trans_dict:


### PR DESCRIPTION
Sentry: [Bulk Upload Translations Error](https://sentry.io/organizations/dimagi/issues/1048611766/events/3fbbc6ac19d4442197b800cb6acfa889/?project=136860)

Fixes bug when a UI translations upload includes a language previously not uploaded to the linked app. Only affects domains with "partial_ui_translations" feature flag enabled.

Feature Flag: "Enable uploading a subset of translations in the UI Translations Excel upload"