### PR TITLE
restructure OData feed so each config has its own metadata doc

### DIFF
--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -140,8 +140,8 @@ class ODataCaseSerializer(Serializer):
         assert all([domain, config_id, api_path]), [domain, config_id, api_path]
 
         data['@odata.context'] = '{}#{}'.format(
-            absolute_reverse(ODataCaseMetadataView.urlname, args=[domain]),
-            config_id
+            absolute_reverse(ODataCaseMetadataView.urlname, args=[domain, config_id]),
+            'feed'
         )
 
         next_link = self.get_next_url(data.pop('meta'), api_path)
@@ -192,8 +192,8 @@ class ODataFormSerializer(Serializer):
         assert all([domain, config_id, api_path]), [domain, config_id, api_path]
 
         data['@odata.context'] = '{}#{}'.format(
-            absolute_reverse(ODataFormMetadataView.urlname, args=[domain]),
-            config_id
+            absolute_reverse(ODataFormMetadataView.urlname, args=[domain, config_id]),
+            'feed'
         )
 
         next_link = self.get_next_url(data.pop('meta'), api_path)

--- a/corehq/apps/api/odata/tests/data/populated_case_odata_metadata_document_from_config.xml
+++ b/corehq/apps/api/odata/tests/data/populated_case_odata_metadata_document_from_config.xml
@@ -2,12 +2,7 @@
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
-            <EntityType Name="odata_config_1">
-                <Key>
-                    <PropertyRef Name="caseid"/>
-                </Key>
-            </EntityType>
-            <EntityType Name="odata_config_2">
+            <EntityType Name="feed">
                 <Key>
                     <PropertyRef Name="caseid"/>
                 </Key>
@@ -15,8 +10,7 @@
                 <Property Name="selected_property_2" Type="Edm.String"/>
             </EntityType>
             <EntityContainer Name="Container" >
-                <EntitySet EntityType="CommCare.odata_config_1" Name="odata_config_1"/>
-                <EntitySet EntityType="CommCare.odata_config_2" Name="odata_config_2"/>
+                <EntitySet EntityType="CommCare.feed" Name="feed"/>
             </EntityContainer>
         </Schema>
     </edmx:DataServices>

--- a/corehq/apps/api/odata/tests/data/populated_form_odata_metadata_document_from_config.xml
+++ b/corehq/apps/api/odata/tests/data/populated_form_odata_metadata_document_from_config.xml
@@ -2,12 +2,7 @@
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
-            <EntityType Name="odata_config_1">
-                <Key>
-                    <PropertyRef Name="formid"/>
-                </Key>
-            </EntityType>
-            <EntityType Name="odata_config_2">
+            <EntityType Name="feed">
                 <Key>
                     <PropertyRef Name="formid"/>
                 </Key>
@@ -15,8 +10,7 @@
                 <Property Name="selected_property_2" Type="Edm.String"/>
             </EntityType>
             <EntityContainer Name="Container" >
-                <EntitySet EntityType="CommCare.odata_config_1" Name="odata_config_1"/>
-                <EntitySet EntityType="CommCare.odata_config_2" Name="odata_config_2"/>
+                <EntitySet EntityType="CommCare.feed" Name="feed"/>
             </EntityContainer>
         </Schema>
     </edmx:DataServices>

--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -336,7 +336,7 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
                 'domain': domain_name,
                 'api_name': 'v0.5',
                 'resource_name': ODataCaseResource._meta.resource_name,
-                'pk': config_id,
+                'pk': config_id + '/feed',
             }
         )
 
@@ -488,7 +488,7 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
                 'domain': domain_name,
                 'api_name': 'v0.5',
                 'resource_name': ODataFormResource._meta.resource_name,
-                'pk': config_id,
+                'pk': config_id + '/feed',
             }
         )
 

--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -315,7 +315,7 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
         self.assertEqual(
             json.loads(response.content.decode('utf-8')),
             {
-                '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/cases/$metadata#config_id',
+                '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/cases/config_id/$metadata#feed',
                 'value': []
             }
         )
