### PR TITLE
add soft asserts when processing incoming SMS

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -35,6 +35,12 @@ from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.utils import is_commcarecase
 from corehq.util.datadog.utils import sms_load_counter
 from corehq.util.python_compatibility import soft_assert_type_text
+from corehq.util.soft_assert import soft_assert
+
+_sms_content_is_unicode = soft_assert(
+    to='{}@{}'.format('npellegrino', 'dimagi.com'),
+    exponential_backoff=True,
+)
 
 # A list of all keywords which allow registration via sms.
 # Meant to allow support for multiple languages.
@@ -513,6 +519,18 @@ def incoming(phone_number, text, backend_api, timestamp=None,
     timestamp - message received timestamp; defaults to now (UTC)
     domain_scope - set the domain scope for this SMS; see SMSBase.domain_scope for details
     """
+    _sms_content_is_unicode(
+        isinstance(phone_number, six.text_type),
+        '[SMS] phone_number is type %s' % type(phone_number)
+    )
+    _sms_content_is_unicode(
+        isinstance(text, six.text_type),
+        '[SMS] text is type %s' % type(text)
+    )
+    _sms_content_is_unicode(
+        isinstance(raw_text, (six.text_type, type(None))),
+        '[SMS] raw_text is type %s' % type(raw_text)
+    )
     # Log message in message log
     if text is None:
         text = ""

--- a/corehq/messaging/smsbackends/grapevine/models.py
+++ b/corehq/messaging/smsbackends/grapevine/models.py
@@ -236,6 +236,9 @@ class GrapevineResource(Resource):
             date_string = root.find('smsDateTime').text
             phone_number = root.find('cellNumber').text
             content_text = root.find('content').text
+            if six.PY2:
+                phone_number = phone_number.decode('utf-8')
+                content_text = content_text.decode('utf-8')
             bundle.obj = SmsMessage(phone_number, content_text)
 
         elif root.tag == 'gviSmsResponse':
@@ -245,6 +248,9 @@ class GrapevineResource(Resource):
 
             if resp_type == 'reply':
                 response_text = root.find('response').text
+                if six.PY2:
+                    phone_number = phone_number.decode('utf-8')
+                    response_text = response_text.decode('utf-8')
                 bundle.obj = SmsMessage(phone_number, response_text)
 
         return bundle


### PR DESCRIPTION
Used to sanity check that incoming SMS data is being properly decoded.  If bytes are passed, that is an immediate warning that decoding is not happening properly.

Set ```exponential_backoff=True``` for now.  Will set to ```False``` once we've verified that the soft assert passes most of the time.