### PR TITLE
cleanup OData tests

### DIFF
--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -24,6 +24,9 @@ from pillowtop.es_utils import initialize_index_and_mapping
 
 class TestCaseOdataFeed(TestCase, OdataTestMixin):
 
+    # flag_enabled is used in the test function body because class-level flags in child classes
+    # cancel out class level decorators or decorators on non-overriden functions.
+
     @classmethod
     def setUpClass(cls):
         super(TestCaseOdataFeed, cls).setUpClass()

--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -37,13 +37,15 @@ class TestCaseOdataFeed(TestCase, OdataTestMixin):
         super(TestCaseOdataFeed, cls).tearDownClass()
 
     def test_no_credentials(self):
-        response = self.client.get(self.view_url)
-        self.assertEqual(response.status_code, 404)
+        with flag_enabled('ODATA'):
+            response = self.client.get(self.view_url)
+        self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        response = self._execute_query(wrong_credentials)
-        self.assertEqual(response.status_code, 404)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(wrong_credentials)
+        self.assertEqual(response.status_code, 401)
 
     def test_wrong_domain(self):
         other_domain = Domain(name='other_domain')
@@ -51,11 +53,12 @@ class TestCaseOdataFeed(TestCase, OdataTestMixin):
         self.addCleanup(other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        response = self.client.get(
-            self._odata_feed_url_by_domain(other_domain.name),
-            HTTP_AUTHORIZATION='Basic ' + correct_credentials,
-        )
-        self.assertEqual(response.status_code, 404)
+        with flag_enabled('ODATA'):
+            response = self.client.get(
+                self._odata_feed_url_by_domain(other_domain.name),
+                HTTP_AUTHORIZATION='Basic ' + correct_credentials,
+            )
+        self.assertEqual(response.status_code, 401)
 
     def test_missing_feature_flag(self):
         correct_credentials = self._get_correct_credentials()
@@ -129,13 +132,15 @@ class TestFormOdataFeed(TestCase, OdataTestMixin):
         super(TestFormOdataFeed, cls).tearDownClass()
 
     def test_no_credentials(self):
-        response = self.client.get(self.view_url)
-        self.assertEqual(response.status_code, 404)
+        with flag_enabled('ODATA'):
+            response = self.client.get(self.view_url)
+        self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        response = self._execute_query(wrong_credentials)
-        self.assertEqual(response.status_code, 404)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(wrong_credentials)
+        self.assertEqual(response.status_code, 401)
 
     def test_wrong_domain(self):
         other_domain = Domain(name='other_domain')
@@ -143,11 +148,12 @@ class TestFormOdataFeed(TestCase, OdataTestMixin):
         self.addCleanup(other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        response = self.client.get(
-            self._odata_feed_url_by_domain(other_domain.name),
-            HTTP_AUTHORIZATION='Basic ' + correct_credentials,
-        )
-        self.assertEqual(response.status_code, 404)
+        with flag_enabled('ODATA'):
+            response = self.client.get(
+                self._odata_feed_url_by_domain(other_domain.name),
+                HTTP_AUTHORIZATION='Basic ' + correct_credentials,
+            )
+        self.assertEqual(response.status_code, 401)
 
     def test_missing_feature_flag(self):
         correct_credentials = self._get_correct_credentials()

--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -63,10 +63,6 @@ class TestCaseOdataFeed(TestCase, OdataTestMixin):
         self.assertEqual(response.status_code, 404)
 
     def test_request_succeeded(self):
-        self._test_request_succeeded()
-
-    @flag_enabled('ODATA')
-    def _test_request_succeeded(self):
         with trap_extra_setup(ConnectionError):
             elasticsearch_instance = get_es_new()
             initialize_index_and_mapping(elasticsearch_instance, CASE_INDEX_INFO)
@@ -76,7 +72,8 @@ class TestCaseOdataFeed(TestCase, OdataTestMixin):
         self.web_user.save()
 
         correct_credentials = self._get_correct_credentials()
-        response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
 
     @property
@@ -158,10 +155,6 @@ class TestFormOdataFeed(TestCase, OdataTestMixin):
         self.assertEqual(response.status_code, 404)
 
     def test_request_succeeded(self):
-        self._test_request_succeeded()
-
-    @flag_enabled('ODATA')
-    def _test_request_succeeded(self):
         with trap_extra_setup(ConnectionError):
             elasticsearch_instance = get_es_new()
             initialize_index_and_mapping(elasticsearch_instance, XFORM_INDEX_INFO)
@@ -171,7 +164,8 @@ class TestFormOdataFeed(TestCase, OdataTestMixin):
         self.web_user.save()
 
         correct_credentials = self._get_correct_credentials()
-        response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             json.loads(response.content.decode('utf-8')),

--- a/corehq/apps/api/odata/tests/test_metadata.py
+++ b/corehq/apps/api/odata/tests/test_metadata.py
@@ -36,12 +36,14 @@ class TestCaseMetadataDocumentCase(TestCase, CaseOdataTestMixin, TestXmlMixin):
         super(TestCaseMetadataDocumentCase, cls).tearDownClass()
 
     def test_no_credentials(self):
-        response = self.client.get(self.view_url)
+        with flag_enabled('ODATA'):
+            response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        response = self._execute_query(wrong_credentials)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_domain(self):
@@ -49,10 +51,11 @@ class TestCaseMetadataDocumentCase(TestCase, CaseOdataTestMixin, TestXmlMixin):
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
-            HTTP_AUTHORIZATION='Basic ' + correct_credentials,
-        )
+        with flag_enabled('ODATA'):
+            response = self.client.get(
+                reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
+                HTTP_AUTHORIZATION='Basic ' + correct_credentials,
+            )
         self.assertEqual(response.status_code, 403)
 
     def test_missing_feature_flag(self):
@@ -121,12 +124,14 @@ class TestFormMetadataDocumentCase(TestCase, FormOdataTestMixin, TestXmlMixin):
         super(TestFormMetadataDocumentCase, cls).tearDownClass()
 
     def test_no_credentials(self):
-        response = self.client.get(self.view_url)
+        with flag_enabled('ODATA'):
+            response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        response = self._execute_query(wrong_credentials)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_domain(self):
@@ -134,10 +139,11 @@ class TestFormMetadataDocumentCase(TestCase, FormOdataTestMixin, TestXmlMixin):
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'app_id': 'my_app_id'}),
-            HTTP_AUTHORIZATION='Basic ' + correct_credentials,
-        )
+        with flag_enabled('ODATA'):
+            response = self.client.get(
+                reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'app_id': 'my_app_id'}),
+                HTTP_AUTHORIZATION='Basic ' + correct_credentials,
+            )
         self.assertEqual(response.status_code, 403)
 
     def test_missing_feature_flag(self):

