### PR TITLE
Location-safe case import

### DIFF
--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -13,11 +13,11 @@ from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.toggles import LOCATION_SAFE_CASE_IMPORTS
 
 
-def locsafe_imports_enabled(view_func, request, *args, **kwargs):
+def location_safe_case_imports_enabled(view_func, request, *args, **kwargs):
     return LOCATION_SAFE_CASE_IMPORTS.enabled_for_request(request)
 
 
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 class ImportCases(DataInterface):
     name = ugettext_lazy("Import Cases from Excel")
     slug = "import_cases"

--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -9,10 +9,15 @@ from corehq.apps.case_importer.tracking.dbaccessors import (
 )
 from corehq.apps.data_interfaces.interfaces import DataInterface
 from corehq.apps.data_interfaces.views import DataInterfaceSection
-from corehq.apps.locations.permissions import location_safe
+from corehq.apps.locations.permissions import conditionally_location_safe
+from corehq.toggles import LOCATION_SAFE_CASE_IMPORTS
 
 
-@location_safe
+def locsafe_imports_enabled(view_func, request, *args, **kwargs):
+    return LOCATION_SAFE_CASE_IMPORTS.enabled_for_request(request)
+
+
+@conditionally_location_safe(locsafe_imports_enabled)
 class ImportCases(DataInterface):
     name = ugettext_lazy("Import Cases from Excel")
     slug = "import_cases"

--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -1,11 +1,14 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from corehq.apps.case_importer.tracking.dbaccessors import get_case_upload_record_count
-from corehq.apps.data_interfaces.interfaces import DataInterface
-from corehq.apps.data_interfaces.views import DataInterfaceSection
-from django.utils.translation import ugettext_noop as _
+from __future__ import absolute_import, unicode_literals
+
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy
+from django.utils.translation import ugettext_noop as _
+
+from corehq.apps.case_importer.tracking.dbaccessors import (
+    get_case_upload_record_count,
+)
+from corehq.apps.data_interfaces.interfaces import DataInterface
+from corehq.apps.data_interfaces.views import DataInterfaceSection
 
 
 class ImportCases(DataInterface):

--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -30,7 +30,7 @@ class ImportCases(DataInterface):
         return {
             'current_page': self.current_page_context(domain=self.domain),
             'section': self.section_context(),
-            'record_count': get_case_upload_record_count(self.domain),
+            'record_count': get_case_upload_record_count(self.domain, self.request.couch_user),
         }
 
     @classmethod

--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -9,8 +9,10 @@ from corehq.apps.case_importer.tracking.dbaccessors import (
 )
 from corehq.apps.data_interfaces.interfaces import DataInterface
 from corehq.apps.data_interfaces.views import DataInterfaceSection
+from corehq.apps.locations.permissions import location_safe
 
 
+@location_safe
 class ImportCases(DataInterface):
     name = ugettext_lazy("Import Cases from Excel")
     slug = "import_cases"

--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_noop
 
 from corehq.apps.case_importer.tracking.dbaccessors import (
     get_case_upload_record_count,
@@ -52,11 +52,11 @@ class ImportCases(DataInterface):
     def get_subpages(cls):
         return [
             {
-                'title': _('Case Options'),
+                'title': ugettext_noop('Case Options'),
                 'urlname': 'excel_config'
             },
             {
-                'title': _('Match Excel Columns to Case Properties'),
+                'title': ugettext_noop('Match Excel Columns to Case Properties'),
                 'urlname': 'excel_fields'
             }
         ]

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -460,10 +460,11 @@ def _is_valid_owner(owner, domain, user_id=None, locations=ALL_LOCATIONS):
 
 
 def _is_valid_location_owner(owner, domain):
-    if isinstance(owner, SQLLocation):
-        return owner.domain == domain and owner.location_type.shares_cases
-    else:
-        return False
+    return (
+        isinstance(owner, SQLLocation) and
+        owner.domain == domain and
+        owner.location_type.shares_cases
+    )
 
 
 def _is_owner_location_accessible_to_user(owner, domain, user_id, locations_accessible_to_user):

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -118,6 +118,9 @@ class _Importer(object):
         )
 
     def user_can_access_owner_location(self, caseblock):
+        if caseblock.owner_id == self.user._id:
+            return True
+
         if self.user.has_permission(self.domain, 'access_all_locations'):
             return True
 

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -451,12 +451,11 @@ def _is_valid_id(uploaded_id, domain, cache, user_id, locations):
 
 
 def _is_valid_owner(owner, domain, user_id=None, locations=ALL_LOCATIONS):
