### PR TITLE
Fixed issue with subprocess hanging on \r in python3

### DIFF
--- a/corehq/apps/app_manager/xpath_validator/tests.py
+++ b/corehq/apps/app_manager/xpath_validator/tests.py
@@ -17,7 +17,7 @@ class XpathValidatorTest(SimpleTestCase):
         self.assertEqual(
             validate_xpath('data node'),
             XpathValidationResponse(is_valid=False, message=
-b"""Lexical error on line 1. Unrecognized text.
+"""Lexical error on line 1. Unrecognized text.
 data node
 -----^
 """))
@@ -43,7 +43,7 @@ data node
             validate_xpath(
                 "if(count(instance('commcaresession')/session/user/data/commcare_location_id) &gt; 0, instance('commcaresession')/session/user/data/commcare_location_id, /data/meta/userID)"),
             XpathValidationResponse(is_valid=False, message=
-b"""Lexical error on line 1. Unrecognized text.
+"""Lexical error on line 1. Unrecognized text.
 ...mmcare_location_id) &gt; 0, instance('co
 -----------------------^
 """))
@@ -57,7 +57,7 @@ b"""Lexical error on line 1. Unrecognized text.
         self.assertEqual(
             validate_xpath('#hashtag'),
             XpathValidationResponse(is_valid=False,
-                                    message=b"hashtag is not a valid # expression\n"))
+                                    message="hashtag is not a valid # expression\n"))
 
     def test_case_hashtag(self):
         self.assertEqual(
@@ -68,4 +68,4 @@ b"""Lexical error on line 1. Unrecognized text.
         self.assertEqual(
             validate_xpath('#case', allow_case_hashtags=False),
             XpathValidationResponse(is_valid=False,
-                                    message=b"case is not a valid # expression\n"))
+                                    message="case is not a valid # expression\n"))

--- a/corehq/apps/app_manager/xpath_validator/wrapper.py
+++ b/corehq/apps/app_manager/xpath_validator/wrapper.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from corehq.apps.app_manager.xpath_validator.config import get_xpath_validator_path
 from corehq.apps.app_manager.xpath_validator.exceptions import XpathValidationError
 from dimagi.utils.subprocess_manager import subprocess_context
+import six
 import re
 
 XpathValidationResponse = namedtuple('XpathValidationResponse', ['is_valid', 'message'])
@@ -16,9 +17,13 @@ def validate_xpath(xpath, allow_case_hashtags=False):
             cmd = ['node', path, '--allow-case-hashtags']
         else:
             cmd = ['node', path]
-        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, universal_newlines=True)
-        stdout, stderr = p.communicate(xpath)
+        if six.PY3:
+            p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, universal_newlines=True, encoding='utf-8')
+            stdout, stderr = p.communicate(xpath)
+        else:
+            p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate(re.sub(r'\s+', ' ', xpath).encode('utf-8'))
         exit_code = p.wait()
     if exit_code == 0:
         return XpathValidationResponse(is_valid=True, message=None)

--- a/corehq/apps/app_manager/xpath_validator/wrapper.py
+++ b/corehq/apps/app_manager/xpath_validator/wrapper.py
@@ -5,7 +5,6 @@ from corehq.apps.app_manager.xpath_validator.config import get_xpath_validator_p
 from corehq.apps.app_manager.xpath_validator.exceptions import XpathValidationError
 from dimagi.utils.subprocess_manager import subprocess_context
 import six
-import re
 
 XpathValidationResponse = namedtuple('XpathValidationResponse', ['is_valid', 'message'])
 
@@ -23,7 +22,7 @@ def validate_xpath(xpath, allow_case_hashtags=False):
             stdout, stderr = p.communicate(xpath)
         else:
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = p.communicate(re.sub(r'\s+', ' ', xpath).encode('utf-8'))
+            stdout, stderr = p.communicate(xpath.encode('utf-8'))
         exit_code = p.wait()
     if exit_code == 0:
         return XpathValidationResponse(is_valid=True, message=None)

--- a/corehq/apps/app_manager/xpath_validator/wrapper.py
+++ b/corehq/apps/app_manager/xpath_validator/wrapper.py
@@ -17,9 +17,8 @@ def validate_xpath(xpath, allow_case_hashtags=False):
         else:
             cmd = ['node', path]
         p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-        # Collapse whitespace. '\r' mysteriously causes the process to hang in python 3.
-        stdout, stderr = p.communicate(re.sub(r'\s+', ' ', xpath).encode('utf-8'))
+                             stderr=subprocess.PIPE, universal_newlines=True)
+        stdout, stderr = p.communicate(xpath)
         exit_code = p.wait()
     if exit_code == 0:
         return XpathValidationResponse(is_valid=True, message=None)


### PR DESCRIPTION
Still testing, but I believe this will replace https://github.com/dimagi/commcare-hq/pull/24802 as well as my trifecta of https://github.com/dimagi/commcare-hq/pull/24839, https://github.com/dimagi/commcare-hq/pull/24870, and https://github.com/dimagi/commcare-hq/pull/24871 

However, this seems to not be compatible with python 2, where it causes an encoding bug similar to the one fixed way back in https://github.com/dimagi/commcare-hq/pull/11199 to pop up again.