### PR TITLE
OData Configuration for Forms

### DIFF
--- a/corehq/apps/dashboard/models.py
+++ b/corehq/apps/dashboard/models.py
@@ -205,7 +205,7 @@ class DataPaginator(TilePaginator):
         exports = []
         if self.permissions.has_form_export_permissions:
             from corehq.apps.export.dbaccessors import get_form_exports_by_domain
-            exports = get_form_exports_by_domain(self.request.domain, self.permissions.has_deid_view_permissions)
+            exports = get_form_exports_by_domain(self.request.domain)
         return exports
 
     @property
@@ -214,7 +214,7 @@ class DataPaginator(TilePaginator):
         exports = []
         if self.permissions.has_case_export_permissions:
             from corehq.apps.export.dbaccessors import get_case_exports_by_domain
-            exports = get_case_exports_by_domain(self.request.domain, self.permissions.has_deid_view_permissions)
+            exports = get_case_exports_by_domain(self.request.domain)
         return exports
 
     def _paginated_items(self, items_per_page, skip):

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -468,7 +468,7 @@ def num_repeaters(domain):
 
 
 def _get_domain_exports(domain):
-    return get_form_exports_by_domain(domain, True) + get_case_exports_by_domain(domain, True)
+    return get_form_exports_by_domain(domain) + get_case_exports_by_domain(domain)
 
 
 def num_deid_exports(domain):

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -64,44 +64,31 @@ def get_form_inferred_schema(domain, app_id, xmlns):
     return FormInferredSchema.wrap(result['doc']) if result else None
 
 
-def get_form_export_instances(domain, include_docs=True):
+def get_form_export_instances(domain):
     from .models import FormExportInstance
     key = [domain, 'FormExportInstance']
-    return _get_export_instance(FormExportInstance, key, include_docs=include_docs)
+    return _get_export_instance(FormExportInstance, key)
 
 
-def get_case_export_instances(domain, include_docs=True):
+def get_case_export_instances(domain):
     from .models import CaseExportInstance
     key = [domain, 'CaseExportInstance']
-    return _get_export_instance(CaseExportInstance, key, include_docs=include_docs)
+    return _get_export_instance(CaseExportInstance, key)
 
 
-def _get_saved_exports(domain, has_deid_permissions, new_exports_getter, include_docs=True):
-    exports = new_exports_getter(domain, include_docs=include_docs)
-    if not include_docs:
-        return _get_brief_saved_exports(domain, has_deid_permissions, new_exports_getter)
+def _get_saved_exports(domain, has_deid_permissions, new_exports_getter):
+    exports = new_exports_getter(domain)
     if not has_deid_permissions:
         exports = [e for e in exports if not e.is_safe]
     return exports
 
 
-def _get_brief_saved_exports(domain, has_deid_permissions, new_exports_getter):
-    exports = new_exports_getter(domain)
-    if not has_deid_permissions:
-        exports = [e for e in exports if not e['is_deidentified']]
-    return exports
+def get_case_exports_by_domain(domain, has_deid_permissions):
+    return _get_saved_exports(domain, has_deid_permissions, get_case_export_instances)
 
 
-# Note that if include_docs is True, this will return wrapped documents, but
-# if False, it will return dicts (the value from export_instances_by_domain's map.js)
-def get_case_exports_by_domain(domain, has_deid_permissions, include_docs=True):
-    return _get_saved_exports(domain, has_deid_permissions, get_case_export_instances, include_docs=include_docs)
-
-
-# Note that if include_docs is True, this will return wrapped documents, but
-# if False, it will return dicts (the value from export_instances_by_domain's map.js)
-def get_form_exports_by_domain(domain, has_deid_permissions, include_docs=True):
-    return _get_saved_exports(domain, has_deid_permissions, get_form_export_instances, include_docs=include_docs)
+def get_form_exports_by_domain(domain, has_deid_permissions):
+    return _get_saved_exports(domain, has_deid_permissions, get_form_export_instances)
 
 
 def get_brief_exports(domain, form_or_case=None):

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -64,31 +64,16 @@ def get_form_inferred_schema(domain, app_id, xmlns):
     return FormInferredSchema.wrap(result['doc']) if result else None
 
 
-def get_form_export_instances(domain):
-    from .models import FormExportInstance
-    key = [domain, 'FormExportInstance']
-    return _get_export_instance(FormExportInstance, key)
-
-
-def get_case_export_instances(domain):
+def get_case_exports_by_domain(domain):
     from .models import CaseExportInstance
     key = [domain, 'CaseExportInstance']
     return _get_export_instance(CaseExportInstance, key)
 
 
