### PR TITLE
Fixed select2 js error on champ reports

### DIFF
--- a/custom/champ/static/champ/js/knockout/select2-binding.js
+++ b/custom/champ/static/champ/js/knockout/select2-binding.js
@@ -1,5 +1,3 @@
-/* global ko */
-
 ko.bindingHandlers.select2 = {
     init: function (element, valueAccessor) {
         $(element).select2(valueAccessor());
@@ -11,7 +9,7 @@ ko.bindingHandlers.select2 = {
         var allBindings = allBindingsAccessor(),
             value = ko.utils.unwrapObservable(allBindings.value || allBindings.selectedOptions);
         if (value) {
-            $(element).select2('val', value).trigger('change');
+            $(element).val(value).trigger('change');
         } else {
             $(element).select2();
         }


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/24433

New select2 does support `$(...).select2('val', value)` just like the old one, except it now returns undefined instead of the jQuery object. Updated to use the more semantic `val`.

These reports haven't been accessed since April according to Google analytics.