### PR TITLE
Fix RestoreConfig.__repr__ error

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -806,13 +806,12 @@ class RestoreConfig(object):
 
     def __repr__(self):
         return \
-            "RestoreConfig(project='{}', domain={}, restore_user={}, params='{}', cache_settings='{}', " \
+            "RestoreConfig(project='{}', domain={}, restore_user={}, cache_settings='{}', " \
             "is_async='{}', restore_state='{}', force_cache='{}', cache_timeout='{}', overwrite_cache='{}', " \
             "timing_context='{}')".format(
                 self.project,
                 self.domain,
                 self.restore_user,
-                self.params,
                 self.cache_settings,
                 self.is_async,
                 self.restore_state,

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime
 from django.db.models import Min
-import logging
 
 from celery import current_task, current_app
 from celery.schedules import crontab
@@ -12,6 +11,7 @@ from django.conf import settings
 from casexml.apps.phone.cleanliness import set_cleanliness_flags_for_all_domains
 from casexml.apps.phone.models import SyncLogSQL
 from corehq.form_processor.backends.sql.dbaccessors import get_cursor
+from dimagi.utils.logging import notify_exception
 
 
 ASYNC_RESTORE_QUEUE = 'async_restore_queue'
@@ -49,9 +49,11 @@ def get_async_restore_payload(restore_config, domain=None, username=None):
     try:
         repr(restore_config)
     except Exception as e:
-        logging.error('Something went wrong with RestoreConfig.__repr__() : {msg}'.format(
-            msg=str(e)
-        ))
+        notify_exception(
+            None,
+            'Something went wrong with RestoreConfig.__repr__()',
+            details={'error': str(e)}
+        )
 
     response = restore_config.generate_payload(async_task=current_task)
 


### PR DESCRIPTION
This PR removes `params` from `RestoreConfig.__repr__`, because [this error](https://sentry.io/organizations/dimagi/issues/1055323560/?project=136860&query=is%3Aunresolved) is causing more problems for INDDEX fixtures.

 I'm also changing the `logging` call to `notify_exception`, to give us a better error message in case `__repr__` continues to cause problems.