### PR TITLE
Tag flaky tests

### DIFF
--- a/corehq/apps/api/odata/tests/test_metadata.py
+++ b/corehq/apps/api/odata/tests/test_metadata.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from django.test import TestCase
 from django.urls import reverse
 
+from flaky import flaky
 from mock import patch
 
 from corehq.apps.api.odata.tests.utils import (
@@ -147,6 +148,7 @@ class TestDeprecatedFormMetadataDocument(TestCase, DeprecatedFormOdataTestMixin,
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
+    @flaky
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
         with flag_enabled('ODATA'):

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from django.urls import reverse
 from django.utils.http import urlencode
 
+from flaky import flaky
+
 from corehq.apps.api.resources import v0_5
 from corehq.apps.groups.models import Group
 from corehq.apps.users.analytics import update_analytics_indexes
@@ -40,6 +42,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.assertEqual(len(api_users), 1)
         self.assertEqual(api_users[0]['id'], backend_id)
 
+    @flaky
     def test_get_single(self):
 
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****')


### PR DESCRIPTION
Tagging some flaky tests found in https://github.com/dimagi/commcare-hq/pull/24735

@nickpell one of these is Odata, so I think it was added fairly recently. Maybe you have still have some context that could help fix it more permanently?