### PR TITLE
create targeted ccz if build has commcare flavor set

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4143,6 +4143,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
 
     use_j2me_endpoint = BooleanProperty(default=False)
 
+    # use commcare_flavor to avoid checking for none
     target_commcare_flavor = StringProperty(
         default='none',
         choices=['none', TARGET_COMMCARE, TARGET_COMMCARE_LTS]
@@ -4600,6 +4601,10 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         del self.linked_app_logo_refs
         del self.linked_app_attrs
         del self.uses_master_app_form_ids
+
+    @property
+    def commcare_flavor(self):
+        return None if self.target_commcare_flavor == "none" else self.target_commcare_flavor
 
 
 def validate_lang(lang):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4143,7 +4143,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
 
     use_j2me_endpoint = BooleanProperty(default=False)
 
-    # use commcare_flavor to avoid checking for none
     target_commcare_flavor = StringProperty(
         default='none',
         choices=['none', TARGET_COMMCARE, TARGET_COMMCARE_LTS]
@@ -4603,8 +4602,8 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         del self.uses_master_app_form_ids
 
     @property
-    def commcare_flavor(self):
-        return None if self.target_commcare_flavor == "none" else self.target_commcare_flavor
+    def has_commcare_flavor(self):
+        return self.target_commcare_flavor != "none"
 
 
 def validate_lang(lang):

--- a/custom/icds/tasks/hosted_ccz.py
+++ b/custom/icds/tasks/hosted_ccz.py
@@ -25,7 +25,8 @@ def setup_ccz_file_for_hosting(hosted_ccz_id):
         # profile_id should be None and not any other false value
         profile_id = hosted_ccz.profile_id or None
         build = wrap_app(get_build_doc_by_version(hosted_ccz.domain, hosted_ccz.app_id, version))
-        ccz_file = create_files_for_ccz(build, profile_id)
+        download_targeted_version = bool(build.commcare_flavor)
+        ccz_file = create_files_for_ccz(build, profile_id, download_targeted_version=download_targeted_version)
         try:
             with open(ccz_file, 'rb') as ccz:
                 ccz_utility.store_file_in_blobdb(ccz, name=hosted_ccz.file_name)

--- a/custom/icds/tasks/hosted_ccz.py
+++ b/custom/icds/tasks/hosted_ccz.py
@@ -25,8 +25,7 @@ def setup_ccz_file_for_hosting(hosted_ccz_id):
         # profile_id should be None and not any other false value
         profile_id = hosted_ccz.profile_id or None
         build = wrap_app(get_build_doc_by_version(hosted_ccz.domain, hosted_ccz.app_id, version))
-        download_targeted_version = bool(build.commcare_flavor)
-        ccz_file = create_files_for_ccz(build, profile_id, download_targeted_version=download_targeted_version)
+        ccz_file = create_files_for_ccz(build, profile_id, download_targeted_version=build.has_commcare_flavor)
         try:
             with open(ccz_file, 'rb') as ccz:
                 ccz_utility.store_file_in_blobdb(ccz, name=hosted_ccz.file_name)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-677

the logic of checking for "none" is distributed over the code base so i added `commcare_flavor` and used that instead of checking for "none" here as well
If it's an okay change should i try and modify all uses of `target_commcare_flavor` to `commcare_flavor` so only one thing is used? or just replace `target_commcare_favor` == 'None` checks?

FF: `TARGET_COMMCARE_FLAVOR`
fyi @esoergel 