### PR TITLE
Persist migration state so it is not lost on stop/resume

### DIFF
--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -160,16 +160,16 @@ def filter_form_diffs(couch_form, sql_form, diffs):
     return _filter_ignored(couch_form, sql_form, diffs, [doc_type, 'XFormInstance*'])
 
 
-def filter_case_diffs(couch_case, sql_case, diffs, forms_that_touch_cases_without_actions=None):
+def filter_case_diffs(couch_case, sql_case, diffs, statedb=None):
     doc_type = couch_case['doc_type']
     doc_types = [doc_type, 'CommCareCase*']
     diffs = _filter_ignored(couch_case, sql_case, diffs, doc_types)
-    if forms_that_touch_cases_without_actions:
-        diffs = _filter_forms_touch_case(diffs, forms_that_touch_cases_without_actions)
+    if statedb is not None:
+        diffs = _filter_forms_touch_case(diffs, statedb)
     return diffs
 
 
-def _filter_forms_touch_case(diffs, forms_that_touch_cases_without_actions):
+def _filter_forms_touch_case(diffs, statedb):
     """Legacy bug in case processing would not add the form ID to the list of
     xform_ids for the case if the case block had no actions"""
     other_diffs = []
@@ -182,12 +182,10 @@ def _filter_forms_touch_case(diffs, forms_that_touch_cases_without_actions):
 
     if form_id_diffs:
         diffs = other_diffs
+        exclusions = statedb.get_no_action_case_forms()
         for diff in form_id_diffs:
             form_ids = diff.new_value.split(',')
-            diff_ids = [
-                form_id for form_id in form_ids
-                if form_id not in forms_that_touch_cases_without_actions
-            ]
+            diff_ids = [f for f in form_ids if f not in exclusions]
             if diff_ids:
                 diff = diff._replace(new_value=','.join(diff_ids))
                 diffs.append(diff)

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -25,12 +25,12 @@ from corehq.apps.couch_sql_migration.progress import (
     set_couch_sql_migration_started,
 )
 from corehq.apps.couch_sql_migration.statedb import (
+    Counts,
     delete_state_db,
     open_state_db,
 )
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_type
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
-from corehq.apps.tzmigration.planning import Counts
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseAccessorSQL,
     FormAccessorSQL,

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
@@ -16,7 +16,8 @@ from corehq.util.markup import SimpleTableWriter, TableRowFormatter
 from couchforms.dbaccessors import get_form_ids_by_type
 from couchforms.models import XFormInstance, doc_types
 
