### PR TITLE
expire cache post save

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4566,6 +4566,8 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         if user and user.days_since_created == 0:
             track_workflow(user.get_email(), 'Saved the App Builder within first 24 hours')
         send_hubspot_form(HUBSPOT_SAVED_APP_FORM_ID, request)
+        if self.copy_of:
+            cache.delete('app_build_cache_{}_{}'.format(self.domain, self.get_id))
         super(ApplicationBase, self).save(
             response_json=response_json, increment_version=increment_version, **params)
 


### PR DESCRIPTION
This cache was originally added in https://github.com/dimagi/commcare-hq/pull/19901. I think it would be good to expire it when build is updated.
I am using this [here](https://github.com/dimagi/commcare-hq/pull/24663/commits/4e463db5955b65bf0e4dd7cf105228ad818c15e2) and would need this cache to expire in case the build is mark as released or unreleased but in general too this should be done.