### PR TITLE
Bulk conditional alerts: custom schedules

### DIFF
--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -432,9 +432,9 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
         self._assertPatternIn(r"Could not update rule with id \d+ in 'translated' sheet: "
-                              "expected 2 .* but found 3.", msgs)
+                              r"expected 2 .* but found 3.", msgs)
         self._assertPatternIn(r"Could not update rule with id \d+ in 'not translated' sheet: "
-                              "expected 2 .* but found 1.", msgs)
+                              r"expected 2 .* but found 1.", msgs)
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
     def test_upload_custom_schedule_name_mismatch(self, language_list_patch):
@@ -454,7 +454,7 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'not translated' sheet: "
-                              "Rule name must be the same", msgs)
+                              r"Rule name must be the same", msgs)
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
     def test_upload_blank_content(self, language_list_patch):
@@ -477,9 +477,9 @@ class TestBulkConditionalAlerts(TestCase):
 
         self.assertEqual(len(msgs), 5)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'translated' sheet: "
-                              "Missing content for en", msgs)
+                              r"Missing content for en", msgs)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'translated' sheet: "
-                              "Missing content for en, es", msgs)
+                              r"Missing content for en, es", msgs)
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'not translated' sheet: Missing content", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -453,8 +453,8 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertEqual(len(msgs), 3)
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
-        self._assertPatternIn(r"Could not update rule with id \d+ in 'not translated' sheet: "
-                               "rule name must be the same in all rows.", msgs)
+        self._assertPatternIn(r"Error updating rule with id \d+ in 'not translated' sheet: "
+                               "Rule name must be the same", msgs)
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
     def test_upload_blank_content(self, language_list_patch):
@@ -476,10 +476,12 @@ class TestBulkConditionalAlerts(TestCase):
         msgs = self._upload(data, headers)
 
         self.assertEqual(len(msgs), 5)
-        self._assertPatternIn(r"Error updating row 2 in 'translated' sheet, .*: Missing content for en", msgs)
-        self._assertPatternIn(r"Error updating row 3 in 'translated' sheet, .*: Missing content for en, es", msgs)
+        self._assertPatternIn(r"Error updating rule with id \d+ in 'translated' sheet: "
+                               "Missing content for en", msgs)
+        self._assertPatternIn(r"Error updating rule with id \d+ in 'translated' sheet: "
+                               "Missing content for en, es", msgs)
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
-        self._assertPatternIn(r"Error updating row 2 in 'not translated' sheet, .*: Missing content", msgs)
+        self._assertPatternIn(r"Error updating rule with id \d+ in 'not translated' sheet: Missing content", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -151,6 +151,16 @@ class TestBulkConditionalAlerts(TestCase):
             self.assertEqual(event1.day, event2.day)
             self.assertEqual(event1.get_scheduling_info(), event2.get_scheduling_info())
 
+    def _assertContent(self, schedule, message):
+        for event in schedule.memoized_events:
+            self.assertEqual(event.content.message, message)
+
+    def _assertCustomContent(self, schedule, messages):
+        events = schedule.memoized_events
+        self.assertEqual(len(messages), len(events))
+        for i, event in enumerate(events):
+            self.assertEqual(messages[i], events[i].content.message)
+
     def _add_immediate_rule(self, content):
         schedule = AlertSchedule.create_simple_alert(self.domain, content)
         return self._add_rule(alert_schedule_id=schedule.schedule_id)
@@ -252,7 +262,13 @@ class TestBulkConditionalAlerts(TestCase):
                                        [['test', 'Just Like This Train'],
                                         ['test', 'Free Man in Paris']])
 
-    def _upload(self, headers, data):
+    def _upload(self, data, headers=None):
+        if headers is None:
+            headers = (
+                ("translated", ("id", "name", "message_en", "message_es")),
+                ("not translated", ("id", "name", "message")),
+            )
+
         file = BytesIO()
         export_raw(headers, data, file, format=Format.XLS_2007)
 
@@ -266,10 +282,6 @@ class TestBulkConditionalAlerts(TestCase):
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
     def test_upload(self, language_list_patch):
         language_list_patch.return_value = self.langs
