### PR TITLE
DRYer tests

### DIFF
--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -134,17 +134,11 @@ class UnpackRequestArgsTests(SimpleTestCase):
         self.response_mock.content = self.content_json
         self.response_mock.json.return_value = content
 
-    def test_post_with_no_args(self):
-        with patch.object(requests.Session, 'request') as request_mock, \
-                patch.object(RequestLog.objects, 'create') as create_mock:
-            request_mock.return_value = self.response_mock
-
-            self.requests.post(self.uri)
-
+    def assert_create_called_with_request_body(self, create_mock, request_body):
             create_mock.assert_called_with(
                 domain=TEST_DOMAIN,
                 log_level=logging.INFO,
-                request_body=None,
+                request_body=request_body,
                 request_error=self.error_message,
                 request_headers={
                     'Content-type': 'application/json',
@@ -156,6 +150,14 @@ class UnpackRequestArgsTests(SimpleTestCase):
                 response_body=self.content_json,
                 response_status=self.status_code,
             )
+
+    def test_post_with_no_args(self):
+        with patch.object(requests.Session, 'request') as request_mock, \
+                patch.object(RequestLog.objects, 'create') as create_mock:
+            request_mock.return_value = self.response_mock
+
+            self.requests.post(self.uri)
+            self.assert_create_called_with_request_body(create_mock, None)
 
     def test_post_with_data_kwarg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -163,22 +165,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, data=self.data)
-
-            create_mock.assert_called_with(
-                domain=TEST_DOMAIN,
-                log_level=logging.INFO,
-                request_body=self.data,
-                request_error=self.error_message,
-                request_headers={
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json'
-                },
-                request_method='POST',
-                request_params=None,
-                request_url='http://localhost:9080/api/person/',
-                response_body=self.content_json,
-                response_status=self.status_code,
-            )
+            self.assert_create_called_with_request_body(create_mock, self.data)
 
     def test_post_with_json_kwarg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -186,22 +173,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, json=self.json_data)
-
-            create_mock.assert_called_with(
-                domain=TEST_DOMAIN,
-                log_level=logging.INFO,
-                request_body=self.json_data,
-                request_error=self.error_message,
-                request_headers={
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json'
-                },
-                request_method='POST',
-                request_params=None,
-                request_url='http://localhost:9080/api/person/',
-                response_body=self.content_json,
-                response_status=self.status_code,
-            )
+            self.assert_create_called_with_request_body(create_mock, self.json_data)
 
     def test_post_with_data_arg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -209,22 +181,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, self.data)
-
-            create_mock.assert_called_with(
-                domain=TEST_DOMAIN,
-                log_level=logging.INFO,
-                request_body=self.data,
-                request_error=self.error_message,
-                request_headers={
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json'
-                },
-                request_method='POST',
-                request_params=None,
-                request_url='http://localhost:9080/api/person/',
-                response_body=self.content_json,
-                response_status=self.status_code,
-            )
+            self.assert_create_called_with_request_body(create_mock, self.data)
 
     def test_post_with_json_arg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -232,22 +189,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, None, self.json_data)
-
-            create_mock.assert_called_with(
-                domain=TEST_DOMAIN,
-                log_level=logging.INFO,
-                request_body=self.json_data,
-                request_error=self.error_message,
-                request_headers={
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json'
-                },
-                request_method='POST',
-                request_params=None,
-                request_url='http://localhost:9080/api/person/',
-                response_body=self.content_json,
-                response_status=self.status_code,
-            )
+            self.assert_create_called_with_request_body(create_mock, self.json_data)
 
     def test_post_with_data_and_json(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -255,19 +197,4 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, self.data, self.json_data)
-
-            create_mock.assert_called_with(
-                domain=TEST_DOMAIN,
-                log_level=logging.INFO,
-                request_body=self.data,
-                request_error=self.error_message,
-                request_headers={
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json'
-                },
-                request_method='POST',
-                request_params=None,
-                request_url='http://localhost:9080/api/person/',
-                response_body=self.content_json,
-                response_status=self.status_code,
-            )
+            self.assert_create_called_with_request_body(create_mock, self.data)

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -17,106 +17,6 @@ TEST_API_PASSWORD = 'district'
 TEST_DOMAIN = 'test-domain'
 
 
