### PR TITLE
Unicode name in Unicode name test

### DIFF
--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -56,14 +56,12 @@ class _BlobDBTests(object):
             timedelta(minutes=60),
         )
 
-    def test_put_and_get_with_unicode_names(self):
-        identifier = new_meta()
-        assert not identifier.name
-        identifier.name = 'Łukasz'
-        meta = self.db.put(BytesIO(b"content"), meta=identifier)
+    def test_put_and_get_with_unicode(self):
+        identifier = new_meta(name=u'Łukasz')
+        meta = self.db.put(BytesIO(b'\xc5\x81ukasz'), meta=identifier)
         self.assertEqual(identifier, meta)
         with self.db.get(key=meta.key) as fh:
-            self.assertEqual(fh.read(), b"content")
+            self.assertEqual(fh.read(), b'\xc5\x81ukasz')
 
     def test_put_from_get_stream(self):
         old = self.db.put(BytesIO(b"content"), meta=new_meta())

--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
@@ -56,7 +57,11 @@ class _BlobDBTests(object):
         )
 
     def test_put_and_get_with_unicode_names(self):
-        meta = self.db.put(BytesIO(b"content"), meta=new_meta())
+        identifier = new_meta()
+        assert not identifier.name
+        identifier.name = 'Łukasz'
+        meta = self.db.put(BytesIO(b"content"), meta=identifier)
+        self.assertEqual(identifier, meta)
         with self.db.get(key=meta.key) as fh:
             self.assertEqual(fh.read(), b"content")
 


### PR DESCRIPTION
@millerdev it looks like this test should be testing Unicode attachment names ... but it isn't ... or is it? Am I missing something?

This change gives the attachment a Unicode name.

buddy @calellowitz 