### PR TITLE
enforce that Domain.get_all_names return a list of unique names

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -681,7 +681,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     @classmethod
     def get_all_names(cls):
-        return list({d['key'] for d in cls.get_all(include_docs=False)})
+        return sorted({d['key'] for d in cls.get_all(include_docs=False)})
 
     @classmethod
     def get_all_ids(cls):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -681,7 +681,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     @classmethod
     def get_all_names(cls):
-        return [d['key'] for d in cls.get_all(include_docs=False)]
+        return list({d['key'] for d in cls.get_all(include_docs=False)})
 
     @classmethod
     def get_all_ids(cls):


### PR DESCRIPTION
Currently on production, this function returns duplicates, which leads to errors like https://sentry.io/organizations/dimagi/issues/1052319022/