-class RequestLogTests(SimpleTestCase):
-
-    def setUp(self):
-        self.requests = Requests(TEST_DOMAIN, TEST_API_URL, TEST_API_USERNAME, TEST_API_PASSWORD)
-
-    def test_get_request_log(self):
-        with patch.object(requests.Session, 'request') as request_mock, \
-                patch.object(RequestLog, 'log') as log_mock:
-
-            content = {'code': TEST_API_USERNAME}
-            content_json = json.dumps(content)
-            status_code = 200
-            error_message = ''
-            uri = 'me'
-            response_mock = Mock()
-            response_mock.status_code = status_code
-            response_mock.content = content_json
-            response_mock.json.return_value = content
-            request_mock.return_value = response_mock
-
-            self.requests.get(uri, {'code': TEST_API_USERNAME})
-
-            log_mock.assert_called_with(
-                logging.INFO,
-                TEST_DOMAIN,
-                error_message,
-                status_code,
-                content_json,
-                'GET',
-                TEST_API_URL + uri,
-                {'code': TEST_API_USERNAME},
-                allow_redirects=True,
-                auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
-                headers={'Accept': 'application/json'},
-            )
-
-    def test_delete_request_log(self):
-        with patch.object(requests.Session, 'request') as request_mock, \
-                patch.object(RequestLog, 'log') as log_mock:
-
-            content = {'status': 'Deleted'}
-            content_json = json.dumps(content)
-            status_code = 200
-            error_message = ''
-            uri = 'person/123'
-            response_mock = Mock()
-            response_mock.status_code = status_code
-            response_mock.content = content_json
-            response_mock.json.return_value = content
-            request_mock.return_value = response_mock
-
-            self.requests.delete(uri)
-
-            log_mock.assert_called_with(
-                logging.INFO,
-                TEST_DOMAIN,
-                error_message,
-                status_code,
-                content_json,
-                'DELETE',
-                TEST_API_URL + uri,
-                auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
-                headers={'Accept': 'application/json'},
-            )
-
-    def test_post_request_log(self):
-        with patch.object(requests.Session, 'request') as request_mock, \
-                patch.object(RequestLog, 'log') as log_mock:
-
-            content = {'status': 'Created'}
-            content_json = json.dumps(content)
-            status_code = 201
-            error_message = ''
-            uri = 'person/'
-            response_mock = Mock()
-            response_mock.status_code = status_code
-            response_mock.content = content_json
-            response_mock.json.return_value = content
-            request_mock.return_value = response_mock
-
-            self.requests.post(uri, json={'name': 'Alice'})
-
-            log_mock.assert_called_with(
-                logging.INFO,
-                TEST_DOMAIN,
-                error_message,
-                status_code,
-                content_json,
-                'POST',
-                TEST_API_URL + uri,
-                auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
-                data=None,
-                headers={
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json',
-                },
-                json={'name': 'Alice'},
-            )
-
-
 class UnpackRequestArgsTests(SimpleTestCase):
 
     def setUp(self):
@@ -124,6 +24,11 @@ class UnpackRequestArgsTests(SimpleTestCase):
 
         content = {'status': 'Created'}
         self.content_json = json.dumps(content)
+        self.request_method = 'POST'
+        self.request_headers = {
+            'Content-type': 'application/json',
+            'Accept': 'application/json'
+        }
         self.status_code = 201
         self.error_message = ''
         self.uri = 'person/'
@@ -135,18 +40,15 @@ class UnpackRequestArgsTests(SimpleTestCase):
         self.response_mock.content = self.content_json
         self.response_mock.json.return_value = content
 
