### PR TITLE
Removed advanced modules warning

### DIFF
--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -588,7 +588,6 @@ def _new_advanced_module(request, domain, app, name, lang):
     app.save()
     response = back_to_main(request, domain, app_id=app.id, module_id=module_id)
     response.set_cookie('suppress_build_errors', 'yes')
-    messages.info(request, _('Caution: Advanced modules are a labs feature'))
     return response
 
 


### PR DESCRIPTION
Tiny. This message is a relic of an earlier era - "labs feature" doesn't mean anything anymore (if it ever did).

Feature flag: advanced modules