### PR TITLE
Add solutions feature flag recommendations

### DIFF
--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -18,6 +18,9 @@ hqDefine('toggle_ui/js/flags', [
                 return true;
             }
             var tag = aData[0].replace(/\n/g," ").replace(/<.*?>/g, "");
+            if (viewModel.tagFilter() === "Solutions" && tag.includes("Solutions")) {
+                return true;
+            }
             return tag === viewModel.tagFilter();
         }
     );

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -20,7 +20,7 @@ from corehq.apps.users.models import CouchUser
 from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.toggles import (
     ALL_NAMESPACES,
-    ALL_TAGS,
+    ALL_TAG_GROUPS,
     NAMESPACE_USER,
     NAMESPACE_DOMAIN,
     TAG_CUSTOM,
@@ -89,7 +89,7 @@ class ToggleListView(BasePageView):
             'page_url': self.page_url,
             'show_usage': self.show_usage,
             'toggles': toggles,
-            'tags': ALL_TAGS,
+            'tags': ALL_TAG_GROUPS,
             'user_counts': user_counts,
             'last_used': last_used,
             'last_modified': last_modified,

--- a/corehq/tests/test_toggles.py
+++ b/corehq/tests/test_toggles.py
@@ -14,3 +14,12 @@ def test_toggle_properties():
         assert toggle.tag, 'Toggle "{}" tag missing'.format(toggle.slug)
         assert toggle.tag in ALL_TAGS, 'Toggle "{}" tag "{}" unrecognized'.format(toggle.slug, toggle.tag)
         assert toggle.namespaces, 'Toggle "{}" namespaces missing'.format(toggle.slug)
+
+
+def test_solutions_sub_tags():
+    """
+    Check Solutions sub-tags begin with 'Solutions - '
+    """
+    solutions_tags = [toggles.TAG_SOLUTIONS_OPEN, toggles.TAG_SOLUTIONS_CONDITIONAL, toggles.TAG_SOLUTIONS_LIMITED]
+    for tag in solutions_tags:
+        assert tag.name.startswith('Solutions - ')

--- a/corehq/tests/test_toggles.py
+++ b/corehq/tests/test_toggles.py
@@ -19,6 +19,9 @@ def test_toggle_properties():
 def test_solutions_sub_tags():
     """
     Check Solutions sub-tags begin with 'Solutions - '
+
+    Client side toggle filtering logic currently depends on "Solutions" being in these tag names.
+    For context, see https://github.com/dimagi/commcare-hq/pull/24575#discussion_r293995391
     """
     solutions_tags = [toggles.TAG_SOLUTIONS_OPEN, toggles.TAG_SOLUTIONS_CONDITIONAL, toggles.TAG_SOLUTIONS_LIMITED]
     for tag in solutions_tags:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1446,8 +1446,7 @@ DISPLAY_CONDITION_ON_TABS = StaticToggle(
 
 PHONE_HEARTBEAT = StaticToggle(
     'phone_apk_heartbeat',
-    "Ability to configure a mobile feature to prompt "
-    "users to update to latest CommCare app and apk",
+    "Ability to configure a mobile feature to prompt users to update to latest CommCare app and apk",
     TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN]
 )
@@ -1485,8 +1484,7 @@ ENABLE_ALL_ADD_ONS = StaticToggle(
 
 FILTERED_BULK_USER_DOWNLOAD = StaticToggle(
     'filtered_bulk_user_download',
-    "Ability to filter mobile workers based on Role and username "
-    "when doing bulk download",
+    "Ability to filter mobile workers based on Role and username when doing bulk download",
     TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN]
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -430,7 +430,7 @@ APP_BUILDER_CUSTOM_PARENT_REF = StaticToggle(
 APP_BUILDER_ADVANCED = StaticToggle(
     'advanced-app-builder',
     'Advanced Module in App-Builder',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
     description="Advanced Modules allow you to autoload and manage multiple case types, "
                 "but may behave in unexpected ways.",
@@ -448,7 +448,7 @@ APP_BUILDER_SHADOW_MODULES = StaticToggle(
 CASE_LIST_CUSTOM_XML = StaticToggle(
     'case_list_custom_xml',
     'Allow custom XML to define case lists (ex. for case tiles)',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
     help_link='https://confluence.dimagi.com/display/public/Custom+Case+XML+Overview',
 )
@@ -456,7 +456,7 @@ CASE_LIST_CUSTOM_XML = StaticToggle(
 CASE_LIST_CUSTOM_VARIABLES = StaticToggle(
     'case_list_custom_variables',
     'Show text area for entering custom variables',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
     description='Defines custom variables that can be used in case list or detail calculations',
 )
@@ -529,7 +529,7 @@ DETAIL_LIST_TAB_NODESETS = StaticToggle(
 DHIS2_INTEGRATION = StaticToggle(
     'dhis2_integration',
     'DHIS2 Integration',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN]
 )
 
@@ -574,7 +574,7 @@ VISIT_SCHEDULER = StaticToggle(
 USER_CONFIGURABLE_REPORTS = StaticToggle(
     'user_reports',
     'User configurable reports UI',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN, NAMESPACE_USER],
     description=(
         "A feature which will allow your domain to create User Configurable Reports."
@@ -758,7 +758,7 @@ ALLOW_CASE_ATTACHMENTS_VIEW = StaticToggle(
 LOCATION_TYPE_STOCK_RATES = StaticToggle(
     'location_type_stock_rates',
     "Specify stock rates per location type.",
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN]
 )
 
@@ -783,7 +783,7 @@ FORM_LINK_WORKFLOW = StaticToggle(
 VELLUM_SAVE_TO_CASE = StaticToggle(
     'save_to_case',
     "Adds save to case as a question to the form builder",
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
     description='This flag allows case management inside repeat groups',
     help_link='https://confluence.dimagi.com/display/ccinternal/Save+to+Case+Feature+Flag',
@@ -792,7 +792,7 @@ VELLUM_SAVE_TO_CASE = StaticToggle(
 VELLUM_PRINTING = StaticToggle(
     'printing',
     "Enables the Print Android App Callout",
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
     description='Allows printing from CommCare on the device',
     help_link='https://confluence.dimagi.com/display/ccinternal/Printing+from+a+form+in+CommCare+Android',
@@ -801,7 +801,7 @@ VELLUM_PRINTING = StaticToggle(
 VELLUM_DATA_IN_SETVALUE = StaticToggle(
     'allow_data_reference_in_setvalue',
     "Allow data references in a setvalue",
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
     description="This allows referencing other questions in the form in a setvalue. "
                 "This may still cause issues if the other questions have not been calculated yet",
@@ -818,7 +818,7 @@ CACHE_AND_INDEX = StaticToggle(
 CUSTOM_PROPERTIES = StaticToggle(
     'custom_properties',
     'Allow users to add arbitrary custom properties to their application',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     help_link='https://confluence.dimagi.com/display/internal/CommCare+Android+Developer+Options+--+Internal#'
               'CommCareAndroidDeveloperOptions--Internal-SettingtheValueofaDeveloperOptionfromHQ',
     namespaces=[NAMESPACE_DOMAIN]
@@ -843,7 +843,7 @@ MOBILE_UCR = StaticToggle(
     'mobile_ucr',
     ('Mobile UCR: Configure viewing user configurable reports on the mobile '
      'through the app builder'),
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     namespaces=[NAMESPACE_DOMAIN],
     always_enabled={'icds-cas'}
 )
@@ -900,7 +900,7 @@ def _commtrackify(domain_name, toggle_is_enabled):
 COMMTRACK = StaticToggle(
     'commtrack',
     "CommCare Supply",
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     description=(
         '<a href="https://help.commcarehq.org/display/commtrack/CommCare+Supply+Home">CommCare Supply</a> '
         "is a logistics and supply chain management module. It is designed "
@@ -993,7 +993,7 @@ RETRY_SMS_INDEFINITELY = StaticToggle(
 OPENMRS_INTEGRATION = StaticToggle(
     'openmrs_integration',
     'Enable OpenMRS integration',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
 )
 
@@ -1128,7 +1128,7 @@ BULK_CONDITIONAL_ALERTS = StaticToggle(
 COPY_CONDITIONAL_ALERTS = StaticToggle(
     'copy_conditional_alerts',
     'Allow copying conditional alerts to another project (or within the same project).',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_USER],
 )
 
@@ -1412,7 +1412,7 @@ COUCH_SQL_MIGRATION_BLACKLIST = StaticToggle(
 PAGINATED_EXPORTS = StaticToggle(
     'paginated_exports',
     'Allows for pagination of exports for very large exports',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN]
 )
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -440,7 +440,7 @@ APP_BUILDER_ADVANCED = StaticToggle(
 APP_BUILDER_SHADOW_MODULES = StaticToggle(
     'shadow-app-builder',
     'Shadow Modules',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN],
     help_link='https://confluence.dimagi.com/display/ccinternal/Shadow+Modules',
 )
@@ -471,14 +471,14 @@ CASE_LIST_TILE = StaticToggle(
 SHOW_PERSIST_CASE_CONTEXT_SETTING = StaticToggle(
     'show_persist_case_context_setting',
     'Allow toggling the persistent case context tile',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN],
 )
 
 CASE_LIST_LOOKUP = StaticToggle(
     'case_list_lookup',
     'Allow external android callouts to search the caselist',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN]
 )
 
@@ -492,7 +492,7 @@ BIOMETRIC_INTEGRATION = StaticToggle(
 ADD_USERS_FROM_LOCATION = StaticToggle(
     'add_users_from_location',
     "Allow users to add new mobile workers from the locations page",
-    TAG_PRODUCT,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN]
 )
 
@@ -521,7 +521,7 @@ DATA_FILE_DOWNLOAD = StaticToggle(
 DETAIL_LIST_TAB_NODESETS = StaticToggle(
     'detail-list-tab-nodesets',
     'Associate a nodeset with a case detail tab',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     help_link='https://confluence.dimagi.com/display/ccinternal/Case+Detail+Nodesets',
     namespaces=[NAMESPACE_DOMAIN]
 )
@@ -536,7 +536,7 @@ DHIS2_INTEGRATION = StaticToggle(
 GRAPH_CREATION = StaticToggle(
     'graph-creation',
     'Case list/detail graph creation',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     help_link='https://confluence.dimagi.com/display/RD/Graphing+in+HQ',
     namespaces=[NAMESPACE_DOMAIN]
 )
@@ -654,7 +654,7 @@ ROLE_WEBAPPS_PERMISSIONS = StaticToggle(
 SYNC_SEARCH_CASE_CLAIM = StaticToggle(
     'search_claim',
     'Enable synchronous mobile searching and case claiming',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     help_link='https://confluence.dimagi.com/display/ccinternal/Remote+Case+Search+and+Claim',
     namespaces=[NAMESPACE_DOMAIN]
 )
@@ -773,7 +773,7 @@ TRANSFER_DOMAIN = StaticToggle(
 FORM_LINK_WORKFLOW = StaticToggle(
     'form_link_workflow',
     'Form linking workflow available on forms',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN],
 )
 
@@ -834,7 +834,7 @@ WEBAPPS_CASE_MIGRATION = StaticToggle(
 ENABLE_LOADTEST_USERS = StaticToggle(
     'enable_loadtest_users',
     'Enable creating loadtest users on HQ',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     namespaces=[NAMESPACE_DOMAIN],
     help_link='https://confluence.dimagi.com/display/ccinternal/Loadtest+Users',
 )
@@ -937,7 +937,7 @@ CUSTOM_INSTANCES = StaticToggle(
 CUSTOM_ASSERTIONS = StaticToggle(
     'custom_assertions',
     'Inject custom assertions into the suite',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     description=(
         'Enables the insertion of custom assertions into the suite file. '
     ),
@@ -1186,7 +1186,7 @@ CUSTOM_APP_BASE_URL = StaticToggle(
 PHONE_NUMBERS_REPORT = StaticToggle(
     'phone_numbers_report',
     "Report related to the phone numbers owned by a project's contacts",
-    TAG_PRODUCT,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN]
 )
 
@@ -1235,7 +1235,7 @@ EXPORT_ZIPPED_APPS = StaticToggle(
 SEND_UCR_REBUILD_INFO = StaticToggle(
     'send_ucr_rebuild_info',
     'Notify when UCR rebuilds finish or error.',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_USER]
 )
 
@@ -1380,14 +1380,14 @@ LOCATION_SAFETY_EXEMPTION = StaticToggle(
 SORT_CALCULATION_IN_CASE_LIST = StaticToggle(
     'sort_calculation_in_case_list',
     'Configure a custom xpath calculation for Sort Property in Case Lists',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN]
 )
 
 INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS = StaticToggle(
     'include_metadata_in_ucr_excel_exports',
     'Include metadata in UCR excel exports',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN]
 )
 
@@ -1448,7 +1448,7 @@ PHONE_HEARTBEAT = StaticToggle(
     'phone_apk_heartbeat',
     "Ability to configure a mobile feature to prompt "
     "users to update to latest CommCare app and apk",
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN]
 )
 
@@ -1560,7 +1560,7 @@ MOBILE_LOGIN_LOCKOUT = StaticToggle(
 LINKED_DOMAINS = StaticToggle(
     'linked_domains',
     'Allow linking project spaces (successor to linked apps)',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     [NAMESPACE_DOMAIN],
     description=(
         "Link project spaces to allow syncing apps, lookup tables, organizations etc."
@@ -1642,7 +1642,7 @@ AGGREGATE_UCRS = StaticToggle(
 SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER = StaticToggle(
     'show_raw_data_sources_in_report_builder',
     'Allow building report builder reports directly from raw UCR Data Sources',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_CONDITIONAL,
     namespaces=[NAMESPACE_DOMAIN],
 )
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -51,6 +51,27 @@ TAG_SOLUTIONS = Tag(
     description="These features are only available for our services projects. This may affect support and "
     "pricing when the project is transitioned to a subscription."
 )
+TAG_SOLUTIONS_OPEN = Tag(
+    name='Solutions - Open Use',
+    css_class='info',
+    description="These features are only available for our services projects. This may affect support and "
+    "pricing when the project is transitioned to a subscription. Open Use Solutions Feature Flags can be "
+    "enabled by GS."
+)
+TAG_SOLUTIONS_CONDITIONAL = Tag(
+    name='Solutions - Conditional Use',
+    css_class='info',
+    description="These features are only available for our services projects. This may affect support and "
+    "pricing when the project is transitioned to a subscription. Conditional Use Solutions Feature Flags can be "
+    "complicated and should be enabled by GS only after ensuring your partners have the proper training materials."
+)
+TAG_SOLUTIONS_LIMITED = Tag(
+    name='Solutions - Limited Use',
+    css_class='info',
+    description="These features are only available for our services projects. This may affect support and "
+    "pricing when the project is transitioned to a subscription. Limited Use Solutions Feature Flags cannot be "
+    "enabled by GS before emailing solutions@dimagi.com and requesting the feature."
+)
 TAG_INTERNAL = Tag(
     name='Internal Engineering Tools',
     css_class='default',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -78,7 +78,8 @@ TAG_INTERNAL = Tag(
     description="These are tools for our engineering team to use to manage the product",
 )
 # Order roughly corresponds to how much we want you to use it
-ALL_TAGS = [TAG_SOLUTIONS, TAG_PRODUCT, TAG_CUSTOM, TAG_INTERNAL, TAG_DEPRECATED]
+ALL_TAG_GROUPS = [TAG_SOLUTIONS, TAG_PRODUCT, TAG_CUSTOM, TAG_INTERNAL, TAG_DEPRECATED]
+ALL_TAGS = [TAG_SOLUTIONS_OPEN, TAG_SOLUTIONS_CONDITIONAL, TAG_SOLUTIONS_LIMITED] + ALL_TAG_GROUPS
 
 
 class StaticToggle(object):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -513,7 +513,7 @@ COPY_FORM_TO_APP = StaticToggle(
 DATA_FILE_DOWNLOAD = StaticToggle(
     'data_file_download',
     'Offer hosting and sharing data files for downloading from a secure dropzone',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     help_link='https://confluence.dimagi.com/display/ccinternal/Offer+hosting+and+sharing+data+files+for+downloading+from+a+secure+dropzone',
     namespaces=[NAMESPACE_DOMAIN],
 )
@@ -673,7 +673,7 @@ def _enable_search_index(domain, enabled):
 CASE_LIST_EXPLORER = StaticToggle(
     'case_list_explorer',
     'Show the case list explorer report',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     namespaces=[NAMESPACE_DOMAIN],
     save_fn=_enable_search_index,
 )
@@ -948,7 +948,7 @@ CUSTOM_ASSERTIONS = StaticToggle(
 APPLICATION_ERROR_REPORT = StaticToggle(
     'application_error_report',
     'Show Application Error Report',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     help_link='https://confluence.dimagi.com/display/ccinternal/Show+Application+Error+Report+Feature+Flag',
     namespaces=[NAMESPACE_USER],
 )
@@ -1033,7 +1033,7 @@ SUPPORT = StaticToggle(
 BASIC_CHILD_MODULE = StaticToggle(
     'child_module',
     'Basic modules can be child modules',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN]
 )
 
@@ -1218,7 +1218,7 @@ UNLIMITED_REPORT_BUILDER_REPORTS = StaticToggle(
 MOBILE_USER_DEMO_MODE = StaticToggle(
     'mobile_user_demo_mode',
     'Ability to make a mobile worker into Demo only mobile worker',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     help_link='https://confluence.dimagi.com/display/internal/Demo+Mobile+Workers',
     namespaces=[NAMESPACE_DOMAIN]
 )
@@ -1271,7 +1271,7 @@ DISABLE_COLUMN_LIMIT_IN_UCR = StaticToggle(
 CLOUDCARE_LATEST_BUILD = StaticToggle(
     'use_latest_build_cloudcare',
     'Uses latest build for Web Apps instead of latest published',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
@@ -1317,7 +1317,7 @@ DATA_MIGRATION = StaticToggle(
 EMWF_WORKER_ACTIVITY_REPORT = StaticToggle(
     'emwf_worker_activity_report',
     'Make the Worker Activity Report use the Groups or Users or Locations filter',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     namespaces=[NAMESPACE_DOMAIN],
     description=(
         "This flag allows you filter the users to display in the same way as the "
@@ -1345,7 +1345,7 @@ ICDS = StaticToggle(
 DATA_DICTIONARY = StaticToggle(
     'data_dictionary',
     'Project level data dictionary of cases',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN],
     description='Available in the Data section, shows the names of all properties of each case type.',
 )
@@ -1394,7 +1394,7 @@ INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS = StaticToggle(
 VIEW_APP_CHANGES = StaticToggle(
     'app-changes-with-improved-diff',
     'Improved app changes view',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN, NAMESPACE_USER],
 )
 
@@ -1440,7 +1440,7 @@ PUBLISH_CUSTOM_REPORTS = StaticToggle(
 DISPLAY_CONDITION_ON_TABS = StaticToggle(
     'display_condition_on_nodeset',
     'Show Display Condition on Case Detail Tabs',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN]
 )
 
@@ -1479,7 +1479,7 @@ PREVENT_MOBILE_UCR_SYNC = StaticToggle(
 ENABLE_ALL_ADD_ONS = StaticToggle(
     'enable_all_add_ons',
     'Enable all app manager add-ons',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN]
 )
 
@@ -1487,7 +1487,7 @@ FILTERED_BULK_USER_DOWNLOAD = StaticToggle(
     'filtered_bulk_user_download',
     "Ability to filter mobile workers based on Role and username "
     "when doing bulk download",
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN]
 )
 
@@ -1501,7 +1501,7 @@ BULK_UPLOAD_DATE_OPENED = StaticToggle(
 REGEX_FIELD_VALIDATION = StaticToggle(
     'regex_field_validation',
     'Enable regex validation for custom data fields',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     namespaces=[NAMESPACE_DOMAIN],
 )
 
@@ -1601,7 +1601,7 @@ TRAINING_MODULE = StaticToggle(
 EXPORT_MULTISORT = StaticToggle(
     'export_multisort',
     'Sort multiple rows in exports at once.',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN],
 )
 
@@ -1609,7 +1609,7 @@ EXPORT_MULTISORT = StaticToggle(
 EXPORT_OWNERSHIP = StaticToggle(
     'export_ownership',
     'Allow exports to have ownership.',
-    TAG_SOLUTIONS,
+    TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN],
 )
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SLTNS-150

This PR adds recommendations for GS enabling Solutions feature flags, according to [this confluence doc](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=ccinternal&title=Feature+Flags%3A+Solutions). The new Solutions tags ("Solutions - Open Use", "Solutions - Conditional Use", and "Solutions - Limited Use") will be the same blue color as the regular Solutions tag, and all Solutions Feature Flags can still be found under the "Solutions" toggle:

<img width="1248" alt="Screen Shot 2019-06-14 at 2 54 27 PM" src="https://user-images.githubusercontent.com/15271571/59531933-5357d280-8eb5-11e9-8c82-6b100f01b3a4.png">
