### PR TITLE
Updated quietMillis to delay

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/widgets.js
+++ b/corehq/apps/accounting/static/accounting/js/widgets.js
@@ -36,7 +36,7 @@ hqDefine('accounting/js/widgets', [
                     placeholder: '',    // required for allowClear to work
                     allowClear: true,
                     ajax: {
-                        quietMillis: 150,
+                        delay: 150,
                         url: '',
                         dataType: 'json',
                         type: 'post',

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view_report.js
@@ -93,7 +93,7 @@ hqDefine("app_manager/js/modules/module_view_report", function () {
                     url: (hqImport("hqwebapp/js/initial_page_data").reverse("choice_list_api").split('report_id')[0]
                           + element.data("filter-name") + "/"),
                     dataType: 'json',
-                    quietMillis: 250,
+                    delay: 250,
                     data: choiceListUtils.getApiQueryParams,
                     processResults: choiceListUtils.formatPageForSelect2,
                     cache: true,

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -69,7 +69,7 @@ hqDefine("translations/js/translations", function () {
                         tags: true,
                         width: '100%',
                         ajax: {
-                            quietMillis: 100,
+                            delay: 100,
                             url: suggestionURL,
                             data: function () {
                                 return {

--- a/corehq/apps/users/static/users/js/mobile_workers.ng.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.ng.js
@@ -226,7 +226,7 @@
                     width: '100%',
                     placeholder: gettext("Select location"),
                     ajax: {
-                        quietMillis: 100,
+                        delay: 100,
                         url: location_url,
                         data: function (params) {
                             return {


### PR DESCRIPTION
This is an API change from [old select2](https://select2.github.io/select2/) to [new select2](https://select2.org/data-sources/ajax) that I missed in a few places.

Product: this is basically invisible. It affects how long ajax-based dropdowns wait before querying the server.