### PR TITLE
clean OData column names

### DIFF
--- a/corehq/apps/api/odata/tests/test_models.py
+++ b/corehq/apps/api/odata/tests/test_models.py
@@ -1,0 +1,149 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from corehq.apps.export.models import (
+    CaseExportInstance,
+    FormExportInstance,
+    ExportColumn,
+    ExportInstance,
+    ExportItem,
+    PathNode,
+    RowNumberColumn,
+    TableConfiguration,
+)
+
+
+class TestODataWrap(TestCase):
+
+    def test_column_label_containing_period(self):
+        export_with_column_containing_period = ExportInstance(
+            is_odata_config=True,
+            tables=[
+                TableConfiguration(
+                    columns=[
+                        ExportColumn(
+                            label='.label',
+                            item=ExportItem(
+                                path=[
+                                    PathNode(name='val')
+                                ]
+                            ),
+                            selected=True,
+                        )
+                    ]
+                )
+            ]
+        )
+        export_with_column_containing_period.save()
+        self.addCleanup(export_with_column_containing_period.delete)
+        cleaned_export = ExportInstance.get(export_with_column_containing_period.get_id)
+        self.assertEqual(cleaned_export.tables[0].columns[0].label, ' label')
+
+    def test_column_label_containing_at_sign(self):
+        export_with_column_containing_at_sign = ExportInstance(
+            is_odata_config=True,
+            tables=[
+                TableConfiguration(
+                    columns=[
+                        ExportColumn(
+                            label='@label',
+                            item=ExportItem(
+                                path=[
+                                    PathNode(name='val')
+                                ]
+                            ),
+                            selected=True,
+                        )
+                    ]
+                )
+            ]
+        )
+        export_with_column_containing_at_sign.save()
+        self.addCleanup(export_with_column_containing_at_sign.delete)
+        cleaned_export = ExportInstance.get(export_with_column_containing_at_sign.get_id)
+        self.assertEqual(cleaned_export.tables[0].columns[0].label, 'label')
+
+    def test_row_number_column_is_removed(self):
+        export_with_row_number_column = ExportInstance(
+            is_odata_config=True,
+            tables=[
+                TableConfiguration(
+                    columns=[
+                        RowNumberColumn(
+                            label='row-number',
+                        ),
+                        ExportColumn(
+                            label='label',
+                            item=ExportItem(
+                                path=[
+                                    PathNode(name='val')
+                                ]
+                            ),
+                            selected=True,
+                        )
+                    ]
+                )
+            ]
+        )
+        export_with_row_number_column.save()
+        self.addCleanup(export_with_row_number_column.delete)
+        cleaned_export = ExportInstance.get(export_with_row_number_column.get_id)
+        tables = cleaned_export.tables
+        self.assertEqual(len(tables), 1)
+        columns = tables[0].columns
+        self.assertEqual(len(columns), 1)
+        self.assertFalse(isinstance(columns[0], RowNumberColumn))
+        self.assertEqual(columns[0].label, 'label')
+
+    def test_caseid_column_label(self):
+        export_with_modified_caseid_column = CaseExportInstance(
+            is_odata_config=True,
+            tables=[
+                TableConfiguration(
+                    columns=[
+                        ExportColumn(
+                            label='modified_case_id_column',
+                            item=ExportItem(
+                                path=[
+                                    PathNode(name='_id')
+                                ]
+                            ),
+                            selected=True,
+                        )
+                    ]
+                )
+            ]
+        )
+        export_with_modified_caseid_column.save()
+        self.addCleanup(export_with_modified_caseid_column.delete)
+        cleaned_export = CaseExportInstance.get(export_with_modified_caseid_column.get_id)
+        self.assertEqual(cleaned_export.tables[0].columns[0].label, 'caseid')
+
+    def test_formid_column_label(self):
+        export_with_modified_formid_column = FormExportInstance(
+            is_odata_config=True,
+            tables=[
+                TableConfiguration(
+                    columns=[
+                        ExportColumn(
+                            label='modified_form_id_column',
+                            item=ExportItem(
+                                path=[
+                                    PathNode(name='form'),
+                                    PathNode(name='meta'),
+                                    PathNode(name='instanceID')
+                                ]
+                            ),
+                            selected=True,
+                        )
+                    ]
+                )
+            ]
+        )
+        export_with_modified_formid_column.save()
+        self.addCleanup(export_with_modified_formid_column.delete)
+        cleaned_export = FormExportInstance.get(export_with_modified_formid_column.get_id)
+        self.assertEqual(cleaned_export.tables[0].columns[0].label, 'formid')
+

--- a/corehq/apps/api/odata/tests/test_models.py
+++ b/corehq/apps/api/odata/tests/test_models.py
@@ -146,4 +146,3 @@ class TestODataWrap(TestCase):
         self.addCleanup(export_with_modified_formid_column.delete)
         cleaned_export = FormExportInstance.get(export_with_modified_formid_column.get_id)
         self.assertEqual(cleaned_export.tables[0].columns[0].label, 'formid')
