### PR TITLE
toggle to disable 'run_case_update_rules' task

### DIFF
--- a/corehq/apps/data_interfaces/tasks.py
+++ b/corehq/apps/data_interfaces/tasks.py
@@ -11,6 +11,7 @@ from corehq.apps.data_interfaces.models import (
     CaseRuleSubmission)
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.apps.domain.models import Domain
+from corehq.toggles import DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK
 from corehq.util.decorators import serial_task
 from datetime import datetime, timedelta
 
@@ -67,7 +68,7 @@ def run_case_update_rules(now=None):
                .distinct()
                .order_by('domain'))
     for domain in domains:
-        if not any_migrations_in_progress(domain):
+        if not any_migrations_in_progress(domain) and not DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK.enabled(domain):
             run_case_update_rules_for_domain.delay(domain, now)
 
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1838,7 +1838,8 @@ MPR_ASR_CONDITIONAL_AGG = DynamicallyPredictablyRandomToggle(
 
 DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK = StaticToggle(
     'disable_case_update_rule_task',
-    'Disable the `run_case_update_rules` periodic task',
+    'Disable the `run_case_update_rules` periodic task '
+    'while investigating database performance issues.',
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN]
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1835,3 +1835,10 @@ MPR_ASR_CONDITIONAL_AGG = DynamicallyPredictablyRandomToggle(
     TAG_CUSTOM,
     [NAMESPACE_USER]
 )
+
+DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK = StaticToggle(
+    'disable_case_update_rule_task',
+    'Disable the `run_case_update_rules` periodic task',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
Since I suspect that the queries run by this task may be impacting the ICDS PG shard cluster I'd like to be able to turn them off for a day or two.