+    owner_is_user = isinstance(owner, CouchUser) and owner.is_member_of(domain)
+    owner_is_casesharing_group = isinstance(owner, Group) and owner.case_sharing and owner.is_member_of(domain)
     return (
-        (
-            (isinstance(owner, CouchUser) and owner.is_member_of(domain)) or
-            (isinstance(owner, Group) and owner.case_sharing and owner.is_member_of(domain)) or
-            _is_valid_location_owner(owner, domain)
-        ) and _is_owner_location_accessible_to_user(owner, domain, user_id, locations)
+        (owner_is_user or owner_is_casesharing_group or _is_valid_location_owner(owner, domain))
+        and _is_owner_location_accessible_to_user(owner, domain, user_id, locations)
     )
 
 

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -22,7 +22,7 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import format_username
-from corehq.toggles import BULK_UPLOAD_DATE_OPENED
+from corehq.toggles import BULK_UPLOAD_DATE_OPENED, LOCATION_SAFE_CASE_IMPORTS
 from corehq.util.datadog.utils import case_load_counter
 from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.soft_assert import soft_assert
@@ -98,6 +98,11 @@ class _Importer(object):
             else:
                 caseblock = row.get_update_caseblock()
                 self.results.add_updated(row_num)
+            if (
+                    LOCATION_SAFE_CASE_IMPORTS.enabled(self.domain)
+                    and not self.user_can_access_owner_location(caseblock)
+            ):
+                raise exceptions.InvalidLocation()
         except CaseBlockError:
             raise exceptions.CaseGeneration()
 
@@ -106,6 +111,27 @@ class _Importer(object):
     @cached_property
     def user(self):
         return CouchUser.get_by_user_id(self.config.couch_user_id, self.domain)
+
+    @cached_property
+    def location_ids_accessible_to_user(self):
+        return set(
+            SQLLocation.objects
+            .accessible_to_user(self.domain, self.user)
+            .values_list('location_id', flat=True)
+        )
+
+    def user_can_access_owner_location(self, caseblock):
+        if self.user.has_permission(self.domain, 'access_all_locations'):
+            return True
+
+        if caseblock.owner_id in self.location_ids_accessible_to_user:
+            return True
+
+        owner = CouchUser.get_by_user_id(caseblock.owner_id)
+        if owner and owner.get_location_id() in self.location_ids_accessible_to_user:
+            return True
+
+        return False
 
     def add_caseblock(self, caseblock):
         self._unsubmitted_caseblocks.append(caseblock)

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -106,6 +106,14 @@ class DuplicateLocationName(CaseRowError):
     )
 
 
+class InvalidLocation(CaseRowError):
+    title = ugettext_noop('Invalid Location')
+    message = ugettext_lazy(
+        "The location of the case owner needs to be at or below the "
+        "location of the user importing the cases."
+    )
+
+
 class InvalidInteger(CaseRowError):
     title = ugettext_noop('Invalid Integer')
     message = ugettext_lazy(

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -106,14 +106,6 @@ class DuplicateLocationName(CaseRowError):
     )
 
 
-class InvalidLocation(CaseRowError):
-    title = ugettext_noop('Invalid Location')
-    message = ugettext_lazy(
-        "The location of the case owner needs to be at or below the "
-        "location of the user importing the cases."
-    )
-
-
 class InvalidInteger(CaseRowError):
     title = ugettext_noop('Invalid Integer')
     message = ugettext_lazy(

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -452,8 +452,8 @@ class ImporterTest(TestCase):
         cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa.group_id)
         self.assertTrue(res['errors'])
-        error_message = exceptions.InvalidLocation.title
-        error_col = None
+        error_message = exceptions.InvalidOwnerId.title
+        error_col = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_col]['rows'], [2, 3])
 
     def test_user_can_access_owner(self):
@@ -474,8 +474,8 @@ class ImporterTest(TestCase):
         cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa_owner._id)
         self.assertTrue(res['errors'])
-        error_message = exceptions.InvalidLocation.title
-        error_col = None
+        error_message = exceptions.InvalidOwnerId.title
+        error_col = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_col]['rows'], [2, 3])
 
 

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -442,13 +442,12 @@ class ImporterTest(TestCase):
     def test_user_can_access_location(self):
         with make_business_units(self.domain) as (inc, dsi, dsa), \
                 restrict_user_to_location(self, dsa):
