### PR TITLE
base command to create dd events

### DIFF
--- a/corehq/util/django_management.py
+++ b/corehq/util/django_management.py
@@ -1,0 +1,34 @@
+from django.core.management import BaseCommand
+from django.core.management.base import SystemCheckError
+
+from corehq.util.datadog.utils import create_datadog_event
+
+
+class AuditedBaseCommand(BaseCommand):
+    command_name = None
+
+    def create_parser(self, prog_name, subcommand):
+        self.command_name = prog_name
+        return super(AuditedBaseCommand, self).create_parser(prog_name, subcommand)
+
+    def execute(self, *args, **options):
+        self.create_datadog_event('start', args, options)
+        try:
+            output = super(AuditedBaseCommand, self).execute(*args, **options)
+        except SystemCheckError:
+            raise
+        except Exception as e:
+            self.create_datadog_event('stop', args, options, e)
+            raise
+        else:
+            self.create_datadog_event('stop', args, options)
+            return output
+
+    def create_datadog_event(self, start_stop, args, options, error=None):
+        text = 'args: {}\noptions: {}'.format(args, options)
+        if error:
+            text += '\nerror: {}'.format(error)
+        event = '{}: {}'.format(self.command_name, start_stop)
+        create_datadog_event(
+            event, text, aggregation_key=self.command_name
+        )


### PR DESCRIPTION
Before I go adding this as the base class to all our management commands I though it best to get some input as to whether it's a good idea.

This will create 2 events in datadog for every management command run, one at the start and one at the end.

Management commands is one place we have very little visibility. 

Commands like `run_sms_queue` don't need to extend this class.
