### PR TITLE
Diff cases as forms are processed during Couch to SQL migration

### DIFF
--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -31,13 +31,14 @@ class AsyncFormProcessor(object):
     def __enter__(self):
         self.pool = Pool(15)
         self.queues = PartiallyLockingQueue()
-        self._rebuild_queues(self.statedb.pop_saved_resume_state())
+        form_ids = self.statedb.pop_resume_state(type(self).__name__, [])
+        self._rebuild_queues(form_ids)
         return self
 
     def __exit__(self, exc_type, exc, exc_tb):
         if exc_type is None:
             self._finish_processing_queues()
-        self.statedb.save_resume_state(self.queues.queue_ids)
+        self.statedb.set_resume_state(type(self).__name__, self.queues.queue_ids)
         self.queues = self.pool = None
 
     def _rebuild_queues(self, form_ids):

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -1,0 +1,329 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import logging
+from collections import defaultdict, deque
+from datetime import datetime, timedelta
+
+import gevent
+import six
+from gevent.pool import Pool
+
+from casexml.apps.case.xform import get_case_ids_from_form, get_case_updates
+
+from corehq.apps.cleanup.management.commands.swap_duplicate_xforms import (
+    PROBLEM_TEMPLATE_START,
+)
+from corehq.form_processor.backends.couch.dbaccessors import FormAccessorCouch
+from corehq.form_processor.parsers.ledgers.form import MissingFormXml
+from couchforms.models import XFormInstance, XFormOperation
+from dimagi.utils.chunked import chunked
+
+log = logging.getLogger(__name__)
+
+
+class AsyncFormProcessor(object):
+
+    def __init__(self, statedb, migrate_form):
+        self.statedb = statedb
+        self.migrate_form = migrate_form
+        self.processed_docs = 0
+
+    def __enter__(self):
+        self.pool = Pool(15)
+        self.queues = PartiallyLockingQueue()
+        self._rebuild_queues(self.statedb.pop_saved_resume_state())
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb):
+        if exc_type is None:
+            self._finish_processing_queues()
+        self.statedb.save_resume_state(self.queues.queue_ids)
+        self.queues = self.pool = None
+
+    def _rebuild_queues(self, form_ids):
+        for chunk in chunked(form_ids, 100, list):
+            for form in FormAccessorCouch.get_forms(chunk):
+                self._try_to_process_form(form)
+        self._try_to_empty_queues()
+
+    def process_xform(self, doc):
+        """Process XFormInstance document asynchronously"""
+        form_id = doc["_id"]
+        log.debug('Processing doc: XFormInstance(%s)', form_id)
+        if doc.get('problem'):
+            if six.text_type(doc['problem']).startswith(PROBLEM_TEMPLATE_START):
+                doc = _fix_replacement_form_problem_in_couch(doc)
+            else:
+                self.statedb.add_problem_form(form_id)
+                return
+        try:
+            wrapped_form = XFormInstance.wrap(doc)
+        except Exception:
+            log.exception("Error migrating form %s", form_id)
+        self._try_to_process_form(wrapped_form)
+        self._try_to_empty_queues()
+
+    def _try_to_process_form(self, wrapped_form):
+        case_ids = get_case_ids(wrapped_form)
+        if self.queues.try_obj(case_ids, wrapped_form):
+            self.pool.spawn(self._async_migrate_form, wrapped_form, case_ids)
+        elif self.queues.full:
+            gevent.sleep()  # swap greenlets
+
+    def _async_migrate_form(self, wrapped_form, case_ids):
+        try:
+            self.migrate_form(wrapped_form, case_ids)
+        finally:
+            self.queues.release_lock_for_queue_obj(wrapped_form)
+
+    def _try_to_empty_queues(self):
+        while True:
+            new_wrapped_form, case_ids = self.queues.get_next()
+            if not new_wrapped_form:
+                break
+            self.pool.spawn(self._async_migrate_form, new_wrapped_form, case_ids)
+
+    def _finish_processing_queues(self):
+        update_interval = timedelta(seconds=10)
+        next_check = datetime.now()
+        pool = self.pool
+        while self.queues.has_next():
+            wrapped_form, case_ids = self.queues.get_next()
+            if wrapped_form:
+                pool.spawn(self._async_migrate_form, wrapped_form, case_ids)
+            else:
+                gevent.sleep()  # swap greenlets
+
+            now = datetime.now()
+            if now > next_check:
+                remaining_items = self.queues.remaining_items + len(pool)
+                log.info('Waiting on {} docs'.format(remaining_items))
+                next_check += update_interval
+
+        while not pool.join(timeout=10):
+            log.info('Waiting on {} docs'.format(len(pool)))
+
+        unprocessed = self.queues.queue_ids
+        if unprocessed:
+            log.error("Unprocessed forms (unexpected): %s", unprocessed)
+
+
+class PartiallyLockingQueue(object):
+    """ Data structure that holds a queue of objects returning them as locks become free
+
+    This is not currently thread safe
+
+    Interface:
+    `.try_obj(lock_ids, queue_obj)` use to add a new object, seeing if it can be
+        processed immediately
+    `.get_next()` use to get the next object that can be processed
+    `.has_next()` use to make sure there are still objects in the queue
+    `.release_lock_for_queue_obj(queue_obj)` use to release the locks associated
+        with an object once finished processing
+    """
+
+    def __init__(self, queue_id_param="form_id", max_size=10000):
+        """
+        :queue_id_param string: param of the queued objects to pull an id from
+        :max_size int: the maximum size the queue should reach. -1 means no limit
+        """
+        self.queue_by_lock_id = defaultdict(deque)
+        self.lock_ids_by_queue_id = {}
+        self.queue_objs_by_queue_id = {}
+        self.currently_locked = set()
+        self.max_size = max_size
+
+        def get_queue_obj_id(queue_obj):
+            return getattr(queue_obj, queue_id_param)
+        self.get_queue_obj_id = get_queue_obj_id
+
+    @property
+    def queue_ids(self):
+        """Return a list of queue object ids
+
+        Queue state can be ruilt using this list by looking up each
+        queue object and lock ids and passing them to `try_obj()`.
+        """
+        return list(self.lock_ids_by_queue_id)
+
+    def try_obj(self, lock_ids, queue_obj):
+        """ Checks if the object can acquire some locks. If not, adds item to queue
+
+        :lock_ids set<string>: set of ids that this object needs to wait on
+        :queue_obj object: whatever kind of object is being queued
+
+        First checks the current locks, then makes sure this object would be the first in each
+        queue it would sit in
+
+        Returns :boolean: True if it acquired the lock, False if it was added to queue
+        """
+        if not lock_ids:
+            self._add_item(lock_ids, queue_obj, to_queue=False)
+            return True
+        if self._check_lock(lock_ids):  # if it's currently locked, it can't acquire the lock
+            self._add_item(lock_ids, queue_obj)
+            return False
+        for lock_id in lock_ids:  # if other objs are waiting for the same locks, it has to wait
+            queue = self.queue_by_lock_id[lock_id]
+            if queue:
+                self._add_item(lock_ids, queue_obj)
+                return False
+        self._add_item(lock_ids, queue_obj, to_queue=False)
+        self._set_lock(lock_ids)
+        return True
+
+    def get_next(self):
+        """Returns the next object and lock ids that can be processed
+
+        Iterates through the first object in each queue, then checks
+        that that object is the first in every lock queue it is in.
+
+        :returns: A tuple: `(<queue_obj>, <lock_ids>)`; `(None, None)`
+        if nothing can acquire the lock currently.
+        """
+        def is_first(queue_id, lock_id):
+            return queue_by_lock_id[lock_id][0] == queue_id
+
+        queue_by_lock_id = self.queue_by_lock_id
+        lock_ids_by_queue_id = self.lock_ids_by_queue_id
+        for queue in six.itervalues(queue_by_lock_id):
+            if not queue:
+                continue
+            queue_id = queue[0]
+            lock_ids = lock_ids_by_queue_id[queue_id]
+            if all(is_first(queue_id, x) for x in lock_ids) and self._set_lock(lock_ids):
+                return self._pop_queue_obj(queue_id), lock_ids
+        return None, None
+
+    def has_next(self):
+        """ Makes sure there are still objects in the queue
+
+        Returns :boolean: True if there are objs left, False if not
+        """
+        for queue in six.itervalues(self.queue_by_lock_id):
+            if queue:
+                return True
+        return False
+
+    def release_lock_for_queue_obj(self, queue_obj):
+        """ Releases all locks for an object in the queue
+
+        :queue_obj obj: An object of the type in the queues
+
+        At some point in the future it might raise an exception if it trys
+        releasing a lock that isn't held
+        """
+        queue_obj_id = self.get_queue_obj_id(queue_obj)
+        lock_ids = self.lock_ids_by_queue_id.pop(queue_obj_id, None)
+        if lock_ids:
+            self._release_lock(lock_ids)
+            return True
+        return False
+
+    @property
+    def remaining_items(self):
+        return len(self.queue_objs_by_queue_id)
+
+    @property
+    def full(self):
+        if self.max_size == -1:
+            return False
+        return self.remaining_items >= self.max_size
+
+    def _add_item(self, lock_ids, queue_obj, to_queue=True):
+        """
+        :to_queue boolean: adds object to queues if True, just to lock tracking if not
+        """
+        queue_obj_id = self.get_queue_obj_id(queue_obj)
+        if to_queue:
+            for lock_id in lock_ids:
+                self.queue_by_lock_id[lock_id].append(queue_obj_id)
+            self.queue_objs_by_queue_id[queue_obj_id] = queue_obj
+        self.lock_ids_by_queue_id[queue_obj_id] = lock_ids
+
+    def _pop_queue_obj(self, queued_obj_id):
+        """Removes and returns a queued obj from data model
+
+        :queue_obj_id string: An id of an object of the type in the queues
+
+        Assumes the obj is the first in every queue it inhabits. This seems reasonable
+        for the intended use case, as this function should only be used by `.get_next`.
+
+        Raises UnexpectedObjectException if this assumption doesn't hold
+        """
+        lock_ids = self.lock_ids_by_queue_id.get(queued_obj_id)
+        for lock_id in lock_ids:
+            queue = self.queue_by_lock_id[lock_id]
+            if queue[0] != queued_obj_id:
+                raise UnexpectedObjectException("This object shouldn't be removed")
+        for lock_id in lock_ids:
+            queue = self.queue_by_lock_id[lock_id]
+            queue.popleft()
+        return self.queue_objs_by_queue_id.pop(queued_obj_id)
+
+    def _check_lock(self, lock_ids):
+        return any(lock_id in self.currently_locked for lock_id in lock_ids)
+
+    def _set_lock(self, lock_ids):
+        """ Trys to set locks for given lock ids
+
+        If already locked, returns false. If acquired, returns True
+        """
+        if self._check_lock(lock_ids):
+            return False
+        self.currently_locked.update(lock_ids)
+        return True
+
+    def _release_lock(self, lock_ids):
+        self.currently_locked.difference_update(lock_ids)
+
+
+class UnexpectedObjectException(Exception):
+    pass
+
+
+def _fix_replacement_form_problem_in_couch(doc):
+    """Fix replacement form created by swap_duplicate_xforms
+
+    The replacement form was incorrectly created with "problem" text,
+    which causes it to be counted as an error form, and that messes up
+    the diff counts at the end of this migration.
+
+    NOTE the replacement form's _id does not match instanceID in its
+    form.xml. That issue is not resolved here.
+
+    See:
+    - corehq/apps/cleanup/management/commands/swap_duplicate_xforms.py
+    - couchforms/_design/views/all_submissions_by_domain/map.js
+    """
+    problem = doc["problem"]
+    assert problem.startswith(PROBLEM_TEMPLATE_START), doc
+    assert doc["doc_type"] == "XFormInstance", doc
+    deprecated_id = problem[len(PROBLEM_TEMPLATE_START):].split(" on ", 1)[0]
+    form = XFormInstance.wrap(doc)
+    form.deprecated_form_id = deprecated_id
+    form.history.append(XFormOperation(
+        user="system",
+        date=datetime.utcnow(),
+        operation="Resolved bad duplicate form during couch-to-sql "
+        "migration. Original problem: %s" % problem,
+    ))
+    form.problem = None
+    old_form = XFormInstance.get(deprecated_id)
+    if old_form.initial_processing_complete and not form.initial_processing_complete:
+        form.initial_processing_complete = True
+    form.save()
+    return form.to_json()
+
+
+def get_case_ids(form):
+    """Get case ids referenced in form
+
+    Gracefully handles missing XML, but will omit case ids referenced in
+    ledger updates if XML is missing.
+    """
+    try:
+        return get_case_ids_from_form(form)
+    except MissingFormXml:
+        return [update.id for update in get_case_updates(form)]

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -318,7 +318,7 @@ def _fix_replacement_form_problem_in_couch(doc):
 
 
 def get_case_ids(form):
