### PR TITLE
 Re-add Python 2 test jobs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
     - master
 env:
   matrix:
+    - TEST=python NOSE_DIVIDED_WE_RUN=05 JS_SETUP=yes
+    - TEST=python NOSE_DIVIDED_WE_RUN=6a JS_SETUP=yes
+    - TEST=python NOSE_DIVIDED_WE_RUN=bf JS_SETUP=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=05 JS_SETUP=yes PYTHON3=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=6a JS_SETUP=yes PYTHON3=yes
     - TEST=python NOSE_DIVIDED_WE_RUN=bf JS_SETUP=yes PYTHON3=yes


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/24853 was too eager, unfortunately.

I did not re-add the sharded and JS test runner since @snopoke said it was not necessary. Please chime in if you know of code paths that would not—but should—be tested on Python 2 as a result of this omission.

@snopoke @nickpell @ctsims 