### PR TITLE
Edit case_list media if module.case_list exists

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -571,8 +571,8 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
 
     handle_media_edits(request, module, should_edit, resp, lang)
     handle_media_edits(request, module.case_list_form, should_edit, resp, lang, prefix='case_list_form_')
-    handle_media_edits(request, module.case_list, should_edit, resp, lang, prefix='case_list-menu_item_')
-
+    if module.case_list:
+        handle_media_edits(request, module.case_list, should_edit, resp, lang, prefix='case_list-menu_item_')
 
     app.save(resp)
     resp['case_list-show'] = module.requires_case_details()

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -571,7 +571,7 @@ def edit_module_attr(request, domain, app_id, module_unique_id, attr):
 
     handle_media_edits(request, module, should_edit, resp, lang)
     handle_media_edits(request, module.case_list_form, should_edit, resp, lang, prefix='case_list_form_')
-    if module.case_list:
+    if hasattr(module, 'case_list'):
         handle_media_edits(request, module.case_list, should_edit, resp, lang, prefix='case_list-menu_item_')
 
     app.save(resp)


### PR DESCRIPTION
Currently, people are not able to edit the name or description in their Report Menus.  `ReportModule` is the only module class that does not have a `case_list`, so this should be the only use case that's affected

Jira Ticket: https://dimagi-dev.atlassian.net/browse/HI-665
Sentry Error: https://sentry.io/organizations/dimagi/issues/1024889178/?project=136860&query=domain%253Areach-sandbox&statsPeriod=14d