### PR TITLE
Remove partitioned query that uses iterator

### DIFF
--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -22,7 +22,7 @@ from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors, FormAc
 from corehq.form_processor.models import LedgerTransaction
 from corehq.form_processor.tests.utils import use_sql_backend
 from corehq.form_processor.utils.general import should_use_sql_backend
-from corehq.sql_db.util import run_query_across_partitioned_databases
+from corehq.sql_db.util import paginate_query_across_partitioned_databases
 from dimagi.utils.parsing import json_format_datetime, json_format_date
 from casexml.apps.stock import const as stockconst
 from casexml.apps.stock.models import StockReport, StockTransaction
@@ -265,7 +265,7 @@ class CommTrackSubmissionTest(XMLTest):
             self.assertEqual(expected_qty, latest_trans.quantity)
 
     def _get_all_ledger_transactions(self, q_):
-        return list(run_query_across_partitioned_databases(LedgerTransaction, q_))
+        return list(paginate_query_across_partitioned_databases(LedgerTransaction, q_))
 
 
 class CommTrackBalanceTransferTest(CommTrackSubmissionTest):

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -503,7 +503,7 @@ class AutomaticUpdateRule(models.Model):
             for c_id in CommCareCaseSQL.objects.using(db).filter(q_expression).values_list('case_id', flat=True):
                 yield c_id
         else:
