### PR TITLE
add warm shutdown to UCR pillows

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -63,7 +63,7 @@ class WarmShutdown(object):
         self.current_handler = signal.signal(signal.SIGTERM, self.handler)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self.shutting_down:
+        if self.shutting_down and exc_type is None:
             exit(0)
         signal.signal(signal.SIGTERM, self.current_handler)
 


### PR DESCRIPTION
This creates a context manager that lets the current batch succeed for UCR pillows when supervisor shuts them down. It does so by creating a context manager that intercepts `SIGTERM` and shutting down the program only on exit from that context.

Supervisor shuts down processes with `SIGTERM`, then waits a specified amount of time and sends `SIGKILL`. This context manager does not catch `SIGKILL` so after the timeout these will be killed, which should prevent the kind of long running zombie processes we see with celery. The timeout for that is set in a commcare cloud PR I will link.