### PR TITLE
Better arguments for make async build

### DIFF
--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -23,13 +23,13 @@ def create_user_cases(domain_name):
 
 
 @serial_task('{app_id}-{version}', max_retries=0, timeout=60*60)
-def make_async_build_v2(app_id, domain, version, username, allow_prune=True, comment=None):
+def make_async_build_v2(app_id, domain, version, allow_prune=True, comment=None):
     app = get_app(domain, app_id)
-    return make_async_build(app, username, allow_prune=allow_prune, comment=comment)
+    return make_async_build(app, allow_prune=allow_prune, comment=comment)
 
 
 @serial_task('{app._id}-{app.version}', max_retries=0, timeout=60*60)
-def make_async_build(app, username, allow_prune=True, comment=None):
+def make_async_build(app, allow_prune=True, comment=None):
     previous_version = app.get_previous_version()
     if previous_version and previous_version.version == app.version:
         return

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -22,13 +22,13 @@ def create_user_cases(domain_name):
         sync_usercase(user)
 
 
-@serial_task('{app_id}-{version}', max_retries=0, timeout=60*60)
+@serial_task('{app_id}-{version}', max_retries=0, timeout=60 * 60)
 def make_async_build_v2(app_id, domain, version, allow_prune=True, comment=None):
     app = get_app(domain, app_id)
     return make_async_build(app, allow_prune=allow_prune, comment=comment)
 
 
-@serial_task('{app._id}-{app.version}', max_retries=0, timeout=60*60)
+@serial_task('{app._id}-{app.version}', max_retries=0, timeout=60 * 60)
 def make_async_build(app, allow_prune=True, comment=None):
     previous_version = app.get_previous_version()
     if previous_version and previous_version.version == app.version:

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -22,6 +22,12 @@ def create_user_cases(domain_name):
         sync_usercase(user)
 
 
+@serial_task('{app_id}-{version}', max_retries=0, timeout=60*60)
+def make_async_build_v2(app_id, domain, version, username, allow_prune=True, comment=None):
+    app = get_app(domain, app_id)
+    return make_async_build(app, username, allow_prune=allow_prune, comment=comment)
+
+
 @serial_task('{app._id}-{app.version}', max_retries=0, timeout=60*60)
 def make_async_build(app, username, allow_prune=True, comment=None):
     previous_version = app.get_previous_version()

--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -267,7 +267,7 @@ class AppManagerTest(TestCase):
 
         # Build #2, auto-generated
         app.save()
-        make_async_build_v2(app.get_id, app.domain, app.version, 'someone')
+        make_async_build_v2(app.get_id, app.domain, app.version)
         build_ids = get_built_app_ids_for_app_id(app.domain, app.id)
         self.assertEqual(len(build_ids), 2)
         self.assertEqual(build_ids[0], build1.id)

--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -14,7 +14,7 @@ from django.test import TestCase, SimpleTestCase
 from corehq.apps.app_manager.dbaccessors import get_app, get_built_app_ids_for_app_id
 from corehq.apps.app_manager.models import Application, DetailColumn, import_app, APP_V1, ApplicationBase, Module, \
     ReportModule, ReportAppConfig
-from corehq.apps.app_manager.tasks import make_async_build, prune_auto_generated_builds
+from corehq.apps.app_manager.tasks import make_async_build_v2, prune_auto_generated_builds
 from corehq.apps.app_manager.tests.util import add_build, patch_default_builds
 from corehq.apps.app_manager.util import add_odk_profile_after_build, purge_report_from_mobile_ucr
 from corehq.apps.builds.models import BuildSpec
@@ -267,7 +267,7 @@ class AppManagerTest(TestCase):
 
         # Build #2, auto-generated
         app.save()