-def _get_saved_exports(domain, has_deid_permissions, new_exports_getter):
-    exports = new_exports_getter(domain)
-    if not has_deid_permissions:
-        exports = [e for e in exports if not e.is_safe]
-    return exports
-
-
-def get_case_exports_by_domain(domain, has_deid_permissions):
-    return _get_saved_exports(domain, has_deid_permissions, get_case_export_instances)
-
-
-def get_form_exports_by_domain(domain, has_deid_permissions):
-    return _get_saved_exports(domain, has_deid_permissions, get_form_export_instances)
+def get_form_exports_by_domain(domain):
+    from .models import FormExportInstance
+    key = [domain, 'FormExportInstance']
+    return _get_export_instance(FormExportInstance, key)
 
 
 def get_brief_exports(domain, form_or_case=None):

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -104,6 +104,32 @@ def get_form_exports_by_domain(domain, has_deid_permissions, include_docs=True):
     return _get_saved_exports(domain, has_deid_permissions, get_form_export_instances, include_docs=include_docs)
 
 
+def get_brief_exports(domain, form_or_case=None):
+    from .models import ExportInstance
+    if form_or_case == 'form':
+        key = [domain, 'FormExportInstance']
+    elif form_or_case == 'case':
+        key = [domain, 'CaseExportInstance']
+    else:
+        key = [domain]
+    return _get_export_instance(ExportInstance, key, include_docs=False)
+
+
+def get_brief_deid_exports(domain, form_or_case=None):
+    from .models import ExportInstance
+    doc_types = [doc_type for doc_type in [
+        'FormExportInstance' if form_or_case in ['form', None] else None,
+        'CaseExportInstance' if form_or_case in ['case', None] else None,
+    ] if doc_type is not None]
+    results = ExportInstance.get_db().view(
+        'export_instances_by_domain/view',
+        keys=[[domain, doc_type, True] for doc_type in doc_types],
+        include_docs=False,
+        reduce=False,
+    ).all()
+    return [result['value'] for result in results]
+
+
 def get_export_count_by_domain(domain):
     from .models import ExportInstance
 

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -215,10 +215,10 @@ class TestExportInstanceDBAccessors(TestCase):
         self.assertEqual(len(instances), 1)
 
     def test_deid_case_exports_permissions(self):
-        instances = get_form_exports_by_domain(self.domain, has_deid_permissions=True)
+        instances = get_case_exports_by_domain(self.domain, has_deid_permissions=True)
         self.assertEqual(len(instances), 2)
 
-        instances = get_form_exports_by_domain(self.domain, has_deid_permissions=False)
+        instances = get_case_exports_by_domain(self.domain, has_deid_permissions=False)
         self.assertEqual(len(instances), 1)
 
 

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -23,7 +23,9 @@ from corehq.apps.export.dbaccessors import (
     get_case_inferred_schema,
     get_form_inferred_schema,
     get_form_exports_by_domain,
-    get_case_exports_by_domain
+    get_case_exports_by_domain,
+    get_brief_exports,
+    get_brief_deid_exports,
 )
 
 
@@ -220,6 +222,26 @@ class TestExportInstanceDBAccessors(TestCase):
 
         instances = get_case_exports_by_domain(self.domain, has_deid_permissions=False)
         self.assertEqual(len(instances), 1)
+
+    def test_get_brief_exports(self):
+        stubs = get_brief_exports(self.domain, form_or_case='form')
+        self.assertEqual(len(stubs), 2)
+
+        stubs = get_brief_exports(self.domain, form_or_case='case')
+        self.assertEqual(len(stubs), 2)
+
+        stubs = get_brief_exports(self.domain, form_or_case=None)
+        self.assertEqual(len(stubs), 4)
+
+    def test_get_brief_deid_exports(self):
+        stubs = get_brief_deid_exports(self.domain, form_or_case='form')
+        self.assertEqual(len(stubs), 1)
+
+        stubs = get_brief_deid_exports(self.domain, form_or_case='case')
+        self.assertEqual(len(stubs), 1)
+
+        stubs = get_brief_deid_exports(self.domain, form_or_case=None)
+        self.assertEqual(len(stubs), 2)
 
 
 class TestInferredSchemasDBAccessors(TestCase):

