### PR TITLE
Don't try to remove blobexpiration on partitioned databases

### DIFF
--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -38,8 +38,8 @@ class MultiDBRouter(object):
     def db_for_write(self, model, **hints):
         return db_for_read_write(model, write=True)
 
-    def allow_migrate(self, db, app_label, model=None, **hints):
-        return allow_migrate(db, app_label)
+    def allow_migrate(self, db, app_label, model=None, model_name=None, **hints):
+        return allow_migrate(db, app_label, model_name)
 
     def allow_relation(self, obj1, obj2, **hints):
         from corehq.sql_db.models import PartitionedModel
@@ -56,7 +56,7 @@ class MultiDBRouter(object):
         return False
 
 
-def allow_migrate(db, app_label):
+def allow_migrate(db, app_label, model_name=None):
     """
     Return ``True`` if a app's migrations should be applied to the specified database otherwise
     return ``False``.
@@ -83,6 +83,8 @@ def allow_migrate(db, app_label):
         return db == partition_config.get_proxy_db()
     elif app_label == BLOB_DB_APP and db == 'default':
         return True
+    elif app_label == BLOB_DB_APP and model_name == 'blobexpiration':
+        return False
     elif app_label in (FORM_PROCESSOR_APP, SCHEDULING_PARTITIONED_APP, BLOB_DB_APP):
         return (
             db == partition_config.get_proxy_db() or


### PR DESCRIPTION
@calellowitz 

https://github.com/dimagi/commcare-hq/pull/24555 caused migrations to fail because blob expiration only exists in the main database and not in partitioned nodes, but blob db always allows blob migrations on partitioned databases. This means that more recent deployments have a blobexpiration table on their main database and their partitioned databases. I'm ignoring that particular issue since our environments are not subject to that and we are unlikely to re-introduce the same tablename