### PR TITLE
hotfix don't lowercase xmlns.exact filter

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -675,6 +675,7 @@ class TermParam(object):
 
 query_param_consumers = [
     TermParam('xmlns', 'xmlns.exact'),
+    TermParam('xmlns.exact'),
     TermParam('case_name', 'name', analyzed=True),
     TermParam('case_type', 'type', analyzed=True),
     DateRangeParams('received_on'),


### PR DESCRIPTION
Also included in https://github.com/dimagi/commcare-hq/pull/24453 along with a test. 