@@ -467,7 +467,7 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
         self.assertEqual(
             json.loads(response.content.decode('utf-8')),
             {
-                '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/forms/$metadata#config_id',
+                '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/forms/config_id/$metadata#feed',
                 'value': []
             }
         )

--- a/corehq/apps/api/odata/tests/test_metadata.py
+++ b/corehq/apps/api/odata/tests/test_metadata.py
@@ -257,7 +257,7 @@ class TestCaseMetadataDocument(TestCase, CaseOdataTestMixin, TestXmlMixin):
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
         response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
+            reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'config_id': 'my_config_id'}),
             HTTP_AUTHORIZATION='Basic ' + correct_credentials,
         )
         self.assertEqual(response.status_code, 403)
@@ -277,30 +277,15 @@ class TestCaseMetadataDocument(TestCase, CaseOdataTestMixin, TestXmlMixin):
         response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 404)
 
-    def test_successful_request(self):
+    def test_missing_feed(self):
         correct_credentials = self._get_correct_credentials()
         with flag_enabled('ODATA'):
             response = self._execute_query(correct_credentials)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['Content-Type'], 'application/xml')
-        self.assertEqual(response['OData-Version'], '4.0')
-        self.assertXmlEqual(
-            self.get_xml('empty_metadata_document', override_path=PATH_TO_TEST_DATA),
-            response.content
-        )
+        self.assertEqual(response.status_code, 404)
 
     def test_populated_metadata_document(self):
-        odata_config_1 = CaseExportInstance(
-            _id='odata_config_1',
-            domain=self.domain.name,
-            is_odata_config=True,
-            tables=[TableConfiguration(columns=[])]
-        )
-        odata_config_1.save()
-        self.addCleanup(odata_config_1.delete)
-
-        odata_config_2 = CaseExportInstance(
-            _id='odata_config_2',
+        odata_config = CaseExportInstance(
+            _id='my_config_id',
             domain=self.domain.name,
             is_odata_config=True,
             tables=[
@@ -313,8 +298,8 @@ class TestCaseMetadataDocument(TestCase, CaseOdataTestMixin, TestXmlMixin):
                 ),
             ]
         )
-        odata_config_2.save()
-        self.addCleanup(odata_config_2.delete)
+        odata_config.save()
+        self.addCleanup(odata_config.delete)
 
         non_odata_config = CaseExportInstance(domain=self.domain.name)
         non_odata_config.save()
@@ -326,14 +311,7 @@ class TestCaseMetadataDocument(TestCase, CaseOdataTestMixin, TestXmlMixin):
 
         correct_credentials = self._get_correct_credentials()
         with flag_enabled('ODATA'):
-            with patch(
-                'corehq.apps.api.odata.views.get_odata_case_configs_by_domain',
-                return_value=sorted(
-                    get_odata_case_configs_by_domain(self.domain.name),
-                    key=lambda _config: _config.get_id
-                )
-            ):
-                response = self._execute_query(correct_credentials)
+            response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/xml')
         self.assertEqual(response['OData-Version'], '4.0')
@@ -392,7 +370,7 @@ class TestFormMetadataDocument(TestCase, FormOdataTestMixin, TestXmlMixin):
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
         response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
+            reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'config_id': 'my_config_id'}),
             HTTP_AUTHORIZATION='Basic ' + correct_credentials,
         )
         self.assertEqual(response.status_code, 403)
@@ -412,30 +390,15 @@ class TestFormMetadataDocument(TestCase, FormOdataTestMixin, TestXmlMixin):
         response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 404)
 
-    def test_successful_request(self):
+    def test_missing_feed(self):
         correct_credentials = self._get_correct_credentials()
         with flag_enabled('ODATA'):
             response = self._execute_query(correct_credentials)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['Content-Type'], 'application/xml')
-        self.assertEqual(response['OData-Version'], '4.0')
-        self.assertXmlEqual(
-            self.get_xml('empty_metadata_document', override_path=PATH_TO_TEST_DATA),
-            response.content
-        )
+        self.assertEqual(response.status_code, 404)
 
     def test_populated_metadata_document(self):