-        headers = (
-            ("translated", ("id", "name", "message_en", "message_es")),
-            ("not translated", ("id", "name", "message")),
-        )
         data = (
             ("translated", (
                 (self._get_rule(self.DAILY_RULE).id, 'test daily', 'Rustier', 'Más Oxidado'),
@@ -281,10 +293,8 @@ class TestBulkConditionalAlerts(TestCase):
             ("not translated", (
                 (self._get_rule(self.UNTRANSLATED_IMMEDIATE_RULE).id, 'test untranslated', 'Roberta'),
                 (self._get_rule(self.IMMEDIATE_RULE).id, 'test immediate', 'Bicycle on a Hill'),
-                (self._get_rule(self.CUSTOM_DAILY_RULE).id, 'test', 'unsupported', 'Just Like This Train'),
-                (self._get_rule(self.CUSTOM_DAILY_RULE).id, 'test', 'unsupported', 'Free Man in Paris'),
-                (self._get_rule(self.LOCKED_RULE).id, 'test locked', 'nope', 'nope'),
-                (None, 'missing id', 'is', 'bad'),
+                (self._get_rule(self.LOCKED_RULE).id, 'test locked', 'nope'),
+                (None, 'missing id', 'is bad'),
                 (self._get_rule(self.MONTHLY_RULE).id, 'test monthly change sheet', 'The Other Side Now'),
             )),
         )
@@ -294,17 +304,14 @@ class TestBulkConditionalAlerts(TestCase):
         old_schedules = {test_case: self._get_rule(test_case).get_messaging_rule_schedule()
                          for test_case in test_cases}
 
-        msgs = self._upload(headers, data)
+        msgs = self._upload(data)
 
-        self.assertEqual(len(msgs), 8)
+        self.assertEqual(len(msgs), 6)
         self._assertPatternIn(r"Row 4 in 'translated' sheet, with rule id \d+, does not use SMS content", msgs)
         self._assertPatternIn(r"Could not find rule for row 5 in 'translated' sheet, with id \d+", msgs)
         self.assertIn("Updated 3 rule(s) in 'translated' sheet", msgs)
-        self._assertPatternIn(r"Row 4 in 'not translated' sheet.* rule id \d+, uses a custom schedule", msgs)
-        self._assertPatternIn(r"Row 5 in 'not translated' sheet.* rule id \d+, uses a custom schedule", msgs)
-        self._assertPatternIn(r"Row 6 in 'not translated' sheet.* rule id \d+, .*currently processing", msgs)
-        self.assertIn(r"Row 7 in 'not translated' sheet is missing an id.", msgs)
-        self.assertIn("Updated 3 rule(s) in 'not translated' sheet", msgs)
+        self._assertPatternIn(r"Row 4 in 'not translated' sheet.* rule id \d+, .*currently processing", msgs)
+        self.assertIn(r"Row 5 in 'not translated' sheet is missing an id.", msgs)
 
         untranslated_immediate_rule = self._get_rule(self.UNTRANSLATED_IMMEDIATE_RULE)
         self.assertEqual(untranslated_immediate_rule.name, 'test untranslated')
@@ -341,8 +348,7 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertEqual(daily_rule.name, 'test daily')
         daily_schedule = daily_rule.get_messaging_rule_schedule()
         self._assertTimedScheduleEventsEqual(daily_schedule, old_schedules[self.DAILY_RULE])
-        daily_content = daily_schedule.memoized_events[0].content
-        self.assertEqual(daily_content.message, {
+        self._assertContent(daily_schedule, {
             'en': 'Rustier',
             'es': 'Más Oxidado',
         })
@@ -350,8 +356,7 @@ class TestBulkConditionalAlerts(TestCase):
         weekly_rule = self._get_rule(self.WEEKLY_RULE)
         weekly_schedule = weekly_rule.get_messaging_rule_schedule()
         self._assertTimedScheduleEventsEqual(weekly_schedule, old_schedules[self.WEEKLY_RULE])
-        weekly_content = weekly_rule.get_messaging_rule_schedule().memoized_events[0].content
-        self.assertEqual(weekly_content.message, {
+        self._assertContent(weekly_schedule, {
             'en': 'It\'s On Time',
             'es': 'Está a Tiempo',
         })
@@ -359,10 +364,97 @@ class TestBulkConditionalAlerts(TestCase):
         monthly_rule = self._get_rule(self.MONTHLY_RULE)
         monthly_schedule = monthly_rule.get_messaging_rule_schedule()
         self._assertTimedScheduleEventsEqual(monthly_schedule, old_schedules[self.MONTHLY_RULE])
-        monthly_content = monthly_rule.get_messaging_rule_schedule().memoized_events[0].content
-        self.assertEqual(monthly_content.message, {
+        self._assertContent(monthly_schedule, {
             '*': 'The Other Side Now',
         })
+
+    @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
+    def test_upload_custom_schedule(self, language_list_patch):
+        language_list_patch.return_value = self.langs
+        data = (
+            ("translated", (
+                (self._get_rule(self.CUSTOM_IMMEDIATE_RULE).id, 'test', 'Plastic Bag', 'Bolsa de Plastico'),
+                (self._get_rule(self.CUSTOM_IMMEDIATE_RULE).id, 'test', 'A Correction', 'Una Corrección'),
+            )),
+            ("not translated", (
+                (self._get_rule(self.CUSTOM_DAILY_RULE).id, 'test', 'Not Like This Train'),
+                (self._get_rule(self.CUSTOM_DAILY_RULE).id, 'test', 'Free Man in Nice'),
+            )),
+        )
+
+        test_cases = (self.CUSTOM_IMMEDIATE_RULE, self.CUSTOM_DAILY_RULE)
+        old_schedules = {test_case: self._get_rule(test_case).get_messaging_rule_schedule()
+                         for test_case in test_cases}
+
+        msgs = self._upload(data)
+
+        self.assertEqual(len(msgs), 2)
+        self.assertIn("Updated 1 rule(s) in 'translated' sheet", msgs)
+        self.assertIn("Updated 1 rule(s) in 'not translated' sheet", msgs)
+
+        custom_daily_rule = self._get_rule(self.CUSTOM_DAILY_RULE)
+        custom_daily_schedule = custom_daily_rule.get_messaging_rule_schedule()
+        self._assertTimedScheduleEventsEqual(custom_daily_schedule, old_schedules[self.CUSTOM_DAILY_RULE])
+        self._assertCustomContent(custom_daily_schedule, [
+            {'*': 'Not Like This Train'},
+            {'*': 'Free Man in Nice'},
+        ])
+
+        custom_immediate_rule = self._get_rule(self.CUSTOM_IMMEDIATE_RULE)
+        custom_immediate_schedule = custom_immediate_rule.get_messaging_rule_schedule()
+        self._assertAlertScheduleEventsEqual(custom_immediate_schedule, old_schedules[self.CUSTOM_IMMEDIATE_RULE])
+        self._assertCustomContent(custom_immediate_schedule, [{
+            'en': 'Plastic Bag',
+            'es': 'Bolsa de Plastico',
+        }, {
+            'en': 'A Correction',
+            'es': 'Una Corrección',
+        }])
+
+    @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
+    def test_upload_custom_schedule_message_count_mismatch(self, language_list_patch):
+        language_list_patch.return_value = self.langs
+
+        data = (
+            ("translated", (
+                (self._get_rule(self.CUSTOM_IMMEDIATE_RULE).id, 'test', 'Plastic Bag', 'Bolsa de Plastico'),
+                (self._get_rule(self.CUSTOM_IMMEDIATE_RULE).id, 'test', 'Cloth Bag', 'Bolsa de Tela'),
+                (self._get_rule(self.CUSTOM_IMMEDIATE_RULE).id, 'test', 'Fishnet Bag', 'Bolsa de Red'),
+            )),
+            ("not translated", (
+                (self._get_rule(self.CUSTOM_DAILY_RULE).id, 'test', 'Like That Other Train'),
+            )),
+        )
+
+        msgs = self._upload(data)
+
+        self.assertEqual(len(msgs), 4)
+        self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
+        self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
+        self._assertPatternIn(r"Could not update rule with id \d+ in 'translated' sheet: "
+                               "expected 2 .* but found 3.", msgs)
+        self._assertPatternIn(r"Could not update rule with id \d+ in 'not translated' sheet: "
+                               "expected 2 .* but found 1.", msgs)
+
+    @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
+    def test_upload_custom_schedule_name_mismatch(self, language_list_patch):
+        language_list_patch.return_value = self.langs
+
+        data = (
+            ("translated", ()),
+            ("not translated", (
+                (self._get_rule(self.CUSTOM_DAILY_RULE).id, 'test', 'Like That Other Train'),
+                (self._get_rule(self.CUSTOM_DAILY_RULE).id, 'test different name', 'Free Man in Nice'),
+            )),
+        )
+
+        msgs = self._upload(data)
+
+        self.assertEqual(len(msgs), 3)
+        self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
+        self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
+        self._assertPatternIn(r"Could not update rule with id \d+ in 'not translated' sheet: "
+                               "rule name must be the same in all rows.", msgs)
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
     def test_upload_blank_content(self, language_list_patch):
@@ -381,7 +473,7 @@ class TestBulkConditionalAlerts(TestCase):
             )),
         )
 
-        msgs = self._upload(headers, data)
+        msgs = self._upload(data, headers)
 
         self.assertEqual(len(msgs), 5)
         self._assertPatternIn(r"Error updating row 2 in 'translated' sheet, .*: Missing content for en", msgs)
@@ -406,7 +498,7 @@ class TestBulkConditionalAlerts(TestCase):
             )),
         )
 
-        msgs = self._upload(headers, data)
+        msgs = self._upload(data, headers)
 
         self.assertEqual(len(msgs), 2)
         self.assertIn("Updated 1 rule(s) in 'translated' sheet", msgs)
@@ -445,7 +537,7 @@ class TestBulkConditionalAlerts(TestCase):
             )),
         )
 
