### PR TITLE
deleting an OData feed should redirect to the OData feed list, not export configs

### DIFF
--- a/corehq/apps/export/views/edit.py
+++ b/corehq/apps/export/views/edit.py
@@ -74,11 +74,23 @@ class EditNewCustomFormExportView(BaseEditNewCustomExportView):
     page_title = ugettext_lazy("Edit Form Data Export")
     export_type = FORM_EXPORT
 
+    @property
+    @memoized
+    def report_class(self):
+        from corehq.apps.export.views.list import FormExportListView
+        return FormExportListView
+
 
 class EditNewCustomCaseExportView(BaseEditNewCustomExportView):
     urlname = 'edit_new_custom_export_case'
     page_title = ugettext_lazy("Edit Case Data Export")
     export_type = CASE_EXPORT
+
+    @property
+    @memoized
+    def report_class(self):
+        from corehq.apps.export.views.list import CaseExportListView
+        return CaseExportListView
 
 
 class EditCaseFeedView(DashboardFeedMixin, EditNewCustomCaseExportView):

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -319,8 +319,11 @@ class DeleteNewCustomExportView(BaseExportView):
             FormExportListView,
             DashboardFeedListView,
             DailySavedExportListView,
+            ODataFeedListView,
         )
-        if self.export_instance.is_daily_saved_export:
+        if self.export_instance.is_odata_config:
+            return ODataFeedListView
+        elif self.export_instance.is_daily_saved_export:
             if self.export_instance.export_format == "html":
                 return DashboardFeedListView
             return DailySavedExportListView

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -73,19 +73,6 @@ class BaseExportView(BaseProjectDataView):
         return reverse(self.report_class.urlname, args=(self.domain,))
 
     @property
-    @memoized
-    def report_class(self):
-        from corehq.apps.export.views.list import CaseExportListView, FormExportListView
-        try:
-            base_views = {
-                'form': FormExportListView,
-                'case': CaseExportListView,
-            }
-            return base_views[self.export_type]
-        except KeyError:
-            raise SuspiciousOperation('Attempted to access list view {}'.format(self.export_type))
-
-    @property
     def terminology(self):
         return {
             'page_header': _("Export Settings"),
@@ -213,6 +200,12 @@ class CreateNewCustomFormExportView(BaseExportView):
     page_title = ugettext_lazy("Create Form Data Export")
     export_type = FORM_EXPORT
 
+    @property
+    @memoized
+    def report_class(self):
+        from corehq.apps.export.views.list import FormExportListView
+        return FormExportListView
+
     def create_new_export_instance(self, schema):
         return self.export_instance_cls.generate_instance_from_schema(schema)
 
@@ -231,6 +224,12 @@ class CreateNewCustomCaseExportView(BaseExportView):
     urlname = 'new_custom_export_case'
     page_title = ugettext_lazy("Create Case Data Export")
     export_type = CASE_EXPORT
+
+    @property
+    @memoized
+    def report_class(self):
+        from corehq.apps.export.views.list import CaseExportListView
+        return CaseExportListView
 
     def create_new_export_instance(self, schema):
         return self.export_instance_cls.generate_instance_from_schema(schema)


### PR DESCRIPTION
First commit is a refactor, the second applies the fix.