-    """Get case ids referenced in form
+    """Get a set of case ids referenced in form
 
     Gracefully handles missing XML, but will omit case ids referenced in
     ledger updates if XML is missing.
@@ -326,4 +326,4 @@ def get_case_ids(form):
     try:
         return get_case_ids_from_form(form)
     except MissingFormXml:
-        return [update.id for update in get_case_updates(form)]
+        return {update.id for update in get_case_updates(form)}

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -27,7 +27,6 @@ class AsyncFormProcessor(object):
     def __init__(self, statedb, migrate_form):
         self.statedb = statedb
         self.migrate_form = migrate_form
-        self.processed_docs = 0
 
     def __enter__(self):
         self.pool = Pool(15)

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -233,7 +233,7 @@ class PartiallyLockingQueue(object):
 
     def _add_item(self, lock_ids, queue_obj, to_queue=True):
         """
-        :to_queue boolean: adds object to queues if True, just to lock tracking if not
+        :to_queue boolean: adds object to queues if True, just do lock tracking if not
         """
         queue_obj_id = self.get_queue_obj_id(queue_obj)
         if to_queue:

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -211,15 +211,6 @@ def task_switch():
     gevent.sleep()
 
 
-def get_case_form_ids(couch_case):
-    """Get the set of form ids that touched the given couch case object"""
-    form_ids = set(couch_case.xform_ids)
-    for action in couch_case.actions:
-        if action.xform_id:
-            form_ids.add(action.xform_id)
-    return form_ids
-
-
 @attr.s(slots=True)
 class CaseRecord(object):
 
@@ -252,6 +243,15 @@ class CaseRecord(object):
     @property
     def is_unexpected(self):
         return not self.processed_forms
+
+
+def get_case_form_ids(couch_case):
+    """Get the set of form ids that touched the given couch case object"""
+    form_ids = set(couch_case.xform_ids)
+    for action in couch_case.actions:
+        if action.xform_id:
+            form_ids.add(action.xform_id)
+    return form_ids
 
 
 class BatchProcessor(object):

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -51,7 +51,7 @@ class CaseDiffQueue(object):
     def __exit__(self, exc_type, exc, exc_tb):
         try:
             if exc_type is None:
-                self._process_remaining_diffs()
+                self.process_remaining_diffs()
         finally:
             self._save_resume_state()
 
@@ -119,7 +119,7 @@ class CaseDiffQueue(object):
         self.diff_batcher.spawn(self.diff_cases, self.cases_to_diff)
         self.cases_to_diff = {}
 
