### PR TITLE
Show service success if Rabbit is not needed

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -71,6 +71,8 @@ def check_rabbitmq():
             return ServiceStatus(False, 'RabbitMQ Offline')
         except Exception as e:
             return ServiceStatus(False, "RabbitMQ Error: %s" % e)
+    elif settings.BROKER_URL.startswith('redis'):
+        return ServiceStatus(True, "RabbitMQ Not configured, but not needed")
     else:
         return ServiceStatus(False, "RabbitMQ Not configured")
 


### PR DESCRIPTION
The default broker in commcare is redis.

https://github.com/dimagi/commcare-cloud/pull/2917