-from ...couchsqlmigration import do_couch_to_sql_migration, get_diff_db, setup_logging
+from ...couchsqlmigration import do_couch_to_sql_migration, setup_logging
+from ...statedb import open_state_db
 from ...progress import (
     couch_sql_migration_in_progress,
     set_couch_sql_migration_complete,
@@ -99,7 +100,7 @@ class Command(BaseCommand):
 
 
 def get_diff_stats(domain, strict=True):
-    db = get_diff_db(domain)
+    db = open_state_db(domain)
     diff_stats = db.get_diff_stats()
 
     stats = {}

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -4,20 +4,23 @@ from __future__ import unicode_literals
 import errno
 import os
 import os.path
+from collections import namedtuple
 
 from django.conf import settings
 
-from corehq.apps.tzmigration.planning import DiffDB
+from sqlalchemy import func, Column, Integer, String
+
+from corehq.apps.tzmigration.planning import Base, DiffDB
 
 
 def init_state_db(domain):
     db_filepath = _get_state_db_filepath(domain)
-    return DiffDB.init(db_filepath)
+    return StateDB.init(db_filepath)
 
 
 def open_state_db(domain):
     db_filepath = _get_state_db_filepath(domain)
-    return DiffDB.open(db_filepath)
+    return StateDB.open(db_filepath)
 
 
 def delete_state_db(domain):
@@ -32,3 +35,78 @@ def delete_state_db(domain):
 def _get_state_db_filepath(domain):
     return os.path.join(settings.SHARED_DRIVE_CONF.tzmigration_planning_dir,
                         '{}-tzmigration.db'.format(domain))
+
+
+class StateDB(DiffDB):
+
+    def add_missing_docs(self, kind, doc_ids):
+        session = self.Session()
+        session.bulk_save_objects([
+            MissingDoc(kind=kind, doc_id=doc_id)
+            for doc_id in doc_ids
+        ])
+        session.commit()
+
+    def increment_counter(self, kind, value):
+        session = self.Session()
+        updated = (
+            session.query(DocCount)
+            .filter_by(kind=kind)
+            .update(
+                {DocCount.value: DocCount.value + value},
+                synchronize_session=False,
+            )
+        )
+        if not updated:
+            session.add(DocCount(kind=kind, value=value))
+        else:
+            assert updated == 1, (kind, updated)
+        session.commit()
+
+    def get_doc_counts(self):
+        """Returns a dict of counts by kind
+
+        Values are `Counts` objects having `total` and `missing`
+        fields:
+
+        - total: number of items counted with `increment_counter`.
+        - missing: count of ids added with `add_missing_docs`.
+        """
+        session = self.Session()
+        totals = {dc.kind: dc.value for dc in session.query(DocCount)}
+        missing = {row[0]: row[1] for row in session.query(
+            MissingDoc.kind,
+            func.count(MissingDoc.doc_id),
+        ).group_by(MissingDoc.kind).all()}
+        return {kind: Counts(
+            total=totals.get(kind, 0),
+            missing=missing.get(kind, 0),
+        ) for kind in set(missing) | set(totals)}
+
+    def has_doc_counts(self):
+        return self.engine.dialect.has_table(self.engine, "doc_count")
+
+    def get_missing_doc_ids(self, doc_type):
+        return {
+            missing.doc_id for missing in self.Session()
+            .query(MissingDoc.doc_id)
+            .filter(MissingDoc.kind == doc_type)
+        }
+
+
+class DocCount(Base):
+    __tablename__ = 'doc_count'
+
+    kind = Column(String(50), primary_key=True)
+    value = Column(Integer, nullable=False)
+
+
+class MissingDoc(Base):
+    __tablename__ = 'missing_doc'
+
+    id = Column(Integer, primary_key=True)
+    kind = Column(String(50), nullable=False)
+    doc_id = Column(String(50), nullable=False)
+
+
+Counts = namedtuple('Counts', 'total missing')

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import errno
+import os
+import os.path
+
+from django.conf import settings
+
+from corehq.apps.tzmigration.planning import DiffDB
+
+
+def init_state_db(domain):
+    db_filepath = _get_state_db_filepath(domain)
+    return DiffDB.init(db_filepath)
+
+
+def open_state_db(domain):
+    db_filepath = _get_state_db_filepath(domain)
+    return DiffDB.open(db_filepath)
+
+
+def delete_state_db(domain):
+    db_filepath = _get_state_db_filepath(domain)
+    try:
+        os.remove(db_filepath)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+
+
+def _get_state_db_filepath(domain):
+    return os.path.join(settings.SHARED_DRIVE_CONF.tzmigration_planning_dir,
+                        '{}-tzmigration.db'.format(domain))

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -26,18 +26,6 @@ from corehq.apps.cleanup.management.commands.swap_duplicate_xforms import (
     FIXED_FORM_PROBLEM_TEMPLATE,
 )
 from corehq.apps.commtrack.helpers import make_product
-from corehq.apps.couch_sql_migration.couchsqlmigration import (
-    MigrationRestricted,
-    PartiallyLockingQueue,
-    get_case_ids,
-    sql_form_to_json,
-)
-from corehq.apps.couch_sql_migration.management.commands.migrate_domain_from_couch_to_sql import (
-    COMMIT,
-    MIGRATE,
-    RESET,
-)
-from corehq.apps.couch_sql_migration.statedb import open_state_db
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_type
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
@@ -74,6 +62,19 @@ from corehq.util.test_utils import (
     softer_assert,
     trap_extra_setup,
 )
+
+from ..couchsqlmigration import (
+    MigrationRestricted,
+    PartiallyLockingQueue,
+    get_case_ids,
+    sql_form_to_json,
+)
+from ..management.commands.migrate_domain_from_couch_to_sql import (
+    COMMIT,
+    MIGRATE,
+    RESET,
+)
+from ..statedb import delete_state_db, init_state_db, open_state_db
 
 
 class BaseMigrationTestCase(TestCase, TestFileMixin):
@@ -807,7 +808,7 @@ class LedgerMigrationTests(BaseMigrationTestCase):
 
 class TestLockingQueues(TestCase):
     def setUp(self):
-        self.queues = PartiallyLockingQueue(0, "id", max_size=-1)
+        self.queues = PartiallyLockingQueue("id", max_size=-1)
 
     def _add_to_queues(self, queue_obj_id, lock_ids):
         self.queues._add_item(lock_ids, DummyObject(queue_obj_id))

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -74,7 +74,7 @@ from ..management.commands.migrate_domain_from_couch_to_sql import (
     MIGRATE,
     RESET,
 )
-from ..statedb import delete_state_db, init_state_db, open_state_db
+from ..statedb import open_state_db
 
 
 class BaseMigrationTestCase(TestCase, TestFileMixin):

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 
 import re
 
-from testil import eq
+from testil import assert_raises, eq
 
-from ..statedb import Counts, delete_state_db, init_state_db
+from ..statedb import Counts, delete_state_db, init_state_db, ResumeError
 
 
 def teardown():
@@ -46,6 +46,20 @@ def test_no_action_case_forms():
         eq(db.get_no_action_case_forms(), {"abc", "def"})
 
 
+def test_save_resume_state():
+    with init_state_db("test") as db:
+        eq(db.pop_saved_resume_state(), [])
+        db.save_resume_state(["abc", "def"])
+
+    with init_state_db("test") as db:
+        eq(db.pop_saved_resume_state(), ["abc", "def"])
+
+    # simulate resume without save
+    with init_state_db("test") as db:
+        with assert_raises(ResumeError):
+            db.pop_saved_resume_state()
+
+
 def test_counters():
     with init_state_db("test") as db:
         db.increment_counter("abc", 1)
@@ -57,4 +71,3 @@ def test_counters():
             "abc": Counts(4, 3),
             "def": Counts(2, 0),
         })
