### PR TITLE
Revert "Use Python 3.7 on Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-dist: xenial
-python: 3.7
+python: 2.7
 sudo: required
 group: edge
 branches:


### PR DESCRIPTION
Reverts dimagi/commcare-hq#24858

This change may have caused longer travis runs; see https://github.com/dimagi/commcare-hq/pull/24858#issuecomment-513904335. Reverting to test that theory. @emord, please monitor and update here if things improve or not.