### PR TITLE
updates to case OData format

### DIFF
--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -62,10 +62,11 @@ class ODataCommCareCaseSerializer(Serializer):
             'resource_uri',
         ]:
             case_json.pop(remove_property)
-        case_json['properties'] = {
-            property_name: case_json['properties'].get(property_name, None)
+        case_properties = case_json.pop('properties')
+        case_json.update({
+            property_name: case_properties.get(property_name, None)
             for property_name in properties_to_include
-        }
+        })
 
     @memoized
     def get_properties_to_include(self, domain, case_type):

--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -14,13 +14,6 @@ from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.web import get_url_base
 
 
-# clean properties
-def _clean_property_name(name):
-    # for whatever ridiculous reason, at least in Tableau,
-    # when these are nested inside an object they can't have underscores in them
-    return name.replace('_', '')
-
-
 class ODataCommCareCaseSerializer(Serializer):
     """
     A custom serializer that converts case data into an odata-compliant format.
@@ -53,7 +46,6 @@ class ODataCommCareCaseSerializer(Serializer):
         return json.dumps(data, cls=DjangoJSONEncoder, sort_keys=True)
 
     def update_case_json(self, case_json, domain, case_type):
-        case_json['properties'] = {_clean_property_name(k): v for k, v in case_json['properties'].items()}
         properties_to_include = self.get_properties_to_include(domain, case_type)
         for remove_property in [
             'id',
@@ -72,7 +64,7 @@ class ODataCommCareCaseSerializer(Serializer):
     def get_properties_to_include(self, domain, case_type):
         case_type_to_properties = get_case_type_to_properties(domain)
         return [
-            'casename', 'casetype', 'dateopened', 'ownerid', 'backendid'
+            'case_name', 'case_type', 'date_opened', 'owner_id', 'backend_id'
         ] + case_type_to_properties.get(case_type, [])
 
 

--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -62,10 +62,10 @@ class ODataCommCareCaseSerializer(Serializer):
             'resource_uri',
         ]:
             case_json.pop(remove_property)
-        properties = case_json.get('properties')
-        for property_name in list(properties):
-            if property_name not in properties_to_include:
-                properties.pop(property_name)
+        case_json['properties'] = {
+            property_name: case_json['properties'].get(property_name, None)
+            for property_name in properties_to_include
+        }
 
     @memoized
     def get_properties_to_include(self, domain, case_type):

--- a/corehq/apps/api/odata/tests/data/populated_case_metadata_document.xml
+++ b/corehq/apps/api/odata/tests/data/populated_case_metadata_document.xml
@@ -1,22 +1,6 @@
  <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
    <edmx:DataServices>
      <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
-       <ComplexType Name="CaseProperties:case_type_with_no_case_properties">
-         <Property Name="backend_id" Type="Edm.String"/>
-         <Property Name="case_name" Type="Edm.String"/>
-         <Property Name="case_type" Type="Edm.String"/>
-         <Property Name="date_opened" Type="Edm.String"/>
-         <Property Name="owner_id" Type="Edm.String"/>
-       </ComplexType>
-       <ComplexType Name="CaseProperties:case_type_with_case_properties">
-         <Property Name="backend_id" Type="Edm.String"/>
-         <Property Name="case_name" Type="Edm.String"/>
-         <Property Name="case_type" Type="Edm.String"/>
-         <Property Name="date_opened" Type="Edm.String"/>
-         <Property Name="owner_id" Type="Edm.String"/>
-         <Property Name="property_1" Type="Edm.String"/>
-         <Property Name="property_2" Type="Edm.String"/>
-       </ComplexType>
        <EntityType Name="case_type_with_no_case_properties">
          <Key>
            <PropertyRef Name="case_id"/>
@@ -27,12 +11,16 @@
          <Property Name="date_closed" Type="Edm.DateTimeOffset"/>
          <Property Name="date_modified" Type="Edm.DateTimeOffset"/>
          <Property Name="opened_by" Type="Edm.String"/>
-         <Property Name="properties" Nullable="false" Type="CommCare.CaseProperties:case_type_with_no_case_properties"/>
          <Property Name="server_date_modified" Type="Edm.DateTimeOffset"/>
          <Property Name="server_date_opened" Type="Edm.DateTimeOffset"/>
          <Property Name="user_id" Type="Edm.String"/>
          <!-- todo: this isn't working - may be a tableau limitation on list properties -->
          <Property Name="xform_ids" Type="Collection(Edm.String)"/>
+         <Property Name="backend_id" Type="Edm.String"/>
+         <Property Name="case_name" Type="Edm.String"/>
+         <Property Name="case_type" Type="Edm.String"/>
+         <Property Name="date_opened" Type="Edm.String"/>
+         <Property Name="owner_id" Type="Edm.String"/>
        </EntityType>
        <EntityType Name="case_type_with_case_properties">
          <Key>
@@ -44,12 +32,18 @@
          <Property Name="date_closed" Type="Edm.DateTimeOffset"/>
          <Property Name="date_modified" Type="Edm.DateTimeOffset"/>
          <Property Name="opened_by" Type="Edm.String"/>
-         <Property Name="properties" Nullable="false" Type="CommCare.CaseProperties:case_type_with_case_properties"/>
          <Property Name="server_date_modified" Type="Edm.DateTimeOffset"/>
          <Property Name="server_date_opened" Type="Edm.DateTimeOffset"/>
          <Property Name="user_id" Type="Edm.String"/>
          <!-- todo: this isn't working - may be a tableau limitation on list properties -->
          <Property Name="xform_ids" Type="Collection(Edm.String)"/>
+         <Property Name="backend_id" Type="Edm.String"/>
+         <Property Name="case_name" Type="Edm.String"/>
+         <Property Name="case_type" Type="Edm.String"/>
+         <Property Name="date_opened" Type="Edm.String"/>
+         <Property Name="owner_id" Type="Edm.String"/>
+         <Property Name="property_1" Type="Edm.String"/>
+         <Property Name="property_2" Type="Edm.String"/>
        </EntityType>
        <EntityContainer Name="Container">
          <EntitySet EntityType="CommCare.case_type_with_no_case_properties" Name="case_type_with_no_case_properties"/>

--- a/corehq/apps/api/odata/tests/data/populated_case_metadata_document.xml
+++ b/corehq/apps/api/odata/tests/data/populated_case_metadata_document.xml
@@ -2,18 +2,18 @@
    <edmx:DataServices>
      <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
        <ComplexType Name="CaseProperties:case_type_with_no_case_properties">
-         <Property Name="backendid" Type="Edm.String"/>
-         <Property Name="casename" Type="Edm.String"/>
-         <Property Name="casetype" Type="Edm.String"/>
-         <Property Name="dateopened" Type="Edm.String"/>
-         <Property Name="ownerid" Type="Edm.String"/>
+         <Property Name="backend_id" Type="Edm.String"/>
+         <Property Name="case_name" Type="Edm.String"/>
+         <Property Name="case_type" Type="Edm.String"/>
+         <Property Name="date_opened" Type="Edm.String"/>
+         <Property Name="owner_id" Type="Edm.String"/>
        </ComplexType>
        <ComplexType Name="CaseProperties:case_type_with_case_properties">
-         <Property Name="backendid" Type="Edm.String"/>
-         <Property Name="casename" Type="Edm.String"/>
-         <Property Name="casetype" Type="Edm.String"/>
-         <Property Name="dateopened" Type="Edm.String"/>
-         <Property Name="ownerid" Type="Edm.String"/>
+         <Property Name="backend_id" Type="Edm.String"/>
+         <Property Name="case_name" Type="Edm.String"/>
+         <Property Name="case_type" Type="Edm.String"/>
+         <Property Name="date_opened" Type="Edm.String"/>
+         <Property Name="owner_id" Type="Edm.String"/>
          <Property Name="property_1" Type="Edm.String"/>
          <Property Name="property_2" Type="Edm.String"/>
        </ComplexType>

--- a/corehq/apps/api/odata/tests/test_serializers.py
+++ b/corehq/apps/api/odata/tests/test_serializers.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from mock import patch
+
+from django.test import SimpleTestCase
+
+from corehq.apps.api.odata.serializers import ODataCommCareCaseSerializer, ODataXFormInstanceSerializer
+
+
+class TestODataCommCareCaseSerializer(SimpleTestCase):
+
+    def test_update_case_json(self):
+        case_json = {
+            'date_closed': None,
+            'domain': 'test-domain',
+            'xform_ids': ['ddee0178-bce1-49cd-bf26-4d5be0fb5a27'],
+            'date_modified': '2019-01-23T18:24:33.118000Z',
+            'server_date_modified': '2019-01-23T18:24:33.199266Z',
+            'id': '50ff9e8b-30de-4a9a-98fd-f997e7b438da',
+            'opened_by': '753f34ff0856210e339878e36a0001a5',
+            'server_date_opened': '2019-01-23T18:24:33.199266Z',
+            'case_id': '50ff9e8b-30de-4a9a-98fd-f997e7b438da',
+            'closed': False,
+            'indices': {},
+            'user_id': '753f34ff0856210e339878e36a0001a5',
+            'indexed_on': '2019-04-29T16:03:12.434334',
+            'properties': {
+                'case_type': 'my_case_type',
+                'owner_id': '753f34ff0856210e339878e36a0001a5',
+                'external_id': None,
+                'case_name': 'nick',
+                'date_opened': '2019-01-23T18:24:33.118000Z',
+                'included_property': 'abc'
+            },
+            'resource_uri': ''
+        }
+        with patch('corehq.apps.api.odata.serializers.get_case_type_to_properties', return_value={
+            'my_case_type': ['includedproperty', 'missingproperty']
+        }):
+            ODataCommCareCaseSerializer().update_case_json(case_json, 'test-domain', 'my_case_type')
+        self.assertEqual(case_json, {
+            'date_closed': None,
+            'domain': 'test-domain',
+            'xform_ids': ['ddee0178-bce1-49cd-bf26-4d5be0fb5a27'],
+            'date_modified': '2019-01-23T18:24:33.118000Z',
+            'server_date_modified': '2019-01-23T18:24:33.199266Z',
+            'opened_by': '753f34ff0856210e339878e36a0001a5',
+            'server_date_opened': '2019-01-23T18:24:33.199266Z',
+            'case_id': '50ff9e8b-30de-4a9a-98fd-f997e7b438da',
+            'closed': False,
+            'user_id': '753f34ff0856210e339878e36a0001a5',
+            'properties': {
+                'ownerid': '753f34ff0856210e339878e36a0001a5',
+                'casetype': 'my_case_type',
+                'casename': 'nick',
+                'dateopened': '2019-01-23T18:24:33.118000Z',
+                'includedproperty': 'abc'
+            }
+        })

--- a/corehq/apps/api/odata/tests/test_serializers.py
+++ b/corehq/apps/api/odata/tests/test_serializers.py
@@ -55,6 +55,8 @@ class TestODataCommCareCaseSerializer(SimpleTestCase):
                 'casetype': 'my_case_type',
                 'casename': 'nick',
                 'dateopened': '2019-01-23T18:24:33.118000Z',
-                'includedproperty': 'abc'
+                'includedproperty': 'abc',
+                'missingproperty': None,
+                'backendid': None
             }
         })

--- a/corehq/apps/api/odata/tests/test_serializers.py
+++ b/corehq/apps/api/odata/tests/test_serializers.py
@@ -36,7 +36,7 @@ class TestODataCommCareCaseSerializer(SimpleTestCase):
             'resource_uri': ''
         }
         with patch('corehq.apps.api.odata.serializers.get_case_type_to_properties', return_value={
-            'my_case_type': ['includedproperty', 'missingproperty']
+            'my_case_type': ['included_property', 'missing_property']
         }):
             ODataCommCareCaseSerializer().update_case_json(case_json, 'test-domain', 'my_case_type')
         self.assertEqual(case_json, {
@@ -50,11 +50,11 @@ class TestODataCommCareCaseSerializer(SimpleTestCase):
             'case_id': '50ff9e8b-30de-4a9a-98fd-f997e7b438da',
             'closed': False,
             'user_id': '753f34ff0856210e339878e36a0001a5',
-            'ownerid': '753f34ff0856210e339878e36a0001a5',
-            'casetype': 'my_case_type',
-            'casename': 'nick',
-            'dateopened': '2019-01-23T18:24:33.118000Z',
-            'includedproperty': 'abc',
-            'missingproperty': None,
-            'backendid': None
+            'owner_id': '753f34ff0856210e339878e36a0001a5',
+            'case_type': 'my_case_type',
+            'case_name': 'nick',
+            'date_opened': '2019-01-23T18:24:33.118000Z',
+            'included_property': 'abc',
+            'missing_property': None,
+            'backend_id': None
         })

--- a/corehq/apps/api/odata/tests/test_serializers.py
+++ b/corehq/apps/api/odata/tests/test_serializers.py
@@ -50,13 +50,11 @@ class TestODataCommCareCaseSerializer(SimpleTestCase):
             'case_id': '50ff9e8b-30de-4a9a-98fd-f997e7b438da',
             'closed': False,
             'user_id': '753f34ff0856210e339878e36a0001a5',
-            'properties': {
-                'ownerid': '753f34ff0856210e339878e36a0001a5',
-                'casetype': 'my_case_type',
-                'casename': 'nick',
-                'dateopened': '2019-01-23T18:24:33.118000Z',
-                'includedproperty': 'abc',
-                'missingproperty': None,
-                'backendid': None
-            }
+            'ownerid': '753f34ff0856210e339878e36a0001a5',
+            'casetype': 'my_case_type',
+            'casename': 'nick',
+            'dateopened': '2019-01-23T18:24:33.118000Z',
+            'includedproperty': 'abc',
+            'missingproperty': None,
+            'backendid': None
         })

--- a/corehq/apps/api/odata/tests/test_serializers.py
+++ b/corehq/apps/api/odata/tests/test_serializers.py
@@ -5,7 +5,7 @@ from mock import patch
 
 from django.test import SimpleTestCase
 
-from corehq.apps.api.odata.serializers import ODataCommCareCaseSerializer, ODataXFormInstanceSerializer
+from corehq.apps.api.odata.serializers import ODataCommCareCaseSerializer
 
 
 class TestODataCommCareCaseSerializer(SimpleTestCase):

--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -21,8 +21,7 @@ def get_case_type_to_properties(domain):
             or CaseExportDataSchema.generate_schema_from_builds(domain, None, case_type)
         )
         for export_group_schema in case_export_schema.group_schemas[0].items:
-            cleaned_case_property = export_group_schema.label.replace('_', '')
-            case_type_to_properties[case_type].append(cleaned_case_property)
+            case_type_to_properties[case_type].append(export_group_schema.label)
     return dict(case_type_to_properties)
 
 

--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -42,7 +42,7 @@ class ODataCaseMetadataView(View):
         case_type_to_properties = get_case_type_to_properties(domain)
         for case_type in case_type_to_properties:
             case_type_to_properties[case_type] = sorted(
-                {'casename', 'casetype', 'dateopened', 'ownerid', 'backendid'}
+                {'case_name', 'case_type', 'date_opened', 'owner_id', 'backend_id'}
                 | set(case_type_to_properties[case_type])
             )
         metadata = render_to_string('api/odata_metadata.xml', {

--- a/corehq/apps/api/templates/api/odata_metadata.xml
+++ b/corehq/apps/api/templates/api/odata_metadata.xml
@@ -3,14 +3,6 @@
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
             {% for case_type, properties in case_type_to_properties.items %}
-            <ComplexType Name="CaseProperties:{{ case_type }}" >
-                {% for property in properties %}
-                <Property Name="{{ property }}" Type="Edm.String" />
-                {% endfor %}
-            </ComplexType>
-            {% endfor %}
-
-            {% for case_type in case_type_to_properties %}
             <EntityType Name="{{ case_type }}" >
                 <Key>
                     <PropertyRef Name="case_id" />
@@ -21,12 +13,14 @@
                 <Property Name="date_closed" Type="Edm.DateTimeOffset" />
                 <Property Name="date_modified" Type="Edm.DateTimeOffset" />
                 <Property Name="opened_by" Type="Edm.String" />
-                <Property Name="properties" Type="CommCare.CaseProperties:{{ case_type }}" Nullable="false"/>
                 <Property Name="server_date_modified" Type="Edm.DateTimeOffset" />
                 <Property Name="server_date_opened" Type="Edm.DateTimeOffset" />
                 <Property Name="user_id" Type="Edm.String" />
                 <!-- todo: this isn't working - may be a tableau limitation on list properties -->
                 <Property Name="xform_ids" Type="Collection(Edm.String)" />
+                {% for property in properties %}
+                <Property Name="{{ property }}" Type="Edm.String" />
+                {% endfor %}
             </EntityType>
             {% endfor %}
 


### PR DESCRIPTION
🐡 

This PR addresses [two issues](https://trello.com/c/ujKXg4mz/73-commcare-data-3rd-party-reporting-tool):
1) For expected case properties missing from a case, represents this with null, so PowerBI doesn't claim that there's an error with the row.
2) Avoids nesting in the row, which means we can add back underscores in case properties (Tableau doesn't like underscores in nested structures)

After these changes are deployed we will need to tell people in the beta group to refresh their metadata documents.