-            table = """
-                case_id | name            | owner_id
-                        | Leonard Nimoy   | {inc}
-                        | Kapil Dev       | {dsi}
-                        | Quinton Fortune | {dsa}
-            """.format(inc=inc.group_id, dsi=dsi.group_id, dsa=dsa.group_id)
-            res = self.import_mock_file(_get_rows(table))
+            res = self.import_mock_file([
+                ['case_id', 'name', 'owner_id'],
+                ['', 'Leonard Nimoy', inc.group_id],
+                ['', 'Kapil Dev', dsi.group_id],
+                ['', 'Quinton Fortune', dsa.group_id],
+            ])
 
         case_ids = self.accessor.get_case_ids_in_domain()
         cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
@@ -464,13 +463,13 @@ class ImporterTest(TestCase):
             inc_owner = CommCareUser.create(self.domain, 'inc', 'pw', location=inc)
             dsi_owner = CommCareUser.create(self.domain, 'dsi', 'pw', location=dsi)
             dsa_owner = CommCareUser.create(self.domain, 'dsa', 'pw', location=dsa)
-            table = """
-                case_id | name            | owner_id
-                        | Leonard Nimoy   | {inc}
-                        | Kapil Dev       | {dsi}
-                        | Quinton Fortune | {dsa}
-            """.format(inc=inc_owner._id, dsi=dsi_owner._id, dsa=dsa_owner._id)
-            res = self.import_mock_file(_get_rows(table))
+
+            res = self.import_mock_file([
+                ['case_id', 'name', 'owner_id'],
+                ['', 'Leonard Nimoy', inc_owner._id],
+                ['', 'Kapil Dev', dsi_owner._id],
+                ['', 'Quinton Fortune', dsa_owner._id],
+            ])
 
         case_ids = self.accessor.get_case_ids_in_domain()
         cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
@@ -479,11 +478,6 @@ class ImporterTest(TestCase):
         error_message = exceptions.InvalidLocation.title
         error_col = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_col]['rows'], [2, 3])
-
-
-def _get_rows(table):
-    lines = (line for line in table.split('\n') if line.strip())
-    return [[column.strip() for column in row.split('|')] for row in lines]
 
 
 def make_worksheet_wrapper(*rows):

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -454,7 +454,7 @@ class ImporterTest(TestCase):
         cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa.group_id)
         self.assertTrue(res['errors'])
-        error_message = exceptions.InvalidOwnerId.title
+        error_message = exceptions.InvalidLocation.title
         error_col = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_col]['rows'], [2, 3])
 
@@ -476,7 +476,7 @@ class ImporterTest(TestCase):
         cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
         self.assertEqual(cases['Quinton Fortune'].owner_id, dsa_owner._id)
         self.assertTrue(res['errors'])
-        error_message = exceptions.InvalidOwnerId.title
+        error_message = exceptions.InvalidLocation.title
         error_col = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_col]['rows'], [2, 3])
 

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -442,10 +442,10 @@ class ImporterTest(TestCase):
         with make_business_units(self.domain) as (inc, dsi, dsa), \
                 restrict_user_to_location(self, dsa):
             res = self.import_mock_file([
-                ['case_id', 'name',             'owner_id'  ],
-                ['',        'Leonard Nimoy',    inc.group_id],
-                ['',        'Kapil Dev',        dsi.group_id],
-                ['',        'Quinton Fortune',  dsa.group_id],
+                ['case_id', 'name',             'owner_id'],  # noqa: E241
+                ['',        'Leonard Nimoy',    inc.group_id],  # noqa: E241
+                ['',        'Kapil Dev',        dsi.group_id],  # noqa: E241
+                ['',        'Quinton Fortune',  dsa.group_id],  # noqa: E241
             ])
 
         case_ids = self.accessor.get_case_ids_in_domain()
@@ -454,7 +454,7 @@ class ImporterTest(TestCase):
         self.assertTrue(res['errors'])
         error_message = exceptions.InvalidLocation.title
         error_col = None
-        self.assertEqual(res['errors'][error_message ][error_col]['rows'], [2, 3])
+        self.assertEqual(res['errors'][error_message][error_col]['rows'], [2, 3])
 
     def test_user_can_access_owner(self):
         with make_business_units(self.domain) as (inc, dsi, dsa), \
