### PR TITLE
Add specialized pagination query for queue_schedule_instances

### DIFF
--- a/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
@@ -1,11 +1,14 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from corehq.sql_db.util import (
-    paginate_query_across_partitioned_databases,
-    get_db_aliases_for_partitioned_query,
-)
-from django.db.models import Q
+from __future__ import absolute_import, unicode_literals
+
 from uuid import UUID
+
+from django.db.models import Q
+
+from corehq.sql_db.util import (
+    get_db_aliases_for_partitioned_query,
+    paginate_query_across_partitioned_databases,
+)
+from corehq.util.datadog.utils import load_counter_for_model
 
 
 def _validate_class(obj, cls):
@@ -136,13 +139,88 @@ def get_active_case_schedule_instance_ids(cls, due_before, due_after=None):
             raise ValueError("Expected due_before > due_after")
         active_filter = active_filter & Q(next_event_due__gt=due_after)
 
-    for domain, case_id, schedule_instance_id, next_event_due in paginate_query_across_partitioned_databases(
+    for domain, case_id, schedule_instance_id, next_event_due in _paginate_query_across_partitioned_databases(
         cls,
         active_filter,
         values=['domain', 'case_id', 'schedule_instance_id', 'next_event_due'],
         load_source='get_schedule_instance_ids'
     ):
         yield (domain, case_id, schedule_instance_id, next_event_due)
+
+
+def _paginate_query_across_partitioned_databases(model_class, q_expression, load_source):
+    """Optimized version of the generic paginate_query_across_partitioned_databases for case schedules
+
+    queue_schedule_instances uses a lock to ensure that the same case_id cannot be queued within one
+    hour of another instance
+    The celery tasks handle_case_alert_schedule_instance and handle_case_timed_schedule_instance both
+    use locks to ensure only one taks is operating on a case at one time. Each task also checks if the
+    schedule is still valid on this case before processing it further
+
+    Assumes that q_expression includes active = True
+    """
+    from corehq.messaging.scheduling.scheduling_partitioned.models import (
+        CaseAlertScheduleInstance,
+        CaseTimedScheduleInstance,
+    )
+
+    if model_class not in (CaseAlertScheduleInstance, CaseTimedScheduleInstance):
+        raise TypeError("Expected CaseAlertScheduleInstance or CaseTimedScheduleInstance")
+
+    db_names = get_db_aliases_for_partitioned_query()
+    for db_name in db_names:
+        for row in _paginate_query(db_name, model_class, q_expression, load_source):
+            yield row
+
+
+def _paginate_query(db_name, model_class, q_expression, load_source, query_size=5000):
+    track_load = load_counter_for_model(model_class)(load_source, None, extra_tags=['db:{}'.format(db_name)])
+    sort_cols = ('active', 'next_event_due')
+
+    # active is always set to true in the queryset's q_expression so we
+    # don't need to include it here or filter it further later
+    return_values = ['pk', 'domain', 'case_id', 'schedule_instance_id', 'next_event_due']
+
+    qs = (
+        model_class.objects.using(db_name)
+        .filter(q_expression)
+        .order_by(*sort_cols)
+        .values_list(*return_values)
+    )
+
+    filter_expression = {}
+    previous_pks = set()
+    while True:
+        current_pks = set()
+        last_row = None
+        results = qs.filter(**filter_expression)[:query_size]
+
+        for row in results:
+            track_load()
+
+            current_pks.add(row[0])
+            if row[0] in previous_pks:
+                continue
+
+            yield row[1:]
+            last_row = row
+
+        if len(results) < query_size:
+            break
+
+        if last_row is None:
+            # This iteration produced the same result set as last time
+            # likely because the next_event_due is the same for > query_size records
+            # break here because the next iteration of this code should pick up
+            # these instances once already queued instances have been processed
+            break
+
+        # Use gte here because its not guaranteed to have completed the final
+        # events that are due on this instance for the same time
+        filter_expression = {
+            'next_event_due__gte': last_row[4]
+        }
+        previous_pks = current_pks
 
 
 def get_alert_schedule_instances_for_schedule(schedule):


### PR DESCRIPTION
@snopoke We started talking about this during the scale team call Thursday. Currently because we're using a generic method that orders by PK, postgres does not use the expected index:

```sql
commcarehq_p6=> explain SELECT 
    "scheduling_casetimedscheduleinstance"."schedule_instance_id", 
    "scheduling_casetimedscheduleinstance"."domain", 
    "scheduling_casetimedscheduleinstance"."case_id", 
    "scheduling_casetimedscheduleinstance"."schedule_instance_id", 
    "scheduling_casetimedscheduleinstance"."next_event_due" 
FROM "scheduling_casetimedscheduleinstance"
WHERE (
    "scheduling_casetimedscheduleinstance"."active" = true 
    AND "scheduling_casetimedscheduleinstance"."next_event_due" <= '2019-07-18T06:42:07.106152'::timestamp) 
ORDER BY "scheduling_casetimedscheduleinstance"."schedule_instance_id" ASC 
LIMIT 5000;
```

```
                                                                       QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..17788.34 rows=5000 width=85)
   ->  Index Scan using scheduling_casetimedscheduleinstance_pkey on scheduling_casetimedscheduleinstance  (cost=0.43..1779673.05 rows=500248 width=85)
         Filter: (active AND (next_event_due <= '2019-07-18 06:42:07.106152'::timestamp without time zone))
```

This PR would change this query to something similar to (which uses the active, next_event_due index):

```sql
commcarehq_p6=> explain SELECT 
    "scheduling_casetimedscheduleinstance"."schedule_instance_id", 
    "scheduling_casetimedscheduleinstance"."domain", 
    "scheduling_casetimedscheduleinstance"."case_id", 
    "scheduling_casetimedscheduleinstance"."schedule_instance_id", 
    "scheduling_casetimedscheduleinstance"."next_event_due" 
FROM "scheduling_casetimedscheduleinstance" 
WHERE (
    "scheduling_casetimedscheduleinstance"."active" = true 
    AND "scheduling_casetimedscheduleinstance"."next_event_due" <= '2019-07-18T06:42:07.106152'::timestamp) 
ORDER BY active, "scheduling_casetimedscheduleinstance"."next_event_due" ASC 
LIMIT 5000;
```

```
                                                                              QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.56..6403.03 rows=5000 width=86)
   ->  Index Scan using scheduling_casetimedscheduleinstance_active_41bd9955_idx on scheduling_casetimedscheduleinstance  (cost=0.56..640565.62 rows=500248 width=86)
         Index Cond: ((active = true) AND (next_event_due <= '2019-07-18 06:42:07.106152'::timestamp without time zone))
         Filter: active
(4 rows)
```

I didn't think it was going to be very easy to change the generic method to have parameterized sort columns at the moment, so went ahead and made a new method. If we find other queries we want to do some similar optimazation on I think that we could come up with some pattern for these custom queries that removes some of the common code.