### PR TITLE
Run recalculate_stagnant_cases only on icds envs and india

### DIFF
--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -7,7 +7,7 @@ from time import sleep, time
 from celery import Celery, current_app
 from celery.backends.base import DisabledBackend
 from celery.schedules import crontab
-from celery.task import task
+from celery.task import task, periodic_task
 from django.conf import settings
 import kombu.five
 import six
@@ -211,3 +211,10 @@ def deserialize_run_every_setting(run_every_setting):
         return fn(**params)
     else:
         raise generic_value_error
+
+
+def periodic_task_on_envs(envs, *args, **kwargs):
+    if settings.SERVER_ENVIRONMENT in envs:
+        return periodic_task(*args, **kwargs)
+    else:
+        return lambda fn: fn

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -697,7 +697,7 @@ def email_dashboad_team(aggregation_date, aggregation_start_time, force_citus=Fa
 
 
 @periodic_task_on_envs(
-    settings.ICDS_TESTING_ENVS,
+    settings.ICDS_ENVS,
     queue='background_queue',
     run_every=crontab(day_of_week='tuesday,thursday,saturday', minute=0, hour=16),
     acks_late=True

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -696,7 +696,8 @@ def email_dashboad_team(aggregation_date, aggregation_start_time, force_citus=Fa
     icds_data_validation.delay(aggregation_date)
 
 
-@periodic_task(
+@periodic_task_on_envs(
+    settings.ICDS_TESTING_ENVS,
     queue='background_queue',
     run_every=crontab(day_of_week='tuesday,thursday,saturday', minute=0, hour=16),
     acks_late=True

--- a/settings.py
+++ b/settings.py
@@ -458,6 +458,7 @@ ENABLE_SOFT_ASSERT_EMAILS = True
 
 SERVER_ENVIRONMENT = 'localdev'
 ICDS_ENVS = ('icds', 'icds-new')
+ICDS_TESTING_ENVS = ('icds', 'icds-new', 'india',)
 UNLIMITED_RULE_RESTART_ENVS = ('echis', 'pna', 'swiss')
 
 # minimum minutes between updates to user reporting metadata

--- a/settings.py
+++ b/settings.py
@@ -458,7 +458,6 @@ ENABLE_SOFT_ASSERT_EMAILS = True
 
 SERVER_ENVIRONMENT = 'localdev'
 ICDS_ENVS = ('icds', 'icds-new')
-ICDS_TESTING_ENVS = ('icds', 'icds-new', 'india',)
 UNLIMITED_RULE_RESTART_ENVS = ('echis', 'pna', 'swiss')
 
 # minimum minutes between updates to user reporting metadata


### PR DESCRIPTION
This error https://sentry.io/organizations/dimagi/issues/1107518919/?project=136860&query=is%3Aunresolved+StaticDataSourceConfigurationNotFoundError&statsPeriod=14d shows up quite a bit. Don't think it causes much harm but it was annoying me in sentry and it's an easy fix.