-

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -712,6 +712,15 @@ class ExportInstance(BlobMixin, Document):
     class Meta(object):
         app_label = 'export'
 
+    @classmethod
+    def wrap(cls, data):
+        from corehq.apps.export.views.utils import clean_odata_columns, remove_row_number_from_export_columns
+        export_instance = super(ExportInstance, cls).wrap(data)
+        if export_instance.is_odata_config:
+            clean_odata_columns(export_instance)
+            remove_row_number_from_export_columns(export_instance)
+        return export_instance
+
     @property
     def is_safe(self):
         """For compatibility with old exports"""

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1037,6 +1037,17 @@ class CaseExportInstance(ExportInstance):
     # filters are only used in daily saved and HTML (dashboard feed) exports
     filters = SchemaProperty(CaseExportInstanceFilters)
 
+    @classmethod
+    def wrap(cls, data):
+        export_instance = super(CaseExportInstance, cls).wrap(data)
+        if export_instance.is_odata_config:
+            for table in export_instance.tables:
+                for column in table.columns:
+                    if [path_node.name for path_node in column.item.path] == ['_id']:
+                        column.label = 'caseid'
+                        column.selected = True
+        return export_instance
+
     @property
     def identifier(self):
         return self.case_type
@@ -1088,6 +1099,17 @@ class FormExportInstance(ExportInstance):
     # static filters to limit the data in this export
     # filters are only used in daily saved and HTML (dashboard feed) exports
     filters = SchemaProperty(FormExportInstanceFilters)
+
+    @classmethod
+    def wrap(cls, data):
+        export_instance = super(FormExportInstance, cls).wrap(data)
+        if export_instance.is_odata_config:
+            for table in export_instance.tables:
+                for column in table.columns:
+                    if [path_node.name for path_node in column.item.path] == ['form', 'meta', 'instanceID']:
+                        column.label = 'formid'
+                        column.selected = True
+        return export_instance
 
     @property
     def identifier(self):

--- a/corehq/apps/export/views/edit.py
+++ b/corehq/apps/export/views/edit.py
@@ -17,6 +17,7 @@ from corehq.apps.export.views.utils import (
     DailySavedExportMixin,
     DashboardFeedMixin,
     ODataFeedMixin,
+    clean_odata_columns,
     remove_row_number_from_export_columns,
 )
 
@@ -123,6 +124,7 @@ class EditODataCaseFeedView(ODataFeedMixin, EditNewCustomCaseExportView):
     def get_export_instance(self, schema, original_export_instance):
         export_instance = super(EditODataCaseFeedView, self).get_export_instance(schema, original_export_instance)
         remove_row_number_from_export_columns(export_instance)
+        clean_odata_columns(export_instance)
         return export_instance
 
 
@@ -133,6 +135,7 @@ class EditODataFormFeedView(ODataFeedMixin, EditNewCustomFormExportView):
     def get_export_instance(self, schema, original_export_instance):
         export_instance = super(EditODataFormFeedView, self).get_export_instance(schema, original_export_instance)
         remove_row_number_from_export_columns(export_instance)
+        clean_odata_columns(export_instance)
         return export_instance
 
 

--- a/corehq/apps/export/views/edit.py
+++ b/corehq/apps/export/views/edit.py
@@ -17,6 +17,7 @@ from corehq.apps.export.views.utils import (
     DailySavedExportMixin,
     DashboardFeedMixin,
     ODataFeedMixin,
+    remove_row_number_from_export_columns,
 )
 
 
@@ -119,10 +120,20 @@ class EditODataCaseFeedView(ODataFeedMixin, EditNewCustomCaseExportView):
     urlname = 'edit_odata_case_feed'
     page_title = ugettext_lazy("Copy OData Feed")
 
+    def get_export_instance(self, schema, original_export_instance):
+        export_instance = super(EditODataCaseFeedView, self).get_export_instance(schema, original_export_instance)
+        remove_row_number_from_export_columns(export_instance)
+        return export_instance
+
 
 class EditODataFormFeedView(ODataFeedMixin, EditNewCustomFormExportView):
     urlname = 'edit_odata_form_feed'
     page_title = ugettext_lazy("Copy OData Feed")
+
+    def get_export_instance(self, schema, original_export_instance):
+        export_instance = super(EditODataFormFeedView, self).get_export_instance(schema, original_export_instance)
+        remove_row_number_from_export_columns(export_instance)
+        return export_instance
 
 
 class EditExportAttrView(BaseEditNewCustomExportView):

--- a/corehq/apps/export/views/edit.py
+++ b/corehq/apps/export/views/edit.py
@@ -31,6 +31,14 @@ class BaseEditNewCustomExportView(BaseExportView):
     def new_export_instance(self):
         return self.export_instance_cls.get(self.export_id)
 
