### PR TITLE
keep infra child tables

### DIFF
--- a/custom/icds_reports/management/commands/create_citus_child_tables.py
+++ b/custom/icds_reports/management/commands/create_citus_child_tables.py
@@ -30,6 +30,7 @@ keep_child_tables = [
     'agg_awc_daily',
     AWW_INCENTIVE_TABLE,
     ICDSAuditEntryRecord._meta.db_table,
+    AGG_INFRASTRUCTURE_TABLE,
 ]
 
 """
@@ -51,7 +52,6 @@ drop_child_tables = [
     'daily_attendance',
     'child_health_monthly',
     'ccs_record_monthly',
-    AGG_INFRASTRUCTURE_TABLE,
 ]
 
 """


### PR DESCRIPTION
@snopoke 
As far as I can tell this is a local table that should keep its child tables (and the agg script does that). I think this was just in the wrong category. This will resolve the last diff.