-    def _process_remaining_diffs(self):
+    def process_remaining_diffs(self):
         log.debug("process remaining diffs")
         if self.pending_cases:
             add_pending = self._add_pending_cases(self.pending_cases)

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import logging
+from collections import defaultdict
+
+from gevent.pool import Pool
+
+from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
+
+log = logging.getLogger(__name__)
+
+
+class CaseDiffQueue(object):
+
+    def __init__(self, statedb, diff_cases):
+        self.statedb = statedb
+        self.diff_cases = diff_cases
+        self.processed_forms = defaultdict(set)  # case id -> processed form ids
+        self.cases_to_diff = {}  # case id -> case doc (JSON)
+        self.pool = Pool(5)
+
+    def __enter__(self):
+        # TODO load resume state from self.statedb
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb):
+        if exc_type is None:
+            self._process_remaining_diffs()
+        # TODO save resume state to self.statedb
+
+    def update(self, case_ids, form_id):
+        """Update the case diff queue with case ids touched by form
+
+        :param case_ids: set of case ids.
+        :param form_id: form id touching case ids.
+        """
+        log.debug("update: cases=%s form=%s", case_ids, form_id)
+        processed = self.processed_forms
+        for case_id in case_ids:
+            processed[case_id].add(form_id)
+
+    def _lookup_pending_cases(self):
+        """Lookup cases to be diffed
+
+        Clears `self.processed_forms`
+        """
+        processed = self.processed_forms
+        case_ids = list(processed)
+        for case in CaseAccessorCouch.get_cases(case_ids):
+            self.enqueue(case.to_json())
+        self.processed_forms = defaultdict(set)
+
+    def enqueue(self, case_doc):
+        case_id = case_doc["_id"]
+        log.debug("enqueue case for diff: %s", case_id)
+        self.cases_to_diff[case_id] = case_doc
+
+    def _process_remaining_diffs(self):
+        if self.processed_forms:
+            self._lookup_pending_cases()
+            assert not self.processed_forms, self.processed_forms
+        self.pool, pool = None, self.pool
+        if self.cases_to_diff:
+            cases_to_diff = self.cases_to_diff
+            self.cases_to_diff = None  # prevent enqueue after close
+            pool.spawn(self.diff_cases, cases_to_diff)
+
+        while not pool.join(timeout=10):
+            log.info('Waiting on {} case diffs'.format(len(pool)))
+
+
+def get_case_form_ids(couch_case):
+    """Get the set of form ids that touched the given couch case object"""
+    form_ids = set(couch_case.xform_ids)
+    for action in couch_case.actions:
+        form_ids.add(action.xform_id)
+    return form_ids

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -6,13 +6,22 @@ from collections import defaultdict
 
 import gevent
 from gevent.pool import Pool
+from itertools import count
 
 from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
+from dimagi.utils.chunked import chunked
 
 log = logging.getLogger(__name__)
 
 
 class CaseDiffQueue(object):
+    """A queue that diffs cases when all relevant forms have been processed
+
+    Cases and other internal state of this queue are persisted in the
+    state db so they will be preserved between invocations when the
+    queue is used as a context manager. Some cases may be diffed more
+    than once, but none should be lost on account of of stop/resume.
+    """
 
     BATCH_SIZE = 100
 
@@ -22,15 +31,18 @@ class CaseDiffQueue(object):
         self.processed_forms = defaultdict(set)  # case id -> processed form ids
         self.cases_to_diff = {}  # case id -> case doc (JSON)
         self.pool = Pool(5)
+        self.case_batcher = BatchProcessor(self.pool)
 
     def __enter__(self):
-        # TODO load resume state from self.statedb
+        self._load_resume_state()
         return self
 
     def __exit__(self, exc_type, exc, exc_tb):
-        if exc_type is None:
-            self._process_remaining_diffs()
-        # TODO save resume state to self.statedb
+        try:
+            if exc_type is None:
+                self._process_remaining_diffs()
+        finally:
+            self._save_resume_state()
 
     def update(self, case_ids, form_id):
         """Update the case diff queue with case ids touched by form
@@ -43,42 +55,70 @@ class CaseDiffQueue(object):
         for case_id in case_ids:
             processed[case_id].add(form_id)
             if len(processed) >= self.BATCH_SIZE:
-                self._lookup_pending_cases()
-                processed = self.processed_forms
+                self._enqueue_pending_cases(processed)
+                processed = self.processed_forms = defaultdict(set)
+        task_switch()
 
-    def _lookup_pending_cases(self):
-        """Lookup cases to be diffed
+    def _enqueue_pending_cases(self, processed):
+        self.case_batcher.spawn(self._enqueue_cases, list(processed))
 
