### PR TITLE
Moved resource_versions to YAML and only update it in build_requirejs…

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -36,13 +36,15 @@ class Command(BaseCommand):
         print("Current commit SHA: %s" % sha)
         return sha
 
-    def output_resources(self, resources, overwrite=True):
+    def output_resources(self, resources, overwrite=True, path=None):
         if not overwrite:
             from get_resource_versions import get_resource_versions
-            old_resources = get_resource_versions()
+            old_resources = get_resource_versions(path=path)
             old_resources.update(resources)
             resources = old_resources
-        with open(os.path.join(self.root_dir, 'resource_versions.yaml'), 'w') as fout:
+        if not path:
+            path = os.path.join(self.root_dir, 'resource_versions.yaml')
+        with open(path, 'w') as fout:
             fout.write(yaml.dump([{'name': name, 'version': version}
                                   for name, version in resources.items()]))
 

--- a/corehq/apps/hqwebapp/tests/data/resource_versions.yaml
+++ b/corehq/apps/hqwebapp/tests/data/resource_versions.yaml
@@ -1,0 +1,2 @@
+- name: somefile.js
+  version: 123abc

--- a/corehq/apps/hqwebapp/tests/data/resource_versions.yaml
+++ b/corehq/apps/hqwebapp/tests/data/resource_versions.yaml
@@ -1,2 +1,0 @@
-- name: somefile.js
-  version: 123abc

--- a/corehq/apps/hqwebapp/tests/test_static_resource_command.py
+++ b/corehq/apps/hqwebapp/tests/test_static_resource_command.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+import os
+import yaml
+from nose.plugins.attrib import attr
+
+from django.test import SimpleTestCase
+from corehq.apps.hqwebapp.management.commands.resource_static import Command as ResourceStaticCommand
+from get_resource_versions import get_resource_versions
+
+
+class TestResourceStatic(SimpleTestCase):
+    @classmethod
+    def resource_versions_filename(cls):
+        return os.path.join(os.path.dirname(__file__), 'data', 'resource_versions.yaml')
+
+    def setUp(self):
+        super(TestResourceStatic, self).setUp()
+        with open(self.resource_versions_filename(), 'r') as f:
+            self.original_resources = yaml.safe_load(f)
+
+    def tearDown(self):
+        super(TestResourceStatic, self).tearDown()
+        with open(self.resource_versions_filename(), 'w') as f:
+            f.write(yaml.dump(self.original_resources))
+
+    def get_resource_versions(self):
+        resource_versions = get_resource_versions(path=self.resource_versions_filename())
+        self.assertEquals(resource_versions, {
+            'somefile.js': '123abc',
+        })
+
+    def test_output_resources(self):
+        ResourceStaticCommand().output_resources({
+            'anotherfile.js': '890xyz',
+        }, overwrite=False, path=self.resource_versions_filename())
+        resource_versions = get_resource_versions(path=self.resource_versions_filename())
+        self.assertEquals(resource_versions, {
+            'somefile.js': '123abc',
+            'anotherfile.js': '890xyz',
+        })
+
+    def test_output_resources_with_overwrite(self):
+        ResourceStaticCommand().output_resources({
+            'anotherfile.js': '890xyz',
+        }, overwrite=True, path=self.resource_versions_filename())
+        resource_versions = get_resource_versions(path=self.resource_versions_filename())
+        self.assertEquals(resource_versions, {
+            'anotherfile.js': '890xyz',
+        })

--- a/corehq/apps/hqwebapp/tests/test_static_resource_command.py
+++ b/corehq/apps/hqwebapp/tests/test_static_resource_command.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import os
 import yaml
-from nose.plugins.attrib import attr
 
 from django.test import SimpleTestCase
 from corehq.apps.hqwebapp.management.commands.resource_static import Command as ResourceStaticCommand

--- a/get_resource_versions.py
+++ b/get_resource_versions.py
@@ -6,10 +6,11 @@ from io import open
 import os
 
 
-def get_resource_versions():
+def get_resource_versions(path=None):
     resource_versions = {}
 
-    path = os.path.join(settings.FILEPATH, 'resource_versions.yaml')
+    if not path:
+        path = os.path.join(settings.FILEPATH, 'resource_versions.yaml')
     if not os.path.exists(path):
         return resource_versions
 


### PR DESCRIPTION
… instead of overwriting

https://dimagi-dev.atlassian.net/browse/HI-769

Quick recap of how resource versions work, since we rarely touch this code: `resource_versions` is a massive mapping of all static files in HQ. Each key is a file path and each value is a hash of that file's contents. This is used by our `static` custom template tag, which adds `?version=<hash>` to the end of static files urls - notably, to the `src` in <script> tags for javascript. This controls caching of static files: new content => different hash => different version => CDN interprets that as a different url and fetches the file from HQ instead of serving the cached version.

Resource versions are generated on deploy: `resource_static` handles all static files that are in source control or in bower, and then `build_requirejs`, which generates a bunch of minified js files, adds in those files. 

The bug was that `build_requirejs` was overwriting all of resource versions, wiping out the non-requirejs files, so non-requirejs files were sometimes being served with stale content. I haven't been able to track down exactly where or when this happened, although https://github.com/dimagi/commcare-hq/pull/21756 and https://github.com/dimagi/commcare-hq/pull/23240 are the obvious suspects. This could have gone undetected for a long time - it only affects non-requirejs pages (half of HQ) and only js files that are not in a django compress block (django compression causes the entire js filename to change when the content changes, it doesn't need the url param).

The fix is to have `resource_static` create resource versions from scratch and then have `build_requirejs` update it instead of overwriting it. Because this means both reading and writing resource versions, I moved them from python to yaml to parse more easily.