### PR TITLE
revert caching of program and product fixtures

### DIFF
--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -16,6 +16,9 @@ def simple_fixture_generator(restore_user, id, name, fields, data_fn, last_sync=
     # expand this here to prevent two separate couch calls
     data = data_fn()
 
+    if not _should_sync(data, last_sync):
+        return []
+
     name_plural = "{}s".format(name)
     root = ElementTree.Element('fixture',
                                {
@@ -49,3 +52,22 @@ def simple_fixture_generator(restore_user, id, name, fields, data_fn, last_sync=
                 item_elem.append(field_elem)
 
     return [root]
+
+
+def _should_sync(data, last_sync):
+    """
+    Determine if a data collection needs to be synced.
+    """
+
+    # definitely sync if we haven't synced before
+    if not last_sync or not last_sync.date:
+        return True
+
+    # check if any items have been modified since last sync
+    for data_item in data:
+        # >= used because if they are the same second, who knows
+        # which actually happened first
+        if not data_item.last_modified or data_item.last_modified >= last_sync.date:
+            return True
+
+    return False

--- a/corehq/apps/commtrack/tests/test_fixture.py
+++ b/corehq/apps/commtrack/tests/test_fixture.py
@@ -135,7 +135,7 @@ class FixtureTest(TestCase, TestXmlMixin):
         fixture_xml = self.generate_product_fixture_xml(user)
         index_schema, fixture = call_fixture_generator(product_fixture_generator, user)
 
-        self.assertXmlEqual(fixture_xml, fixture)
+        self.assertXmlEqual(fixture_xml, ElementTree.tostring(fixture))
 
         schema_xml = """
             <schema id="commtrack:products">
@@ -155,38 +155,57 @@ class FixtureTest(TestCase, TestXmlMixin):
         fixture_xml = self.generate_product_fixture_xml(user2)
         index_schema, fixture = call_fixture_generator(product_fixture_generator, user2)
 
-        self.assertXmlEqual(fixture_xml, fixture)
+        self.assertXmlEqual(fixture_xml, ElementTree.tostring(fixture))
 
-    def test_product_fixture_cache(self):
+    def test_selective_product_sync(self):
         user = self.user
 
         expected_xml = self.generate_product_fixture_xml(user)
 
+        product_list = Product.by_domain(user.domain)
+        self._initialize_product_names(len(product_list))
+
         fixture_original = call_fixture_generator(product_fixture_generator, user)[1]
+        deprecated_generate_restore_payload(self.domain_obj, user)
         self.assertXmlEqual(
             expected_xml,
-            fixture_original
+            ElementTree.tostring(fixture_original)
         )
 
-        product = Product.by_domain(user.domain)[0]
-        product.name = 'new_name'
-        super(Product, product).save()  # save but skip clearing the cache
+        first_sync = self._get_latest_synclog()
 
-        fixture_cached = call_fixture_generator(product_fixture_generator, user)[1]
+        # make sure the time stamp on this first sync is
+        # not on the same second that the products were created
+        first_sync.date += datetime.timedelta(seconds=1)
+
+        # second sync is before any changes are made, so there should
+        # be no products synced
+        fixture_pre_change = call_fixture_generator(product_fixture_generator, user, last_sync=first_sync)
+        deprecated_generate_restore_payload(self.domain_obj, user)
+        self.assertEqual(
+            [],
+            fixture_pre_change,
+            "Fixture was not empty on second sync"
+        )
+
+        second_sync = self._get_latest_synclog()
+
+        self.assertTrue(first_sync._id != second_sync._id)
+
+        # save should make the product more recently updated than the
+        # last sync
+        for product in product_list:
+            product.save()
+
+        # now that we've updated a product, we should get
+        # product data in sync again
+        fixture_post_change = call_fixture_generator(product_fixture_generator, user, last_sync=second_sync)[1]
+
+        # regenerate the fixture xml to make sure it is still legit
         self.assertXmlEqual(
             expected_xml,
-            fixture_cached
+            ElementTree.tostring(fixture_post_change)
         )
-
-        # This will update all the products and re-save them.
-        expected_xml_new = self.generate_product_fixture_xml(user)
-
-        fixture_cached = call_fixture_generator(product_fixture_generator, user)[1]
-        self.assertXmlEqual(
-            expected_xml_new,
-            fixture_cached
-        )
-        self.assertXMLNotEqual(expected_xml_new, expected_xml)
 
     def generate_program_xml(self, program_list, user):
         program_xml = ''
@@ -231,7 +250,7 @@ class FixtureTest(TestCase, TestXmlMixin):
 
         self.assertXmlEqual(
             program_xml,
-            fixture[0]
+            ElementTree.tostring(fixture[0])
         )
 
         # test restore with different user
@@ -242,10 +261,10 @@ class FixtureTest(TestCase, TestXmlMixin):
 
         self.assertXmlEqual(
             program_xml,
-            fixture[0]
+            ElementTree.tostring(fixture[0])
         )
 
-    def test_program_fixture_cache(self):
+    def test_selective_program_sync(self):
         user = self.user
         Program(
             domain=user.domain,
@@ -253,32 +272,47 @@ class FixtureTest(TestCase, TestXmlMixin):
             code="t1"
         ).save()
 
-        program_list = list(Program.by_domain(user.domain))
+        program_list = Program.by_domain(user.domain)
         program_xml = self.generate_program_xml(program_list, user)
 
-        fixture = call_fixture_generator(program_fixture_generator, user)
+        fixture_original = call_fixture_generator(program_fixture_generator, user)
 
+        deprecated_generate_restore_payload(self.domain_obj, user)
         self.assertXmlEqual(
             program_xml,
-            fixture[0]
+            ElementTree.tostring(fixture_original[0])
         )
 
-        program = program_list[0]
-        program.name = 'new_name'
-        super(Program, program).save()  # save but skip clearing the cache
+        first_sync = self._get_latest_synclog()
+        # make sure the time stamp on this first sync is
+        # not on the same second that the programs were created
+        first_sync.date += datetime.timedelta(seconds=1)
 
-        fixture_cached = call_fixture_generator(program_fixture_generator, user)
+        # second sync is before any changes are made, so there should
+        # be no programs synced
+        fixture_pre_change = call_fixture_generator(program_fixture_generator, user, last_sync=first_sync)
+        deprecated_generate_restore_payload(self.domain_obj, user)
+        self.assertEqual(
+            [],
+            fixture_pre_change,
+            "Fixture was not empty on second sync"
+        )
+
+        second_sync = self._get_latest_synclog()
+
+        self.assertTrue(first_sync._id != second_sync._id)
+
+        # save should make the program more recently updated than the
+        # last sync
+        for program in program_list:
+            program.save()
+
+        # now that we've updated a program, we should get
+        # program data in sync again
+        fixture_post_change = call_fixture_generator(program_fixture_generator, user, last_sync=second_sync)
+
+        # regenerate the fixture xml to make sure it is still legit
         self.assertXmlEqual(
             program_xml,
-            fixture_cached[0]
+            ElementTree.tostring(fixture_post_change[0])
         )
-
-        program.save()
-        program_xml_new = self.generate_program_xml(program_list, user)
-
-        fixture_regen = call_fixture_generator(program_fixture_generator, user)
-        self.assertXmlEqual(
-            program_xml_new,
-            fixture_regen[0]
-        )
-        self.assertXMLNotEqual(program_xml_new, program_xml)

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -66,9 +66,16 @@ class ProductFixturesProvider(FixtureProvider):
             or restore_state.params.openrosa_version >= LooseVersion(OPENROSA_VERSION_MAP['INDEXED_PRODUCTS_FIXTURE'])
         )
 
-        data_fn = partial(self._get_fixture_items, restore_state, indexed)
-        cache_prefix = PRODUCT_FIXTURE_BUCKET_INDEXED if indexed else PRODUCT_FIXTURE_BUCKET
-        fixture_nodes = get_or_cache_global_fixture(restore_state, cache_prefix, self.id, data_fn)
+        # disable caching temporarily
+        # https://dimagi-dev.atlassian.net/browse/IIO-332
+
+        # data_fn = partial(self._get_fixture_items, restore_state, indexed)
+        # cache_prefix = PRODUCT_FIXTURE_BUCKET_INDEXED if indexed else PRODUCT_FIXTURE_BUCKET
+        # fixture_nodes = get_or_cache_global_fixture(restore_state, cache_prefix, self.id, data_fn)
+
+        fixture_nodes = self._get_fixture_items(restore_state, indexed)
+        if not fixture_nodes:
+            return []
 
         if not indexed:
             # Don't include index schema when openrosa version is specified and below 2.1
@@ -88,7 +95,7 @@ class ProductFixturesProvider(FixtureProvider):
 
         fixture_nodes = simple_fixture_generator(
             restore_user, self.id, "product", PRODUCT_FIELDS,
-            get_products, restore_state.last_sync_log, GLOBAL_USER_ID
+            get_products, restore_state.last_sync_log
         )
         if not fixture_nodes:
             return []

--- a/corehq/apps/programs/fixtures.py
+++ b/corehq/apps/programs/fixtures.py
@@ -34,8 +34,11 @@ class ProgramFixturesProvider(FixtureProvider):
     id = 'commtrack:programs'
 
     def __call__(self, restore_state):
-        data_fn = partial(self._get_fixture_items, restore_state)
-        return get_or_cache_global_fixture(restore_state, PROGRAM_FIXTURE_BUCKET, self.id, data_fn)
+        # disable caching temporarily
+        # https://dimagi-dev.atlassian.net/browse/IIO-332
+        # data_fn = partial(self._get_fixture_items, restore_state)
+        # return get_or_cache_global_fixture(restore_state, PROGRAM_FIXTURE_BUCKET, self.id, data_fn)
+        return self._get_fixture_items(restore_state)
 
     def _get_fixture_items(self, restore_state):
         restore_user = restore_state.restore_user
@@ -45,7 +48,7 @@ class ProgramFixturesProvider(FixtureProvider):
 
         return simple_fixture_generator(
             restore_user, self.id, "program",
-            PROGRAM_FIELDS, get_programs, restore_state.last_sync_log, GLOBAL_USER_ID
+            PROGRAM_FIELDS, get_programs, restore_state.last_sync_log
         )
 
 


### PR DESCRIPTION
This is still causing issues on pgshard7. Periodically the DB get's locked up with a slew of queries to update the blob meta for the `product` fixture.

I haven't been able to figure out why the redis locking isn't working or why the cache is getting cleared (assuming it is getting cleared and not just returning 404).