-        Clears `self.processed_forms`
-        """
-        processed = self.processed_forms
-        case_ids = list(processed)
+    def _enqueue_cases(self, case_ids):
         for case in CaseAccessorCouch.get_cases(case_ids):
             self.enqueue(case.to_json())
-        self.processed_forms = defaultdict(set)
 
     def enqueue(self, case_doc):
         case_id = case_doc["_id"]
-        log.debug("enqueue case for diff: %s", case_id)
-        cases_to_diff = self.cases_to_diff
-        cases_to_diff[case_id] = case_doc
-        if len(cases_to_diff) >= self.BATCH_SIZE:
-            self.cases_to_diff = {}
-            self.pool.spawn(self.diff_cases, cases_to_diff)
-            gevent.sleep()  # swap greenlets
+        self.cases_to_diff[case_id] = case_doc
+        if len(self.cases_to_diff) >= self.BATCH_SIZE:
+            self._diff_cases()
+
+    def _diff_cases(self):
+        self.case_batcher.spawn(self.diff_cases, self.cases_to_diff)
+        self.cases_to_diff = {}
 
     def _process_remaining_diffs(self):
+        log.debug("process remaining diffs")
         if self.processed_forms:
-            self._lookup_pending_cases()
-            assert not self.processed_forms, self.processed_forms
-        self.pool, pool = None, self.pool
-        if self.cases_to_diff:
-            cases_to_diff = self.cases_to_diff
-            self.cases_to_diff = None  # prevent enqueue after close
-            pool.spawn(self.diff_cases, cases_to_diff)
+            self._enqueue_pending_cases(self.processed_forms)
+        pool = self.pool
+        while self.cases_to_diff or pool:
+            if self.cases_to_diff:
+                self._diff_cases()
+            while not pool.join(timeout=10):
+                log.info('Waiting on {} case diff workers'.format(len(pool)))
+        self.pool = None
+        self.processed_forms = None
 
-        while not pool.join(timeout=10):
-            log.info('Waiting on {} case diffs'.format(len(pool)))
+    def _save_resume_state(self):
+        state = {}
+        if self.processed_forms:
+            state["processed"] = dict_of_lists(self.processed_forms)
+        if self.case_batcher or self.cases_to_diff:
+            state["to_diff"] = list(iter_unprocessed(self.case_batcher))
+            state["to_diff"].extend(self.cases_to_diff)
+        log.debug("resume state: %s", state)
+        self.statedb.set_resume_state(type(self).__name__, state)
+
+    def _load_resume_state(self):
+        state = self.statedb.pop_resume_state(type(self).__name__, {})
+        if "to_diff" in state:
+            for chunk in chunked(state["to_diff"], self.BATCH_SIZE, list):
+                self._enqueue_pending_cases(chunk)
+        if "processed" in state:
+            for key, value in state["processed"].items():
+                self.processed_forms[key].update(value)
+
+
+def task_switch():
+    gevent.sleep()
+
+
+def dict_of_lists(value):
+    return {k: list(v) for k, v in value.items()}
+
+
+def iter_unprocessed(batcher):
+    return (item for batch in batcher for item in batch)
 
 
 def get_case_form_ids(couch_case):
@@ -87,3 +127,48 @@ def get_case_form_ids(couch_case):
     for action in couch_case.actions:
         form_ids.add(action.xform_id)
     return form_ids
+
+
+class BatchProcessor(object):
+    """Process batches of items with a worker pool
+
+    Each batch of items is retained until its processing job has
+    completed successfully. Unprocessed batches can be retrieved
+    by iterating on the processor object.
+    """
+
+    def __init__(self, pool):
+        self.pool = pool
+        self.batches = {}
+        self.key_gen = count()
+
+    def __repr__(self):
+        return "<BatchProcessor {}>".format(self.batches)
+
+    def spawn(self, process, batch):
+        key = next(self.key_gen)
+        self.batches[key] = batch
+        self._process_batch(process, key)
+
+    def _process_batch(self, process, key):
+        def process_batch(key):
+            log.debug("call %s key=%s", process.__name__, key)
+            try:
+                process(self.batches[key])
+            except Exception as err:
+                log.warn("batch processing error: %s: %s", type(err).__name__, err)
+                raise
+            else:
+                self.batches.pop(key)
+
+        log.debug("schedule %s key=%s", process.__name__, key)
+        self.pool.spawn(process_batch, key)
+
+    def __bool__(self):
+        """Return true if there are unprocessed batches else false"""
+        return bool(self.batches)
+
+    __nonzero__ = __bool__
+
+    def __iter__(self):
+        return iter(self.batches.values())

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -188,7 +188,8 @@ def get_case_form_ids(couch_case):
     """Get the set of form ids that touched the given couch case object"""
     form_ids = set(couch_case.xform_ids)
     for action in couch_case.actions:
-        form_ids.add(action.xform_id)
+        if action.xform_id:
+            form_ids.add(action.xform_id)
     return form_ids
 
 

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -121,6 +121,13 @@ class CaseDiffQueue(object):
         self._flush()
         self._rediff_unexpected()
         self._flush()
+        assert not self.pending_cases, self.pending_cases
+        for batcher, action in [
+            (self.case_batcher, "loaded"),
+            (self.diff_batcher, "diffed"),
+        ]:
+            if batcher:
+                log.warn("%s batches of cases could not be %s", len(batcher), action)
         self.pool = None
 
     def _flush(self):
@@ -260,11 +267,9 @@ class BatchProcessor(object):
         self.retries[key] += 1
         return self.retries[key] < self.MAX_RETRIES
 
-    def __bool__(self):
-        """Return true if there are unprocessed batches else false"""
-        return bool(self.batches)
-
-    __nonzero__ = __bool__
+    def __len__(self):
+        """Return the number of unprocessed batches"""
+        return len(self.batches)
 
     def __iter__(self):
         return iter(self.batches.values())

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -117,6 +117,8 @@ class CouchSqlDomainMigrator(object):
         self.with_progress = with_progress
         self.domain = domain
         self.statedb = init_state_db(domain)
+        # exit immediately on uncaught greenlet error
+        gevent.get_hub().SYSTEM_ERROR = BaseException
 
     def migrate(self):
         log.info('migrating domain {}'.format(self.domain))

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -6,9 +6,9 @@ from __future__ import unicode_literals
 import logging
 import os
 import sys
-from collections import defaultdict, deque
+from collections import defaultdict
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import gevent
 import six
@@ -24,9 +24,7 @@ from django.conf import settings
 from django.db.utils import IntegrityError
 from gevent.pool import Pool
 
-from corehq.apps.cleanup.management.commands.swap_duplicate_xforms import (
-    PROBLEM_TEMPLATE_START,
-)
+from corehq.apps.couch_sql_migration.asyncforms import AsyncFormProcessor
 from corehq.apps.couch_sql_migration.diff import (
     filter_case_diffs,
     filter_form_diffs,
@@ -78,8 +76,7 @@ from corehq.util.log import with_progress_bar
 from corehq.util.pagination import PaginationEventHandler
 from corehq.util.timer import TimingContext
 from couchforms.models import XFormInstance, all_known_formlike_doc_types
-from couchforms.models import XFormOperation, doc_types as form_doc_types
-from dimagi.utils.chunked import chunked
+from couchforms.models import doc_types as form_doc_types
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from pillowtop.reindexer.change_providers.couch import CouchDomainDocTypeChangeProvider
@@ -653,40 +650,6 @@ def _migrate_couch_attachments_to_blob_db(couch_form):
         assert not set(couch_form._attachments) - set(couch_form.blobs), couch_form
 
 
-def _fix_replacement_form_problem_in_couch(doc):
-    """Fix replacement form created by swap_duplicate_xforms
-
-    The replacement form was incorrectly created with "problem" text,
-    which causes it to be counted as an error form, and that messes up
-    the diff counts at the end of this migration.
-
-    NOTE the replacement form's _id does not match instanceID in its
-    form.xml. That issue is not resolved here.
-
-    See:
-    - corehq/apps/cleanup/management/commands/swap_duplicate_xforms.py
-    - couchforms/_design/views/all_submissions_by_domain/map.js
-    """
-    problem = doc["problem"]
-    assert problem.startswith(PROBLEM_TEMPLATE_START), doc
-    assert doc["doc_type"] == "XFormInstance", doc
-    deprecated_id = problem[len(PROBLEM_TEMPLATE_START):].split(" on ", 1)[0]
-    form = XFormInstance.wrap(doc)
-    form.deprecated_form_id = deprecated_id
-    form.history.append(XFormOperation(
-        user="system",
-        date=datetime.utcnow(),
-        operation="Resolved bad duplicate form during couch-to-sql "
-        "migration. Original problem: %s" % problem,
-    ))
-    form.problem = None
-    old_form = XFormInstance.get(deprecated_id)
-    if old_form.initial_processing_complete and not form.initial_processing_complete:
-        form.initial_processing_complete = True
-    form.save()
-    return form.to_json()
-
-
 def sql_form_to_json(form):
     """Serialize SQL form to JSON
 
@@ -776,18 +739,6 @@ def _get_case_and_ledger_updates(domain, sql_form):
     )
 
 
