### PR TITLE
Removed default_app view

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/apps_base.js
+++ b/corehq/apps/app_manager/static/app_manager/js/apps_base.js
@@ -5,7 +5,7 @@ hqDefine("app_manager/js/apps_base", function () {
             keyboard: false,
             show: true,
         }).on('hide.bs.modal', function () {
-            window.location = hqImport('hqwebapp/js/initial_page_data').reverse('default_app');
+            window.location = hqImport('hqwebapp/js/initial_page_data').reverse('dashboard_default');
         });
         var previewApp = hqImport('app_manager/js/preview_app');
         previewApp.initPreviewWindow();

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -54,7 +54,7 @@
 {% block page_breadcrumbs %}{% endblock %}
 
 {% block content %}{{ block.super }}
-  {% registerurl "default_app" domain %}
+  {% registerurl "dashboard_default" domain %}
   {% include 'app_manager/partials/preview_app.html'%}
 {% endblock %}
 

--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -221,12 +221,6 @@ class TestViews(TestCase):
             'module_unique_id': module.unique_id,
         })
 
-    def test_dashboard(self, mock):
-        # This redirects to the dashboard
-        self._test_status_codes(['default_app'], {
-            'domain': self.project.name,
-        }, True)
-
     def test_default_new_app(self, mock):
         response = self.client.get(reverse('default_new_app', kwargs={
             'domain': self.project.name,

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -84,7 +84,6 @@ app_urls = [
 
 
 urlpatterns = [
-    url(r'^$', view_app, name='default_app'),
     url(r'^browse/(?P<app_id>[\w-]+)/(?P<form_unique_id>[\w-]+)/source/$',
         get_xform_source, name='get_xform_source'),
     url(r'^casexml/(?P<form_unique_id>[\w-]+)/$', form_casexml, name='form_casexml'),

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -66,7 +66,7 @@ def back_to_main(request, domain, app_id=None, module_id=None, form_id=None,
     page = None
     params = {}
     args = [domain]
-    view_name = 'default_app'
+    view_name = 'dashboard_default'
 
     form_view = 'form_source'
 

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -47,9 +47,6 @@ def default_dashboard_url(request, domain):
     if couch_user and user_has_custom_top_menu(domain, couch_user):
         return reverse('saved_reports', args=[domain])
 
-    if not domain_has_apps(domain):
-        return reverse('default_app', args=[domain])
-
     return reverse(DomainDashboardView.urlname, args=[domain])
 
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -825,13 +825,9 @@ class ProjectDataTab(UITab):
 
 
 class ApplicationsTab(UITab):
-    view = "default_app"
+    view = "default_new_app"
 
     url_prefix_formats = ('/a/{domain}/apps/',)
-
-    @property
-    def view(self):
-        return "default_new_app"
 
     @property
     def title(self):


### PR DESCRIPTION
Part of https://github.com/dimagi/commcare-hq/pull/24946#discussion_r307893913

We used to have a landing page for app manager (where you'd pick from a template app or a new app). Now you just get redirected to the dashboard, but the code remains more complicated than it needs to be.