### PR TITLE
Updated EOF nav to no allow menus that use display only forms

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -26,6 +26,7 @@ from corehq.apps.app_manager.const import (
     AUTO_SELECT_RAW,
     AUTO_SELECT_USER,
     WORKFLOW_FORM,
+    WORKFLOW_MODULE,
     WORKFLOW_PARENT_MODULE,
 )
 from corehq.apps.app_manager.exceptions import (
@@ -745,9 +746,14 @@ class FormBaseValidator(object):
                     self.form.get_app().get_form(form_link.form_id)
                 except FormNotFoundException:
                     errors.append(dict(type='bad form link', **meta))
+        elif self.form.post_form_workflow == WORKFLOW_MODULE:
+            if module.put_in_root:
+                errors.append(dict(type='form link to display only forms', **meta))
         elif self.form.post_form_workflow == WORKFLOW_PARENT_MODULE:
             if not module.root_module:
                 errors.append(dict(type='form link to missing root', **meta))
+            if module.root_module.put_in_root:
+                errors.append(dict(type='form link to display only forms', **meta))
 
         # this isn't great but two of FormBase's subclasses have form_filter
         if hasattr(self.form, 'form_filter') and self.form.form_filter:

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -96,7 +96,9 @@ hqDefine("app_manager/js/forms/form_view", function () {
             var labels = {};
             labels[FormWorkflow.Values.DEFAULT] = gettext("Home Screen");
             labels[FormWorkflow.Values.ROOT] = gettext("First Menu");
-            labels[FormWorkflow.Values.MODULE] = gettext("Menu: ") + initialPageData('module_name');
+            if (initialPageData('module_name')) {
+                labels[FormWorkflow.Values.MODULE] = gettext("Menu: ") + initialPageData('module_name');
+            }
             if (initialPageData('root_module_name')) {
                 labels[FormWorkflow.Values.PARENT_MODULE] = gettext("Parent Menu: ") + initialPageData('root_module_name');
             }

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -166,8 +166,10 @@
   {% initial_page_data 'allow_form_workflow' allow_form_workflow %}
   {% initial_page_data 'form_links' form.form_links %}
   {% initial_page_data 'linkable_forms' linkable_forms %}
-  {% initial_page_data 'module_name' module.name|trans:langs %}
-  {% if module.root_module_id %}
+  {% if not module.put_in_root %}
+    {% initial_page_data 'module_name' module.name|trans:langs %}
+  {% endif %}
+  {% if module.root_module_id and not module.root_module.put_in_root %}
     {% initial_page_data 'root_module_name' module.root_module.name|trans:langs %}
   {% endif %}
   {% initial_page_data 'post_form_workflow' form.post_form_workflow %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -39,6 +39,12 @@
         {% blocktrans %}
           Please check that end of form navigation is correct. It appears to be pointing
           to a parent menu form, but the menu doesn't have a parent.
+         {% endblocktrans %}
+        {% include "app_manager/partials/form_error_message.html" %}
+          {% case "form link to display only forms" %}
+        {% blocktrans %}
+          Please check that end of form navigation is correct. It appears to be pointing
+          to a menu using "Display only forms," which makes that menu an invalid choice.
         {% endblocktrans %}
         {% include "app_manager/partials/form_error_message.html" %}
           {% case "no ref detail" %}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-708

fyi @dimagi/product this also adds a build error, so that apps that were previously failing silently (with the EOF nav returning to the home screen rather than the desired menu) will now be unable to build new versions until they update the EOF nav.