### PR TITLE
Explicitly sets ACE editor JSON mode as a requirement

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
@@ -4,7 +4,8 @@ hqDefine('hqwebapp/js/base_ace', [
     'ace-builds/src-min-noconflict/mode-json',
 ], function (
     $,
-    ace
+    ace,
+    jsonMode  // eslint-disable-line no-unused-vars
 ) {
 
     var initAceEditor = function (element, mode, options, value) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
@@ -4,8 +4,7 @@ hqDefine('hqwebapp/js/base_ace', [
     'ace-builds/src-min-noconflict/mode-json',
 ], function (
     $,
-    ace,
-    jsonMode
+    ace
 ) {
 
     var initAceEditor = function (element, mode, options, value) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
@@ -1,15 +1,13 @@
 hqDefine('hqwebapp/js/base_ace', [
     'jquery',
     'ace-builds/src-min-noconflict/ace',
+    'ace-builds/src-min-noconflict/mode-json',
 ], function (
     $,
-    ace
+    ace,
+    jsonMode
 ) {
 
-    if (!ace.config.get('basePath')) {
-        var basePath = requirejs.s.contexts._.config.paths["ace-builds/src-min-noconflict/ace"];
-        ace.config.set("basePath",basePath.substring(0,basePath.lastIndexOf("/")));
-    }
     var initAceEditor = function (element, mode, options, value) {
         var defaultOptions = {
             showPrintMargin: false,

--- a/corehq/ex-submodules/dimagi/utils/gitinfo.py
+++ b/corehq/ex-submodules/dimagi/utils/gitinfo.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import os
 import re
-from subprocess import Popen, PIPE
+try:
+    # Backports Popen as context manager for Py2
+    from subprocess32 import Popen, PIPE
+except ImportError:
+    from subprocess import Popen, PIPE
 
 
 def git_file_deltas(git_dir, commit, compare=None):

--- a/corehq/ex-submodules/dimagi/utils/gitinfo.py
+++ b/corehq/ex-submodules/dimagi/utils/gitinfo.py
@@ -12,8 +12,8 @@ def git_file_deltas(git_dir, commit, compare=None):
 
 def sub_git_remote_url(git_dir):
     args = ['config', '--get', "remote.origin.url"]
-    p = sub_git_cmd(git_dir, args)
-    gitout = p.stdout.read().decode('utf-8').strip()
+    with sub_git_cmd(git_dir, args) as p:
+        gitout = p.stdout.read().decode('utf-8').strip()
     return gitout
 
 
@@ -61,8 +61,9 @@ def sub_get_current_branch(git_dir):
         '--abbrev-ref',
         'HEAD'
     ]
-    p = sub_git_cmd(git_dir, args)
-    return p.stdout.read().strip()
+    with sub_git_cmd(git_dir, args) as p:
+        gitout = p.stdout.read().decode('utf-8').strip()
+    return gitout
 
 
 def get_project_snapshot(git_dir, submodules=False, log_count=1, submodule_count=1):
@@ -103,9 +104,9 @@ def sub_git_info(git_dir, log_count=1):
             '-z',
             '--pretty=format:%s' % line_by_line_format
     ]
-    p = sub_git_cmd(git_dir, args)
+    with sub_git_cmd(git_dir, args) as p:
+        gitout = p.stdout.read().decode('utf-8').strip()
     url = sub_git_remote_url(git_dir)
-    gitout = p.stdout.read().decode('utf-8').strip()
     all_raw_revs = gitout.split('\0')
 
     def parse_rev_block(block_text):
@@ -141,8 +142,8 @@ def sub_git_submodules(git_dir, log_count=1):
     Using shell, get the active submodule info
     """
     args =['submodule', 'status' ]
-    p = sub_git_cmd(git_dir, args)
-    gitout = p.stdout.read().split('\n')
+    with sub_git_cmd(git_dir, args) as p:
+        gitout = p.stdout.read().decode('utf-8').strip()
 
     for x in gitout:
         splits = x.strip().split(' ')

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -187,6 +187,7 @@ sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.3
 sqlparse==0.3.0           # via django-debug-toolbar
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 testil==1.1
 text-unidecode==1.2       # via faker

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -156,6 +156,7 @@ socketpool==0.5.3
 sqlagg==0.13.0
 sqlalchemy==1.3.3
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 text-unidecode==1.2       # via faker
 tinycss2==0.6.1           # via cssselect2, weasyprint

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -139,6 +139,7 @@ socketpool==0.5.3
 sqlagg==0.13.0
 sqlalchemy==1.3.3
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 text-unidecode==1.2       # via faker
 tinycss2==0.6.1           # via cssselect2, weasyprint

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -154,6 +154,7 @@ sqlagg==0.13.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.3
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 testil==1.1
 text-unidecode==1.2       # via faker

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -197,6 +197,7 @@ sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.3
 sqlparse==0.3.0           # via django-debug-toolbar
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 testil==1.1
 text-unidecode==1.2       # via faker

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -164,6 +164,7 @@ socketpool==0.5.3
 sqlagg==0.13.0
 sqlalchemy==1.3.3
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 text-unidecode==1.2       # via faker
 tinycss2==0.6.1           # via cssselect2, weasyprint

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -40,6 +40,7 @@ python-magic~=0.4.13
 pytz>=2017.2
 PyYAML~=5.1
 requests~=2.20
+subprocess32
 suds-jurko==0.6
 tropo-webapi-python==0.1.3
 Unidecode==0.04.20

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -145,6 +145,7 @@ socketpool==0.5.3
 sqlagg==0.13.0
 sqlalchemy==1.3.3
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 text-unidecode==1.2       # via faker
 tinycss2==0.6.1           # via cssselect2, weasyprint

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -161,6 +161,7 @@ sqlagg==0.13.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.3
 stripe==1.67.0
+subprocess32==3.5.4
 suds-jurko==0.6
 testil==1.1
 text-unidecode==1.2       # via faker


### PR DESCRIPTION
Context: [HI-744](https://dimagi-dev.atlassian.net/browse/HI-744)

This PR effectively reverts [this commit](https://github.com/dimagi/commcare-hq/commit/16ee0688d7ee48d68c5b9a669e79bee057e09afd/), which removed the explicit requirement of the ACE editor's JSON mode in favour of finding its path.

The `build_requirejs` script doesn't parse the requirement of JSON mode, and doesn't include the path "ace-builds/src-min-noconflict/ace" in [the `requirejs.s.contexts._.config.paths` dictionary used in base_ace.js on line 10](https://github.com/dimagi/commcare-hq/blob/16ee0688d7ee48d68c5b9a669e79bee057e09afd/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js#L10). As a result, `basePath` is set to `undefined` on line 10, and the script errors out on the next line at `basePath.substring` because `undefined` doesn't have a "substring" property.

The `build_requirejs` script works as expected when we reintroduce JSON mode as an explicit requirement.
