### PR TITLE
Log rather than print unicode info

### DIFF
--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -1,10 +1,12 @@
 # coding: utf-8
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import getpass
+import logging
+
 from django.core.management.base import BaseCommand, CommandError
-from email_validator import validate_email, EmailSyntaxError
+
+from email_validator import EmailSyntaxError, validate_email
 
 
 class Command(BaseCommand):
@@ -32,11 +34,11 @@ class Command(BaseCommand):
         if couch_user:
             if not isinstance(couch_user, WebUser):
                 raise CommandError('Username already in use by a non-web user')
-            print("✓ User {} exists".format(couch_user.username))
+            logging.info("✓ User {} exists".format(couch_user.username))
         else:
             password = self.get_password_from_user()
             couch_user = WebUser.create(None, username, password)
-            print("→ User {} created".format(couch_user.username))
+            logging.info("→ User {} created".format(couch_user.username))
 
         is_superuser_changed = not couch_user.is_superuser
         is_staff_changed = not couch_user.is_staff
@@ -47,11 +49,11 @@ class Command(BaseCommand):
             couch_user.save()
 
         if is_superuser_changed:
-            print("→ User {} is now a superuser".format(couch_user.username))
+            logging.info("→ User {} is now a superuser".format(couch_user.username))
         else:
-            print("✓ User {} is a superuser".format(couch_user.username))
+            logging.info("✓ User {} is a superuser".format(couch_user.username))
 
         if is_staff_changed:
-            print("→ User {} can now access django admin".format(couch_user.username))
+            logging.info("→ User {} can now access django admin".format(couch_user.username))
         else:
-            print("✓ User {} can access django admin".format(couch_user.username))
+            logging.info("✓ User {} can access django admin".format(couch_user.username))


### PR DESCRIPTION
For some reason this fails when run through commcare-cloud's django-manage command, though it succeeds when run locally or even directly on the server with the exact same parameters.

https://forum.dimagi.com/t/error-on-superuser-creation/6668

I was also able to get this to succeed by `.encode(utf-8)`ing from unicode to string and continuing to use print, though that feels quite ugly.  Sounds like something about this evaluation context requires `print()` to convert to string.

The drawback of this approach is that instead of
```
2019-07-15 21:15:41,155 INFO AXES: BEGIN LOG
✓ User esoergel+testingsuperuser@dimagi.com exists
✓ User esoergel+testingsuperuser@dimagi.com is a superuser
✓ User esoergel+testingsuperuser@dimagi.com can access django admin
```
You see
```
2019-07-15 21:26:54,408 INFO AXES: BEGIN LOG
2019-07-15 21:26:55,101 INFO ✓ User esoergel+testingsuperuser@dimagi.com exists
2019-07-15 21:26:55,101 INFO ✓ User esoergel+testingsuperuser@dimagi.com is a superuser
2019-07-15 21:26:55,102 INFO ✓ User esoergel+testingsuperuser@dimagi.com can access django admin
```

Dunno, I'm open to other suggestions, and curious if anyone has an explanation for why we can't print unicode.

@dimagi/py3 @biyeun 