### PR TITLE
Added UTF-8 encoding in FormBase.validate_form

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1135,7 +1135,7 @@ class FormBase(DocumentSchema):
             form.strip_vellum_ns_attributes()
             try:
                 if form.xml is not None:
-                    validate_xform(self.get_app().domain, etree.tostring(form.xml))
+                    validate_xform(self.get_app().domain, etree.tostring(form.xml, encoding="unicode"))
             except XFormValidationError as e:
                 validation_dict = {
                     "fatal_error": e.fatal_error,


### PR DESCRIPTION
Noticed while investigating https://dimagi-dev.atlassian.net/browse/HI-755 It occurs on both prod and in my local python 2 environment.

The broken form was throwing an `XFormException` in [FormBaseValidator.validate_for_build](https://github.com/dimagi/commcare-hq/blob/dfc088b02fafacdb4a6e4c21577b8204933aeb82/corehq/apps/app_manager/helpers/validators.py#L732), which came from [this parse_xml call](https://github.com/dimagi/commcare-hq/blob/dfc088b02fafacdb4a6e4c21577b8204933aeb82/corehq/apps/app_manager/xform.py#L593)...which was weird, because the `parse_xml` was already called on that form [a few lines above](https://github.com/dimagi/commcare-hq/blob/dfc088b02fafacdb4a6e4c21577b8204933aeb82/corehq/apps/app_manager/helpers/validators.py#L707), yet that call wasn't throwing an `XFormException`.

Turned out to be because the first time the xml was parsed, it was passed unicode input (`form.source`) but the second time it was passed non-unicode (the `etree.tostring(form.xml)` expression that this PR updates).

Product: this will make a small number of build errors show a semi-helpful error message (with the form name and a line number) instead of the generic "Something went wrong" error.