### PR TITLE
Remove -e from repo requirements

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
@@ -22,6 +21,7 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -4,7 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
--e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==2.4.2
@@ -55,6 +54,7 @@ django-cte==1.1.4
 django-debug-toolbar==1.11
 django-extensions==2.1.6
 django-formtools==2.1
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
 django-partial-index==0.5.2
 django-phonenumber-field==1.3.0

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -4,11 +4,11 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==2.4.2
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 argparse==1.4.0
 asn1crypto==0.24.0
 attrs==18.2.0

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2
 asn1crypto==0.24.0
@@ -18,6 +17,7 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -4,9 +4,9 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
 amqp==2.4.2
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
@@ -16,6 +15,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
 amqp==2.4.2               # via kombu
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
 babel==2.6.0              # via django-phonenumber-field

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -4,10 +4,10 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0
 attrs==18.2.0

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
@@ -20,6 +19,7 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -4,7 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
--e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
@@ -48,6 +47,7 @@ django-countries==4.6
 django-crispy-forms==1.7.0
 django-cte==1.1.4
 django-formtools==2.1
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
 django-partial-index==0.5.2
 django-phonenumber-field==1.3.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
@@ -22,6 +21,7 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -4,7 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
--e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==2.4.2
@@ -55,6 +54,7 @@ django-cte==1.1.4
 django-debug-toolbar==1.11
 django-extensions==2.1.6
 django-formtools==2.1
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
 django-partial-index==0.5.2
 django-phonenumber-field==1.3.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -4,11 +4,11 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alabaster==0.7.12         # via sphinx
 alembic==0.8.6
 amqp==2.4.2
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 argparse==1.4.0
 asn1crypto==0.24.0
 attrs==18.2.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2
 asn1crypto==0.24.0
@@ -18,6 +17,7 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -4,9 +4,9 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
 amqp==2.4.2
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 asn1crypto==0.24.0
 attrs==18.2.0
 babel==2.6.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -109,8 +109,4 @@ werkzeug==0.11.15
 CommcareTranslationChecker==0.9.3.5
 WeasyPrint==0.42.3
 
-# Workaround for https://github.com/jazzband/pip-tools/issues/355
-# git URL installs need to be listed with -e to satisfy pip-compile
-# but once they're in requirements.txt we will strip the -e
-
--e git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@ jsonobject==0.9.9
 jsonobject-couchdbkit~=0.9
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 # required by django-digest
 decorator==4.0.11
 django>=1.11.21  # security update

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 alembic==0.8.6
 amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
@@ -16,6 +15,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 alembic==0.8.6
 amqp==2.4.2               # via kombu
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0
 babel==2.6.0              # via django-phonenumber-field

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -2,7 +2,7 @@
 
 beautifulsoup4>=4.4.1
 coverage==4.5.1
--e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 fakecouch==0.0.15
 nose==1.3.7
 nose-exclude==0.5.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,10 +4,10 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
+git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0
 attrs==18.2.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -5,7 +5,6 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
--e git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 -e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
@@ -20,6 +19,7 @@ boto3==1.9.143
 botocore==1.12.143
 cairocffi==0.9.0
 cairosvg==1.0.22
+git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,7 +4,6 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
--e git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 alembic==0.8.6
 amqp==2.4.2
 git+git://github.com/dimagi/architect@v0.5.7a3#egg=architect==0.5.7a3
@@ -48,6 +47,7 @@ django-countries==4.6
 django-crispy-forms==1.7.0
 django-cte==1.1.4
 django-formtools==2.1
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
 django-partial-index==0.5.2
 django-phonenumber-field==1.3.0


### PR DESCRIPTION
https://github.com/jazzband/pip-tools/issues/355 is resolved by https://github.com/jazzband/pip-tools/pull/807 so we don't need the ```-e``` anymore.