### PR TITLE
Extract queue and pool logic into a class

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -927,9 +927,9 @@ class AsyncFormProcessor(object):
             form_received = wrapped_form.received_on
             assert self.last_received_on <= form_received
             self.last_received_on = form_received
-            self._try_to_process_form(wrapped_form)
         except Exception:
             log.exception("Error migrating form %s", form_id)
+        self._try_to_process_form(wrapped_form)
         self._try_to_empty_queues()
 
     def _try_to_process_form(self, wrapped_form):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -183,9 +183,9 @@ class CouchSqlDomainMigrator(object):
             else:
                 gevent.sleep()  # swap greenlets
 
-            remaining_items = self.queues.remaining_items + len(pool)
             now = datetime.now()
             if now > next_check:
+                remaining_items = self.queues.remaining_items + len(pool)
                 log.info('Waiting on {} docs'.format(remaining_items))
                 next_check += update_interval
 

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -894,7 +894,7 @@ class AsyncFormProcessor(object):
 
     def __enter__(self):
         self.pool = Pool(15)
-        self.queues = PartiallyLockingQueue(run_timestamp=self.run_timestamp)
+        self.queues = PartiallyLockingQueue(self.run_timestamp)
         self._rebuild_queues()
         return self
 
@@ -992,7 +992,7 @@ class PartiallyLockingQueue(object):
         with an object once finished processing
     """
 
-    def __init__(self, queue_id_param="form_id", max_size=10000, run_timestamp=None):
+    def __init__(self, run_timestamp, queue_id_param="form_id", max_size=10000):
         """
         :queue_id_param string: param of the queued objects to pull an id from
         :max_size int: the maximum size the queue should reach. -1 means no limit

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -890,7 +890,6 @@ class AsyncFormProcessor(object):
     def __init__(self, run_timestamp, migrate_form):
         self.run_timestamp = run_timestamp
         self.migrate_form = migrate_form
-        self.last_received_on = datetime.min
         self.processed_docs = 0
 
     def __enter__(self):
@@ -924,9 +923,6 @@ class AsyncFormProcessor(object):
                 raise ProblemForm(form_id)
         try:
             wrapped_form = XFormInstance.wrap(doc)
-            form_received = wrapped_form.received_on
-            assert self.last_received_on <= form_received
-            self.last_received_on = form_received
         except Exception:
             log.exception("Error migrating form %s", form_id)
         self._try_to_process_form(wrapped_form)

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -897,6 +897,8 @@ class AsyncFormProcessor(object):
         self.pool = Pool(15)
         self.queues = PartiallyLockingQueue(run_timestamp=self.run_timestamp)
         self._rebuild_queues()
+        # FIXME initializing without run_timestamp looks like a bug:
+        # form ids saved with wrong key? -> resume is probably broken
         self.queues = PartiallyLockingQueue()
         return self
 

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -127,7 +127,10 @@ class CouchSqlDomainMigrator(object):
         self.run_timestamp = run_timestamp or int(time())
         db_filepath = get_diff_db_filepath(domain)
         self.diff_db = DiffDB.init(db_filepath)
+        # FIXME state is lost on resume
+        # this one is bad: forms would be lost (not migrated) on stop/resume
         self.errors_with_normal_doc_type = []
+        # this one may only affect diffs?
         self.forms_that_touch_cases_without_actions = set()
 
     def migrate(self):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -152,7 +152,7 @@ class CouchSqlDomainMigrator(object):
     def _process_main_forms(self):
         last_received_on = datetime.min
         # form_id needs to be on self to release appropriately
-        self.queues = PartiallyLockingQueue("form_id", max_size=10000, run_timestamp=self.run_timestamp)
+        self.queues = PartiallyLockingQueue(run_timestamp=self.run_timestamp)
         pool = Pool(15)
         self._rebuild_queues(pool)
 
@@ -160,7 +160,7 @@ class CouchSqlDomainMigrator(object):
         changes = self._get_resumable_iterator(['XFormInstance'], 'main_forms')
 
         # form_id needs to be on self to release appropriately
-        self.queues = PartiallyLockingQueue("form_id", max_size=10000)
+        self.queues = PartiallyLockingQueue()
 
         for change in self._with_progress(['XFormInstance'], changes):
             log.debug('Processing doc: {}({})'.format('XFormInstance', change.id))
@@ -966,7 +966,7 @@ class PartiallyLockingQueue(object):
         with an object once finished processing
     """
 
-    def __init__(self, queue_id_param="id", max_size=-1, run_timestamp=None):
+    def __init__(self, queue_id_param="form_id", max_size=10000, run_timestamp=None):
         """
         :queue_id_param string: param of the queued objects to pull an id from
         :max_size int: the maximum size the queue should reach. -1 means no limit

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -896,9 +896,6 @@ class AsyncFormProcessor(object):
         self.pool = Pool(15)
         self.queues = PartiallyLockingQueue(run_timestamp=self.run_timestamp)
         self._rebuild_queues()
-        # FIXME initializing without run_timestamp looks like a bug:
-        # form ids saved with wrong key? -> resume is probably broken
-        self.queues = PartiallyLockingQueue()
         return self
 
     def __exit__(self, exc_type, exc, exc_tb):

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -807,7 +807,7 @@ class LedgerMigrationTests(BaseMigrationTestCase):
 
 class TestLockingQueues(TestCase):
     def setUp(self):
-        self.queues = PartiallyLockingQueue()
+        self.queues = PartiallyLockingQueue("id", max_size=-1)
 
     def _add_to_queues(self, queue_obj_id, lock_ids):
         self.queues._add_item(lock_ids, DummyObject(queue_obj_id))

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -807,7 +807,7 @@ class LedgerMigrationTests(BaseMigrationTestCase):
 
 class TestLockingQueues(TestCase):
     def setUp(self):
-        self.queues = PartiallyLockingQueue("id", max_size=-1)
+        self.queues = PartiallyLockingQueue(0, "id", max_size=-1)
 
     def _add_to_queues(self, queue_obj_id, lock_ids):
         self.queues._add_item(lock_ids, DummyObject(queue_obj_id))


### PR DESCRIPTION
Move the queue and gevent worker pool logic used to process forms asynchronously into a separate class. Found a couple bugs along the way; one has been fixed, one will be fixed in future work.

🐡 Review by commit

@orangejenny 