### PR TITLE
Retry task when standby cancels the query, also track in DD

### DIFF
--- a/custom/icds_reports/reports/disha.py
+++ b/custom/icds_reports/reports/disha.py
@@ -10,6 +10,7 @@ import re
 from corehq.apps.reports.util import batch_qs
 from corehq.util.download import get_download_response
 from corehq.util.files import TransientTempfile
+from corehq.util.sentry import is_pg_cancelled_query_exception
 from couchexport.export import Format
 
 from custom.icds_reports.const import AggregationLevels
@@ -122,5 +123,19 @@ def build_dumps_for_month(month, rebuild=False):
             logger.info("Skipping, export is already generated for state {}".format(state_name))
         else:
             logger.info("Generating for state {}".format(state_name))
-            dump.build_export_json()
+            MAX_RETRY_COUNT = 5
+            retry_count = 0
+            while True:
+                try:
+                    dump.build_export_json()
+                except Exception as e:
+                    # The DISHA sql query that runs on aggregate tables can be cancelled by Postgres
+                    #   if the query is routed to standby and that standby needs to alter the matching rows
+                    if not is_pg_cancelled_query_exception(e) or retry_count == MAX_RETRY_COUNT:
+                        raise e
+                    else:
+                        retry_count += 1
+                        logger.info("Postgres cancelled the DISHA query. Retry count: {}".format(str(retry_count)))
+                else:
+                    break
             logger.info("Finished for state {}".format(state_name))


### PR DESCRIPTION
The DISHA task is failing because the standby cancels the DISHA query for some reason. I have ran the task after the agg task finished, to make sure there is nothing else that would update the DISHA related agg tables, but still the postgres cancelled the query for some reason. I am adding a retry attempt now to address this. If this also fails, I will update the code to force use the master.

I have also noticed in the postgres logs that there are many queries being cancelled by standby. So, I have added a simple datadog counter to see the extent.

@calellowitz @mkangia 
Also @emord who I offlined with about this.
