### PR TITLE
Fix filter interpretation for invalid filters

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -588,6 +588,10 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
             return [None]
 
         expression = config_filter['expression']
+
+        if not isinstance(expression, dict):
+            return [None]
+
         if expression['type'] == 'property_name' and expression['property_name'] == property_name:
             prop_value = config_filter['property_value']
             if not isinstance(prop_value, list):

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -242,6 +242,17 @@ class DataSourceFilterInterpolationTest(SimpleTestCase):
             ["ticket"]
         )
 
+    def test_invalid_expression(self):
+        self._test_helper(
+            self._form_config({
+                "operator": "eq",
+                "type": "boolean_expression",
+                "expression": 1,
+                "property_value": 2
+            }),
+            [None]
+        )
+
 
 class DataSourceConfigurationDbTest(TestCase):
 


### PR DESCRIPTION
Fixes https://sentry.io/organizations/dimagi/issues/1080725623/?project=136860

Pillows running into this issue. The `expression` is a `DefaultProperty` so its not enforced as a dict in the UI if someone changes that to an integer like `1`. This function is only valid when an `expression` is an `dict`