### PR TITLE
tag case changes with case type in enterprise envs

### DIFF
--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -368,8 +368,7 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
             if add_case_type_tag and settings.ENTERPRISE_MODE and change.metadata.document_type == 'CommCareCase':
                 metric_tags.append('case_type:{}'.format(change.metadata.document_subtype))
 
-            count = 1 if processor else len(self.processors)
-            datadog_counter(metric, value=count, tags=metric_tags)
+            datadog_counter(metric, tags=metric_tags)
 
             change_lag = (datetime.utcnow() - change.metadata.publish_timestamp).total_seconds()
             datadog_gauge('commcare.change_feed.change_lag', change_lag, tags=[

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 from abc import ABCMeta, abstractproperty, abstractmethod
+from collections import Counter
 from datetime import datetime
+
+from django.conf import settings
 from memoized import memoized
 
 import sys
@@ -287,10 +290,21 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
 
     def _record_datadog_metrics(self, changes_chunk, processing_time):
         tags = ["pillow_name:{}".format(self.get_name()), "mode:chunked"]
-        # Since success/fail count is tracked per processor, to get sense of
-        #   actual operations count, multiply by number of processors
-        count = len(changes_chunk) * len(self.processors)
-        datadog_counter('commcare.change_feed.changes.count', count, tags=tags)
+        change_count = len(changes_chunk)
+        if settings.ENTERPRISE_MODE:
+            type_counter = Counter([
+                change.metadata.document_subtype
+                for change in changes_chunk if change.metadata.document_type == 'CommCareCase'
+            ])
+            for case_type, type_count in type_counter.items():
+                tags_with_type = tags + ['case_type:{}'.format(case_type)]
+                datadog_counter('commcare.change_feed.changes.count', type_count, tags=tags_with_type)
+
+            remainder = change_count - sum(type_counter.values())
+            if remainder:
+                datadog_counter('commcare.change_feed.changes.count', remainder, tags=tags)
+        else:
+            datadog_counter('commcare.change_feed.changes.count', change_count, tags=tags)
 
         max_change_lag = (datetime.utcnow() - changes_chunk[0].metadata.publish_timestamp).total_seconds()
         min_change_lag = (datetime.utcnow() - changes_chunk[-1].metadata.publish_timestamp).total_seconds()
@@ -300,14 +314,14 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
         # processing_time per change
         datadog_histogram(
             'commcare.change_feed.processing_time',
-            processing_time / len(changes_chunk),
-            tags=tags + ["chunk_size:".format(str(len(changes_chunk)))]
+            processing_time / change_count,
+            tags=tags + ["chunk_size:".format(str(change_count))]
         )
 
-        if len(changes_chunk) == self.processor_chunk_size:
+        if change_count == self.processor_chunk_size:
             # don't report offset chunks to ease up datadog calculations
             datadog_histogram('commcare.change_feed.chunked.processing_time_total', processing_time,
-                tags=tags + ["chunk_size:{}".format(str(len(changes_chunk)))])
+                              tags=tags + ["chunk_size:{}".format(str(change_count))])
 
     def _record_checkpoint_in_datadog(self):
         datadog_counter('commcare.change_feed.change_feed.checkpoint', tags=[
@@ -321,7 +335,10 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
             ])
 
     def _record_change_in_datadog(self, change, processing_time):
-        self.__record_change_metric_in_datadog('commcare.change_feed.changes.count', change, processing_time=processing_time)
+        self.__record_change_metric_in_datadog(
+            'commcare.change_feed.changes.count', change,
+            processing_time=processing_time, add_case_type_tag=True
+        )
 
     def _record_batch_exception_in_datadog(self, processor):
         datadog_counter(
@@ -337,16 +354,22 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
     def _record_change_exception_in_datadog(self, change, processor):
         self.__record_change_metric_in_datadog('commcare.change_feed.changes.exceptions', change, processor)
 
-    def __record_change_metric_in_datadog(self, metric, change, processor=None, processing_time=None):
+    def __record_change_metric_in_datadog(self, metric, change, processor=None, processing_time=None,
+                                          add_case_type_tag=False):
         if change.metadata is not None:
-            tags = [
+            common_tags = [
                 'datasource:{}'.format(change.metadata.data_source_name),
                 'is_deletion:{}'.format(change.metadata.is_deletion),
                 'pillow_name:{}'.format(self.get_name()),
                 'processor:{}'.format(processor.__class__.__name__ if processor else "all_processors"),
             ]
+
+            metric_tags = list(common_tags)
+            if add_case_type_tag and settings.ENTERPRISE_MODE and change.metadata.document_type == 'CommCareCase':
+                metric_tags.append('case_type:{}'.format(change.metadata.document_subtype))
+
             count = 1 if processor else len(self.processors)
-            datadog_counter(metric, value=count, tags=tags)
+            datadog_counter(metric, value=count, tags=metric_tags)
 
             change_lag = (datetime.utcnow() - change.metadata.publish_timestamp).total_seconds()
             datadog_gauge('commcare.change_feed.change_lag', change_lag, tags=[
@@ -355,7 +378,7 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
             ])
 
             if processing_time:
-                datadog_histogram('commcare.change_feed.processing_time', processing_time, tags=tags)
+                datadog_histogram('commcare.change_feed.processing_time', processing_time, tags=common_tags)
 
     @staticmethod
     def _deduplicate_changes(changes_chunk):

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -312,11 +312,7 @@ class PillowBase(six.with_metaclass(ABCMeta, object)):
         datadog_gauge('commcare.change_feed.chunked.max_change_lag', max_change_lag, tags=tags)
 
         # processing_time per change
-        datadog_histogram(
-            'commcare.change_feed.processing_time',
-            processing_time / change_count,
-            tags=tags + ["chunk_size:".format(str(change_count))]
-        )
+        datadog_histogram('commcare.change_feed.processing_time', processing_time / change_count, tags=tags)
 
         if change_count == self.processor_chunk_size:
             # don't report offset chunks to ease up datadog calculations

--- a/corehq/ex-submodules/pillowtop/tests/test_metrics.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_metrics.py
@@ -1,0 +1,73 @@
+import uuid
+
+from django.test import SimpleTestCase, override_settings
+
+from corehq.util.test_utils import patch_datadog
+from pillowtop.feed.interface import Change, ChangeMeta
+from pillowtop.tests.test_import_pillows import FakePillow
+
+
+class TestPillowMetrics(SimpleTestCase):
+    maxDiff = None
+
+    def _get_stats(self, changes, batch=False):
+        pillow = FakePillow()
+        with patch_datadog() as stats:
+            if batch:
+                pillow._record_datadog_metrics(changes, 5)
+            else:
+                for change in changes:
+                    pillow._record_change_in_datadog(change, 2)
+        return stats
+
+    def test_basic_metrics(self):
+        stats = self._get_stats([self._get_change()])
+        self.assertEqual(set(stats), {
+            'commcare.change_feed.changes.count.datasource:test_commcarehq',
+            'commcare.change_feed.changes.count.is_deletion:False',
+            'commcare.change_feed.changes.count.pillow_name:fake pillow',
+            'commcare.change_feed.changes.count.processor:all_processors',
+            'commcare.change_feed.change_lag.pillow_name:fake pillow',
+            'commcare.change_feed.change_lag.topic:case',
+            'commcare.change_feed.processing_time.datasource:test_commcarehq',
+            'commcare.change_feed.processing_time.is_deletion:False',
+            'commcare.change_feed.processing_time.pillow_name:fake pillow',
+            'commcare.change_feed.processing_time.processor:all_processors',
+        })
+
+    @override_settings(ENTERPRISE_MODE=True)
+    def test_case_type_metrics(self):
+        stats = self._get_stats([self._get_change()])
+        self.assertIn('commcare.change_feed.changes.count.case_type:person', stats)
+
+    @override_settings(ENTERPRISE_MODE=True)
+    def test_case_type_metrics_batch(self):
+        stats = self._get_stats([
+            self._get_change(doc_subtype='person'),
+            self._get_change(doc_subtype='person'),
+            self._get_change(doc_subtype='cat'),
+            self._get_change(doc_type='form'),
+        ], batch=True)
+
+        self.assertEqual(stats['commcare.change_feed.changes.count.case_type:person'], [2])
+        self.assertEqual(stats['commcare.change_feed.changes.count.case_type:cat'], [1])
+
+        # extra 1 for the change with a different doc type
+        self.assertEqual(stats['commcare.change_feed.changes.count.pillow_name:fake pillow'], [2, 1, 1])
+
+    def _get_change(self, topic='case', doc_type='CommCareCase', doc_subtype='person'):
+        doc_id = uuid.uuid4().hex
+        return Change(
+            doc_id,
+            'seq',
+            topic=topic,
+            metadata=ChangeMeta(
+                data_source_type='couch',
+                data_source_name='test_commcarehq',
+                document_id=doc_id,
+                document_type=doc_type,
+                document_subtype=doc_subtype,
+                is_deletion=False,
+
+            )
+        )

--- a/corehq/ex-submodules/pillowtop/tests/test_metrics.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_metrics.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import uuid
 
 from django.test import SimpleTestCase, override_settings


### PR DESCRIPTION
The goal with this tagging is to get more insight into the kinds of changes being processed. On ICDS we sometime have load issues but don't see much change in overall form submissions. Insight into what cases are being touched may help to identify changes in usage.

I'm not convinced this will give us enough info but I'm interested to see the data.

One big change is to count each change only once instead of once per processor. I don't think having the count multiplied by the number of processors is useful and actually makes the metric much harder to use.