-

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from testil import eq
+
+from ..statedb import Counts, init_state_db
+
+
+def test_counters():
+    db = init_state_db("test")
+    db.increment_counter("abc", 1)
+    db.add_missing_docs("abc", ["doc1"])
+    db.increment_counter("def", 2)
+    db.increment_counter("abc", 3)
+    db.add_missing_docs("abc", ["doc2", "doc4"])
+    eq(db.get_doc_counts(), {
+        "abc": Counts(4, 3),
+        "def": Counts(2, 0),
+    })

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -3,17 +3,30 @@ from __future__ import unicode_literals
 
 from testil import eq
 
-from ..statedb import Counts, init_state_db
+from ..statedb import Counts, delete_state_db, init_state_db
+
+
+def teardown():
+    delete_state_db("test")
+
+
+def test_problem_forms():
+    with init_state_db("test") as db:
+        db.add_problem_form("abc")
+
+    with init_state_db("test") as db:
+        db.add_problem_form("def")
+        eq(set(db.iter_problem_forms()), {"abc", "def"})
 
 
 def test_counters():
-    db = init_state_db("test")
-    db.increment_counter("abc", 1)
-    db.add_missing_docs("abc", ["doc1"])
-    db.increment_counter("def", 2)
-    db.increment_counter("abc", 3)
-    db.add_missing_docs("abc", ["doc2", "doc4"])
-    eq(db.get_doc_counts(), {
-        "abc": Counts(4, 3),
-        "def": Counts(2, 0),
-    })
+    with init_state_db("test") as db:
+        db.increment_counter("abc", 1)
+        db.add_missing_docs("abc", ["doc1"])
+        db.increment_counter("def", 2)
+        db.increment_counter("abc", 3)
+        db.add_missing_docs("abc", ["doc2", "doc4"])
+        eq(db.get_doc_counts(), {
+            "abc": Counts(4, 3),
+            "def": Counts(2, 0),
+        })

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -19,6 +19,18 @@ def test_problem_forms():
         eq(set(db.iter_problem_forms()), {"abc", "def"})
 
 
+def test_no_action_case_forms():
+    with init_state_db("test") as db:
+        db.add_no_action_case_form("abc")
+
+    with init_state_db("test") as db:
+        eq(db.get_no_action_case_forms(), {"abc"})
+
+        # verify that memoized result is cleared on add
+        db.add_no_action_case_form("def")
+        eq(db.get_no_action_case_forms(), {"abc", "def"})
+
+
 def test_counters():
     with init_state_db("test") as db:
         db.increment_counter("abc", 1)
@@ -30,3 +42,4 @@ def test_counters():
             "abc": Counts(4, 3),
             "def": Counts(2, 0),
         })
+

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import re
+
 from testil import eq
 
 from ..statedb import Counts, delete_state_db, init_state_db
@@ -8,6 +10,19 @@ from ..statedb import Counts, delete_state_db, init_state_db
 
 def teardown():
     delete_state_db("test")
+
+
+def test_db_unique_id():
+    with init_state_db("test") as db:
+        uid = db.unique_id
+        assert re.search(r"\d{8}-\d{6}.\d{6}", uid), uid
+
+    with init_state_db("test") as db:
+        eq(db.unique_id, uid)
+
+    delete_state_db("test")
+    with init_state_db("test") as db:
+        assert db.unique_id != uid, uid
 
 
 def test_problem_forms():

--- a/corehq/apps/tzmigration/planning.py
+++ b/corehq/apps/tzmigration/planning.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import json
 import sqlite3
-from collections import namedtuple
 from sqlite3 import dbapi2 as sqlite
 
 from sqlalchemy import create_engine, Column, Integer, ForeignKey, String, \
@@ -80,24 +79,6 @@ class PlanningStockReportHelper(Base):
     stock_report_helper_json = Column(UnicodeText, nullable=False)
 
 
