### PR TITLE
Fix success setting in s3 deletes

### DIFF
--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -101,7 +101,6 @@ class S3BlobDB(AbstractBlobDB):
         check_safe_key(key)
         success = False
         with maybe_not_found(), self.report_timing('delete', key):
-            success = True
             obj = self._s3_bucket().Object(key)
             # may raise a not found error -> return False
             deleted_bytes = obj.content_length


### PR DESCRIPTION
This was introduced in https://github.com/dimagi/commcare-hq/commit/9849b2b67347f2f4e97abfe8fde8d93188a26621#diff-8d02f7437bd84d94316fa35215e84987R148

From my reading it looks like we're returning `True` even if no delete happened which is not the same as what's happening in the fsdb https://github.com/dimagi/commcare-hq/blob/7a7f368f819a1ce46d30ef4197a12a6efec3358f/corehq/blobs/fsdb.py#L65-L74

I don't really know what this means and how this is used, but it does appear to be a bug.