### PR TITLE
[HQ] clean data after the tests

### DIFF
--- a/corehq/apps/callcenter/tests/test_location_owners.py
+++ b/corehq/apps/callcenter/tests/test_location_owners.py
@@ -6,7 +6,7 @@ from corehq.apps.callcenter.sync_user_case import sync_call_center_user_case
 from corehq.apps.domain.models import CallCenterProperties
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import LocationType
-from corehq.apps.locations.tests.util import make_loc
+from corehq.apps.locations.tests.util import make_loc, delete_all_locations
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
@@ -28,6 +28,7 @@ class CallCenterLocationOwnerTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(CallCenterLocationOwnerTest, cls).setUpClass()
         # Create domain
         cls.domain = create_domain(TEST_DOMAIN)
         cls.domain.call_center_config = cls.get_call_center_config()
@@ -55,10 +56,8 @@ class CallCenterLocationOwnerTest(TestCase):
     def tearDownClass(cls):
         cls.user.delete()
         cls.domain.delete()
-        cls.grandchild_location.delete()
-        cls.child_location.delete()
-        cls.root_location.delete()
-        cls.location_type.delete()
+        delete_all_locations()
+        super(CallCenterLocationOwnerTest, cls).tearDownClass()
 
     def tearDown(self):
         delete_all_cases()

--- a/corehq/apps/callcenter/tests/test_location_owners.py
+++ b/corehq/apps/callcenter/tests/test_location_owners.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.test import TestCase
-from casexml.apps.case.tests.util import delete_all_cases
+from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from corehq.apps.callcenter.sync_user_case import sync_call_center_user_case
 from corehq.apps.domain.models import CallCenterProperties
 from corehq.apps.domain.shortcuts import create_domain
@@ -37,7 +37,7 @@ class CallCenterLocationOwnerTest(TestCase):
         cls.user = CommCareUser.create(TEST_DOMAIN, 'user1', '***')
 
         # Create locations
-        LocationType.objects.get_or_create(
+        cls.location_type, _ = LocationType.objects.get_or_create(
             domain=cls.domain.name,
             name=LOCATION_TYPE,
         )
@@ -55,9 +55,14 @@ class CallCenterLocationOwnerTest(TestCase):
     def tearDownClass(cls):
         cls.user.delete()
         cls.domain.delete()
+        cls.grandchild_location.delete()
+        cls.child_location.delete()
+        cls.root_location.delete()
+        cls.location_type.delete()
 
     def tearDown(self):
         delete_all_cases()
+        delete_all_xforms()
 
     def test_no_location_sync(self):
         self.user.unset_location()

--- a/corehq/apps/callcenter/tests/test_owner_options_view.py
+++ b/corehq/apps/callcenter/tests/test_owner_options_view.py
@@ -7,6 +7,7 @@ import math
 from django.test import TestCase
 from elasticsearch import ConnectionError
 
+from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from corehq.apps.callcenter.views import CallCenterOwnerOptionsView
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.groups.models import Group
@@ -89,8 +90,12 @@ class CallCenterLocationOwnerOptionsViewTest(TestCase):
         CALL_CENTER_LOCATION_OWNERS.set(cls.domain.name, False, NAMESPACE_DOMAIN)
         cls.domain.delete()
         cls.web_user.delete()
+        for loc in cls.locations:
+            loc.delete()
         ensure_index_deleted(USER_INDEX_INFO.index)
         ensure_index_deleted(GROUP_INDEX_INFO.index)
+        delete_all_cases()
+        delete_all_xforms()
 
     def test_pages(self):
         """

--- a/corehq/apps/reports/tests/test_analytics.py
+++ b/corehq/apps/reports/tests/test_analytics.py
@@ -60,9 +60,9 @@ class ReportAppAnalyticsTest(SetupSimpleAppMixin, TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(ReportAppAnalyticsTest, cls).tearDownClass()
         cls.app.delete()
         cls.deleted_app.delete()
+        super(ReportAppAnalyticsTest, cls).tearDownClass()
 
     def test_get_all_form_definitions_grouped_by_app_and_xmlns_no_data(self):
         self.assertEqual([], get_all_form_definitions_grouped_by_app_and_xmlns('missing'))

--- a/corehq/apps/reports/tests/test_analytics.py
+++ b/corehq/apps/reports/tests/test_analytics.py
@@ -58,6 +58,12 @@ class ReportAppAnalyticsTest(SetupSimpleAppMixin, TestCase):
         super(ReportAppAnalyticsTest, cls).setUpClass()
         cls.class_setup()
 
+    @classmethod
+    def tearDownClass(cls):
+        super(ReportAppAnalyticsTest, cls).tearDownClass()
+        cls.app.delete()
+        cls.deleted_app.delete()
+
     def test_get_all_form_definitions_grouped_by_app_and_xmlns_no_data(self):
         self.assertEqual([], get_all_form_definitions_grouped_by_app_and_xmlns('missing'))
 

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -79,6 +79,12 @@ class FormsByApplicationFilterDbTest(SetupSimpleAppMixin, TestCase):
         super(FormsByApplicationFilterDbTest, cls).setUpClass()
         cls.class_setup()
 
+    @classmethod
+    def tearDownClass(cls):
+        super(FormsByApplicationFilterDbTest, cls).tearDownClass()
+        cls.app.delete()
+        cls.deleted_app.delete()
+
     def test_get_filtered_data_by_app_id_missing(self):
         params = FormsByApplicationFilterParams([
             _make_filter(PARAM_SLUG_STATUS, PARAM_VALUE_STATUS_ACTIVE),


### PR DESCRIPTION
Hi @calellowitz 

I noticed that when we run all tests locally then some of the tests don't clear the data after all tests in class pass. So I found which test don't do this and I added clearing data.

Please let me know if you have any questions.

Regards,
Łukasz