-        odata_config_1 = FormExportInstance(
-            _id='odata_config_1',
-            domain=self.domain.name,
-            is_odata_config=True,
-            tables=[TableConfiguration(columns=[])]
-        )
-        odata_config_1.save()
-        self.addCleanup(odata_config_1.delete)
-
-        odata_config_2 = FormExportInstance(
-            _id='odata_config_2',
+        odata_config = FormExportInstance(
+            _id='my_config_id',
             domain=self.domain.name,
             is_odata_config=True,
             tables=[
@@ -448,27 +411,12 @@ class TestFormMetadataDocument(TestCase, FormOdataTestMixin, TestXmlMixin):
                 ),
             ]
         )
-        odata_config_2.save()
-        self.addCleanup(odata_config_2.delete)
-
-        non_odata_config = FormExportInstance(domain=self.domain.name)
-        non_odata_config.save()
-        self.addCleanup(non_odata_config.delete)
-
-        config_in_other_domain = FormExportInstance(domain='other_domain', is_odata_config=True)
-        config_in_other_domain.save()
-        self.addCleanup(config_in_other_domain.delete)
+        odata_config.save()
+        self.addCleanup(odata_config.delete)
 
         correct_credentials = self._get_correct_credentials()
         with flag_enabled('ODATA'):
-            with patch(
-                'corehq.apps.api.odata.views.get_odata_form_configs_by_domain',
-                return_value=sorted(
-                    get_odata_form_configs_by_domain(self.domain.name),
-                    key=lambda _config: _config.get_id
-                )
-            ):
-                response = self._execute_query(correct_credentials)
+            response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/xml')
         self.assertEqual(response['OData-Version'], '4.0')

--- a/corehq/apps/api/odata/tests/test_service.py
+++ b/corehq/apps/api/odata/tests/test_service.py
@@ -257,7 +257,7 @@ class TestCaseServiceDocument(TestCase, CaseOdataTestMixin):
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
         response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
+            reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'config_id': 'my_config_id'}),
             HTTP_AUTHORIZATION='Basic ' + correct_credentials,
         )
         self.assertEqual(response.status_code, 403)
@@ -285,49 +285,12 @@ class TestCaseServiceDocument(TestCase, CaseOdataTestMixin):
         self.assertEqual(response['OData-Version'], '4.0')
         self.assertEqual(json.loads(response.content.decode('utf-8')), {
             '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/cases/$metadata',
-            'value': [],
+            'value': [{
+                'name': 'feed',
+                'kind': 'EntitySet',
+                'url': 'feed',
+            }],
         })
-
-    def test_populated_service_document(self):
-        odata_config_1 = CaseExportInstance(domain=self.domain.name, is_odata_config=True)
-        odata_config_1.save()
-        self.addCleanup(odata_config_1.delete)
-
-        odata_config_2 = CaseExportInstance(domain=self.domain.name, is_odata_config=True)
-        odata_config_2.save()
-        self.addCleanup(odata_config_2.delete)
-
-        non_odata_config = CaseExportInstance(domain=self.domain.name)
-        non_odata_config.save()
-        self.addCleanup(non_odata_config.delete)
-
-        config_in_other_domain = CaseExportInstance(domain='other_domain', is_odata_config=True)
-        config_in_other_domain.save()
-        self.addCleanup(config_in_other_domain.delete)
-
-        correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
-            response = self._execute_query(correct_credentials)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['OData-Version'], '4.0')
-        response_content = json.loads(response.content.decode('utf-8'))
-        self.assertCountEqual(response_content, ['@odata.context', 'value'])
-        self.assertEqual(
-            response_content['@odata.context'],
-            'http://localhost:8000/a/test_domain/api/v0.5/odata/cases/$metadata'
-        )
-        self.assertCountEqual(response_content['value'], [
-            {
-                'url': odata_config_1.get_id,
-                'kind': 'EntitySet',
-                'name': odata_config_1.get_id,
-            },
-            {
-                'url': odata_config_2.get_id,
-                'kind': 'EntitySet',
-                'name': odata_config_2.get_id,
-            },
-        ])
 
 
 class TestCaseServiceDocumentUsingApiKey(TestCaseServiceDocument):