-def get_case_ids(form):
-    """Get case ids referenced in form
-
-    Gracefully handles missing XML, but will omit case ids referenced in
-    ledger updates if XML is missing.
-    """
-    try:
-        return get_case_ids_from_form(form)
-    except MissingFormXml:
-        return [update.id for update in get_case_updates(form)]
-
-
 def _save_migrated_models(sql_form, case_stock_result=None):
     """
     See SubmissionPost.save_processed_models for ~what this should do.
@@ -849,267 +800,6 @@ def commit_migration(domain_name):
             "could not set use_sql_backend for domain %s (try again)" % domain_name
     datadog_counter("commcare.couch_sql_migration.total_committed")
     log.info("committed migration for {}".format(domain_name))
-
-
-class AsyncFormProcessor(object):
-
-    def __init__(self, statedb, migrate_form):
-        self.statedb = statedb
-        self.migrate_form = migrate_form
-        self.processed_docs = 0
-
-    def __enter__(self):
-        self.pool = Pool(15)
-        self.queues = PartiallyLockingQueue()
-        self._rebuild_queues(self.statedb.pop_saved_resume_state())
-        return self
-
-    def __exit__(self, exc_type, exc, exc_tb):
-        if exc_type is None:
-            self._finish_processing_queues()
-        self.statedb.save_resume_state(self.queues.queue_ids)
-        self.queues = self.pool = None
-
-    def _rebuild_queues(self, form_ids):
-        for chunk in chunked(form_ids, 100, list):
-            for form in FormAccessorCouch.get_forms(chunk):
-                self._try_to_process_form(form)
-        self._try_to_empty_queues()
-
-    def process_xform(self, doc):
-        """Process XFormInstance document asynchronously"""
-        form_id = doc["_id"]
-        log.debug('Processing doc: XFormInstance(%s)', form_id)
-        if doc.get('problem'):
-            if six.text_type(doc['problem']).startswith(PROBLEM_TEMPLATE_START):
-                doc = _fix_replacement_form_problem_in_couch(doc)
-            else:
-                self.statedb.add_problem_form(form_id)
-                return
-        try:
-            wrapped_form = XFormInstance.wrap(doc)
-        except Exception:
-            log.exception("Error migrating form %s", form_id)
-        self._try_to_process_form(wrapped_form)
-        self._try_to_empty_queues()
-
-    def _try_to_process_form(self, wrapped_form):
-        case_ids = get_case_ids(wrapped_form)
-        if self.queues.try_obj(case_ids, wrapped_form):
-            self.pool.spawn(self._async_migrate_form, wrapped_form, case_ids)
-        elif self.queues.full:
-            gevent.sleep()  # swap greenlets
-
-    def _async_migrate_form(self, wrapped_form, case_ids):
-        try:
-            self.migrate_form(wrapped_form, case_ids)
-        finally:
-            self.queues.release_lock_for_queue_obj(wrapped_form)
-
-    def _try_to_empty_queues(self):
-        while True:
-            new_wrapped_form, case_ids = self.queues.get_next()
-            if not new_wrapped_form:
-                break
-            self.pool.spawn(self._async_migrate_form, new_wrapped_form, case_ids)
-
-    def _finish_processing_queues(self):
-        update_interval = timedelta(seconds=10)
-        next_check = datetime.now()
-        pool = self.pool
-        while self.queues.has_next():
-            wrapped_form, case_ids = self.queues.get_next()
-            if wrapped_form:
-                pool.spawn(self._async_migrate_form, wrapped_form, case_ids)
-            else:
-                gevent.sleep()  # swap greenlets
-
-            now = datetime.now()
-            if now > next_check:
-                remaining_items = self.queues.remaining_items + len(pool)
-                log.info('Waiting on {} docs'.format(remaining_items))
-                next_check += update_interval
-
-        while not pool.join(timeout=10):
-            log.info('Waiting on {} docs'.format(len(pool)))
-
-        unprocessed = self.queues.queue_ids
-        if unprocessed:
-            log.error("Unprocessed forms (unexpected): %s", unprocessed)
-
-
-class PartiallyLockingQueue(object):
-    """ Data structure that holds a queue of objects returning them as locks become free
-
-    This is not currently thread safe
-
-    Interface:
-    `.try_obj(lock_ids, queue_obj)` use to add a new object, seeing if it can be
-        processed immediately
-    `.get_next()` use to get the next object that can be processed
-    `.has_next()` use to make sure there are still objects in the queue
-    `.release_lock_for_queue_obj(queue_obj)` use to release the locks associated
-        with an object once finished processing
-    """
-
-    def __init__(self, queue_id_param="form_id", max_size=10000):
-        """
-        :queue_id_param string: param of the queued objects to pull an id from
-        :max_size int: the maximum size the queue should reach. -1 means no limit
-        """
-        self.queue_by_lock_id = defaultdict(deque)
-        self.lock_ids_by_queue_id = {}
-        self.queue_objs_by_queue_id = {}
-        self.currently_locked = set()
-        self.max_size = max_size
-
-        def get_queue_obj_id(queue_obj):
-            return getattr(queue_obj, queue_id_param)
-        self.get_queue_obj_id = get_queue_obj_id
-
-    @property
-    def queue_ids(self):
-        """Return a list of queue object ids
-
-        Queue state can be ruilt using this list by looking up each
-        queue object and lock ids and passing them to `try_obj()`.
-        """
-        return list(self.lock_ids_by_queue_id)
-
-    def try_obj(self, lock_ids, queue_obj):
-        """ Checks if the object can acquire some locks. If not, adds item to queue
-
-        :lock_ids list<string>: list of ids that this object needs to wait on
-        :queue_obj object: whatever kind of object is being queued
-
-        First checks the current locks, then makes sure this object would be the first in each
-        queue it would sit in
-
-        Returns :boolean: True if it acquired the lock, False if it was added to queue
-        """
-        if not lock_ids:
-            self._add_item(lock_ids, queue_obj, to_queue=False)
-            return True
-        if self._check_lock(lock_ids):  # if it's currently locked, it can't acquire the lock
-            self._add_item(lock_ids, queue_obj)
-            return False
-        for lock_id in lock_ids:  # if other objs are waiting for the same locks, it has to wait
-            queue = self.queue_by_lock_id[lock_id]
-            if queue:
-                self._add_item(lock_ids, queue_obj)
-                return False
-        self._add_item(lock_ids, queue_obj, to_queue=False)
-        self._set_lock(lock_ids)
-        return True
-
-    def get_next(self):
-        """Returns the next object and lock ids that can be processed
-
-        Iterates through the first object in each queue, then checks
-        that that object is the first in every lock queue it is in.
-
-        :returns: A tuple: `(<queue_obj>, <lock_ids>)`; `(None, None)`
-        if nothing can acquire the lock currently.
-        """
-        def is_first(queue_id, lock_id):
-            return queue_by_lock_id[lock_id][0] == queue_id
-
-        queue_by_lock_id = self.queue_by_lock_id
-        lock_ids_by_queue_id = self.lock_ids_by_queue_id
-        for queue in six.itervalues(queue_by_lock_id):
-            if not queue:
-                continue
-            queue_id = queue[0]
-            lock_ids = lock_ids_by_queue_id[queue_id]
-            if all(is_first(queue_id, x) for x in lock_ids) and self._set_lock(lock_ids):
-                return self._pop_queue_obj(queue_id), lock_ids
-        return None, None
-
-    def has_next(self):
-        """ Makes sure there are still objects in the queue
-
-        Returns :boolean: True if there are objs left, False if not
-        """
-        for queue in six.itervalues(self.queue_by_lock_id):
-            if queue:
-                return True
-        return False
-
-    def release_lock_for_queue_obj(self, queue_obj):
-        """ Releases all locks for an object in the queue
-
-        :queue_obj obj: An object of the type in the queues
-
-        At some point in the future it might raise an exception if it trys
-        releasing a lock that isn't held
-        """
-        queue_obj_id = self.get_queue_obj_id(queue_obj)
-        lock_ids = self.lock_ids_by_queue_id.pop(queue_obj_id, None)
-        if lock_ids:
-            self._release_lock(lock_ids)
-            return True
-        return False
-
-    @property
-    def remaining_items(self):
-        return len(self.queue_objs_by_queue_id)
-
-    @property
-    def full(self):
-        if self.max_size == -1:
-            return False
-        return self.remaining_items >= self.max_size
-
-    def _add_item(self, lock_ids, queue_obj, to_queue=True):
-        """
-        :to_queue boolean: adds object to queues if True, just to lock tracking if not
-        """
-        queue_obj_id = self.get_queue_obj_id(queue_obj)
-        if to_queue:
-            for lock_id in lock_ids:
-                self.queue_by_lock_id[lock_id].append(queue_obj_id)
-            self.queue_objs_by_queue_id[queue_obj_id] = queue_obj
-        self.lock_ids_by_queue_id[queue_obj_id] = lock_ids
-
-    def _pop_queue_obj(self, queued_obj_id):
-        """Removes and returns a queued obj from data model
-
-        :queue_obj_id string: An id of an object of the type in the queues
-
-        Assumes the obj is the first in every queue it inhabits. This seems reasonable
-        for the intended use case, as this function should only be used by `.get_next`.
-
-        Raises UnexpectedObjectException if this assumption doesn't hold
-        """
-        lock_ids = self.lock_ids_by_queue_id.get(queued_obj_id)
-        for lock_id in lock_ids:
-            queue = self.queue_by_lock_id[lock_id]
-            if queue[0] != queued_obj_id:
-                raise UnexpectedObjectException("This object shouldn't be removed")
-        for lock_id in lock_ids:
-            queue = self.queue_by_lock_id[lock_id]
-            queue.popleft()
-        return self.queue_objs_by_queue_id.pop(queued_obj_id)
-
-    def _check_lock(self, lock_ids):
-        return any(lock_id in self.currently_locked for lock_id in lock_ids)
-
-    def _set_lock(self, lock_ids):
-        """ Trys to set locks for given lock ids
-
-        If already locked, returns false. If acquired, returns True
-        """
-        if self._check_lock(lock_ids):
-            return False
-        self.currently_locked.update(lock_ids)
-        return True
-
-    def _release_lock(self, lock_ids):
-        self.currently_locked.difference_update(lock_ids)
-
-
-class UnexpectedObjectException(Exception):
-    pass
 
 
 class MigrationRestricted(Exception):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -9,7 +9,6 @@ import sys
 from collections import defaultdict, deque
 from copy import deepcopy
 from datetime import datetime, timedelta
-from time import time
 
 import gevent
 import six

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -6,8 +6,6 @@ from __future__ import unicode_literals
 import logging
 import os
 import sys
-from collections import defaultdict
-from copy import deepcopy
 from datetime import datetime
 
 import gevent

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -274,6 +274,7 @@ def is_case_actions(old_obj, new_obj, rule, diff):
 
 def ignore_renamed(old_name, new_name):
     def is_renamed(old_obj, new_obj, rule, diff):
+        assert diff.path, repr(diff)
         diffname = diff.path[0]
         if diffname == old_name or diffname == new_name:
             old_value = old_obj.get(old_name, MISSING)

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -171,8 +171,10 @@ class Command(BaseCommand):
         ZERO = Counts(0, 0)
         if db.has_doc_counts():
             doc_counts = db.get_doc_counts()
+            couch_missing_cases = doc_counts.get("CommCareCase-couch", ZERO).missing
         else:
             doc_counts = None
+            couch_missing_cases = 0
         for doc_type in CASE_DOC_TYPES:
             if doc_counts is not None:
                 counts = doc_counts.get(doc_type, ZERO)
@@ -198,6 +200,12 @@ class Command(BaseCommand):
                 short,
                 diffs_only,
             )
+            if doc_type == "CommCareCase" and couch_missing_cases:
+                has_diffs = True
+                print(shell_red("%s cases could not be loaded from Couch" % couch_missing_cases))
+                if not short:
+                    for case_id in db.get_missing_doc_ids("CommCareCase-couch"):
+                        print(case_id)
 
         if diff_stats:
             for key, counts in diff_stats.items():

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -150,7 +150,7 @@ class StateDB(DiffDB):
         """Add case that has been updated by a form it does not reference"""
         with self.session() as session:
             sql = (
-                "INSERT INTO {table} (id) VALUES (:id) ON CONFLICT DO NOTHING"
+                "INSERT OR IGNORE INTO {table} (id) VALUES (:id)"
             ).format(table=UnexpectedCaseUpdate.__tablename__)
             session.execute(sql, {"id": case_id})
 

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -1,0 +1,133 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import attr
+from django.test import SimpleTestCase
+
+from ..asyncforms import PartiallyLockingQueue
+
+
+class TestLockingQueues(SimpleTestCase):
+
+    def setUp(self):
+        self.queues = PartiallyLockingQueue("id", max_size=-1)
+
+    def _add_to_queues(self, queue_obj_id, lock_ids):
+        self.queues._add_item(lock_ids, DummyObject(queue_obj_id))
+        self._check_queue_dicts(queue_obj_id, lock_ids, -1)
+
+    def _check_queue_dicts(self, queue_obj_id, lock_ids, location=None, present=True):
+        """
+        if location is None, it looks anywhere. If it is an int, it'll look in that spot
+        present determines whether it's expected to be in the queue_by_lock_id or not
+        """
+        for lock_id in lock_ids:
+            queue = self.queues.queue_by_lock_id[lock_id]
+            if location is not None:
+                self.assertEqual(
+                    present,
+                    len(queue) > location - 1 and queue_obj_id == queue[location],
+                )
+            else:
+                self.assertEqual(present, queue_obj_id in queue)
+
+        self.assertItemsEqual(lock_ids, self.queues.lock_ids_by_queue_id[queue_obj_id])
+
+    def _check_locks(self, lock_ids, lock_set=True):
+        self.assertEqual(lock_set, self.queues._check_lock(lock_ids))
+
+    def test_has_next(self):
+        self.assertFalse(self.queues.has_next())
+        self._add_to_queues('monadnock', ['heady_topper', 'sip_of_sunshine', 'focal_banger'])
+        self.assertTrue(self.queues.has_next())
+
+    def test_try_obj(self):
+        # first object is fine
+        lock_ids = ['grapefruit_sculpin', '60_minute', 'boom_sauce']
+        queue_obj = DummyObject('little_haystack')
+        self.assertTrue(self.queues.try_obj(lock_ids, queue_obj))
+        self._check_locks(lock_ids, lock_set=True)
+        self._check_queue_dicts('little_haystack', lock_ids, present=False)
+
+        # following objects without overlapping locks are fine
+        new_lock_ids = ['brew_free', 'steal_this_can']
+        new_queue_obj = DummyObject('lincoln')
+        self.assertTrue(self.queues.try_obj(new_lock_ids, new_queue_obj))
+        self._check_locks(new_lock_ids, lock_set=True)
+        self._check_queue_dicts('lincoln', new_lock_ids, present=False)
+
+        # following ojbects with overlapping locks add to queue
+        final_lock_ids = ['grapefruit_sculpin', 'wrought_iron']
+        final_queue_obj = DummyObject('lafayette')
+        self.assertFalse(self.queues.try_obj(final_lock_ids, final_queue_obj))
+        self._check_queue_dicts('lafayette', final_lock_ids, -1)
+        self._check_locks(['grapefruit_sculpin'], lock_set=True)
+        self._check_locks(['wrought_iron'], lock_set=False)
+
+    def test_get_next(self):
+        # nothing returned if nothing in queues
+        self.assertEqual((None, None), self.queues.get_next())
+
+        # first obj in queues will be returned if nothing blocking
+        lock_ids = ['old_chub', 'dales_pale', 'little_yella']
+        queue_obj_id = 'moosilauke'
+        self._add_to_queues(queue_obj_id, lock_ids)
+        self.assertEqual(queue_obj_id, self.queues.get_next()[0].id)
+        self._check_locks(lock_ids, lock_set=True)
+
+        # next object will not be returned if anything locks are held
+        new_lock_ids = ['old_chub', 'ten_fidy']
+        new_queue_obj_id = 'flume'
+        self._add_to_queues(new_queue_obj_id, new_lock_ids)
+        self.assertEqual((None, None), self.queues.get_next())
+        self._check_locks(['ten_fidy'], lock_set=False)
+
+        # next object will not be returned if not first in all queues
+        next_lock_ids = ['ten_fidy', 'death_by_coconut']
+        next_queue_obj_id = 'liberty'
+        self._add_to_queues(next_queue_obj_id, next_lock_ids)
+        self.assertEqual((None, None), self.queues.get_next())
+        self._check_locks(next_lock_ids, lock_set=False)
+
+        # will return something totally orthogonal though
+        final_lock_ids = ['fugli', 'pinner']
+        final_queue_obj_id = 'sandwich'
+        self._add_to_queues(final_queue_obj_id, final_lock_ids)
+        self.assertEqual(final_queue_obj_id, self.queues.get_next()[0].id)
+        self._check_locks(final_lock_ids)
+
+    def test_release_locks(self):
+        lock_ids = ['rubaeus', 'dirty_bastard', 'red\'s_rye']
+        self._check_locks(lock_ids, lock_set=False)
+        self.queues._set_lock(lock_ids)
+        self._check_locks(lock_ids, lock_set=True)
+        self.queues._release_lock(lock_ids)
+        self._check_locks(lock_ids, lock_set=False)
+
+        queue_obj = DummyObject('kancamagus')
+        self.queues._add_item(lock_ids, queue_obj, to_queue=False)
+        self.queues._set_lock(lock_ids)
+        self._check_locks(lock_ids, lock_set=True)
+        self.queues.release_lock_for_queue_obj(queue_obj)
+        self._check_locks(lock_ids, lock_set=False)
+
+    def test_max_size(self):
+        self.assertEqual(-1, self.queues.max_size)
+        self.assertFalse(self.queues.full)  # not full when no max size set
+        self.queues.max_size = 2  # set max_size
+        lock_ids = ['dali', 'manet', 'monet']
+        queue_obj = DummyObject('osceola')
+        self.queues._add_item(lock_ids, queue_obj)
+        self.assertFalse(self.queues.full)  # not full when not full
+        queue_obj = DummyObject('east osceola')
+        self.queues._add_item(lock_ids, queue_obj)
+        self.assertTrue(self.queues.full)  # full when full
+        queue_obj = DummyObject('west osceola')
+        self.queues._add_item(lock_ids, queue_obj)
+        self.assertTrue(self.queues.full)  # full when over full
+
+
+@attr.s
+class DummyObject(object):
+
+    id = attr.ib()

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -49,6 +49,12 @@ class TestCaseDiffQueue(SimpleTestCase):
             queue.update({"cx"}, "fx")
         self.assertDiffed("cx")
 
+    def test_case_with_unprocessed_form(self):
+        self.add_cases("c", "f0 f1")
+        with self.queue() as queue:
+            queue.update({"c"}, "f0")
+        self.assertDiffed("c")
+
     def test_diff_batching(self):
         self.add_cases("a b c d e", "fx")
         batch_size = mod.CaseDiffQueue.BATCH_SIZE

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -102,7 +102,7 @@ class TestCaseDiffQueue(SimpleTestCase):
             # HACK mutate queue internal state
             # currently there is no easier way to stop non-empty cases_to_diff
             queue.cases_to_diff["a"] = self.get_cases("a")[0]
-            raise Error("do not _process_remaining_diffs")
+            raise Error("do not process_remaining_diffs")
         self.assertTrue(queue.cases_to_diff)
         with self.queue() as queue:
             pass
@@ -112,7 +112,7 @@ class TestCaseDiffQueue(SimpleTestCase):
         self.add_cases("a b c", "f1")
         self.add_cases("d", "f2")
         with self.assertRaises(Error), self.queue() as queue:
-            mock = patch.object(queue, "_process_remaining_diffs").start()
+            mock = patch.object(queue, "process_remaining_diffs").start()
             mock.side_effect = Error("cannot process remaining diffs")
             queue.update({"a", "b", "c"}, "f1")
         queue.pool.kill()  # simulate end process

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import attr
+import gevent
+import six
+from django.test import SimpleTestCase
+from mock import patch
+
+from ..casediff import CaseDiffQueue
+from ..statedb import delete_state_db, init_state_db
+
+
+@patch.object(gevent.get_hub(), "SYSTEM_ERROR", BaseException)
+class TestCaseDiffQueue(SimpleTestCase):
+
+    def setUp(self):
+        def make_get_cases():
+            return lambda case_ids: [self.cases[x] for x in case_ids]
+
+        def diff_cases(cases):
+            for case in six.itervalues(cases):
+                case_id = case["_id"]
+                if case_id in diffed:
+                    diffed[case_id] += 1
+                else:
+                    diffed[case_id] = 1
+
+        self.close_context = _test_context(self,
+            get_cases=patch(
+                "corehq.form_processor.backends.couch.dbaccessors."
+                "CaseAccessorCouch.get_cases",
+                new_callable=make_get_cases,
+            ),
+            statedb=init_state_db("test"),
+        )
+
+        self.cases = {}
+        self.diffed = diffed = {}
+        self.queue = CaseDiffQueue(self.statedb, diff_cases)
+
+    def tearDown(self):
+        self.close_context()
+        delete_state_db("test")
+
+    def add_case(self, case_id, xform_ids=None):
+        if isinstance(xform_ids, six.text_type):
+            xform_ids = xform_ids.split()
+        self.cases[case_id] = FakeCase(case_id, xform_ids or [])
+
+    def test_case_diff(self):
+        self.add_case("cx", "fx")
+        with self.queue as queue:
+            queue.update({"cx"}, "fx")
+        self.assertEqual(self.diffed, {"cx": 1})
+
+
+@attr.s
+class FakeCase(object):
+
+    _id = attr.ib()
+    xform_ids = attr.ib(factory=list)
+    actions = attr.ib(factory=list)
+
+    @property
+    def case_id(self):
+        return self._id
+
+    def to_json(self):
+        return {f.name: getattr(self, f.name) for f in attr.fields(type(self))}
+
+
+def _test_context(test, **contexts):
+    def close():
+        for context in six.itervalues(contexts):
+            context.__exit__(None, None, None)
+
+    for name, context in six.iteritems(contexts):
+        value = context.__enter__()
+        setattr(test, name, value)
+    return close

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -94,6 +94,17 @@ class TestCaseDiffQueue(SimpleTestCase):
             queue.update({"d"}, "f2")
         self.assertDiffed("a b c d")
 
+    def test_num_diffed_cases_on_resume(self):
+        self.add_cases("a b c", "f1")
+        self.add_cases("d", "f2")
+        # simulate a single call to couch failing
+        with self.queue() as queue:
+            queue.update({"a", "b", "c"}, "f1")
+        self.assertEqual(queue.num_diffed_cases, 3)
+        with self.queue() as queue:
+            queue.update({"d"}, "f2")
+        self.assertEqual(queue.num_diffed_cases, 4)
+
     def test_diff_cases_failure(self):
         self.add_cases("a b c", "f1")
         self.add_cases("d", "f2")

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -861,7 +861,7 @@ class TestHelperFunctions(TestCase):
 
     def test_get_case_ids_with_missing_xml(self):
         form = self.get_form_with_missing_xml()
-        self.assertEqual(get_case_ids(form), ["test-case"])
+        self.assertEqual(get_case_ids(form), {"test-case"})
 
 
 def create_form_with_missing_xml(domain_name):

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -65,10 +65,9 @@ from corehq.util.test_utils import (
     trap_extra_setup,
 )
 
+from ..asyncforms import get_case_ids
 from ..couchsqlmigration import (
     MigrationRestricted,
-    PartiallyLockingQueue,
-    get_case_ids,
     sql_form_to_json,
 )
 from ..diffrule import ANY
@@ -836,124 +835,6 @@ class LedgerMigrationTests(BaseMigrationTestCase):
         return LedgerAccessors(self.domain_name).get_case_ledger_state(case_id)
 
 
-class TestLockingQueues(TestCase):
-    def setUp(self):
-        self.queues = PartiallyLockingQueue("id", max_size=-1)
-
-    def _add_to_queues(self, queue_obj_id, lock_ids):
-        self.queues._add_item(lock_ids, DummyObject(queue_obj_id))
-        self._check_queue_dicts(queue_obj_id, lock_ids, -1)
-
-    def _check_queue_dicts(self, queue_obj_id, lock_ids, location=None, present=True):
-        """
-        if location is None, it looks anywhere. If it is an int, it'll look in that spot
-        present determines whether it's expected to be in the queue_by_lock_id or not
-        """
-        for lock_id in lock_ids:
-            if location is not None:
-                self.assertEqual(
-                    present,
-                    (len(self.queues.queue_by_lock_id[lock_id]) > (location - 1) and
-                        queue_obj_id == self.queues.queue_by_lock_id[lock_id][location]))
-            else:
-                self.assertEqual(present, queue_obj_id in self.queues.queue_by_lock_id[lock_id])
-
-        self.assertItemsEqual(lock_ids, self.queues.lock_ids_by_queue_id[queue_obj_id])
-
-    def _check_locks(self, lock_ids, lock_set=True):
-        self.assertEqual(lock_set, self.queues._check_lock(lock_ids))
-
-    def test_has_next(self):
-        self.assertFalse(self.queues.has_next())
-        self._add_to_queues('monadnock', ['heady_topper', 'sip_of_sunshine', 'focal_banger'])
-        self.assertTrue(self.queues.has_next())
-
-    def test_try_obj(self):
-        # first object is fine
-        lock_ids = ['grapefruit_sculpin', '60_minute', 'boom_sauce']
-        queue_obj = DummyObject('little_haystack')
-        self.assertTrue(self.queues.try_obj(lock_ids, queue_obj))
-        self._check_locks(lock_ids, lock_set=True)
-        self._check_queue_dicts('little_haystack', lock_ids, present=False)
-
-        # following objects without overlapping locks are fine
-        new_lock_ids = ['brew_free', 'steal_this_can']
-        new_queue_obj = DummyObject('lincoln')
-        self.assertTrue(self.queues.try_obj(new_lock_ids, new_queue_obj))
-        self._check_locks(new_lock_ids, lock_set=True)
-        self._check_queue_dicts('lincoln', new_lock_ids, present=False)
-
-        # following ojbects with overlapping locks add to queue
-        final_lock_ids = ['grapefruit_sculpin', 'wrought_iron']
-        final_queue_obj = DummyObject('lafayette')
-        self.assertFalse(self.queues.try_obj(final_lock_ids, final_queue_obj))
-        self._check_queue_dicts('lafayette', final_lock_ids, -1)
-        self._check_locks(['grapefruit_sculpin'], lock_set=True)
-        self._check_locks(['wrought_iron'], lock_set=False)
-
-    def test_get_next(self):
-        # nothing returned if nothing in queues
-        self.assertEqual((None, None), self.queues.get_next())
-
-        # first obj in queues will be returned if nothing blocking
-        lock_ids = ['old_chub', 'dales_pale', 'little_yella']
-        queue_obj_id = 'moosilauke'
-        self._add_to_queues(queue_obj_id, lock_ids)
-        self.assertEqual(queue_obj_id, self.queues.get_next()[0].id)
-        self._check_locks(lock_ids, lock_set=True)
-
-        # next object will not be returned if anything locks are held
-        new_lock_ids = ['old_chub', 'ten_fidy']
-        new_queue_obj_id = 'flume'
-        self._add_to_queues(new_queue_obj_id, new_lock_ids)
-        self.assertEqual((None, None), self.queues.get_next())
-        self._check_locks(['ten_fidy'], lock_set=False)
-
-        # next object will not be returned if not first in all queues
-        next_lock_ids = ['ten_fidy', 'death_by_coconut']
-        next_queue_obj_id = 'liberty'
-        self._add_to_queues(next_queue_obj_id, next_lock_ids)
-        self.assertEqual((None, None), self.queues.get_next())
-        self._check_locks(next_lock_ids, lock_set=False)
-
-        # will return something totally orthogonal though
-        final_lock_ids = ['fugli', 'pinner']
-        final_queue_obj_id = 'sandwich'
-        self._add_to_queues(final_queue_obj_id, final_lock_ids)
-        self.assertEqual(final_queue_obj_id, self.queues.get_next()[0].id)
-        self._check_locks(final_lock_ids)
-
-    def test_release_locks(self):
-        lock_ids = ['rubaeus', 'dirty_bastard', 'red\'s_rye']
-        self._check_locks(lock_ids, lock_set=False)
-        self.queues._set_lock(lock_ids)
-        self._check_locks(lock_ids, lock_set=True)
-        self.queues._release_lock(lock_ids)
-        self._check_locks(lock_ids, lock_set=False)
-
-        queue_obj = DummyObject('kancamagus')
-        self.queues._add_item(lock_ids, queue_obj, to_queue=False)
-        self.queues._set_lock(lock_ids)
-        self._check_locks(lock_ids, lock_set=True)
-        self.queues.release_lock_for_queue_obj(queue_obj)
-        self._check_locks(lock_ids, lock_set=False)
-
-    def test_max_size(self):
-        self.assertEqual(-1, self.queues.max_size)
-        self.assertFalse(self.queues.full)  # not full when no max size set
-        self.queues.max_size = 2  # set max_size
-        lock_ids = ['dali', 'manet', 'monet']
-        queue_obj = DummyObject('osceola')
-        self.queues._add_item(lock_ids, queue_obj)
-        self.assertFalse(self.queues.full)  # not full when not full
-        queue_obj = DummyObject('east osceola')
-        self.queues._add_item(lock_ids, queue_obj)
-        self.assertTrue(self.queues.full)  # full when full
-        queue_obj = DummyObject('west osceola')
-        self.queues._add_item(lock_ids, queue_obj)
-        self.assertTrue(self.queues.full)  # full when over full
-
-
 class TestHelperFunctions(TestCase):
 
     def setUp(self):
@@ -1025,14 +906,6 @@ class Diff(object):
         return not (self == other)
 
     __hash__ = None
-
-
-class DummyObject(object):
-    def __init__(self, id=None):
-        self.id = id or uuid.uuid4().hex
-
-    def __repr__(self):
-        return "DummyObject<id={}>".format(self.id)
 
 
 TEST_FORM = """

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -893,34 +893,34 @@ class TestLockingQueues(TestCase):
 
     def test_get_next(self):
         # nothing returned if nothing in queues
