### PR TITLE
allow for inline editing an Odata feed name

### DIFF
--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -66,6 +66,7 @@ hqDefine("export/js/export_list", [
             'isDailySaved',
             'isFeed',
             'isOData',
+            'editNameUrl',
             'showLink',
         ]);
         assertProperties.assert(pageOptions.urls, ['poll', 'toggleEnabled', 'update']);
@@ -82,6 +83,10 @@ hqDefine("export/js/export_list", [
         self.hasEmailedExport = !!options.emailedExport;
         if (self.hasEmailedExport) {
             self.emailedExport = emailedExportModel(options.emailedExport, pageOptions, self.id(), self.exportType());
+        }
+
+        if (options.editNameUrl) {
+            self.editNameUrl = options.editNameUrl;
         }
 
         if (options.isOData) {

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -64,7 +64,17 @@
   <tr>
     <td>
       <h4 data-bind="css: {'text-muted': hasEmailedExport && !isAutoRebuildEnabled()}">
-        <span data-bind="text: name"></span>
+        {% if not is_odata %}
+          <span data-bind="text: name"></span>
+        {% else %}
+          <inline-edit params="
+            value: name,
+            id: 'export-title',
+            url: editNameUrl,
+            placeholder: '{% trans "Enter export name here"|escapejs %}',
+            cols: 50,
+          " data-apply-bindings="false"></inline-edit>
+        {% endif %}
         <label class="label label-default label-default" data-bind="visible: isDeid()">
           {% trans 'De-Identified' %}
         </label>

--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -21,6 +21,7 @@ from corehq.apps.export.views.edit import (
     EditFormDailySavedExportView,
     EditODataCaseFeedView,
     EditODataFormFeedView,
+    EditExportName,
 )
 from corehq.apps.export.views.list import (
     DailySavedExportListView,
@@ -164,6 +165,9 @@ urlpatterns = [
     url(r"^custom/copy/(?P<export_id>[\w\-]+)/$",
         CopyExportView.as_view(),
         name=CopyExportView.urlname),
+    url(r'^custom/edit_export_name/(?P<export_id>[\w\-]+)/$',
+        EditExportName.as_view(),
+        name=EditExportName.urlname),
     url(r'^add_export_email_request/$', add_export_email_request, name='add_export_email_request'),
     url(r'^commit_filters/$', commit_filters, name='commit_filters'),
     url(r'^get_app_data_drilldown_values/$', get_app_data_drilldown_values, name='get_app_data_drilldown_values'),

--- a/corehq/apps/export/views/edit.py
+++ b/corehq/apps/export/views/edit.py
@@ -11,6 +11,7 @@ from memoized import memoized
 
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.export.const import CASE_EXPORT, FORM_EXPORT
+from corehq.apps.export.models import ExportInstance
 from corehq.apps.export.views.new import BaseExportView
 from corehq.apps.export.views.utils import (
     DailySavedExportMixin,
@@ -119,3 +120,21 @@ class EditODataCaseFeedView(ODataFeedMixin, EditNewCustomCaseExportView):
 class EditODataFormFeedView(ODataFeedMixin, EditNewCustomFormExportView):
     urlname = 'edit_odata_form_feed'
     page_title = ugettext_lazy("Copy OData Feed")
+
+
+class EditExportName(BaseEditNewCustomExportView):
+    urlname = 'edit_export_name'
+    export_home_url = None
+
+    @property
+    @memoized
+    def export_type(self):
+        return ExportInstance.get(self.export_id).type
+
+    def get(self, request, *args, **kwargs):
+        raise Http404
+
+    def commit(self, request):
+        self.new_export_instance.name = request.POST.get('value')
+        self.new_export_instance.save()
+        return self.new_export_instance.get_id

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -50,6 +50,7 @@ from corehq.apps.export.tasks import (
     get_saved_export_task_status,
     rebuild_saved_export,
 )
+from corehq.apps.export.views.edit import EditExportName
 from corehq.apps.export.views.utils import (
     ExportsPermissionsManager,
     user_can_view_deid_exports,
@@ -214,6 +215,7 @@ class ExportListHelper(object):
                                  args=(self.domain, export.type, export.get_id)),
             'downloadUrl': reverse(self._download_view(export).urlname, args=(self.domain, export.get_id)),
             'editUrl': reverse(self._edit_view(export).urlname, args=(self.domain, export.get_id)),
+            'editNameUrl': reverse(EditExportName.urlname, args=(self.domain, export.get_id)),
             'lastBuildDuration': '',
             'addedToBulk': False,
             'emailedExport': self._get_daily_saved_export_metadata(export),


### PR DESCRIPTION
<img width="776" alt="Screen Shot 2019-06-28 at 3 29 43 PM" src="https://user-images.githubusercontent.com/1757035/60366506-b79c8b00-99b9-11e9-9230-198d81a495bc.png">
<img width="795" alt="Screen Shot 2019-06-28 at 3 29 52 PM" src="https://user-images.githubusercontent.com/1757035/60366511-ba977b80-99b9-11e9-8023-3270fbef3945.png">

This is required since the "Edit" option was replaced with "Clone".  Other export lists are unchanged.