### PR TITLE
Manage lookup tables page: stop fetching tables twice

### DIFF
--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -393,7 +393,6 @@ hqDefine("fixtures/js/lookup-manage", [
     var el = $('#fixtures-ui');
     var app = appModel();
     el.koApplyBindings(app);
-    el.removeClass('hide');
     app.loadData();
     $('#fixture-upload').koApplyBindings(app);
     $("#fixture-download").on("hidden.bs.modal", function () {

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -15,13 +15,12 @@
   {% registerurl 'update_lookup_tables' domain %}
   <p>
     {% blocktrans %}
-      Lookup tables are used in applications to provide data that is not directly stored in the application and may change over time.  For example, you can use them for a list of villages that changes over the time of your project.  They also allow you to assign certain data (ex. villages) to certain users
-    {% endblocktrans %}
-  </p>
-  <p class="alert alert-info">
-    <i class="fa fa-info-circle"></i>
-    {% blocktrans %}
-      For more info see the <a href='https://confluence.dimagi.com/pages/viewpage.action?pageId=12222793' target='_blank'>Lookup Tables</a> help page
+      Lookup tables are used in applications to provide data that is not directly stored in the application and may change over time.
+      For example, you can use them for a list of villages that changes over the time of your project.
+      They also allow you to assign certain data (ex. villages) to certain users.
+      <br>
+      Read more about lookup tables on our
+      <a href='https://confluence.dimagi.com/pages/viewpage.action?pageId=12222793' target='_blank'>Help Site</a>.
     {% endblocktrans %}
   </p>
   <p class="alert fade in hide page-level-alert alert-danger" id="editFailure">
@@ -33,7 +32,7 @@
     </span>
   </p>
 
-  <div class="row" id="fixtures-ui">
+  <div class="row ko-template" id="fixtures-ui">
     <div class="col-sm-12">
       <p class="pull-right">
         <a href="#" class="btn btn-primary"
@@ -123,7 +122,7 @@
       </p>
     </div>
   </div>
-  <div class="row" id="fixture-upload">
+  <div class="row ko-template" id="fixture-upload">
     <div class="col-sm-12">
       <form class="form-horizontal"
             id="uploadForm"

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -9,9 +9,9 @@
 {% endblock %}
 
 {% block page_content %}
+  {% initial_page_data 'data_types' types %}
   {% registerurl 'download_fixtures' domain %}
   {% registerurl 'fixture_interface_dispatcher' domain 'view_lookup_tables' %}
-  {% registerurl 'fixture_data_types' domain %}
   {% registerurl 'update_lookup_tables' domain %}
   <p>
     {% blocktrans %}
@@ -50,7 +50,7 @@
           </th>
           <th class="col-sm-2">
             {% trans "View Table" %}
-            <i class="fa fa-share"></i>
+            <i class="fa fa-external-link"></i>
           </th>
           <th class="col-sm-3">
             {% trans "Edit or Delete Table" %}
@@ -143,7 +143,7 @@
               <div class="checkbox">
                 <label>
                   <input id="replace" type="checkbox" name="replace"/>
-                  {% trans "Replace Existing Tables" %}
+                  {% trans "Replace existing tables" %}
                 </label>
               </div>
             </div>

--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -6,7 +6,7 @@ from django.views.generic import RedirectView
 from corehq.apps.fixtures.dispatcher import FixtureInterfaceDispatcher
 from corehq.apps.fixtures.views import (
     UploadItemLists, FixtureUploadStatusView,
-    upload_fixture_api, fixture_metadata, tables, download_item_lists,
+    upload_fixture_api, fixture_metadata, download_item_lists,
     download_file, update_tables, fixture_upload_job_poll,
     fixture_api_upload_status,
 )
@@ -18,7 +18,6 @@ urlpatterns = [
     url(r'^metadata/$', fixture_metadata, name='fixture_metadata'),
     url(r'^$', RedirectView.as_view(url='edit_lookup_tables', permanent=True), name='edit_lookup_tables'),
     FixtureInterfaceDispatcher.url_pattern(),
-    url(r'^edit_lookup_tables/data-types/$', tables, name='fixture_data_types'),
     url(r'^edit_lookup_tables/download/$', download_item_lists, name="download_fixtures"),
     url(r'^edit_lookup_tables/upload/$', UploadItemLists.as_view(), name='upload_fixtures'),
     url(r'^edit_lookup_tables/file/$', download_file, name="download_fixture_file"),

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -96,15 +96,6 @@ def _to_kwargs(req):
 
 
 @require_can_edit_fixtures
-def tables(request, domain):
-    if request.method == 'GET':
-        return json_response(
-            [strip_json(x) for x in
-             sorted(FixtureDataType.by_domain(domain), key=lambda data_type: data_type.tag)]
-        )
-
-
-@require_can_edit_fixtures
 def update_tables(request, domain, data_type_id):
     """
     receives a JSON-update patch like following


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-690

- speeds up the page by loading lookup tables on initial page load instead of issuing a separate ajax call to fetch them
- prevents the page from showing a table header and partially-blank row while the page loads