-class DocCount(Base):
-    __tablename__ = 'doc_count'
-
-    kind = Column(String(50), primary_key=True)
-    value = Column(Integer, nullable=False)
-
-
-class MissingDoc(Base):
-    __tablename__ = 'missing_doc'
-
-    id = Column(Integer, primary_key=True)
-    kind = Column(String(50), nullable=False)
-    doc_id = Column(String(50), nullable=False)
-
-
-Counts = namedtuple('Counts', 'total missing')
-
-
 class BaseDB(object):
 
     def __init__(self, db_filepath):
@@ -143,30 +124,6 @@ class DiffDB(BaseDB):
                 new_value=json_dumps_or_none(d.new_value)))
         session.commit()
 
-    def increment_counter(self, kind, value):
-        session = self.Session()
-        updated = (
-            session.query(DocCount)
-            .filter_by(kind=kind)
-            .update(
-                {DocCount.value: DocCount.value + value},
-                synchronize_session=False,
-            )
-        )
-        if not updated:
-            session.add(DocCount(kind=kind, value=value))
-        else:
-            assert updated == 1, (kind, updated)
-        session.commit()
-
-    def add_missing_docs(self, kind, doc_ids):
-        session = self.Session()
-        session.bulk_save_objects([
-            MissingDoc(kind=kind, doc_id=doc_id)
-            for doc_id in doc_ids
-        ])
-        session.commit()
-
     def get_diffs(self):
         session = self.Session()
         return session.query(PlanningDiff).all()
@@ -187,36 +144,6 @@ class DiffDB(BaseDB):
         return {
             res[0]: (res[1], res[2])
             for res in results
-        }
-
-    def get_doc_counts(self):
-        """Returns a dict of counts by kind
-
-        Values are `Counts` objects having `total` and `missing`
-        fields:
-
-        - total: number of items counted with `increment_counter`.
-        - missing: count of ids added with `add_missing_docs`.
-        """
-        session = self.Session()
-        totals = {dc.kind: dc.value for dc in session.query(DocCount)}
-        missing = {row[0]: row[1] for row in session.query(
-            MissingDoc.kind,
-            func.count(MissingDoc.doc_id),
-        ).group_by(MissingDoc.kind).all()}
-        return {kind: Counts(
-            total=totals.get(kind, 0),
-            missing=missing.get(kind, 0),
-        ) for kind in set(missing) | set(totals)}
-
-    def has_doc_counts(self):
-        return self.engine.dialect.has_table(self.engine, "doc_count")
-
-    def get_missing_doc_ids(self, doc_type):
-        return {
-            missing.doc_id for missing in self.Session()
-            .query(MissingDoc.doc_id)
-            .filter(MissingDoc.kind == doc_type)
         }
 
 

--- a/corehq/ex-submodules/dimagi/utils/chunked.py
+++ b/corehq/ex-submodules/dimagi/utils/chunked.py
@@ -1,25 +1,32 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from six.moves import range
+from itertools import islice
 
 
-def chunked(it, n):
+def chunked(it, n, collection=tuple):
     """
     >>> for nums in chunked(range(10), 4):
-    ...    print nums
+    ...    print(nums)
+    ...
     (0, 1, 2, 3)
     (4, 5, 6, 7)
     (8, 9)
+    >>> for nums in chunked(range(10), 4, list):
+    ...    print(nums)
+    ...
+    [0, 1, 2, 3]
+    [4, 5, 6, 7]
+    [8, 9]
     """
-    it = iter(it)
+    itr = iter(it)
     while True:
-        buffer = []
-        try:
-            for i in range(n):
-                buffer.append(next(it))
-            yield tuple(buffer)
-        except StopIteration:
-            if buffer:
-                yield tuple(buffer)
+        items = take(n, itr, collection)
+        if not items:
             break
+        yield items
+
+
+def take(n, iterable, collection=list):
+    # https://docs.python.org/2/library/itertools.html#recipes
+    return collection(islice(iterable, n))


### PR DESCRIPTION
This fixes a [couple](https://github.com/dimagi/commcare-hq/commit/5b9b153db49f66ebec49407515858ca0c34c4e7d) [bugs](https://github.com/dimagi/commcare-hq/commit/f2f50c06811b142ba93e34029997f1dad2f4e63d) found while implementing the previous PR (#24572).

It also moves the locking queue persistence from redis (which has not always been reliable) to the state db while also making it more performant by only writing out to disk on error/exit. For safety, this write to db is done in a way that will not allow the migration to be resumed if the write fails or is not done.

The run-timestamp has been internalized in the state db and is no longer a user-accessible option. It is more reliable and user friendly now since it does not require paying close attention to specific log messages, which are easily lost and could result in a bad outcome if the wrong run timestamp were used to resume a migration.

🐡 Review by commit

@orangejenny @dannyroberts @kaapstorm 