### PR TITLE
Prepare fixtures for db migration

### DIFF
--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -29,15 +29,15 @@ def get_fixture_data_types_in_domain(domain):
     ))
 
 
-@quickcache(['domain', 'data_type_ids'], timeout=60 * 60, memoize_timeout=60, skip_arg='bypass_cache')
-def get_fixture_items_for_data_types(domain, data_type_ids, bypass_cache=False):
+@quickcache(['domain', 'data_type_id'], timeout=60 * 60, memoize_timeout=60, skip_arg='bypass_cache')
+def get_fixture_items_for_data_type(domain, data_type_id, bypass_cache=False):
     from corehq.apps.fixtures.models import FixtureDataItem
     return list(FixtureDataItem.view(
         'fixtures/data_items_by_domain_type',
-        keys=[[domain, id] for id in data_type_ids],
+        startkey=[domain, data_type_id],
+        endkey=[domain, data_type_id, {}],
         reduce=False,
         include_docs=True,
-        descending=True
     ))
 
 

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from collections import defaultdict
+from operator import attrgetter
 from xml.etree import cElementTree as ElementTree
 from io import BytesIO
 
@@ -116,46 +117,40 @@ class ItemListsProvider(FixtureProvider):
         return global_items
 
     def _get_global_items(self, global_types, domain, bypass_cache):
-        items_by_type = defaultdict(list)
-        for item in FixtureDataItem.by_data_types(domain, global_types, bypass_cache):
-            data_type = global_types[item.data_type_id]
-            self._set_cached_type(item, data_type)
-            items_by_type[data_type].append(item)
-        return self._get_fixtures(global_types, items_by_type, GLOBAL_USER_ID)
+        def get_items_by_type(data_type):
+            items = []
+            for item in FixtureDataItem.by_data_type(domain, data_type, bypass_cache):
+                self._set_cached_type(item, data_type)
+                items.append(item)
+            return sorted(items, key=attrgetter('sort_key'))
+
+        return self._get_fixtures(global_types, get_items_by_type, GLOBAL_USER_ID)
 
     def get_user_items(self, user_types, restore_user):
         items_by_type = defaultdict(list)
         for item in restore_user.get_fixture_data_items():
-            try:
-                data_type = user_types[item.data_type_id]
-            except KeyError:
-                continue
-            self._set_cached_type(item, data_type)
-            items_by_type[data_type].append(item)
-        return self._get_fixtures(user_types, items_by_type, restore_user.user_id)
+            data_type = user_types.get(item.data_type_id)
+            if data_type:
+                self._set_cached_type(item, data_type)
+                items_by_type[data_type].append(item)
+
+        def get_items_by_type(data_type):
+            return sorted(items_by_type.get(data_type, []),
+                          key=attrgetter('sort_key'))
+
+        return self._get_fixtures(user_types, get_items_by_type, restore_user.user_id)
 
     def _set_cached_type(self, item, data_type):
         # set the cached version used by the object so that it doesn't
         # have to do another db trip later
         item._data_type = data_type
 
-    def _get_fixtures(self, data_types, items_by_type, user_id):
-        def tag(item):
-            data_type, items = item
-            return data_type.tag
-
-        def sort_key(item):
-            return item.sort_key
-
-        items_by_type = dict(items_by_type)
-        for data_type in data_types.values():
-            if data_type not in items_by_type:
-                items_by_type[data_type] = []
+    def _get_fixtures(self, data_types, get_items_by_type, user_id):
         fixtures = []
-        for data_type, items in sorted(list(items_by_type.items()), key=tag):
+        for data_type in sorted(data_types.values(), key=lambda data_type: data_type.tag):
             if data_type.is_indexed:
                 fixtures.append(self._get_schema_element(data_type))
-            items = sorted(items, key=sort_key)
+            items = get_items_by_type(data_type)
             fixtures.append(self._get_fixture_element(data_type, user_id, items))
         return fixtures
 

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -25,7 +25,7 @@ from dimagi.utils.couch.bulk import CouchTransaction
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.fixtures.dbaccessors import (
     get_fixture_data_types_in_domain,
-    get_fixture_items_for_data_types,
+    get_fixture_items_for_data_type,
     get_owner_ids_by_type,
 )
 from corehq.apps.fixtures.exceptions import (
@@ -438,12 +438,7 @@ class FixtureDataItem(Document):
 
     @classmethod
     def by_data_type(cls, domain, data_type, bypass_cache=False):
-        return cls.by_data_types(domain, [data_type], bypass_cache)
-
-    @classmethod
-    def by_data_types(cls, domain, data_types, bypass_cache=False):
-        data_type_ids = set(_id_from_doc(d) for d in data_types)
-        return get_fixture_items_for_data_types(domain, data_type_ids, bypass_cache)
+        return get_fixture_items_for_data_type(domain, _id_from_doc(data_type), bypass_cache)
 
     @classmethod
     def by_domain(cls, domain):

--- a/corehq/apps/fixtures/upload/run_upload.py
+++ b/corehq/apps/fixtures/upload/run_upload.py
@@ -242,15 +242,9 @@ def clear_fixture_quickcache(domain, data_types):
         type_ids.add(data_type.get_id)
         data_type.clear_caches()
 
-    from corehq.apps.fixtures.dbaccessors import get_fixture_items_for_data_types
-    get_fixture_items_for_data_types.clear(domain, type_ids)
-
-    # We always call get_fixture_items_for_data_types with a list of all global
-    # type ids when doing a restore (i.e. the cache key is a set of all global
-    # type ids) So when updating just a subset of types, we still need to clear
-    # the cache key that contains all types.
-    global_type_ids = {dt.get_id for dt in FixtureDataType.by_domain(domain) if dt.is_global}
-    get_fixture_items_for_data_types.clear(domain, global_type_ids)
+    from corehq.apps.fixtures.dbaccessors import get_fixture_items_for_data_type
+    for type_id in type_ids:
+        get_fixture_items_for_data_type.clear(domain, type_id)
 
 
 def _create_data_type(domain, table_def, replace, transaction):


### PR DESCRIPTION
This is pulled from https://github.com/dimagi/commcare-hq/pull/24483
It should be compatible with both versions of the view, so I'm going to deploy it before deploying the view changes, to avoid temporarily breaking the view.