### PR TITLE
Fix error when there is large exponent

### DIFF
--- a/corehq/ex-submodules/couchforms/jsonobject_extensions.py
+++ b/corehq/ex-submodules/couchforms/jsonobject_extensions.py
@@ -20,9 +20,6 @@ def _canonical_decimal(n):
         decimal = Decimal(n)
     except InvalidOperation:
         value_error = True
-    else:
-        if six.text_type(decimal) != n:
-            value_error = True
     if value_error:
         raise ValueError('{!r} is not a canonically formatted decimal'
                          .format(n))


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1044666856/?cursor=0%3A100%3A0&project=136860&referrer=slack Someone's GPS accuracy is extremely large (6.1743444E7) and this code is choking on it because its trying to compare that exponent value with '61743444' which means they're going ot be blocked on submitting at least one form.

This string comparison code pre-existed https://github.com/dimagi/commcare-hq/pull/15405/ and I can't tell what the sentry error was there because the error has been deleted, but I'm assuming it was to catch `InvalidOperation` which I think/hope should catch a super-set of errors compared to this string comparison.

@snopoke @calellowitz fyi since you are the last who touched this a couple years ago