@@ -376,7 +339,7 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
         response = self.client.get(
-            reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
+            reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'config_id': 'my_config_id'}),
             HTTP_AUTHORIZATION='Basic ' + correct_credentials,
         )
         self.assertEqual(response.status_code, 403)
@@ -404,49 +367,12 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         self.assertEqual(response['OData-Version'], '4.0')
         self.assertEqual(json.loads(response.content.decode('utf-8')), {
             '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/forms/$metadata',
-            'value': [],
+            'value': [{
+                'name': 'feed',
+                'kind': 'EntitySet',
+                'url': 'feed',
+            }],
         })
-
-    def test_populated_service_document(self):
-        odata_config_1 = FormExportInstance(domain=self.domain.name, is_odata_config=True)
-        odata_config_1.save()
-        self.addCleanup(odata_config_1.delete)
-
-        odata_config_2 = FormExportInstance(domain=self.domain.name, is_odata_config=True)
-        odata_config_2.save()
-        self.addCleanup(odata_config_2.delete)
-
-        non_odata_config = FormExportInstance(domain=self.domain.name)
-        non_odata_config.save()
-        self.addCleanup(non_odata_config.delete)
-
-        config_in_other_domain = FormExportInstance(domain='other_domain', is_odata_config=True)
-        config_in_other_domain.save()
-        self.addCleanup(config_in_other_domain.delete)
-
-        correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
-            response = self._execute_query(correct_credentials)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['OData-Version'], '4.0')
-        response_content = json.loads(response.content.decode('utf-8'))
-        self.assertCountEqual(response_content, ['@odata.context', 'value'])
-        self.assertEqual(
-            response_content['@odata.context'],
-            'http://localhost:8000/a/test_domain/api/v0.5/odata/forms/$metadata'
-        )
-        self.assertCountEqual(response_content['value'], [
-            {
-                'url': odata_config_1.get_id,
-                'kind': 'EntitySet',
-                'name': odata_config_1.get_id,
-            },
-            {
-                'url': odata_config_2.get_id,
-                'kind': 'EntitySet',
-                'name': odata_config_2.get_id,
-            },
-        ])
 
 
 class TestFormServiceDocumentUsingApiKey(TestFormServiceDocument):

