### PR TITLE
Make conditionally_location_safe importer appear

### DIFF
--- a/corehq/apps/case_importer/base.py
+++ b/corehq/apps/case_importer/base.py
@@ -14,7 +14,7 @@ from corehq.toggles import LOCATION_SAFE_CASE_IMPORTS
 
 
 def location_safe_case_imports_enabled(view_func, request, *args, **kwargs):
-    return LOCATION_SAFE_CASE_IMPORTS.enabled_for_request(request)
+    return LOCATION_SAFE_CASE_IMPORTS.enabled(kwargs['domain'])
 
 
 @conditionally_location_safe(location_safe_case_imports_enabled)

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -188,6 +188,7 @@ def conditionally_location_safe(conditional_function):
     safe based on the arguments or kwarguments. That function should return
     True or False.
 
+    Note - for the page to show up in the menus, the function should not rely on `request`.
     """
     def _inner(view_fn):
         if isinstance(view_fn, type):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/PF-389
Feature flag: "Allow location-restricted users to import cases owned at their location or below"

This makes the link to the case importer appear for location-restricted users on domains with the feature flag `LOCATION_SAFE_CASE_IMPORTS` enabled.

When uitabs checks if a URL is location safe, it does not pass `request` to the conditional function (since request params will vary).  This only needed access to domain, which is already available in `kwargs`, so a switch to that makes it work.