### PR TITLE
Route analytics periodic data failure to support

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -431,15 +431,6 @@ def _get_report_count(domain):
     return get_report_builder_count(domain)
 
 
-def _log_failed_periodic_data(email, message):
-    soft_assert(to='{}@{}'.format('bbuczyk', 'dimagi.com'))(
-        False, "ANALYTICS - Failed to sync periodic data", {
-            'user_email': email,
-            'message': message,
-        }
-    )
-
-
 @periodic_task(run_every=crontab(minute="0", hour="4"), queue='background_queue')
 def track_periodic_data():
     """

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -50,14 +50,6 @@ from corehq.apps.analytics.utils import analytics_enabled_for_email
 from io import open
 from six.moves import range
 
-_hubspot_failure_soft_assert = soft_assert(to=['{}@{}'.format('cellowitz', 'dimagi.com'),
-                                               '{}@{}'.format('biyeun', 'dimagi.com'),
-                                               '{}@{}'.format('jschweers', 'dimagi.com'),
-                                               '{}@{}'.format('aphilippot', 'dimagi.com'),
-                                               '{}@{}'.format('colaughlin', 'dimagi.com'),
-                                               '{}@{}'.format('miemma', 'dimagi.com')],
-                                           send_to_ops=False)
-
 logger = logging.getLogger('analytics')
 logger.setLevel('DEBUG')
 
@@ -595,7 +587,13 @@ def submit_data_to_hub_and_kiss(submit_json):
         try:
             dispatcher(submit_json)
         except requests.exceptions.HTTPError as e:
-            _hubspot_failure_soft_assert(False, e.response.content.decode('utf-8'))
+            soft_assert(to=[settings.SUPPORT_EMAIL,
+                            '{}@{}'.format('miemma', 'dimagi.com'),
+                            '{}@{}'.format('aphilippot', 'dimagi.com'),
+                            '{}@{}'.format('colaughlin', 'dimagi.com')],
+                        send_to_ops=False)(False,
+                                           'Error submitting periodic analytics data to Hubspot or Kissmetrics',
+                                           {'response': e.response.content.decode('utf-8')})
         except Exception as e:
             notify_exception(None, "{msg}: {exc}".format(msg=error_message, exc=e))
 


### PR DESCRIPTION
As discussed over email: send this failure to support, who will route it to either interrupt or the SaaS team, and CC the growth team so they can track the ticket.