-    def assert_create_called_with_request_body(self, create_mock, request_body):
+    def assert_create_called_with_request_body_and_params(self, create_mock, request_body, request_params=None):
             create_mock.assert_called_with(
                 domain=TEST_DOMAIN,
                 log_level=logging.INFO,
                 request_body=request_body,
                 request_error=self.error_message,
-                request_headers={
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json'
-                },
-                request_method='POST',
-                request_params=None,
+                request_headers=self.request_headers,
+                request_method=self.request_method,
+                request_params=request_params,
                 request_url='http://localhost:9080/api/person/',
                 response_body=self.content_json,
                 response_status=self.status_code,
@@ -158,7 +60,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri)
-            self.assert_create_called_with_request_body(create_mock, None)
+            self.assert_create_called_with_request_body_and_params(create_mock, None)
 
     def test_post_with_data_kwarg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -166,7 +68,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, data=self.data)
-            self.assert_create_called_with_request_body(create_mock, self.data)
+            self.assert_create_called_with_request_body_and_params(create_mock, self.data)
 
     def test_post_with_json_kwarg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -174,7 +76,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, json=self.json_data)
-            self.assert_create_called_with_request_body(create_mock, self.json_data)
+            self.assert_create_called_with_request_body_and_params(create_mock, self.json_data)
 
     def test_post_with_data_arg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -182,7 +84,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, self.data)
-            self.assert_create_called_with_request_body(create_mock, self.data)
+            self.assert_create_called_with_request_body_and_params(create_mock, self.data)
 
     def test_post_with_json_arg(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -190,7 +92,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, None, self.json_data)
-            self.assert_create_called_with_request_body(create_mock, self.json_data)
+            self.assert_create_called_with_request_body_and_params(create_mock, self.json_data)
 
     def test_post_with_data_and_json(self):
         with patch.object(requests.Session, 'request') as request_mock, \
@@ -198,4 +100,39 @@ class UnpackRequestArgsTests(SimpleTestCase):
             request_mock.return_value = self.response_mock
 
             self.requests.post(self.uri, self.data, self.json_data)
-            self.assert_create_called_with_request_body(create_mock, self.data)
+            self.assert_create_called_with_request_body_and_params(create_mock, self.data)
+
+    def test_get_with_params(self):
+        content = {'code': TEST_API_USERNAME}
+        self.content_json = json.dumps(content)
+        self.request_method = 'GET'
+        request_params = {'v': 'full'}
+        self.request_headers = {'Accept': 'application/json'}
+        self.status_code = 200
+        self.response_mock.status_code = self.status_code
+        self.response_mock.content = self.content_json
+        self.response_mock.json.return_value = content
+
+        with patch.object(requests.Session, 'request') as request_mock, \
+                patch.object(RequestLog.objects, 'create') as create_mock:
+            request_mock.return_value = self.response_mock
+
+            self.requests.get(self.uri, request_params)
+            self.assert_create_called_with_request_body_and_params(create_mock, None, request_params)
+
+    def test_delete(self):
+        content = {'status': 'Deleted'}
+        self.content_json = json.dumps(content)
+        self.request_method = 'DELETE'
+        self.request_headers = {'Accept': 'application/json'}
+        self.status_code = 200
+        self.response_mock.status_code = self.status_code
+        self.response_mock.content = self.content_json
+        self.response_mock.json.return_value = content
+
+        with patch.object(requests.Session, 'request') as request_mock, \
+                patch.object(RequestLog.objects, 'create') as create_mock:
+            request_mock.return_value = self.response_mock
+
+            self.requests.delete(self.uri)
+            self.assert_create_called_with_request_body_and_params(create_mock, None)

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -37,7 +37,7 @@ class RequestLogTests(SimpleTestCase):
             response_mock.json.return_value = content
             request_mock.return_value = response_mock
 
-            self.requests.get(uri)
+            self.requests.get(uri, {'code': TEST_API_USERNAME})
 
             log_mock.assert_called_with(
                 logging.INFO,
@@ -47,6 +47,7 @@ class RequestLogTests(SimpleTestCase):
                 content_json,
                 'GET',
                 TEST_API_URL + uri,
+                {'code': TEST_API_USERNAME},
                 allow_redirects=True,
                 auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
                 headers={'Accept': 'application/json'},


### PR DESCRIPTION
I removed some duplication from `UnpackRequestArgsTests`, and moved the GET and DELETE tests from the more verbose test case to the less verbose test case. (The first test case wasn't as useful as the second test case anyway. I'm less interested in how `log()` gets called and more interested in what it does.)