### PR TITLE
Remove sort from fetching initial case type value in ECD filter

### DIFF
--- a/corehq/apps/reports/standard/cases/utils.py
+++ b/corehq/apps/reports/standard/cases/utils.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
 from corehq.apps.locations.dbaccessors import (
     user_ids_at_locations,
     user_ids_at_locations_and_descendants,
@@ -14,7 +13,6 @@ from corehq.apps.es import (
     filters,
     users as user_es,
     cases as case_es,
-    CaseSearchES,
 )
 from corehq.apps.es.es_query import HQESQuery
 
@@ -177,12 +175,3 @@ def _get_location_accessible_ids(request):
 def query_location_restricted_cases(query, request):
     accessible_ids = _get_location_accessible_ids(request)
     return query.OR(case_es.owner(accessible_ids))
-
-
-def get_most_recent_case_type(domain):
-    # gets most recently submitted case type in a domain
-    query = (CaseSearchES().domain(domain)
-             .NOT(case_es.case_type(USER_LOCATION_OWNER_MAP_TYPE)))
-    query = query.sort('modified_on', desc=True)
-    result = query.size(1).values_list('type', flat=True)
-    return result[0] if len(result) > 0 else None


### PR DESCRIPTION
currently just having `sort` in there causes an order of magnitude longer request. We already had a few timeouts reported for CRS domains this morning, so I'm hoping this will placate things until I sort out more deeply rooted issues with elasticsearch needing an upgrade...