### PR TITLE
Headers should skip Transifex too

### DIFF
--- a/corehq/apps/translations/validator.py
+++ b/corehq/apps/translations/validator.py
@@ -47,7 +47,11 @@ class UploadedTranslationsValidator(object):
             self.lang_prefix)
 
     def _generate_expected_headers_and_rows(self):
-        self.headers = {h[0]: h[1] for h in get_bulk_app_sheet_headers(self.app)}
+        self.headers = {h[0]: h[1] for h in get_bulk_app_sheet_headers(
+            self.app,
+            exclude_module=lambda module: SKIP_TRANSFEX_STRING in module.comment,
+            exclude_form=lambda form: SKIP_TRANSFEX_STRING in form.comment
+        )}
         self.expected_rows = get_bulk_app_sheets_by_name(
             self.app,
             exclude_module=lambda module: SKIP_TRANSFEX_STRING in module.comment,


### PR DESCRIPTION
@orangejenny @mkangia If `UploadedTranslationsValidator` is skipping Transifex when getting rows, shouldn't it skip Transifex when getting headers?

[`AppTranslationsGenerator` does](https://github.com/dimagi/commcare-hq/blob/4a0cdc34d4c2bd91f27ebe5feb1f95398e4851e2/corehq/apps/translations/generators.py#L121).

buddy @calellowitz 
