### PR TITLE
Skip SSL cert verify for DHIS2 servers

### DIFF
--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -1,18 +1,9 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-from __future__ import unicode_literals
 from itertools import chain
 
-from corehq.motech.dhis2.utils import (
-    get_date_filter,
-    get_previous_month,
-    get_report_config,
-    get_ucr_data,
-    get_previous_quarter,
-)
-from corehq.motech.dhis2.const import SEND_FREQUENCY_MONTHLY, SEND_FREQUENCY_QUARTERLY, SEND_FREQUENCIES
-from corehq.util.quickcache import quickcache
 from dimagi.ext.couchdbkit import (
+    BooleanProperty,
     Document,
     DocumentSchema,
     IntegerProperty,
@@ -20,12 +11,27 @@ from dimagi.ext.couchdbkit import (
     StringProperty,
 )
 
+from corehq.motech.dhis2.const import (
+    SEND_FREQUENCIES,
+    SEND_FREQUENCY_MONTHLY,
+    SEND_FREQUENCY_QUARTERLY,
+)
+from corehq.motech.dhis2.utils import (
+    get_date_filter,
+    get_previous_month,
+    get_previous_quarter,
+    get_report_config,
+    get_ucr_data,
+)
+from corehq.util.quickcache import quickcache
+
 
 class Dhis2Connection(Document):
     domain = StringProperty()
     server_url = StringProperty()
     username = StringProperty()
     password = StringProperty()
+    skip_cert_verify = BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -45,6 +45,7 @@ def send_datasets(domain_name, send_now=False, send_date=None):
         dhis2_conn.server_url,
         dhis2_conn.username,
         bz2.decompress(b64decode(dhis2_conn.password)),
+        verify=not dhis2_conn.skip_cert_verify,
     )
     endpoint = 'dataValueSets'
     for dataset_map in dataset_maps:


### PR DESCRIPTION
Context: [HI-771](https://dimagi-dev.atlassian.net/browse/HI-711)

Allows DHIS2 DataSet integration to skip SSL certificate verification. Replicates the behaviour of Repeaters.

Feature Flag: DHIS2 Integration
