### PR TITLE
Don't trigger a reorder when changing module settings

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -296,11 +296,14 @@ hqDefine('app_manager/js/app_manager', function () {
         function initChildModuleUpdateListener() {
             // If a child module is created or removed, update the sidebar
             $('#module-settings-form').on('saved-app-manager-form', function () {
-                var $form = $(this),
-                    modulesByUid = getModulesByUid(),
-                    module = modulesByUid[$form.data('moduleuid')],
+                var $parentModuleSelector = $(this).find('select[name=root_module_id]');
+                if ($parentModuleSelector.length === 0) {
+                    return;
+                }
+                var modulesByUid = getModulesByUid(),
+                    module = modulesByUid[$(this).data('moduleuid')],
                     oldRoot = $(module).data('rootmoduleuid') || null,
-                    newRoot = $form.find('select[name=root_module_id]').val() || null;
+                    newRoot = $parentModuleSelector.val() || null;
 
                 if (newRoot !== oldRoot) {
                     $(module).data('rootmoduleuid', newRoot);

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -299,8 +299,8 @@ hqDefine('app_manager/js/app_manager', function () {
                 var $form = $(this),
                     modulesByUid = getModulesByUid(),
                     module = modulesByUid[$form.data('moduleuid')],
-                    oldRoot = $(module).data('rootmoduleuid'),
-                    newRoot = $form.find('select[name=root_module_id]').val();
+                    oldRoot = $(module).data('rootmoduleuid') || null,
+                    newRoot = $form.find('select[name=root_module_id]').val() || null;
 
                 if (newRoot !== oldRoot) {
                     $(module).data('rootmoduleuid', newRoot);


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-716

This happened only with a particular combination of feature flags and addons.  In particular, `BASIC_CHILD_MODULE` had to be disabled.  At any rate, the issue was that `oldRoot` was `""` and `newRoot` was `undefined`, since the the select parent widget was only available for advanced modules.  Since `"" !=== undefined`, this incorrectly triggered a reorder.

@orangejenny @biyeun @nickpell 