### PR TITLE
Add view for profile based app releases

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5870,7 +5870,9 @@ class LatestEnabledBuildProfiles(models.Model):
     @property
     @memoized
     def build(self):
-        return Application.get(self.build_id)
+        if not hasattr(self, '_build'):
+            self._build = Application.get(self.build_id)
+        return self._build
 
     def clean(self):
         if self.active:
@@ -5915,7 +5917,7 @@ class LatestEnabledBuildProfiles(models.Model):
                 build_id=build_id
             )
         # assign it to avoid re-fetching during validations
-        build_profile.build = build
+        build_profile._build = build
         build_profile.activate() if active else build_profile.deactivate()
 
     def activate(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5939,6 +5939,11 @@ class LatestEnabledBuildProfiles(models.Model):
         get_latest_enabled_build_for_profile.clear(domain, self.build_profile_id)
         get_latest_enabled_versions_per_profile.clear(self.app_id)
 
+    def to_json(self, app_names):
+        from corehq.apps.app_manager.serializers import LatestEnabledBuildProfileSerializer
+        return LatestEnabledBuildProfileSerializer(self, context={'app_names': app_names}).data
+
+
 # backwards compatibility with suite-1.0.xml
 FormBase.get_command_id = lambda self: id_strings.form_command(self)
 FormBase.get_locale_id = lambda self: id_strings.form_locale(self)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5868,7 +5868,6 @@ class LatestEnabledBuildProfiles(models.Model):
         self.expire_cache(self.build.domain)
 
     @property
-    @memoized
     def build(self):
         if not hasattr(self, '_build'):
             self._build = Application.get(self.build_id)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5867,7 +5867,8 @@ class LatestEnabledBuildProfiles(models.Model):
         super(LatestEnabledBuildProfiles, self).save(*args, **kwargs)
         self.expire_cache(self.build.domain)
 
-    @cached_property
+    @property
+    @memoized
     def build(self):
         return Application.get(self.build_id)
 

--- a/corehq/apps/app_manager/serializers.py
+++ b/corehq/apps/app_manager/serializers.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from rest_framework import serializers
+
+from corehq.apps.app_manager.models import (
+    LatestEnabledBuildProfiles,
+)
+
+
+class LatestEnabledBuildProfileSerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = LatestEnabledBuildProfiles
+
+    def to_representation(self, instance):
+        ret = super(LatestEnabledBuildProfileSerializer, self).to_representation(instance)
+        return ret

--- a/corehq/apps/app_manager/serializers.py
+++ b/corehq/apps/app_manager/serializers.py
@@ -16,8 +16,6 @@ class LatestEnabledBuildProfileSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         ret = super(LatestEnabledBuildProfileSerializer, self).to_representation(instance)
         build_profile_id = self.instance.build_profile_id
-        profile = self.instance.build.build_profiles.get(build_profile_id)
-        profile_name = profile.name if profile else build_profile_id
         ret['app_name'] = self.context['app_names'][ret['app_id']]
-        ret['profile_name'] = profile_name
+        ret['profile_name'] = self.instance.build.build_profiles[build_profile_id].name
         return ret

--- a/corehq/apps/app_manager/serializers.py
+++ b/corehq/apps/app_manager/serializers.py
@@ -11,7 +11,13 @@ from corehq.apps.app_manager.models import (
 class LatestEnabledBuildProfileSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = LatestEnabledBuildProfiles
+        fields = ['app_id', 'active', 'version']
 
     def to_representation(self, instance):
         ret = super(LatestEnabledBuildProfileSerializer, self).to_representation(instance)
+        build_profile_id = self.instance.build_profile_id
+        profile = self.instance.build.build_profiles.get(build_profile_id)
+        profile_name = profile.name if profile else build_profile_id
+        ret['app_name'] = self.context['app_names'][ret['app_id']]
+        ret['profile_name'] = profile_name
         return ret

--- a/corehq/apps/app_manager/serializers.py
+++ b/corehq/apps/app_manager/serializers.py
@@ -11,7 +11,7 @@ from corehq.apps.app_manager.models import (
 class LatestEnabledBuildProfileSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = LatestEnabledBuildProfiles
-        fields = ['app_id', 'active', 'version']
+        fields = ['id', 'app_id', 'active', 'version']
 
     def to_representation(self, instance):
         ret = super(LatestEnabledBuildProfileSerializer, self).to_representation(instance)

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -10,7 +10,7 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
     ko,
     _,
     initialPageData,
-    assertProperties,
+    assertProperties
 ) {
     'use strict';
     $(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -74,11 +74,7 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
             self.appReleasesByAppProfile = ko.observableArray(appReleasesByAppProfile);
             return self;
         }
-        var appReleasesByAppProfile = _.map(initialPageData.get('app_releases_by_app_profile'), AppRelease);
-        var viewModel = manageReleasesByAppProfileViewModel(appReleasesByAppProfile);
-        if (appReleasesByAppProfile.length) {
-            $('#managed-releases').koApplyBindings(viewModel);
-        }
+
         function manageReleaseSearchViewModel() {
             var self = {};
             self.search = function () {
@@ -92,6 +88,12 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
                 window.location.search = "";
             };
             return self;
+        }
+
+        var appReleasesByAppProfile = _.map(initialPageData.get('app_releases_by_app_profile'), AppRelease);
+        var viewModel = manageReleasesByAppProfileViewModel(appReleasesByAppProfile);
+        if (appReleasesByAppProfile.length) {
+            $('#managed-releases').koApplyBindings(viewModel);
         }
         var searchViewModel = manageReleaseSearchViewModel();
         $("#manage-app-releases").koApplyBindings(searchViewModel);

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -26,7 +26,6 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
             self.profileName = details.profile_name;
             self.domId = "restriction_" + self.id;
             self.errorMessage = ko.observable();
-            self.domId = "restriction_" + self.id;
             self.ajaxInProgress = ko.observable(false);
             self.actionText = ko.computed(function () {
                 return (self.active() ? gettext("Remove") : gettext("Add"));

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -69,12 +69,6 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
             return self;
         };
 
-        function manageReleasesByAppProfileViewModel(appReleasesByAppProfile) {
-            var self = {};
-            self.appReleasesByAppProfile = ko.observableArray(appReleasesByAppProfile);
-            return self;
-        }
-
         function manageReleaseSearchViewModel() {
             var self = {};
             self.search = function () {
@@ -91,9 +85,10 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
         }
 
         var appReleasesByAppProfile = _.map(initialPageData.get('app_releases_by_app_profile'), AppRelease);
-        var viewModel = manageReleasesByAppProfileViewModel(appReleasesByAppProfile);
         if (appReleasesByAppProfile.length) {
-            $('#managed-releases').koApplyBindings(viewModel);
+            $('#managed-releases').koApplyBindings({
+                'appReleasesByAppProfile': ko.observableArray(appReleasesByAppProfile),
+            });
         }
         var searchViewModel = manageReleaseSearchViewModel();
         $("#manage-app-releases").koApplyBindings(searchViewModel);

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -16,7 +16,7 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
     $(function () {
         var AppRelease = function (details) {
             var self = {};
-            assertProperties.assert(details, [], ['id', 'app_id', 'active', 'app_name', 'profile_name',
+            assertProperties.assertRequired(details, ['id', 'app_id', 'active', 'app_name', 'profile_name',
                 'version']);
             self.id = details.id;
             self.active = ko.observable(details.active);

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -21,9 +21,9 @@ hqDefine('app_manager/js/manage_releases_by_app_profile', [
             self.id = details.id;
             self.active = ko.observable(details.active);
             self.status = details.active ? gettext('Active') : gettext('Inactive');
-            self.app_name = details.app_name;
+            self.appName = details.app_name;
             self.version = details.version;
-            self.profile_name = details.profile_name;
+            self.profileName = details.profile_name;
             self.domId = "restriction_" + self.id;
             self.errorMessage = ko.observable();
             self.domId = "restriction_" + self.id;

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_app_profile.js
@@ -1,0 +1,57 @@
+hqDefine('app_manager/js/manage_releases_by_app_profile', [
+    'jquery',
+    'knockout',
+    'underscore',
+    'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/assert_properties',
+    'translations/js/app_translations',
+], function (
+    $,
+    ko,
+    _,
+    initialPageData,
+    assertProperties,
+) {
+    'use strict';
+    $(function () {
+        var AppRelease = function (details) {
+            var self = {};
+            assertProperties.assert(details, [], ['app_id', 'active', 'app_name', 'profile_name',
+                'version']);
+            self.active = details.active;
+            self.status = details.active ? gettext('Active') : gettext('Inactive');
+            self.app_name = details.app_name;
+            self.version = details.version;
+            self.profile_name = details.profile_name;
+            self.domId = "restriction_" + self.id;
+            return self;
+        };
+
+        function manageReleasesByAppProfileViewModel(appReleasesByAppProfile) {
+            var self = {};
+            self.appReleasesByAppProfile = ko.observableArray(appReleasesByAppProfile);
+            return self;
+        }
+        var appReleasesByAppProfile = _.map(initialPageData.get('app_releases_by_app_profile'), AppRelease);
+        var viewModel = manageReleasesByAppProfileViewModel(appReleasesByAppProfile);
+        if (appReleasesByAppProfile.length) {
+            $('#managed-releases').koApplyBindings(viewModel);
+        }
+        function manageReleaseSearchViewModel() {
+            var self = {};
+            self.search = function () {
+                var appId = $("#app-id-search-select").val();
+                var profileId = $("#app-profile-id-input").val() || '';
+                var version = $("#version-input").val() || '';
+                window.location.search = ("build_profile_id=" + profileId + "&app_id=" + appId + "&version=" +
+                    version);
+            };
+            self.clear = function () {
+                window.location.search = "";
+            };
+            return self;
+        }
+        var searchViewModel = manageReleaseSearchViewModel();
+        $("#manage-app-releases").koApplyBindings(searchViewModel);
+    });
+});

--- a/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_location.js
+++ b/corehq/apps/app_manager/static/app_manager/js/manage_releases_by_location.js
@@ -1,4 +1,4 @@
-hqDefine('app_manager/js/manage_releases', [
+hqDefine('app_manager/js/manage_releases_by_location', [
     'jquery',
     'knockout',
     'underscore',

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -61,7 +61,10 @@ from corehq.apps.users.models import CommCareUser
 from corehq.util.datadog.gauges import datadog_bucket_timer
 from corehq.util.view_utils import reverse
 from corehq.apps.app_manager.decorators import (
-    no_conflict_require_POST, require_can_edit_apps, require_deploy_apps)
+    no_conflict_require_POST,
+    require_can_edit_apps,
+    require_deploy_apps,
+)
 from corehq.apps.app_manager.exceptions import ModuleIdMissingException, PracticeUserException
 from corehq.apps.app_manager.models import Application, SavedAppBuild
 from corehq.apps.app_manager.views.download import source_files

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2374,14 +2374,14 @@ class SelectSubscriptionTypeForm(forms.Form):
             )
 
 
-class ManageAppReleasesForm(forms.Form):
+class ManageReleasesByLocationForm(forms.Form):
     app_id = forms.ChoiceField(label=ugettext_lazy("Application"), choices=(), required=False)
     location_id = forms.CharField(label=ugettext_lazy("Location"), widget=Select(choices=[]), required=False)
     version = forms.IntegerField(label=ugettext_lazy('Version'), required=False, widget=Select(choices=[]))
 
     def __init__(self, request, domain, *args, **kwargs):
         self.domain = domain
-        super(ManageAppReleasesForm, self).__init__(*args, **kwargs)
+        super(ManageReleasesByLocationForm, self).__init__(*args, **kwargs)
         self.fields['app_id'].choices = self.app_id_choices()
         if request.GET.get('app_id'):
             self.fields['app_id'].initial = request.GET.get('app_id')

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2465,6 +2465,8 @@ class ManageReleasesByAppProfileForm(forms.Form):
         self.domain = domain
         super(ManageReleasesByAppProfileForm, self).__init__(*args, **kwargs)
         self.fields['app_id'].choices = self.app_id_choices()
+        if request.GET.get('app_id'):
+            self.fields['app_id'].initial = request.GET.get('app_id')
         self.helper = HQFormHelper()
         self.helper.form_tag = False
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2453,3 +2453,35 @@ class ManageReleasesByLocationForm(forms.Form):
         except ValidationError as e:
             return False, ','.join(e.messages)
         return True, None
+
+
+class ManageReleasesByAppProfileForm(forms.Form):
+    app_id = forms.ChoiceField(label=ugettext_lazy("Application"), choices=(), required=True)
+    version = forms.IntegerField(label=ugettext_lazy('Version'), required=False, widget=Select(choices=[]))
+    build_profile_id = forms.CharField(label=ugettext_lazy('Application Profile'),
+                                       required=False, widget=Select(choices=[]))
+
+    def __init__(self, request, domain, *args, **kwargs):
+        self.domain = domain
+        super(ManageReleasesByAppProfileForm, self).__init__(*args, **kwargs)
+        self.fields['app_id'].choices = self.app_id_choices()
+        self.helper = HQFormHelper()
+        self.helper.form_tag = False
+
+        self.helper.layout = crispy.Layout(
+            crispy.Field('app_id', id='app-id-search-select', css_class="ko-select2"),
+            crispy.Field('version', id='version-input'),
+            crispy.Field('build_profile_id', id='app-profile-id-input'),
+            hqcrispy.FormActions(
+                crispy.ButtonHolder(
+                    crispy.Button('search', ugettext_lazy("Search"), data_bind="click: search"),
+                    crispy.Button('clear', ugettext_lazy("Clear"), data_bind="click: clear"),
+                )
+            )
+        )
+
+    def app_id_choices(self):
+        choices = [(None, _('Select Application'))]
+        for app in get_brief_apps_in_domain(self.domain):
+            choices.append((app.id, app.name))
+        return choices

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2403,7 +2403,7 @@ class ManageReleasesByLocationForm(forms.Form):
                 crispy.ButtonHolder(
                     crispy.Button('search', ugettext_lazy("Search"), data_bind="click: search"),
                     crispy.Button('clear', ugettext_lazy("Clear"), data_bind="click: clear"),
-                    Submit('submit', ugettext_lazy("Add Release Restriction"))
+                    Submit('submit', ugettext_lazy("Add New Restriction"))
                 )
             )
         )
@@ -2438,7 +2438,7 @@ class ManageReleasesByLocationForm(forms.Form):
 
     def clean_version(self):
         if not self.cleaned_data.get('version'):
-            self.add_error('version', _("Please enter version"))
+            self.add_error('version', _("Please select version"))
         return self.cleaned_data.get('version')
 
     def clean(self):

--- a/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
+++ b/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
@@ -10,6 +10,7 @@
   {% initial_page_data 'appVersionSelectInitialValue' selected_build_details %}
   {% initial_page_data 'appProfileInitialValues' initial_app_profile_details %}
   {% initial_page_data 'appVersionOnlyShowReleased' True %}
+  {% registerurl 'toggle_release_restriction_by_app_profile' domain '---'%}
   {% registerurl "paginate_releases" domain '---' %}
 
   <div class="row">
@@ -28,14 +29,29 @@
                 <th class="col-sm-2">{% trans 'Profile' %}</th>
                 <th class="col-sm-2">{% trans 'Version' %}</th>
                 <th class="col-sm-2">{% trans 'Status' %}</th>
+                <th class="col-sm-2">{% trans 'Action' %}</th>
               </tr>
               </thead>
               <tbody data-bind="foreach: appReleasesByAppProfile, visible: appReleasesByAppProfile">
-              <tr data-bind="css: {'bg-success': active }">
+              <tr data-bind="attr: {id: domId}, css: {'bg-success': active }">
                 <td data-bind="text: app_name"></td>
                 <td data-bind="text: profile_name"></td>
                 <td data-bind="text: version"></td>
                 <td data-bind="text: status"></td>
+                <td>
+                  <button type="button" class="btn default-btn"
+                          data-bind="click: toggleRestriction, css: buttonClass,
+                                            disable: ajaxInProgress">
+                    <span data-bind="text: actionText"></span>
+                    <i class="spinner fa-spin fa fa-refresh"
+                       data-bind="visible: ajaxInProgress"></i>
+                  </button>
+                  <br/>
+                  <span class="error-message label label-danger" data-bind="visible: error">
+                    {% trans 'Could not update!' %}
+                    <span data-bind="text: errorMessage"></span>
+                  </span>
+                </td>
               </tr>
               </tbody>
             </table>

--- a/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
+++ b/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
@@ -1,0 +1,47 @@
+{% extends "hqwebapp/base_section.html" %}
+{% load hq_shared_tags %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% requirejs_main 'app_manager/js/manage_releases_by_app_profile' %}
+
+{% block page_content %}
+  {% initial_page_data 'app_releases_by_app_profile' app_releases_by_app_profile %}
+  {% initial_page_data 'appVersionSelectInitialValue' selected_build_details %}
+  {% initial_page_data 'appProfileInitialValues' initial_app_profile_details %}
+  {% initial_page_data 'appVersionOnlyShowReleased' True %}
+  {% registerurl "paginate_releases" domain '---' %}
+
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="panel panel-modern-gray panel-form-only">
+        <div class="panel-body">
+          <form class="form-horizontal disable-on-submit" id="manage-app-releases" action=""
+                method='post'>
+            {% crispy manage_releases_by_app_profile_form %}
+          </form>
+          {% if app_releases_by_app_profile %}
+            <table id="managed-releases" class="table">
+              <thead>
+              <tr>
+                <th class="col-sm-2">{% trans 'Application' %}</th>
+                <th class="col-sm-2">{% trans 'Profile' %}</th>
+                <th class="col-sm-2">{% trans 'Version' %}</th>
+                <th class="col-sm-2">{% trans 'Status' %}</th>
+              </tr>
+              </thead>
+              <tbody data-bind="foreach: appReleasesByAppProfile, visible: appReleasesByAppProfile">
+              <tr data-bind="css: {'bg-success': active }">
+                <td data-bind="text: app_name"></td>
+                <td data-bind="text: profile_name"></td>
+                <td data-bind="text: version"></td>
+                <td data-bind="text: status"></td>
+              </tr>
+              </tbody>
+            </table>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
+++ b/corehq/apps/domain/templates/domain/manage_releases_by_app_profile.html
@@ -34,8 +34,8 @@
               </thead>
               <tbody data-bind="foreach: appReleasesByAppProfile, visible: appReleasesByAppProfile">
               <tr data-bind="attr: {id: domId}, css: {'bg-success': active }">
-                <td data-bind="text: app_name"></td>
-                <td data-bind="text: profile_name"></td>
+                <td data-bind="text: appName"></td>
+                <td data-bind="text: profileName"></td>
                 <td data-bind="text: version"></td>
                 <td data-bind="text: status"></td>
                 <td>

--- a/corehq/apps/domain/templates/domain/manage_releases_by_location.html
+++ b/corehq/apps/domain/templates/domain/manage_releases_by_location.html
@@ -21,7 +21,7 @@
         <div class="panel-body">
           <form class="form-horizontal disable-on-submit" id="manage-app-releases" action=""
                 method='post'>
-            {% crispy manage_releases_form %}
+            {% crispy manage_releases_by_location_form %}
           </form>
           {% if app_releases_by_location %}
             <table id="managed-releases" class="table">

--- a/corehq/apps/domain/templates/domain/manage_releases_by_location.html
+++ b/corehq/apps/domain/templates/domain/manage_releases_by_location.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% requirejs_main 'app_manager/js/manage_releases' %}
+{% requirejs_main 'app_manager/js/manage_releases_by_location' %}
 
 {% block page_content %}
   {% initial_page_data 'app_releases_by_location' app_releases_by_location %}

--- a/corehq/apps/domain/templates/domain/manage_releases_by_location.html
+++ b/corehq/apps/domain/templates/domain/manage_releases_by_location.html
@@ -59,9 +59,9 @@
                   </button>
                   <br/>
                   <span class="error-message label label-danger" data-bind="visible: error">
-                                        {% trans 'Could not update!' %}
-                                        <span data-bind="text: errorMessage"></span>
-                                    </span>
+                    {% trans 'Could not update!' %}
+                    <span data-bind="text: errorMessage"></span>
+                  </span>
                 </td>
               </tr>
               </tbody>

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -19,6 +19,7 @@ from corehq.apps.domain.views.releases import (
     ManageReleasesByLocation,
     deactivate_release_restriction,
     activate_release_restriction,
+    ManageReleasesByAppProfile,
 )
 from corehq.apps.domain.views.settings import (
     CaseSearchConfigView,
@@ -229,6 +230,8 @@ domain_settings = [
         name=RecoveryMeasuresHistory.urlname),
     url(r'^manage_releases_by_location/$', ManageReleasesByLocation.as_view(),
         name=ManageReleasesByLocation.urlname),
+    url(r'^manage_releases_by_app_profile/$', ManageReleasesByAppProfile.as_view(),
+        name=ManageReleasesByAppProfile.urlname),
     url(r'^deactivate_release_restriction/(?P<restriction_id>[\w-]+)/$', deactivate_release_restriction,
         name='deactivate_release_restriction'),
     url(r'^activate_release_restriction/(?P<restriction_id>[\w-]+)/$', activate_release_restriction,

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -19,6 +19,7 @@ from corehq.apps.domain.views.releases import (
     ManageReleasesByLocation,
     deactivate_release_restriction,
     activate_release_restriction,
+    toggle_release_restriction_by_app_profile,
     ManageReleasesByAppProfile,
 )
 from corehq.apps.domain.views.settings import (
@@ -236,5 +237,7 @@ domain_settings = [
         name='deactivate_release_restriction'),
     url(r'^activate_release_restriction/(?P<restriction_id>[\w-]+)/$', activate_release_restriction,
         name='activate_release_restriction'),
+    url(r'^toggle_release_restriction_by_app_profile/(?P<restriction_id>[\w-]+)/$',
+        toggle_release_restriction_by_app_profile, name='toggle_release_restriction_by_app_profile'),
     DomainReportDispatcher.url_pattern()
 ]

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -16,7 +16,7 @@ from django.views.generic import RedirectView
 from corehq.apps.callcenter.views import CallCenterOwnerOptionsView
 from corehq.apps.domain.forms import ConfidentialPasswordResetForm, HQSetPasswordForm
 from corehq.apps.domain.views.releases import (
-    ManageReleases,
+    ManageReleasesByLocation,
     deactivate_release_restriction,
     activate_release_restriction,
 )
@@ -227,7 +227,8 @@ domain_settings = [
     url(r'^recovery_measures_history/$',
         RecoveryMeasuresHistory.as_view(),
         name=RecoveryMeasuresHistory.urlname),
-    url(r'^manage_releases/$', ManageReleases.as_view(), name=ManageReleases.urlname),
+    url(r'^manage_releases_by_location/$', ManageReleasesByLocation.as_view(),
+        name=ManageReleasesByLocation.urlname),
     url(r'^deactivate_release_restriction/(?P<restriction_id>[\w-]+)/$', deactivate_release_restriction,
         name='deactivate_release_restriction'),
     url(r'^activate_release_restriction/(?P<restriction_id>[\w-]+)/$', activate_release_restriction,

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -15,6 +15,7 @@ from django.contrib import messages
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
     get_brief_apps_in_domain,
+    get_build_doc_by_version,
 )
 from corehq.apps.app_manager.models import (
     AppReleaseByLocation,
@@ -102,7 +103,17 @@ class ManageReleasesByAppProfile(BaseProjectSettingsView):
         )
 
     def _get_initial_app_profile_details(self, version):
-        return [{}]
+        app_id = self.request.GET.get('app_id')
+        selected_profile_id = self.request.GET.get('profile_id', '')
+        # only when performing search populate these initial values
+        if app_id and version:
+            build_doc = get_build_doc_by_version(self.domain, self.request.GET.get('app_id'), version)
+            if build_doc:
+                return [{
+                    'id': _id,
+                    'text': details['name'],
+                    'selected': selected_profile_id == _id
+                } for _id, details in build_doc['build_profiles'].items()]
 
     @property
     def page_context(self):

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -33,7 +33,8 @@ from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.locations.models import SQLLocation
 
 
-@method_decorator([toggles.MANAGE_RELEASES_PER_LOCATION.required_decorator()], name='dispatch')
+@method_decorator([toggles.MANAGE_RELEASES_PER_LOCATION.required_decorator(),
+                   login_and_domain_required], name='dispatch')
 class ManageReleasesByLocation(BaseProjectSettingsView):
     template_name = 'domain/manage_releases_by_location.html'
     urlname = 'manage_releases_by_location'
@@ -91,7 +92,8 @@ class ManageReleasesByLocation(BaseProjectSettingsView):
             return self.get(request, *args, **kwargs)
 
 
-@method_decorator([toggles.RELEASE_BUILDS_PER_PROFILE.required_decorator()], name='dispatch')
+@method_decorator([toggles.RELEASE_BUILDS_PER_PROFILE.required_decorator(),
+                   login_and_domain_required], name='dispatch')
 class ManageReleasesByAppProfile(BaseProjectSettingsView):
     template_name = 'domain/manage_releases_by_app_profile.html'
     urlname = 'manage_releases_by_app_profile'
@@ -187,6 +189,8 @@ def update_release_restriction(request, domain, restriction_id, active):
     return JsonResponse(data=response_content)
 
 
+@login_and_domain_required
+@require_POST
 def toggle_release_restriction_by_app_profile(request, domain, restriction_id):
     if not toggles.RELEASE_BUILDS_PER_PROFILE.enabled_for_request(request):
         return HttpResponseForbidden()

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import json
 from datetime import datetime
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -108,8 +108,16 @@ class ManageReleasesByAppProfile(BaseProjectSettingsView):
     def page_context(self):
         app_names = {app.id: app.name for app in get_brief_apps_in_domain(self.domain, include_remote=True)}
         query = LatestEnabledBuildProfiles.objects.order_by('version')
-        # ToDo: Filter by params in url
+        if self.request.GET.get('app_id'):
+            query = query.filter(app_id=self.request.GET.get('app_id'))
+        else:
+            query = query.filter(app_id__in=app_names.keys())
         version = self.request.GET.get('version')
+        if version:
+            query = query.filter(version=version)
+        build_profile_id = self.request.GET.get('build_profile_id')
+        if build_profile_id:
+            query = query.filter(build_profile_id=build_profile_id)
         app_releases_by_app_profile = [release.to_json(app_names) for release in query]
         return {
             'manage_releases_by_app_profile_form': self.form,

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -20,6 +20,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_brief_apps_in_domain,
     get_build_doc_by_version,
 )
+from corehq.apps.app_manager.decorators import require_can_edit_apps
 from corehq.apps.app_manager.models import (
     AppReleaseByLocation,
     LatestEnabledBuildProfiles,
@@ -29,12 +30,11 @@ from corehq.apps.domain.forms import (
     ManageReleasesByAppProfileForm,
 )
 from corehq.apps.domain.views import BaseProjectSettingsView
-from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.locations.models import SQLLocation
 
 
 @method_decorator([toggles.MANAGE_RELEASES_PER_LOCATION.required_decorator(),
-                   login_and_domain_required], name='dispatch')
+                   require_can_edit_apps], name='dispatch')
 class ManageReleasesByLocation(BaseProjectSettingsView):
     template_name = 'domain/manage_releases_by_location.html'
     urlname = 'manage_releases_by_location'
@@ -93,7 +93,7 @@ class ManageReleasesByLocation(BaseProjectSettingsView):
 
 
 @method_decorator([toggles.RELEASE_BUILDS_PER_PROFILE.required_decorator(),
-                   login_and_domain_required], name='dispatch')
+                   require_can_edit_apps], name='dispatch')
 class ManageReleasesByAppProfile(BaseProjectSettingsView):
     template_name = 'domain/manage_releases_by_app_profile.html'
     urlname = 'manage_releases_by_app_profile'
@@ -155,13 +155,13 @@ class ManageReleasesByAppProfile(BaseProjectSettingsView):
             return self.get(request, *args, **kwargs)
 
 
-@login_and_domain_required
+@require_can_edit_apps
 @require_POST
 def deactivate_release_restriction(request, domain, restriction_id):
     return _update_release_restriction(request, domain, restriction_id, active=False)
 
 
-@login_and_domain_required
+@require_can_edit_apps
 @require_POST
 def activate_release_restriction(request, domain, restriction_id):
     return _update_release_restriction(request, domain, restriction_id, active=True)
@@ -189,7 +189,7 @@ def _update_release_restriction(request, domain, restriction_id, active):
     return JsonResponse(data=response_content)
 
 
-@login_and_domain_required
+@require_can_edit_apps
 @require_POST
 def toggle_release_restriction_by_app_profile(request, domain, restriction_id):
     if not toggles.RELEASE_BUILDS_PER_PROFILE.enabled_for_request(request):

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -137,6 +137,17 @@ class ManageReleasesByAppProfile(BaseProjectSettingsView):
             'initial_app_profile_details': self._get_initial_app_profile_details(version),
         }
 
+    def post(self, request, *args, **kwargs):
+        if self.form.is_valid():
+            success, error_message = self.form.save()
+            if success:
+                return redirect(self.urlname, self.domain)
+            else:
+                messages.error(request, error_message)
+                return self.get(request, *args, **kwargs)
+        else:
+            return self.get(request, *args, **kwargs)
+
 
 @login_and_domain_required
 @require_POST

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -198,9 +198,9 @@ def toggle_release_restriction_by_app_profile(request, domain, restriction_id):
     if not release:
         return HttpResponseBadRequest()
     if request.POST.get('active') == 'false':
-        return _update_release_restriction_by_app_profile(request, restriction_id, active=False)
+        return _update_release_restriction_by_app_profile(release, restriction_id, active=False)
     elif request.POST.get('active') == 'true':
-        return _update_release_restriction_by_app_profile(request, restriction_id, active=True)
+        return _update_release_restriction_by_app_profile(release, restriction_id, active=True)
 
 
 def _update_release_restriction_by_app_profile(release, restriction_id, active):

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -137,17 +137,6 @@ class ManageReleasesByAppProfile(BaseProjectSettingsView):
             'initial_app_profile_details': self._get_initial_app_profile_details(version),
         }
 
-    def post(self, request, *args, **kwargs):
-        if self.form.is_valid():
-            success, error_message = self.form.save()
-            if success:
-                return redirect(self.urlname, self.domain)
-            else:
-                messages.error(request, error_message)
-                return self.get(request, *args, **kwargs)
-        else:
-            return self.get(request, *args, **kwargs)
-
 
 @login_and_domain_required
 @require_POST

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -158,16 +158,16 @@ class ManageReleasesByAppProfile(BaseProjectSettingsView):
 @login_and_domain_required
 @require_POST
 def deactivate_release_restriction(request, domain, restriction_id):
-    return update_release_restriction(request, domain, restriction_id, active=False)
+    return _update_release_restriction(request, domain, restriction_id, active=False)
 
 
 @login_and_domain_required
 @require_POST
 def activate_release_restriction(request, domain, restriction_id):
-    return update_release_restriction(request, domain, restriction_id, active=True)
+    return _update_release_restriction(request, domain, restriction_id, active=True)
 
 
-def update_release_restriction(request, domain, restriction_id, active):
+def _update_release_restriction(request, domain, restriction_id, active):
     if not toggles.MANAGE_RELEASES_PER_LOCATION.enabled_for_request(request):
         return HttpResponseForbidden()
     release = AppReleaseByLocation.objects.get(id=restriction_id, domain=domain)

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -8,9 +8,9 @@ from django.utils.translation import ugettext_lazy
 from django.utils.functional import cached_property
 from django.shortcuts import redirect
 from django.http.response import (
-    HttpResponse,
     HttpResponseForbidden,
     HttpResponseBadRequest,
+    JsonResponse,
 )
 from django.views.decorators.http import require_POST
 from django.core.exceptions import ValidationError
@@ -184,7 +184,7 @@ def update_release_restriction(request, domain, restriction_id, active):
             'deactivated_on': (datetime.strftime(release.deactivated_on, '%Y-%m-%d %H:%M:%S')
                                if release.deactivated_on else None),
         }
-    return HttpResponse(json.dumps(response_content), content_type='application/json')
+    return JsonResponse(data=response_content)
 
 
 def toggle_release_restriction_by_app_profile(request, domain, restriction_id):
@@ -211,4 +211,4 @@ def _update_release_restriction_by_app_profile(release, restriction_id, active):
             'id': restriction_id,
             'success': True,
         }
-    return HttpResponse(json.dumps(response_content), content_type='application/json')
+    return JsonResponse(data=response_content)

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -19,7 +19,7 @@ from corehq.apps.accounting.utils import domain_has_privilege, domain_is_on_tria
 from corehq.apps.app_manager.dbaccessors import domain_has_apps, get_brief_apps_in_domain
 from corehq.apps.builds.views import EditMenuView
 from corehq.apps.domain.utils import user_has_custom_top_menu
-from corehq.apps.domain.views.releases import ManageReleases
+from corehq.apps.domain.views.releases import ManageReleasesByLocation
 from corehq.apps.hqadmin.reports import RealProjectSpacesReport, \
     CommConnectProjectSpacesReport, CommTrackProjectSpacesReport, \
     DeviceLogSoftAssertReport, UserAuditReport
@@ -870,7 +870,7 @@ class ApplicationsTab(UITab):
         if toggles.MANAGE_RELEASES_PER_LOCATION.enabled_for_request(self._request):
             submenu_context.append(dropdown_dict(
                 _('Manage Releases'),
-                url=(reverse(ManageReleases.urlname, args=[self.domain])),
+                url=(reverse(ManageReleasesByLocation.urlname, args=[self.domain])),
             ))
         return submenu_context
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -867,11 +867,6 @@ class ApplicationsTab(UITab):
                 ManageHostedCCZ.page_title,
                 url=reverse(ManageHostedCCZ.urlname, args=[self.domain])
             ))
-        if toggles.MANAGE_RELEASES_PER_LOCATION.enabled_for_request(self._request):
-            submenu_context.append(dropdown_dict(
-                _('Manage Releases'),
-                url=(reverse(ManageReleasesByLocation.urlname, args=[self.domain])),
-            ))
         return submenu_context
 
     @property
@@ -1672,6 +1667,12 @@ def _get_administration_section(domain):
         administration.append({
             'title': _(TransferDomainView.page_title),
             'url': reverse(TransferDomainView.urlname, args=[domain])
+        })
+
+    if toggles.MANAGE_RELEASES_PER_LOCATION.enabled(domain):
+        administration.append({
+            'title': _(ManageReleasesByLocation.page_title),
+            'url': reverse(ManageReleasesByLocation.urlname, args=[domain])
         })
 
     return administration

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -19,7 +19,10 @@ from corehq.apps.accounting.utils import domain_has_privilege, domain_is_on_tria
 from corehq.apps.app_manager.dbaccessors import domain_has_apps, get_brief_apps_in_domain
 from corehq.apps.builds.views import EditMenuView
 from corehq.apps.domain.utils import user_has_custom_top_menu
-from corehq.apps.domain.views.releases import ManageReleasesByLocation
+from corehq.apps.domain.views.releases import (
+    ManageReleasesByLocation,
+    ManageReleasesByAppProfile,
+)
 from corehq.apps.hqadmin.reports import RealProjectSpacesReport, \
     CommConnectProjectSpacesReport, CommTrackProjectSpacesReport, \
     DeviceLogSoftAssertReport, UserAuditReport
@@ -1673,6 +1676,12 @@ def _get_administration_section(domain):
         administration.append({
             'title': _(ManageReleasesByLocation.page_title),
             'url': reverse(ManageReleasesByLocation.urlname, args=[domain])
+        })
+
+    if toggles.RELEASE_BUILDS_PER_PROFILE.enabled(domain):
+        administration.append({
+            'title': _(ManageReleasesByAppProfile.page_title),
+            'url': reverse(ManageReleasesByAppProfile.urlname, args=[domain])
         })
 
     return administration


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-652

This PR builds on https://github.com/dimagi/commcare-hq/pull/24663
It now adds the view for App profile based app release just like location based app release.
The view needs to list the objects and make them searchable. Also need ability to update status of existing ones just like for location based.

As a set up it renames the earlier "app releases" functionality related things to "app releases by location" naming so that they can be identified separately.
Also, Moves the links under Project Settings instead of Applications Tab.

A follow up to this PR would be removing [feature from "View Source files"](https://github.com/dimagi/commcare-hq/blob/96dce1cc722b0966156c663fe1545bedb1667297/corehq/apps/app_manager/templates/app_manager/download_index.html#L12-L11) page where the settings can be made.

FF: `RELEASE_BUILDS_PER_PROFILE`

buddies: @sravfeyn @calellowitz 