### PR TITLE
Removed unnecessary assignment

### DIFF
--- a/corehq/messaging/scheduling/view_helpers.py
+++ b/corehq/messaging/scheduling/view_helpers.py
@@ -122,7 +122,6 @@ class ConditionalAlertUploader(object):
                 condensed_rows[row['id']].append(row)
                 continue
 
-            rule = getattr(rules_by_id, six.text_type(row['id']), None)
             try:
                 rule = AutomaticUpdateRule.objects.get(
                     pk=row['id'],


### PR DESCRIPTION
Since `condensed_rows` and `rules_by_id` are populated together, and a couple lines above we `continue` if the rule is in `condensed_rows`, at this point there's no chance of the rule being in `rules_by_id`.