-            for pk, c_id in paginate_query_across_partitioned_databases(
+            for c_id in paginate_query_across_partitioned_databases(
                     CommCareCaseSQL, q_expression, values=['case_id']):
                 yield c_id
 

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -505,7 +505,7 @@ class AutomaticUpdateRule(models.Model):
         else:
             for c_id in paginate_query_across_partitioned_databases(
                     CommCareCaseSQL, q_expression, values=['case_id']):
-                yield c_id
+                yield c_id[0]
 
     @classmethod
     def _get_case_ids_from_es(cls, domain, case_type, boundary_date=None):

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -45,7 +45,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import (
     get_case_timed_schedule_instances_for_schedule_id,
 )
 from corehq.messaging.scheduling.scheduling_partitioned.models import CaseScheduleInstanceMixin
-from corehq.sql_db.util import run_query_across_partitioned_databases, get_db_aliases_for_partitioned_query
+from corehq.sql_db.util import paginate_query_across_partitioned_databases, get_db_aliases_for_partitioned_query
 from corehq.util.log import with_progress_bar
 from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
@@ -503,7 +503,8 @@ class AutomaticUpdateRule(models.Model):
             for c_id in CommCareCaseSQL.objects.using(db).filter(q_expression).values_list('case_id', flat=True):
                 yield c_id
         else:
-            for c_id in run_query_across_partitioned_databases(CommCareCaseSQL, q_expression, values=['case_id']):
+            for pk, c_id in paginate_query_across_partitioned_databases(
+                    CommCareCaseSQL, q_expression, values=['case_id']):
                 yield c_id
 
     @classmethod

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -40,7 +40,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
 from corehq.messaging.scheduling.tasks import handle_case_timed_schedule_instance
 from corehq.messaging.scheduling.tests.util import delete_alert_schedules, delete_timed_schedules
 from corehq.messaging.tasks import run_messaging_rule, sync_case_for_messaging_rule
-from corehq.sql_db.util import run_query_across_partitioned_databases
+from corehq.sql_db.util import paginate_query_across_partitioned_databases
 from datetime import datetime, date, time
 from django.db.models import Q
 from django.test import TestCase
@@ -96,10 +96,12 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
         for rule in AutomaticUpdateRule.objects.filter(domain=self.domain):
             rule.hard_delete()
 
-        for instance in run_query_across_partitioned_databases(CaseAlertScheduleInstance, Q(domain=self.domain)):
+        for instance in paginate_query_across_partitioned_databases(
+                CaseAlertScheduleInstance, Q(domain=self.domain)):
             delete_case_schedule_instance(instance)
 
-        for instance in run_query_across_partitioned_databases(CaseTimedScheduleInstance, Q(domain=self.domain)):
+        for instance in paginate_query_across_partitioned_databases(
+                CaseTimedScheduleInstance, Q(domain=self.domain)):
             delete_case_schedule_instance(instance)
 
         delete_alert_schedules(self.domain)

--- a/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
+++ b/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         startdate = options.get('start')
         enddate = options.get('end')
         print("Fetching all form ids...", file=sys.stderr)
-        all_ids = list(iter_form_ids_by_last_modified(startdate, enddate))
+        all_ids = list(form[0] for form in iter_form_ids_by_last_modified(startdate, enddate))
         print("Woo! Done fetching. Here we go", file=sys.stderr)
         for doc_ids in chunked(all_ids, 100):
             es_ids = (FormES()

--- a/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
+++ b/corehq/apps/data_pipeline_audit/management/commands/find_sql_forms_not_in_es.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         startdate = options.get('start')
         enddate = options.get('end')
         print("Fetching all form ids...", file=sys.stderr)
-        all_ids = [form_id for pk, form_id in iter_form_ids_by_last_modified(startdate, enddate)]
+        all_ids = list(iter_form_ids_by_last_modified(startdate, enddate))
         print("Woo! Done fetching. Here we go", file=sys.stderr)
         for doc_ids in chunked(all_ids, 100):
             es_ids = (FormES()

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -420,7 +420,7 @@ class FormAccessorSQL(AbstractFormAccessor):
 
         for form_id in paginate_query_across_partitioned_databases(
                 XFormInstanceSQL, q_expr, values=['form_id']):
-            yield form_id
+            yield form_id[0]
 
     @staticmethod
     def get_with_attachments(form_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -418,7 +418,7 @@ class FormAccessorSQL(AbstractFormAccessor):
         if xmlns:
             q_expr &= Q(xmlns=xmlns)
 
-        for pk, form_id in paginate_query_across_partitioned_databases(
+        for form_id in paginate_query_across_partitioned_databases(
                 XFormInstanceSQL, q_expr, values=['form_id']):
             yield form_id
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -412,13 +412,13 @@ class FormAccessorSQL(AbstractFormAccessor):
 
     @staticmethod
     def iter_form_ids_by_xmlns(domain, xmlns=None):
-        from corehq.sql_db.util import run_query_across_partitioned_databases
+        from corehq.sql_db.util import paginate_query_across_partitioned_databases
 
         q_expr = Q(domain=domain) & Q(state=XFormInstanceSQL.NORMAL)
         if xmlns:
             q_expr &= Q(xmlns=xmlns)
 
-        for form_id in run_query_across_partitioned_databases(
+        for pk, form_id in paginate_query_across_partitioned_databases(
                 XFormInstanceSQL, q_expr, values=['form_id']):
             yield form_id
 

--- a/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from corehq.sql_db.util import (
+    paginate_query_across_partitioned_databases,
     run_query_across_partitioned_databases,
     get_db_aliases_for_partitioned_query,
 )
@@ -148,7 +149,7 @@ def get_alert_schedule_instances_for_schedule(schedule):
     from corehq.messaging.scheduling.scheduling_partitioned.models import AlertScheduleInstance
 
     _validate_class(schedule, AlertSchedule)
-    return run_query_across_partitioned_databases(
+    return paginate_query_across_partitioned_databases(
         AlertScheduleInstance,
         Q(alert_schedule_id=schedule.schedule_id)
     )
@@ -159,7 +160,7 @@ def get_timed_schedule_instances_for_schedule(schedule):
     from corehq.messaging.scheduling.scheduling_partitioned.models import TimedScheduleInstance
 
     _validate_class(schedule, TimedSchedule)
-    return run_query_across_partitioned_databases(
+    return paginate_query_across_partitioned_databases(
         TimedScheduleInstance,
         Q(timed_schedule_id=schedule.schedule_id)
     )

--- a/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
@@ -108,7 +108,7 @@ def get_active_schedule_instance_ids(cls, due_before, due_after=None):
             raise ValueError("Expected due_before > due_after")
         active_filter = active_filter & Q(next_event_due__gt=due_after)
 
-    for pk, domain, schedule_instance_id, next_event_due in paginate_query_across_partitioned_databases(
+    for domain, schedule_instance_id, next_event_due in paginate_query_across_partitioned_databases(
         cls,
         active_filter,
         values=['domain', 'schedule_instance_id', 'next_event_due']
@@ -135,7 +135,7 @@ def get_active_case_schedule_instance_ids(cls, due_before, due_after=None):
             raise ValueError("Expected due_before > due_after")
         active_filter = active_filter & Q(next_event_due__gt=due_after)
 
-    for pk, domain, case_id, schedule_instance_id, next_event_due in paginate_query_across_partitioned_databases(
+    for domain, case_id, schedule_instance_id, next_event_due in paginate_query_across_partitioned_databases(
         cls,
         active_filter,
         values=['domain', 'case_id', 'schedule_instance_id', 'next_event_due']

--- a/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from corehq.sql_db.util import (
     paginate_query_across_partitioned_databases,
-    run_query_across_partitioned_databases,
     get_db_aliases_for_partitioned_query,
 )
 from django.db.models import Q
@@ -109,7 +108,7 @@ def get_active_schedule_instance_ids(cls, due_before, due_after=None):
             raise ValueError("Expected due_before > due_after")
         active_filter = active_filter & Q(next_event_due__gt=due_after)
 
-    for domain, schedule_instance_id, next_event_due in run_query_across_partitioned_databases(
+    for pk, domain, schedule_instance_id, next_event_due in paginate_query_across_partitioned_databases(
         cls,
         active_filter,
         values=['domain', 'schedule_instance_id', 'next_event_due']
@@ -136,7 +135,7 @@ def get_active_case_schedule_instance_ids(cls, due_before, due_after=None):
             raise ValueError("Expected due_before > due_after")
         active_filter = active_filter & Q(next_event_due__gt=due_after)
 
-    for domain, case_id, schedule_instance_id, next_event_due in run_query_across_partitioned_databases(
+    for pk, domain, case_id, schedule_instance_id, next_event_due in paginate_query_across_partitioned_databases(
         cls,
         active_filter,
         values=['domain', 'case_id', 'schedule_instance_id', 'next_event_due']

--- a/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_both.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_both.py
@@ -7,7 +7,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.models import (
     CaseTimedScheduleInstance,
 )
 from corehq.messaging.scheduling.tasks import delete_schedule_instances_for_cases
-from corehq.sql_db.util import run_query_across_partitioned_databases
+from corehq.sql_db.util import paginate_query_across_partitioned_databases
 from datetime import datetime, date
 from django.db.models import Q
 from django.test import TestCase
@@ -52,8 +52,8 @@ class SchedulingDBAccessorsTest(TestCase):
         self.addCleanup(instance.delete)
 
     def get_case_schedule_instances_for_domain(self, domain):
-        instances = list(run_query_across_partitioned_databases(CaseAlertScheduleInstance, Q(domain=domain)))
-        instances.extend(run_query_across_partitioned_databases(CaseTimedScheduleInstance, Q(domain=domain)))
+        instances = list(paginate_query_across_partitioned_databases(CaseAlertScheduleInstance, Q(domain=domain)))
+        instances.extend(paginate_query_across_partitioned_databases(CaseTimedScheduleInstance, Q(domain=domain)))
         return instances
 
     def test_delete_schedule_instances_for_cases(self):

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -33,7 +33,7 @@ from corehq.messaging.scheduling.scheduling_partitioned.dbaccessors import delet
 from corehq.messaging.scheduling.scheduling_partitioned.models import CaseTimedScheduleInstance
 from corehq.messaging.scheduling.tests.util import delete_timed_schedules
 from corehq.messaging.scheduling.view_helpers import get_conditional_alert_rows, upload_conditional_alert_workbook
-from corehq.sql_db.util import run_query_across_partitioned_databases
+from corehq.sql_db.util import paginate_query_across_partitioned_databases
 from corehq.util.workbook_json.excel import get_workbook
 from six.moves import range
 
@@ -139,7 +139,8 @@ class TestBulkConditionalAlerts(TestCase):
         for rule in AutomaticUpdateRule.objects.filter(domain=self.domain):
             rule.hard_delete()
 
-        for instance in run_query_across_partitioned_databases(CaseTimedScheduleInstance, Q(domain=self.domain)):
+        for instance in paginate_query_across_partitioned_databases(
+                CaseTimedScheduleInstance, Q(domain=self.domain)):
             delete_case_schedule_instance(instance)
 
         delete_timed_schedules(self.domain)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -93,8 +93,7 @@ def paginated_case_ids(domain, case_type):
         values=['case_id']
     )
     for row in row_generator:
-        # return value from case generator is ('<pk>', '<case_id>')
-        yield row[1]
+        yield row[0]
 
 
 def get_case_ids_for_messaging_rule(domain, case_type):

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -28,47 +28,6 @@ ACCEPTABLE_STANDBY_DELAY_SECONDS = 3
 STALE_CHECK_FREQUENCY = 30
 
 
-def run_query_across_partitioned_databases(model_class, q_expression, values=None, annotate=None):
-    """
-    Runs a query across all partitioned databases and produces a generator
-    with the results.
-
-    :param model_class: A Django model class
-
-    :param q_expression: An instance of django.db.models.Q representing the
-    filter to apply
-
-    :param values: (optional) If specified, should be a list of values to retrieve rather
-    than retrieving entire objects. If a list with a single value is given, the result will
-    be a generator of single values. If a list with multiple values is given, the result
-    will be a generator of tuples.
-
-    :param annotate: (optional) If specified, should by a dictionary of annotated fields
-    and their calculations. The dictionary will be splatted into the `.annotate` function
-
-    :return: A generator with the results
-    """
-    db_names = get_db_aliases_for_partitioned_query()
-
-    if values and not isinstance(values, (list, tuple)):
-        raise ValueError("Expected a list or tuple")
-
-    for db_name in db_names:
-        qs = model_class.objects.using(db_name)
-        if annotate:
-            qs = qs.annotate(**annotate)
-
-        qs = qs.filter(q_expression)
-        if values:
-            if len(values) == 1:
-                qs = qs.values_list(*values, flat=True)
-            else:
-                qs = qs.values_list(*values)
-
-        for result in qs.iterator():
-            yield result
-
-
 def paginate_query_across_partitioned_databases(model_class, q_expression, annotate=None, query_size=5000,
                                                 values=None):
     """

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -65,7 +65,7 @@ def paginate_query_across_partitioned_databases(model_class, q_expression, annot
         last_value = qs.order_by('-{}'.format(sort_col)).values_list(sort_col, flat=True).first()
         if last_value is not None:
             qs = qs.order_by(sort_col)
-            value = qs.order_by(sort_col).values_list(sort_col, flat=True).first()
+            value = qs.values_list(sort_col, flat=True).first()
             if return_values:
                 qs = qs.values_list(*return_values)
             while value < last_value:

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -62,10 +62,10 @@ def paginate_query_across_partitioned_databases(model_class, q_expression, annot
             qs = qs.annotate(**annotate)
 
         qs = qs.filter(q_expression)
-        value = 0
         last_value = qs.order_by('-{}'.format(sort_col)).values_list(sort_col, flat=True).first()
         if last_value is not None:
             qs = qs.order_by(sort_col)
+            value = qs.order_by(sort_col).values_list(sort_col, flat=True).first()
             if return_values:
                 qs = qs.values_list(*return_values)
             while value < last_value:

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -113,10 +113,7 @@ def paginate_query_across_partitioned_databases(model_class, q_expression, annot
             while value < last_value:
                 filter_expression = {'{}__gt'.format(sort_col): value}
                 for row in qs.filter(**filter_expression)[:query_size]:
-                    if return_values:
-                        value = row[0]
-                    else:
-                        value = row.pk
+                    value = row[0] if return_values else row.pk
                     yield row
 
 


### PR DESCRIPTION
Django's queryset `iterator` method returns the entire result set at once (though at least it does not cache it), because we use pgbouncer as a transaction pooler. More info here: https://docs.djangoproject.com/en/1.11/ref/models/querysets/#iterator

@snopoke I see in you weren't in favor of making this sort of pagination the default for all queries https://github.com/dimagi/commcare-hq/pull/21551/files/7adc73c2bf651b13f38bc64e78f5de4f74a52430#r210297660

>  I think there should be a separate path for queries that we know are going to return very large numbers.

I think by a result of this method only being used on the partitioned databases we are expecting them to return very large numbers (at least on ICDS). Do you think this is worthwhile now?