### PR TITLE
Switch docker S3 service from Riak CS to minio

### DIFF
--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -1,74 +1,65 @@
 """Test S3 Blob DB
 
-Commands to setup Docker with Riak CS for development/testing
+Commands to setup Docker with minio for development/testing
 
-First, [install Docker](https://docs.docker.com/mac/#h_installation). Then
-initialize a docker machine for Riak CS:
+First, [install Docker](https://docs.docker.com/mac/#h_installation).
 
-    git clone https://github.com/hectcastro/docker-riak-cs
-    cd docker-riak-cs
-    docker-machine create --driver virtualbox riakcs
-    eval "$(docker-machine env riakcs)"
-    # recommended 5-node cluster is slow and resource hungry; use 1 node
-    DOCKER_RIAK_CS_CLUSTER_SIZE=1 make start-cluster
+Initialize a docker machine for minio (skip if you already have one):
 
-Test Riak CS connection:
+    docker-machine create --driver virtualbox minio
+    eval "$(docker-machine env minio)"
 
-    DOCKER_RIAKCS_HOST=$(echo $DOCKER_HOST | cut -d/ -f3 | cut -d: -f1)
-    DOCKER_RIAKCS_PORT=$(docker port riak-cs01 8080 | cut -d: -f2)
-    curl -i http://$DOCKER_RIAKCS_HOST:$DOCKER_RIAKCS_PORT; echo ""
+Start the minio service:
+
+    mkdir -p ~/.minio/data && mkdir ~/.minio/conf
+
+    # INSECURE KEY VALUES FOR TESTING ONLY, DO NOT USE IN PRODUCTION!
+    docker run -p 9988:9000 --name minio1 --detach \
+      -e "MINIO_ACCESS_KEY=admin-key" \
+      -e "MINIO_SECRET_KEY=admin-secret" \
+      -v ~/.minio/data:/data \
+      -v ~/.minio/conf:/root/.minio \
+      minio/minio server /data
+
+Test minio connection:
+
+    DOCKER_MINIO_HOST=$(echo $DOCKER_HOST | cut -d/ -f3 | cut -d: -f1)
+    curl -i http://$DOCKER_MINIO_HOST:9988; echo ""
     # expected output:
     # HTTP/1.1 403 Forbidden
-    # Server: Riak CS ...
-
-Get admin-key and admin-secret from riak-cs01 container:
-
-    RIAKCS_SSH_PORT=$(docker port riak-cs01 22 | cut -d: -f2)
-    ssh -i .insecure_key -p $RIAKCS_SSH_PORT root@$DOCKER_RIAKCS_HOST \
-        'egrep "admin_key|admin_secret" /etc/riak-cs/app.config'
-    # copy key values into localsettings.py S3_BLOB_DB_SETTINGS (see below)
+    # ...
 
 Finally, add the following to `localsettings.py`:
 
-    def _get_riak_params():
+    def _get_s3_params():
         # these can change depending on host state
         import os, re, subprocess
         def run(command, pattern=None, group=1):
             out = subprocess.check_output(command.split())
             return re.search(pattern, out).group(group) if pattern else out
         try:
-            evars = run("docker-machine env riakcs")
+            evars = run("docker-machine env minio")
             for match in re.finditer(r'export (.*?)="(.*?)"', evars):
                 os.environ[match.group(1)] = match.group(2)
             host = re.search(r'DOCKER_HOST="tcp://(.*?):', evars).group(1)
-            port = run("docker port riak-cs01 8080", r':(\d+)')
+            port = run("docker port minio1 9000", r':(\d+)')
             return {"host": host, "port": port}
         except Exception:
             return None  # docker host is not running
-    _riak_params = _get_riak_params()
-    if _riak_params:
+    _s3_params = _get_s3_params()
+    if _s3_params:
         S3_BLOB_DB_SETTINGS = {
-            "url": "http://{host}:{port}".format(**_riak_params),
-            "access_key": "admin key value",
-            "secret_key": "admin secret value",
+            "url": "http://{host}:{port}".format(**_s3_params),
+
+            # NOTE: THESE KEYS ARE INSECURE AND MEANT FOR TESTING ONLY
+            "access_key": "admin-key",
+            "secret_key": "admin-secret",
 
             # reduce timeouts to make tests fail faster
             "config": {"connect_timeout": 1, "read_timeout": 1}
         }
 
-## Alternate/easier/faster testing setup using moto (probably not as robust)
-
-    mkdir moto-s3 && cd moto-s3
-    virtualenv env
-    git clone https://github.com/dimagi/moto.git
-    env/bin/pip install -e ./moto
-    env/bin/moto_server -p 5000
-
-Add the following to localsettings.py
-
-    S3_BLOB_DB_SETTINGS = {"url": "http://127.0.0.1:5000"}
-
-"""
+"""  # noqa: W605
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from io import BytesIO, SEEK_SET, TextIOWrapper

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,7 @@ There are two different localsettings configurations, depending on whether HQ is
 This is the recommended setup for local development.  If you want to run the server process in docker, see below.
 
 * If you are using _Docker Toolbox_ (not _Docker for Mac_): change all service host settings (DATABASES HOST, COUCH_SERVER_ROOT, etc.) in your localsettings.py file to point to the IP address of your virtualbox docker VM.
-* Run `./scripts/docker up -d postgres couch redis elasticsearch kafka riakcs` to build and start those docker services in the background.
+* Run `./scripts/docker up -d postgres couch redis elasticsearch kafka minio` to build and start those docker services in the background.
 * Once the services are all up (`./scripts/docker ps` to check) you can return to the CommCare HQ DEV_SETUP and [Setup your Django environment](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#set-up-your-django-environment).
 
 ### Run services and HQ in docker

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: "${DOCKERFILE}"
     environment:
       COMMCAREHQ_BOOTSTRAP: "yes"
-      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 kafka:9092 elasticsearch:9200 riakcs:9980"
+      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 kafka:9092 elasticsearch:9200 minio:9980"
       DOCKER_HQ_OVERLAY: "${DOCKER_HQ_OVERLAY}"
     privileged: true  # allows mount inside container
     command: [runserver]
@@ -17,7 +17,7 @@ services:
       - redis
       - elasticsearch
       - kafka
-      - riakcs
+      - minio
     expose:
       - 8000
     ports:
@@ -66,7 +66,7 @@ services:
       file: hq-compose-services.yml
       service: kafka
 
-  riakcs:
+  minio:
     extends:
       file: hq-compose-services.yml
-      service: riakcs
+      service: minio

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -59,9 +59,9 @@ services:
       - "2181:2181"
       - "9092:9092"
 
-  riakcs:
+  minio:
     extends:
       file: hq-compose.yml
-      service: riakcs
+      service: minio
     ports:
       - "9980:9980"

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: "${DOCKERFILE}"
     environment:
-      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 kafka:9092 elasticsearch:9200 riakcs:9980"
+      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 kafka:9092 elasticsearch:9200 minio:9980"
       DOCKER_HQ_OVERLAY: "${DOCKER_HQ_OVERLAY}"
       JS_SETUP: "${JS_SETUP}"
       PYTHON_VERSION: "${PYTHON_VERSION}"
@@ -24,7 +24,7 @@ services:
       - redis
       - elasticsearch
       - kafka
-      - riakcs
+      - minio
     volumes:
       - ..:/mnt/commcare-hq-ro${RO}
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-lib:}/mnt/lib
@@ -90,12 +90,17 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/tmp/kafka-logs
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/var/lib/zookeeper
 
-  riakcs:
-    image: dimagi/riak-cs
+  minio:
+    image: minio/minio
+    command: server --address :9980 /data
     expose:
       - "9980"
     volumes:
-      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-riakcs:}/var/lib/riak-data
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-minio-conf:}/root/.minio
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-minio-data:}/data
+    environment:
+      MINIO_ACCESS_KEY: admin-key
+      MINIO_SECRET_KEY: admin-secret
 
   citus_master:
     image: 'citusdata/citus:8.1.1'

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -141,7 +141,7 @@ ELASTICSEARCH_HOST = 'elasticsearch'
 ELASTICSEARCH_PORT = 9200
 
 S3_BLOB_DB_SETTINGS = {
-    "url": "http://riakcs:9980/",
+    "url": "http://minio:9980/",
     "access_key": "admin-key",
     "secret_key": "admin-secret",
     "config": {

--- a/scripts/docker
+++ b/scripts/docker
@@ -299,7 +299,8 @@ else
             ${VOLUME_PREFIX}lib \
             ${VOLUME_PREFIX}postgresql \
             ${VOLUME_PREFIX}redis \
-            ${VOLUME_PREFIX}riakcs \
+            ${VOLUME_PREFIX}minio-conf \
+            ${VOLUME_PREFIX}minio-data \
             ${VOLUME_PREFIX}zookeeper
     fi
 fi


### PR DESCRIPTION
MinIO is a much lighter S3 service than Riak CS, and the docker image is _much_ smaller as well (61MB vs 484MB). Hopefully it will also perform better.

Once minio is running in docker, you can verify that it's working by browsing to

http://localhost:9980/

(replace _localhost_ with the hostname or IP of your docker host as necessary)

## Migrating data from Riak CS to MinIO

Do this if you want to preserve data you have in Riak CS. This would include blob db content such as app multimedia, XForms and form submissions stored in your local HQ instance. One way to tell if you're using Riak CS is if you have `S3_BLOB_DB_SETTINGS` in _localsettings.py_. If `S3_BLOB_DB_SETTINGS` is not in your localsettings then you can probably skip this.

1. Commit or stash any uncommitted work in git.
2. Checkout the commit before https://github.com/dimagi/commcare-hq/commit/a8f8464a6602d481be617d0f373dc2a59358fad4:
   `git checkout a8f8464a6602d481be617d0f373dc2a59358fad4^`
3. Stop the _riakcs_ container
   `./scripts/docker stop riakcs`
4. Change all occurrences of `9980` to `9981` in files in the _./docker/_ directory.
5. Start the _riakcs_ container
   `./scripts/docker up -d riakcs`
6. Verify that riakcs is running on port 9981
   `curl -i http://$DOCKER_HOST:9981; echo ""`

   Expected output:
   ```
   HTTP/1.1 403 Forbidden
   ...
   ```
7. Discard the port changes in _./docker/_
   `git checkout docker/`
8. Checkout https://github.com/dimagi/commcare-hq/commit/a8f8464a6602d481be617d0f373dc2a59358fad4 (or the latest version of master, assuming this PR has been merged).
9. Start _minio_
   `./scripts/docker up -d minio`
10. Update localsettings
    ```py
    S3_BLOB_DB_SETTINGS = { ... }  # same as before

    # add two new settings:
    BLOB_DB_MIGRATING_FROM_S3_TO_S3 = True
    OLD_S3_BLOB_DB_SETTINGS = {
        # copy S3_BLOB_DB_SETTINGS and replace port 9980 with 9981
    }
    ```
11. Run blob db migration
    ```sh
    mkdir ./blob-logs  # directory for migration logs
    ./manage.py run_blob_migration migrate_backend --log-dir=./blob-logs
    ```
12. Checkout the commit before https://github.com/dimagi/commcare-hq/commit/a8f8464a6602d481be617d0f373dc2a59358fad4:
   `git checkout a8f8464a6602d481be617d0f373dc2a59358fad4^`
13. Stop _riakcs_ container
    `./scripts/docker stop riakcs`
14. Remove `OLD_S3_BLOB_DB_SETTINGS` and `BLOB_DB_MIGRATING_FROM_S3_TO_S3` from _localsettings.py_
15. Checkout the branch you were on at the beginning and go on your merry way.

## Stop the _riakcs_ service

You may need to stop the old _riakcs_ docker service if you get a port binding error from _minio_ when starting docker services:

`docker stop hqservice_riakcs_1`

Or you can revert to a commit prior to https://github.com/dimagi/commcare-hq/commit/a8f8464a6602d481be617d0f373dc2a59358fad4 and use docker-compose to stop it:

```
git checkout a8f8464a6602d481be617d0f373dc2a59358fad4^
./scripts/docker stop riakcs
```

Then start _minio_

`./scripts/docker up -d minio`

And verify that it is working by visiting the URL listed above.

@dannyroberts @emord @snopoke 
FYI @dimagi/team-commcare-hq 