### PR TITLE
update text on feature previews page

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/feature_previews.html
+++ b/corehq/apps/domain/templates/domain/admin/feature_previews.html
@@ -3,37 +3,114 @@
 {% load hq_shared_tags %}
 
 {% block page_content %}
+  <p class="lead">
+    {% trans "Feature Previews" %}
+  </p>
   <div class="row">
-    <div class="col-sm-6">
-      <p>
+    <div class="col-md-6">
+      <p class="help-block">
+        <strong>
+          {% trans "What are Feature Previews?" %}
+        </strong>
+        <br/>
         {% blocktrans %}
-          Feature Preview lets you turn on features that we are still actively developing and are not quite ready yet.
-          Please only enable a feature if you are sure that you need it in your project and that you understand how to use it.
-          Preview features will often require more technical expertise than usual.
+          Before we invest in making certain product features generally
+          available, we release them as Feature Previews to learn the
+          following two things from usage data and qualitative feedback.
         {% endblocktrans %}
       </p>
-      <p>
+      <ul>
+        <li>
+          <p class="help-block">
+            {% blocktrans %}
+              Perceived Value: The biggest risk in product development is to
+              build something that offers little value to our users. As such,
+              we make Feature Previews generally available only if they have
+              high perceived value.
+            {% endblocktrans %}
+          </p>
+        </li>
+        <li>
+          <p class="help-block">
+            {% blocktrans %}
+              User Experience: Even if a feature has high perceived value,
+              it is important that the user experience of the feature is
+              optimized such that our users actually receive the value. As such,
+              we make high value Feature Previews generally available after we
+              optimize the user experience.
+            {% endblocktrans %}
+          </p>
+        </li>
+      </ul>
+      <p class="help-block">
         {% blocktrans %}
-          We would love to get your feedback as we continue to develop these features!
-          Please let us know how it goes by reporting any problems through the "Report an Issue" button,
-          which you can find under the question mark in the navigation bar.
+          We encourage you to use Feature Previews and provide us feedback,
+          however please note that:
+        {% endblocktrans %}
+      </p>
+      <ul>
+        <li>
+          <p class="help-block">
+            {% blocktrans %}
+              Feature Previews may not be optimized for performance
+            {% endblocktrans %}
+          </p>
+        </li>
+        <li>
+          <p class="help-block">
+            {% blocktrans %}
+              Our Support
+              <a href="https://confluence.dimagi.com/display/commcarepublic/Dimagi+Support+and+Service+Level+Agreement+%28SLA%29+FAQ"
+                 target="_blank">Service Level Agreement</a>
+              does not apply to Feature Previews
+            {% endblocktrans %}
+          </p>
+        </li>
+        <li>
+          <p class="help-block">
+            {% blocktrans %}
+              Feature Previews may change at any time without notice
+            {% endblocktrans %}
+          </p>
+        </li>
+        <li>
+          <p class="help-block">
+            {% blocktrans %}
+              Feature Previews are not subject to any warranties on current
+              and future availability.
+            {% endblocktrans %}
+          </p>
+        </li>
+      </ul>
+      <p class="help-block">
+        {% blocktrans %}
+          We recommend that you do not use Feature Previews for business
+          critical workflows. Please refer to our
+          <a href="http://www.dimagi.com/terms/latest/tos/"
+             target="_blank">terms</a> to
+          learn more.
         {% endblocktrans %}
       </p>
       <div class="alert alert-info">
-        {% blocktrans %}
-          Looking for something that used to be here?
-          <br><br>
-          The feature flags
-          <strong>Conditional ID Mapping in Case List</strong>,
-          <strong>Custom Calculations in Case List</strong>,
-          <strong>Custom Single and Multiple Answer Questions</strong>, and
-          <strong>Icons in Case List</strong> are now add-ons for individual apps. To turn them on,
-          go to the application's settings and choose the <strong>Add-Ons</strong> tab.
-        {% endblocktrans %}
+        <p>
+          {% blocktrans %}
+            Looking for something that used to be here?
+          {% endblocktrans %}
+        </p>
+        <p>
+          {% blocktrans %}
+            The feature flags <strong>Control Mapping in Case List</strong>,
+            <strong>Custom Calculations in Case List</strong>, <strong>Custom
+            Single and Multiple Answer Questions</strong>, and <strong>Icons in
+            Case List</strong> are now add-ons for individual apps. To turn
+            them on, go to the application's settings and choose the
+            <strong>Add-Ons</strong> tab.
+          {% endblocktrans %}
+        </p>
       </div>
-      <br/>
     </div>
   </div>
+
   <div class="row">
     <div class="col-sm-10">
       <form action="" method="post">


### PR DESCRIPTION
Just a quick update to the copy (not any changes yet to the feature preview functionality) for the feature previews page.

<img width="1546" alt="Screen Shot 2019-07-01 at 2 38 36 PM" src="https://user-images.githubusercontent.com/716573/60437332-689b6380-9c0e-11e9-9ba8-c74108cd822f.png">
