### PR TITLE
Avoid parallel release requests

### DIFF
--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -149,12 +149,14 @@ def no_conflict(fn):
 
 def avoid_parallel_build_request(fn):
     @wraps(fn)
-    def new_fn(request, domain, app_id, *args, **kwargs):
+    def new_fn(app, comment, user_id, *args, **kwargs):
+        domain = app.domain
+        app_id = app.get_id
         if _build_request_in_progress(domain, app_id):
             return HttpResponse(_("There is already a version build in progress. Please wait."), status=400)
         else:
             _set_build_in_progress_lock(domain, app_id)
-            fn_return = fn(request, domain, app_id, *args, **kwargs)
+            fn_return = fn(app, comment, user_id, *args, **kwargs)
             _release_build_in_progress_lock(domain, app_id)
             return fn_return
     return new_fn

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -166,7 +166,7 @@ def avoid_parallel_build_request(fn):
 
 def _set_build_in_progress_lock(domain, app_id):
     key = _build_request_cache_key(domain, app_id)
-    cache.set(key, True, 60*60)  # Lock for an hour
+    cache.set(key, True, 60 * 60)  # Lock for an hour
 
 
 def _build_request_cache_key(domain, app_id):

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -166,7 +166,7 @@ def avoid_parallel_build_request(fn):
 
 def _set_build_in_progress_lock(domain, app_id):
     key = _build_request_cache_key(domain, app_id)
-    cache.set(key, True)
+    cache.set(key, True, 60*60)  # Lock for an hour
 
 
 def _build_request_cache_key(domain, app_id):

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -175,3 +175,7 @@ class MultimediaMissingError(AppManagerException):
 
 class BuildNotFoundException(AppManagerException):
     pass
+
+
+class BuildConflictException(Exception):
+    pass

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -452,7 +452,9 @@ hqDefine('app_manager/js/releases/releases', function () {
                 error: function (xhr) {
                     self.buildErrorCode(xhr.status);
                     self.buildState('error');
-                    self.errorMessage(xhr.responseText);
+                    if (xhr.responseText) {
+                        self.errorMessage(xhr.responseText);
+                    }
                 },
             });
         };

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -215,7 +215,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         var asyncDownloader = hqImport('app_manager/js/download_async_modal').asyncDownloader;
         var appDiff = hqImport('app_manager/js/releases/app_diff').init('#app-diff-modal .modal-body');
         var self = this;
