### PR TITLE
Fix html element sizes for child menu forms

### DIFF
--- a/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
@@ -234,11 +234,17 @@ nav.appmanager-content {
     }
   }
   // Form in child module
-  > .appnav-menu-nested > li > .appnav-item a.appnav-title {
-    margin-left: @nesting-indent;
-    margin-right: -@nesting-indent;
-    > .appnav-drag-icon {
-        right: @nesting-indent + @drag-icon-right;
+  > .appnav-menu-nested > li > .appnav-item {
+    > a.appnav-title {
+        margin-left: @nesting-indent;
+        margin-right: -@nesting-indent;
+        width: @appnav-width - @appnav-trash-width - @appnav-secondary-width - @nesting-indent;
+        > .appnav-drag-icon {
+            right: @drag-icon-right;
+        }
+    }
+    > .appnav-settings {
+        margin-left: @nesting-indent;
     }
   }
 }

--- a/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/navigation.less
@@ -236,15 +236,15 @@ nav.appmanager-content {
   // Form in child module
   > .appnav-menu-nested > li > .appnav-item {
     > a.appnav-title {
-        margin-left: @nesting-indent;
-        margin-right: -@nesting-indent;
-        width: @appnav-width - @appnav-trash-width - @appnav-secondary-width - @nesting-indent;
-        > .appnav-drag-icon {
-            right: @drag-icon-right;
-        }
+      margin-left: @nesting-indent;
+      margin-right: -@nesting-indent;
+      width: @appnav-width - @appnav-trash-width - @appnav-secondary-width - @nesting-indent;
+      > .appnav-drag-icon {
+        right: @drag-icon-right;
+      }
     }
     > .appnav-settings {
-        margin-left: @nesting-indent;
+      margin-left: @nesting-indent;
     }
   }
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-734

![image](https://user-images.githubusercontent.com/2367539/60919061-c5c49400-a262-11e9-95bc-7ba50a84359b.png)

This allows you to click directly on the :gear: rather than slightly to the right.
feature flag: submenus