### PR TITLE
Added support for SMS surveys to linked apps

### DIFF
--- a/corehq/apps/reminders/util.py
+++ b/corehq/apps/reminders/util.py
@@ -65,7 +65,7 @@ def get_form_list(domain):
     form_list = []
     for app_id in get_app_ids_in_domain(domain):
         latest_app = get_app(domain, app_id, latest=True)
-        if latest_app.doc_type != "RemoteApp":
+        if latest_app.doc_type in ('Application', 'LinkedApplication'):
             for m in latest_app.get_modules():
                 for f in m.get_forms():
                     form_list.append({"code": f.unique_id, "name": f.full_path_name})

--- a/corehq/apps/reminders/util.py
+++ b/corehq/apps/reminders/util.py
@@ -65,7 +65,7 @@ def get_form_list(domain):
     form_list = []
     for app_id in get_app_ids_in_domain(domain):
         latest_app = get_app(domain, app_id, latest=True)
-        if latest_app.doc_type == "Application":
+        if latest_app.doc_type != "RemoteApp":
             for m in latest_app.get_modules():
                 for f in m.get_forms():
                     form_list.append({"code": f.unique_id, "name": f.full_path_name})


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-792

This was added back in 2012 (https://github.com/dimagi/commcare-hq/commit/685e0308cc27e4a6cdaee9b8617fc98c61b06c6a) for the purpose of excluding remote apps. Tweak it to *only* exclude remote apps.

Feature flag: linked project spaces.