-        msgs = self._upload(headers, data)
+        msgs = self._upload(data, headers)
 
         self.assertEqual(len(msgs), 2)
         self.assertIn("The 'translated' sheet is missing an id column. This sheet has been skipped.", msgs)

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -432,9 +432,9 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
         self._assertPatternIn(r"Could not update rule with id \d+ in 'translated' sheet: "
-                               "expected 2 .* but found 3.", msgs)
+                              "expected 2 .* but found 3.", msgs)
         self._assertPatternIn(r"Could not update rule with id \d+ in 'not translated' sheet: "
-                               "expected 2 .* but found 1.", msgs)
+                              "expected 2 .* but found 1.", msgs)
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
     def test_upload_custom_schedule_name_mismatch(self, language_list_patch):
@@ -454,7 +454,7 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'not translated' sheet: "
-                               "Rule name must be the same", msgs)
+                              "Rule name must be the same", msgs)
 
     @patch('corehq.messaging.scheduling.view_helpers.get_language_list')
     def test_upload_blank_content(self, language_list_patch):
@@ -477,9 +477,9 @@ class TestBulkConditionalAlerts(TestCase):
 
         self.assertEqual(len(msgs), 5)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'translated' sheet: "
-                               "Missing content for en", msgs)
+                              "Missing content for en", msgs)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'translated' sheet: "
-                               "Missing content for en, es", msgs)
+                              "Missing content for en, es", msgs)
         self.assertIn("Updated 0 rule(s) in 'translated' sheet", msgs)
         self._assertPatternIn(r"Error updating rule with id \d+ in 'not translated' sheet: Missing content", msgs)
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -263,7 +263,7 @@ class ConditionalAlertUploader(object):
     def save_custom_immediate_schedule(self, schedule, messages):
         AlertSchedule.assert_is(schedule)
         assert len(messages) == len(schedule.memoized_events), \