-        self.assertEqual(None, self.queues.get_next())
+        self.assertEqual((None, None), self.queues.get_next())
 
         # first obj in queues will be returned if nothing blocking
         lock_ids = ['old_chub', 'dales_pale', 'little_yella']
         queue_obj_id = 'moosilauke'
         self._add_to_queues(queue_obj_id, lock_ids)
-        self.assertEqual(queue_obj_id, self.queues.get_next().id)
+        self.assertEqual(queue_obj_id, self.queues.get_next()[0].id)
         self._check_locks(lock_ids, lock_set=True)
 
         # next object will not be returned if anything locks are held
         new_lock_ids = ['old_chub', 'ten_fidy']
         new_queue_obj_id = 'flume'
         self._add_to_queues(new_queue_obj_id, new_lock_ids)
-        self.assertEqual(None, self.queues.get_next())
+        self.assertEqual((None, None), self.queues.get_next())
         self._check_locks(['ten_fidy'], lock_set=False)
 
         # next object will not be returned if not first in all queues
         next_lock_ids = ['ten_fidy', 'death_by_coconut']
         next_queue_obj_id = 'liberty'
         self._add_to_queues(next_queue_obj_id, next_lock_ids)
-        self.assertEqual(None, self.queues.get_next())
+        self.assertEqual((None, None), self.queues.get_next())
         self._check_locks(next_lock_ids, lock_set=False)
 
         # will return something totally orthogonal though
         final_lock_ids = ['fugli', 'pinner']
         final_queue_obj_id = 'sandwich'
         self._add_to_queues(final_queue_obj_id, final_lock_ids)
