### PR TITLE
Removed no-op updates from data cleaning

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1961,7 +1961,7 @@ def _get_data_cleaning_updates(request, old_properties):
     updates = {}
     properties = json.loads(request.POST.get('properties'))
     for prop, value in six.iteritems(properties):
-        if prop not in old_properties or old_properties[prop] != value:
+        if prop not in old_properties or old_properties[prop].get('value') != value:
             updates[prop] = value
     return updates
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-745

This was expecting the values in `old_properties` to be scalars, but they're dicts. This is causing data cleaning to attempt to update every question. There's presumably a bug in data cleaning affecting some question(s) in the form, but the questions this domain is trying to edit are fine, so this should unblock them.

Product: this will fix occasional 500s when data cleaning complex forms on couch domains.