### PR TITLE
handle edge case earlier

### DIFF
--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -136,12 +136,12 @@ class EditFormTest(TestCase, TestFileMixin):
             owner_id='some-owner',
         )
 
-        form, _ = submit_case_blocks(case_block.as_string().decode('utf-8'), domain=self.domain, form_id=form_id)
+        form, _ = submit_case_blocks(case_block.as_text(), domain=self.domain, form_id=form_id)
         self.assertTrue(form.is_error)
         self.assertTrue('IllegalCaseId' in form.problem)
 
         case_block.case_id = uuid.uuid4().hex
-        form, _ = submit_case_blocks(case_block.as_string().decode('utf-8'), domain=self.domain, form_id=form_id)
+        form, _ = submit_case_blocks(case_block.as_text(), domain=self.domain, form_id=form_id)
         self.assertFalse(form.is_error)
         self.assertEqual(None, getattr(form, 'problem', None))
 

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -200,12 +200,23 @@ def _handle_duplicate(new_doc):
             )
             return xform, None
         else:
-            # if the form contents are not the same:
-            #  - "Deprecate" the old form by making a new document with the same contents
-            #    but a different ID and a doc_type of XFormDeprecated
-            #  - Save the new instance to the previous document to preserve the ID
-            existing_doc, new_doc = apply_deprecation(existing_doc, new_doc, interface)
-            return new_doc, existing_doc
+            if existing_doc.is_error and not existing_doc.initial_processing_complete:
+                # edge case from ICDS where a form errors and then future re-submissions of the same
+                # form do not have the same MD5 hash due to a bug on mobile:
+                # see https://dimagi-dev.atlassian.net/browse/ICDS-376
+
+                # since we have a new form and the old one was not successfully processed
+                # we can effectively ignore this form and process the new one as normal
+                interface.assign_new_id(existing_doc)
+                existing_doc.save()
+                return new_doc, None
+            else:
+                # if the form contents are not the same:
+                #  - "Deprecate" the old form by making a new document with the same contents
+                #    but a different ID and a doc_type of XFormDeprecated
+                #  - Save the new instance to the previous document to preserve the ID
+                existing_doc, new_doc = apply_deprecation(existing_doc, new_doc, interface)
+                return new_doc, existing_doc
     else:
         # follow standard dupe handling, which simply saves a copy of the form
         # but a new doc_id, and a doc_type of XFormDuplicate

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -207,6 +207,8 @@ def _handle_duplicate(new_doc):
 
                 # since we have a new form and the old one was not successfully processed
                 # we can effectively ignore this form and process the new one as normal
+                if not interface.use_sql_domain:
+                    new_doc._rev, existing_doc._rev = existing_doc._rev, new_doc._rev
                 interface.assign_new_id(existing_doc)
                 existing_doc.save()
                 return new_doc, None

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -253,22 +253,6 @@ class SubmissionPost(object):
             with case_db_cache as case_db:
                 instance = xforms[0]
 
-                is_edit_of_error = len(xforms) == 2 and xforms[1].is_error
-                if not instance.is_duplicate and is_edit_of_error:
-                    # edge case from ICDS where a form errors and then future re-submissions of the same
-                    # form do not have the same MD5 hash due to a bug on mobile:
-                    # see https://dimagi-dev.atlassian.net/browse/ICDS-376
-                    existing_form = xforms[1]
-                    if not existing_form.initial_processing_complete:
-                        # since we have a new form and the old one was not successfully processed
-                        # we can effectively ignore this form and process the new one as normal
-                        # since this form will have been marked as deprecated and have a new ID etc.
-                        existing_form.save()
-                        xforms = [instance]
-                    else:
-                        # not clear what to do in this case, try the normal edit workflow
-                        pass
-
                 if instance.is_duplicate:
                     with tracer.trace('submission.process_duplicate'):
                         submission_type = 'duplicate'


### PR DESCRIPTION
This moves were the edge case is handled to before the deprecation happens. The main reason for this is that after deprecation the state of the form is changed from `error` to `deprecated`.

https://sentry.io/organizations/dimagi/issues/1104734139