### PR TITLE
Refactor command line parameters for couch2sql management command

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -220,7 +220,7 @@ class CouchSqlDomainMigrator(object):
         prev_ids = self.queues.get_ids_from_run_timestamp()
 
         for chunked_ids in chunked(prev_ids, 100):
-            chunk = list([_id for _id in chunked_ids if _id])
+            chunk = [_id for _id in chunked_ids if _id]
             for form in FormAccessorCouch.get_forms(chunk):
                 self._try_to_process_form(form, pool)
 

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -107,6 +107,8 @@ class Command(BaseCommand):
 
     def do_MIGRATE(self, domain):
         if self.run_timestamp:
+            if self.dry_run:
+                raise CommandError("--dry-run and --run-timestamp are mutually exclusive")
             if not couch_sql_migration_in_progress(domain):
                 raise CommandError("Migration must be in progress if --run-timestamp is provided")
         else:

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -131,9 +131,6 @@ class Command(BaseCommand):
         set_couch_sql_migration_not_started(domain)
         blow_away_migration(domain)
 
-    def do_stats(self, domain):
-        self.print_stats(domain, short=not self.verbose)
-
     def do_COMMIT(self, domain):
         if not couch_sql_migration_in_progress(domain, include_dry_runs=False):
             raise CommandError("cannot commit a migration that is not in state in_progress")
@@ -144,6 +141,9 @@ class Command(BaseCommand):
                 "Are you sure you want to do this for domain '{}'?".format(domain)
             )
         set_couch_sql_migration_complete(domain)
+
+    def do_stats(self, domain):
+        self.print_stats(domain, short=not self.verbose)
 
     def do_diff(self, domain):
         db = get_diff_db(domain)

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         if should_use_sql_backend(domain):
             raise CommandError('It looks like {} has already been migrated.'.format(domain))
 
-        for opt in ["no_input", "debug", "verbose", "dry_run", "run_timestamp"]:
+        for opt in ["no_input", "verbose", "dry_run", "run_timestamp"]:
             setattr(self, opt, options[opt])
 
         if self.no_input and not settings.UNIT_TESTING:
@@ -102,7 +102,7 @@ class Command(BaseCommand):
         if action != STATS and self.verbose:
             raise CommandError("--verbose only allowed for `stats`")
 
-        setup_logging(options['log_dir'])
+        setup_logging(options['log_dir'], options['debug'])
         getattr(self, "do_" + action)(domain)
 
     def do_MIGRATE(self, domain):
@@ -117,7 +117,6 @@ class Command(BaseCommand):
         do_couch_to_sql_migration(
             domain,
             with_progress=not self.no_input,
-            debug=self.debug,
             run_timestamp=self.run_timestamp)
 
         has_diffs = self.print_stats(domain, short=True, diffs_only=True)

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -40,25 +40,36 @@ from couchforms.models import XFormInstance, doc_types
 
 log = logging.getLogger('main_couch_sql_datamigration')
 
+# Script action constants
+MIGRATE = "MIGRATE"
+COMMIT = "COMMIT"
+RESET = "reset"  # was --blow-away
+STATS = "stats"
+DIFF = "diff"
+
 
 class Command(BaseCommand):
     help = """
-    Step 1: Run with '--MIGRATE'
-    Step 2a: If no diffs or diffs acceptable run with '--COMMIT'
-    Step 2b: If diffs, use '--show-diffs' to view diffs
-    Step 3: Run with '--blow-away' to abort
+    Step 1: Run 'MIGRATE'
+    Step 2a: If diffs, use 'diff' to view diffs
+    Step 2b: Use 'stats --verbose' to view more stats output
+    Step 3: If no diffs or diffs are acceptable run 'COMMIT'
+    Step 4: Run 'reset' to abort the current migration
     """
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
-        parser.add_argument('--MIGRATE', action='store_true', default=False)
-        parser.add_argument('--COMMIT', action='store_true', default=False)
-        parser.add_argument('--blow-away', action='store_true', default=False)
-        parser.add_argument('--stats-short', action='store_true', default=False)
-        parser.add_argument('--stats-long', action='store_true', default=False)
-        parser.add_argument('--show-diffs', action='store_true', default=False)
+        parser.add_argument('action', choices=[
+            MIGRATE,
+            COMMIT,
+            RESET,
+            STATS,
+            DIFF,
+        ])
         parser.add_argument('--no-input', action='store_true', default=False)
         parser.add_argument('--debug', action='store_true', default=False)