--- a/corehq/apps/api/odata/tests/test_metadata.py
+++ b/corehq/apps/api/odata/tests/test_metadata.py
@@ -61,13 +61,10 @@ class TestCaseMetadataDocumentCase(TestCase, CaseOdataTestMixin, TestXmlMixin):
         self.assertEqual(response.status_code, 404)
 
     def test_no_case_types(self):
-        self._test_no_case_types()
-
-    @flag_enabled('ODATA')
-    def _test_no_case_types(self):
         correct_credentials = self._get_correct_credentials()
-        with patch('corehq.apps.api.odata.views.get_case_type_to_properties', return_value={}):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch('corehq.apps.api.odata.views.get_case_type_to_properties', return_value={}):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertXmlEqual(
             response.content,
@@ -75,19 +72,16 @@ class TestCaseMetadataDocumentCase(TestCase, CaseOdataTestMixin, TestXmlMixin):
         )
 
     def test_populated_metadata_document(self):
-        self._test_populated_metadata_document()
-
-    @flag_enabled('ODATA')
-    def _test_populated_metadata_document(self):
         correct_credentials = self._get_correct_credentials()
-        with patch(
-            'corehq.apps.api.odata.views.get_case_type_to_properties',
-            return_value=OrderedDict([
-                ('case_type_with_no_case_properties', []),
-                ('case_type_with_case_properties', ['property_1', 'property_2']),
-            ])
-        ):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch(
+                'corehq.apps.api.odata.views.get_case_type_to_properties',
+                return_value=OrderedDict([
+                    ('case_type_with_no_case_properties', []),
+                    ('case_type_with_case_properties', ['property_1', 'property_2']),
+                ])
+            ):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertXmlEqual(
             response.content,
@@ -152,13 +146,10 @@ class TestFormMetadataDocumentCase(TestCase, FormOdataTestMixin, TestXmlMixin):
         self.assertEqual(response.status_code, 404)
 
     def test_no_xmlnss(self):
-        self._test_no_xmlnss()
-
-    @flag_enabled('ODATA')
-    def _test_no_xmlnss(self):
         correct_credentials = self._get_correct_credentials()
-        with patch('corehq.apps.api.odata.views.get_xmlns_to_properties', return_value={}):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch('corehq.apps.api.odata.views.get_xmlns_to_properties', return_value={}):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertXmlEqual(
             response.content,
@@ -166,19 +157,16 @@ class TestFormMetadataDocumentCase(TestCase, FormOdataTestMixin, TestXmlMixin):
         )
 
     def test_populated_metadata_document(self):
-        self._test_populated_metadata_document()
-
-    @flag_enabled('ODATA')
-    def _test_populated_metadata_document(self):
         correct_credentials = self._get_correct_credentials()
-        with patch(
-            'corehq.apps.api.odata.views.get_xmlns_to_properties',
-            return_value=OrderedDict([
-                ('form_with_no_properties', []),
-                ('form_with_properties', ['property_1', 'property_2']),
-            ])
-        ):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch(
+                'corehq.apps.api.odata.views.get_xmlns_to_properties',
+                return_value=OrderedDict([
+                    ('form_with_no_properties', []),
+                    ('form_with_properties', ['property_1', 'property_2']),
+                ])
+            ):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertXmlEqual(
             response.content,

--- a/corehq/apps/api/odata/tests/test_service.py
+++ b/corehq/apps/api/odata/tests/test_service.py
@@ -58,13 +58,10 @@ class TestCaseServiceDocumentCase(TestCase, CaseOdataTestMixin):
         self.assertEqual(response.status_code, 404)
 
     def test_no_case_types(self):
-        self._test_no_case_types()
-
-    @flag_enabled('ODATA')
-    def _test_no_case_types(self):
         correct_credentials = self._get_correct_credentials()
-        with patch('corehq.apps.api.odata.views.get_case_types_for_domain_es', return_value=set()):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch('corehq.apps.api.odata.views.get_case_types_for_domain_es', return_value=set()):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             json.loads(response.content.decode('utf-8')),
@@ -72,16 +69,13 @@ class TestCaseServiceDocumentCase(TestCase, CaseOdataTestMixin):
         )
 
     def test_with_case_types(self):
-        self._test_with_case_types()
-
-    @flag_enabled('ODATA')
-    def _test_with_case_types(self):
         correct_credentials = self._get_correct_credentials()
-        with patch(
-            'corehq.apps.api.odata.views.get_case_types_for_domain_es',
-            return_value=['case_type_1', 'case_type_2'],  # return ordered iterable for deterministic test
-        ):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch(
+                'corehq.apps.api.odata.views.get_case_types_for_domain_es',
+                return_value=['case_type_1', 'case_type_2'],  # return ordered iterable for deterministic test
+            ):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             json.loads(response.content.decode('utf-8')),
@@ -152,13 +146,10 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         self.assertEqual(response.status_code, 404)
 
     def test_no_xmlnss(self):
-        self._test_no_xmlnss()
-
-    @flag_enabled('ODATA')
-    def _test_no_xmlnss(self):
         correct_credentials = self._get_correct_credentials()
-        with patch('corehq.apps.api.odata.views.get_xmlns_by_app', return_value=[]):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch('corehq.apps.api.odata.views.get_xmlns_by_app', return_value=[]):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             json.loads(response.content.decode('utf-8')),
@@ -169,13 +160,10 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         )
 
     def test_with_xmlnss(self):