@@ -464,10 +464,10 @@ class ImporterTest(TestCase):
             dsa_owner = CommCareUser.create(self.domain, 'dsa', 'pw', location=dsa)
 
             res = self.import_mock_file([
-                ['case_id', 'name',             'owner_id'   ],
-                ['',        'Leonard Nimoy',    inc_owner._id],
-                ['',        'Kapil Dev',        dsi_owner._id],
-                ['',        'Quinton Fortune',  dsa_owner._id],
+                ['case_id', 'name',             'owner_id'],  # noqa: E241
+                ['',        'Leonard Nimoy',    inc_owner._id],  # noqa: E241
+                ['',        'Kapil Dev',        dsi_owner._id],  # noqa: E241
+                ['',        'Quinton Fortune',  dsa_owner._id],  # noqa: E241
             ])
 
         case_ids = self.accessor.get_case_ids_in_domain()
@@ -476,7 +476,7 @@ class ImporterTest(TestCase):
         self.assertTrue(res['errors'])
         error_message = exceptions.InvalidLocation.title
         error_col = None
-        self.assertEqual(res['errors'][error_message ][error_col]['rows'], [2, 3])
+        self.assertEqual(res['errors'][error_message][error_col]['rows'], [2, 3])
 
 
 def make_worksheet_wrapper(*rows):

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from contextlib import contextmanager
-from string import Template
 
 from celery import states
 from celery.exceptions import Ignore

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -510,13 +510,13 @@ def restrict_user_to_location(test_case, location):
 
 @contextmanager
 def make_business_units(domain, shares_cases=True):
-        bu = LocationType.objects.create(domain=domain, name='bu', shares_cases=shares_cases)
-        dimagi = make_loc('dimagi', 'Dimagi', domain, bu.code)
-        inc = make_loc('inc', 'Inc', domain, bu.code, parent=dimagi)
-        dsi = make_loc('dsi', 'DSI', domain, bu.code, parent=dimagi)
-        dsa = make_loc('dsa', 'DSA', domain, bu.code, parent=dimagi)
-        try:
-            yield inc, dsi, dsa
-        finally:
-            for obj in dsa, dsi, inc, dimagi, bu:
-                obj.delete()
+    bu = LocationType.objects.create(domain=domain, name='bu', shares_cases=shares_cases)
+    dimagi = make_loc('dimagi', 'Dimagi', domain, bu.code)
+    inc = make_loc('inc', 'Inc', domain, bu.code, parent=dimagi)
+    dsi = make_loc('dsi', 'DSI', domain, bu.code, parent=dimagi)
+    dsa = make_loc('dsa', 'DSA', domain, bu.code, parent=dimagi)
+    try:
+        yield inc, dsi, dsa
+    finally:
+        for obj in dsa, dsi, inc, dimagi, bu:
+            obj.delete()

--- a/corehq/apps/case_importer/tests/test_owner.py
+++ b/corehq/apps/case_importer/tests/test_owner.py
@@ -1,24 +1,27 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.test import SimpleTestCase
-from corehq.apps.case_importer.do_import import _is_valid_owner
+from corehq.apps.case_importer.do_import import _check_owner
+from corehq.apps.case_importer.exceptions import InvalidOwnerId
 from corehq.apps.users.models import CommCareUser, DomainMembership, WebUser
 
 
 class TestIsValidOwner(SimpleTestCase):
 
     def test_user_owner_match(self):
-        self.assertTrue(_is_valid_owner(_mk_user(domain='match'), 'match'))
+        self.assertTrue(_check_owner(_mk_user(domain='match'), 'match'))
 
     def test_user_owner_nomatch(self):
-        self.assertFalse(_is_valid_owner(_mk_user(domain='match'), 'nomatch'))
+        with self.assertRaises(InvalidOwnerId):
+            _check_owner(_mk_user(domain='match'), 'nomatch')
 
     def test_web_user_owner_match(self):
-        self.assertTrue(_is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'match'))
-        self.assertTrue(_is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'match2'))
+        self.assertTrue(_check_owner(_mk_web_user(domains=['match', 'match2']), 'match'))
+        self.assertTrue(_check_owner(_mk_web_user(domains=['match', 'match2']), 'match2'))
 
     def test_web_user_owner_nomatch(self):
-        self.assertFalse(_is_valid_owner(_mk_web_user(domains=['match', 'match2']), 'nomatch'))
+        with self.assertRaises(InvalidOwnerId):
+            _check_owner(_mk_web_user(domains=['match', 'match2']), 'nomatch')
 
 
 def _mk_user(domain):

