### PR TITLE
better handle edge case 

### DIFF
--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -187,7 +187,7 @@ class FormProcessorInterface(object):
             raise
         except KafkaPublishingError as e:
             from corehq.form_processor.submission_post import notify_submission_error
-            notify_submission_error(forms.submitted, e, 'Error publishing to Kafka')
+            notify_submission_error(forms.submitted, 'Error publishing to Kafka')
             raise PostSaveError(e)
         except Exception as e:
             from corehq.form_processor.submission_post import handle_unexpected_error

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -534,11 +534,13 @@ def handle_unexpected_error(interface, instance, exception):
         instance = interface.xformerror_from_xform_instance(instance, instance.problem, with_new_id=True)
         FormAccessors(interface.domain).save_new_form(instance)
 
-    notify_submission_error(instance, exec_info, instance.problem)
+    notify_submission_error(instance, instance.problem, exec_info)
 
 
-def notify_submission_error(instance, exec_info, message):
+def notify_submission_error(instance, message, exec_info=None):
     from corehq.util.global_request.api import get_request
+
+    exec_info = exec_info or sys.exc_info()
     domain = getattr(instance, 'domain', '---')
     details = {
         'domain': domain,

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -508,24 +508,29 @@ def _transform_instance_to_error(interface, exception, instance):
 
 def handle_unexpected_error(interface, instance, exception):
     instance = _transform_instance_to_error(interface, exception, instance)
+
+    # get this here in case we hit the integrity error below and lose the exception context
+    exec_info = sys.exc_info()
+
     try:
         FormAccessors(interface.domain).save_new_form(instance)
     except IntegrityError:
         instance = interface.xformerror_from_xform_instance(instance, instance.problem, with_new_id=True)
         FormAccessors(interface.domain).save_new_form(instance)
-    notify_submission_error(instance, exception, instance.problem)
+
+    notify_submission_error(instance, exec_info, instance.problem)
 
 
-def notify_submission_error(instance, exception, message):
+def notify_submission_error(instance, exec_info, message):
     from corehq.util.global_request.api import get_request
     domain = getattr(instance, 'domain', '---')
     details = {
         'domain': domain,
         'error form ID': instance.form_id,
     }
-    should_email = not isinstance(exception, CouchSaveAborted)  # intentionally don't double-email these
+    should_email = not isinstance(exec_info[1], CouchSaveAborted)  # intentionally don't double-email these
     if should_email:
         request = get_request()
-        notify_exception(request, message, details=details)
+        notify_exception(request, message, details=details, exec_info=exec_info)
     else:
         logging.error(message, exc_info=sys.exc_info(), extra={'details': details})

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -254,7 +254,7 @@ class SubmissionPost(object):
                 instance = xforms[0]
 
                 is_edit_of_error = len(xforms) == 2 and xforms[1].is_error
-                if is_edit_of_error:
+                if not instance.is_duplicate and is_edit_of_error:
                     # edge case from ICDS where a form errors and then future re-submissions of the same
                     # form do not have the same MD5 hash due to a bug on mobile:
                     # see https://dimagi-dev.atlassian.net/browse/ICDS-376


### PR DESCRIPTION
Current work flow:

1. Form submitted but errors so saved to DB with same ID but in error state
2. Form re-submitted with different modification times
3. Server treats this as a form edit and tries to do the normal deprecation workflow which fails since original form is an error form.

To fix this we change step 3 to ignoring the deprecated form and process the new form as normal.

Sentry issues: 
* [COMMCAREHQ-VY8](https://sentry.io/organizations/dimagi/issues/1104734139/?referrer=github_integration)
* [COMMCAREHQ-EM0](https://sentry.io/organizations/dimagi/issues/726376005/?referrer=github_integration)