### PR TITLE
cache LatestAppInfo.get_latest_apk_version

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -580,7 +580,9 @@ class LatestAppInfo(object):
 
     def clear_caches(self):
         self.get_latest_app_version.clear(self)
+        self.get_latest_apk_version.clear(self)
 
+    @quickcache(vary_on=['self.app_id'])
     def get_latest_apk_version(self):
         from corehq.apps.app_manager.models import LATEST_APK_VALUE
         from corehq.apps.builds.models import BuildSpec


### PR DESCRIPTION
Noticed a lot of couch requests that I think stem from here. Since the `get_latest_app_version` is also cached in the same way (and cleared in the same way) this seems safe to do.