--- a/corehq/apps/api/odata/tests/test_service.py
+++ b/corehq/apps/api/odata/tests/test_service.py
@@ -284,7 +284,7 @@ class TestCaseServiceDocument(TestCase, CaseOdataTestMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['OData-Version'], '4.0')
         self.assertEqual(json.loads(response.content.decode('utf-8')), {
-            '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/cases/$metadata',
+            '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/cases/my_config_id/$metadata',
             'value': [{
                 'name': 'feed',
                 'kind': 'EntitySet',
@@ -366,7 +366,7 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['OData-Version'], '4.0')
         self.assertEqual(json.loads(response.content.decode('utf-8')), {
-            '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/forms/$metadata',
+            '@odata.context': 'http://localhost:8000/a/test_domain/api/v0.5/odata/forms/my_config_id/$metadata',
             'value': [{
                 'name': 'feed',
                 'kind': 'EntitySet',

--- a/corehq/apps/api/odata/tests/utils.py
+++ b/corehq/apps/api/odata/tests/utils.py
@@ -90,14 +90,14 @@ class CaseOdataTestMixin(OdataTestMixin):
 
     @property
     def view_url(self):
-        return reverse(self.view_urlname, kwargs={'domain': self.domain.name})
+        return reverse(self.view_urlname, kwargs={'domain': self.domain.name, 'config_id': 'my_config_id'})
 
 
 class FormOdataTestMixin(OdataTestMixin):
 
     @property
     def view_url(self):
-        return reverse(self.view_urlname, kwargs={'domain': self.domain.name})
+        return reverse(self.view_urlname, kwargs={'domain': self.domain.name, 'config_id': 'my_config_id'})
 
 
 

--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -109,17 +109,14 @@ class ODataCaseServiceView(View):
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
     @method_decorator(toggles.ODATA.required_decorator())
-    def get(self, request, domain):
+    def get(self, request, domain, **kwargs):
         service_document_content = {
             '@odata.context': absolute_reverse(ODataCaseMetadataView.urlname, args=[domain]),
-            'value': [
-                {
-                    'name': config.get_id,
-                    'kind': 'EntitySet',
-                    'url': config.get_id,
-                }
-                for config in get_odata_case_configs_by_domain(domain)
-            ]
+            'value': [{
+                'name': 'feed',
+                'kind': 'EntitySet',
+                'url': 'feed',
+            }]
         }
         return add_odata_headers(JsonResponse(service_document_content))
 
@@ -149,17 +146,14 @@ class ODataFormServiceView(View):
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
     @method_decorator(toggles.ODATA.required_decorator())
-    def get(self, request, domain):
+    def get(self, request, domain, **kwargs):
         service_document_content = {
             '@odata.context': absolute_reverse(ODataFormMetadataView.urlname, args=[domain]),
-            'value': [
-                {
-                    'name': config.get_id,
-                    'kind': 'EntitySet',
-                    'url': config.get_id,
-                }
-                for config in get_odata_form_configs_by_domain(domain)
-            ]
+            'value': [{
+                'name': 'feed',
+                'kind': 'EntitySet',
+                'url': 'feed',
+            }]
         }
         return add_odata_headers(JsonResponse(service_document_content))
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1037,7 +1037,7 @@ class ODataCaseResource(HqBaseResource, DomainSpecificResourceMixin):
 
     def prepend_urls(self):
         return [
-            url(r"^(?P<resource_name>%s)/(?P<config_id>[\w\d_.-]+)" % self._meta.resource_name,
+            url(r"^(?P<resource_name>%s)/(?P<config_id>[\w\d_.-]+)/feed" % self._meta.resource_name,
                 self.wrap_view('dispatch_list'))
         ]
 
@@ -1086,7 +1086,7 @@ class ODataFormResource(HqBaseResource, DomainSpecificResourceMixin):
 
     def prepend_urls(self):
         return [
-            url(r"^(?P<resource_name>%s)/(?P<config_id>[\w\d_.-]+)" % self._meta.resource_name,
+            url(r"^(?P<resource_name>%s)/(?P<config_id>[\w\d_.-]+)/feed" % self._meta.resource_name,
                 self.wrap_view('dispatch_list'))
         ]
 

--- a/corehq/apps/api/templates/api/case_odata_metadata.xml
+++ b/corehq/apps/api/templates/api/case_odata_metadata.xml
@@ -2,21 +2,17 @@
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
-            {% for config_id, properties in config_ids_to_properties.items %}
-            <EntityType Name="{{ config_id }}" >
+            <EntityType Name="feed" >
                 <Key>
                     <PropertyRef Name="caseid" />
                 </Key>
-                {% for property in properties %}
-                <Property Name="{{ property }}" Type="Edm.String" />
+                {% for field in fields %}
+                <Property Name="{{ field }}" Type="Edm.String" />
                 {% endfor %}
             </EntityType>
-            {% endfor %}
 
             <EntityContainer Name="Container" >
-                {% for config_id in config_ids_to_properties %}
-                <EntitySet Name="{{ config_id }}" EntityType="CommCare.{{ config_id }}"/>
-                {% endfor %}
+                <EntitySet Name="feed" EntityType="CommCare.feed"/>
             </EntityContainer>
         </Schema>
     </edmx:DataServices>

--- a/corehq/apps/api/templates/api/form_odata_metadata.xml
+++ b/corehq/apps/api/templates/api/form_odata_metadata.xml
@@ -2,21 +2,17 @@
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="CommCare">
-            {% for config_id, properties in config_ids_to_properties.items %}
-            <EntityType Name="{{ config_id }}" >
+            <EntityType Name="feed" >
                 <Key>
                     <PropertyRef Name="formid" />
                 </Key>
-                {% for property in properties %}
-                <Property Name="{{ property }}" Type="Edm.String" />
+                {% for field in fields %}
+                <Property Name="{{ field }}" Type="Edm.String" />
                 {% endfor %}
             </EntityType>
-            {% endfor %}
 
             <EntityContainer Name="Container" >
-                {% for config_id in config_ids_to_properties %}
-                <EntitySet Name="{{ config_id }}" EntityType="CommCare.{{ config_id }}"/>
-                {% endfor %}
+                <EntitySet Name="feed" EntityType="CommCare.feed"/>
             </EntityContainer>
         </Schema>
     </edmx:DataServices>

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -108,9 +108,9 @@ def api_url_patterns():
     yield url(r'v0.5/odata/Forms/(?P<app_id>[\w\-:]+)/$', DeprecatedODataFormServiceView.as_view(), name=DeprecatedODataFormServiceView.urlname)
     yield url(r'v0.5/odata/Forms/(?P<app_id>[\w\-:]+)/\$metadata$', DeprecatedODataFormMetadataView.as_view(), name=DeprecatedODataFormMetadataView.urlname)
     yield url(r'v0.5/odata/cases/(?P<config_id>[\w\-:]+)/$', ODataCaseServiceView.as_view(), name=ODataCaseServiceView.urlname)
-    yield url(r'v0.5/odata/cases/\$metadata$', ODataCaseMetadataView.as_view(), name=ODataCaseMetadataView.urlname)
+    yield url(r'v0.5/odata/cases/(?P<config_id>[\w\-:]+)/\$metadata$', ODataCaseMetadataView.as_view(), name=ODataCaseMetadataView.urlname)
     yield url(r'v0.5/odata/forms/(?P<config_id>[\w\-:]+)/$', ODataFormServiceView.as_view(), name=ODataFormServiceView.urlname)
-    yield url(r'v0.5/odata/forms/\$metadata$', ODataFormMetadataView.as_view(), name=ODataFormMetadataView.urlname)
+    yield url(r'v0.5/odata/forms/(?P<config_id>[\w\-:]+)/\$metadata$', ODataFormMetadataView.as_view(), name=ODataFormMetadataView.urlname)
     for version, resources in API_LIST:
         api = CommCareHqApi(api_name='v%d.%d' % version)
         for R in resources:

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -107,9 +107,9 @@ def api_url_patterns():
     yield url(r'v0.5/odata/Cases/\$metadata$', DeprecatedODataCaseMetadataView.as_view(), name=DeprecatedODataCaseMetadataView.urlname)
     yield url(r'v0.5/odata/Forms/(?P<app_id>[\w\-:]+)/$', DeprecatedODataFormServiceView.as_view(), name=DeprecatedODataFormServiceView.urlname)
     yield url(r'v0.5/odata/Forms/(?P<app_id>[\w\-:]+)/\$metadata$', DeprecatedODataFormMetadataView.as_view(), name=DeprecatedODataFormMetadataView.urlname)
-    yield url(r'v0.5/odata/cases/$', ODataCaseServiceView.as_view(), name=ODataCaseServiceView.urlname)
+    yield url(r'v0.5/odata/cases/(?P<config_id>[\w\-:]+)/$', ODataCaseServiceView.as_view(), name=ODataCaseServiceView.urlname)
     yield url(r'v0.5/odata/cases/\$metadata$', ODataCaseMetadataView.as_view(), name=ODataCaseMetadataView.urlname)
-    yield url(r'v0.5/odata/forms/$', ODataFormServiceView.as_view(), name=ODataFormServiceView.urlname)
+    yield url(r'v0.5/odata/forms/(?P<config_id>[\w\-:]+)/$', ODataFormServiceView.as_view(), name=ODataFormServiceView.urlname)
     yield url(r'v0.5/odata/forms/\$metadata$', ODataFormMetadataView.as_view(), name=ODataFormMetadataView.urlname)
     for version, resources in API_LIST:
         api = CommCareHqApi(api_name='v%d.%d' % version)

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -233,7 +233,7 @@ class ExportListHelper(object):
                 'domain': export.domain,
                 'api_name': 'v0.5',
                 'resource_name': resource_class._meta.resource_name,
-                'pk': export.get_id,
+                'pk': export.get_id + '/feed',
             }
         )[:-1]  # Remove trailing forward slash for compatibility with BI tools
 


### PR DESCRIPTION
This is designed to:
1) Prevent an invalid feed config from interfering with other feeds
2) Avoid Power BI caching issues by having each feed use a separate metadata doc.

@djmore9 