### PR TITLE
Exports: inline edit for names and descriptions

### DIFF
--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -64,16 +64,12 @@
   <tr>
     <td>
       <h4 data-bind="css: {'text-muted': hasEmailedExport && !isAutoRebuildEnabled()}">
-        {% if not is_odata %}
-          <span data-bind="text: name"></span>
-        {% else %}
-          <inline-edit params="
-            value: name,
-            url: editNameUrl,
-            placeholder: '{% trans "Enter name here"|escapejs %}',
-            cols: 50,
-          " data-apply-bindings="false"></inline-edit>
-        {% endif %}
+        <inline-edit params="
+          value: name,
+          url: editNameUrl,
+          placeholder: '{% trans "Enter name here"|escapejs %}',
+          cols: 50,
+        " data-apply-bindings="false"></inline-edit>
         <label class="label label-default label-default" data-bind="visible: isDeid()">
           {% trans 'De-Identified' %}
         </label>
@@ -82,16 +78,12 @@
         <i class="fa fa-file-o"></i> <strong>{% trans 'Form:' %}</strong>
         <span data-bind="text: formname"></span>
       </p>
-      {% if not is_odata %}
-        <p data-bind="text: description"></p>
-      {% else %}
-        <inline-edit params="
-          value: description,
-          url: editDescriptionUrl,
-          placeholder: '{% trans "Enter description here"|escapejs %}',
-          cols: 50,
-        " data-apply-bindings="false"></inline-edit>
-      {% endif %}
+      <inline-edit params="
+        value: description,
+        url: editDescriptionUrl,
+        placeholder: '{% trans "Enter description here"|escapejs %}',
+        cols: 50,
+      " data-apply-bindings="false"></inline-edit>
 
       <div data-bind="ifnot: isLocationSafeForUser()" class="text-warning">
         {% blocktrans %}

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -632,6 +632,7 @@ class ProjectDataTab(UITab):
                 export_data_views.append({
                     "title": _(DailySavedExportListView.page_title),
                     "url": reverse(DailySavedExportListView.urlname, args=(self.domain,)),
+                    'icon': 'fa fa-calendar',
                     "show_in_dropdown": True,
                     "subpages": [_f for _f in [
                         {
@@ -656,6 +657,7 @@ class ProjectDataTab(UITab):
                 export_data_views.append({
                     'title': _(DailySavedExportListView.page_title),
                     'url': reverse(DailySavedExportPaywall.urlname, args=(self.domain,)),
+                    'icon': 'fa fa-calendar',
                     'show_in_dropdown': True,
                     'subpages': []
                 })
@@ -683,6 +685,7 @@ class ProjectDataTab(UITab):
                 export_data_views.append({
                     'title': _(DashboardFeedListView.page_title),
                     'url': reverse(DashboardFeedListView.urlname, args=(self.domain,)),
+                    'icon': 'fa fa-dashboard',
                     'show_in_dropdown': True,
                     'subpages': subpages
                 })
@@ -690,6 +693,7 @@ class ProjectDataTab(UITab):
                 export_data_views.append({
                     'title': _(DashboardFeedListView.page_title),
                     'url': reverse(DashboardFeedPaywall.urlname, args=(self.domain,)),
+                    'icon': 'fa fa-dashboard',
                     'show_in_dropdown': True,
                     'subpages': []
                 })
@@ -715,6 +719,7 @@ class ProjectDataTab(UITab):
                 export_data_views.append({
                     'title': _(ODataFeedListView.page_title),
                     'url': reverse(ODataFeedListView.urlname, args=(self.domain,)),
+                    'icon': 'fa fa-plug',
                     'show_in_dropdown': True,
                     'subpages': subpages
                 })


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/PF-402

Extend this to all exports, not just OData feeds.

before
<img width="1119" alt="Screen Shot 2019-07-19 at 10 36 53 AM" src="https://user-images.githubusercontent.com/1486591/61543278-28f7b880-aa11-11e9-855a-3e0a11b400f1.png">

after
<img width="1122" alt="Screen Shot 2019-07-19 at 9 21 53 AM" src="https://user-images.githubusercontent.com/1486591/61543289-2d23d600-aa11-11e9-8f3c-ff742fb568d4.png">

and some new icons
<img width="212" alt="Screen Shot 2019-07-19 at 9 30 50 AM" src="https://user-images.githubusercontent.com/1486591/61544132-c69fb780-aa12-11e9-9699-bd11280f45af.png">


fyi @dimagi/product 