### PR TITLE
default to console email backend in dev_settings

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -119,3 +119,6 @@ ELASTICSEARCH_DEBUG_HOSTS = {
 }
 
 FORMPLAYER_INTERNAL_AUTH_KEY = "secretkey"
+
+# use console email by default
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
any reason this isn't already the default for dev environments?