### PR TITLE
[ICDS] left menu always active even modal is open

### DIFF
--- a/custom/icds_reports/static/css/icds_dashboard.css
+++ b/custom/icds_reports/static/css/icds_dashboard.css
@@ -283,7 +283,7 @@ nvd3#sectorChart > div.title.h4 {
     font-size: 14px;
     padding-right: 0;
     padding-left: 0;
-    z-index: 1;
+    z-index: 999999;
 }
 
 .left-menu-with-alert {

--- a/custom/icds_reports/static/js/angular-services/baseControllers.service.js
+++ b/custom/icds_reports/static/js/angular-services/baseControllers.service.js
@@ -2,7 +2,7 @@
 
 window.angular.module('icdsApp').factory('baseControllersService', function() {
     return {
-        BaseController: function ($scope, $routeParams, $location, locationsService, userLocationId,
+        BaseController: function ($scope, $routeParams, $location, $uibModalStack, locationsService, userLocationId,
             storageService, haveAccessToAllLocations, haveAccessToFeatures) {
             var vm = this;
             if (Object.keys($location.search()).length === 0) {
@@ -10,6 +10,8 @@ window.angular.module('icdsApp').factory('baseControllersService', function() {
             } else {
                 storageService.setKey('search', $location.search());
             }
+
+            $uibModalStack.dismissAll();
 
             vm.userLocationId = userLocationId;
             vm.filtersData = $location.search();

--- a/custom/icds_reports/static/js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js
+++ b/custom/icds_reports/static/js/directives/adhaar-beneficiary/adhaar-beneficiary.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function AdhaarController($scope, $routeParams, $location, $filter, demographicsService, locationsService,
+function AdhaarController($scope, $routeParams, $location, $filter, $uibModalStack, demographicsService, locationsService,
     userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "Percent Aadhaar-seeded Beneficiaries";
@@ -68,7 +68,7 @@ function AdhaarController($scope, $routeParams, $location, $filter, demographics
     };
 }
 
-AdhaarController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+AdhaarController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('adhaarBeneficiary', function() {
     return {

--- a/custom/icds_reports/static/js/directives/adolescent-girls/adolescent-girls.directive.js
+++ b/custom/icds_reports/static/js/directives/adolescent-girls/adolescent-girls.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function AdolescentWomenController($scope, $routeParams, $location, $filter, demographicsService, locationsService,
+function AdolescentWomenController($scope, $routeParams, $location, $filter, $uibModalStack, demographicsService, locationsService,
     userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "Adolescent Girls (11-14 years)";
@@ -91,7 +91,7 @@ function AdolescentWomenController($scope, $routeParams, $location, $filter, dem
     };
 }
 
-AdolescentWomenController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+AdolescentWomenController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('adolescentGirls', function() {
     return {

--- a/custom/icds_reports/static/js/directives/adult-weight-scale/adult-weight-scale.directive.js
+++ b/custom/icds_reports/static/js/directives/adult-weight-scale/adult-weight-scale.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function AdultWeightScaleController($scope, $routeParams, $location, $filter, infrastructureService,
+function AdultWeightScaleController($scope, $routeParams, $location, $filter, $uibModalStack, infrastructureService,
     locationsService, userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "AWCs Reported Weighing Scale: Mother and Child";
@@ -69,7 +69,7 @@ function AdultWeightScaleController($scope, $routeParams, $location, $filter, in
     };
 }
 
-AdultWeightScaleController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+AdultWeightScaleController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('adultWeightScale', function() {
     return {

--- a/custom/icds_reports/static/js/directives/awc-daily-status/awc-daily-status.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-daily-status/awc-daily-status.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function AWCDailyStatusController($scope, $routeParams, $location, $filter, icdsCasReachService, locationsService,
+function AWCDailyStatusController($scope, $routeParams, $location, $filter, $uibModalStack, icdsCasReachService, locationsService,
     userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "AWC Daily Status";
@@ -80,7 +80,7 @@ function AWCDailyStatusController($scope, $routeParams, $location, $filter, icds
     };
 }
 
-AWCDailyStatusController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'icdsCasReachService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+AWCDailyStatusController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'icdsCasReachService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('awcDailyStatus', function() {
     return {

--- a/custom/icds_reports/static/js/directives/awc-opened-yesterday/awc-opened-yesterday.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-opened-yesterday/awc-opened-yesterday.directive.js
@@ -1,11 +1,13 @@
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
 
-function AwcOpenedYesterdayController($routeParams, $location, storageService, systemUsageService) {
+function AwcOpenedYesterdayController($routeParams, $location, $uibModalStack, storageService, systemUsageService) {
     var vm = this;
     vm.data = {};
     vm.step = $routeParams.step;
     vm.filters = ['ageServiceDeliveryDashboard'];
+
+    $uibModalStack.dismissAll();
 
     if (Object.keys($location.search()).length === 0) {
         $location.search(storageService.getKey('search'));
@@ -27,7 +29,7 @@ function AwcOpenedYesterdayController($routeParams, $location, storageService, s
     });
 }
 
-AwcOpenedYesterdayController.$inject = ['$routeParams', '$location', 'storageService', 'systemUsageService'];
+AwcOpenedYesterdayController.$inject = ['$routeParams', '$location', '$uibModalStack', 'storageService', 'systemUsageService'];
 
 window.angular.module('icdsApp').directive('awcOpenedYesterday', function() {
     return {

--- a/custom/icds_reports/static/js/directives/awcs-covered/awcs-covered.directive.js
+++ b/custom/icds_reports/static/js/directives/awcs-covered/awcs-covered.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function AWCSCoveredController($scope, $routeParams, $location, $filter, icdsCasReachService, locationsService,
+function AWCSCoveredController($scope, $routeParams, $location, $filter, $uibModalStack, icdsCasReachService, locationsService,
     userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "AWCs Launched";
@@ -76,7 +76,7 @@ function AWCSCoveredController($scope, $routeParams, $location, $filter, icdsCas
     };
 }
 
-AWCSCoveredController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'icdsCasReachService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+AWCSCoveredController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'icdsCasReachService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('awcsCovered', function() {
     return {

--- a/custom/icds_reports/static/js/directives/cas-export/cas-export.directive.js
+++ b/custom/icds_reports/static/js/directives/cas-export/cas-export.directive.js
@@ -1,7 +1,9 @@
 /* global moment */
 
-function CasExportController($window, $location, locationHierarchy, locationsService, downloadService, userLocationId) {
+function CasExportController($window, $location, $uibModalStack, locationHierarchy, locationsService, downloadService, userLocationId) {
     var vm = this;
+
+    $uibModalStack.dismissAll();
 
     vm.months = [];
     vm.monthsCopy = [];
@@ -121,7 +123,7 @@ function CasExportController($window, $location, locationHierarchy, locationsSer
 
 }
 
-CasExportController.$inject = ['$window', '$location', 'locationHierarchy', 'locationsService', 'downloadService', 'userLocationId'];
+CasExportController.$inject = ['$window', '$location', '$uibModalStack', 'locationHierarchy', 'locationsService', 'downloadService', 'userLocationId'];
 
 window.angular.module('icdsApp').directive("casExport", function () {
     var url = hqImport('hqwebapp/js/initial_page_data').reverse;

--- a/custom/icds_reports/static/js/directives/children-initiated/children-initiated.directive.js
+++ b/custom/icds_reports/static/js/directives/children-initiated/children-initiated.directive.js
@@ -1,9 +1,9 @@
 /* global d3, _ */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function ChildrenInitiatedController($scope, $routeParams, $location, $filter, maternalChildService,
+function ChildrenInitiatedController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, genders, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     var genderIndex = _.findIndex(genders, function (x) {
@@ -96,7 +96,7 @@ function ChildrenInitiatedController($scope, $routeParams, $location, $filter, m
     };
 }
 
-ChildrenInitiatedController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
+ChildrenInitiatedController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('childrenInitiated', function() {
     return {

--- a/custom/icds_reports/static/js/directives/clean-water/clean-water.directive.js
+++ b/custom/icds_reports/static/js/directives/clean-water/clean-water.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function CleanWaterController($scope, $routeParams, $location, $filter, infrastructureService, locationsService,
+function CleanWaterController($scope, $routeParams, $location, $filter, $uibModalStack, infrastructureService, locationsService,
     userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     if (Object.keys($location.search()).length === 0) {
@@ -74,7 +74,7 @@ function CleanWaterController($scope, $routeParams, $location, $filter, infrastr
     };
 }
 
-CleanWaterController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+CleanWaterController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('cleanWater', function() {
     return {

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -1,8 +1,10 @@
 /* global moment */
 
-function DownloadController($rootScope, $location, locationHierarchy, locationsService, userLocationId, haveAccessToFeatures,
+function DownloadController($rootScope, $location, $uibModalStack, locationHierarchy, locationsService, userLocationId, haveAccessToFeatures,
     downloadService) {
     var vm = this;
+
+    $uibModalStack.dismissAll();
 
     vm.months = [];
     vm.monthsCopy = [];
@@ -538,7 +540,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
 
 }
 
-DownloadController.$inject = ['$rootScope', '$location', 'locationHierarchy', 'locationsService', 'userLocationId',
+DownloadController.$inject = ['$rootScope', '$location', '$uibModalStack', 'locationHierarchy', 'locationsService', 'userLocationId',
     'haveAccessToFeatures', 'downloadService'];
 
 window.angular.module('icdsApp').directive("download", function() {

--- a/custom/icds_reports/static/js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js
+++ b/custom/icds_reports/static/js/directives/early_initiation_breastfeeding/early_initiation_breastfeeding.directive.js
@@ -1,9 +1,9 @@
 /* global d3, _ */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function EarlyInitiationBreastfeedingController($scope, $routeParams, $location, $filter, maternalChildService,
+function EarlyInitiationBreastfeedingController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, genders, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     var genderIndex = _.findIndex(genders, function (x) {
@@ -98,7 +98,7 @@ function EarlyInitiationBreastfeedingController($scope, $routeParams, $location,
     };
 }
 
-EarlyInitiationBreastfeedingController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
+EarlyInitiationBreastfeedingController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('earlyInitiationBreastfeeding', function() {
     return {

--- a/custom/icds_reports/static/js/directives/enrolled-children/enrolled-children.directive.js
+++ b/custom/icds_reports/static/js/directives/enrolled-children/enrolled-children.directive.js
@@ -1,10 +1,10 @@
 /* global d3, _ */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function EnrolledChildrenController($scope, $routeParams, $location, $filter, demographicsService,
+function EnrolledChildrenController($scope, $routeParams, $location, $filter, $uibModalStack, demographicsService,
     locationsService, userLocationId, storageService, genders, ages, haveAccessToAllLocations,
     baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
 
@@ -121,7 +121,7 @@ function EnrolledChildrenController($scope, $routeParams, $location, $filter, de
     };
 }
 
-EnrolledChildrenController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService'];
+EnrolledChildrenController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('enrolledChildren', function() {
     return {

--- a/custom/icds_reports/static/js/directives/enrolled-women/enrolled-women.directive.js
+++ b/custom/icds_reports/static/js/directives/enrolled-women/enrolled-women.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function EnrolledWomenController($scope, $routeParams, $location, $filter, demographicsService, locationsService,
+function EnrolledWomenController($scope, $routeParams, $location, $filter, $uibModalStack, demographicsService, locationsService,
     userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "Pregnant Women enrolled for Anganwadi Services";
@@ -92,7 +92,7 @@ function EnrolledWomenController($scope, $routeParams, $location, $filter, demog
     };
 }
 
-EnrolledWomenController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+EnrolledWomenController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('enrolledWomen', function() {
     return {

--- a/custom/icds_reports/static/js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js
+++ b/custom/icds_reports/static/js/directives/exclusive-breastfeeding/exlusive-breastfeeding.directive.js
@@ -1,9 +1,9 @@
 /* global d3, _ */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function ExclusiveBreasfeedingController($scope, $routeParams, $location, $filter, maternalChildService,
+function ExclusiveBreasfeedingController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, genders, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
 
@@ -97,7 +97,7 @@ function ExclusiveBreasfeedingController($scope, $routeParams, $location, $filte
     };
 }
 
-ExclusiveBreasfeedingController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
+ExclusiveBreasfeedingController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('exclusiveBreastfeeding', function() {
     return {

--- a/custom/icds_reports/static/js/directives/functional-toilet/functional-toilet.directive.js
+++ b/custom/icds_reports/static/js/directives/functional-toilet/functional-toilet.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function FunctionalToiletController($scope, $routeParams, $location, $filter, infrastructureService,
+function FunctionalToiletController($scope, $routeParams, $location, $filter, $uibModalStack, infrastructureService,
     locationsService, userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "AWCs Reported Functional Toilet";
@@ -69,7 +69,7 @@ function FunctionalToiletController($scope, $routeParams, $location, $filter, in
     };
 }
 
-FunctionalToiletController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+FunctionalToiletController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('functionalToilet', function() {
     return {

--- a/custom/icds_reports/static/js/directives/immunization_coverage/immunization_coverage.directive.js
+++ b/custom/icds_reports/static/js/directives/immunization_coverage/immunization_coverage.directive.js
@@ -1,9 +1,9 @@
 /* global d3, _ */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function ImmunizationCoverageController($scope, $routeParams, $location, $filter, maternalChildService,
+function ImmunizationCoverageController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, genders, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     var genderIndex = _.findIndex(genders, function (x) {
@@ -92,7 +92,7 @@ function ImmunizationCoverageController($scope, $routeParams, $location, $filter
     };
 }
 
-ImmunizationCoverageController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
+ImmunizationCoverageController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('immunizationCoverage', function() {
     return {

--- a/custom/icds_reports/static/js/directives/infants-weight-scale/infants-weight-scale.directive.js
+++ b/custom/icds_reports/static/js/directives/infants-weight-scale/infants-weight-scale.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function InfantsWeightScaleController($scope, $routeParams, $location, $filter, infrastructureService,
+function InfantsWeightScaleController($scope, $routeParams, $location, $filter, $uibModalStack, infrastructureService,
     locationsService, userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "AWCs Reported Weighing Scale: Infants";
@@ -69,7 +69,7 @@ function InfantsWeightScaleController($scope, $routeParams, $location, $filter, 
     };
 }
 
-InfantsWeightScaleController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+InfantsWeightScaleController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('infantsWeightScale', function() {
     return {

--- a/custom/icds_reports/static/js/directives/institutional-deliveries/institutional-deliveries.directive.js
+++ b/custom/icds_reports/static/js/directives/institutional-deliveries/institutional-deliveries.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function InstitutionalDeliveriesController($scope, $routeParams, $location, $filter, maternalChildService,
+function InstitutionalDeliveriesController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "Institutional deliveries";
@@ -82,7 +82,7 @@ function InstitutionalDeliveriesController($scope, $routeParams, $location, $fil
     };
 }
 
-InstitutionalDeliveriesController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+InstitutionalDeliveriesController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('institutionalDeliveries', function() {
     return {

--- a/custom/icds_reports/static/js/directives/lactating-enrolled-women/lactating-enrolled-women.directive.js
+++ b/custom/icds_reports/static/js/directives/lactating-enrolled-women/lactating-enrolled-women.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function LactatingEnrolledWomenController($scope, $routeParams, $location, $filter, demographicsService,
+function LactatingEnrolledWomenController($scope, $routeParams, $location, $filter, $uibModalStack, demographicsService,
     locationsService, userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "Lactating Mothers enrolled for Anganwadi Services";
@@ -92,7 +92,7 @@ function LactatingEnrolledWomenController($scope, $routeParams, $location, $filt
     };
 }
 
-LactatingEnrolledWomenController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+LactatingEnrolledWomenController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('lactatingEnrolledWomen', function() {
     return {

--- a/custom/icds_reports/static/js/directives/lady-supervisor/lady-supervisor.directive.js
+++ b/custom/icds_reports/static/js/directives/lady-supervisor/lady-supervisor.directive.js
@@ -2,7 +2,7 @@
 
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function LadySupervisorController($scope, $http, $log, $routeParams, $location, storageService, userLocationId, haveAccessToAllLocations) {
+function LadySupervisorController($scope, $http, $log, $routeParams, $location, $uibModalStack, storageService, userLocationId, haveAccessToAllLocations) {
     var vm = this;
     vm.data = {};
     vm.label = "LS Indicators";
@@ -65,7 +65,7 @@ function LadySupervisorController($scope, $http, $log, $routeParams, $location, 
     vm.getData();
 }
 
-LadySupervisorController.$inject = ['$scope', '$http', '$log', '$routeParams', '$location', 'storageService', 'userLocationId', 'haveAccessToAllLocations'];
+LadySupervisorController.$inject = ['$scope', '$http', '$log', '$routeParams', '$location', '$uibModalStack', 'storageService', 'userLocationId', 'haveAccessToAllLocations'];
 
 window.angular.module('icdsApp').directive('ladySupervisor', function () {
     return {

--- a/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/location-filter/location-filter.directive.js
@@ -132,6 +132,10 @@ function LocationModalController($uibModalInstance, $location, locationsService,
         return $location.path().indexOf('awc_reports') !== -1;
     };
 
+    vm.isLSReport = function () {
+        return $location.path().indexOf('lady_supervisor') !== -1;
+    };
+
     vm.close = function () {
         $uibModalInstance.dismiss('cancel');
     };
@@ -145,7 +149,7 @@ function LocationModalController($uibModalInstance, $location, locationsService,
 }
 
 
-function LocationFilterController($rootScope, $scope, $location, $uibModal, locationHierarchy, locationsService, storageService, userLocationId, haveAccessToAllLocations, allUserLocationId) {
+function LocationFilterController($rootScope, $scope, $location, $uibModal, $uibModalStack, locationHierarchy, locationsService, storageService, userLocationId, haveAccessToAllLocations, allUserLocationId) {
     var vm = this;
     if (Object.keys($location.search()).length === 0) {
         $location.search(storageService.getKey('search'));
@@ -213,7 +217,12 @@ function LocationFilterController($rootScope, $scope, $location, $uibModal, loca
         return $location.path().indexOf('awc_reports') !== -1;
     };
 
+    vm.isLSReport = function () {
+        return $location.path().indexOf('lady_supervisor') !== -1;
+    };
+
     vm.open = function () {
+        $uibModalStack.dismissAll();
         var modalInstance = $uibModal.open({
             animation: vm.animationsEnabled,
             ariaLabelledBy: 'modal-title',
@@ -221,7 +230,7 @@ function LocationFilterController($rootScope, $scope, $location, $uibModal, loca
             templateUrl: 'locationModalContent.html',
             controller: LocationModalController,
             controllerAs: '$ctrl',
-            backdrop: vm.isAwcReport() ? 'static' : true,
+            backdrop: vm.isAwcReport() || vm.isLSReport() ? 'static' : true,
             resolve: {
                 location_id: function () {
                     return vm.location_id;
@@ -463,7 +472,7 @@ function LocationFilterController($rootScope, $scope, $location, $uibModal, loca
     init();
 }
 
-LocationFilterController.$inject = ['$rootScope', '$scope', '$location', '$uibModal', 'locationHierarchy', 'locationsService', 'storageService', 'userLocationId', 'haveAccessToAllLocations', 'allUserLocationId'];
+LocationFilterController.$inject = ['$rootScope', '$scope', '$location', '$uibModal', '$uibModalStack', 'locationHierarchy', 'locationsService', 'storageService', 'userLocationId', 'haveAccessToAllLocations', 'allUserLocationId'];
 LocationModalController.$inject = ['$uibModalInstance', '$location', 'locationsService', 'selectedLocationId', 'hierarchy', 'selectedLocations', 'locationsCache', 'maxLevel', 'userLocationId', 'showMessage', 'showSectorMessage'];
 
 window.angular.module('icdsApp').directive("locationFilter", function() {

--- a/custom/icds_reports/static/js/directives/medicine-kit/medicine-kit.directive.js
+++ b/custom/icds_reports/static/js/directives/medicine-kit/medicine-kit.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function MedicineKitController($scope, $routeParams, $location, $filter, infrastructureService, locationsService,
+function MedicineKitController($scope, $routeParams, $location, $filter, $uibModalStack, infrastructureService, locationsService,
     userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "AWCs Reported Medicine Kit";
@@ -69,7 +69,7 @@ function MedicineKitController($scope, $routeParams, $location, $filter, infrast
     };
 }
 
-MedicineKitController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+MedicineKitController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'infrastructureService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('medicineKit', function() {
     return {

--- a/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
+++ b/custom/icds_reports/static/js/directives/newborn_with_low_weight/newborn_with_low_weight.directive.js
@@ -1,9 +1,9 @@
 /* global d3, _ */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function NewbornWithLowBirthController($scope, $routeParams, $location, $filter, maternalChildService,
+function NewbornWithLowBirthController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, genders, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     var genderIndex = _.findIndex(genders, function (x) {
@@ -131,7 +131,7 @@ function NewbornWithLowBirthController($scope, $routeParams, $location, $filter,
     };
 }
 
-NewbornWithLowBirthController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
+NewbornWithLowBirthController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('newbornLowWeight', function() {
     return {

--- a/custom/icds_reports/static/js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js
+++ b/custom/icds_reports/static/js/directives/prevalence-of-severe-report/prevalence-of-severe-report.directive.js
@@ -2,11 +2,13 @@
 
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function PrevalenceOfSevereReportController($scope, $routeParams, $location, $filter, maternalChildService,
+function PrevalenceOfSevereReportController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, genders, ages, haveAccessToAllLocations,
     baseControllersService, haveAccessToFeatures) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations, haveAccessToFeatures);
+
     var vm = this;
     var ageIndex = _.findIndex(ages,function (x) {
         return x.id === vm.filtersData.age;
@@ -217,7 +219,7 @@ function PrevalenceOfSevereReportController($scope, $routeParams, $location, $fi
     };
 }
 
-PrevalenceOfSevereReportController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService', 'haveAccessToFeatures'];
+PrevalenceOfSevereReportController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService', 'haveAccessToFeatures'];
 
 window.angular.module('icdsApp').directive('prevalenceOfSevere', function () {
     return {

--- a/custom/icds_reports/static/js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js
+++ b/custom/icds_reports/static/js/directives/prevalence-of-stunting-report/prevalence-of-stunting-report.directive.js
@@ -2,10 +2,10 @@
 
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function PrevalenceOfStuntingReportController($scope, $routeParams, $location, $filter, maternalChildService,
+function PrevalenceOfStuntingReportController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService,  genders, ages, haveAccessToAllLocations,
     baseControllersService, haveAccessToFeatures) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations, haveAccessToFeatures);
     var vm = this;
 
@@ -165,7 +165,7 @@ function PrevalenceOfStuntingReportController($scope, $routeParams, $location, $
     };
 }
 
-PrevalenceOfStuntingReportController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService', 'haveAccessToFeatures'];
+PrevalenceOfStuntingReportController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService', 'haveAccessToFeatures'];
 
 window.angular.module('icdsApp').directive('prevalenceOfStunting', function() {
     return {

--- a/custom/icds_reports/static/js/directives/progress-report/progress-report.directive.js
+++ b/custom/icds_reports/static/js/directives/progress-report/progress-report.directive.js
@@ -3,7 +3,9 @@
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
 function ProgressReportController($scope, $location, progressReportService,
-    storageService, $routeParams, userLocationId, DTOptionsBuilder, DTColumnDefBuilder, haveAccessToAllLocations) {
+    storageService, $routeParams, $uibModalStack, userLocationId, DTOptionsBuilder, DTColumnDefBuilder, haveAccessToAllLocations) {
+
+    $uibModalStack.dismissAll();
 
     var vm = this;
     if (Object.keys($location.search()).length === 0) {
@@ -168,7 +170,7 @@ function ProgressReportController($scope, $location, progressReportService,
 }
 
 ProgressReportController.$inject = [
-    '$scope', '$location', 'progressReportService', 'storageService', '$routeParams', 'userLocationId', 'DTOptionsBuilder', 'DTColumnDefBuilder', 'haveAccessToAllLocations',
+    '$scope', '$location', 'progressReportService', 'storageService', '$routeParams', '$uibModalStack', 'userLocationId', 'DTOptionsBuilder', 'DTColumnDefBuilder', 'haveAccessToAllLocations',
 ];
 
 window.angular.module('icdsApp').directive('progressReport', function() {

--- a/custom/icds_reports/static/js/directives/registered-household/registered-household.directive.js
+++ b/custom/icds_reports/static/js/directives/registered-household/registered-household.directive.js
@@ -1,9 +1,9 @@
 /* global d3 */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function RegisteredHouseholdController($scope, $routeParams, $location, $filter, demographicsService,
+function RegisteredHouseholdController($scope, $routeParams, $location, $filter, $uibModalStack, demographicsService,
     locationsService, userLocationId, storageService, haveAccessToAllLocations, baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
     vm.label = "Registered Household";
@@ -73,7 +73,7 @@ function RegisteredHouseholdController($scope, $routeParams, $location, $filter,
     };
 }
 
-RegisteredHouseholdController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
+RegisteredHouseholdController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'demographicsService', 'locationsService', 'userLocationId', 'storageService', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('registeredHousehold', function() {
     return {

--- a/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
+++ b/custom/icds_reports/static/js/directives/service-delivery-dashboard/service-delivery-dashboard.directive.js
@@ -1,7 +1,10 @@
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function ServiceDeliveryDashboardController($scope, $http, $location, $routeParams, $log, DTOptionsBuilder, DTColumnBuilder, $compile, storageService, userLocationId, haveAccessToAllLocations) {
+function ServiceDeliveryDashboardController($scope, $http, $location, $routeParams, $log, $uibModalStack, DTOptionsBuilder, DTColumnBuilder, $compile, storageService, userLocationId, haveAccessToAllLocations) {
     var vm = this;
+
+    $uibModalStack.dismissAll();
+
     vm.data = {};
     vm.label = "Service Delivery Dashboard";
     vm.tooltipPlacement = "right";
@@ -248,7 +251,7 @@ function ServiceDeliveryDashboardController($scope, $http, $location, $routePara
     vm.getData();
 }
 
-ServiceDeliveryDashboardController.$inject = ['$scope', '$http', '$location', '$routeParams', '$log', 'DTOptionsBuilder', 'DTColumnBuilder', '$compile', 'storageService', 'userLocationId', 'haveAccessToAllLocations'];
+ServiceDeliveryDashboardController.$inject = ['$scope', '$http', '$location', '$routeParams', '$log', '$uibModalStack', 'DTOptionsBuilder', 'DTColumnBuilder', '$compile', 'storageService', 'userLocationId', 'haveAccessToAllLocations'];
 
 window.angular.module('icdsApp').directive('serviceDeliveryDashboard', function () {
     return {

--- a/custom/icds_reports/static/js/directives/system-usage/system-usage.directive.js
+++ b/custom/icds_reports/static/js/directives/system-usage/system-usage.directive.js
@@ -2,8 +2,11 @@
 
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function SystemUsageController($scope, $http, $log, $routeParams, $location, storageService, userLocationId, haveAccessToAllLocations) {
+function SystemUsageController($scope, $http, $log, $routeParams, $location, $uibModalStack, storageService, userLocationId, haveAccessToAllLocations) {
     var vm = this;
+
+    $uibModalStack.dismissAll();
+
     vm.data = {};
     vm.label = "Program Summary";
     vm.filters = ['gender', 'age', 'ageServiceDeliveryDashboard'];
@@ -125,7 +128,7 @@ function SystemUsageController($scope, $http, $log, $routeParams, $location, sto
     vm.getDataForStep(vm.step);
 }
 
-SystemUsageController.$inject = ['$scope', '$http', '$log', '$routeParams', '$location', 'storageService', 'userLocationId', 'haveAccessToAllLocations'];
+SystemUsageController.$inject = ['$scope', '$http', '$log', '$routeParams', '$location', '$uibModalStack', 'storageService', 'userLocationId', 'haveAccessToAllLocations'];
 
 window.angular.module('icdsApp').directive('systemUsage', function() {
     return {

--- a/custom/icds_reports/static/js/directives/underweight-children-report/underweight-children-report.directive.js
+++ b/custom/icds_reports/static/js/directives/underweight-children-report/underweight-children-report.directive.js
@@ -1,10 +1,10 @@
 /* global d3, _ */
 var url = hqImport('hqwebapp/js/initial_page_data').reverse;
 
-function UnderweightChildrenReportController($scope, $routeParams, $location, $filter, maternalChildService,
+function UnderweightChildrenReportController($scope, $routeParams, $location, $filter, $uibModalStack, maternalChildService,
     locationsService, userLocationId, storageService, genders, ages, haveAccessToAllLocations,
     baseControllersService) {
-    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, locationsService,
+    baseControllersService.BaseController.call(this, $scope, $routeParams, $location, $uibModalStack, locationsService,
         userLocationId, storageService, haveAccessToAllLocations);
     var vm = this;
 
@@ -153,7 +153,7 @@ function UnderweightChildrenReportController($scope, $routeParams, $location, $f
     };
 }
 
-UnderweightChildrenReportController.$inject = ['$scope', '$routeParams', '$location', '$filter', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService'];
+UnderweightChildrenReportController.$inject = ['$scope', '$routeParams', '$location', '$filter', '$uibModalStack', 'maternalChildService', 'locationsService', 'userLocationId', 'storageService', 'genders', 'ages', 'haveAccessToAllLocations', 'baseControllersService'];
 
 window.angular.module('icdsApp').directive('underweightChildrenReport', function() {
     return {

--- a/custom/icds_reports/templates/icds_reports/icds_app/location_filter.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/location_filter.html
@@ -1,6 +1,6 @@
 <script type="text/ng-template" id="locationModalContent.html">
     <div class="modal-header">
-        <h3 class="modal-title" id="modal-title">Select Location <i ng-show="!$ctrl.isAwcReport()" style="float: right;" ng-click="$ctrl.close()" class="fa fa-close pointer"></i></h3>
+        <h3 class="modal-title" id="modal-title">Select Location <i ng-show="!$ctrl.isAwcReport() && !$ctrl.isLSReport()" style="float: right;" ng-click="$ctrl.close()" class="fa fa-close pointer"></i></h3>
     </div>
     <div class="modal-body" id="modal-body" cg-busy="[$ctrl.myPromise, $rootScope.locationPromise]">
         <div class="alert alert-info" ng-show="$ctrl.showMessage">


### PR DESCRIPTION
Hi @calellowitz @Rohit25negi 

I updated the implementation of the modal in the Dashboard, so now in AWC Report and LS Report we can't close the modal by 'X' or when user will click outside the modal. Also, I found a solution to make the left menu active when modal is open.

Need QA: no
Environment: ICDS
Locally tested: yes

Regards,
Łukasz