### PR TITLE
don't use cached app attachments if is unicode

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3790,8 +3790,7 @@ class LazyBlobDoc(BlobMixin):
             content = cache.get(self.__attachment_cache_key(name))
             if content is not None:
                 if isinstance(content, six.text_type):
-                    _soft_assert(False, 'cached attachment has type unicode')
-                    content = content.encode('utf-8')
+                    return None
                 self._LAZY_ATTACHMENTS_CACHE[name] = content
         return content
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-747

Currently, cached app attachments from py2 (bytes) are decoded as latin1 in py3.  This change ensures that these cached objects are discarded.

Corrupted form sources can be reset using:
```form.source = form.source.encode('latin1').decode('utf-8')```

@dimagi/py3 