### PR TITLE
Refactoring and cleanup of get cases referenced by form

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -412,25 +412,8 @@ def _update_order_index(update):
 
 
 def get_case_ids_from_form(xform):
-    from corehq.form_processor.parsers.ledgers.form import (
-        get_case_ids_from_stock_transactions,
-        MissingFormXml,
-    )
+    from corehq.form_processor.parsers.ledgers.form import get_case_ids_from_stock_transactions
     case_ids = set(cu.id for cu in get_case_updates(xform))
     if xform:
-        try:
-            case_ids.update(get_case_ids_from_stock_transactions(xform))
-        except MissingFormXml:
-            pass
+        case_ids.update(get_case_ids_from_stock_transactions(xform))
     return case_ids
-
-
-def cases_referenced_by_xform(xform):
-    """
-    Returns a list of CommCareCase or CommCareCaseSQL given a JSON
-    representation of an XFormInstance
-    """
-    assert xform.domain, "Form is missing 'domain'"
-    case_ids = get_case_ids_from_form(xform)
-    case_accessor = CaseAccessors(xform.domain)
-    return list(case_accessor.get_cases(list(case_ids)))

--- a/corehq/form_processor/parsers/ledgers/form.py
+++ b/corehq/form_processor/parsers/ledgers/form.py
@@ -127,9 +127,6 @@ def get_all_stock_report_helpers_from_form(xform):
     Given an instance of an AbstractXFormInstance, extract the ledger actions and convert
     them to StockReportHelper objects.
     """
-    if xform.get_xml_element is None:
-        # ESXFormInstance (has a weird API)
-        raise MissingFormXml(xform.form_id)
     form_xml = xform.get_xml_element()
     if form_xml is None:
         # HACK should be raised by xform.get_xml_element()

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -9,7 +9,7 @@ import warnings
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.translation import ugettext_lazy as _
-from casexml.apps.case.xform import cases_referenced_by_xform
+from casexml.apps.case.xform import get_case_ids_from_form
 from corehq.apps.receiverwrapper.exceptions import DuplicateFormatException
 
 from casexml.apps.case.xml import V2
@@ -279,10 +279,10 @@ class ShortFormRepeaterJsonPayloadGenerator(BasePayloadGenerator):
     deprecated_format_names = ('short_form_json',)
 
     def get_payload(self, repeat_record, form):
-        cases = cases_referenced_by_xform(form)
+        case_ids = list(get_case_ids_from_form(form))
         return json.dumps({'form_id': form.form_id,
                            'received_on': json_format_datetime(form.received_on),
-                           'case_ids': [case.case_id for case in cases]})
+                           'case_ids': case_ids})
 
     @property
     def content_type(self):

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -12,7 +12,7 @@ from mock import patch
 from six.moves import range
 
 from casexml.apps.case.mock import CaseBlock, CaseFactory
-from casexml.apps.case.xform import cases_referenced_by_xform
+from casexml.apps.case.xform import get_case_ids_from_form
 from couchforms.const import DEVICE_LOG_XMLNS
 from dimagi.utils.parsing import json_format_datetime
 
@@ -405,11 +405,10 @@ class ShortFormRepeaterTest(BaseRepeaterTest, TestXmlMixin):
         form = self.post_xml(self.xform_xml, self.domain_name).xform
         repeat_records = self.repeat_records(self.domain_name).all()
         payload = repeat_records[0].get_payload()
-        cases = cases_referenced_by_xform(form)
         self.assertEqual(json.loads(payload), {
             'received_on': json_format_datetime(form.received_on),
             'form_id': form.form_id,
-            'case_ids': [case.case_id for case in cases]
+            'case_ids': list(get_case_ids_from_form(form))
         })
 
 


### PR DESCRIPTION
Was not happy with how `get_case_ids_from_form` and `get_all_stock_report_helpers_from_form` gained special logic to deal with `ESXFormInstance` in https://github.com/dimagi/commcare-hq/pull/24431

Review by commit 🐠 

@snopoke cc @sravfeyn 