### PR TITLE
Fixed 500 caused by subcase_node being None

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1895,7 +1895,8 @@ class XForm(WrappedNode):
             path, subcase_node = get_action_path(action)
 
             open_case_block = CaseBlock(self, path)
-            subcase_node.insert(0, open_case_block.elem)
+            if subcase_node is not None:
+                subcase_node.insert(0, open_case_block.elem)
             open_case_block.add_create_block(
                 relevance=self.action_relevance(action.open_condition),
                 case_name=action.name_path,


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1003911696/

I'm mot terribly familiar with this logic, but it looks straightforward: `get_action_path` sometimes returns `None` for the subcase node, but the calling code always tries to call `insert`.

Marked invisible because this error is being silently swallowed: see https://github.com/dimagi/commcare-hq/pull/22849