-        self._test_with_xmlnss()
-
-    @flag_enabled('ODATA')
-    def _test_with_xmlnss(self):
         correct_credentials = self._get_correct_credentials()
-        with patch('corehq.apps.api.odata.views.get_xmlns_by_app', return_value=['xmlns_1', 'xmlns_2']):
-            response = self._execute_query(correct_credentials)
+        with flag_enabled('ODATA'):
+            with patch('corehq.apps.api.odata.views.get_xmlns_by_app', return_value=['xmlns_1', 'xmlns_2']):
+                response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             json.loads(response.content.decode('utf-8')),

--- a/corehq/apps/api/odata/tests/test_service.py
+++ b/corehq/apps/api/odata/tests/test_service.py
@@ -33,12 +33,14 @@ class TestCaseServiceDocumentCase(TestCase, CaseOdataTestMixin):
         super(TestCaseServiceDocumentCase, cls).tearDownClass()
 
     def test_no_credentials(self):
-        response = self.client.get(self.view_url)
+        with flag_enabled('ODATA'):
+            response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        response = self._execute_query(wrong_credentials)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_domain(self):
@@ -46,10 +48,11 @@ class TestCaseServiceDocumentCase(TestCase, CaseOdataTestMixin):
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
-            HTTP_AUTHORIZATION='Basic ' + correct_credentials,
-        )
+        with flag_enabled('ODATA'):
+            response = self.client.get(
+                reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
+                HTTP_AUTHORIZATION='Basic ' + correct_credentials,
+            )
         self.assertEqual(response.status_code, 403)
 
     def test_missing_feature_flag(self):
@@ -121,12 +124,14 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         super(TestFormServiceDocument, cls).tearDownClass()
 
     def test_no_credentials(self):
-        response = self.client.get(self.view_url)
+        with flag_enabled('ODATA'):
+            response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        response = self._execute_query(wrong_credentials)
+        with flag_enabled('ODATA'):
+            response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_domain(self):
@@ -134,10 +139,11 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'app_id': 'my_app_id'}),
-            HTTP_AUTHORIZATION='Basic ' + correct_credentials,
-        )
+        with flag_enabled('ODATA'):
+            response = self.client.get(
+                reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'app_id': 'my_app_id'}),
+                HTTP_AUTHORIZATION='Basic ' + correct_credentials,
+            )
         self.assertEqual(response.status_code, 403)
 
     def test_missing_feature_flag(self):


### PR DESCRIPTION
The first commit replaces the use of a decorator with a ```with``` statement.  That enables writing certain test cases without introducing a helper function, which was previously required when subclasses use a class-level decorator that overrides the individual function decorators.  I wasn't able to confirm if the overriding behavior is intentional or a bug, but either way the new code is cleaner.

The second commit enables the OData feature flag when testing other conditions that cause the request to fail.  This way, we test a single failing condition in isolation, rather than testing a failing condition when the feature flag will also fail.  This change also means that the API returns a 401 (expected) rather than a 404 which is returned whenever the feature flag is not enabled. 

Recommend 🐡 and ```?w=1```.