### PR TITLE
ECD Report Feedback, pt1

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -66,12 +66,17 @@
 
 
   <p class="lead">
-    {% trans "Explore Case Data" %}
+    {% trans "Explore Case Data (Preview)" %}
   </p>
   <p class="help-block">
     {% blocktrans %}
-      Create a custom report or look for data inconsistencies.
+      This feature allows you to quickly discover the cases of your interest.<br />
+      This is a Preview Feature.
     {% endblocktrans %}
+    <a href="https://confluence.dimagi.com/display/commcarepublic/Add-Ons+and+Feature+Previews"
+       target="_blank">
+      {% trans "Learn more." %}
+    </a>
   </p>
   <div class="ko-loading">
     <i class="fa fa-spinner fa-spin"></i>
@@ -412,8 +417,8 @@
           </div>
           <div class="modal-body">
             {% blocktrans %}
-              This task is currently not supported, but we are happy to see
-              your interest.
+              This task is currently not supported, but we are happy to
+              learn about your interest.
             {% endblocktrans %}
           </div>
           <div class="modal-footer">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -276,8 +276,17 @@
                                      }" ></select>
                 </div>
               </div>
+
+              <hr data-bind="visible: $root.editColumnController.showColumnFilters()
+                             || $root.editColumnController.showColumnFilterPlaceholder()" />
+              <button type="button"
+                      class="btn btn-default disabled"
+                      disabled="disabled"
+                      data-bind="visible: $root.editColumnController.showColumnFilterPlaceholder">
+                {% trans "Filter Data in Column" %}
+              </button>
+
               <!-- ko if: $root.editColumnController.showColumnFilters -->
-                <hr />
                 <div class="form-group"
                      data-bind="visible: hasFilters">
                   <div class="datagrid-column-filter-clause">
@@ -342,6 +351,7 @@
                   </a>
                 </div>
                 <!-- /ko -->
+
                 <button type="button"
                         class="btn btn-default"
                         data-bind="click: $root.editColumnController.addFilter,
@@ -356,6 +366,7 @@
                   {% trans "Add Expression" %}
                 </button>
               <!-- /ko -->
+
             </div>
           </div>
           <div class="modal-footer">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/explore_case_data.html
@@ -292,38 +292,36 @@
               </button>
 
               <!-- ko if: $root.editColumnController.showColumnFilters -->
-                <div class="form-group"
-                     data-bind="visible: hasFilters">
-                  <div class="datagrid-column-filter-clause">
-                    {% trans "Match" %}
-                    <select data-bind="value: clause,
-                                     event: { change: $root.editColumnController.updateFilter }"
-                            class="form-control">
-                      <option value="all">
-                        {% trans "all of the" %}
-                      </option>
-                      <option value="any">
-                        {% trans "any of the" %}
-                      </option>
-                    </select>
-                    {% trans "following conditions:" %}
-                  </div>
-                </div>
-
                 <!-- ko foreach: appliedFilters -->
-                <div class="datagrid-filter">
+
                   <!-- ko if: $index() === 0 -->
-                  <select class="form-control datagrid-filter-type"
-                          data-bind="options: $root.editColumnController.availableFilterNames,
-                                     optionsText: function (val) {
-                                       return $root.editColumnController.filterTitleByName[val];
-                                     },
-                                     value: filterName,
-                                     event: { change: $root.editColumnController.updateFilterName }"></select>
+                  <div class="datagrid-filter-settings">
+                    {% blocktrans %}
+                      Treat this property as
+                      <select class="form-control filter-type"
+                              data-bind="options: $root.editColumnController.availableFilterNames,
+                                         optionsText: function (val) {
+                                           return $root.editColumnController.filterTitleByName[val];
+                                         },
+                                         value: filterName,
+                                         event: { change: $root.editColumnController.updateFilterName }"></select>
+                      and match
+                      <select data-bind="value: $parent.clause,
+                                         event: { change: $root.editColumnController.updateFilter }"
+                              class="form-control filter-clause">
+                        <option value="all">
+                          all of the
+                        </option>
+                        <option value="any">
+                          any of the
+                        </option>
+                      </select>
+                      following conditions:
+                    {% endblocktrans %}
+                  </div>
                   <!-- /ko -->
-                  <!-- ko if: $index() !== 0 -->
-                  <div class="datagrid-filter-type-spacer"></div>
-                  <!-- /ko -->
+
+                  <div class="datagrid-filter">
                   <select class="form-control datagrid-filter-choice"
                           data-bind="options: $root.editColumnController.availableChoiceNames,
                                      optionsText: function (val) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datagrid.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datagrid.less
@@ -94,7 +94,7 @@ for the new reporting grids (tables).
 .datagrid-add-link {
   display: block;
   width: 100px%;
-  height: @_header-height;
+  height: auto;
   line-height: @_header-height;
 }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datagrid.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/datagrid.less
@@ -38,10 +38,15 @@ for the new reporting grids (tables).
   }
 }
 
