### PR TITLE
Fixed appcues pre-login on python 3

### DIFF
--- a/corehq/apps/analytics/templates/analytics/initial/appcues.html
+++ b/corehq/apps/analytics/templates/analytics/initial/appcues.html
@@ -3,8 +3,10 @@
 {% if ANALYTICS_CONFIG.DEBUG %}
   {# Developer is working on analytics #}
   {% initial_analytics_data 'appcues.apiId' ANALYTICS_IDS.APPCUES_ID %}
-{% elif is_saas_environment and request.couch_user.days_since_created < 31 %}
-  {% initial_analytics_data 'appcues.apiId' ANALYTICS_IDS.APPCUES_ID %}
+{% elif is_saas_environment %}
+  {% if not request.user.is_authenticated or request.couch_user.days_since_created < 31 %}
+    {% initial_analytics_data 'appcues.apiId' ANALYTICS_IDS.APPCUES_ID %}
+  {% endif %}
 {% endif %}
 
 {% initial_analytics_data 'appcues.username' request.couch_user.username %}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-790

Python 3 raises a `TypeError` when comparing unorderable types, which I believe is causing `request.couch_user.days_since_created < 31` to error out when `request.couch_user` is None, and therefore the appcues api id isn't getting inserted during user registration, so the user isn't getting the "Appcues Test" proeprty assigned and therefore never sees the appcues flow.