### PR TITLE
Couch 2 SQL: Ignore cases with no referencing forms

### DIFF
--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -13,6 +13,7 @@ from six.moves import input, zip_longest
 from sqlalchemy.exc import OperationalError
 
 from corehq.apps.couch_sql_migration.couchsqlmigration import (
+    CASE_DOC_TYPES,
     delete_diff_db,
     do_couch_to_sql_migration,
     get_diff_db,
@@ -26,7 +27,7 @@ from corehq.apps.couch_sql_migration.progress import (
     set_couch_sql_migration_started,
 )
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_type
-from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
+from corehq.apps.tzmigration.planning import Counts
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseAccessorSQL,
     FormAccessorSQL,
@@ -185,22 +186,22 @@ class Command(BaseCommand):
             diff_count, num_docs_with_diffs, short, diffs_only
         )
 
-        case_ids_in_couch = set(get_case_ids_in_domain(domain))
-        case_ids_in_sql = set(CaseAccessorSQL.get_case_ids_in_domain(domain))
-        diff_count, num_docs_with_diffs = diff_stats.pop("CommCareCase", (0, 0))
-        has_diffs |= self._print_status(
-            'CommCareCase', case_ids_in_couch, case_ids_in_sql, diff_count, num_docs_with_diffs, short, diffs_only
-        )
-
-        case_ids_in_couch = set(get_doc_ids_in_domain_by_type(
-            domain, "CommCareCase-Deleted", XFormInstance.get_db())
-        )
-        case_ids_in_sql = set(CaseAccessorSQL.get_deleted_case_ids_in_domain(domain))
-        diff_count, num_docs_with_diffs = diff_stats.pop("CommCareCase-Deleted", (0, 0))
-        has_diffs |= self._print_status(
-            'CommCareCase-Deleted', case_ids_in_couch, case_ids_in_sql,
-            diff_count, num_docs_with_diffs, short, diffs_only
-        )
+        ZERO = Counts(0, 0)
+        doc_counts = db.get_doc_counts()
+        for doc_type in CASE_DOC_TYPES:
+            counts = doc_counts.get(doc_type, ZERO)
+            case_ids_in_couch = db.get_missing_doc_ids(doc_type) if counts.missing else set()
+            case_ids_in_sql = counts
+            diff_count, num_docs_with_diffs = diff_stats.pop(doc_type, (0, 0))
+            has_diffs |= self._print_status(
+                doc_type,
+                case_ids_in_couch,
+                case_ids_in_sql,
+                diff_count,
+                num_docs_with_diffs,
+                short,
+                diffs_only,
+            )
 
         if diff_stats:
             for key, counts in diff_stats.items():
@@ -214,8 +215,14 @@ class Command(BaseCommand):
         return has_diffs
 
     def _print_status(self, name, ids_in_couch, ids_in_sql, diff_count, num_docs_with_diffs, short, diffs_only):
-        n_couch = len(ids_in_couch)
-        n_sql = len(ids_in_sql)
+        if isinstance(ids_in_sql, Counts):
+            counts, ids_in_sql = ids_in_sql, set()
+            assert len(ids_in_couch) == counts.missing, (len(ids_in_couch), counts.missing)
+            n_couch = counts.total
+            n_sql = counts.total - counts.missing
+        else:
+            n_couch = len(ids_in_couch)
+            n_sql = len(ids_in_sql)
         has_diff = ids_in_couch != ids_in_sql or diff_count
 
         if diffs_only and not has_diff:

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -12,7 +12,9 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase, override_settings
 
+import six
 from couchdbkit.exceptions import ResourceNotFound
+from six.moves import zip
 
 from casexml.apps.case.mock import CaseBlock
 from couchforms.models import XFormInstance
@@ -42,6 +44,7 @@ from corehq.form_processor.backends.sql.dbaccessors import (
     FormAccessorSQL,
     LedgerAccessorSQL,
 )
+from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -63,7 +66,6 @@ from corehq.util.test_utils import (
     softer_assert,
     trap_extra_setup,
 )
-from six.moves import zip
 
 
 class BaseMigrationTestCase(TestCase, TestFileMixin):
@@ -106,9 +108,15 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
         self.assertTrue(should_use_sql_backend(domain))
 
     def _compare_diffs(self, expected):
-        diffs = get_diff_db(self.domain_name).get_diffs()
+        diff_db = get_diff_db(self.domain_name)
+        diffs = diff_db.get_diffs()
         json_diffs = [(diff.kind, diff.json_diff) for diff in diffs]
         self.assertEqual(expected, json_diffs)
+        self.assertEqual({
+            kind: counts.missing
+            for kind, counts in six.iteritems(diff_db.get_doc_counts())
+            if counts.missing
+        }, {})
 
     def _get_form_ids(self, doc_type='XFormInstance'):
         return FormAccessors(domain=self.domain_name).get_all_form_ids_in_domain(doc_type=doc_type)
@@ -712,6 +720,26 @@ class MigrationTestCase(BaseMigrationTestCase):
         form = FormAccessors(self.domain_name).get_form('new-form')
         self.assertEqual(form.deprecated_form_id, "test-form")
         self.assertIsNone(form.problem)
+
+    def test_missing_case(self):
+        # This can happen when a form is edited, removing the last
+        # remaining reference to a case. The case effectively becomes
+        # orphaned, and will be ignored by the migration.
+        from corehq.apps.cloudcare.const import DEVICE_ID
+        # replace device id to avoid edit form soft assert
+        test_form = TEST_FORM.replace("cloudcare", DEVICE_ID)
+        submit_form_locally(test_form, self.domain_name)
+        edited_form = test_form.replace("test-case", "other-case")
+        submit_form_locally(edited_form, self.domain_name)
+        self.assertEqual(self._get_case("test-case").xform_ids, ["test-form"])
+        self.assertEqual(self._get_case("other-case").xform_ids, ["test-form"])
+
+        self._do_migration_and_assert_flags(self.domain_name)
+
+        self.assertEqual(self._get_case("other-case").xform_ids, ["test-form"])
+        with self.assertRaises(CaseNotFound):
+            self._get_case("test-case")
+        self._compare_diffs([])
 
 
 class LedgerMigrationTests(BaseMigrationTestCase):


### PR DESCRIPTION
This is the beginning of a larger refactor of document counting and id diffing so they can be done incrementally rather than by loading all ids (from both backends) for each doc_type into RAM to do the comparison. This optimization removes the ability to tell if documents exist in SQL but not in Couch. Anecdotally, in all the migrations I have run I have only ever seen one (commconnect-demo) that has reported documents existing in SQL but not in Couch.

@czue @snopoke cc @sravfeyn 