### PR TITLE
replace assertions with exceptions

### DIFF
--- a/corehq/form_processor/backends/sql/update_strategy.py
+++ b/corehq/form_processor/backends/sql/update_strategy.py
@@ -29,7 +29,7 @@ from corehq.apps.couch_sql_migration.progress import (
     couch_sql_migration_in_progress,
 )
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.form_processor.exceptions import AttachmentNotFound
+from corehq.form_processor.exceptions import AttachmentNotFound, StockProcessingError
 from corehq.form_processor.models import (
     CaseAttachmentSQL,
     CaseTransaction,
@@ -77,10 +77,12 @@ class SqlCaseUpdateStrategy(UpdateStrategy):
     def apply_action_intents(self, primary_intent, deprecation_intent=None):
         # for now we only allow commtrack actions to be processed this way so just assert that's the case
         if primary_intent:
-            assert primary_intent.action_type == CASE_ACTION_COMMTRACK
+            if primary_intent.action_type != CASE_ACTION_COMMTRACK:
+                raise StockProcessingError('intent not of expected type: {}'.format(primary_intent.action_type))
             transaction = CaseTransaction.ledger_transaction(self.case, primary_intent.form)
             if deprecation_intent:
-                assert transaction.is_saved()
+                if not transaction.is_saved():
+                    raise StockProcessingError('Deprecated transaction not saved')
             elif transaction not in self.case.get_tracked_models_to_create(CaseTransaction):
                 # hack: clear the sync log id so this modification always counts
                 # since consumption data could change server-side

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -6,6 +6,10 @@ from couchdbkit import ResourceNotFound
 from django.core.exceptions import ObjectDoesNotExist
 
 
+class StockProcessingError(Exception):
+    pass
+
+
 class CaseNotFound(ResourceNotFound, ObjectDoesNotExist):
     pass
 


### PR DESCRIPTION
If assertion errors get caught and logged by 'notify_exception'
they do not contain a message. Since these are violations that
we expect to keep I decided to make them an exception rather than
just add a message to the assertion.