### PR TITLE
Added form errors as messages when testing form is valid

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -433,6 +433,14 @@ class LocationFormSet(object):
     def is_valid(self):
         return all(form.is_valid() for form in self.forms)
 
+    @property
+    @memoized
+    def errors(self):
+        errors = {}
+        for form in self.forms:
+            errors.update(form.errors)
+        return errors
+
     def save(self):
         if not self.is_valid():
             raise ValueError('Form is not valid')

--- a/corehq/apps/locations/tests/test_change_has_user.py
+++ b/corehq/apps/locations/tests/test_change_has_user.py
@@ -64,7 +64,7 @@ class TestChangeHasUser(TestCase):
             request_user=MagicMock(),
             is_new=True,
         )
-        self.assertTrue(form.is_valid())
+        self.assertTrue(form.is_valid(), form.errors)
         form.save()
 
     @flaky


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/24769#pullrequestreview-259495170

Checking out 45810d82e14 makes the test fail. Output is now:
```
FAIL: corehq.apps.locations.tests.test_change_has_user:TestChangeHasUser.test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jschweers/.virtualenvs/hq/lib/python2.7/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/locations/tests/test_change_has_user.py", line 81, in test
    self.submit_form('Essex')
  File "/Users/jschweers/Documents/commcare-hq/corehq/apps/locations/tests/test_change_has_user.py", line 66, in submit_form
    self.assertTrue(form.is_valid(), form.errors)
AssertionError: {'new_password': [u'This field is required.']}
```