### PR TITLE
don't use temp table where it isn't needed

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/aww_incentive.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/aww_incentive.py
@@ -77,10 +77,10 @@ class AwwIncentiveAggregationDistributedHelper(BaseICDSAggregationDistributedHel
           INNER JOIN agg_ccs_record_monthly AS ccsm
           ON ccsm.month=awcm.month AND ccsm.awc_id=awcm.awc_id AND ccsm.aggregation_level=awcm.aggregation_level
           WHERE awcm.month = %(month)s AND awcm.state_id = %(state_id)s and awcm.aggregation_level=5
-          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name, awcm.district_name,
-                   awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
-                   awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
-                   awcm.awc_days_open, awcm.is_launched
+          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name,
+                awcm.district_name, awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
+                awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
+                awcm.awc_days_open, awcm.is_launched
         );
         /* update visits for cf cases (not in agg_ccs_record) */
         CREATE TEMPORARY TABLE "tmp_ccs_cf" AS SELECT

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/aww_incentive.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/aww_incentive.py
@@ -40,10 +40,16 @@ class AwwIncentiveAggregationDistributedHelper(BaseICDSAggregationDistributedHel
         }
 
         return """
-        CREATE TEMPORARY TABLE "tmp_incentive" AS SELECT
+        INSERT INTO "{tablename}" (
+            state_id, district_id, month, awc_id, block_id, supervisor_id, state_name, district_name, block_name,
+            supervisor_name, awc_name, aww_name, contact_phone_number, wer_weighed,
+            wer_eligible, awc_num_open, valid_visits, expected_visits, is_launched,
+            visit_denominator, awh_eligible, incentive_eligible
+        ) (
+          SELECT
             %(state_id)s AS state_id,
             awcm.district_id,
-            %(month)s::DATE AS month,
+            %(month)s AS month,
             awcm.awc_id,
             awcm.block_id,
             awcm.supervisor_id,
@@ -57,33 +63,25 @@ class AwwIncentiveAggregationDistributedHelper(BaseICDSAggregationDistributedHel
             awcm.wer_weighed,
             awcm.wer_eligible,
             awcm.awc_days_open,
-            sum(ccsm.valid_visits) as valid_visits,
-            sum(ccsm.expected_visits) as expected_visits,
-            awcm.is_launched = 'yes' as is_launched,
-            round(sum(ccsm.expected_visits)) as visit_denominator,
-            awcm.awc_days_open >= 21 as awh_eligible,
+            sum(ccsm.valid_visits),
+            sum(ccsm.expected_visits),
+            awcm.is_launched = 'yes',
+            round(sum(ccsm.expected_visits)),
+            awcm.awc_days_open >= 21,
             CASE
                 WHEN round(sum(ccsm.expected_visits)) = 0 AND awcm.wer_eligible = 0 THEN true
                 ELSE (awcm.wer_weighed / GREATEST(awcm.wer_eligible, 1)) >= 0.6 AND
                      (sum(ccsm.valid_visits) / GREATEST(round(sum(ccsm.expected_visits)), 1)) >= 0.6
-            END as incentive_eligible
-        FROM agg_awc_monthly as awcm
-        INNER JOIN agg_ccs_record_monthly AS ccsm
-        ON ccsm.month=awcm.month AND ccsm.awc_id=awcm.awc_id AND ccsm.aggregation_level=awcm.aggregation_level
-        WHERE awcm.month = %(month)s AND awcm.state_id = %(state_id)s and awcm.aggregation_level=5
-        GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id,
-            awcm.state_name, awcm.district_name,
-            awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
-            awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
-            awcm.awc_days_open, awcm.is_launched;
-        INSERT INTO "{tablename}" (
-            state_id, district_id, month, awc_id, block_id, supervisor_id, state_name, district_name, block_name,
-            supervisor_name, awc_name, aww_name, contact_phone_number, wer_weighed,
-            wer_eligible, awc_num_open, valid_visits, expected_visits, is_launched,
-            visit_denominator, awh_eligible, incentive_eligible
-        )
-        SELECT * FROM "tmp_incentive";
-        DROP TABLE "tmp_incentive";
+            END
+          FROM agg_awc_monthly as awcm
+          INNER JOIN agg_ccs_record_monthly AS ccsm
+          ON ccsm.month=awcm.month AND ccsm.awc_id=awcm.awc_id AND ccsm.aggregation_level=awcm.aggregation_level
+          WHERE awcm.month = %(month)s AND awcm.state_id = %(state_id)s and awcm.aggregation_level=5
+          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name, awcm.district_name,
+                   awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
+                   awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
+                   awcm.awc_days_open, awcm.is_launched
+        );
         /* update visits for cf cases (not in agg_ccs_record) */
         CREATE TEMPORARY TABLE "tmp_ccs_cf" AS SELECT
             SUM(0.39) AS expected,

--- a/custom/icds_reports/utils/aggregation_helpers/monolith/aww_incentive.py
+++ b/custom/icds_reports/utils/aggregation_helpers/monolith/aww_incentive.py
@@ -77,10 +77,10 @@ class AwwIncentiveAggregationHelper(BaseICDSAggregationHelper):
           INNER JOIN agg_ccs_record_monthly AS ccsm
           ON ccsm.month=awcm.month AND ccsm.awc_id=awcm.awc_id AND ccsm.aggregation_level=awcm.aggregation_level
           WHERE awcm.month = %(month)s AND awcm.state_id = %(state_id)s and awcm.aggregation_level=5
-          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name, awcm.district_name,
-                   awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
-                   awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
-                   awcm.awc_days_open, awcm.is_launched
+          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name,
+                awcm.district_name, awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
+                awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
+                awcm.awc_days_open, awcm.is_launched
         );
         /* update visits for cf cases (not in agg_ccs_record) */
         UPDATE "{tablename}" perf
@@ -92,8 +92,13 @@ class AwwIncentiveAggregationHelper(BaseICDSAggregationHelper):
              SUM(COALESCE(agg_cf.valid_visits, 0)) as valid,
              ucr.awc_id
              FROM "{ccs_record_case_ucr}" ucr
-             LEFT OUTER JOIN "{agg_cf_table}" agg_cf ON ucr.doc_id = agg_cf.case_id AND agg_cf.month = %(month)s
-             WHERE %(month)s - add BETWEEN 184 AND 548 AND (closed_on IS NULL OR date_trunc('month', closed_on)::DATE > %(month)s) AND date_trunc('month', opened_on) <= %(month)s
+             LEFT OUTER JOIN "{agg_cf_table}" agg_cf ON ucr.doc_id = agg_cf.case_id
+                AND agg_cf.month = %(month)s
+             WHERE %(month)s - add BETWEEN 184 AND 548
+                AND (
+                    closed_on IS NULL OR date_trunc('month', closed_on)::DATE > %(month)s
+                )
+                AND date_trunc('month', opened_on) <= %(month)s
              GROUP BY ucr.awc_id
              ) cf_data
         WHERE cf_data.awc_id = perf.awc_id

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/awc-incentive.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/awc-incentive.distributed.txt
@@ -8,10 +8,16 @@ DROP TABLE IF EXISTS "icds_db_aww_incentive_7a197ee47818209780c23ed9"
         
 {"month_string": "2019-01-01", "state_id": "st1"}
 
-        CREATE TEMPORARY TABLE "tmp_incentive" AS SELECT
+        INSERT INTO "icds_db_aww_incentive_7a197ee47818209780c23ed9" (
+            state_id, district_id, month, awc_id, block_id, supervisor_id, state_name, district_name, block_name,
+            supervisor_name, awc_name, aww_name, contact_phone_number, wer_weighed,
+            wer_eligible, awc_num_open, valid_visits, expected_visits, is_launched,
+            visit_denominator, awh_eligible, incentive_eligible
+        ) (
+          SELECT
             %(state_id)s AS state_id,
             awcm.district_id,
-            %(month)s::DATE AS month,
+            %(month)s AS month,
             awcm.awc_id,
             awcm.block_id,
             awcm.supervisor_id,
@@ -25,33 +31,25 @@ DROP TABLE IF EXISTS "icds_db_aww_incentive_7a197ee47818209780c23ed9"
             awcm.wer_weighed,
             awcm.wer_eligible,
             awcm.awc_days_open,
-            sum(ccsm.valid_visits) as valid_visits,
-            sum(ccsm.expected_visits) as expected_visits,
-            awcm.is_launched = 'yes' as is_launched,
-            round(sum(ccsm.expected_visits)) as visit_denominator,
-            awcm.awc_days_open >= 21 as awh_eligible,
+            sum(ccsm.valid_visits),
+            sum(ccsm.expected_visits),
+            awcm.is_launched = 'yes',
+            round(sum(ccsm.expected_visits)),
+            awcm.awc_days_open >= 21,
             CASE
                 WHEN round(sum(ccsm.expected_visits)) = 0 AND awcm.wer_eligible = 0 THEN true
                 ELSE (awcm.wer_weighed / GREATEST(awcm.wer_eligible, 1)) >= 0.6 AND
                      (sum(ccsm.valid_visits) / GREATEST(round(sum(ccsm.expected_visits)), 1)) >= 0.6
-            END as incentive_eligible
-        FROM agg_awc_monthly as awcm
-        INNER JOIN agg_ccs_record_monthly AS ccsm
-        ON ccsm.month=awcm.month AND ccsm.awc_id=awcm.awc_id AND ccsm.aggregation_level=awcm.aggregation_level
-        WHERE awcm.month = %(month)s AND awcm.state_id = %(state_id)s and awcm.aggregation_level=5
-        GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id,
-            awcm.state_name, awcm.district_name,
-            awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
-            awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
-            awcm.awc_days_open, awcm.is_launched;
-        INSERT INTO "icds_db_aww_incentive_7a197ee47818209780c23ed9" (
-            state_id, district_id, month, awc_id, block_id, supervisor_id, state_name, district_name, block_name,
-            supervisor_name, awc_name, aww_name, contact_phone_number, wer_weighed,
-            wer_eligible, awc_num_open, valid_visits, expected_visits, is_launched,
-            visit_denominator, awh_eligible, incentive_eligible
-        )
-        SELECT * FROM "tmp_incentive";
-        DROP TABLE "tmp_incentive";
+            END
+          FROM agg_awc_monthly as awcm
+          INNER JOIN agg_ccs_record_monthly AS ccsm
+          ON ccsm.month=awcm.month AND ccsm.awc_id=awcm.awc_id AND ccsm.aggregation_level=awcm.aggregation_level
+          WHERE awcm.month = %(month)s AND awcm.state_id = %(state_id)s and awcm.aggregation_level=5
+          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name,
+                awcm.district_name, awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
+                awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
+                awcm.awc_days_open, awcm.is_launched
+        );
         /* update visits for cf cases (not in agg_ccs_record) */
         CREATE TEMPORARY TABLE "tmp_ccs_cf" AS SELECT
             SUM(0.39) AS expected,

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/awc-incentive.monolith.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/awc-incentive.monolith.txt
@@ -45,10 +45,10 @@ DROP TABLE IF EXISTS "icds_db_aww_incentive_7a197ee47818209780c23ed9"
           INNER JOIN agg_ccs_record_monthly AS ccsm
           ON ccsm.month=awcm.month AND ccsm.awc_id=awcm.awc_id AND ccsm.aggregation_level=awcm.aggregation_level
           WHERE awcm.month = %(month)s AND awcm.state_id = %(state_id)s and awcm.aggregation_level=5
-          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name, awcm.district_name,
-                   awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
-                   awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
-                   awcm.awc_days_open, awcm.is_launched
+          GROUP BY awcm.awc_id, awcm.block_id, awcm.supervisor_id, awcm.district_id, awcm.state_name,
+                awcm.district_name, awcm.block_name, awcm.supervisor_name, awcm.awc_name, awcm.aww_name,
+                awcm.contact_phone_number, awcm.wer_weighed, awcm.wer_eligible,
+                awcm.awc_days_open, awcm.is_launched
         );
         /* update visits for cf cases (not in agg_ccs_record) */
         UPDATE "icds_db_aww_incentive_7a197ee47818209780c23ed9" perf
@@ -60,8 +60,13 @@ DROP TABLE IF EXISTS "icds_db_aww_incentive_7a197ee47818209780c23ed9"
              SUM(COALESCE(agg_cf.valid_visits, 0)) as valid,
              ucr.awc_id
              FROM "ucr_icds-cas_static-ccs_record_cases_cedcca39" ucr
-             LEFT OUTER JOIN "icds_dashboard_ccs_record_cf_forms" agg_cf ON ucr.doc_id = agg_cf.case_id AND agg_cf.month = %(month)s
-             WHERE %(month)s - add BETWEEN 184 AND 548 AND (closed_on IS NULL OR date_trunc('month', closed_on)::DATE > %(month)s) AND date_trunc('month', opened_on) <= %(month)s
+             LEFT OUTER JOIN "icds_dashboard_ccs_record_cf_forms" agg_cf ON ucr.doc_id = agg_cf.case_id
+                AND agg_cf.month = %(month)s
+             WHERE %(month)s - add BETWEEN 184 AND 548
+                AND (
+                    closed_on IS NULL OR date_trunc('month', closed_on)::DATE > %(month)s
+                )
+                AND date_trunc('month', opened_on) <= %(month)s
              GROUP BY ucr.awc_id
              ) cf_data
         WHERE cf_data.awc_id = perf.awc_id


### PR DESCRIPTION
+ a few formatting changes

This is a no-op change. Here's the diff between monolith and distributed queries:

```diff
39c39
<             CASE 
---
>             CASE
41c41
<                 ELSE (awcm.wer_weighed / GREATEST(awcm.wer_eligible, 1)) >= 0.6 AND 
---
>                 ELSE (awcm.wer_weighed / GREATEST(awcm.wer_eligible, 1)) >= 0.6 AND
54,65c54,61
<         UPDATE "icds_db_aww_incentive_7a197ee47818209780c23ed9" perf
<         SET expected_visits = expected_visits + cf_data.expected,
<             valid_visits = valid_visits + cf_data.valid
<         FROM (
<              SELECT
<              SUM(0.39) AS expected,
<              SUM(COALESCE(agg_cf.valid_visits, 0)) as valid,
<              ucr.awc_id
<              FROM "ucr_icds-cas_static-ccs_record_cases_cedcca39" ucr
<              LEFT OUTER JOIN "icds_dashboard_ccs_record_cf_forms" agg_cf ON ucr.doc_id = agg_cf.case_id
<                 AND agg_cf.month = %(month)s
<              WHERE %(month)s - add BETWEEN 184 AND 548
---
>         CREATE TEMPORARY TABLE "tmp_ccs_cf" AS SELECT
>             SUM(0.39) AS expected,
>             SUM(COALESCE(agg_cf.valid_visits, 0)) as valid,
>             ucr.awc_id
>             FROM "ucr_icds-cas_static-ccs_record_cases_cedcca39" ucr
>             LEFT OUTER JOIN "icds_dashboard_ccs_record_cf_forms" agg_cf ON ucr.doc_id = agg_cf.case_id
>                 AND agg_cf.month = %(month)s AND agg_cf.supervisor_id = ucr.supervisor_id
>             WHERE %(month)s - add BETWEEN 184 AND 548
70,72c66,72
<              GROUP BY ucr.awc_id
<              ) cf_data
<         WHERE cf_data.awc_id = perf.awc_id
---
>             GROUP BY ucr.awc_id, ucr.supervisor_id;
>         UPDATE "icds_db_aww_incentive_7a197ee47818209780c23ed9" perf
>         SET expected_visits = expected_visits + cf_data.expected,
>             valid_visits = valid_visits + cf_data.valid
>         FROM "tmp_ccs_cf" cf_data
>         WHERE cf_data.awc_id = perf.awc_id;
>         DROP TABLE "tmp_ccs_cf";
```