+    def get_export_instance(self, schema, original_export_instance):
+        return self.export_instance_cls.generate_instance_from_schema(
+            schema,
+            saved_export=original_export_instance,
+            # The export exists - we don't want to automatically select new columns
+            auto_select=False,
+        )
+
     @property
     def page_url(self):
         return reverse(self.urlname, args=[self.domain, self.export_id])
@@ -46,12 +54,7 @@ class BaseEditNewCustomExportView(BaseExportView):
             self.request.GET.get('app_id') or getattr(export_instance, 'app_id'),
             export_instance.identifier
         )
-        self.export_instance = self.export_instance_cls.generate_instance_from_schema(
-            schema,
-            saved_export=export_instance,
-            # The export exists - we don't want to automatically select new columns
-            auto_select=False,
-        )
+        self.export_instance = self.get_export_instance(schema, export_instance)
         for message in self.export_instance.error_messages():
             messages.error(request, message)
         return super(BaseEditNewCustomExportView, self).get(request, *args, **kwargs)

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -39,6 +39,7 @@ from corehq.apps.export.views.utils import (
     DailySavedExportMixin,
     DashboardFeedMixin,
     ODataFeedMixin,
+    clean_odata_columns,
     remove_row_number_from_export_columns,
 )
 
@@ -273,6 +274,7 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     def create_new_export_instance(self, schema):
         export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(schema)
         remove_row_number_from_export_columns(export_instance)
+        clean_odata_columns(export_instance)
         return export_instance
 
 
@@ -285,6 +287,7 @@ class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
     def create_new_export_instance(self, schema):
         export_instance = super(CreateODataFormFeedView, self).create_new_export_instance(schema)
         remove_row_number_from_export_columns(export_instance)
+        clean_odata_columns(export_instance)
         return export_instance
 
 

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -265,12 +265,20 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     page_title = ugettext_lazy("Create OData Case Feed")
     allow_deid = False
 
+    def create_new_export_instance(self, schema):
+        export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(schema)
+        return export_instance
+
 
 @method_decorator(toggles.ODATA.required_decorator(), name='dispatch')
 class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
     urlname = 'new_odata_form_feed'
     page_title = ugettext_lazy("Create OData Form Feed")
     allow_deid = False
+
+    def create_new_export_instance(self, schema):
+        export_instance = super(CreateODataFormFeedView, self).create_new_export_instance(schema)
+        return export_instance
 
 
 class DeleteNewCustomExportView(BaseExportView):

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -35,7 +35,12 @@ from corehq.apps.export.models import (
     FormExportInstance,
     CaseExportInstance,
 )
-from corehq.apps.export.views.utils import DailySavedExportMixin, DashboardFeedMixin, ODataFeedMixin
+from corehq.apps.export.views.utils import (
+    DailySavedExportMixin,
+    DashboardFeedMixin,
+    ODataFeedMixin,
+    remove_row_number_from_export_columns,
+)
 
 
 class BaseExportView(BaseProjectDataView):
@@ -267,6 +272,7 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
 
     def create_new_export_instance(self, schema):
         export_instance = super(CreateODataCaseFeedView, self).create_new_export_instance(schema)
+        remove_row_number_from_export_columns(export_instance)
         return export_instance
 
 
@@ -278,6 +284,7 @@ class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
 
     def create_new_export_instance(self, schema):
         export_instance = super(CreateODataFormFeedView, self).create_new_export_instance(schema)
+        remove_row_number_from_export_columns(export_instance)
         return export_instance
 
 

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -370,3 +370,9 @@ def can_view_case_exports(couch_user, domain):
 def remove_row_number_from_export_columns(export_instance):
     for table in export_instance.tables:
         table.columns = [column for column in table.columns if not isinstance(column, RowNumberColumn)]
+
+
+def clean_odata_columns(export_instance):
+    for table in export_instance.tables:
+        for column in table.columns:
+            column.label = column.label.replace('@', '').replace('.', ' ')

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -40,7 +40,7 @@ from corehq.util.timezones.utils import get_timezone_for_user
 
 from corehq.apps.export.const import FORM_EXPORT, CASE_EXPORT, MAX_DATA_FILE_SIZE, MAX_DATA_FILE_SIZE_TOTAL
 from corehq.apps.export.models import FormExportDataSchema, CaseExportDataSchema
-from corehq.apps.export.models.new import DataFile, DatePeriod
+from corehq.apps.export.models.new import DataFile, DatePeriod, RowNumberColumn
 from corehq.apps.export.tasks import generate_schema_for_all_builds
 
 
@@ -365,3 +365,8 @@ def can_view_form_exports(couch_user, domain):
 
 def can_view_case_exports(couch_user, domain):
     return ExportsPermissionsManager('case', domain, couch_user).has_form_export_permissions
+
+
+def remove_row_number_from_export_columns(export_instance):
+    for table in export_instance.tables:
+        table.columns = [column for column in table.columns if not isinstance(column, RowNumberColumn)]


### PR DESCRIPTION
Require:
1) case/form ID to be "caseid" and "formid"
2) remove "@" and "." for compatibility with BI tools
3) exclude row number because it's not implemented in the OData feeds
