### PR TITLE
Export list slow

### DIFF
--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -44,11 +44,11 @@
         <pagination data-apply-bindings="false"
                     data-bind="visible: showPagination"
                     params="goToPage: goToPage,
-                                    slug: 'export-list',
-                                    perPage: itemsPerPage,
-                                    totalItems: totalItems,
-                                    watchChanges: showPagination,
-                                    showSpinner: isLoadingPage"></pagination>
+                            slug: 'export-list',
+                            perPage: itemsPerPage,
+                            totalItems: totalItems,
+                            watchChanges: showPagination,
+                            showSpinner: isLoadingPage"></pagination>
       </div>
     </div>
   </div>

--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -47,6 +47,7 @@
                                     slug: 'export-list',
                                     perPage: itemsPerPage,
                                     totalItems: totalItems,
+                                    watchChanges: showPagination,
                                     showSpinner: isLoadingPage"></pagination>
       </div>
     </div>

--- a/corehq/apps/export/templates/export/partials/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partials/export_list_controller.html
@@ -47,7 +47,7 @@
                             slug: 'export-list',
                             perPage: itemsPerPage,
                             totalItems: totalItems,
-                            watchChanges: showPagination,
+                            isReady: showPagination,
                             showSpinner: isLoadingPage"></pagination>
       </div>
     </div>

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -151,7 +151,7 @@ class ExportListHelper(object):
             raise Http404
 
         # Calls self.get_saved_exports and formats each item using self.fmt_export_data
-        brief_exports = sorted(self.get_saved_exports(), key=lambda x: x['name'])
+        brief_exports = self.get_saved_exports()
         if toggles.EXPORT_OWNERSHIP.enabled(self.domain):
 
             def _can_view(e, user_id):
@@ -178,7 +178,8 @@ class ExportListHelper(object):
             exports = get_brief_deid_exports(self.domain, self.form_or_case)
         else:
             exports = get_brief_exports(self.domain, self.form_or_case)
-        return [x for x in exports if self._should_appear_in_list(x)]
+        exports = [x for x in exports if self._should_appear_in_list(x)]
+        return sorted(exports, key=lambda x: x['name'])
 
     def _should_appear_in_list(self, export):
         raise NotImplementedError("must implement _should_appear_in_list")

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -48,9 +48,7 @@ hqDefine('hqwebapp/js/components/pagination', [
 
             self.totalItems = params.totalItems;
             self.totalItems.subscribe(function (newValue) {
-                if (self.isReady()) {
-                    self.goToPage(1);
-                }
+                self.goToPage(1);
             });
 
             self.slug = params.slug;
@@ -60,9 +58,7 @@ hqDefine('hqwebapp/js/components/pagination', [
                 self.perPageCookieName = 'ko-pagination-' + self.slug;
                 self.perPage(self.initialValues.limit || $.cookie(self.perPageCookieName) || self.perPage());
                 self.perPage.subscribe(function (newValue) {
-                    if (self.isReady()) {
-                        self.goToPage(1);
-                    }
+                    self.goToPage(1);
                     if (self.slug) {
                         $.cookie(self.perPageCookieName, newValue, { expires: 365, path: '/' });
                     }
@@ -87,6 +83,7 @@ hqDefine('hqwebapp/js/components/pagination', [
                 self.goToPage(Math.max(self.currentPage() - 1, 1), e);
             };
             self.goToPage = function (page, e) {
+                if (!self.isReady()) return;
                 // make sure that the first goToPage that's called does not override the initialValues from GET
                 self.currentPage(self.initialValues.page || page);
                 self.initialValues.page = undefined;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -41,12 +41,15 @@ hqDefine('hqwebapp/js/components/pagination', [
             if (params.limitSlug) {
                 self.initialValues.limit = parseInt(self._url.searchParams.get(params.limitSlug));
             }
+            self.watchChanges = (typeof params.watchChanges !== 'undefined') ? params.watchChanges : true;
 
             self.currentPage = ko.observable(self.initialValues.page || self.currentPage || 1);
 
             self.totalItems = params.totalItems;
             self.totalItems.subscribe(function (newValue) {
-                self.goToPage(1);
+                if (self.watchChanges()) {
+                    self.goToPage(1);
+                }
             });
 
             self.slug = params.slug;
@@ -56,7 +59,9 @@ hqDefine('hqwebapp/js/components/pagination', [
                 self.perPageCookieName = 'ko-pagination-' + self.slug;
                 self.perPage(self.initialValues.limit || $.cookie(self.perPageCookieName) || self.perPage());
                 self.perPage.subscribe(function (newValue) {
-                    self.goToPage(1);
+                    if (self.watchChanges()) {
+                        self.goToPage(1);
+                    }
                     if (self.slug) {
                         $.cookie(self.perPageCookieName, newValue, { expires: 365, path: '/' });
                     }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -18,6 +18,8 @@
  *      itemsTextTemplate: Optional. A string that contains <%= firstItem %>, <%= lastItem %>, <%= maxItems %>
  *          which shows up next to the left of the limit dropdown.
  *      isReady: Optional. An observable. If provided, only call goToPage when it is true.
+ *          This can be used to indicate to the view model when the page has been populated and perPage and
+ *          totalItems have been set.
  *
  *  See releases_table.html for an example.
  */

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -17,6 +17,7 @@
  *          in a cookie.
  *      itemsTextTemplate: Optional. A string that contains <%= firstItem %>, <%= lastItem %>, <%= maxItems %>
  *          which shows up next to the left of the limit dropdown.
+ *      isReady: Optional. An observable. If provided, only call goToPage when it is true.
  *
  *  See releases_table.html for an example.
  */
@@ -41,13 +42,13 @@ hqDefine('hqwebapp/js/components/pagination', [
             if (params.limitSlug) {
                 self.initialValues.limit = parseInt(self._url.searchParams.get(params.limitSlug));
             }
-            self.watchChanges = (typeof params.watchChanges !== 'undefined') ? params.watchChanges : true;
+            self.isReady = (typeof params.isReady !== 'undefined') ? params.isReady : ko.observable(true);
 
             self.currentPage = ko.observable(self.initialValues.page || self.currentPage || 1);
 
             self.totalItems = params.totalItems;
             self.totalItems.subscribe(function (newValue) {
-                if (self.watchChanges()) {
+                if (self.isReady()) {
                     self.goToPage(1);
                 }
             });
@@ -59,7 +60,7 @@ hqDefine('hqwebapp/js/components/pagination', [
                 self.perPageCookieName = 'ko-pagination-' + self.slug;
                 self.perPage(self.initialValues.limit || $.cookie(self.perPageCookieName) || self.perPage());
                 self.perPage.subscribe(function (newValue) {
-                    if (self.watchChanges()) {
+                    if (self.isReady()) {
                         self.goToPage(1);
                     }
                     if (self.slug) {


### PR DESCRIPTION
Context: [HI-705](https://dimagi-dev.atlassian.net/browse/HI-705)

The (Django) view was getting called three times. This is because the pagination view model is initialised before list items have been returned. `exportPanelModel` fetches the exports, and the pagination view model also fetches them in order to set `perPage`. When either of the responses arrives, it changes the value of `totalItems` and so the pagination view model sends a third request.

This change allows the subscriptions to only send requests after the export list has been populated by `exportPanelModel`, so that only one request is sent when the page is built. It also preserves current behaviour if the `watchChanges` parameter is not used.