--- a/corehq/apps/case_importer/tracking/dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/dbaccessors.py
@@ -8,12 +8,18 @@ from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 MAX_RECENT_UPLOADS = 100
 
 
-def get_case_upload_records(domain, limit, skip=0):
-    return CaseUploadRecord.objects.filter(domain=domain).order_by('-created')[skip:skip + limit]
+def get_case_upload_records(domain, user, limit, skip=0):
+    query_set = CaseUploadRecord.objects.filter(domain=domain)
+    if not user.has_permission(domain, 'access_all_locations'):
+        query_set = query_set.filter(couch_user_id=user._id)
+    return query_set.order_by('-created')[skip:skip + limit]
 
 
-def get_case_upload_record_count(domain):
-    return min(MAX_RECENT_UPLOADS, CaseUploadRecord.objects.filter(domain=domain).count())
+def get_case_upload_record_count(domain, user):
+    query_set = CaseUploadRecord.objects.filter(domain=domain)
+    if not user.has_permission(domain, 'access_all_locations'):
+        query_set = query_set.filter(couch_user_id=user._id)
+    return min(MAX_RECENT_UPLOADS, query_set.count())
 
 
 def get_case_ids_for_case_upload(case_upload):

--- a/corehq/apps/case_importer/tracking/permissions.py
+++ b/corehq/apps/case_importer/tracking/permissions.py
@@ -1,6 +1,9 @@
 def user_may_view_file_upload(domain, couch_user, case_upload_record):
-    return (couch_user.is_domain_admin(domain) or
-            couch_user.user_id == case_upload_record.couch_user_id)
+    return (
+        # Safely assumes that domain admins are not location-restricted
+        couch_user.is_domain_admin(domain) or
+        couch_user.user_id == case_upload_record.couch_user_id
+    )
 
 
 def user_may_update_comment(couch_user, case_upload_record):

--- a/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
@@ -13,16 +13,18 @@ from corehq.apps.case_importer.tracking.dbaccessors import get_case_upload_recor
     get_case_ids_for_case_upload
 from corehq.apps.case_importer.tracking.models import CaseUploadRecord
 from corehq.apps.case_importer.util import ImporterConfig
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser, CouchUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 class DbaccessorsTest(TestCase):
-    domain = 'test-case-importer-dbaccessors'
 
     @classmethod
     def setUpClass(cls):
         super(DbaccessorsTest, cls).setUpClass()
