### PR TITLE
fix vertex tests in python 3

### DIFF
--- a/corehq/messaging/smsbackends/vertex/tests/test_request.py
+++ b/corehq/messaging/smsbackends/vertex/tests/test_request.py
@@ -41,16 +41,12 @@ class TestVertexBackendRequestContent(TestCase):
         self.assertEqual(params['response'], 'Y')
         self.assertEqual(params['dest_mobileno'], strip_plus(TEST_PHONE_NUMBER))
         self.assertEqual(params['msgtype'], TEXT_MSG_TYPE)
-        self.assertEqual(params['message'], TEST_TEXT_MESSAGE)
+        self.assertEqual(params['message'].decode('ascii'), TEST_TEXT_MESSAGE)
 
         self.queued_sms.text = TEST_UNICODE_MESSAGE
         params = self.vertex_backend.populate_params(self.queued_sms)
-        if six.PY3:
-            self.assertEqual(params['message'], TEST_UNICODE_MESSAGE)
-            self.assertEqual(params['msgtype'], TEXT_MSG_TYPE)
-        else:
-            self.assertEqual(params['message'].decode('utf-8'), TEST_UNICODE_MESSAGE)
-            self.assertEqual(params['msgtype'], UNICODE_MSG_TYPE)
+        self.assertEqual(params['message'].decode('utf-8'), TEST_UNICODE_MESSAGE)
+        self.assertEqual(params['msgtype'], UNICODE_MSG_TYPE)
 
     def test_phone_number_is_valid(self):
         self.assertFalse(VertexBackend().phone_number_is_valid('+91'))


### PR DESCRIPTION
This test was broken in Python 3 by https://github.com/dimagi/commcare-hq/pull/24546, which feels like a good thing for test coverage.  As-is the test documents incorrect behavior in Python 3.