### PR TITLE
Fixed select2 not updating other filters properly on up-nrhm reports

### DIFF
--- a/custom/up_nrhm/templates/up_nrhm/asha_report.html
+++ b/custom/up_nrhm/templates/up_nrhm/asha_report.html
@@ -95,13 +95,13 @@
             }
         }
         $('#report_filter_sf').on('change', function() {
-            sf = $(this).select2('data').id;
+            sf = $(this).val();
             hideFilters(sf);
         });
         $('#hq-report-filters').on('change', function() {
             hideFilters(sf);
         });
-        sf = $('#report_filter_sf').select2('data').id;
+        sf = $('#report_filter_sf').val();
         hideFilters(sf);
     </script>
 {% endblock %}


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/24433

`$(this).select2('data')` now returns an array of objects, rather than a single object, even for single selects. With the new version of select2, `val` works just as well and is more semantic.