### PR TITLE
 Removed password format check on build validation for non-J2ME apps

### DIFF
--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -11,7 +11,6 @@ import six
 from io import open
 
 from corehq.apps.app_manager.util import app_doc_types
-from corehq.apps.builds.models import CommCareBuildConfig
 from corehq.util.python_compatibility import soft_assert_type_text
 
 PROFILE_SETTINGS_TO_TRANSLATE = [
@@ -71,7 +70,7 @@ def _load_commcare_settings_layout(app):
         layout = yaml.safe_load(f)
 
     doc_type = app.get_doc_type()
-    j2me_enabled = app.build_spec.version in [i.build.version for i in CommCareBuildConfig.j2me_enabled_configs()]
+    j2me_section_ids = ['app-settings-j2me-properties', 'app-settings-j2me-ui']
     for section in layout:
         # i18n; not statically analyzable
         section['title'] = ugettext_noop(section['title'])
@@ -96,7 +95,7 @@ def _load_commcare_settings_layout(app):
                 if prop in setting:
                     setting[prop] = _translate_setting(setting, prop)
 
-        if not j2me_enabled and section['id'] in ['app-settings-j2me-properties', 'app-settings-j2me-ui']:
+        if not app.build_spec.supports_j2me() and section['id'] in j2me_section_ids:
             section['always_show'] = False
 
     if settings:

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -52,6 +52,7 @@ from corehq.apps.app_manager.util import (
 from corehq.apps.app_manager.xform import parse_xml as _parse_xml
 from corehq.apps.app_manager.xpath import interpolate_xpath, LocationXpath
 from corehq.apps.app_manager.xpath_validator import validate_xpath
+from corehq.apps.builds.models import CommCareBuildConfig
 from corehq.apps.domain.models import Domain
 
 
@@ -163,7 +164,10 @@ class ApplicationBaseValidator(object):
 
     def _check_password_charset(self):
         errors = []
-        if hasattr(self.app, 'profile'):
+        j2me_enabled = self.app.build_spec.version in [
+            i.build.version for i in CommCareBuildConfig.j2me_enabled_configs()
+        ]
+        if j2me_enabled and hasattr(self.app, 'profile'):
             password_format = self.app.profile.get('properties', {}).get('password_format', 'n')
             message = _(
                 'Your app requires {0} passwords but the admin password is not '

--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -52,7 +52,6 @@ from corehq.apps.app_manager.util import (
 from corehq.apps.app_manager.xform import parse_xml as _parse_xml
 from corehq.apps.app_manager.xpath import interpolate_xpath, LocationXpath
 from corehq.apps.app_manager.xpath_validator import validate_xpath
-from corehq.apps.builds.models import CommCareBuildConfig
 from corehq.apps.domain.models import Domain
 
 
@@ -164,10 +163,7 @@ class ApplicationBaseValidator(object):
 
     def _check_password_charset(self):
         errors = []
-        j2me_enabled = self.app.build_spec.version in [
-            i.build.version for i in CommCareBuildConfig.j2me_enabled_configs()
-        ]
-        if j2me_enabled and hasattr(self.app, 'profile'):
+        if self.app.build_spec.supports_j2me() and hasattr(self.app, 'profile'):
             password_format = self.app.profile.get('properties', {}).get('password_format', 'n')
             message = _(
                 'Your app requires {0} passwords but the admin password is not '

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -13,6 +13,7 @@ from io import open
 
 @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
 @patch('corehq.apps.app_manager.helpers.validators.domain_has_privilege', return_value=True)
+@patch('corehq.apps.builds.models.BuildSpec.supports_j2me', return_value=False)
 class BuildErrorsTest(SimpleTestCase):
 
     @staticmethod

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -70,6 +70,7 @@ class ModuleAsChildTestBase(TestXmlMixin):
 
     @patch('corehq.apps.app_manager.helpers.validators.domain_has_privilege', return_value=True)
     @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    @patch('corehq.apps.builds.models.BuildSpec.supports_j2me', return_value=False)
     def test_deleted_parent(self, *args):
         self.module_1.root_module_id = "unknownmodule"
 
@@ -81,6 +82,7 @@ class ModuleAsChildTestBase(TestXmlMixin):
 
     @patch('corehq.apps.app_manager.helpers.validators.domain_has_privilege', return_value=True)
     @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    @patch('corehq.apps.builds.models.BuildSpec.supports_j2me', return_value=False)
     def test_circular_relation(self, *args):
         self.module_0.root_module_id = self.module_1.unique_id
         cycle_error = {

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -77,7 +77,7 @@ class CommCareBuild(BlobMixin, Document):
             jad = self.fetch_file(path, "CommCare.jad")
         except ResourceNotFound:
             jad = None
-            
+
         return JadJar(
             jad=jad,
             jar=self.fetch_file(path, "CommCare.jar"),


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-736

Product: this fixes a rare issue where Android apps see an error when making a build that has to do with the admin password format, an app setting that's only relevant for J2ME apps.