### PR TITLE
Make auxiliary case views location-safe

### DIFF
--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -12,7 +12,7 @@ from corehq.apps.locations.permissions import location_safe
 from dimagi.utils.django.cached_object import IMAGE_SIZE_ORDERING, OBJECT_ORIGINAL
 
 from corehq.apps.domain.decorators import api_auth
-from corehq.apps.reports.views import can_view_attachments, _get_location_safe_form, require_form_view_permission
+from corehq.apps.reports.views import can_view_attachments, safely_get_form, require_form_view_permission
 from corehq.form_processor.exceptions import CaseNotFound, AttachmentNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, get_cached_case_attachment, FormAccessors
 
@@ -128,13 +128,13 @@ class FormAttachmentAPI(View):
             raise Http404
 
         # this raises a PermissionDenied error if necessary
-        _get_location_safe_form(domain, request.couch_user, form_id)
+        safely_get_form(request, domain, form_id)
 
         try:
             content = FormAccessors(domain).get_attachment_content(form_id, attachment_id)
         except AttachmentNotFound:
             raise Http404
-        
+
         return StreamingHttpResponse(
             streaming_content=FileWrapper(content.content_stream),
             content_type=content.content_type

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -277,6 +277,8 @@ def user_can_access_other_user(domain, user, other_user):
 
 def user_can_access_case(domain, user, case):
     from corehq.apps.reports.standard.cases.data_sources import CaseInfo
+    if user.has_permission(domain, 'access_all_locations'):
+        return True
 
     info = CaseInfo(None, case.to_json())
     if info.owner_type == 'location':

--- a/corehq/apps/reports/static/reports/js/case_details.js
+++ b/corehq/apps/reports/static/reports/js/case_details.js
@@ -82,11 +82,11 @@ hqDefine("reports/js/case_details", [
         };
 
         self.get_xform_data = function (xformId) {
+            var $panel = $("#xform_data_panel");
             $.memoizedAjax({
                 "type": "GET",
                 "url": initialPageData.reverse('case_form_data', xformId),
                 "success": function (data) {
-                    var $panel = $("#xform_data_panel");
                     $panel.html(data.html);
 
                     // form data panel uses sticky tabs when it's its own page
@@ -100,6 +100,15 @@ hqDefine("reports/js/case_details", [
                         ordered_question_values: data.ordered_question_values,
                         container: $panel,
                     });
+                },
+                "error": function (jqXHR, textStatus, errorThrown) {
+                    var message;
+                    if (jqXHR.status === 403) {
+                        message = jqXHR.responseJSON.html;
+                    } else {
+                        message = gettext("Sorry, there was an issue communicating with the server.");
+                    }
+                    $panel.html(message);
                 },
             });
         };

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1683,7 +1683,12 @@ class FormDataView(BaseProjectReportSectionView):
 @login_and_domain_required
 @require_GET
 def case_form_data(request, domain, case_id, xform_id):
-    instance = safely_get_form(request, domain, xform_id)
+    instance = get_form_or_404(domain, xform_id)
+    if not can_edit_form_location(domain, request.couch_user, instance):
+        # This can happen if a user can view the case but not a particular form
+        return JsonResponse({
+            'html': _("You do not have permission to view this form."),
+        }, status=403)
     context = _get_form_render_context(request, domain, instance, case_id)
     return JsonResponse({
         'html': render_to_string("reports/form/partials/single_form.html", context, request=request),


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-44

Currently, location-restricted users see the buttons and various actions on the case data page, but many of them fail, as does viewing forms which updated the case.  This addresses these issues.

Specifically, the things that are now accessible are:

* Case cleaning
* Close case
* Undo close case
* Export case history
* View forms that updated a case

@millerdev 