+        parser.add_argument('--verbose', action='store_true', default=False,
+            help="Show verbose stats output.")
         parser.add_argument('--log-dir', help="""
             Directory for couch2sql logs, which are not written if this is not
             provided. Standard HQ logs will be used regardless of this setting.
@@ -77,81 +88,64 @@ class Command(BaseCommand):
             help='use this option to continue a previous run that was started at this timestamp'
         )
 
-    @staticmethod
-    def require_only_option(sole_option, options):
-        this_command_opts = {
-            'MIGRATE',
-            'COMMIT',
-            'blow_away',
-            'stats',
-            'show_diffs',
-            'no_input',
-            'debug',
-            'dry_run',
-        }
-        for key, value in options.items():
-            if value and key in this_command_opts and key != sole_option:
-                raise CommandError("%s must be the sole option used" % key)
-
-    def handle(self, domain, **options):
+    def handle(self, domain, action, **options):
         if should_use_sql_backend(domain):
             raise CommandError('It looks like {} has already been migrated.'.format(domain))
 
-        self.no_input = options.pop('no_input', False)
-        self.debug = options.pop('debug', False)
-        self.dry_run = options.pop('dry_run', False)
+        for opt in ["no_input", "debug", "verbose", "dry_run", "run_timestamp"]:
+            setattr(self, opt, options[opt])
 
         if self.no_input and not settings.UNIT_TESTING:
-            raise CommandError('no-input only allowed for unit testing')
+            raise CommandError('--no-input only allowed for unit testing')
+        if action != MIGRATE and self.dry_run:
+            raise CommandError("--dry-run only allowed for `MIGRATE`")
+        if action != STATS and self.verbose:
+            raise CommandError("--verbose only allowed for `stats`")
 
         setup_logging(options['log_dir'])
-        if options['MIGRATE']:
-            self.require_only_option('MIGRATE', options)
+        getattr(self, "do_" + action)(domain)
 
-            if options.get('run_timestamp'):
-                if not couch_sql_migration_in_progress(domain):
-                    raise CommandError("Migration must be in progress if run_timestamp is passed in")
-            else:
-                set_couch_sql_migration_started(domain, self.dry_run)
+    def do_MIGRATE(self, domain):
+        if self.run_timestamp:
+            if not couch_sql_migration_in_progress(domain):
+                raise CommandError("Migration must be in progress if --run-timestamp is provided")
+        else:
+            set_couch_sql_migration_started(domain, self.dry_run)
 
-            do_couch_to_sql_migration(
-                domain,
-                with_progress=not self.no_input,
-                debug=self.debug,
-                run_timestamp=options.get('run_timestamp'))
+        do_couch_to_sql_migration(
+            domain,
+            with_progress=not self.no_input,
+            debug=self.debug,
+            run_timestamp=self.run_timestamp)
 
-            has_diffs = self.print_stats(domain, short=True, diffs_only=True)
-            if has_diffs:
-                print("\nUse '--stats-short', '--stats-long', '--show-diffs' to see more info.\n")
+        has_diffs = self.print_stats(domain, short=True, diffs_only=True)
+        if has_diffs:
+            print("\nRun `diff` or `stats --verbose` for more details.\n")
 
-        if options['blow_away']:
-            self.require_only_option('blow_away', options)
-            if not self.no_input:
-                _confirm(
-                    "This will delete all SQL forms and cases for the domain {}. "
-                    "Are you sure you want to continue?".format(domain)
-                )
-            set_couch_sql_migration_not_started(domain)
-            blow_away_migration(domain)
+    def do_reset(self, domain):
+        if not self.no_input:
+            _confirm(
+                "This will delete all SQL forms and cases for the domain {}. "
+                "Are you sure you want to continue?".format(domain)
+            )
+        set_couch_sql_migration_not_started(domain)
+        blow_away_migration(domain)
 
-        if options['stats_short'] or options['stats_long']:
-            self.print_stats(domain, short=options['stats_short'])
-        if options['show_diffs']:
-            self.show_diffs(domain)
+    def do_stats(self, domain):
+        self.print_stats(domain, short=not self.verbose)
 
-        if options['COMMIT']:
-            self.require_only_option('COMMIT', options)
-            if not couch_sql_migration_in_progress(domain, include_dry_runs=False):
-                raise CommandError("cannot commit a migration that is not in state in_progress")
-            if not self.no_input:
-                _confirm(
-                    "This will convert the domain to use the SQL backend and"
-                    "allow new form submissions to be processed. "
-                    "Are you sure you want to do this for domain '{}'?".format(domain)
-                )
-            set_couch_sql_migration_complete(domain)
+    def do_COMMIT(self, domain):
+        if not couch_sql_migration_in_progress(domain, include_dry_runs=False):
+            raise CommandError("cannot commit a migration that is not in state in_progress")
+        if not self.no_input:
+            _confirm(
+                "This will convert the domain to use the SQL backend and"
+                "allow new form submissions to be processed. "
+                "Are you sure you want to do this for domain '{}'?".format(domain)
+            )
+        set_couch_sql_migration_complete(domain)
 
-    def show_diffs(self, domain):
+    def do_diff(self, domain):
         db = get_diff_db(domain)
         diffs = sorted(db.get_diffs(), key=lambda d: d.kind)
         for doc_type, diffs in groupby(diffs, key=lambda d: d.kind):


### PR DESCRIPTION
Change mutually exclusive run-mode options to a required "action" parameter. Also a bit of minor cleanup in the core migration module. Review by commit 🐠 

@orangejenny 