### PR TITLE
Hide non-functional options in Odata export & implement feature preview

### DIFF
--- a/corehq/apps/api/odata/tests/test_feed.py
+++ b/corehq/apps/api/odata/tests/test_feed.py
@@ -45,13 +45,13 @@ class TestDeprecatedODataCaseFeed(TestCase, OdataTestMixin):
         super(TestDeprecatedODataCaseFeed, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -61,7 +61,7 @@ class TestDeprecatedODataCaseFeed(TestCase, OdataTestMixin):
         self.addCleanup(other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain(other_domain.name),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -75,7 +75,7 @@ class TestDeprecatedODataCaseFeed(TestCase, OdataTestMixin):
 
     def test_request_succeeded(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
 
@@ -130,13 +130,13 @@ class TestDeprecatedODataFormFeed(TestCase, OdataTestMixin):
         super(TestDeprecatedODataFormFeed, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -146,7 +146,7 @@ class TestDeprecatedODataFormFeed(TestCase, OdataTestMixin):
         self.addCleanup(other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain(other_domain.name),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -160,7 +160,7 @@ class TestDeprecatedODataFormFeed(TestCase, OdataTestMixin):
 
     def test_request_succeeded(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -222,13 +222,13 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
         super(TestODataCaseFeed, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -238,7 +238,7 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
         self.addCleanup(other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain(other_domain.name),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -260,7 +260,7 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
         self.addCleanup(export_config.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -275,7 +275,7 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
         self.addCleanup(export_config_in_other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain_and_config_id(self.domain.name, export_config_in_other_domain.get_id),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -284,7 +284,7 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
 
     def test_missing_config_id(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain_and_config_id(self.domain.name, 'missing_config_id'),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -307,7 +307,7 @@ class TestODataCaseFeed(TestCase, OdataTestMixin):
         self.addCleanup(export_config.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json; charset=utf-8')
@@ -375,13 +375,13 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
         super(TestODataFormFeed, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -391,7 +391,7 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
         self.addCleanup(other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain(other_domain.name),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -412,7 +412,7 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
         self.addCleanup(export_config.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -426,7 +426,7 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
         self.addCleanup(export_config_in_other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain_and_config_id(
                     self.domain.name, export_config_in_other_domain.get_id),
@@ -436,7 +436,7 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
 
     def test_missing_config_id(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 self._odata_feed_url_by_domain_and_config_id(self.domain.name, 'missing_config_id'),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -459,7 +459,7 @@ class TestODataFormFeed(TestCase, OdataTestMixin):
         self.addCleanup(export_config.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json; charset=utf-8')

--- a/corehq/apps/api/odata/tests/test_metadata.py
+++ b/corehq/apps/api/odata/tests/test_metadata.py
@@ -46,13 +46,13 @@ class TestDeprecatedCaseMetadataDocument(TestCase, DeprecatedCaseOdataTestMixin,
         super(TestDeprecatedCaseMetadataDocument, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -61,7 +61,7 @@ class TestDeprecatedCaseMetadataDocument(TestCase, DeprecatedCaseOdataTestMixin,
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -74,7 +74,7 @@ class TestDeprecatedCaseMetadataDocument(TestCase, DeprecatedCaseOdataTestMixin,
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -85,7 +85,7 @@ class TestDeprecatedCaseMetadataDocument(TestCase, DeprecatedCaseOdataTestMixin,
 
     def test_no_case_types(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch('corehq.apps.api.odata.views.get_case_type_to_properties', return_value={}):
                 response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
@@ -96,7 +96,7 @@ class TestDeprecatedCaseMetadataDocument(TestCase, DeprecatedCaseOdataTestMixin,
 
     def test_populated_metadata_document(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch(
                 'corehq.apps.api.odata.views.get_case_type_to_properties',
                 return_value=OrderedDict([
@@ -144,14 +144,14 @@ class TestDeprecatedFormMetadataDocument(TestCase, DeprecatedFormOdataTestMixin,
         super(TestDeprecatedFormMetadataDocument, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     @flaky
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -160,7 +160,7 @@ class TestDeprecatedFormMetadataDocument(TestCase, DeprecatedFormOdataTestMixin,
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'app_id': 'my_app_id'}),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -173,7 +173,7 @@ class TestDeprecatedFormMetadataDocument(TestCase, DeprecatedFormOdataTestMixin,
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -184,7 +184,7 @@ class TestDeprecatedFormMetadataDocument(TestCase, DeprecatedFormOdataTestMixin,
 
     def test_no_xmlnss(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch('corehq.apps.api.odata.views.get_xmlns_to_properties', return_value={}):
                 response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
@@ -195,7 +195,7 @@ class TestDeprecatedFormMetadataDocument(TestCase, DeprecatedFormOdataTestMixin,
 
     def test_populated_metadata_document(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch(
                 'corehq.apps.api.odata.views.get_xmlns_to_properties',
                 return_value=OrderedDict([
@@ -268,7 +268,7 @@ class TestCaseMetadataDocument(TestCase, CaseOdataTestMixin, TestXmlMixin):
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -279,7 +279,7 @@ class TestCaseMetadataDocument(TestCase, CaseOdataTestMixin, TestXmlMixin):
 
     def test_missing_feed(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 404)
 
@@ -315,7 +315,7 @@ class TestCaseMetadataDocument(TestCase, CaseOdataTestMixin, TestXmlMixin):
         self.addCleanup(config_in_other_domain.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/xml')
@@ -386,7 +386,7 @@ class TestFormMetadataDocument(TestCase, FormOdataTestMixin, TestXmlMixin):
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -397,7 +397,7 @@ class TestFormMetadataDocument(TestCase, FormOdataTestMixin, TestXmlMixin):
 
     def test_missing_feed(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 404)
 
@@ -429,7 +429,7 @@ class TestFormMetadataDocument(TestCase, FormOdataTestMixin, TestXmlMixin):
         self.addCleanup(odata_config.delete)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/xml')

--- a/corehq/apps/api/odata/tests/test_service.py
+++ b/corehq/apps/api/odata/tests/test_service.py
@@ -41,13 +41,13 @@ class TestDeprecatedCaseServiceDocument(TestCase, DeprecatedCaseOdataTestMixin):
         super(TestDeprecatedCaseServiceDocument, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -56,7 +56,7 @@ class TestDeprecatedCaseServiceDocument(TestCase, DeprecatedCaseOdataTestMixin):
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 reverse(self.view_urlname, kwargs={'domain': other_domain.name}),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -69,7 +69,7 @@ class TestDeprecatedCaseServiceDocument(TestCase, DeprecatedCaseOdataTestMixin):
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -80,7 +80,7 @@ class TestDeprecatedCaseServiceDocument(TestCase, DeprecatedCaseOdataTestMixin):
 
     def test_no_case_types(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch('corehq.apps.api.odata.views.get_case_types_for_domain_es', return_value=set()):
                 response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
@@ -91,7 +91,7 @@ class TestDeprecatedCaseServiceDocument(TestCase, DeprecatedCaseOdataTestMixin):
 
     def test_with_case_types(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch(
                 'corehq.apps.api.odata.views.get_case_types_for_domain_es',
                 return_value=['case_type_1', 'case_type_2'],  # return ordered iterable for deterministic test
@@ -142,13 +142,13 @@ class TestDeprecatedFormServiceDocument(TestCase, DeprecatedFormOdataTestMixin):
         super(TestDeprecatedFormServiceDocument, cls).tearDownClass()
 
     def test_no_credentials(self):
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(self.view_url)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
         wrong_credentials = self._get_basic_credentials(self.web_user.username, 'wrong_password')
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(wrong_credentials)
         self.assertEqual(response.status_code, 401)
 
@@ -157,7 +157,7 @@ class TestDeprecatedFormServiceDocument(TestCase, DeprecatedFormOdataTestMixin):
         other_domain.save()
         self.addCleanup(other_domain.delete)
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self.client.get(
                 reverse(self.view_urlname, kwargs={'domain': other_domain.name, 'app_id': 'my_app_id'}),
                 HTTP_AUTHORIZATION='Basic ' + correct_credentials,
@@ -170,7 +170,7 @@ class TestDeprecatedFormServiceDocument(TestCase, DeprecatedFormOdataTestMixin):
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -181,7 +181,7 @@ class TestDeprecatedFormServiceDocument(TestCase, DeprecatedFormOdataTestMixin):
 
     def test_no_xmlnss(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch('corehq.apps.api.odata.views.get_xmlns_by_app', return_value=[]):
                 response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
@@ -195,7 +195,7 @@ class TestDeprecatedFormServiceDocument(TestCase, DeprecatedFormOdataTestMixin):
 
     def test_with_xmlnss(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             with patch('corehq.apps.api.odata.views.get_xmlns_by_app', return_value=['xmlns_1', 'xmlns_2']):
                 response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
@@ -268,7 +268,7 @@ class TestCaseServiceDocument(TestCase, CaseOdataTestMixin):
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -279,7 +279,7 @@ class TestCaseServiceDocument(TestCase, CaseOdataTestMixin):
 
     def test_successful_request(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['OData-Version'], '4.0')
@@ -350,7 +350,7 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
         self.addCleanup(self._setup_user_permissions)
 
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 403)
 
@@ -361,7 +361,7 @@ class TestFormServiceDocument(TestCase, FormOdataTestMixin):
 
     def test_successful_request(self):
         correct_credentials = self._get_correct_credentials()
-        with flag_enabled('ODATA'):
+        with flag_enabled('BI_INTEGRATION_PREVIEW', is_preview=True):
             response = self._execute_query(correct_credentials)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['OData-Version'], '4.0')

--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -17,6 +17,7 @@ from corehq.apps.export.models import CaseExportInstance, FormExportInstance
 from corehq.apps.reports.analytics.esaccessors import get_case_types_for_domain_es
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.feature_previews import BI_INTEGRATION_PREVIEW
 from corehq.util import get_document_or_404
 from corehq.util.view_utils import absolute_reverse
 
@@ -27,7 +28,7 @@ class DeprecatedODataCaseServiceView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain):
         data = {
             '@odata.context': absolute_reverse(DeprecatedODataCaseMetadataView.urlname, args=[domain]),
@@ -49,7 +50,7 @@ class DeprecatedODataCaseMetadataView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain):
         case_type_to_properties = get_case_type_to_properties(domain)
         for case_type in case_type_to_properties:
@@ -69,7 +70,7 @@ class DeprecatedODataFormServiceView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain, app_id):
         data = {
             '@odata.context': absolute_reverse(DeprecatedODataFormMetadataView.urlname, args=[domain, app_id]),
@@ -91,7 +92,7 @@ class DeprecatedODataFormMetadataView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain, app_id):
         xmlns_to_properties = get_xmlns_to_properties(domain, app_id)
         metadata = render_to_string('api/odata_form_metadata.xml', {
@@ -106,7 +107,7 @@ class ODataCaseServiceView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain, config_id):
         service_document_content = {
             '@odata.context': absolute_reverse(ODataCaseMetadataView.urlname, args=[domain, config_id]),
@@ -125,7 +126,7 @@ class ODataCaseMetadataView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain, config_id):
         config = get_document_or_404(CaseExportInstance, domain, config_id)
         metadata = render_to_string('api/case_odata_metadata.xml', {
@@ -140,7 +141,7 @@ class ODataFormServiceView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain, config_id):
         service_document_content = {
             '@odata.context': absolute_reverse(ODataFormMetadataView.urlname, args=[domain, config_id]),
@@ -159,7 +160,7 @@ class ODataFormMetadataView(View):
 
     @method_decorator(basic_auth_or_try_api_key_auth)
     @method_decorator(require_permission(Permissions.edit_data, login_decorator=None))
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def get(self, request, domain, config_id):
         config = get_document_or_404(FormExportInstance, domain, config_id)
         metadata = render_to_string('api/form_odata_metadata.xml', {

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -54,6 +54,7 @@ from corehq.apps.userreports.reports.view import query_dict_to_dict, \
 from corehq.apps.users.dbaccessors.all_commcare_users import get_all_user_id_username_pairs_by_domain
 from corehq.apps.users.models import CommCareUser, WebUser, Permissions, CouchUser, UserRole
 from corehq.apps.users.util import raw_username
+from corehq.feature_previews import BI_INTEGRATION_PREVIEW
 from corehq.util import get_document_or_404
 from corehq.util.couch import get_document_or_not_found, DocumentNotFound
 from corehq.util.timer import TimingContext
@@ -914,7 +915,7 @@ class DeprecatedODataCaseResource(v0_4.CommCareCaseResource):
     case_type = None
 
     def dispatch(self, request_type, request, **kwargs):
-        if not toggles.ODATA.enabled_for_request(request):
+        if not BI_INTEGRATION_PREVIEW.enabled_for_request(request):
             raise ImmediateHttpResponse(response=HttpResponseNotFound('Feature flag not enabled.'))
         self.case_type = kwargs['case_type']
         return super(DeprecatedODataCaseResource, self).dispatch(request_type, request, **kwargs)
@@ -959,7 +960,7 @@ class DeprecatedODataFormResource(v0_4.XFormInstanceResource):
     xmlns = None
 
     def dispatch(self, request_type, request, **kwargs):
-        if not toggles.ODATA.enabled_for_request(request):
+        if not BI_INTEGRATION_PREVIEW.enabled_for_request(request):
             raise ImmediateHttpResponse(response=HttpResponseNotFound('Feature flag not enabled.'))
         self.app_id = kwargs['app_id']
         self.xmlns = kwargs['xmlns']
@@ -1002,7 +1003,7 @@ class ODataCaseResource(HqBaseResource, DomainSpecificResourceMixin):
     config_id = None
 
     def dispatch(self, request_type, request, **kwargs):
-        if not toggles.ODATA.enabled_for_request(request):
+        if not BI_INTEGRATION_PREVIEW.enabled_for_request(request):
             raise ImmediateHttpResponse(response=HttpResponseNotFound('Feature flag not enabled.'))
         self.config_id = kwargs['config_id']
         with TimingContext() as timer:
@@ -1051,7 +1052,7 @@ class ODataFormResource(HqBaseResource, DomainSpecificResourceMixin):
     config_id = None
 
     def dispatch(self, request_type, request, **kwargs):
-        if not toggles.ODATA.enabled_for_request(request):
+        if not BI_INTEGRATION_PREVIEW.enabled_for_request(request):
             raise ImmediateHttpResponse(response=HttpResponseNotFound('Feature flag not enabled.'))
         self.config_id = kwargs['config_id']
         with TimingContext() as timer:

--- a/corehq/apps/export/static/export/js/export_list.js
+++ b/corehq/apps/export/static/export/js/export_list.js
@@ -22,7 +22,7 @@ hqDefine("export/js/export_list", [
     'analytix/js/kissmetrix',
     'export/js/utils',
     'hqwebapp/js/validators.ko',        // needed for validation of startDate and endDate
-    'hqwebapp/js/components.ko',        // pagination widget
+    'hqwebapp/js/components.ko',        // pagination & feedback widget
     'select2/dist/js/select2.full.min',
 ], function (
     $,

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -32,64 +32,75 @@
         </a>
       </div>
     {% endif %}
+
     {% include "export/partials/customize_export_header.html" %}
-    <form class="form-horizontal" method="post">
+
+    <form class="form-horizontal"
+          method="post">
       {% csrf_token %}
       <fieldset>
         <div class="form-group">
-          <label
-            for="export-type"
-            class="col-sm-3 col-md-2 control-label">
-            {% if export_instance.type == 'case' %}{% trans "Case Type" %}{% else %}{% trans "Form" %}{% endif %}
+          <label for="export-type"
+                 class="col-sm-3 col-md-2 control-label">
+            {% if export_instance.type == 'case' %}
+              {% trans "Case Type" %}
+            {% else %}
+              {% trans "Form" %}
+            {% endif %}
           </label>
           <div class="col-sm-9 col-md-8 col-lg-6">
             <p class="form-control-static">
-              {% if export_instance.type == 'case' %}{{ export_instance.case_type }}{% else %}{{ export_instance.formname }}{% endif %}
+              {% if export_instance.type == 'case' %}
+                {{ export_instance.case_type }}
+              {% else %}
+                {{ export_instance.formname }}
+              {% endif %}
             </p>
           </div>
         </div>
         <div class="form-group">
-          <label
-            for="export-name"
-            class="col-sm-3 col-md-2 control-label">
+          <label for="export-name"
+                 class="col-sm-3 col-md-2 control-label">
             {{ terminology.name_label }}
           </label>
           <div class="col-sm-9 col-md-8 col-lg-6">
-            <input type="text" class="form-control" id="export-name" data-bind="value: name" />
+            <input type="text"
+                   class="form-control"
+                   id="export-name"
+                   data-bind="value: name" />
           </div>
         </div>
         <div class="form-group">
-          <label
-            for="export-description"
-            class="col-sm-3 col-md-2 control-label">
+          <label for="export-description"
+                 class="col-sm-3 col-md-2 control-label">
             {% trans "Description" %}
           </label>
           <div class="col-sm-9 col-md-8 col-lg-6">
-                    <textarea
-                      data-bind="value: description"
+            <textarea data-bind="value: description"
                       id="export-description"
                       class="form-control"
                       rows="3">
-                    </textarea>
+            </textarea>
           </div>
         </div>
-        <div class="form-group" data-bind="
-                css: {'has-error': hasDisallowedHtmlFormat},
-                visible: formatOptions.length > 1
-            ">
-          <label
-            for="format-select"
-            class="col-sm-3 col-md-2 control-label">
+        <div class="form-group"
+             data-bind="css: {
+                          'has-error': hasDisallowedHtmlFormat
+                        },
+                        visible: formatOptions.length > 1">
+          <label for="format-select"
+                 class="col-sm-3 col-md-2 control-label">
             {% trans "Default file type" %}
           </label>
           <div class="col-sm-9 col-md-8 col-lg-6">
-            <select class="form-control" id="format-select" data-bind="
-                            options: getFormatOptionValues(),
-                            optionsText: getFormatOptionText,
-                            value: export_format
-                        ">
+            <select class="form-control"
+                    id="format-select"
+                    data-bind="options: getFormatOptionValues(),
+                               optionsText: getFormatOptionText,
+                               value: export_format">
             </select>
-            <div class="help-block" data-bind="visible: hasDisallowedHtmlFormat">
+            <div class="help-block"
+                 data-bind="visible: hasDisallowedHtmlFormat">
               {% url "domain_subscription_view" domain as software_plan_url %}
               {% blocktrans %}
                 Excel Dashboard Integration is only available on the Standard Plan or higher.
@@ -101,30 +112,30 @@
         </div>
         <div class="form-group">
           <div class="col-sm-offset-4 col-md-offset-3 col-lg-offset-2 col-sm-4">
-              {% if not export_instance.is_odata_config %}
+            {% if not export_instance.is_odata_config %}
               <div class="checkbox">
                 <label>
-                  <input type="checkbox" id="transform-dates-checkbox" data-bind="checked: transform_dates" />
+                  <input type="checkbox"
+                         id="transform-dates-checkbox"
+                         data-bind="checked: transform_dates" />
                   {% trans "Automatically convert dates and links for Excel" %}
                 </label>
               </div>
 
               <div class="checkbox">
                 <label>
-                  <input
-                    type="checkbox"
-                    id="daily-saved-export-checkbox"
-                    data-bind="checked: is_daily_saved_export,
-                               attr: { disabled: hasHtmlFormat() || !{{ has_daily_saved_export_access|JSON }}}"/>
+                  <input type="checkbox"
+                         id="daily-saved-export-checkbox"
+                         data-bind="checked: is_daily_saved_export,
+                                    attr: { disabled: hasHtmlFormat() || !{{ has_daily_saved_export_access|JSON }}}"/>
                   {% trans "Create a Daily Saved Export" %}
                 </label>
                 {% if not has_daily_saved_export_access %}
-                  <span
-                    class="hq-help-template"
-                    data-content='{% blocktrans %}
-                                    Daily saved exports are only available on the Standard Plan or higher.
-                                    Click <a href="{{ software_plan_url }}">here</a> to manage the software plan for your project.
-                                  {% endblocktrans %}'
+                  <span class="hq-help-template"
+                        data-content='{% blocktrans %}
+                                        Daily saved exports are only available on the Standard Plan or higher.
+                                        Click <a href="{{ software_plan_url }}">here</a> to manage the software plan for your project.
+                                      {% endblocktrans %}'
                   ></span>
                 {% endif %}
               </div>
@@ -132,15 +143,20 @@
 
 
             {% if export_instance.type == 'form' %}
-              <div class="checkbox" {% if not request|toggle_enabled:'SUPPORT' %}data-bind="visible: initiallyIncludeErrors"{% endif %}>
+              <div class="checkbox"
+                   {% if not request|toggle_enabled:'SUPPORT' %}data-bind="visible: initiallyIncludeErrors"{% endif %}>
                 <label>
-                  <input type="checkbox" id="include-errors-checkbox" data-bind="checked: include_errors" />
+                  <input type="checkbox"
+                         id="include-errors-checkbox"
+                         data-bind="checked: include_errors" />
                   {% trans "Include duplicates and other unprocessed forms" %}
                 </label>
               </div>
               <div class="checkbox">
                 <label>
-                  <input type="checkbox" id="split-multiselects-checkbox" data-bind="checked: split_multiselects" />
+                  <input type="checkbox"
+                         id="split-multiselects-checkbox"
+                         data-bind="checked: split_multiselects" />
                   {% trans "Expand Checkbox Questions" %}
                 </label>
               </div>
@@ -148,21 +164,21 @@
           </div>
         </div>
         {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
-          <div class="form-group" data-bind="css: { 'has-warning': hasOtherOwner && sharing() != initialSharing }">
-            <label
-              for="sharing-select"
-              class="col-sm-3 col-md-2 control-label">
+          <div class="form-group"
+               data-bind="css: { 'has-warning': hasOtherOwner && sharing() != initialSharing }">
+            <label for="sharing-select"
+                   class="col-sm-3 col-md-2 control-label">
               {% trans "Sharing" %}
               <span data-bind="makeHqHelp: {description: getSharingHelpText}"></span>
             </label>
             <div class="col-sm-9 col-md-8 col-lg-6">
-              <select class="form-control" id="sharing-select" data-bind="
-                            options: getSharingOptionValues(),
-                            optionsText: getSharingOptionText,
-                            value: sharing
-                        ">
+              <select class="form-control" id="sharing-select"
+                      data-bind="options: getSharingOptionValues(),
+                                 optionsText: getSharingOptionText,
+                                 value: sharing">
               </select>
-              <div class="help-block" data-bind="visible: hasOtherOwner && sharing() != initialSharing">
+              <div class="help-block"
+                   data-bind="visible: hasOtherOwner && sharing() != initialSharing">
                 <div data-bind="visible: sharing() == 'private'">
                   {% blocktrans %}
                     This export was created by <strong>{{ owner_name }}</strong>.
@@ -184,16 +200,16 @@
           </div>
         {% endif %}
       </fieldset>
-      <fieldset data-bind="
-            template: { foreach: tables, as: 'table', name: 'ko-table-configuration-template' }"
-      ></fieldset>
+      <fieldset data-bind="template: {
+                             foreach: tables,
+                             as: 'table',
+                             name: 'ko-table-configuration-template' }"></fieldset>
 
       {% if request|toggle_enabled:"ALLOW_USER_DEFINED_EXPORT_COLUMNS" %}
         <fieldset>
           <div class="col-sm-10">
-            <button class="btn btn-default" data-bind="
-                    click: addUserDefinedTableConfiguration
-                ">
+            <button class="btn btn-default"
+                    data-bind="click: addUserDefinedTableConfiguration">
               {% trans "Add custom table configuration " %}
             </button>
           </div>
@@ -202,25 +218,29 @@
 
       {% if allow_deid %}
         <fieldset>
-          <legend>{% trans "Privacy Settings" %}</legend>
+          <legend>
+            {% trans "Privacy Settings" %}
+          </legend>
           <div class="form-group">
-            <label for="is_safe" class="col-sm-3 col-md-2 control-label"></label>
-            <div class="col-sm-9 col-md-8 col-lg-6 deid-column" >
+            <label for="is_safe"
+                   class="col-sm-3 col-md-2 control-label"></label>
+            <div class="col-sm-9 col-md-8 col-lg-6 deid-column">
               <div data-bind="visible: isDeidColumnVisible()">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" id="is_deidentified" data-bind="checked: is_deidentified" />
+                    <input type="checkbox"
+                           id="is_deidentified"
+                           data-bind="checked: is_deidentified" />
                     {% trans "Publish as De-Identified" %}
                   </label>
                 </div>
                 <span class="help-inline">
-                            {% trans "Check only if this export has been fully and safely de-identified." %}
-                        </span>
+                  {% trans "Check only if this export has been fully and safely de-identified." %}
+                </span>
               </div>
-              <button class="btn btn-default" data-bind="
-                        visible: !isDeidColumnVisible(),
-                        click: showDeidColumn
-                    ">
+              <button class="btn btn-default"
+                      data-bind="visible: !isDeidColumnVisible(),
+                                 click: showDeidColumn">
                 {% trans "Allow me to mark sensitive data" %}
               </button>
             </div>
@@ -230,24 +250,22 @@
       <div class="form-actions">
         <div class="col-sm-offset-4 col-md-offset-3 col-lg-offset-2 col-sm-8 col-md-9 col-lg-10 controls">
           {% if can_edit %}
-            <button type="submit" class="btn btn-lg btn-primary" data-bind="
-                        click: save,
-                        disable: saveStateSaving() || saveStateSuccess || !isValid()
-                    ">
-                        <span data-bind="
-                            visible: saveStateReady(),
-                            text: getSaveText()">
-                        </span>
+            <button type="submit"
+                    class="btn btn-lg btn-primary"
+                    data-bind="click: save,
+                               disable: saveStateSaving() || saveStateSuccess || !isValid()">
+              <span data-bind="visible: saveStateReady(),
+                               text: getSaveText()"></span>
               <span data-bind="visible: saveStateSaving()">
-                            <i class="fa fa-refresh fa-spin"></i>
-                            {% trans "Saving" %}
-                        </span>
+                <i class="fa fa-refresh fa-spin"></i>
+                {% trans "Saving" %}
+              </span>
               <span data-bind="visible: saveStateError()">
-                            {% trans "Try Again" %}
-                        </span>
+                {% trans "Try Again" %}
+              </span>
               <span data-bind="visible: saveStateSuccess()">
-                            {% trans "Saved!" %}
-                        </span>
+                {% trans "Saved!" %}
+              </span>
             </button>
           {% endif %}
           <a class="btn btn-default btn-lg" href="{{ export_home_url }}">
@@ -258,12 +276,14 @@
             {% endif %}
           </a>
           {% if export_instance.get_id and can_edit %}
-            <a class="btn btn-lg btn-default pull-right" href="{% url 'copy_export' domain export_instance.get_id %}?next={{ export_home_url }}">
+            <a class="btn btn-lg btn-default pull-right"
+               href="{% url 'copy_export' domain export_instance.get_id %}?next={{ export_home_url }}">
               <i class="fa fa-copy fa-white"></i>
               {% trans "Copy this Export" %}
             </a>
           {% endif %}
-          <div class="text-danger" data-bind="if: !isValid()">
+          <div class="text-danger"
+               data-bind="if: !isValid()">
             {% trans "There are errors with your configuration. Please fix them before creating the export." %}
           </div>
         </div>

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -210,6 +210,26 @@
                              name: 'ko-table-configuration-template'
                            }"></fieldset>
 
+      {% if export_instance.is_odata_config %}
+        <!-- ko if: tables().length > 1 -->
+        <div class="alert alert-info">
+          <p class="lead">
+            {% blocktrans %}
+              Your application has Repeat Groups or Child Cases, so some
+              options are currently missing.
+            {% endblocktrans %}
+          </p>
+          <p>
+            {% blocktrans %}
+              Please note that PowerBi / Tableau Integration (Preview) currently
+              does not support Repeat Groups or Child Cases. We are working
+              to support this feature soon.
+            {% endblocktrans %}
+          </p>
+        </div>
+        <!-- /ko -->
+      {% endif %}
+
       {% if request|toggle_enabled:"ALLOW_USER_DEFINED_EXPORT_COLUMNS" %}
         <fieldset>
           <div class="col-sm-10">

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -203,7 +203,8 @@
       <fieldset data-bind="template: {
                              foreach: tables,
                              as: 'table',
-                             name: 'ko-table-configuration-template' }"></fieldset>
+                             name: 'ko-table-configuration-template'
+                           }"></fieldset>
 
       {% if request|toggle_enabled:"ALLOW_USER_DEFINED_EXPORT_COLUMNS" %}
         <fieldset>

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -152,14 +152,18 @@
                   {% trans "Include duplicates and other unprocessed forms" %}
                 </label>
               </div>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox"
-                         id="split-multiselects-checkbox"
-                         data-bind="checked: split_multiselects" />
-                  {% trans "Expand Checkbox Questions" %}
-                </label>
-              </div>
+
+              {% if not export_instance.is_odata_config %}
+                {# todo odata - make this work #}
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox"
+                           id="split-multiselects-checkbox"
+                           data-bind="checked: split_multiselects" />
+                    {% trans "Expand Checkbox Questions" %}
+                  </label>
+                </div>
+              {% endif %}
             {% endif %}
           </div>
         </div>

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -27,7 +27,7 @@
   {% registerurl 'update_emailed_export_data' domain %}
 
   <p>{{ lead_text }}</p>
-  
+
   {% if is_odata %}
     <div class="pull-right">
       <feedback params="featureName: '{% trans_html_attr 'PowerBI / Tableau Integration' %}'"></feedback>

--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -27,6 +27,12 @@
   {% registerurl 'update_emailed_export_data' domain %}
 
   <p>{{ lead_text }}</p>
+  
+  {% if is_odata %}
+    <div class="pull-right">
+      <feedback params="featureName: '{% trans_html_attr 'PowerBI / Tableau Integration' %}'"></feedback>
+    </div>
+  {% endif %}
 
   {% include 'export/partials/export_list_controller.html' with is_daily_saved_export=is_daily_saved_export %}
 {% endblock %}

--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -1,349 +1,396 @@
 {% load hq_shared_tags %}
 {% load i18n %}
+
 <!-- Template for a Table (i.e. sheet) in the Export page -->
 <script type="text/html" id="ko-table-configuration-template">
   <div>
-    <legend data-bind="visible: table.isVisible(), visible: table.label() !== 'Case History'">
-            <span>
-                <input type="checkbox" data-bind="checked: table.selected" />
-            </span>
+    <legend data-bind="visible: table.isVisible(),
+                       visible: table.label() !== 'Case History'">
       <span>
-                <span data-bind="text: table.label()" />
-            </span>
+        <input type="checkbox"
+               data-bind="checked: table.selected" />
+      </span>
       <span>
-                <span class="label label-warning" data-bind="visible: table.is_deleted">deleted</span>
-            </span>
+        <span data-bind="text: table.label()" />
+      </span>
+      <span>
+        <span class="label label-warning"
+              data-bind="visible: table.is_deleted">
+          {% trans "deleted" %}
+        </span>
+      </span>
 
       <!-- ko if: table.is_user_defined -->
       <div class="remove-user-defined-table pull-right">
-        <button class="btn btn-danger btn-xs" data-bind="
-                    click: function() {
-                        $parent.tables.remove(table)
-                    }
-                ">
+        <button class="btn btn-danger btn-xs"
+                data-bind="click: function() {
+                             $parent.tables.remove(table)
+                           }">
           {% trans "Remove" %}
         </button>
       </div>
       <!-- /ko -->
     </legend>
-    <div class="col-sm-12" data-bind="slideVisible: table.selected">
+    <div class="col-sm-12"
+         data-bind="slideVisible: table.selected">
       {% if not export_instance.is_odata_config %}
         <div class="form-group">
-          <label class="col-sm-4 col-md-3 col-lg-2 control-label">{% trans "Sheet Name" %}</label>
+          <label class="col-sm-4 col-md-3 col-lg-2 control-label">
+            {% trans "Sheet Name" %}
+          </label>
           <div class="col-sm-9 col-md-8 col-lg-6">
-            <input type="text" class="form-control" data-bind="value: table.label" />
+            <input type="text"
+                   class="form-control"
+                   data-bind="value: table.label" />
           </div>
         </div>
       {% endif %}
       <!-- ko if: table.is_user_defined -->
       <div class="form-group">
-        <label class="col-sm-4 col-md-3 col-lg-2 control-label">{% trans "Custom Path" %}</label>
+        <label class="col-sm-4 col-md-3 col-lg-2 control-label">
+          {% trans "Custom Path" %}
+        </label>
         <div class="col-sm-4 col-md-3 col-lg-2">
-          <input type="text" class="form-control" data-bind="value: table.customPathString" />
+          <input type="text"
+                 class="form-control"
+                 data-bind="value: table.customPathString" />
         </div>
       </div>
       <!-- /ko -->
       <h4>{{ terminology.choose_fields_label }}</h4>
       <div class="help-block">
         {% if request|toggle_enabled:"EXPORT_MULTISORT" %}
-          {% blocktrans %}
-            <p>You can drag and drop fields to reorder them.</p>
-            <ul>
-              <li>To drag multiple fields, select by clicking while holding the CTRL key on a PC, or the Command key on a Mac.</li>
-              <li>To select a range of fields hold the Shift key and select the first and last field in the range.</li>
-              <li>To unselect a field hold the CTRL key on a PC, or the Command key on a Mac, and click.</li>
-            </ul>
-          {% endblocktrans %}
+          <p>
+            {% blocktrans %}
+              You can drag and drop fields to reorder them.
+            {% endblocktrans %}
+          </p>
+          <ul>
+            <li>
+              {% blocktrans %}
+                To drag multiple fields, select by clicking while holding
+                the CTRL key on a PC, or the Command key on a Mac.
+              {% endblocktrans %}
+            </li>
+            <li>
+              {% blocktrans %}
+                To select a range of fields hold the Shift key and select
+                the first and last field in the range.
+              {% endblocktrans %}
+            </li>
+            <li>
+              {% blocktrans %}
+                To unselect a field hold the CTRL key on a PC, or the
+                Command key on a Mac, and click.
+              {% endblocktrans %}
+            </li>
+          </ul>
+
           {% if not export_instance.is_odata_config %}
-            {% blocktrans %}
-              <p>You can also rename fields, which will update the headers in the export file.</p>
-            {% endblocktrans %}
+            <p>
+              {% blocktrans %}
+                You can also rename fields, which will update the headers
+                in the export file.
+              {% endblocktrans %}
+            </p>
           {% else %}
-            {% blocktrans %}
-              <p>You can also rename fields, which will update the column headers in Power BI or Tableau.</p>
-            {% endblocktrans %}
+            <p>
+              {% blocktrans %}
+                You can also rename fields, which will update the column
+                headers in Power BI or Tableau.
+              {% endblocktrans %}
+            </p>
           {% endif %}
+
         {% else %}
           {{ terminology.choose_fields_description }}
         {% endif %}
       </div>
 
-      <table class="table table-bordered table-striped table-condensed" id="field-select">
+      <table class="table table-bordered table-striped table-condensed"
+             id="field-select">
         <thead>
-        <tr class="nodrag nodrop">
-          <th class="col-sm-1">{% trans "Include?" %}<br />
-            <a class="btn btn-xs btn-primary" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
-            <a class="btn btn-xs btn-default" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
-          </th>
-          {% if request|toggle_enabled:"EXPORT_MULTISORT" %}
-            <th>
-              {% trans "Send to Bottom" %}
-            </th>
-            <th>
-              {% trans "Send to Top" %}
-            </th>
-          {% endif %}
-          <th data-bind="attr: { 'class': $root.questionColumnClass }">
-            {% if export_instance.type == 'form' %}
-              {% trans "Question" %}
-            {% else %}
-              {% trans "Property" %}
-            {% endif %}
-            <br />
-
-            <!-- Advanced Button -->
-            <button type="button" class="btn btn-default btn-xs" data-bind="
-                            click: table.toggleShowAdvanced,
-                            css: {active: table.showAdvanced}">
-                            <span data-bind="visible: !table.showAdvanced()">
-                            {% trans "Show Advanced Questions" %}
-                            </span>
-              <span data-bind="visible: table.showAdvanced">
-                            {% trans "Hide Advanced Questions" %}
-                            </span>
-            </button>
-
-            <!-- Deleted Button -->
-            <button class="btn btn-default btn-xs" data-bind="
-                            click: $root.toggleShowDeleted.bind($root),
-                            css: {active: table.showDeleted}
-                            ">
-                            <span data-bind="visible: !table.showDeleted()">
-                            {% if export_instance.type == 'form' %}
-                              {% trans "Show Deleted Questions" %}
-                            {% else %}
-                              {% trans "Show Deleted Properties" %}
-                            {% endif %}
-                            </span>
-
-              <span data-bind="visible: table.showDeleted()">
-                            {% if export_instance.type == 'form' %}
-                              {% trans "Hide Deleted Questions" %}
-                            {% else %}
-                              {% trans "Hide Deleted Properties" %}
-                            {% endif %}
-                            </span>
-            </button>
-          </th>
-          <th data-bind="attr: { 'class': $root.displayColumnClass }">
-            {% trans "Display" %}<br />
-            {% if export_instance.type == 'form' %}
-              <a
-                class="btn btn-xs btn-default"
-                data-bind="click: table.useLabels">
-                {% trans "Use question labels" %}
+          <tr class="nodrag nodrop">
+            <th class="col-sm-1">
+              {% trans "Include?" %}<br />
+              <a class="btn btn-xs btn-primary"
+                 data-bind="click: table.selectAll">
+                {% trans "Select All" %}
               </a>
-              <a
-                class="btn btn-xs btn-default"
-                data-bind="click: table.useIds">
-                {% trans "Use question ids" %}
+              <a class="btn btn-xs btn-default"
+                 data-bind="click: table.selectNone">
+                {% trans "Select None" %}
               </a>
-            {% endif %}
-          </th>
-          {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
-            <th class="col-sm-2">
-              {% trans "Type" %}
-              <span data-bind="
-                            makeHqHelp: {
-                                name: '{% trans "Split multi-select data" %}',
-                                placement: 'left'
-                            }
-                        "></span>
             </th>
-          {% endif %}
-          {% if allow_deid %}
-            <th class="col-sm-2 deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
-          {% endif %}
-        </tr>
+            {% if request|toggle_enabled:"EXPORT_MULTISORT" %}
+              <th>
+                {% trans "Send to Bottom" %}
+              </th>
+              <th>
+                {% trans "Send to Top" %}
+              </th>
+            {% endif %}
+            <th data-bind="attr: {
+                             'class': $root.questionColumnClass
+                           }">
+              {% if export_instance.type == 'form' %}
+                {% trans "Question" %}
+              {% else %}
+                {% trans "Property" %}
+              {% endif %}
+              <br />
+
+              <!-- Advanced Button -->
+              <button type="button"
+                      class="btn btn-default btn-xs"
+                      data-bind="click: table.toggleShowAdvanced,
+                                 css: {
+                                   active: table.showAdvanced
+                                 }">
+                <span data-bind="visible: !table.showAdvanced()">
+                  {% trans "Show Advanced Questions" %}
+                </span>
+                <span data-bind="visible: table.showAdvanced">
+                  {% trans "Hide Advanced Questions" %}
+                </span>
+              </button>
+
+              <!-- Deleted Button -->
+              <button class="btn btn-default btn-xs"
+                      data-bind="click: $root.toggleShowDeleted.bind($root),
+                                 css: {
+                                   active: table.showDeleted
+                                 }">
+                <span data-bind="visible: !table.showDeleted()">
+                  {% if export_instance.type == 'form' %}
+                    {% trans "Show Deleted Questions" %}
+                  {% else %}
+                    {% trans "Show Deleted Properties" %}
+                  {% endif %}
+                </span>
+
+                <span data-bind="visible: table.showDeleted()">
+                  {% if export_instance.type == 'form' %}
+                    {% trans "Hide Deleted Questions" %}
+                  {% else %}
+                    {% trans "Hide Deleted Properties" %}
+                  {% endif %}
+                </span>
+              </button>
+            </th>
+            <th data-bind="attr: { 'class': $root.displayColumnClass }">
+              {% trans "Display" %}<br />
+              {% if export_instance.type == 'form' %}
+                <a class="btn btn-xs btn-default"
+                   data-bind="click: table.useLabels">
+                  {% trans "Use question labels" %}
+                </a>
+                <a class="btn btn-xs btn-default"
+                   data-bind="click: table.useIds">
+                  {% trans "Use question ids" %}
+                </a>
+              {% endif %}
+            </th>
+            {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
+              <th class="col-sm-2">
+                {% trans "Type" %}
+                <span data-bind="makeHqHelp: {
+                                   name: '{% trans "Split multi-select data" %}',
+                                   placement: 'left'
+                                 }"></span>
+              </th>
+            {% endif %}
+            {% if allow_deid %}
+              <th class="col-sm-2 deid-column"
+                  data-bind="visible: $root.isDeidColumnVisible()">
+                {% trans "Sensitivity" %}
+              </th>
+            {% endif %}
+          </tr>
         </thead>
-
 
         {% if request|toggle_enabled:"ALLOW_USER_DEFINED_EXPORT_COLUMNS" %}
           <tfoot>
-          <tr>
-            <td colspan="100%">
-              <button class="btn btn-default btn-sm" data-bind="
-                                click: table.addUserDefinedExportColumn
-                            ">
-                {% trans "Add custom export property" %}
-              </button>
-            </td>
-          </tr>
+            <tr>
+              <td colspan="100%">
+                <button class="btn btn-default btn-sm"
+                        data-bind="click: table.addUserDefinedExportColumn">
+                  {% trans "Add custom export property" %}
+                </button>
+              </td>
+            </tr>
           </tfoot>
         {% endif %}
 
-        {% if request|toggle_enabled:"EXPORT_MULTISORT" %}
-          <tbody data-bind="
-                    multirow_sortable: {
-                        data: table.columns,
-                        as: 'column',
-                        name: 'ko-export-column-template'
-                    }
-                ">
-          {% else %}
-          <tbody data-bind="
-                    sortable: {
-                        data: table.columns,
-                        as: 'column',
-                        name: 'ko-export-column-template'
-                    }
-                ">
-        {% endif %}
-        <tr data-bind="
-                        visible: column.isVisible($parent),
-                        attr: {'data-order': _sortableOrder},
-                        css: { success: column.selectedForSort, 'selected-for-sort': column.selectedForSort }
-                        "
-            {% if request|toggle_enabled:"EXPORT_MULTISORT" %}style="cursor:pointer"{% endif %}
-        >
-          <td class="text-center">
-                            <span class="sortable-handle">
-                                <i class="fa fa-arrows-v"></i>
-                            </span>
-            &nbsp;&nbsp;&nbsp;
-            <!--ko if: ($root.is_deidentified() && column.item.isCaseName()) -->
-            <input type="checkbox"
-                   class="field-include"
-                   disabled="disabled" />
-            <!--/ko-->
-            <!--ko ifnot: ($root.is_deidentified() && column.item.isCaseName()) -->
-            <input type="checkbox"
-                   class="field-include export-table-checkbox"
-                   data-bind="checked: column.selected" />
-            <!--/ko-->
-            <!-- ko if: column.isEditable() -->
-            <div class="remove-user-defined-column pull-right">
-              <button class="btn btn-danger btn-xs" data-bind="
-                                    click: function() {
-                                        $parent.columns.remove(column)
-                                    }
-                                ">
-                {% trans "Remove" %}
-              </button>
-            </div>
-            <!-- /ko -->
-          </td>
+      {% if request|toggle_enabled:"EXPORT_MULTISORT" %}
+        <tbody data-bind="multirow_sortable: {
+                            data: table.columns,
+                            as: 'column',
+                            name: 'ko-export-column-template'
+                          }">
+      {% else %}
+        <tbody data-bind="sortable: {
+                            data: table.columns,
+                            as: 'column',
+                            name: 'ko-export-column-template'
+                          }">
+      {% endif %}
+          <tr data-bind="visible: column.isVisible($parent),
+                         attr: {
+                           'data-order': _sortableOrder
+                         },
+                         css: {
+                           success: column.selectedForSort,
+                           'selected-for-sort': column.selectedForSort
+                         }"
+              {% if request|toggle_enabled:"EXPORT_MULTISORT" %}style="cursor:pointer"{% endif %}>
+            <td class="text-center">
+              <span class="sortable-handle">
+                <i class="fa fa-arrows-v"></i>
+              </span>
+              &nbsp;&nbsp;&nbsp;
+              <!--ko if: ($root.is_deidentified() && column.item.isCaseName()) -->
+              <input type="checkbox"
+                     class="field-include"
+                     disabled="disabled" />
+              <!--/ko-->
+              <!--ko ifnot: ($root.is_deidentified() && column.item.isCaseName()) -->
+              <input type="checkbox"
+                     class="field-include export-table-checkbox"
+                     data-bind="checked: column.selected" />
+              <!--/ko-->
+              <!-- ko if: column.isEditable() -->
+              <div class="remove-user-defined-column pull-right">
+                <button class="btn btn-danger btn-xs"
+                        data-bind="click: function() {
+                                     $parent.columns.remove(column)
+                                   }">
+                  {% trans "Remove" %}
+                </button>
+              </div>
+              <!-- /ko -->
+            </td>
           {% if request|toggle_enabled:"EXPORT_MULTISORT" %}
             <td class="text-center">
-                            <span class="send-to-bottom">
-                                <button class="btn btn-default btn-sm">
-                                    <i class="fa fa-angle-double-down"></i>
-                                </button>
-                            </span>
+              <span class="send-to-bottom">
+                <button class="btn btn-default btn-sm">
+                  <i class="fa fa-angle-double-down"></i>
+                </button>
+              </span>
             </td>
             <td class="text-center">
-                            <span class="send-to-top">
-                                <button class="btn btn-default btn-sm">
-                                    <i class="fa fa-angle-double-up"></i>
-                                </button>
-                            </span>
+              <span class="send-to-top">
+                <button class="btn btn-default btn-sm">
+                  <i class="fa fa-angle-double-up"></i>
+                </button>
+              </span>
             </td>
           {% endif %}
-          <td>
-                            <span data-bind="foreach: { data: column.tags, as: 'tag' }">
-                                <span data-bind="
-                                    text: tag,
-                                    attr: { class: $root.getTagCSSClass(tag) }"></span>
-                            </span>
+            <td>
+              <span data-bind="foreach: {
+                                 data: column.tags,
+                                 as: 'tag'
+                               }">
+                <span data-bind="text: tag,
+                                 attr: { class: $root.getTagCSSClass(tag) }"></span>
+              </span>
 
-            <!-- ko if: !column.isEditable() -->
-            <code data-toggle="tooltip" data-placement="top"
-                  data-bind="
-                                    text: column.formatProperty(),
-                                    attr: {
-                                        'data-original-title': column.help_text,
-                                        'data-toggle': column.help_text ? 'tooltip' : null
-                                    },
-                                    css: {
-                                        'export-tooltip': column.translatedHelp(),
-                                        'break-all-words': 1,
-                                    }
-                                "></code>
-            <!-- /ko -->
-            <!-- ko if: column.isEditable() -->
-            <input
-              type="text"
-              class="form-control"
-              data-bind="
-                                    value: column.customPathString
-                                "
-            />
-            <!-- /ko -->
-          </td>
-          <td><input class="form-control" type="text" data-bind="value: column.label" /></td>
+              <!-- ko if: !column.isEditable() -->
+              <code data-toggle="tooltip"
+                    data-placement="top"
+                    data-bind="text: column.formatProperty(),
+                               attr: {
+                                 'data-original-title': column.help_text,
+                                 'data-toggle': column.help_text ? 'tooltip' : null
+                               },
+                               css: {
+                                 'export-tooltip': column.translatedHelp(),
+                                 'break-all-words': 1,
+                               }"></code>
+              <!-- /ko -->
+              <!-- ko if: column.isEditable() -->
+              <input type="text"
+                     class="form-control"
+                     data-bind="value: column.customPathString"/>
+              <!-- /ko -->
+            </td>
+            <td>
+              <input class="form-control"
+                     type="text"
+                     data-bind="value: column.label" />
+            </td>
           {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
             <td>
-              <form
-                class="form-horizontal col-xs-12"
-                data-bind="
-                                    if: column.doc_type() === 'SplitUserDefinedExportColumn',
-                                    submit: column.addUserDefinedOption
-                                ">
+              <div class="form-horizontal col-xs-12"
+                    data-bind="if: column.doc_type() === 'SplitUserDefinedExportColumn',
+                               submit: column.addUserDefinedOption">
                 <div class="form-group">
-                  <select style="width:200px" class="form-control" data-bind="
-                                        options: $root.splitTypes.userDefined,
-                                        value: column.split_type,
-                                    "/></select>
+                  <select style="width:200px"
+                          class="form-control"
+                          data-bind="options: $root.splitTypes.userDefined,
+                                     value: column.split_type"></select>
                 </div>
                 <!-- ko if: column.split_type() === $root.splitTypes.multiselect -->
                 <div class="form-group">
-                  <button class="btn btn-default btn-xs" data-bind="
-                                        visible: !column.showOptions(),
-                                        click: function() {column.showOptions(true);}
-                                    ">{% trans "Show Options" %}</button>
+                  <button class="btn btn-default btn-xs"
+                          data-bind="visible: !column.showOptions(),
+                                     click: function() {
+                                       column.showOptions(true);
+                                     }">
+                    {% trans "Show Options" %}
+                  </button>
 
-                  <button class="btn btn-default btn-xs" data-bind="
-                                        visible: column.showOptions(),
-                                        click: function() {column.showOptions(false);}
-                                    ">{% trans "Hide Options" %}</button>
+                  <button class="btn btn-default btn-xs"
+                          data-bind="visible: column.showOptions(),
+                                     click: function() {
+                                       column.showOptions(false);
+                                     }">
+                    {% trans "Hide Options" %}
+                  </button>
                 </div>
                 <div data-bind="visible: column.showOptions()">
-                  <ul class="list-group" data-bind="
-                                        foreach: column.user_defined_options
-                                    ">
+                  <ul class="list-group"
+                      data-bind="foreach: column.user_defined_options">
                     <li class="list-group-item">
                       <span data-bind="text: $data"></span>
-                      <i
-                        style="cursor: pointer"
-                        class="text-danger fa fa-trash pull-right"
-                        data-bind="click: column.removeUserDefinedOption.bind(column)"
-                      ></i>
+                      <i style="cursor: pointer"
+                         class="text-danger fa fa-trash pull-right"
+                         data-bind="click: column.removeUserDefinedOption.bind(column)"></i>
                     </li>
                   </ul>
                   <div class="form-group">
-                    <div style="max-width: 200px" class="input-group">
-                      <input
-                        class="form-control input-sm"
-                        type="text"
-                        data-bind="value: column.userDefinedOptionToAdd"/>
+                    <div style="max-width: 200px"
+                         class="input-group">
+                      <input class="form-control input-sm"
+                             type="text"
+                             data-bind="value: column.userDefinedOptionToAdd"/>
                       <span class="input-group-btn">
-                                                <button
-                                                  type="submit"
-                                                  class="btn btn-default btn-sm"
-                                                  data-bind="click: column.addUserDefinedOption">
-                                                {% trans "Add" %}
-                                                </button>
-                                            </span>
+                        <button type="submit"
+                                class="btn btn-default btn-sm"
+                                data-bind="click: column.addUserDefinedOption">
+                          {% trans "Add" %}
+                        </button>
+                      </span>
                     </div>
                   </div>
                 </div>
                 <!-- /ko -->
-            </div>
+              </div>
             </td>
           {% endif %}
-    {% if allow_deid %}
-      <td class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">
-        <select class="form-control" data-bind="
-                                value: deid_transform,
-                                options: getDeidOptions(),
-                                optionsText: getDeidOptionText
-                            ">
-        </select>
-      </td>
-    {% endif %}
-    </tr>
-    </tbody>
-    </table>
-  </div>
+          {% if allow_deid %}
+            <td class="deid-column"
+                data-bind="visible: $root.isDeidColumnVisible()">
+              <select class="form-control"
+                      data-bind="value: deid_transform,
+                                 options: getDeidOptions(),
+                                 optionsText: getDeidOptionText">
+              </select>
+            </td>
+          {% endif %}
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </script>

--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -3,7 +3,7 @@
 
 <!-- Template for a Table (i.e. sheet) in the Export page -->
 <script type="text/html" id="ko-table-configuration-template">
-  <div>
+  <div {% if export_instance.is_odata_config %}data-bind="visible: $index() == 0"{% endif %}>
     <legend data-bind="visible: table.isVisible(),
                        visible: table.label() !== 'Case History'">
       <span>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -17,17 +17,15 @@
       </th>
     {% endif %}
 
-    {% if not is_odata %}
-      <th class="col-sm-1">
-        {% if export_filter_form %}
-          {% if has_edit_permissions %}
-            {% trans "Edit Filters" %}
-          {% endif %}
-        {% else %}
-          {{ export_type_caps }}
+    <th class="col-sm-1">
+      {% if export_filter_form %}
+        {% if has_edit_permissions and not is_odata %}
+          {% trans "Edit Filters" %}
         {% endif %}
-      </th>
-    {% endif %}
+      {% else %}
+        {{ export_type_caps }}
+      {% endif %}
+    </th>
 
     {%  if allow_bulk_export %} {# form exports only #}
       <th class="col-sm-1">
@@ -411,28 +409,26 @@
       </td>
     {% endif %}
 
-    {% if not is_odata %}
-      <td>
-        <a data-bind="attr: {href: downloadUrl},
-                      visible: !showSavedFilters,
-                      click: $root.sendExportAnalytics"
-           class="btn btn-primary">
-          {{ export_type_caps }}
+    <td>
+      <a data-bind="attr: {href: downloadUrl},
+                    visible: !showSavedFilters,
+                    click: $root.sendExportAnalytics"
+         class="btn btn-primary">
+        {{ export_type_caps }}
+      </a>
+      {% if has_edit_permissions and not is_odata %}
+        <a class="btn btn-default"
+           data-bind="visible: showSavedFilters && isLocationSafeForUser(),
+                      click: function (model) {
+                        $root.filterModalExportId(model.id());
+                      }"
+           href="#setFeedFiltersModal"
+           data-toggle="modal">
+          <i class="fa fa-filter"></i>
+          {% trans "Edit Filters" %}
         </a>
-        {% if has_edit_permissions %}
-          <a class="btn btn-default"
-             data-bind="visible: showSavedFilters && isLocationSafeForUser(),
-                        click: function (model) {
-                          $root.filterModalExportId(model.id());
-                        }"
-             href="#setFeedFiltersModal"
-             data-toggle="modal">
-            <i class="fa fa-filter"></i>
-            {% trans "Edit Filters" %}
-          </a>
-        {% endif %}
-      </td>
-    {% endif %}
+      {% endif %}
+    </td>
 
     {% if allow_bulk_export %}
       <td>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -3,7 +3,8 @@
 {% load hq_shared_tags %}
 {% load humanize %}
 
-<table class="table table-striped" data-bind="visible: exports().length">
+<table class="table table-striped"
+       data-bind="visible: exports().length">
   <thead>
     <tr>
       <th class="col-sm-4">

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -5,31 +5,40 @@
 
 <table class="table table-striped" data-bind="visible: exports().length">
   <thead>
-  <tr>
-    <th class="col-sm-4">{% trans 'Name' %}</th>
+    <tr>
+      <th class="col-sm-4">
+        {% trans 'Name' %}
+      </th>
 
     {% if model_type == "case" %}
-      <th class="col-sm-2">{% trans 'Case Type' %}</th>
+      <th class="col-sm-2">
+        {% trans 'Case Type' %}
+      </th>
     {% endif %}
 
-    <th class="col-sm-1">
-      {% if export_filter_form %}
-        {% if has_edit_permissions %}
-          {% trans "Edit Filters" %}
+      <th class="col-sm-1">
+        {% if export_filter_form %}
+          {% if has_edit_permissions %}
+            {% trans "Edit Filters" %}
+          {% endif %}
+        {% else %}
+          {{ export_type_caps }}
         {% endif %}
-      {% else %}
-        {{ export_type_caps }}
-      {% endif %}
-    </th>
+      </th>
 
     {%  if allow_bulk_export %} {# form exports only #}
       <th class="col-sm-1">
         {% blocktrans %}Bulk {{ export_type_caps }}{% endblocktrans %}
         <br>
-        <button type="button" class="btn btn-xs btn-default" data-bind="click: $root.selectAll">
+        <button type="button"
+                class="btn btn-xs btn-default"
+                data-bind="click: $root.selectAll">
           {% trans 'All' %}
-        </button> {% trans 'or' %}
-        <button type="button" class="btn btn-xs btn-default" data-bind="click: $root.selectNone">
+        </button>
+        {% trans 'or' %}
+        <button type="button"
+                class="btn btn-xs btn-default"
+                data-bind="click: $root.selectNone">
           {% trans 'None' %}
         </button>
       </th>
@@ -49,298 +58,383 @@
           {% trans 'Copy' %}
         {% endif %}
       </th>
-      <th class="col-sm-1">{% trans 'Delete' %}</th>
+      <th class="col-sm-1">
+        {% trans 'Delete' %}
+      </th>
     {% endif %}
 
     {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
-      <th class="col-sm-1" data-bind="visible: showOwnership">
-        <span data-bind="visible: myExports">{% trans "Share" %}</span>
-        <span data-bind="visible: !myExports">{% trans "Shared By" %}</span>
+      <th class="col-sm-1"
+          data-bind="visible: showOwnership">
+        <span data-bind="visible: myExports">
+          {% trans "Share" %}
+        </span>
+        <span data-bind="visible: !myExports">
+          {% trans "Shared By" %}
+        </span>
       </th>
     {% endif %}
-  </tr>
+    </tr>
   </thead>
   <tbody data-bind="foreach: exports()">
-  <tr>
-    <td>
-      <h4 data-bind="css: {'text-muted': hasEmailedExport && !isAutoRebuildEnabled()}">
-        <inline-edit params="
-          value: name,
-          url: editNameUrl,
-          placeholder: '{% trans "Enter name here"|escapejs %}',
-          cols: 50,
-        " data-apply-bindings="false"></inline-edit>
-        <label class="label label-default label-default" data-bind="visible: isDeid()">
-          {% trans 'De-Identified' %}
-        </label>
-      </h4>
-      <p data-bind="visible: formname, css: {'text-muted': hasEmailedExport && !isAutoRebuildEnabled()}">
-        <i class="fa fa-file-o"></i> <strong>{% trans 'Form:' %}</strong>
-        <span data-bind="text: formname"></span>
-      </p>
-      <inline-edit params="
-        value: description,
-        url: editDescriptionUrl,
-        placeholder: '{% trans "Enter description here"|escapejs %}',
-        cols: 50,
-      " data-apply-bindings="false"></inline-edit>
+    <tr>
+      <td>
+        <h4 data-bind="css: {'text-muted': hasEmailedExport && !isAutoRebuildEnabled()}">
+          <inline-edit params="value: name,
+                               url: editNameUrl,
+                               placeholder: '{% trans "Enter name here"|escapejs %}',
+                               cols: 50"
+                       data-apply-bindings="false"></inline-edit>
+          <label class="label label-default label-default"
+                 data-bind="visible: isDeid()">
+            {% trans 'De-Identified' %}
+          </label>
+        </h4>
+        <p data-bind="visible: formname,
+                      css: {
+                        'text-muted': hasEmailedExport && !isAutoRebuildEnabled()
+                      }">
+          <i class="fa fa-file-o"></i>
+          <strong>
+            {% trans 'Form:' %}
+          </strong>
+          <span data-bind="text: formname"></span>
+        </p>
+        <inline-edit params="value: description,
+                             url: editDescriptionUrl,
+                             placeholder: '{% trans "Enter description here"|escapejs %}',
+                             cols: 50"
+                     data-apply-bindings="false"></inline-edit>
 
-      <div data-bind="ifnot: isLocationSafeForUser()" class="text-warning">
-        {% blocktrans %}
-          This export is filtered to data you don't have access to.
-        {% endblocktrans %}
-      </div>
+        <div data-bind="ifnot: isLocationSafeForUser()"
+             class="text-warning">
+          {% blocktrans %}
+            This export is filtered to data you don't have access to.
+          {% endblocktrans %}
+        </div>
 
-      <!-- ko if: isOData -->
-      <div class="input-group">
-          <span data-bind="css: {'input-group-btn': showLink}, click: copyLinkRequested">
-              <a class="btn btn-default btn-sm">
-                  <i class="fa fa-clipboard"></i>
-                  {% trans "Copy OData Feed Link" %}
-              </a>
+        <!-- ko if: isOData -->
+        <div class="input-group">
+          <span data-bind="css: {
+                             'input-group-btn': showLink
+                           },
+                           click: copyLinkRequested">
+            <a class="btn btn-default btn-sm">
+              <i class="fa fa-clipboard"></i>
+              {% trans "Copy OData Feed Link" %}
+            </a>
           </span>
-          <input data-bind="visible: showLink, value: odataFeedUrl"
-                 type="text" class="form-control input-sm" readonly />
-      </div>
-      <!-- /ko -->
+          <input data-bind="visible: showLink,
+                            value: odataFeedUrl"
+                 type="text"
+                 class="form-control input-sm"
+                 readonly />
+        </div>
+        <!-- /ko -->
 
-      <!-- ko if: hasEmailedExport && !isAutoRebuildEnabled() -->
-      <p class="text-warning">
-        <i class="fa fa-exclamation-triangle"></i>
-        {% blocktrans %}
-          Automatic updates for this saved {{ export_type }} have been disabled. Click 'Enable'
-          to re-enable automatic updates.
-        {% endblocktrans %}
-      </p>
-      <!-- /ko -->
-      <!-- ko if: hasEmailedExport && isLocationSafeForUser() -->
-      <div class="alert alert-neutral alert-small">
-        <div class="h5">
-                            <span data-bind="if: emailedExport.hasFile()">
-                                <strong>{% trans "Size:" %}</strong>
-                                <span data-bind="text: emailedExport.fileData.size()"></span>
-                                &nbsp;&nbsp;&nbsp;
-                                <strong>{% trans "Last Updated:" %}</strong>
-                                <span data-bind="if: !emailedExport.justUpdated()">
-                                    <span data-bind="text: emailedExport.fileData.lastUpdated()"></span>
-                                    &nbsp;&nbsp;&nbsp;
-                                </span>
-                                <span data-bind="if: emailedExport.justUpdated()">
-                                    {% trans "Just now" %}&nbsp;&nbsp;&nbsp;
-                                </span>
-                                <strong>{% trans "Last Downloaded:" %}</strong>
-                                <span data-bind="text: emailedExport.fileData.lastAccessed()"></span>
-                              {% if request|toggle_enabled:"SUPPORT" %}
-                                <span data-bind="if: lastBuildDuration">
-                                        <strong>{% trans "Last Build Duration:" %}</strong>
-                                        <span data-bind="text: lastBuildDuration"></span>
-                                    </span>
-                              {% endif %}
-                            </span>
-          &nbsp;&nbsp;
-          <div data-bind="if: isLocationSafeForUser()">
-            <button type="button"
-                    class="btn btn-default btn-xs"
-                    data-bind="visible: emailedExport.canUpdateData,
-                               attr: {'data-target': '#modalRefreshExportConfirm-' + id() + '-' + emailedExport.groupId()}"
-                    data-toggle="modal">
-              <i class="fa fa-refresh"></i>
-              {% trans "Update Data" %}
-            </button>
-            <button type="button"
-                    class="btn btn-default btn-xs btn-disabled"
-                    data-bind="visible: emailedExport.updatingData() && !emailedExport.prepareExportError()"
-                    disabled="disabled">
-              <i class="fa fa-refresh fa-spin"></i>
-              {% trans "Updating Data, please wait..." %}
-            </button>
-            <div data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.started()">
-              <div class="progress">
-                <div class="progress-bar progress-bar-striped active"
-                     role="progressbar"
-                     aria-valuemin="0"
-                     aria-valuemax="100"
-                     data-bind="attr: {
-                                                'aria-valuenow': emailedExport.taskStatus.percentComplete(),
-                                                'style': 'width: ' + emailedExport.taskStatus.percentComplete() + '%',
-                                             }">
+        <!-- ko if: hasEmailedExport && !isAutoRebuildEnabled() -->
+        <p class="text-warning">
+          <i class="fa fa-exclamation-triangle"></i>
+          {% blocktrans %}
+            Automatic updates for this saved {{ export_type }} have been disabled. Click 'Enable'
+            to re-enable automatic updates.
+          {% endblocktrans %}
+        </p>
+        <!-- /ko -->
+        <!-- ko if: hasEmailedExport && isLocationSafeForUser() -->
+        <div class="alert alert-neutral alert-small">
+          <div class="h5">
+            <span data-bind="if: emailedExport.hasFile()">
+              <strong>
+                {% trans "Size:" %}
+              </strong>
+              <span data-bind="text: emailedExport.fileData.size()"></span>
+              <strong>
+                {% trans "Last Updated:" %}
+              </strong>
+              <span data-bind="if: !emailedExport.justUpdated()">
+                <span data-bind="text: emailedExport.fileData.lastUpdated()"></span>
+              </span>
+              <span data-bind="if: emailedExport.justUpdated()">
+                {% trans "Just now" %}&nbsp;&nbsp;&nbsp;
+              </span>
+              <strong>
+                {% trans "Last Downloaded:" %}
+              </strong>
+              <span data-bind="text: emailedExport.fileData.lastAccessed()"></span>
+              {% if request|toggle_enabled:"SUPPORT" %}
+                <span data-bind="if: lastBuildDuration">
+                  <strong>
+                    {% trans "Last Build Duration:" %}
+                  </strong>
+                  <span data-bind="text: lastBuildDuration"></span>
+                </span>
+              {% endif %}
+            </span>
+            &nbsp;&nbsp;
+            <div data-bind="if: isLocationSafeForUser()">
+              <button type="button"
+                      class="btn btn-default btn-xs"
+                      data-bind="visible: emailedExport.canUpdateData,
+                                 attr: {
+                                   'data-target': '#modalRefreshExportConfirm-' + id() + '-' + emailedExport.groupId()
+                                 }"
+                      data-toggle="modal">
+                <i class="fa fa-refresh"></i>
+                {% trans "Update Data" %}
+              </button>
+              <button type="button"
+                      class="btn btn-default btn-xs btn-disabled"
+                      data-bind="visible: emailedExport.updatingData() && !emailedExport.prepareExportError()"
+                      disabled="disabled">
+                <i class="fa fa-refresh fa-spin"></i>
+                {% trans "Updating Data, please wait..." %}
+              </button>
+              <div data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.started()">
+                <div class="progress">
+                  <div class="progress-bar progress-bar-striped active"
+                       role="progressbar"
+                       aria-valuemin="0"
+                       aria-valuemax="100"
+                       data-bind="attr: {
+                                    'aria-valuenow': emailedExport.taskStatus.percentComplete(),
+                                    'style': 'width: ' + emailedExport.taskStatus.percentComplete() + '%',
+                                  }">
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div class="h5" data-bind="if: emailedExport.hasFile() && isLocationSafeForUser()">
+          <div class="h5"
+               data-bind="if: emailedExport.hasFile() && isLocationSafeForUser()">
 
-          <a data-bind="
-                                   visible: !isFeed(),
-                                   attr: {href: emailedExport.fileData.downloadUrl()},
-                                   click: downloadRequested,
-                               "
-             class="btn btn-info btn-xs">
-            <i class="fa fa-cloud-download"></i>
-            {% trans "Download" %}
-          </a>
+            <a data-bind="visible: !isFeed(),
+                          attr: {
+                            href: emailedExport.fileData.downloadUrl()
+                          },
+                          click: downloadRequested"
+               class="btn btn-info btn-xs">
+              <i class="fa fa-cloud-download"></i>
+              {% trans "Download" %}
+            </a>
 
-          <div class="input-group" data-bind="visible: isFeed">
-                                <span data-bind="css: {'input-group-btn': showLink}, click: copyLinkRequested">
-                                    <a class="btn btn-default btn-sm">
-                                        <i class="fa fa-clipboard"></i>
-                                        {% trans "Copy Dashboard Feed Link" %}
-                                    </a>
-                                </span>
-            <input data-bind="visible: showLink, value: emailedExport.fileData.downloadUrl()"
-                   type="text" class="form-control input-sm" readonly />
+            <div class="input-group" data-bind="visible: isFeed">
+              <span data-bind="css: {
+                                 'input-group-btn': showLink
+                               },
+                               click: copyLinkRequested">
+                <a class="btn btn-default btn-sm">
+                  <i class="fa fa-clipboard"></i>
+                  {% trans "Copy Dashboard Feed Link" %}
+                </a>
+              </span>
+              <input data-bind="visible: showLink,
+                                value: emailedExport.fileData.downloadUrl()"
+                     type="text"
+                     class="form-control input-sm"
+                     readonly />
+            </div>
           </div>
-        </div>
 
-        <div data-bind="if: isLocationSafeForUser">
-          <p class="text-warning" data-bind="if: emailedExport.hasFile() && emailedExport.fileData.showExpiredWarning() && isAutoRebuildEnabled()">
-            <i class="fa fa-exclamation-triangle"></i>
-            {% blocktrans %}
-              This saved {{ export_type }} has expired because it has not been used in
-              the last 35 days. To renew daily updates, click the 'Update Data'
-              button and download the file.
-            {% endblocktrans %}
-          </p>
-
-          <p class="text-success" data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.success()">
-            <i class="fa fa-check"></i>
-            <strong>{% trans "Data update complete" %}</strong>
-          </p>
-
-          <p class="text-danger" data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.failed()">
-            <i class="fa fa-exclamation-triangle"></i>
-            <strong>{% trans "Data update failed!" %}</strong>
-            {% blocktrans %}If this problem persists, please <a href="#modalReportIssue" data-toggle="modal">Report an Issue</a>.{% endblocktrans %}
-          </p>
-
-        </div>
-
-        <div data-bind="if: isLocationSafeForUser">
-          <div data-bind="if: !emailedExport.hasFile() && emailedExport.taskStatus && !emailedExport.taskStatus.justFinished()">
-            <div class="alert alert-warning" data-bind="visible: emailedExport.prepareExportError()">
+          <div data-bind="if: isLocationSafeForUser">
+            <p class="text-warning"
+               data-bind="if: emailedExport.hasFile() && emailedExport.fileData.showExpiredWarning() && isAutoRebuildEnabled()">
               <i class="fa fa-exclamation-triangle"></i>
-              <span data-bind="text: emailedExport.prepareExportError"></span>
-            </div>
-            {% blocktrans %}
-              <strong>No data is available yet.</strong><br />
-              Please click 'update data' if the automatic scheduler hasn't picked up the changes in a while.
-            {% endblocktrans %}
+              {% blocktrans %}
+                This saved {{ export_type }} has expired because it has not been used in
+                the last 35 days. To renew daily updates, click the 'Update Data'
+                button and download the file.
+              {% endblocktrans %}
+            </p>
+
+            <p class="text-success"
+               data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.success()">
+              <i class="fa fa-check"></i>
+              <strong>
+                {% trans "Data update complete" %}
+              </strong>
+            </p>
+
+            <p class="text-danger"
+               data-bind="if: emailedExport.taskStatus && emailedExport.taskStatus.justFinished() && emailedExport.taskStatus.failed()">
+              <i class="fa fa-exclamation-triangle"></i>
+              <strong>
+                {% trans "Data update failed!" %}
+              </strong>
+              {% blocktrans %}
+                If this problem persists, please <a href="#modalReportIssue" data-toggle="modal">Report an Issue</a>.
+              {% endblocktrans %}
+            </p>
+
           </div>
-          <div class="modal fade" data-bind="attr: {id: 'modalRefreshExportConfirm-' + id() + '-' + emailedExport.groupId()}">
-            <div class="modal-dialog">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal">
-                    <span aria-hidden="true">&times;</span>
-                    <span class="sr-only">{% trans 'Close' %}</span>
-                  </button>
-                  <h4 class="modal-title">{% trans "Confirm data updates" %}</h4>
-                </div>
-                <div class="modal-body" data-bind="visible: emailedExport.hasFile() && emailedExport.fileData.showExpiredWarning()">
-                  {% blocktrans %}
-                    To renew daily updates, click the Update Data button below and check back in a little
-                    bit once the updates have finished processing.
-                  {% endblocktrans %}
-                </div>
-                <div class="modal-body" data-bind="visible: !(emailedExport.hasFile() && emailedExport.fileData.showExpiredWarning())">
-                  <p class="lead">
+
+          <div data-bind="if: isLocationSafeForUser">
+            <div data-bind="if: !emailedExport.hasFile() && emailedExport.taskStatus && !emailedExport.taskStatus.justFinished()">
+              <div class="alert alert-warning"
+                   data-bind="visible: emailedExport.prepareExportError()">
+                <i class="fa fa-exclamation-triangle"></i>
+                <span data-bind="text: emailedExport.prepareExportError"></span>
+              </div>
+
+              <strong>
+                {% blocktrans %}
+                  No data is available yet.
+                {% endblocktrans %}
+              </strong>
+              <br />
+              {% blocktrans %}
+                Please click 'update data' if the automatic scheduler hasn't picked up the changes in a while.
+              {% endblocktrans %}
+
+            </div>
+            <div class="modal fade"
+                 data-bind="attr: {id: 'modalRefreshExportConfirm-' + id() + '-' + emailedExport.groupId()}">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button"
+                            class="close"
+                            data-dismiss="modal">
+                      <span aria-hidden="true">&times;</span>
+                      <span class="sr-only">
+                        {% trans 'Close' %}
+                      </span>
+                    </button>
+                    <h4 class="modal-title">
+                      {% trans "Confirm data updates" %}
+                    </h4>
+                  </div>
+                  <div class="modal-body"
+                       data-bind="visible: emailedExport.hasFile() && emailedExport.fileData.showExpiredWarning()">
                     {% blocktrans %}
-                      <strong>Once the data is updated, a data refresh should occur automatically on a daily basis.</strong>
+                      To renew daily updates, click the Update Data button below and check back in a little
+                      bit once the updates have finished processing.
                     {% endblocktrans %}
-                  </p>
-                  <p data-bind="ifnot: isDailySaved()">
-                    {% blocktrans %}
-                      To download data now, please click the Export button instead.
-                    {% endblocktrans %}
-                  </p>
-                  <p data-bind="if: isDailySaved() && isFeed()">
-                    To export data now, please copy the dashboard feed link instead.
-                  </p>
-                  <p data-bind="ifnot: isFeed()">
-                    To export data now, please click the Download button instead.
-                  </p>
-                </div>
-                <div class="modal-footer">
-                  <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
-                  <button type="button" class="btn btn-primary"
-                          data-bind="click: emailedExport.updateData">
-                    {% trans "Update Data" %}
-                  </button>
+                  </div>
+                  <div class="modal-body"
+                       data-bind="visible: !(emailedExport.hasFile() && emailedExport.fileData.showExpiredWarning())">
+                    <p class="lead">
+                      <strong>
+                        {% blocktrans %}
+                          Once the data is updated, a data refresh should
+                          occur automatically on a daily basis.
+                        {% endblocktrans %}
+                      </strong>
+                    </p>
+                    <p data-bind="ifnot: isDailySaved()">
+                      {% blocktrans %}
+                        To download data now, please click the Export button instead.
+                      {% endblocktrans %}
+                    </p>
+                    <p data-bind="if: isDailySaved() && isFeed()">
+                      To export data now, please copy the dashboard feed link instead.
+                    </p>
+                    <p data-bind="ifnot: isFeed()">
+                      To export data now, please click the Download button instead.
+                    </p>
+                  </div>
+                  <div class="modal-footer">
+                    <a href="#"
+                       class="btn btn-default"
+                       data-dismiss="modal">
+                      {% trans "Cancel" %}
+                    </a>
+                    <button type="button"
+                            class="btn btn-primary"
+                            data-bind="click: emailedExport.updateData">
+                      {% trans "Update Data" %}
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div class="modal fade" data-bind="attr: {id: 'modalEnableDisableAutoRefresh-' + id() + '-' + emailedExport.groupId()}">
-            <div class="modal-dialog">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal">
-                    <span aria-hidden="true">&times;</span><span class="sr-only">{% trans 'Close' %}</span>
-                  </button>
-                  <h4 class="modal-title">{% trans "Confirm data updates." %}</h4>
-                </div>
-                <div class="modal-body">
-                  <p data-bind="if: isDailySaved() && !isAutoRebuildEnabled()">
-                    {% blocktrans %}
-                      This will enable the daily automatic updates of this export.
-                    {% endblocktrans %}
-                  </p>
-                  <p data-bind="if: isDailySaved() && isAutoRebuildEnabled()">
-                    {% blocktrans %}
-                      This will disable the daily automatic updates of this export.
-                    {% endblocktrans %}
-                  </p>
-                </div>
-                <div class="modal-footer">
-                  <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
-                  <button type="button" class="btn btn-primary" data-bind="click: updateDisabledState">
-                                                <span data-bind="if: isAutoRebuildEnabled()">
-                                                    {% trans "Disable auto update" %}
-                                                </span>
-                    <span data-bind="ifnot: isAutoRebuildEnabled()">
-                                                    {% trans "Enable auto update" %}
-                                                </span>
-                  </button>
+            <div class="modal fade"
+                 data-bind="attr: {id: 'modalEnableDisableAutoRefresh-' + id() + '-' + emailedExport.groupId()}">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button"
+                            class="close"
+                            data-dismiss="modal">
+                      <span aria-hidden="true">&times;</span>
+                      <span class="sr-only">
+                        {% trans 'Close' %}
+                      </span>
+                    </button>
+                    <h4 class="modal-title">
+                      {% trans "Confirm data updates." %}
+                    </h4>
+                  </div>
+                  <div class="modal-body">
+                    <p data-bind="if: isDailySaved() && !isAutoRebuildEnabled()">
+                      {% blocktrans %}
+                        This will enable the daily automatic updates of this export.
+                      {% endblocktrans %}
+                    </p>
+                    <p data-bind="if: isDailySaved() && isAutoRebuildEnabled()">
+                      {% blocktrans %}
+                        This will disable the daily automatic updates of this export.
+                      {% endblocktrans %}
+                    </p>
+                  </div>
+                  <div class="modal-footer">
+                    <a href="#"
+                       class="btn btn-default"
+                       data-dismiss="modal">
+                      {% trans "Cancel" %}
+                    </a>
+                    <button type="button"
+                            class="btn btn-primary"
+                            data-bind="click: updateDisabledState">
+                      <span data-bind="if: isAutoRebuildEnabled()">
+                        {% trans "Disable auto update" %}
+                      </span>
+                      <span data-bind="ifnot: isAutoRebuildEnabled()">
+                        {% trans "Enable auto update" %}
+                      </span>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <!-- /ko -->
-    </td>
+        <!-- /ko -->
+      </td>
     {% if model_type == "case" %}
       <td>
         <h4 data-bind="text: case_type"></h4>
       </td>
     {% endif %}
 
-    <td>
-      <a data-bind="attr: {href: downloadUrl},
-                    visible: !showSavedFilters,
-                    click: $root.sendExportAnalytics"
-         class="btn btn-primary">
-        {{ export_type_caps }}
-      </a>
-      {% if has_edit_permissions %}
-        <a class="btn btn-default"
-           data-bind="visible: showSavedFilters && isLocationSafeForUser(), click: function (model) { $root.filterModalExportId(model.id()); }"
-           href="#setFeedFiltersModal"
-           data-toggle="modal"
-        >
-          <i class="fa fa-filter"></i>
-          {% trans "Edit Filters" %}
+      <td>
+        <a data-bind="attr: {href: downloadUrl},
+                      visible: !showSavedFilters,
+                      click: $root.sendExportAnalytics"
+           class="btn btn-primary">
+          {{ export_type_caps }}
         </a>
-      {% endif %}
-    </td>
+        {% if has_edit_permissions %}
+          <a class="btn btn-default"
+             data-bind="visible: showSavedFilters && isLocationSafeForUser(),
+                        click: function (model) {
+                          $root.filterModalExportId(model.id());
+                        }"
+             href="#setFeedFiltersModal"
+             data-toggle="modal">
+            <i class="fa fa-filter"></i>
+            {% trans "Edit Filters" %}
+          </a>
+        {% endif %}
+      </td>
 
     {% if allow_bulk_export %}
       <td>
         <div class="checkbox checkbox-table-cell">
           <label>
-            <input type="checkbox" data-bind="checked: addedToBulk" />
+            <input type="checkbox"
+                   data-bind="checked: addedToBulk" />
           </label>
         </div>
       </td>
@@ -350,11 +444,15 @@
       <td>
         <a class="btn btn-default"
            data-bind="attr: {
-                                'data-target': '#modalEnableDisableAutoRefresh-' + id() + '-' + emailedExport.groupId(),
-                            }"
+                        'data-target': '#modalEnableDisableAutoRefresh-' + id() + '-' + emailedExport.groupId(),
+                      }"
            data-toggle="modal">
-          <span data-bind="visible: !isAutoRebuildEnabled()">{% trans "Enable" %}</span>
-          <span data-bind="visible: isAutoRebuildEnabled()">{% trans "Disable" %}</span>
+          <span data-bind="visible: !isAutoRebuildEnabled()">
+            {% trans "Enable" %}
+          </span>
+          <span data-bind="visible: isAutoRebuildEnabled()">
+            {% trans "Disable" %}
+          </span>
         </a>
       </td>
     {% endif %}
@@ -364,40 +462,62 @@
         <div data-bind="if: $parent.showOwnership">
           <div data-bind="if: can_edit()">
             <div data-bind="if: isLocationSafeForUser">
-              <a data-bind="attr: {href: editUrl}" class="btn btn-default">
+              <a data-bind="attr: {href: editUrl}"
+                 class="btn btn-default">
                 <div data-bind="ifnot: isOData()">
                   <i class="fa fa-pencil"></i>
-                  <span data-bind="visible: !isDailySaved()">{% trans 'Edit' %}</span>
-                  <span data-bind="visible: isDailySaved()">{% trans 'Edit Columns' %}</span>
+                  <span data-bind="visible: !isDailySaved()">
+                    {% trans 'Edit' %}
+                  </span>
+                  <span data-bind="visible: isDailySaved()">
+                    {% trans 'Edit Columns' %}
+                  </span>
                 </div>
                 <div data-bind="if: isOData()">
                   <i class="fa fa-pencil"></i>
-                  <span>{% trans 'Copy' %}</span>
+                  <span>
+                    {% trans 'Copy' %}
+                  </span>
                 </div>
               </a>
             </div>
           </div>
           <div data-bind="ifnot: can_edit()">
             <div data-bind="if: isLocationSafeForUser">
-              <a class="btn btn-default disabled" data-bind="visible: $parent.myExports">
+              <a class="btn btn-default disabled"
+                 data-bind="visible: $parent.myExports">
                 <div data-bind="ifnot: isOData()">
                   <i class="fa fa-pencil"></i>
-                  <span data-bind="visible: !isDailySaved()">{% trans 'Edit' %}</span>
-                  <span data-bind="visible: isDailySaved()">{% trans 'Edit Columns' %}</span>
+                  <span data-bind="visible: !isDailySaved()">
+                    {% trans 'Edit' %}
+                  </span>
+                  <span data-bind="visible: isDailySaved()">
+                    {% trans 'Edit Columns' %}
+                  </span>
                 </div>
                 <div data-bind="if: isOData()">
                   <i class="fa fa-pencil"></i>
-                  <span>{% trans 'Copy Feed' %}</span>
+                  <span>
+                    {% trans 'Copy Feed' %}
+                  </span>
                 </div>
               </a>
-              <a data-bind="attr: {href: editUrl}, visible: !$parent.myExports" class="btn btn-default">
+              <a data-bind="attr: {href: editUrl},
+                            visible: !$parent.myExports"
+                 class="btn btn-default">
                 <div data-bind="ifnot: isOData()">
-                  <span data-bind="visible: !isDailySaved()">{% trans 'View' %}</span>
-                  <span data-bind="visible: isDailySaved()">{% trans 'View Columns' %}</span>
+                  <span data-bind="visible: !isDailySaved()">
+                    {% trans 'View' %}
+                  </span>
+                  <span data-bind="visible: isDailySaved()">
+                    {% trans 'View Columns' %}
+                  </span>
                 </div>
                 <div data-bind="if: isOData()">
                   <i class="fa fa-pencil"></i>
-                  <span>{% trans 'View Feed' %}</span>
+                  <span>
+                    {% trans 'View Feed' %}
+                  </span>
                 </div>
               </a>
             </div>
@@ -405,15 +525,22 @@
         </div>
         <div data-bind="ifnot: $parent.showOwnership">
           <div data-bind="if: isLocationSafeForUser">
-            <a data-bind="attr: {href: editUrl}" class="btn btn-default"{% if odata_feeds_over_limit %} data-toggle="modal"{% endif %}>
+            <a data-bind="attr: {href: editUrl}"
+               class="btn btn-default"{% if odata_feeds_over_limit %} data-toggle="modal"{% endif %}>
               <div data-bind="ifnot: isOData()">
                 <i class="fa fa-pencil"></i>
-                <span data-bind="visible: !isDailySaved()">{% trans 'Edit' %}</span>
-                <span data-bind="visible: isDailySaved()">{% trans 'Edit Columns' %}</span>
+                <span data-bind="visible: !isDailySaved()">
+                  {% trans 'Edit' %}
+                </span>
+                <span data-bind="visible: isDailySaved()">
+                  {% trans 'Edit Columns' %}
+                </span>
               </div>
               <div data-bind="if: isOData()">
                 <i class="fa fa-pencil"></i>
-                <span>{% trans 'Copy Feed' %}</span>
+                <span>
+                  {% trans 'Copy Feed' %}
+                </span>
               </div>
             </a>
           </div>
@@ -421,7 +548,11 @@
       </td>
       <td>
         <div data-bind="if: isLocationSafeForUser()">
-          <a class="btn btn-danger" data-toggle="modal" data-bind="attr: {href: '#delete-export-modal-' + id()}">
+          <a class="btn btn-danger"
+             data-toggle="modal"
+             data-bind="attr: {
+                          href: '#delete-export-modal-' + id()
+                        }">
             <i class="fa fa-remove"></i>
             <span>{% trans 'Delete' %}</span>
           </a>
@@ -445,12 +576,15 @@
         </div>
         <div data-bind="visible: !$parent.myExports">
           <div data-bind="visible: owner_username === 'unknown'">
-            <div class="label label-default">{% trans 'Unknown' %}</div>
+            <div class="label label-default">
+              {% trans 'Unknown' %}
+            </div>
           </div>
-          <div data-bind="visible: owner_username !== 'unknown', text: owner_username"></div>
+          <div data-bind="visible: owner_username !== 'unknown',
+                          text: owner_username"></div>
         </div>
       </td>
     {% endif %}
-  </tr>
+    </tr>
   </tbody>
 </table>

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -17,6 +17,7 @@
       </th>
     {% endif %}
 
+    {% if not is_odata %}
       <th class="col-sm-1">
         {% if export_filter_form %}
           {% if has_edit_permissions %}
@@ -26,6 +27,7 @@
           {{ export_type_caps }}
         {% endif %}
       </th>
+    {% endif %}
 
     {%  if allow_bulk_export %} {# form exports only #}
       <th class="col-sm-1">
@@ -409,6 +411,7 @@
       </td>
     {% endif %}
 
+    {% if not is_odata %}
       <td>
         <a data-bind="attr: {href: downloadUrl},
                       visible: !showSavedFilters,
@@ -429,6 +432,7 @@
           </a>
         {% endif %}
       </td>
+    {% endif %}
 
     {% if allow_bulk_export %}
       <td>

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -899,10 +899,16 @@ class ODataFeedListHelper(ExportListHelper):
 @method_decorator(toggles.ODATA.required_decorator(), name='dispatch')
 class ODataFeedListView(BaseExportListView, ODataFeedListHelper):
     urlname = 'list_odata_feeds'
-    page_title = ugettext_lazy("Power BI/Tableau Integration")
+    page_title = ugettext_lazy("PowerBi/Tableau Integration (Preview)")
     lead_text = ugettext_lazy('''
         Use OData feeds to integrate your CommCare data with Power BI or Tableau.
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Integration+with+PowerBi+and+Tableau">
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Integration+with+PowerBi+and+Tableau" 
+           target="_blank">
+            Learn more.
+        </a><br />
+        This is a Feature Preview.
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Feature+Previews" 
+           target="_blank">
             Learn more.
         </a>
     ''')

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -868,7 +868,7 @@ class ODataFeedListHelper(ExportListHelper):
 
     @property
     def create_export_form_title(self):
-        return ""
+        return _("Select a model to export to a feed")
 
     def _should_appear_in_list(self, export):
         return export['is_odata_config']

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -17,6 +17,7 @@ from django.views.decorators.http import require_GET, require_POST
 from couchdbkit import ResourceNotFound
 from memoized import memoized
 
+from corehq.feature_previews import BI_INTEGRATION_PREVIEW
 from couchexport.models import Format
 from couchexport.writers import XlsLengthException
 from dimagi.utils.couch import CriticalSection
@@ -605,7 +606,7 @@ def commit_filters(request, domain):
         raise Http404
     if export.export_format == "html" and not domain_has_privilege(domain, EXCEL_DASHBOARD):
         raise Http404
-    if export.is_odata_config and not toggles.ODATA.enabled_for_request(request):
+    if export.is_odata_config and not BI_INTEGRATION_PREVIEW.enabled_for_request(request):
         raise Http404
     if not export.filters.is_location_safe_for_user(request):
         return location_restricted_response(request)
@@ -896,7 +897,7 @@ class ODataFeedListHelper(ExportListHelper):
         return DownloadNewCaseExportView
 
 
-@method_decorator(toggles.ODATA.required_decorator(), name='dispatch')
+@method_decorator(BI_INTEGRATION_PREVIEW.required_decorator(), name='dispatch')
 class ODataFeedListView(BaseExportListView, ODataFeedListHelper):
     urlname = 'list_odata_feeds'
     page_title = ugettext_lazy("PowerBi/Tableau Integration (Preview)")

--- a/corehq/apps/export/views/list.py
+++ b/corehq/apps/export/views/list.py
@@ -903,12 +903,12 @@ class ODataFeedListView(BaseExportListView, ODataFeedListHelper):
     page_title = ugettext_lazy("PowerBi/Tableau Integration (Preview)")
     lead_text = ugettext_lazy('''
         Use OData feeds to integrate your CommCare data with Power BI or Tableau.
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Integration+with+PowerBi+and+Tableau" 
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Integration+with+PowerBi+and+Tableau"
            target="_blank">
             Learn more.
         </a><br />
         This is a Feature Preview.
-        <a href="https://confluence.dimagi.com/display/commcarepublic/Feature+Previews" 
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Feature+Previews"
            target="_blank">
             Learn more.
         </a>

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import json
 
 from couchdbkit import ResourceNotFound
+
+from corehq.feature_previews import BI_INTEGRATION_PREVIEW
 from dimagi.utils.web import json_response
 from django.conf import settings
 from django.contrib import messages
@@ -265,7 +267,7 @@ class CreateNewDailySavedFormExport(DailySavedExportMixin, CreateNewCustomFormEx
     urlname = 'new_form_faily_saved_export'
 
 
-@method_decorator(toggles.ODATA.required_decorator(), name='dispatch')
+@method_decorator(BI_INTEGRATION_PREVIEW.required_decorator(), name='dispatch')
 class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
     urlname = 'new_odata_case_feed'
     page_title = ugettext_lazy("Create OData Case Feed")
@@ -278,7 +280,7 @@ class CreateODataCaseFeedView(ODataFeedMixin, CreateNewCustomCaseExportView):
         return export_instance
 
 
-@method_decorator(toggles.ODATA.required_decorator(), name='dispatch')
+@method_decorator(BI_INTEGRATION_PREVIEW.required_decorator(), name='dispatch')
 class CreateODataFormFeedView(ODataFeedMixin, CreateNewCustomFormExportView):
     urlname = 'new_odata_form_feed'
     page_title = ugettext_lazy("Create OData Form Feed")

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 from datetime import datetime, timedelta
 
 import pytz
+
+from corehq.feature_previews import BI_INTEGRATION_PREVIEW
 from couchexport.models import Format
 from dimagi.utils.web import json_response, get_url_base
 from django.contrib import messages
@@ -182,7 +184,7 @@ class DashboardFeedMixin(DailySavedExportMixin):
 
 class ODataFeedMixin(object):
 
-    @method_decorator(toggles.ODATA.required_decorator())
+    @method_decorator(BI_INTEGRATION_PREVIEW.required_decorator())
     def dispatch(self, *args, **kwargs):
         return super(ODataFeedMixin, self).dispatch(*args, **kwargs)
 

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -18,6 +18,7 @@ from .toggles import (
     all_toggles_by_name_in_scope,
     ECD_MIGRATED_DOMAINS,
     ECD_PREVIEW_ENTERPRISE_DOMAINS,
+    ODATA,
 )
 
 
@@ -190,6 +191,22 @@ EXPLORE_CASE_DATA_PREVIEW = FeaturePreview(
     description=_(
         "This feature allows you to quickly explore your case data for "
         "ad-hoc data queries or to identify unclean data."
+    ),
+    can_self_enable_fn=is_eligible_for_ecd_preview,
+    save_fn=clear_project_data_tab_cache,
+)
+
+
+def is_eligible_for_bi_integration_preview(request):
+    return ODATA.enabled_for_request(request)
+
+
+BI_INTEGRATION_PREVIEW = FeaturePreview(
+    slug='bi_integration_preview',
+    label=_("PowerBi / Tableau Integration"),
+    description=_(
+        "Use OData feeds to integrate your CommCare data with Power "
+        "BI or Tableau."
     ),
     can_self_enable_fn=is_eligible_for_ecd_preview,
     save_fn=clear_project_data_tab_cache,

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -208,6 +208,6 @@ BI_INTEGRATION_PREVIEW = FeaturePreview(
         "Use OData feeds to integrate your CommCare data with Power "
         "BI or Tableau."
     ),
-    can_self_enable_fn=is_eligible_for_ecd_preview,
+    can_self_enable_fn=is_eligible_for_bi_integration_preview,
     save_fn=clear_project_data_tab_cache,
 )

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -721,7 +721,7 @@ class ProjectDataTab(UITab):
                     'title': _(ODataFeedListView.page_title),
                     'url': reverse(ODataFeedListView.urlname, args=(self.domain,)),
                     'icon': 'fa fa-plug',
-                    'show_in_dropdown': True,
+                    'show_in_dropdown': False,
                     'subpages': subpages
                 })
 
@@ -817,6 +817,12 @@ class ProjectDataTab(UITab):
             items.append(dropdown_dict(
                 _('Explore Case Data (Preview)'),
                 url=reverse(ExploreCaseDataView.urlname, args=(self.domain,)),
+            ))
+        if BI_INTEGRATION_PREVIEW.enabled_for_request(self._request):
+            from corehq.apps.export.views.list import ODataFeedListView
+            items.append(dropdown_dict(
+                _(ODataFeedListView.page_title),
+                url=reverse(ODataFeedListView.urlname, args=(self.domain,)),
             ))
 
         if items:

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -52,6 +52,7 @@ from corehq.apps.users.permissions import (
 from corehq.feature_previews import (
     EXPLORE_CASE_DATA_PREVIEW,
     is_eligible_for_ecd_preview,
+    BI_INTEGRATION_PREVIEW,
 )
 from corehq.messaging.scheduling.views import (
     MessagingDashboardView,
@@ -697,7 +698,7 @@ class ProjectDataTab(UITab):
                     'show_in_dropdown': True,
                     'subpages': []
                 })
-            if toggles.ODATA.enabled(self.domain):
+            if BI_INTEGRATION_PREVIEW.enabled_for_request(self._request):
                 subpages = [
                     {
                         'title': _(CreateODataCaseFeedView.page_title),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1749,11 +1749,17 @@ HIDE_HQ_ON_MOBILE_EXPERIENCE = StaticToggle(
 )
 
 
+def _enable_bi_integration_preview(domain, enabled):
+    from corehq.feature_previews import BI_INTEGRATION_PREVIEW
+    BI_INTEGRATION_PREVIEW.set(domain, enabled, NAMESPACE_DOMAIN)
+
+
 ODATA = StaticToggle(
     'odata',
     'Enable Odata feed.',
     TAG_PRODUCT,
     namespaces=[NAMESPACE_DOMAIN, NAMESPACE_USER],
+    save_fn=_enable_bi_integration_preview,
 )
 
 

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -123,9 +123,10 @@ class flag_enabled(object):
     """
     enabled = True
 
-    def __init__(self, toggle_name):
+    def __init__(self, toggle_name, is_preview=False):
+        location = 'corehq.feature_previews' if is_preview else 'corehq.toggles'
         self.patches = [
-            mock.patch('.'.join(['corehq.toggles', toggle_name, method_name]),
+            mock.patch('.'.join([location, toggle_name, method_name]),
                        new=lambda *args, **kwargs: self.enabled)
             for method_name in ['enabled', 'enabled_for_request']
         ]


### PR DESCRIPTION
Hides the following export features which are not functional with Odata right now:
- Repeat Groups for Forms 
- Parent-Child Linking for Cases
- Edit Filters
- Expand Checkbox Questions checkbox

Also:
- Creates the Feature Preview for Power BI / Tableau Integration which is only available to be enabled / disabled if the `ODATA` feature flag is enabled for that domain. When `ODATA` is disabled, the feature preview is also disabled.
- Adds link to odata feed in dropdown
- Adds feedback widget to odata feed list page
- Some cleanup of the exports templates I had to touch in terms of whitespacing and formatting for improved readability.
