### PR TITLE
AWC report redirect to the specific report

### DIFF
--- a/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
@@ -273,7 +273,19 @@ function LocationFilterController($rootScope, $scope, $location, $uibModal, loca
             }
             storageService.setKey('search', $location.search());
             if (selectedLocationIndex() === 4 && $location.path().indexOf('awc_reports') === -1) {
-                $location.path('awc_reports');
+                var awcReportPath = 'awc_reports';
+                if ($location.path().indexOf('maternal_child') !== -1) {
+                    awcReportPath += '/maternal_child';
+                } else if ($location.path().indexOf('demographics') !== -1) {
+                    awcReportPath += '/demographics';
+                } else if ($location.path().indexOf('awc_infrastructure') !== -1) {
+                    awcReportPath += '/awc_infrastructure';
+                } else if ($location.path().indexOf('beneficiary') !== -1) {
+                    awcReportPath += '/beneficiary';
+                } else {
+                    awcReportPath += '/pse';
+                }
+                $location.path(awcReportPath);
             }
             $scope.$emit('filtersChange');
         });


### PR DESCRIPTION
Hi @calellowitz @Rohit25negi 

I added new behaviour and now when the user will choose the AWC on the other report than in AWC Report he/she will be redirected to the specific report in the AWC report, more details: https://dimagi-dev.atlassian.net/browse/ICDS-577

Need QA: no
Environment: ICDs
locally tested: yes

Regards,
Łukasz