### PR TITLE
Fixed releases page pagination using 10 instead of cookie value

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
@@ -15,8 +15,8 @@ hqDefine("app_manager/js/releases/app_view_release_manager", function () {
     var el = $('#releases-table');
     if (el.length) {
         var releasesMain = releasesMainModel(o);
-        _.defer(function () { releasesMain.goToPage(1); });
         el.koApplyBindings(releasesMain);
+        _.defer(function () { releasesMain.goToPage(1); });
     }
 
     // View changes / app diff


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/23524

On the first page load, perPage/fetchLimit wasn't yet set, so the page was showing 10 items regardless of what the user had last chosen.