### PR TITLE
split EMWF saved report values against choice delimiter

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -12,6 +12,7 @@ from corehq.apps.es import users as user_es, filters
 from corehq.apps.domain.models import Domain
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.permissions import user_can_access_other_user
+from corehq.apps.userreports.reports.filters.values import CHOICE_DELIMITER
 from corehq.apps.users.cases import get_wrapped_owner
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.commtrack.models import SQLLocation
@@ -275,7 +276,9 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
     @property
     @memoized
     def selected(self):
-        selected_ids = self.request.GET.getlist(self.slug)
+        selected_ids = []
+        for ids in self.request.GET.getlist(self.slug):
+            selected_ids.extend(ids.split(CHOICE_DELIMITER))
         if not selected_ids:
             return [{'id': url_id, 'text': text}
                     for url_id, text in self.get_default_selections()]


### PR DESCRIPTION
so [this change](https://github.com/dimagi/commcare-hq/commit/8e086c1a752f84a1e87a83f7eac496273fbc54ab#diff-c185b3f356890af823a32078b0c7c0e9R255) was introduced presumably for UCR filters that flattened any list into a string separated by the `CHOICE_DELIMITER` during the saving of `ReportConfig`s. This affected the `ExpandedMobileWorkerFilter`, as it still expected a proper list to be passed into the `emwf` `GET` parameter. So if you saved a report with more than one value in the `EMWF` field, it would show up as blank when loading the report.

fixes [HI-731](https://dimagi-dev.atlassian.net/browse/HI-731)