### PR TITLE
handle TypeError

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3787,7 +3787,11 @@ class LazyBlobDoc(BlobMixin):
             # it has been fetched already during this request
             content = self._LAZY_ATTACHMENTS_CACHE[name]
         except KeyError:
-            content = cache.get(self.__attachment_cache_key(name))
+            try:
+                content = cache.get(self.__attachment_cache_key(name))
+            except TypeError:
+                # TODO - remove try/except sometime after Python 3 migration is complete
+                return None
             if content is not None:
                 if isinstance(content, six.text_type):
                     _soft_assert(False, 'cached attachment has type unicode')


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1106295022/

This error should stop once attachments stored in Python 2 are evicted from the cache.

@dimagi/py3 