### PR TITLE
Query fact sheet on Same level which is requested

### DIFF
--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -813,6 +813,11 @@ class FactSheetsView(BaseReportView):
         }
 
         config.update(get_location_filter(location, domain))
+
+        # query database at same level for which it is requested
+        if config.get('aggregation_level') > 1:
+            config['aggregation_level'] -= 1
+
         loc_level = get_location_level(config.get('aggregation_level'))
 
         beta = icds_pre_release_features(request.user)


### PR DESCRIPTION
previously what was happening is if the when the report is fetched, the database is queried for a level below. i.e is state level is pulled then the database is queried at the level of the district. which was increasing the response time. This code change will allow to query the database at same level(expect National level).
https://dimagi-dev.atlassian.net/browse/ICDS-296