### PR TITLE
Removed conditional alerts flag

### DIFF
--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -85,8 +85,7 @@ class BulkUploadForm(forms.Form):
                 *self.crispy_form_fields(context)
             ),
             StrictButton(
-                ('<i class="fa fa-cloud-upload"></i> Upload %s'
-                 % plural_noun.title()),
+                ('<i class="fa fa-cloud-upload"></i> Upload %s' % plural_noun),
                 css_class='btn-primary',
                 data_bind='disable: !file()',
                 onclick='this.disabled=true;this.form.submit();',

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bulk_upload.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bulk_upload.html
@@ -4,11 +4,11 @@
 
 {% if not no_header %}
   <h2>
-    {% blocktrans with verb=bulk_upload.verb|default:"Upload"|title %}
+    {% blocktrans with verb=bulk_upload.verb|default:"Upload" %}
       {{ verb }}
     {% endblocktrans %}
-    {% blocktrans with plural_noun=bulk_upload.plural_noun|title %}
-      {{ plural_noun }} Using Excel
+    {% blocktrans with plural_noun=bulk_upload.plural_noun %}
+      {{ plural_noun }} using Excel
     {% endblocktrans %}
   </h2>
 {% endif %}
@@ -34,7 +34,7 @@
           <a id="download_link" href="{{ bulk_upload.download_url }}" data-bind="attr: {href: url}">
             <button class="btn btn-primary">
               <i class="fa fa-cloud-download"></i>
-              {% blocktrans with plural_noun=bulk_upload.plural_noun|title %}
+              {% blocktrans with plural_noun=bulk_upload.plural_noun %}
                 Download {{ plural_noun }}
               {% endblocktrans %}
             </button>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -39,7 +39,7 @@
 
           <a href="{% url 'upload_conditional_alert' domain %}" class="btn btn-info">
             <i class="fa fa-cloud-upload"></i>
-            {% trans "Bulk Upload Conditional Alerts" %}
+            {% trans "Bulk Upload SMS Alert Content" %}
           </a>
         </div>
       </div>

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert_list.html
@@ -37,12 +37,10 @@
             {% trans "New Conditional Alert" %}
           </a>
 
-          {% if request|toggle_enabled:'BULK_CONDITIONAL_ALERTS' %}
-            <a href="{% url 'upload_conditional_alert' domain %}" class="btn btn-info">
-              <i class="fa fa-cloud-upload"></i>
-              {% trans "Bulk Upload Conditional Alerts" %}
-            </a>
-          {% endif %}
+          <a href="{% url 'upload_conditional_alert' domain %}" class="btn btn-info">
+            <i class="fa fa-cloud-upload"></i>
+            {% trans "Bulk Upload Conditional Alerts" %}
+          </a>
         </div>
       </div>
       <div class="col-sm-4 col-md-3">

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -1015,7 +1015,6 @@ class DownloadConditionalAlertView(ConditionalAlertBaseView):
     urlname = 'download_conditional_alert'
     http_method_names = ['get']
 
-    @method_decorator(toggles.BULK_CONDITIONAL_ALERTS.required_decorator())
     def dispatch(self, *args, **kwargs):
         return super(DownloadConditionalAlertView, self).dispatch(*args, **kwargs)
 
@@ -1038,7 +1037,6 @@ class UploadConditionalAlertView(BaseMessagingSectionView):
     page_title = ugettext_lazy("Upload Conditional Alerts")
     template_name = 'hqwebapp/bulk_upload.html'
 
-    @method_decorator(toggles.BULK_CONDITIONAL_ALERTS.required_decorator())
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))
     def dispatch(self, *args, **kwargs):
         return super(UploadConditionalAlertView, self).dispatch(*args, **kwargs)

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -1046,8 +1046,8 @@ class UploadConditionalAlertView(BaseMessagingSectionView):
         context = {
             'bulk_upload': {
                 "download_url": reverse("download_conditional_alert", args=(self.domain,)),
-                "adjective": _("conditional alert"),
-                "plural_noun": _("conditional alerts"),
+                "adjective": _("SMS alert content"),
+                "plural_noun": _("SMS alert content"),
                 "help_link": "https://confluence.dimagi.com/display/ccinternal/Allow+bulk+download+and+upload+of+conditional+alerts", # noqa
             },
         }

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -1048,7 +1048,7 @@ class UploadConditionalAlertView(BaseMessagingSectionView):
                 "download_url": reverse("download_conditional_alert", args=(self.domain,)),
                 "adjective": _("SMS alert content"),
                 "plural_noun": _("SMS alert content"),
-                "help_link": "https://confluence.dimagi.com/display/ccinternal/Allow+bulk+download+and+upload+of+conditional+alerts", # noqa
+                "help_link": "https://confluence.dimagi.com/display/commcarepublic/Bulk+download+and+upload+of+SMS+content+in+conditional+alerts", # noqa
             },
         }
         context.update({

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -1034,7 +1034,7 @@ class DownloadConditionalAlertView(ConditionalAlertBaseView):
 
 class UploadConditionalAlertView(BaseMessagingSectionView):
     urlname = 'upload_conditional_alert'
-    page_title = ugettext_lazy("Upload Conditional Alerts")
+    page_title = ugettext_lazy("Upload SMS Alert Content")
     template_name = 'hqwebapp/bulk_upload.html'
 
     @method_decorator(requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK))

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1119,14 +1119,6 @@ MESSAGE_LOG_METADATA = StaticToggle(
     [NAMESPACE_USER],
 )
 
-BULK_CONDITIONAL_ALERTS = StaticToggle(
-    'bulk_conditional_alerts',
-    'Allow bulk download and upload of conditional alerts',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/ccinternal/Allow+bulk+download+and+upload+of+conditional+alerts', # noqa
-)
-
 COPY_CONDITIONAL_ALERTS = StaticToggle(
     'copy_conditional_alerts',
     'Allow copying conditional alerts to another project (or within the same project).',


### PR DESCRIPTION
Request from @djmore9 

I changed the text from "upload conditional alerts" to "upload SMS alert content" since that's all you can update.

Marked don't merge because I still need to move the help page to public confluence and update the link to it.