-               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events))
+            "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events))
 
         event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_alert(event_and_content_objects, extra_options=schedule.get_extra_scheduling_options())
@@ -271,7 +271,7 @@ class ConditionalAlertUploader(object):
     def save_custom_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
         assert len(messages) == len(schedule.memoized_events), \
-               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events))
+            "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events))
 
         event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_daily_schedule(

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -161,10 +161,10 @@ class ConditionalAlertUploader(object):
 
             if send_frequency in (ScheduleForm.SEND_CUSTOM_DAILY, ScheduleForm.SEND_CUSTOM_IMMEDIATE):
                 # Check that user provided one row for each event in the custom schedule
-                events = rule.get_messaging_rule_schedule().memoized_events
-                expected = len([e for e in events if self.event_is_relevant(e)])
+                all_events = rule.get_messaging_rule_schedule().memoized_events
+                expected = len([e for e in all_events if self.event_is_relevant(e)])
                 actual = len(rows)
-                if expected != actual:
+                if expected != actual and actual != len(all_events):
                     self.msgs.append((messages.error, _("Could not update rule with id {id} in '{sheet_name}' "
                                                         "sheet: expected {expected} row(s) but found "
                                                         "{actual}.").format(id=rule.id, sheet_name=self.sheet_name,

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -264,14 +264,14 @@ class ConditionalAlertUploader(object):
         AlertSchedule.assert_is(schedule)
         assert(len(messages) == len(schedule.memoized_events))
 
-        event_and_content_objects = zip(schedule.memoized_events, [SMSContent(message=m) for m in messages])
+        event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_alert(event_and_content_objects, extra_options=schedule.get_extra_scheduling_options())
 
     def save_custom_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
         assert(len(messages) == len(schedule.memoized_events))
 
-        event_and_content_objects = zip(schedule.memoized_events, [SMSContent(message=m) for m in messages])
+        event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_daily_schedule(
             event_and_content_objects,
             total_iterations=schedule.total_iterations,
@@ -288,7 +288,7 @@ class TranslatedConditionalAlertUploader(ConditionalAlertUploader):
         dirty = super(TranslatedConditionalAlertUploader, self).update_rule(rule, rows)
 
         if is_custom:
-            events_and_rows = zip(rule.get_messaging_rule_schedule().memoized_events, rows)
+            events_and_rows = list(zip(rule.get_messaging_rule_schedule().memoized_events, rows))
         else:
             events_and_rows = [(rule.get_messaging_rule_schedule().memoized_events[0], rows[0])]
 
@@ -322,8 +322,8 @@ class UntranslatedConditionalAlertUploader(ConditionalAlertUploader):
             return dirty
 
         if is_custom:
-            events_and_messages = zip(rule.get_messaging_rule_schedule().memoized_events,
-                                      [row['message'] for row in rows])
+            events_and_messages = list(zip(rule.get_messaging_rule_schedule().memoized_events,
+                                           [row['message'] for row in rows]))
         else:
             events_and_messages = [(rule.get_messaging_rule_schedule().memoized_events[0],
                                     rows[0]['message'])]

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -218,11 +218,15 @@ class ConditionalAlertUploader(object):
 
     def save_immediate_schedule(self, schedule, messages):
         AlertSchedule.assert_is(schedule)
+        assert(len(messages) == 1)
+
         schedule.set_simple_alert(SMSContent(message=messages[0]),
                                   extra_options=schedule.get_extra_scheduling_options())
 
     def save_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
+        assert(len(messages) == 1)
+
         schedule.set_simple_daily_schedule(
             schedule.memoized_events[0],
             SMSContent(message=messages[0]),
@@ -234,6 +238,8 @@ class ConditionalAlertUploader(object):
 
     def save_weekly_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
+        assert(len(messages) == 1)
+
         schedule.set_simple_weekly_schedule(
             schedule.memoized_events[0],
             SMSContent(message=messages[0]),
@@ -245,11 +251,13 @@ class ConditionalAlertUploader(object):
         )
 
     def save_monthly_schedule(self, schedule, messages):
+        TimedSchedule.assert_is(schedule)
+        assert(len(messages) == 1)
+
         # Negative numbers are used for monthly schedules.
         # See comment on TimedSchedule.repeat_every
         repeat_every = schedule.repeat_every * -1
 
-        TimedSchedule.assert_is(schedule)
         schedule.set_simple_monthly_schedule(
             schedule.memoized_events[0],
             [e.day for e in schedule.memoized_events],
@@ -260,13 +268,17 @@ class ConditionalAlertUploader(object):
         )
 
     def save_custom_immediate_schedule(self, schedule, messages):
-        event_and_content_objects = zip(schedule.memoized_events, [SMSContent(message=m) for m in messages])
         AlertSchedule.assert_is(schedule)
+        assert(len(messages) == len(schedule.memoized_events))
+
+        event_and_content_objects = zip(schedule.memoized_events, [SMSContent(message=m) for m in messages])
         schedule.set_custom_alert(event_and_content_objects, extra_options=schedule.get_extra_scheduling_options())
 
     def save_custom_daily_schedule(self, schedule, messages):
-        event_and_content_objects = zip(schedule.memoized_events, [SMSContent(message=m) for m in messages])
         TimedSchedule.assert_is(schedule)
+        assert(len(messages) == len(schedule.memoized_events))
+
+        event_and_content_objects = zip(schedule.memoized_events, [SMSContent(message=m) for m in messages])
         schedule.set_custom_daily_schedule(
             event_and_content_objects,
             total_iterations=schedule.total_iterations,

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -211,14 +211,14 @@ class ConditionalAlertUploader(object):
 
     def save_immediate_schedule(self, schedule, messages):
         AlertSchedule.assert_is(schedule)
-        assert len(messages) == 1, "Immediate schedule expected 1 message, got " + six.text_type(len(messages))
+        assert len(messages) == 1, "Immediate schedule expected 1 message, got %s" % len(messages)
 
         schedule.set_simple_alert(SMSContent(message=messages[0]),
                                   extra_options=schedule.get_extra_scheduling_options())
 
     def save_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert len(messages) == 1, "Daily schedule expected 1 message, got " + six.text_type(len(messages))
+        assert len(messages) == 1, "Daily schedule expected 1 message, got %s" % len(messages)
 
         schedule.set_simple_daily_schedule(
             schedule.memoized_events[0],
@@ -231,7 +231,7 @@ class ConditionalAlertUploader(object):
 
     def save_weekly_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert len(messages) == 1, "Weekly schedule expected 1 message, got " + six.text_type(len(messages))
+        assert len(messages) == 1, "Weekly schedule expected 1 message, got %s" % len(messages)
 
         schedule.set_simple_weekly_schedule(
             schedule.memoized_events[0],
@@ -245,7 +245,7 @@ class ConditionalAlertUploader(object):
 
     def save_monthly_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert len(messages) == 1, "Monthly schedule expected 1 message, got " + six.text_type(len(messages))
+        assert len(messages) == 1, "Monthly schedule expected 1 message, got %s" % len(messages)
 
         # Negative numbers are used for monthly schedules.
         # See comment on TimedSchedule.repeat_every

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -211,14 +211,14 @@ class ConditionalAlertUploader(object):
 
     def save_immediate_schedule(self, schedule, messages):
         AlertSchedule.assert_is(schedule)
-        assert(len(messages) == 1)
+        assert(len(messages) == 1, "Immediate schedule expected 1 message, got " + six.text_type(len(messages)))
 
         schedule.set_simple_alert(SMSContent(message=messages[0]),
                                   extra_options=schedule.get_extra_scheduling_options())
 
     def save_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == 1)
+        assert(len(messages) == 1, "Daily schedule expected 1 message, got " + six.text_type(len(messages)))
 
         schedule.set_simple_daily_schedule(
             schedule.memoized_events[0],
@@ -231,7 +231,7 @@ class ConditionalAlertUploader(object):
 
     def save_weekly_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == 1)
+        assert(len(messages) == 1, "Weekly schedule expected 1 message, got " + six.text_type(len(messages)))
 
         schedule.set_simple_weekly_schedule(
             schedule.memoized_events[0],
@@ -245,7 +245,7 @@ class ConditionalAlertUploader(object):
 
     def save_monthly_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == 1)
+        assert(len(messages) == 1, "Monthly schedule expected 1 message, got " + six.text_type(len(messages)))
 
         # Negative numbers are used for monthly schedules.
         # See comment on TimedSchedule.repeat_every
@@ -262,14 +262,16 @@ class ConditionalAlertUploader(object):
 
     def save_custom_immediate_schedule(self, schedule, messages):
         AlertSchedule.assert_is(schedule)
-        assert(len(messages) == len(schedule.memoized_events))
+        assert(len(messages) == len(schedule.memoized_events),
+               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events)))
 
         event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_alert(event_and_content_objects, extra_options=schedule.get_extra_scheduling_options())
 
     def save_custom_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == len(schedule.memoized_events))
+        assert(len(messages) == len(schedule.memoized_events),
+               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events)))
 
         event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_daily_schedule(

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -345,9 +345,11 @@ class TranslatedConditionalAlertUploader(ConditionalAlertUploader):
 
     @classmethod
     def event_is_relevant(cls, event):
-        relevant = super(TranslatedConditionalAlertUploader, cls).event_is_relevant(event)
+        if not super(TranslatedConditionalAlertUploader, cls).event_is_relevant(event):
+            return False
+
         message = event.content.message
-        return relevant and len(message) and '*' not in message
+        return len(message) and '*' not in message
 
     def check_for_missing_content(self, messages):
         missing = [lang for message in messages for lang, value in message.items() if not message[lang]]
@@ -368,9 +370,11 @@ class UntranslatedConditionalAlertUploader(ConditionalAlertUploader):
 
     @classmethod
     def event_is_relevant(cls, event):
-        relevant = super(UntranslatedConditionalAlertUploader, cls).event_is_relevant(event)
+        if not super(UntranslatedConditionalAlertUploader, cls).event_is_relevant(event):
+            return False
+
         message = event.content.message
-        return relevant and (not len(message) or '*' in message)
+        return (not len(message) or '*' in message)
 
     def check_for_missing_content(self, messages):
         missing = [m for m in messages if not m.get('*', '')]

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -211,14 +211,14 @@ class ConditionalAlertUploader(object):
 
     def save_immediate_schedule(self, schedule, messages):
         AlertSchedule.assert_is(schedule)
-        assert(len(messages) == 1, "Immediate schedule expected 1 message, got " + six.text_type(len(messages)))
+        assert len(messages) == 1, "Immediate schedule expected 1 message, got " + six.text_type(len(messages))
 
         schedule.set_simple_alert(SMSContent(message=messages[0]),
                                   extra_options=schedule.get_extra_scheduling_options())
 
     def save_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == 1, "Daily schedule expected 1 message, got " + six.text_type(len(messages)))
+        assert len(messages) == 1, "Daily schedule expected 1 message, got " + six.text_type(len(messages))
 
         schedule.set_simple_daily_schedule(
             schedule.memoized_events[0],
@@ -231,7 +231,7 @@ class ConditionalAlertUploader(object):
 
     def save_weekly_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == 1, "Weekly schedule expected 1 message, got " + six.text_type(len(messages)))
+        assert len(messages) == 1, "Weekly schedule expected 1 message, got " + six.text_type(len(messages))
 
         schedule.set_simple_weekly_schedule(
             schedule.memoized_events[0],
@@ -245,7 +245,7 @@ class ConditionalAlertUploader(object):
 
     def save_monthly_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == 1, "Monthly schedule expected 1 message, got " + six.text_type(len(messages)))
+        assert len(messages) == 1, "Monthly schedule expected 1 message, got " + six.text_type(len(messages))
 
         # Negative numbers are used for monthly schedules.
         # See comment on TimedSchedule.repeat_every
@@ -262,16 +262,16 @@ class ConditionalAlertUploader(object):
 
     def save_custom_immediate_schedule(self, schedule, messages):
         AlertSchedule.assert_is(schedule)
-        assert(len(messages) == len(schedule.memoized_events),
-               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events)))
+        assert len(messages) == len(schedule.memoized_events), \
+               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events))
 
         event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_alert(event_and_content_objects, extra_options=schedule.get_extra_scheduling_options())
 
     def save_custom_daily_schedule(self, schedule, messages):
         TimedSchedule.assert_is(schedule)
-        assert(len(messages) == len(schedule.memoized_events),
-               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events)))
+        assert len(messages) == len(schedule.memoized_events), \
+               "Custom schedule expected {} messages, got {}".format(len(messages), len(schedule.memoized_events))
 
         event_and_content_objects = list(zip(schedule.memoized_events, [SMSContent(message=m) for m in messages]))
         schedule.set_custom_daily_schedule(


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-327

Followup for https://github.com/dimagi/commcare-hq/pull/24396

See [docs](https://confluence.dimagi.com/display/ccinternal/Allow+bulk+download+and+upload+of+conditional+alerts) for screenshots and description of feature. This PR adds support for rules with custom schedules.

Review by commit.

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-521)

Feature flag: Allow bulk download and upload of conditional alerts