--- a/corehq/apps/export/tests/test_dbaccessors.py
+++ b/corehq/apps/export/tests/test_dbaccessors.py
@@ -14,8 +14,6 @@ from corehq.apps.export.models import (
 from corehq.apps.export.dbaccessors import (
     get_latest_case_export_schema,
     get_latest_form_export_schema,
-    get_form_export_instances,
-    get_case_export_instances,
     get_export_count_by_domain,
     get_deid_export_count,
     get_daily_saved_export_ids_for_auto_rebuild,
@@ -170,12 +168,12 @@ class TestExportInstanceDBAccessors(TestCase):
             instance.delete()
         super(TestExportInstanceDBAccessors, cls).tearDownClass()
 
-    def test_get_form_export_instances(self):
-        instances = get_form_export_instances(self.domain)
+    def test_get_form_exports_by_domain(self):
+        instances = get_form_exports_by_domain(self.domain)
         self.assertEqual(len(instances), 2)
 
-    def test_get_case_export_instances(self):
-        instances = get_case_export_instances(self.domain)
+    def test_get_case_exports_by_domain(self):
+        instances = get_case_exports_by_domain(self.domain)
         self.assertEqual(len(instances), 2)
 
     def test_get_count_export_instances(self):
@@ -191,7 +189,7 @@ class TestExportInstanceDBAccessors(TestCase):
         )
 
     def test_get_case_export_instances_wrong_domain(self):
-        instances = get_case_export_instances('wrong')
+        instances = get_case_exports_by_domain('wrong')
         self.assertEqual(len(instances), 0)
 
     def test_get_daily_saved_exports(self):
@@ -208,20 +206,6 @@ class TestExportInstanceDBAccessors(TestCase):
 
         instance = get_properly_wrapped_export_instance(self.case_instance._id)
         self.assertEqual(type(instance), type(self.case_instance))
-
-    def test_deid_form_exports_permissions(self):
-        instances = get_form_exports_by_domain(self.domain, has_deid_permissions=True)
-        self.assertEqual(len(instances), 2)
-
-        instances = get_form_exports_by_domain(self.domain, has_deid_permissions=False)
-        self.assertEqual(len(instances), 1)
-
-    def test_deid_case_exports_permissions(self):
-        instances = get_case_exports_by_domain(self.domain, has_deid_permissions=True)
-        self.assertEqual(len(instances), 2)
-
-        instances = get_case_exports_by_domain(self.domain, has_deid_permissions=False)
-        self.assertEqual(len(instances), 1)
 
     def test_get_brief_exports(self):
         stubs = get_brief_exports(self.domain, form_or_case='form')

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -17,8 +17,8 @@ from corehq.apps.users.models import WebUser
 from corehq.apps.domain.models import Domain
 from corehq.apps.export.dbaccessors import (
     delete_all_export_instances,
-    get_form_export_instances,
-    get_case_export_instances,
+    get_form_exports_by_domain,
+    get_case_exports_by_domain,
 )
 from corehq.apps.export.views.edit import (
     EditNewCustomCaseExportView,
@@ -190,7 +190,7 @@ class ExportViewTest(ViewTestCase):
             follow=True
         )
         self.assertEqual(resp.status_code, 200)
-        exports = get_form_export_instances(self.domain.name)
+        exports = get_form_exports_by_domain(self.domain.name)
         self.assertEqual(len(exports), 1)
         export = exports[0]
 
@@ -232,7 +232,7 @@ class ExportViewTest(ViewTestCase):
         )
         self.assertEqual(resp.status_code, 200)
 
-        exports = get_case_export_instances(self.domain.name)
+        exports = get_case_exports_by_domain(self.domain.name)
         self.assertEqual(len(exports), 1)
         export = exports[0]
 
@@ -283,7 +283,7 @@ class ExportViewTest(ViewTestCase):
         )
         self.assertEqual(resp.status_code, 200)
 
-        exports = get_case_export_instances(self.domain.name)
+        exports = get_case_exports_by_domain(self.domain.name)
         self.assertEqual(len(exports), 1)
         export = exports[0]
 

