### PR TITLE
Skip messaging rule run for inactive rule 

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -173,7 +173,7 @@ def _deactivate_schedules(domain, survey_only=False):
             else:
                 raise TypeError("Expected AlertSchedule or TimedSchedule")
 
-            initiate_messaging_rule_run(domain.name, rule.pk)
+            initiate_messaging_rule_run(domain.name, rule)
 
 
 class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -173,7 +173,7 @@ def _deactivate_schedules(domain, survey_only=False):
             else:
                 raise TypeError("Expected AlertSchedule or TimedSchedule")
 
-            initiate_messaging_rule_run(domain.name, rule)
+            initiate_messaging_rule_run(rule)
 
 
 class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -415,7 +415,7 @@ class DeactivateScheduleTest(TransactionTestCase):
             self.assertEqual(p3.call_count, 2)
             p3.assert_has_calls(
                 [
-                    call(rule.domain, rule.pk)
+                    call(rule)
                     for rule in (self.domain_1_sms_schedules[2], self.domain_1_survey_schedules[2])
                 ],
                 any_order=True
@@ -445,7 +445,7 @@ class DeactivateScheduleTest(TransactionTestCase):
             p2.assert_called_once_with(b.schedule_id, b.recipients)
 
             rule = self.domain_1_survey_schedules[2]
-            p3.assert_called_once_with(rule.domain, rule.pk)
+            p3.assert_called_once_with(rule)
 
         self.assertSchedulesActive(self.domain_1_sms_schedules)
         self.assertSchedulesInactive(self.domain_1_survey_schedules)

--- a/corehq/messaging/management/commands/import_conditional_alerts.py
+++ b/corehq/messaging/management/commands/import_conditional_alerts.py
@@ -124,6 +124,6 @@ class Command(BaseCommand):
         print("Import complete. Starting instance refresh tasks...")
 
         for rule in rules:
-            initiate_messaging_rule_run(rule.domain, rule)
+            initiate_messaging_rule_run(rule)
 
         print("Done.")

--- a/corehq/messaging/management/commands/import_conditional_alerts.py
+++ b/corehq/messaging/management/commands/import_conditional_alerts.py
@@ -124,6 +124,6 @@ class Command(BaseCommand):
         print("Import complete. Starting instance refresh tasks...")
 
         for rule in rules:
-            initiate_messaging_rule_run(rule.domain, rule.pk)
+            initiate_messaging_rule_run(rule.domain, rule)
 
         print("Done.")

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -182,7 +182,7 @@ class ConditionalAlertUploader(object):
 
                 if dirty:
                     rule.save()
-                    initiate_messaging_rule_run(self.domain, rule)
+                    initiate_messaging_rule_run(rule)
                     success_count += 1
 
         self.msgs.append((messages.success, _("Updated {count} rule(s) in '{sheet_name}' sheet").format(

--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -182,7 +182,7 @@ class ConditionalAlertUploader(object):
 
                 if dirty:
                     rule.save()
-                    initiate_messaging_rule_run(self.domain, rule.pk)
+                    initiate_messaging_rule_run(self.domain, rule)
                     success_count += 1
 
         self.msgs.append((messages.success, _("Updated {count} rule(s) in '{sheet_name}' sheet").format(

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -692,7 +692,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
 
             schedule.active = active_flag
             schedule.save()
-            initiate_messaging_rule_run(self.domain, rule)
+            initiate_messaging_rule_run(rule)
 
         return JsonResponse({
             'status': 'success',
@@ -712,7 +712,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
             minutes_remaining = helper.rule_initiation_key_minutes_remaining()
             return JsonResponse({'status': 'error', 'minutes_remaining': minutes_remaining})
 
-        initiate_messaging_rule_run(rule.domain, rule)
+        initiate_messaging_rule_run(rule)
         return JsonResponse({
             'status': 'success',
             'rule': self._format_rule_for_json(rule),
@@ -746,7 +746,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
                 'error_msg': _("This rule includes references that cannot be copied."),
             })
 
-        initiate_messaging_rule_run(copied_rule.domain, copied_rule)
+        initiate_messaging_rule_run(copied_rule)
         return JsonResponse({
             'status': 'success',
             'rule': self._format_rule_for_json(rule),
@@ -908,7 +908,7 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
                 self.criteria_form.save_criteria(rule)
                 self.schedule_form.save_rule_action_and_schedule(rule)
 
-            initiate_messaging_rule_run(rule.domain, rule)
+            initiate_messaging_rule_run(rule)
             return HttpResponseRedirect(reverse(ConditionalAlertListView.urlname, args=[self.domain]))
 
         return self.get(request, *args, **kwargs)

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -692,7 +692,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
 
             schedule.active = active_flag
             schedule.save()
-            initiate_messaging_rule_run(self.domain, rule.pk)
+            initiate_messaging_rule_run(self.domain, rule)
 
         return JsonResponse({
             'status': 'success',
@@ -712,7 +712,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
             minutes_remaining = helper.rule_initiation_key_minutes_remaining()
             return JsonResponse({'status': 'error', 'minutes_remaining': minutes_remaining})
 
-        initiate_messaging_rule_run(rule.domain, rule.pk)
+        initiate_messaging_rule_run(rule.domain, rule)
         return JsonResponse({
             'status': 'success',
             'rule': self._format_rule_for_json(rule),
@@ -746,7 +746,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
                 'error_msg': _("This rule includes references that cannot be copied."),
             })
 
-        initiate_messaging_rule_run(copied_rule.domain, copied_rule.pk)
+        initiate_messaging_rule_run(copied_rule.domain, copied_rule)
         return JsonResponse({
             'status': 'success',
             'rule': self._format_rule_for_json(rule),
@@ -908,7 +908,7 @@ class CreateConditionalAlertView(BaseMessagingSectionView, AsyncHandlerMixin):
                 self.criteria_form.save_criteria(rule)
                 self.schedule_form.save_rule_action_and_schedule(rule)
 
-            initiate_messaging_rule_run(rule.domain, rule.pk)
+            initiate_messaging_rule_run(rule.domain, rule)
             return HttpResponseRedirect(reverse(ConditionalAlertListView.urlname, args=[self.domain]))
 
         return self.get(request, *args, **kwargs)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -83,10 +83,12 @@ def _sync_case_for_messaging_rule(domain, case_id, rule_id):
         MessagingRuleProgressHelper(rule_id).increment_current_case_count()
 
 
-def initiate_messaging_rule_run(domain, rule_id):
-    MessagingRuleProgressHelper(rule_id).set_initial_progress()
-    AutomaticUpdateRule.objects.filter(pk=rule_id).update(locked_for_editing=True)
-    transaction.on_commit(lambda: run_messaging_rule.delay(domain, rule_id))
+def initiate_messaging_rule_run(domain, rule):
+    if not rule.active:
+        return
+    MessagingRuleProgressHelper(rule.pk).set_initial_progress()
+    AutomaticUpdateRule.objects.filter(pk=rule.pk).update(locked_for_editing=True)
+    transaction.on_commit(lambda: run_messaging_rule.delay(domain, rule.pk))
 
 
 def get_case_ids_for_messaging_rule(domain, case_type):

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -79,12 +79,12 @@ def _sync_case_for_messaging_rule(domain, case_id, rule_id):
         MessagingRuleProgressHelper(rule_id).increment_current_case_count()
 
 
-def initiate_messaging_rule_run(domain, rule):
+def initiate_messaging_rule_run(rule):
     if not rule.active:
         return
     MessagingRuleProgressHelper(rule.pk).set_initial_progress()
     AutomaticUpdateRule.objects.filter(pk=rule.pk).update(locked_for_editing=True)
-    transaction.on_commit(lambda: run_messaging_rule.delay(domain, rule.pk))
+    transaction.on_commit(lambda: run_messaging_rule.delay(rule.domain, rule.pk))
 
 
 def get_case_ids_for_messaging_rule(domain, case_type):

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -67,11 +67,7 @@ def _sync_case_for_messaging(domain, case_id):
 def _get_cached_rule(domain, rule_id):
     rules = AutomaticUpdateRule.by_domain_cached(domain, AutomaticUpdateRule.WORKFLOW_SCHEDULING)
     rules = [rule for rule in rules if rule.pk == rule_id]
-
-    if len(rules) != 1:
-        return None
-
-    return rules[0]
+    return rules[0] if len(rules) == 1 else None
 
 
 def _sync_case_for_messaging_rule(domain, case_id, rule_id):


### PR DESCRIPTION
The rule would not be run anyway since `AutomaticUpdateRule.by_domain_cached(...)` excludes inactive rules. However, previously the progress helper was initialized and the rule was locked, which resulted in the rule being uneditable and appearing to be in progress when in fact nothing was happening.

@orangejenny 