### PR TITLE
Added except blocks for CaseError thrown when getting case properties

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -638,6 +638,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         logging.exception(e)
         form_errors.append("Unexpected error in form: %s" % e)
 
+    has_case_error = False
     if xform and xform.exists():
         if xform.already_has_meta():
             messages.warning(
@@ -681,6 +682,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
                 if not form_action_errors:
                     form.add_stuff_to_xform(xform)
             except CaseError as e:
+                has_case_error = True
                 messages.error(request, "Error in Case Management: %s" % e)
             except XFormException as e:
                 messages.error(request, six.text_type(e))
@@ -721,14 +723,24 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         valid_index_names.append(USERCASE_PREFIX[0:-1])     # strip trailing slash
 
     form_has_schedule = isinstance(form, AdvancedForm) and module.has_schedule
+
+    try:
+        case_properties_map = get_all_case_properties(app)
+        usercase_properties_map = get_usercase_properties(app)
+    except CaseError as e:
+        case_properties_map = {}
+        usercase_properties_map = {}
+        if not has_case_error:
+            messages.error(request, "Error in Case Management: %s" % e)
+
     case_config_options = {
         'caseType': form.get_case_type(),
         'moduleCaseTypes': module_case_types,
-        'propertiesMap': get_all_case_properties(app),
+        'propertiesMap': case_properties_map,
         'propertyDescriptions': get_case_property_description_dict(domain),
         'questions': xform_questions,
         'reserved_words': load_case_reserved_words(),
-        'usercasePropertiesMap': get_usercase_properties(app),
+        'usercasePropertiesMap': usercase_properties_map,
     }
     context = {
         'nav_form': form,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -25,6 +25,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import ParentCaseProper
 from corehq.apps.app_manager import add_ons
 from corehq.apps.app_manager.views.media_utils import process_media_attribute, \
     handle_media_edits
+from corehq.apps.app_manager.xform import CaseError
 from corehq.apps.case_search.models import case_search_enabled_for_domain
 from corehq.apps.domain.decorators import track_domain_request, LoginAndDomainMixin
 from corehq.apps.domain.models import Domain
@@ -97,7 +98,7 @@ def get_module_template(user, module):
         return "app_manager/module_view.html"
 
 
-def get_module_view_context(app, module, lang=None):
+def get_module_view_context(request, app, module, lang=None):
     # shared context
     context = {
         'edit_name_url': reverse('edit_module_attr', args=[app.domain, app.id, module.unique_id, 'name']),
@@ -118,12 +119,12 @@ def get_module_view_context(app, module, lang=None):
             'auto_select_case': module.auto_select_case,
             'has_schedule': module.has_schedule,
         })
-        context.update(_get_shared_module_view_context(app, module, case_property_builder, lang))
+        context.update(_get_shared_module_view_context(request, app, module, case_property_builder, lang))
         context.update(_get_advanced_module_view_context(app, module))
     elif isinstance(module, ReportModule):
         context.update(_get_report_module_context(app, module))
     else:
-        context.update(_get_shared_module_view_context(app, module, case_property_builder, lang))
+        context.update(_get_shared_module_view_context(request, app, module, case_property_builder, lang))
         context.update(_get_basic_module_view_context(app, module, case_property_builder))
     if isinstance(module, ShadowModule):
         context.update(_get_shadow_module_view_context(app, module, lang))
@@ -131,13 +132,13 @@ def get_module_view_context(app, module, lang=None):
     return context
 
 
-def _get_shared_module_view_context(app, module, case_property_builder, lang=None):
+def _get_shared_module_view_context(request, app, module, case_property_builder, lang=None):
     '''
     Get context items that are used by both basic and advanced modules.
     '''
     case_type = module.case_type
     context = {
-        'details': _get_module_details_context(app, module, case_property_builder, case_type),
+        'details': _get_module_details_context(request, app, module, case_property_builder, case_type),
         'case_list_form_options': _case_list_form_options(app, module, case_type, lang),
         'valid_parents_for_child_module': _get_valid_parents_for_child_module(app, module),
         'js_options': {
@@ -346,7 +347,7 @@ def _case_list_form_options(app, module, case_type_, lang=None):
     }
 
 
-def _get_module_details_context(app, module, case_property_builder, case_type_):
+def _get_module_details_context(request, app, module, case_property_builder, case_type_, messages=messages):
     subcase_types = list(app.get_subcase_types(module.case_type))
     item = {
         'label': gettext_lazy('Case List'),
@@ -358,10 +359,14 @@ def _get_module_details_context(app, module, case_property_builder, case_type_):
         'short': module.case_details.short,
         'long': module.case_details.long,
     }
-    case_properties = case_property_builder.get_properties(case_type_)
-    if is_usercase_in_use(app.domain) and case_type_ != USERCASE_TYPE:
-        usercase_properties = prefix_usercase_properties(case_property_builder.get_properties(USERCASE_TYPE))
-        case_properties |= usercase_properties
+    try:
+        case_properties = case_property_builder.get_properties(case_type_)
+        if is_usercase_in_use(app.domain) and case_type_ != USERCASE_TYPE:
+            usercase_properties = prefix_usercase_properties(case_property_builder.get_properties(USERCASE_TYPE))
+            case_properties |= usercase_properties
+    except CaseError as e:
+        case_properties = []
+        messages.error(request, "Error in Case Management: %s" % e)
 
     item['properties'] = sorted(case_properties)
     item['fixture_select'] = module.fixture_select

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -155,7 +155,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
         template = get_module_template(request.user, module)
         # make sure all modules have unique ids
         app.ensure_module_unique_ids(should_save=True)
-        module_context = get_module_view_context(app, module, lang)
+        module_context = get_module_view_context(request, app, module, lang)
         context.update(module_context)
     elif app:
         context.update(get_app_view_context(request, app))


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-715

The `CaseError` is already captured in the usual place it's thrown, in [form view](https://github.com/dimagi/commcare-hq/blob/8dccb4cb5f3114732e3386e9ed3ab144e99d31b0/corehq/apps/app_manager/views/forms.py#L683-L684) for the problematic form.

But it can also pop up when getting case properties in an app, because getting the case properties for a module that uses the visit scheduler [calls add_stuff_to_xform](https://github.com/dimagi/commcare-hq/blob/8dccb4cb5f3114732e3386e9ed3ab144e99d31b0/corehq/apps/app_manager/models.py#L2684).

Feature flag: visit scheduler