--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -20,6 +20,7 @@ from corehq.apps.export.views.edit import (
     EditFormFeedView,
     EditFormDailySavedExportView,
     EditODataCaseFeedView,
+    EditODataFormFeedView,
 )
 from corehq.apps.export.views.list import (
     DailySavedExportListView,
@@ -47,6 +48,7 @@ from corehq.apps.export.views.new import (
     CreateNewCaseFeedView,
     CreateNewFormFeedView,
     CreateODataCaseFeedView,
+    CreateODataFormFeedView,
     CopyExportView,
     DeleteNewCustomExportView,
 )
@@ -110,6 +112,9 @@ urlpatterns = [
     url(r"^custom/new/odata_case_feed/create$",
         CreateODataCaseFeedView.as_view(),
         name=CreateODataCaseFeedView.urlname),
+    url(r"^custom/new/odata_form_feed/create$",
+        CreateODataFormFeedView.as_view(),
+        name=CreateODataFormFeedView.urlname),
     url(r"^custom/new/case_daily_saved/create$",
         CreateNewDailySavedCaseExport.as_view(),
         name=CreateNewDailySavedCaseExport.urlname),
@@ -147,6 +152,9 @@ urlpatterns = [
     url(r"^custom/odata_case_feed/edit/(?P<export_id>[\w\-]+)/$",
         EditODataCaseFeedView.as_view(),
         name=EditODataCaseFeedView.urlname),
+    url(r"^custom/odata_form_feed/edit/(?P<export_id>[\w\-]+)/$",
+        EditODataFormFeedView.as_view(),
+        name=EditODataFormFeedView.urlname),
     url(r"^custom/case_feed/edit/(?P<export_id>[\w\-]+)/$",
         EditCaseFeedView.as_view(),
         name=EditCaseFeedView.urlname),

--- a/corehq/apps/export/views/edit.py
+++ b/corehq/apps/export/views/edit.py
@@ -1,18 +1,22 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
-from couchdbkit import ResourceNotFound
 from django.contrib import messages
 from django.http import Http404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy
+
+from couchdbkit import ResourceNotFound
 from memoized import memoized
 
 from corehq.apps.domain.decorators import login_and_domain_required
-from corehq.apps.export.const import FORM_EXPORT, CASE_EXPORT
+from corehq.apps.export.const import CASE_EXPORT, FORM_EXPORT
 from corehq.apps.export.views.new import BaseModifyNewCustomView
-from corehq.apps.export.views.utils import DailySavedExportMixin, DashboardFeedMixin
+from corehq.apps.export.views.utils import (
+    DailySavedExportMixin,
+    DashboardFeedMixin,
+    ODataFeedMixin,
+)
 
 
 class BaseEditNewCustomExportView(BaseModifyNewCustomView):
@@ -95,6 +99,11 @@ class EditFormDailySavedExportView(DailySavedExportMixin, EditNewCustomFormExpor
     urlname = 'edit_form_daily_saved_export'
 
 
-class EditODataCaseFeedView(EditNewCustomCaseExportView):
+class EditODataCaseFeedView(ODataFeedMixin, EditNewCustomCaseExportView):
     urlname = 'edit_odata_case_feed'
     page_title = ugettext_lazy("Edit OData Case Feed")
+
+
+class EditODataFormFeedView(ODataFeedMixin, EditNewCustomFormExportView):
+    urlname = 'edit_odata_form_feed'
+    page_title = ugettext_lazy("Edit OData Form Feed")

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -151,8 +151,6 @@ class ExportListHelper(object):
                 if _can_view(export, self.request.couch_user.user_id)
                 and ('owner_id' in export and export['owner_id'] == self.request.couch_user.user_id) == my_exports
             ]
-        if self.is_deid:
-            brief_exports = [x for x in brief_exports if x['is_deidentified']]
 
         docs = [self.fmt_export_data(get_properly_wrapped_export_instance(e['_id']))
                 for e in brief_exports[limit * (page - 1):limit * page]]
@@ -409,10 +407,6 @@ class DeIdFormExportListHelper(FormExportListHelper):
 class DeIdDailySavedExportListHelper(DailySavedExportListHelper):
     is_deid = True
 
-    def _should_appear_in_list(self, export):
-        return (super(DeIdDailySavedExportListView, self)._should_appear_in_list(export)
-                and export['is_deidentified'])
-
     @property
     def create_export_form(self):
         return None
@@ -420,10 +414,6 @@ class DeIdDailySavedExportListHelper(DailySavedExportListHelper):
 
 class DeIdDashboardFeedListHelper(DashboardFeedListHelper):
     is_deid = True
-
-    def _should_appear_in_list(self, export):
-        return (super(DeIdDashboardFeedListView, self)._should_appear_in_list(export)
-                and x['is_deidentified'])
 
     @property
     def create_export_form(self):

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -48,8 +48,8 @@ from corehq.apps.export.const import (
     SharingOption,
 )
 from corehq.apps.export.dbaccessors import (
-    get_case_exports_by_domain,
-    get_form_exports_by_domain,
+    get_brief_exports,
+    get_brief_deid_exports,
     get_properly_wrapped_export_instance,
 )
 from corehq.apps.export.forms import CreateExportTagForm, DashboardFeedFilterForm
@@ -163,14 +163,11 @@ class ExportListHelper(object):
         """The source of the data that will be processed by fmt_export_data
         for use in the template.
         """
-        combined_exports = []
-        for model_type, getter, has_permissions in [
-                ('form', get_form_exports_by_domain, self.permissions.has_form_export_permissions),
-                ('case', get_case_exports_by_domain, self.permissions.has_case_export_permissions),
-        ]:
-            if self.form_or_case in [model_type, None] and (self.is_deid or has_permissions):
-                combined_exports.extend(getter(self.domain, self.is_deid, include_docs=False))
-        return [x for x in combined_exports if self._should_appear_in_list(x)]
+        if self.is_deid:
+            exports = get_brief_deid_exports(self.domain, self.form_or_case)
+        else:
+            exports = get_brief_exports(self.domain, self.form_or_case)
+        return [x for x in exports if self._should_appear_in_list(x)]
 
     def _should_appear_in_list(self, export):
         raise NotImplementedError("must implement _should_appear_in_list")

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -264,6 +264,13 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     allow_deid = False
 
 
+@method_decorator(toggles.ODATA.required_decorator(), name='dispatch')
+class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
+    urlname = 'new_odata_form_feed'
+    page_title = ugettext_lazy("Create OData Form Feed")
+    allow_deid = False
+
+
 class DeleteNewCustomExportView(BaseModifyNewCustomView):
     urlname = 'delete_new_custom_export'
     http_method_names = ['post']

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -16,7 +16,7 @@ from django.views.generic import View
 from soil import DownloadBase
 from soil.progress import get_task_status
 
-from corehq import privileges
+from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import api_auth
 from corehq.apps.locations.models import SQLLocation
@@ -180,6 +180,10 @@ class DashboardFeedMixin(DailySavedExportMixin):
 
 
 class ODataFeedMixin(object):
+
+    @method_decorator(toggles.ODATA.required_decorator())
+    def dispatch(self, *args, **kwargs):
+        return super(ODataFeedMixin, self).dispatch(*args, **kwargs)
 
     def create_new_export_instance(self, schema):
         instance = super(ODataFeedMixin, self).create_new_export_instance(schema)

--- a/corehq/couchapps/export_instances_by_domain/views/view/map.js
+++ b/corehq/couchapps/export_instances_by_domain/views/view/map.js
@@ -6,6 +6,7 @@ function(doc) {
             doc_type: doc.doc_type,
             is_deidentified: doc.is_deidentified,
             is_daily_saved_export: doc.is_daily_saved_export,
+            is_odata_config: doc.is_odata_config,
             export_format: doc.export_format,
             name: doc.name,
             owner_id: doc.owner_id,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -519,6 +519,7 @@ class ProjectDataTab(UITab):
                 EditCaseDailySavedExportView,
                 EditCaseFeedView,
                 EditODataCaseFeedView,
+                EditODataFormFeedView,
                 EditFormDailySavedExportView,
                 EditFormFeedView,
                 EditNewCustomCaseExportView,
@@ -539,6 +540,7 @@ class ProjectDataTab(UITab):
                 CreateNewFormFeedView,
                 CreateNewCaseFeedView,
                 CreateODataCaseFeedView,
+                CreateODataFormFeedView,
             )
             from corehq.apps.export.views.utils import (
                 DashboardFeedPaywall,
@@ -688,6 +690,14 @@ class ProjectDataTab(UITab):
                     {
                         'title': _(EditODataCaseFeedView.page_title),
                         'urlname': EditODataCaseFeedView.urlname,
+                    },
+                    {
+                        'title': _(CreateODataFormFeedView.page_title),
+                        'urlname': CreateODataFormFeedView.urlname,
+                    },
+                    {
+                        'title': _(EditODataFormFeedView.page_title),
+                        'urlname': EditODataFormFeedView.urlname,
                     },
                 ]
                 export_data_views.append({


### PR DESCRIPTION
This is PR'd into https://github.com/dimagi/commcare-hq/pull/24549.  It extends support to forms.  There are also some cleanup commits.  More context in the commit messages, and one notable change that's a little too intertwined to easily extract:

Andrea FYI the "all users" change here is that currently, users that have "can view deid exports" _disabled_ can't see DeID exports, even if they can see and create exports.  This is nonsensical, as DeID exports are a subset of regular exports which expose less data.  Previously there were three categories of users:

* can view all exports
* can view only deid exports
* can view only non-deid exports

And I'm removing that last category.