### PR TITLE
cache commtrack fixtures

### DIFF
--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -4,7 +4,7 @@ from xml.etree import cElementTree as ElementTree
 import six
 
 
-def simple_fixture_generator(restore_user, id, name, fields, data_fn, last_sync=None):
+def simple_fixture_generator(restore_user, id, name, fields, data_fn, last_sync=None, user_id=None):
     """
     Fixture generator used to build commtrack related fixtures such
     as products and programs.
@@ -23,7 +23,7 @@ def simple_fixture_generator(restore_user, id, name, fields, data_fn, last_sync=
     root = ElementTree.Element('fixture',
                                {
                                    'id': id,
-                                   'user_id': restore_user.user_id
+                                   'user_id': user_id or restore_user.user_id
                                })
     list_elem = ElementTree.Element(name_plural)
     root.append(list_elem)

--- a/corehq/apps/commtrack/tests/test_fixture.py
+++ b/corehq/apps/commtrack/tests/test_fixture.py
@@ -149,6 +149,14 @@ class FixtureTest(TestCase, TestXmlMixin):
         """
         self.assertXmlEqual(schema_xml, ElementTree.tostring(index_schema))
 
+        # test restore with different user
+        user2 = create_restore_user(self.domain, username='user2')
+        self.addCleanup(user2._couch_user.delete)
+        fixture_xml = self.generate_product_fixture_xml(user2)
+        index_schema, fixture = call_fixture_generator(product_fixture_generator, user2)
+
+        self.assertXmlEqual(fixture_xml, fixture)
+
     def test_product_fixture_cache(self):
         user = self.user
 
@@ -220,6 +228,17 @@ class FixtureTest(TestCase, TestXmlMixin):
         program_xml = self.generate_program_xml(program_list, user)
 
         fixture = call_fixture_generator(program_fixture_generator, user)