-        var genericErrorMessage = gettext(
+        self.genericErrorMessage = gettext(
             'An error occurred. Reload the page and click Make New Version to try again.');
         self.options = o;
         self.recipients = self.options.recipient_contacts;
@@ -437,6 +437,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         };
         self.actuallyMakeBuild = function () {
             self.buildState('pending');
+            self.errorMessage(self.genericErrorMessage);
             $.post({
                 url: self.reverse('save_copy'),
                 success: function (data) {
@@ -452,8 +453,8 @@ hqDefine('app_manager/js/releases/releases', function () {
                 error: function (xhr) {
                     self.buildErrorCode(xhr.status);
                     self.buildState('error');
-                    if (xhr.responseText) {
-                        self.errorMessage(xhr.responseText);
+                    if (xhr.responseJSON && xhr.responseJSON.error) {
+                        self.errorMessage(xhr.responseJSON.error);
                     }
                 },
             });

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -222,6 +222,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.doneFetching = ko.observable(false);
         self.buildState = ko.observable('');
         self.buildErrorCode = ko.observable('');
+        self.genericErrorMessage = ko.observable('');
         self.onlyShowReleased = ko.observable(false);
         self.fetchState = ko.observable('');
         self.fetchLimit = ko.observable();
@@ -449,6 +450,7 @@ hqDefine('app_manager/js/releases/releases', function () {
                 error: function (xhr) {
                     self.buildErrorCode(xhr.status);
                     self.buildState('error');
+                    self.genericErrorMessage(xhr.responseText);
                 },
             });
         };

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -224,7 +224,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.doneFetching = ko.observable(false);
         self.buildState = ko.observable('');
         self.buildErrorCode = ko.observable('');
-        self.errorMessage = ko.observable(genericErrorMessage);
+        self.errorMessage = ko.observable(self.genericErrorMessage);
         self.onlyShowReleased = ko.observable(false);
         self.fetchState = ko.observable('');
         self.fetchLimit = ko.observable();

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -215,6 +215,8 @@ hqDefine('app_manager/js/releases/releases', function () {
         var asyncDownloader = hqImport('app_manager/js/download_async_modal').asyncDownloader;
         var appDiff = hqImport('app_manager/js/releases/app_diff').init('#app-diff-modal .modal-body');
         var self = this;
+        var genericErrorMessage = gettext(
+            'An error occurred. Reload the page and click Make New Version to try again.');
         self.options = o;
         self.recipients = self.options.recipient_contacts;
         self.totalItems = ko.observable();
@@ -222,7 +224,7 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.doneFetching = ko.observable(false);
         self.buildState = ko.observable('');
         self.buildErrorCode = ko.observable('');
-        self.genericErrorMessage = ko.observable('');
+        self.errorMessage = ko.observable(genericErrorMessage);
         self.onlyShowReleased = ko.observable(false);
         self.fetchState = ko.observable('');
         self.fetchLimit = ko.observable();
@@ -450,7 +452,7 @@ hqDefine('app_manager/js/releases/releases', function () {
                 error: function (xhr) {
                     self.buildErrorCode(xhr.status);
                     self.buildState('error');
-                    self.genericErrorMessage(xhr.responseText);
+                    self.errorMessage(xhr.responseText);
                 },
             });
         };

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -69,7 +69,11 @@
       {% trans "Sorry, you don't have permission to do this action!" %}
     </span>
     <span data-bind="visible: buildErrorCode() !== 403">
-      {% trans "An error occurred. Reload the page and click Make New Version to try again." %}
+      <span data-bind="visible: genericErrorMessage, text: genericErrorMessage">
+      </span>
+      <span data-bind="visible: !genericErrorMessage()">
+        {% trans "An error occurred. Reload the page and click Make New Version to try again." %}
+      </span>
     </span>
   </div>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -68,12 +68,7 @@
     <span data-bind="visible: buildErrorCode() === 403">
       {% trans "Sorry, you don't have permission to do this action!" %}
     </span>
-    <span data-bind="visible: buildErrorCode() !== 403">
-      <span data-bind="visible: genericErrorMessage, text: genericErrorMessage">
-      </span>
-      <span data-bind="visible: !genericErrorMessage()">
-        {% trans "An error occurred. Reload the page and click Make New Version to try again." %}
-      </span>
+    <span data-bind="visible: buildErrorCode() !== 403, text: errorMessage">
     </span>
   </div>
 

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -64,6 +64,7 @@ from corehq.apps.app_manager.decorators import (
     no_conflict_require_POST,
     require_can_edit_apps,
     require_deploy_apps,
+    avoid_parallel_build_request,
 )
 from corehq.apps.app_manager.exceptions import ModuleIdMissingException, PracticeUserException
 from corehq.apps.app_manager.models import Application, SavedAppBuild
@@ -268,6 +269,7 @@ def release_build(request, domain, app_id, saved_app_id):
 
 @no_conflict_require_POST
 @require_can_edit_apps
+@avoid_parallel_build_request
 def save_copy(request, domain, app_id):
     """
     Saves a copy of the app to a new doc.

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -299,10 +299,7 @@ def save_copy(request, domain, app_id):
             timer = datadog_bucket_timer('commcare.app_build.new_release', tags=[],
                                          timing_buckets=(1, 10, 30, 60, 120, 240))
             with timer:
-                result = make_app_build(app, comment, user_id)
-                if isinstance(result, HttpResponse):
-                    return result
-                copy = result
+                copy = make_app_build(app, comment, user_id)
             CouchUser.get(user_id).set_has_built_app()
         except BuildConflictException:
             return HttpResponseBadRequest(_("There is already a version build in progress. Please wait."))

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -6,10 +6,10 @@ import uuid
 from math import ceil
 
 from django.db.models import Count
-from django.http import (
+from django.http.response import (
     HttpResponse,
     Http404,
-    HttpResponseBadRequest,
+    JsonResponse
 )
 from django.http import HttpResponseRedirect
 from django_prbac.utils import has_privilege
@@ -302,7 +302,9 @@ def save_copy(request, domain, app_id):
                 copy = make_app_build(app, comment, user_id)
             CouchUser.get(user_id).set_has_built_app()
         except BuildConflictException:
-            return HttpResponseBadRequest(_("There is already a version build in progress. Please wait."))
+            return JsonResponse({
+                'error': _("There is already a version build in progress. Please wait.")
+            }, status=400)
         finally:
             # To make a RemoteApp always available for building
             if app.is_remote_app():


### PR DESCRIPTION
Taking inspiration from how we avoid parallel bulk locations upload, this PR is an attempt to avoid duplicate versions being created.
So if a user starts to create a new version on the app, another user can not initiate a build till the first one finishes. This would probably go unnoticed for smaller apps but for big apps with high build times, this would be useful. ICDS has had instances where the same version is built twice.

[Dev Note]
I initially started with a view decorator and then moved to a more specific function decorator, details in commits.
The first commit is just a setup change to show non-app generic error message.

[Ticket](https://dimagi-dev.atlassian.net/browse/ICDS-466)

fyi @esoergel 