### PR TITLE
MOTECH request timeout

### DIFF
--- a/corehq/motech/const.py
+++ b/corehq/motech/const.py
@@ -3,6 +3,9 @@ from __future__ import unicode_literals
 
 PASSWORD_PLACEHOLDER = '*' * 16
 
+# If any remote service does not respond within 10 minutes, time out
+REQUEST_TIMEOUT = 600
+
 ALGO_AES = 'aes'
 
 DATA_TYPE_UNKNOWN = None

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -5,6 +5,7 @@ import logging
 
 import requests
 
+from corehq.motech.const import REQUEST_TIMEOUT
 from corehq.motech.models import RequestLog
 from corehq.motech.utils import pformat_json
 
@@ -73,6 +74,7 @@ class Requests(object):
         raise_for_status = kwargs.pop('raise_for_status', False)
         if not self.verify:
             kwargs['verify'] = False
+        kwargs.setdefault('timeout', REQUEST_TIMEOUT)
         try:
             if self._session:
                 response = self._session.request(method, *args, **kwargs)

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -40,7 +40,8 @@ class RequestsTests(SimpleTestCase):
                 TEST_API_URL + 'me',
                 allow_redirects=True,
                 headers={'Accept': 'application/json'},
-                auth=(TEST_API_USERNAME, TEST_API_PASSWORD)
+                auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
+                timeout=600,
             )
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json()['code'], TEST_API_USERNAME)
@@ -69,7 +70,8 @@ class RequestsTests(SimpleTestCase):
                 data=None,
                 json=payload,
                 headers={'Content-type': 'application/json', 'Accept': 'application/json'},
-                auth=(TEST_API_USERNAME, TEST_API_PASSWORD)
+                auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
+                timeout=600,
             )
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json()['status'], 'SUCCESS')
@@ -87,6 +89,7 @@ class RequestsTests(SimpleTestCase):
                 allow_redirects=True,
                 headers={'Accept': 'application/json'},
                 auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
+                timeout=600,
                 verify=False
             )
 


### PR DESCRIPTION
It looks like the OpenMRS Reporting API can hold open an HTTP connection indefinitely without responding.

This resolves the problem by setting a default timeout on all requests of 10 minutes. Reports can take a long time to generate, but 10 minutes seems like more than enough time to wait. We can review the value if we find an API call that legitimately needs more time.
