### PR TITLE
Fix rebuildstaging

### DIFF
--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -23,21 +23,21 @@ Where staging.yaml looks as follows:
 
 When not specified, a submodule's trunk and name inherit from the parent
 """
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function, unicode_literals
 
-from __future__ import unicode_literals
 from gevent import monkey
-import six
 monkey.patch_all()
 
 import contextlib
 import os
 import re
-import sh
 import sys
 
 import gevent
+import jsonobject
+import sh
+import six
+
 from gitutils import (
     OriginalBranch,
     get_git,
@@ -45,7 +45,6 @@ from gitutils import (
     has_merge_conflict,
     print_merge_details,
 )
-import jsonobject
 from sh_verbose import ShVerbose
 
 

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -28,10 +28,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 from gevent import monkey
 monkey.patch_all()
 
-import contextlib
 import os
 import re
 import sys
+from contextlib import ExitStack
 
 import gevent
 import jsonobject
@@ -185,9 +185,9 @@ def rebuild_staging(config, print_details=True, push=True):
     merge_conflicts = []
     not_found = []
     all_configs = list(config.span_configs())
-    context_manager = contextlib.nested(*[OriginalBranch(get_git(path))
-                                          for path, _ in all_configs])
-    with context_manager:
+    with ExitStack() as stack:
+        for path, _ in all_configs:
+            stack.enter_context(OriginalBranch(get_git(path)))
         for path, config in all_configs:
             git = get_git(path)
             try:


### PR DESCRIPTION
From https://github.com/dimagi/commcare-hq/pull/24896

Fix usage of `contextlib.nested`.
This could almost certainly be simplified.  I tried briefly to refactor that giant `with` statement and `if` loop, but it quickly became clear that that would be more of an undertaking than I want to consider at the moment.  The goal of this PR is to get rebuildstaging working on python 3, not to refactor rebuildstaging and make it more readable.  This I think is the simplest fix which preserves the old behavior.

@millerdev @orangejenny @kaapstorm 