-        self.assertEqual(final_queue_obj_id, self.queues.get_next().id)
+        self.assertEqual(final_queue_obj_id, self.queues.get_next()[0].id)
         self._check_locks(final_lock_ids)
 
     def test_release_locks(self):

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -643,7 +643,6 @@ class MigrationTestCase(BaseMigrationTestCase):
             'commcare.couch_sql_migration.unprocessed_cases.count.duration:',
             'commcare.couch_sql_migration.main_forms.count.duration:',
             'commcare.couch_sql_migration.unprocessed_forms.count.duration:',
-            'commcare.couch_sql_migration.case_diffs.count.duration:',
             'commcare.couch_sql_migration.count.duration:',
         ]
         for t_stat in tracked_stats:

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -46,18 +46,18 @@ def test_no_action_case_forms():
         eq(db.get_no_action_case_forms(), {"abc", "def"})
 
 
-def test_save_resume_state():
+def test_resume_state():
     with init_state_db("test") as db:
-        eq(db.pop_saved_resume_state(), [])
-        db.save_resume_state(["abc", "def"])
+        eq(db.pop_resume_state("test", []), [])
+        db.set_resume_state("test", ["abc", "def"])
 
     with init_state_db("test") as db:
-        eq(db.pop_saved_resume_state(), ["abc", "def"])
+        eq(db.pop_resume_state("test", []), ["abc", "def"])
 
     # simulate resume without save
     with init_state_db("test") as db:
         with assert_raises(ResumeError):
