### PR TITLE
allow filtering by other 'non_analyzed' fields

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -675,6 +675,7 @@ class TermParam(object):
 
 query_param_consumers = [
     TermParam('xmlns', 'xmlns.exact'),
+    TermParam('xmlns.exact'),
     TermParam('case_name', 'name', analyzed=True),
     TermParam('case_type', 'type', analyzed=True),
     # terms listed here to prevent conversion of their values to lower case since

--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -676,6 +676,13 @@ query_param_consumers = [
     TermParam('xmlns', 'xmlns.exact'),
     TermParam('case_name', 'name', analyzed=True),
     TermParam('case_type', 'type', analyzed=True),
+    # terms listed here to prevent conversion of their values to lower case since
+    # since they are indexed as `not_analyzed` in ES
+    TermParam('type.exact'),
+    TermParam('name.exact'),
+    TermParam('external_id.exact'),
+    TermParam('contact_phone_number'),
+
     DateRangeParams('received_on'),
     DateRangeParams('server_modified_on'),
     DateRangeParams('date_modified', 'modified_on'),

--- a/corehq/apps/api/tests/case_resources.py
+++ b/corehq/apps/api/tests/case_resources.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 import uuid
 from datetime import datetime
-from urllib.parse import urlencode
+from django.utils.http import urlencode
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase

--- a/corehq/apps/api/tests/case_resources.py
+++ b/corehq/apps/api/tests/case_resources.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 import uuid
 from datetime import datetime
+from urllib.parse import urlencode
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
@@ -85,6 +86,62 @@ class TestCommCareCaseResource(APIResourceTest):
 
         api_case = api_cases[0]
         self.assertEqual(api_case['server_date_modified'], json_format_datetime(backend_case.server_modified_on))
+
+    def _test_es_query(self, url_params, expected_query, fake_es=None):
+        fake_es = fake_es or FakeXFormES()
+        v0_3.MOCK_CASE_ES = fake_es
+
+        response = self._assert_auth_get_resource('%s?%s' % (self.list_endpoint, urlencode(url_params)))
+        self.assertEqual(response.status_code, 200)
+        self.assertItemsEqual(fake_es.queries[0]['filter']['and'], expected_query)
+
+    def test_get_list_legacy_filters(self):
+        expected = [
+            {'term': {'domain.exact': 'qwerty'}},
+            {'term': {'type': 'movie'}},
+            {'term': {'name': 'lethal weapon ii'}},
+        ]
+        params = {
+            'case_type': 'Movie',
+            'case_name': 'Lethal Weapon II',
+        }
+        self._test_es_query(params, expected)
+
+    def test_get_list_case_sensitivity(self):
+        expected = [
+            {'term': {'domain.exact': 'qwerty'}},
+            {'term': {'type': 'fish'}},
+            {'term': {'type.exact': 'FISH'}},
+            {'term': {'name': 'nemo'}},
+            {'term': {'name.exact': 'Nemo'}},
+            {'term': {'external_id': 'clownfish_1'}},
+            {'term': {'external_id.exact': 'ClownFish_1'}},
+        ]
+        params = {
+            'type': 'fish',
+            'type.exact': 'FISH',
+            'name': 'Nemo',
+            'name.exact': 'Nemo',
+            'external_id': 'ClownFish_1',
+            'external_id.exact': 'ClownFish_1',
+        }
+        self._test_es_query(params, expected)
+
+    def test_get_list_date_filter(self):
+        start_date = datetime(1969, 6, 14)
+        end_date = datetime(2011, 1, 2)
+        expected = [
+            {'term': {'domain.exact': 'qwerty'}},
+            {'range': {'server_modified_on': {'gte': start_date.isoformat(), 'lte': end_date.isoformat()}}},
+            {'range': {'modified_on': {'gte': start_date.isoformat(), 'lte': end_date.isoformat()}}},
+        ]
+        params = {
+            'server_date_modified_end': end_date.isoformat(),
+            'server_date_modified_start': start_date.isoformat(),
+            'date_modified_start': start_date.isoformat(),
+            'date_modified_end': end_date.isoformat(),
+        }
+        self._test_es_query(params, expected)
 
     @run_with_all_backends
     def test_parent_and_child_cases(self):

--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -101,17 +101,20 @@ class TestXFormInstanceResource(APIResourceTest):
         self.assertEqual(api_form['edited_by_user_id'], 'auth-user-id')
 
     def test_get_list_xmlns(self):
-        """
-        Forms can be filtered by passing ?xmlns=<xmlns>
-
-        Since we not testing ElasticSearch, we only test that the proper query is generated.
-        """
         expected = [
             {'term': {'doc_type': 'xforminstance'}},
             {'term': {'domain.exact': 'qwerty'}},
-            {'term': {'xmlns.exact': 'foo'}}
+            {'term': {'xmlns.exact': 'http://XMLNS'}}
         ]
-        self._test_es_query({'xmlns': 'foo'}, expected)
+        self._test_es_query({'xmlns': 'http://XMLNS'}, expected)
+
+    def test_get_list_xmlns_exact(self):
+        expected = [
+            {'term': {'doc_type': 'xforminstance'}},
+            {'term': {'domain.exact': 'qwerty'}},
+            {'term': {'xmlns.exact': 'http://XMLNS'}}
+        ]
+        self._test_es_query({'xmlns.exact': 'http://XMLNS'}, expected)
 
     def test_get_list_received_on(self):
         """


### PR DESCRIPTION
Previously using `*.exact` was not permitted making it impossible to filter for exact matches.