### PR TITLE
Allows LocationSelectWidget to render scalar values

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import re
 
+import six
 from crispy_forms.layout import Submit
 from django import forms
 from django.db.models import Q
@@ -50,7 +51,7 @@ class LocationSelectWidget(forms.Widget):
         self.template = 'locations/manage/partials/autocomplete_select_widget.html'
 
     def render(self, name, value, attrs=None, renderer=None):
-        location_ids = value or []
+        location_ids = to_list(value) if value else []
         locations = list(SQLLocation.active_objects
                          .filter(domain=self.domain, location_id__in=location_ids))
         initial_data = [{
@@ -725,3 +726,19 @@ class RelatedLocationForm(forms.Form):
                 if name.startswith('relation_distance_')
             }
         )
+
+
+def to_list(value):
+    """
+    Returns ``value`` as a list if it is iterable and not a string,
+    otherwise returns ``value`` in a list.
+
+    >>> to_list(('foo', 'bar', 'baz')) == ['foo', 'bar', 'baz']
+    True
+    >>> to_list('foo bar baz') == ['foo bar baz']
+    True
+
+    """
+    if hasattr(value, '__iter__') and not isinstance(value, six.string_types):
+        return list(value)
+    return [value]

--- a/corehq/motech/repeaters/tests/test_forms.py
+++ b/corehq/motech/repeaters/tests/test_forms.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, unicode_literals
+
+import doctest
+
+from corehq.motech.repeaters import forms
+
+
+def test_doctests():
+    results = doctest.testmod(forms)
+    assert results.failed == 0


### PR DESCRIPTION
`LocationSelectWidget` supports selecting single or multiple locations. But when it is used for selecting a single location, it doesn't render single-location initial values. (The field appears blank.) This fixes that.

I think this hasn't been spotted before because the widget doesn't get used like this much. It is used in four places in HQ: Two of them are used for selecting multiple locations, so `render()` is passed a list value and this issue doesn't happen. One is in [custom code](https://github.com/dimagi/commcare-hq/blob/7ab2e2300d34e4183a1423319e8ad8023a48a254/custom/ewsghana/forms.py#L99). And the last is in [`OpenmrsRepeaterForm`](https://github.com/dimagi/commcare-hq/blob/b853a5d185ffd89f484c60e4576de54158a7204b/corehq/motech/repeaters/forms.py#L210) where I found the problem.