+        cls.domain_obj = create_domain('test-case-importer-dbaccessors')
+        cls.domain = cls.domain_obj.name
         cls.user = WebUser.create(cls.domain, 'username', 'password')
         cls.case_upload_1 = CaseUploadRecord(
             upload_id=UUID('7ca20e75-8ba3-4d0d-9c9c-66371e8895dc'),

--- a/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
+++ b/corehq/apps/case_importer/tracking/tests/test_dbaccessors.py
@@ -23,6 +23,7 @@ class DbaccessorsTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super(DbaccessorsTest, cls).setUpClass()
+        cls.user = WebUser.create(cls.domain, 'username', 'password')
         cls.case_upload_1 = CaseUploadRecord(
             upload_id=UUID('7ca20e75-8ba3-4d0d-9c9c-66371e8895dc'),
             task_id=UUID('a2ebc913-11e6-4b6b-b909-355a863e0682'),
@@ -40,6 +41,7 @@ class DbaccessorsTest(TestCase):
     def tearDownClass(cls):
         cls.case_upload_1.delete()
         cls.case_upload_2.delete()
+        cls.user.delete()
         super(DbaccessorsTest, cls).tearDownClass()
 
     def assert_model_lists_equal(self, list_1, list_2):
@@ -48,16 +50,16 @@ class DbaccessorsTest(TestCase):
 
     def test_get_case_uploads(self):
         self.assert_model_lists_equal(
-            get_case_upload_records(self.domain, limit=1),
+            get_case_upload_records(self.domain, self.user, limit=1),
             # gets latest
             [self.case_upload_2])
         self.assert_model_lists_equal(
-            get_case_upload_records(self.domain, limit=2),
+            get_case_upload_records(self.domain, self.user, limit=2),
             # gets latest first
             [self.case_upload_2,
              self.case_upload_1])
         self.assert_model_lists_equal(
-            get_case_upload_records(self.domain, limit=1, skip=1),
+            get_case_upload_records(self.domain, self.user, limit=1, skip=1),
             # skips latest, gets previous
             [self.case_upload_1])
 

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -12,6 +12,7 @@ from django.http import (
 
 from dimagi.utils.web import json_response
 
+from corehq.apps.case_importer.base import locsafe_imports_enabled
 from corehq.apps.case_importer.tracking.dbaccessors import (
     get_case_ids_for_case_upload,
     get_case_upload_records,
@@ -29,12 +30,12 @@ from corehq.apps.case_importer.tracking.permissions import (
     user_may_view_file_upload,
 )
 from corehq.apps.case_importer.views import require_can_edit_data
-from corehq.apps.locations.permissions import location_safe
+from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.util.view_utils import set_file_download
 
 
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def case_uploads(request, domain):
     try:
         limit = int(request.GET.get('limit'))
@@ -60,7 +61,7 @@ def case_uploads(request, domain):
 
 
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def update_case_upload_comment(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -83,7 +84,7 @@ def update_case_upload_comment(request, domain, upload_id):
 
 
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def case_upload_file(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -100,7 +101,7 @@ def case_upload_file(request, domain, upload_id):
 
 
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def case_upload_form_ids(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -114,7 +115,7 @@ def case_upload_form_ids(request, domain, upload_id):
 
 
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def case_upload_case_ids(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -64,7 +64,7 @@ def case_uploads(request, domain):
 @conditionally_location_safe(location_safe_case_imports_enabled)
 def update_case_upload_comment(request, domain, upload_id):
     try:
-        case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
+        case_upload = _get_case_upload_record(domain, upload_id, request.couch_user)
     except CaseUploadRecord.DoesNotExist:
         return HttpResponseNotFound()
 
@@ -87,7 +87,7 @@ def update_case_upload_comment(request, domain, upload_id):
 @conditionally_location_safe(location_safe_case_imports_enabled)
 def case_upload_file(request, domain, upload_id):
     try:
-        case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
+        case_upload = _get_case_upload_record(domain, upload_id, request.couch_user)
     except CaseUploadRecord.DoesNotExist:
         return HttpResponseNotFound()
 

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -29,10 +29,12 @@ from corehq.apps.case_importer.tracking.permissions import (
     user_may_view_file_upload,
 )
 from corehq.apps.case_importer.views import require_can_edit_data
+from corehq.apps.locations.permissions import location_safe
 from corehq.util.view_utils import set_file_download
 
 
 @require_can_edit_data
+@location_safe
 def case_uploads(request, domain):
     try:
         limit = int(request.GET.get('limit'))
@@ -58,6 +60,7 @@ def case_uploads(request, domain):
 
 
 @require_can_edit_data
+@location_safe
 def update_case_upload_comment(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -80,6 +83,7 @@ def update_case_upload_comment(request, domain, upload_id):
 
 
 @require_can_edit_data
+@location_safe
 def case_upload_file(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -96,6 +100,7 @@ def case_upload_file(request, domain, upload_id):
 
 
 @require_can_edit_data
+@location_safe
 def case_upload_form_ids(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -109,6 +114,7 @@ def case_upload_form_ids(request, domain, upload_id):
 
 
 @require_can_edit_data
+@location_safe
 def case_upload_case_ids(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -12,7 +12,7 @@ from django.http import (
 
 from dimagi.utils.web import json_response
 
-from corehq.apps.case_importer.base import locsafe_imports_enabled
+from corehq.apps.case_importer.base import location_safe_case_imports_enabled
 from corehq.apps.case_importer.tracking.dbaccessors import (
     get_case_ids_for_case_upload,
     get_case_upload_records,
@@ -35,7 +35,7 @@ from corehq.util.view_utils import set_file_download
 
 
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def case_uploads(request, domain):
     try:
         limit = int(request.GET.get('limit'))
@@ -61,7 +61,7 @@ def case_uploads(request, domain):
 
 
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def update_case_upload_comment(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -84,7 +84,7 @@ def update_case_upload_comment(request, domain, upload_id):
 
 
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def case_upload_file(request, domain, upload_id):
     try:
         case_upload = CaseUploadRecord.objects.get(upload_id=upload_id, domain=domain)
@@ -101,7 +101,7 @@ def case_upload_file(request, domain, upload_id):
 
 
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def case_upload_form_ids(request, domain, upload_id):
     try:
         case_upload = _get_case_upload_record(domain, upload_id, request.couch_user)
@@ -115,7 +115,7 @@ def case_upload_form_ids(request, domain, upload_id):
 
 
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def case_upload_case_ids(request, domain, upload_id):
     try:
         case_upload = _get_case_upload_record(domain, upload_id, request.couch_user)

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -1,20 +1,35 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from django.db import transaction
-from django.http import HttpResponseNotFound, HttpResponseForbidden, \
-    StreamingHttpResponse, HttpResponseBadRequest
+from __future__ import absolute_import, unicode_literals
 
-from corehq.apps.case_importer.tracking.dbaccessors import get_case_upload_records, \
-    get_case_ids_for_case_upload, get_form_ids_for_case_upload
-from corehq.apps.case_importer.tracking.jsmodels import case_upload_to_user_json
-from corehq.apps.case_importer.tracking.models import CaseUploadRecord, \
-    MAX_COMMENT_LENGTH
-from corehq.apps.case_importer.tracking.permissions import user_may_view_file_upload, \
-    user_may_update_comment
+from io import open
+
+from django.db import transaction
+from django.http import (
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseNotFound,
+    StreamingHttpResponse,
+)
+
+from dimagi.utils.web import json_response
+
+from corehq.apps.case_importer.tracking.dbaccessors import (
+    get_case_ids_for_case_upload,
+    get_case_upload_records,
+    get_form_ids_for_case_upload,
+)
+from corehq.apps.case_importer.tracking.jsmodels import (
+    case_upload_to_user_json,
+)
+from corehq.apps.case_importer.tracking.models import (
+    MAX_COMMENT_LENGTH,
+    CaseUploadRecord,
+)
+from corehq.apps.case_importer.tracking.permissions import (
+    user_may_update_comment,
+    user_may_view_file_upload,
+)
 from corehq.apps.case_importer.views import require_can_edit_data
 from corehq.util.view_utils import set_file_download
-from dimagi.utils.web import json_response
-from io import open
 
 
 @require_can_edit_data

--- a/corehq/apps/case_importer/urls.py
+++ b/corehq/apps/case_importer/urls.py
@@ -1,9 +1,14 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from django.conf.urls import url
-from corehq.apps.case_importer.tracking.views import case_uploads, case_upload_file, \
-    update_case_upload_comment, case_upload_case_ids, case_upload_form_ids
+from __future__ import absolute_import, unicode_literals
 
+from django.conf.urls import url
+
+from corehq.apps.case_importer.tracking.views import (
+    case_upload_case_ids,
+    case_upload_file,
+    case_upload_form_ids,
+    case_uploads,
+    update_case_upload_comment,
+)
 from corehq.apps.case_importer.views import (
     excel_commit,
     excel_config,

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -21,6 +21,7 @@ from corehq.apps.case_importer.suggested_fields import (
 )
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.util import get_importer_error_message
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es,
 )
@@ -61,6 +62,7 @@ def _case_importer_breadcrumb_context(page_name, domain):
 
 
 @require_can_edit_data
+@location_safe
 def excel_config(request, domain):
     """
     Step one of three.
@@ -150,6 +152,7 @@ def excel_config(request, domain):
 
 @require_POST
 @require_can_edit_data
+@location_safe
 def excel_fields(request, domain):
     """
     Step two of three.
@@ -227,6 +230,7 @@ def excel_fields(request, domain):
 
 @require_POST
 @require_can_edit_data
+@location_safe
 def excel_commit(request, domain):
     """
     Step three of three.

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -14,7 +14,7 @@ from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.app_manager.helpers.validators import validate_property
 from corehq.apps.case_importer import base
 from corehq.apps.case_importer import util as importer_util
-from corehq.apps.case_importer.base import locsafe_imports_enabled
+from corehq.apps.case_importer.base import location_safe_case_imports_enabled
 from corehq.apps.case_importer.const import MAX_CASE_IMPORTER_COLUMNS
 from corehq.apps.case_importer.exceptions import ImporterError
 from corehq.apps.case_importer.suggested_fields import (
@@ -63,7 +63,7 @@ def _case_importer_breadcrumb_context(page_name, domain):
 
 
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def excel_config(request, domain):
     """
     Step one of three.
@@ -153,7 +153,7 @@ def excel_config(request, domain):
 
 @require_POST
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def excel_fields(request, domain):
     """
     Step two of three.
@@ -231,7 +231,7 @@ def excel_fields(request, domain):
 
 @require_POST
 @require_can_edit_data
-@conditionally_location_safe(locsafe_imports_enabled)
+@conditionally_location_safe(location_safe_case_imports_enabled)
 def excel_commit(request, domain):
     """
     Step three of three.

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -1,27 +1,32 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import os.path
+
+from django.contrib import messages
 from django.http import HttpResponseRedirect
+from django.shortcuts import render
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.html import format_html
+from django.utils.translation import ugettext as _
+from django.views.decorators.http import require_POST
+
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.app_manager.helpers.validators import validate_property
 from corehq.apps.case_importer import base
 from corehq.apps.case_importer import util as importer_util
 from corehq.apps.case_importer.const import MAX_CASE_IMPORTER_COLUMNS
 from corehq.apps.case_importer.exceptions import ImporterError
-from django.views.decorators.http import require_POST
-from corehq.apps.case_importer.suggested_fields import get_suggested_case_fields
+from corehq.apps.case_importer.suggested_fields import (
+    get_suggested_case_fields,
+)
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
-from corehq.util.workbook_reading import SpreadsheetFileExtError
 from corehq.apps.case_importer.util import get_importer_error_message
-from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
+from corehq.apps.reports.analytics.esaccessors import (
+    get_case_types_for_domain_es,
+)
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
-
-from django.contrib import messages
-from django.shortcuts import render
-from django.utils.translation import ugettext as _
+from corehq.util.workbook_reading import SpreadsheetFileExtError
 
 require_can_edit_data = require_permission(Permissions.edit_data)
 

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -28,7 +28,6 @@ from corehq.apps.reports.analytics.esaccessors import (
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
-from corehq.toggles import LOCATION_SAFE_CASE_IMPORTS
 from corehq.util.workbook_reading import SpreadsheetFileExtError
 
 require_can_edit_data = require_permission(Permissions.edit_data)

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -14,6 +14,7 @@ from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.app_manager.helpers.validators import validate_property
 from corehq.apps.case_importer import base
 from corehq.apps.case_importer import util as importer_util
+from corehq.apps.case_importer.base import locsafe_imports_enabled
 from corehq.apps.case_importer.const import MAX_CASE_IMPORTER_COLUMNS
 from corehq.apps.case_importer.exceptions import ImporterError
 from corehq.apps.case_importer.suggested_fields import (
@@ -21,12 +22,13 @@ from corehq.apps.case_importer.suggested_fields import (
 )
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.util import get_importer_error_message
-from corehq.apps.locations.permissions import location_safe
+from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es,
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.toggles import LOCATION_SAFE_CASE_IMPORTS
 from corehq.util.workbook_reading import SpreadsheetFileExtError
 
 require_can_edit_data = require_permission(Permissions.edit_data)
@@ -62,7 +64,7 @@ def _case_importer_breadcrumb_context(page_name, domain):
 
 
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def excel_config(request, domain):
     """
     Step one of three.
@@ -152,7 +154,7 @@ def excel_config(request, domain):
 
 @require_POST
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def excel_fields(request, domain):
     """
     Step two of three.
@@ -230,7 +232,7 @@ def excel_fields(request, domain):
 
 @require_POST
 @require_can_edit_data
-@location_safe
+@conditionally_location_safe(locsafe_imports_enabled)
 def excel_commit(request, domain):
     """
     Step three of three.

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1703,6 +1703,14 @@ MANAGE_RELEASES_PER_LOCATION = StaticToggle(
 )
 
 
+LOCATION_SAFE_CASE_IMPORTS = StaticToggle(
+    'location_safe_case_imports',
+    'Allow location-restricted users to import cases owned at their location or below',
+    TAG_SOLUTIONS,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
+
 HIDE_HQ_ON_MOBILE_EXPERIENCE = StaticToggle(
     'hide_hq_on_mobile_experience',
     'Do not show modal on mobile that mobile hq experience is bad',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1703,14 +1703,6 @@ MANAGE_RELEASES_PER_LOCATION = StaticToggle(
 )
 
 
-LOCATION_SAFE_CASE_IMPORTS = StaticToggle(
-    'location_safe_case_imports',
-    'Allow location-restricted users to import cases owned at their location or below',
-    TAG_SOLUTIONS,
-    namespaces=[NAMESPACE_DOMAIN],
-)
-
-
 HIDE_HQ_ON_MOBILE_EXPERIENCE = StaticToggle(
     'hide_hq_on_mobile_experience',
     'Do not show modal on mobile that mobile hq experience is bad',


### PR DESCRIPTION
This change allows location-restricted users to import cases, as long as the location of the owner of the imported case is accessible to the user.

You'll see I started with a feature flag, but I later realised that applying it to the views would be clunky. (Or, at least, I couldn't see a better way of doing it than making a special decorator just for this feature flag, and I didn't think that was great, but I'm open to suggestions/persuasion.) I thought it would be alright to drop it, considering there are no UI changes, so the change would be invisible unless the user has a location-restricted role with Edit Data permissions. Let me know what you think.
