### PR TITLE
move code independent of context manager to outside of with statement

### DIFF
--- a/corehq/apps/app_manager/xpath_validator/wrapper.py
+++ b/corehq/apps/app_manager/xpath_validator/wrapper.py
@@ -19,11 +19,11 @@ def validate_xpath(xpath, allow_case_hashtags=False):
                              stderr=subprocess.PIPE)
         stdout, stderr = p.communicate(xpath.replace('\r', ' ').encode('utf-8'))
         exit_code = p.wait()
-        if exit_code == 0:
-            return XpathValidationResponse(is_valid=True, message=None)
-        elif exit_code == 1:
-            return XpathValidationResponse(is_valid=False, message=stdout)
-        else:
-            raise XpathValidationError(
-                "{path} failed with exit code {exit_code}:\n{stderr}"
-                .format(path=path, exit_code=exit_code, stderr=stderr))
+    if exit_code == 0:
+        return XpathValidationResponse(is_valid=True, message=None)
+    elif exit_code == 1:
+        return XpathValidationResponse(is_valid=False, message=stdout)
+    else:
+        raise XpathValidationError(
+            "{path} failed with exit code {exit_code}:\n{stderr}"
+            .format(path=path, exit_code=exit_code, stderr=stderr))


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1111718536/

I'm a bit confused why the ```RuntimeError``` would be raised, but I suspect this change will fix it (and if not, at least make the chunks of code in this function more independent).

@dimagi/py3 