-            db.pop_saved_resume_state()
+            db.pop_resume_state("test", [])
 
 
 def test_counters():

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -3,9 +3,16 @@ from __future__ import unicode_literals
 
 import re
 
+from sqlalchemy.exc import OperationalError
 from testil import assert_raises, eq
 
-from ..statedb import Counts, delete_state_db, init_state_db, ResumeError
+from ..statedb import (
+    Counts,
+    ResumeError,
+    delete_state_db,
+    diff_doc_id_idx,
+    init_state_db,
+)
 
 
 def teardown():
@@ -71,3 +78,9 @@ def test_counters():
             "abc": Counts(4, 3),
             "def": Counts(2, 0),
         })
+
+
+def test_diff_doc_id_idx_exists():
+    msg = re.compile("index diff_doc_id_idx already exists")
+    with init_state_db("test") as db, assert_raises(OperationalError, msg=msg):
+        diff_doc_id_idx.create(db.engine)


### PR DESCRIPTION
This shifts a major phase of the migration (case diffs) into the main forms iteration, which means more of the migration can happen while the domain continues to be online and accepting new form submissions. In other words, it reduces the amount of time that the domain must be offline to finish up the migration. See [Resumable migration design](https://docs.google.com/document/d/1oZ8ElLFQ-kMTWZmirTQlluoEK9-v3xAJJyGOWnKsFnc/edit?ts=5c4f8144#heading=h.xgilw1xfjnz9) for more details.

While all tests pass and the code in this PR is a fully working prototype, this is still a work in progress and more features are planned before it can be used to migrate some very large domains. Features to be added in subsequent PRs:

- Diff cases in a separate process to improve performance.
- Persist parts of the case/form graph to disk rather than keeping it all in memory. The graph is expected to get quite large and some cases will hang around in there for a very long time due to the usercase model of operation where thousands of forms submitted over a long time period update a single case.

@snopoke @dannyroberts 