### PR TITLE
cleanup users created in tests

### DIFF
--- a/custom/ilsgateway/tests/test_reminders2.py
+++ b/custom/ilsgateway/tests/test_reminders2.py
@@ -36,6 +36,11 @@ class RemindersTest(ILSTestScript):
         )
         create_products(cls, TEST_DOMAIN, ["id", "dp", "fs", "md", "ff", "dx", "bp", "pc", "qi", "jd", "mc", "ip"])
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.user1.delete()
+        super(RemindersTest, cls).tearDownClass()
+
     def tearDown(self):
         SupplyPointStatus.objects.all().delete()
         super(RemindersTest, self).tearDown()
@@ -153,6 +158,11 @@ class TestStockOut(RemindersTest):
         set_default_consumption_for_supply_point(TEST_DOMAIN, cls.id.get_id, cls.facility_sp_id, 100)
         set_default_consumption_for_supply_point(TEST_DOMAIN, cls.dp.get_id, cls.facility_sp_id, 100)
         set_default_consumption_for_supply_point(TEST_DOMAIN, cls.ip.get_id, cls.facility_sp_id, 100)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user2.delete()
+        super(TestStockOut, cls).tearDownClass()
 
     def test_reminder(self):
         now = datetime.utcnow()

--- a/custom/ilsgateway/tests/test_report_reminders.py
+++ b/custom/ilsgateway/tests/test_report_reminders.py
@@ -42,6 +42,7 @@ class TestReportGroups(TestCase):
         delete_domain_phone_numbers(TEST_DOMAIN)
         cls.sms_backend.delete()
         cls.sms_backend_mapping.delete()
+        cls.user1.delete()
         cls.domain.delete()
         super(TestReportGroups, cls).tearDownClass()
 


### PR DESCRIPTION
Seeing if this helps with the intermittent test failure seen in https://github.com/dimagi/commcare-hq/pull/24601

If it doesn't (which is entirely possible), then I'll update the failing test to check if there is a preexisting user.