### PR TITLE
Remove enabling feature for just user from app status report

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -271,9 +271,9 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
         toggle = toggles.LOCATION_COLUMNS_APP_STATUS_REPORT
         return (
             (
-                toggle.enabled(self.request.couch_user.username, toggles.NAMESPACE_USER)
-                or toggle.enabled(self.request.domain, toggles.NAMESPACE_DOMAIN)
-            ) and self.rendered_as in ['export']
+                toggle.enabled(self.request.domain, toggles.NAMESPACE_DOMAIN)
+                and self.rendered_as in ['export']
+            )
         )
 
     def process_rows(self, users, fmt_for_export=False):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1822,7 +1822,7 @@ LOCATION_COLUMNS_APP_STATUS_REPORT = StaticToggle(
     'location_columns_app_status_report',
     'Enables location columns to app status report',
     TAG_CUSTOM,
-    [NAMESPACE_DOMAIN, NAMESPACE_USER]
+    [NAMESPACE_DOMAIN]
 )
 
 MPR_ASR_CONDITIONAL_AGG = DynamicallyPredictablyRandomToggle(


### PR DESCRIPTION
code change remove the enabling feature for just users from new location feature in app status report.

Without this feature flag also we can achieve enabling it for entire domain. But to explicitly state that this at the current time should not be enabled for specific user but for specific domain this code change made.

@calellowitz 