+
+        self.assertXmlEqual(
+            program_xml,
+            fixture[0]
+        )
+
+        # test restore with different user
+        user2 = create_restore_user(self.domain, username='user2')
+        self.addCleanup(user2._couch_user.delete)
+        program_xml = self.generate_program_xml(program_list, user2)
+        fixture = call_fixture_generator(program_fixture_generator, user2)
 
         self.assertXmlEqual(
             program_xml,

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -6,20 +6,12 @@ from xml.etree import cElementTree as ElementTree
 
 from casexml.apps.phone.fixtures import FixtureProvider
 from casexml.apps.phone.utils import write_fixture_items_to_io, cache_fixture_items_data, \
-    get_cached_fixture_items
+    get_cached_fixture_items, GLOBAL_USER_ID
 from corehq.apps.fixtures.dbaccessors import iter_fixture_items_for_data_type
 from corehq.apps.fixtures.models import FIXTURE_BUCKET, FixtureDataType
 from corehq.apps.products.fixtures import product_fixture_generator_json
 from corehq.apps.programs.fixtures import program_fixture_generator_json
 from .utils import get_index_schema_node
-
-# GLOBAL_USER_ID is expected to be a globally unique string that will never
-# change and can always be search-n-replaced in global fixture XML. The UUID
-# in this string was generated with `uuidgen` on Mac OS X 10.11.6
-# HACK if this string is present anywhere in an item list it will be replaced
-# with the restore user's user_id. DO NOT DEPEND ON THIS IMPLEMENTATION DETAIL.
-# This is an optimization to avoid an extra XML parse/serialize cycle.
-GLOBAL_USER_ID = 'global-user-id-7566F038-5000-4419-B3EF-5349FB2FF2E9'
 
 
 def item_lists_by_domain(domain):

--- a/corehq/apps/products/models.py
+++ b/corehq/apps/products/models.py
@@ -72,6 +72,10 @@ class Product(Document):
 
         super(Product, cls).save_docs(docs, use_uuids)
 
+        domains = {doc['domain'] for doc in docs}
+        for domain in domains:
+            cls.clear_caches(domain)
+
     bulk_save = save_docs
 
     def sync_to_sql(self):
@@ -127,6 +131,7 @@ class Product(Document):
 
         result = super(Product, self).save(*args, **kwargs)
 
+        self.clear_caches(self.domain)
         self.sync_to_sql()
 
         return result
@@ -138,6 +143,13 @@ class Product(Document):
     @code.setter
     def code(self, val):
         self.code_ = val.lower() if val else None
+
+    @classmethod
+    def clear_caches(cls, domain):
+        from casexml.apps.phone.utils import clear_fixture_cache
+        from corehq.apps.products.fixtures import ALL_CACHE_PREFIXES
+        for prefix in ALL_CACHE_PREFIXES:
+            clear_fixture_cache(domain, prefix)
 
     @classmethod
     def get_by_code(cls, domain, code):

--- a/corehq/apps/programs/fixtures.py
+++ b/corehq/apps/programs/fixtures.py
@@ -40,10 +40,12 @@ class ProgramFixturesProvider(FixtureProvider):
     def _get_fixture_items(self, restore_state):
         restore_user = restore_state.restore_user
 
-        data_fn = lambda: Program.by_domain(restore_user.domain)
+        def get_programs():
+            return Program.by_domain(restore_user.domain)
+
         return simple_fixture_generator(
             restore_user, self.id, "program",
-            PROGRAM_FIELDS, data_fn, restore_state.last_sync_log
+            PROGRAM_FIELDS, get_programs, restore_state.last_sync_log
         )
 
 program_fixture_generator = ProgramFixturesProvider()

--- a/corehq/apps/programs/fixtures.py
+++ b/corehq/apps/programs/fixtures.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from functools import partial
 
 from casexml.apps.phone.fixtures import FixtureProvider
-from casexml.apps.phone.utils import get_or_cache_global_fixture
+from casexml.apps.phone.utils import get_or_cache_global_fixture, GLOBAL_USER_ID
 from corehq.apps.programs.models import Program
 from corehq.apps.commtrack.fixtures import simple_fixture_generator
 
@@ -45,7 +45,8 @@ class ProgramFixturesProvider(FixtureProvider):
 
         return simple_fixture_generator(
             restore_user, self.id, "program",
-            PROGRAM_FIELDS, get_programs, restore_state.last_sync_log
+            PROGRAM_FIELDS, get_programs, restore_state.last_sync_log, GLOBAL_USER_ID
         )
+
 
 program_fixture_generator = ProgramFixturesProvider()

--- a/corehq/apps/programs/fixtures.py
+++ b/corehq/apps/programs/fixtures.py
@@ -1,10 +1,16 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+from functools import partial
+
 from casexml.apps.phone.fixtures import FixtureProvider
+from casexml.apps.phone.utils import get_or_cache_global_fixture
 from corehq.apps.programs.models import Program
 from corehq.apps.commtrack.fixtures import simple_fixture_generator
 
 PROGRAM_FIELDS = ['name', 'code']
+
+PROGRAM_FIXTURE_BUCKET = 'program_fixture'
 
 
 def program_fixture_generator_json(domain):
@@ -28,6 +34,10 @@ class ProgramFixturesProvider(FixtureProvider):
     id = 'commtrack:programs'
 
     def __call__(self, restore_state):
+        data_fn = partial(self._get_fixture_items, restore_state)
+        return get_or_cache_global_fixture(restore_state, PROGRAM_FIXTURE_BUCKET, self.id, data_fn)
+
+    def _get_fixture_items(self, restore_state):
         restore_user = restore_state.restore_user
 
         data_fn = lambda: Program.by_domain(restore_user.domain)

--- a/corehq/apps/programs/models.py
+++ b/corehq/apps/programs/models.py
@@ -34,8 +34,8 @@ class Program(Document):
 
     def save(self, *args, **kwargs):
         self.last_modified = datetime.utcnow()
-
-        return super(Program, self).save(*args, **kwargs)
+        super(Program, self).save(*args, **kwargs)
+        self.clear_caches(self.domain)
 
     @classmethod
     def by_domain(cls, domain, wrap=True):
@@ -84,7 +84,8 @@ class Program(Document):
         # bulk update sqlproducts
         sql_products.update(program_id=default._id)
 
-        return super(Program, self).delete()
+        super(Program, self).delete()
+        self.clear_caches(self.domain)
 
     def unarchive(self):
         """
@@ -106,3 +107,9 @@ class Program(Document):
         return (SQLProduct.objects
                 .filter(domain=self.domain, program_id=self.get_id)
                 .count())
+
+    @classmethod
+    def clear_caches(cls, domain):
+        from casexml.apps.phone.utils import clear_fixture_cache
+        from corehq.apps.programs.fixtures import PROGRAM_FIXTURE_BUCKET
+        clear_fixture_cache(domain, PROGRAM_FIXTURE_BUCKET)

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -90,6 +90,10 @@ def get_cached_fixture_items(domain, bucket_prefix):
         return None
 
 
+def clear_fixture_cache(domain, bucket_prefix):
+    get_blob_db().delete(key=bucket_prefix + '/' + domain)
+
+
 def get_cached_items_with_count(cached_bytes):
     """Get the number of items encoded in cached XML elements byte string
 

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -44,8 +44,9 @@ def get_or_cache_global_fixture(restore_state, cache_bucket_prefix, fixture_name
     if data is None:
         items = data_fn()
         io_data = write_fixture_items_to_io(items)
-        cache_fixture_items_data(io_data, domain, fixture_name, cache_bucket_prefix)
         data = io_data.read()
+        io_data.seek(0)
+        cache_fixture_items_data(io_data, domain, fixture_name, cache_bucket_prefix)
 
     global_id = GLOBAL_USER_ID.encode('utf-8')
     b_user_id = restore_state.restore_user.user_id.encode('utf-8')
@@ -80,7 +81,6 @@ def cache_fixture_items_data(io_data, domain, fixure_name, key_prefix):
             "key": key_prefix + '/' + domain,
         }
     db.put(io_data, **kw)
-    io_data.seek(0)
 
 
 def get_cached_fixture_items(domain, bucket_prefix):

--- a/corehq/ex-submodules/casexml/apps/phone/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/utils.py
@@ -35,6 +35,15 @@ GLOBAL_USER_ID = 'global-user-id-7566F038-5000-4419-B3EF-5349FB2FF2E9'
 
 
 def get_or_cache_global_fixture(restore_state, cache_bucket_prefix, fixture_name, data_fn):
+    """
+    Get the fixture data for a global fixture (one that does not vary by user).
+
+    :param restore_state: Restore state object used to access features of the restore
+    :param cache_bucket_prefix: Fixture bucket prefix
+    :param fixture_name: Name of the fixture
+    :param data_fn: Function to generate the XML fixture elements
+    :return: byte string representation of the fixture
+    """
     domain = restore_state.restore_user.domain
 
     data = None


### PR DESCRIPTION
Most of the couch errors on ICDS are caused by bulk doc requests and most of those are from fixture queries, particularly the product fixture:

https://sentry.io/organizations/dimagi/issues/1113065195/

This uses the same caching mechanism that we use for the 'item' fixture. The caches are cleared on save /  bulk_save / delete.