-.datagrid-column-filter-clause {
-  padding-left: 10px;
+.datagrid-filter-settings {
+  padding-bottom: 10px;
 
-  select {
+  .filter-type {
+    display: inline-block;
+    width: 80px;
+  }
+
+  .filter-clause {
     display: inline-block;
     width: 100px;
   }
@@ -51,20 +56,14 @@ for the new reporting grids (tables).
 .datagrid-filter {
   padding-bottom: 10px;
 
-  .datagrid-filter-type,
-  .datagrid-filter-type-spacer {
-    display: inline-block;
-    width: 80px;
-  }
-
   .datagrid-filter-choice {
     display: inline-block;
-    width: 120px;
+    width: 197px;
   }
 
   .datagrid-filter-value {
     display: inline-block;
-    width: 348px;
+    width: 354px;
   }
 
   a {

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_feedback.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/ko_feedback.html
@@ -23,7 +23,7 @@
           </button>
           <h4 class="modal-title">
             {% blocktrans %}
-              Give Feedback on <span data-bind="text: featureName"></span>
+              We would love to get your feedback
             {% endblocktrans %}
           </h4>
         </div>
@@ -32,7 +32,7 @@
           <div class="form-group">
             <label class="control-label">
               {% blocktrans %}
-                How would you rate <span data-bind="text: featureName"></span>?
+                How would you rate this feature?
               {% endblocktrans %}
             </label>
             <div class="row feedback-smiles">

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -44,7 +44,7 @@ hqDefine('reports/v2/js/datagrid/columns', [
         });
 
         self.showAddExpression = ko.computed(function () {
-            return self.appliedFilters().length === 1;
+            return self.appliedFilters().length > 0 && self.appliedFilters().length < 5;
         });
 
         self.unwrap = function () {

--- a/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
+++ b/corehq/apps/reports/static/reports/v2/js/datagrid/columns.js
@@ -98,6 +98,11 @@ hqDefine('reports/v2/js/datagrid/columns', [
             return !self.hideColumnFilterCondition(self.column());
         });
 
+        self.showColumnFilterPlaceholder = ko.computed(function () {
+            if (!self.column()) return false;
+            return self.column().name() === undefined || self.column().name().length === 0;
+        });
+
         self.showDelete = ko.computed(function () {
             if (!_.isFunction(self.noDeleteColumnCondition)) return true;
             if (!self.column()) return true;

--- a/corehq/apps/reports/v2/filters/xpath_column.py
+++ b/corehq/apps/reports/v2/filters/xpath_column.py
@@ -82,8 +82,8 @@ class TextXpathColumnFilter(BaseXpathColumnFilter):
     name = 'xpath_column_text'
     data_type = DataType.TEXT
     choices = [
-        ChoiceMeta(ugettext_lazy("Equals"), 'text_equals', '='),
-        ChoiceMeta(ugettext_lazy("Does not equal"), 'text_not_equals', '!='),
+        ChoiceMeta(ugettext_lazy("Text equals"), 'text_equals', '='),
+        ChoiceMeta(ugettext_lazy("Text does not equal"), 'text_not_equals', '!='),
     ]
 
     def format_value(self, value):
@@ -91,14 +91,14 @@ class TextXpathColumnFilter(BaseXpathColumnFilter):
 
 
 class NumericXpathColumnFilter(BaseXpathColumnFilter):
-    title = ugettext_lazy("Number")
+    title = ugettext_lazy("a Number")
     name = 'xpath_column_number'
     data_type = DataType.NUMERIC
     choices = [
-        ChoiceMeta(ugettext_lazy("Is equal to"), 'num_equals', '='),
-        ChoiceMeta(ugettext_lazy("Is less than"), 'num_less_than', '<'),
-        ChoiceMeta(ugettext_lazy("Is greater than"), 'num_greater_than', '>'),
-        ChoiceMeta(ugettext_lazy("Is not equal to"), 'num_not_equals', '!='),
+        ChoiceMeta(ugettext_lazy("Number is equal to"), 'num_equals', '='),
+        ChoiceMeta(ugettext_lazy("Number is less than"), 'num_less_than', '<'),
+        ChoiceMeta(ugettext_lazy("Number is greater than"), 'num_greater_than', '>'),
+        ChoiceMeta(ugettext_lazy("Number is not equal to"), 'num_not_equals', '!='),
     ]
 
     @staticmethod
@@ -113,7 +113,7 @@ class NumericXpathColumnFilter(BaseXpathColumnFilter):
 
 
 class DateXpathColumnFilter(BaseXpathColumnFilter):
-    title = ugettext_lazy("Date")
+    title = ugettext_lazy("a Date")
     name = 'xpath_column_date'
     data_type = DataType.DATE
     choices = [

--- a/corehq/apps/reports/v2/reports/explore_case_data.py
+++ b/corehq/apps/reports/v2/reports/explore_case_data.py
@@ -57,12 +57,6 @@ class ExploreCaseDataReport(BaseReport):
             width=200,
             sort='asc',
         ),
-        ColumnMeta(
-            title=ugettext_lazy("Case Type"),
-            name='@case_type',
-            width=200,
-            sort=None,
-        ),
     ]
 
     column_filters = [


### PR DESCRIPTION
Addresses most of the [ECD feedback](https://docs.google.com/document/d/1kXQHHOywlxojl2itIkdb5y690sq4tuxwUe0WrUbfIaQ/edit). Still need to address loading spinner placement.

- make the "Add Column" fit above the line. 
- should show a disabled Add Filters button on add column modal from the start
- if filters are changed during the loading process, the promise is cancelled and a new ajax request is made immediately
- increase the number of filters from 2 to 5
- remove the Case Type column from the default UI
- copy changes
- improved data typing of filter options:
<img width="594" alt="Screen Shot 2019-06-17 at 4 43 46 PM" src="https://user-images.githubusercontent.com/716573/59613849-ef851200-911f-11e9-957d-72073f8523d4.png">