-        make_async_build(app, 'someone')
+        make_async_build_v2(app.get_id, app.domain, app.version, 'someone')
         build_ids = get_built_app_ids_for_app_id(app.domain, app.id)
         self.assertEqual(len(build_ids), 2)
         self.assertEqual(build_ids[0], build1.id)

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -51,7 +51,7 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.models import import_app as import_app_util
 from corehq.apps.app_manager.tasks import (
-    make_async_build,
+    make_async_build_v2,
     update_linked_app_and_notify_task
 )
 from corehq.apps.app_manager.util import (
@@ -496,7 +496,7 @@ def load_app_from_slug(domain, username, slug):
                         app.create_mapping(multimedia, MULTIMEDIA_PREFIX + path)
 
     comment = _("A sample application you can try out in Web Apps")
-    build = make_async_build(app, username, allow_prune=False, comment=comment)
+    build = make_async_build_v2(app.get_id, app.domain, app.version, username, allow_prune=False, comment=comment)
     build.is_released = True
     build.save(increment_version=False)
     return build

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -496,7 +496,7 @@ def load_app_from_slug(domain, username, slug):
                         app.create_mapping(multimedia, MULTIMEDIA_PREFIX + path)
 
     comment = _("A sample application you can try out in Web Apps")
-    build = make_async_build_v2(app.get_id, app.domain, app.version, username, allow_prune=False, comment=comment)
+    build = make_async_build_v2(app.get_id, app.domain, app.version, allow_prune=False, comment=comment)
     build.is_released = True
     build.save(increment_version=False)
     return build

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -54,7 +54,7 @@ def download_odk_profile(request, domain, app_id):
     """
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)
@@ -68,7 +68,7 @@ def download_odk_profile(request, domain, app_id):
 def download_odk_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)
@@ -333,7 +333,7 @@ def download_profile(request, domain, app_id):
     """
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)
@@ -346,7 +346,7 @@ def download_profile(request, domain, app_id):
 def download_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -23,7 +23,7 @@ from corehq.apps.app_manager.util import (
     get_latest_enabled_versions_per_profile,
 )
 from corehq.apps.app_manager.views.utils import back_to_main, get_langs
-from corehq.apps.app_manager.tasks import make_async_build
+from corehq.apps.app_manager.tasks import make_async_build_v2
 from corehq.apps.builds.jadjar import convert_XML_To_J2ME
 from corehq.apps.hqmedia.views import DownloadMultimediaZip
 from corehq.util.soft_assert import soft_assert
@@ -54,7 +54,7 @@ def download_odk_profile(request, domain, app_id):
     """
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build.delay(request.app, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)
@@ -68,7 +68,7 @@ def download_odk_profile(request, domain, app_id):
 def download_odk_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build.delay(request.app, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)
@@ -333,7 +333,7 @@ def download_profile(request, domain, app_id):
     """
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build.delay(request.app, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)
@@ -346,7 +346,7 @@ def download_profile(request, domain, app_id):
 def download_media_profile(request, domain, app_id):
     if not request.app.copy_of:
         username = request.GET.get('username', 'unknown user')
-        make_async_build.delay(request.app, username)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version, username)
     else:
         request._always_allow_browser_caching = True
     profile = _get_profile(request)
@@ -358,7 +358,7 @@ def download_media_profile(request, domain, app_id):
 @safe_cached_download
 def download_practice_user_restore(request, domain, app_id):
     if not request.app.copy_of:
-        make_async_build.delay(request.app)
+        make_async_build_v2.delay(request.app.get_id, request.app.domain, request.app.version)
     return HttpResponse(
         request.app.create_practice_user_restore()
     )

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -48,7 +48,7 @@ def bulk_upload_async(domain, user_specs, group_specs):
     }
 
 
-@task(serializer='pickle', )
+@task(serializer='pickle')
 def bulk_download_users_async(domain, download_id, user_filters):
     from corehq.apps.users.bulkupload import dump_users_and_groups, GroupNameError
     errors = []

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from elasticsearch.exceptions import ConnectionError
 
 from corehq.apps.app_manager.models import Application
-from corehq.apps.app_manager.tasks import make_async_build, prune_auto_generated_builds
+from corehq.apps.app_manager.tasks import make_async_build_v2, prune_auto_generated_builds
 from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
@@ -102,7 +102,7 @@ class AppPillowTest(TestCase):
 
         # Build #2, auto-generated
         app.save()
-        build2 = make_async_build(app, 'someone')
+        build2 = make_async_build_v2(app.get_id, app.domain, app.version, 'someone')
 
         # Build #3, manually generated
         app.save()

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -102,7 +102,7 @@ class AppPillowTest(TestCase):
 
         # Build #2, auto-generated
         app.save()
-        build2 = make_async_build_v2(app.get_id, app.domain, app.version, 'someone')
+        build2 = make_async_build_v2(app.get_id, app.domain, app.version)
 
         # Build #3, manually generated
         app.save()


### PR DESCRIPTION
`make_async_build` might be choking celery. Noticed twice when celery worker was running 8 of these in parallel and became unresponsive.
It had app doc in the argument. This PR updates to use id and domain to fetch app again. Also removed username argument that was not being used.
Using v2 to avoid failing enqueued tasks and then would convert it back to `make_async_build` and phase out `make_async_build_v2`.

fyi @esoergel 