### PR TITLE
Fix delete_unneeded_fixture_data_item

### DIFF
--- a/corehq/apps/fixtures/tasks.py
+++ b/corehq/apps/fixtures/tasks.py
@@ -58,7 +58,7 @@ def delete_unneeded_fixture_data_item(self, domain, data_type_id):
             item_ids.extend([item.get_id for item in items])
         for item_id_chunk in chunked(item_ids, 1000):
             for docs in chunked(FixtureOwnership.for_all_item_ids(item_id_chunk, domain), 1000):
-                FixtureOwnership.delete_docs(items)
+                FixtureOwnership.delete_docs(docs)
     except (KeyboardInterrupt, SystemExit):
         raise
     except Exception as exc:


### PR DESCRIPTION
to actually delete FixtureOwnership docs as well. See my comment here: https://github.com/dimagi/commcare-hq/commit/63cf1d58faa3d5961f0da60eb5313aab340debf3#r33917668