### PR TITLE
Speed up requirejs tests

### DIFF
--- a/corehq/apps/hqwebapp/tests/test_requirejs.py
+++ b/corehq/apps/hqwebapp/tests/test_requirejs.py
@@ -87,15 +87,17 @@ class TestRequireJS(SimpleTestCase):
                       and not f.endswith("hqwebapp/js/knockout_bindings.ko.js")]
 
         def _test_file(filename):
-            proc = subprocess.Popen(["grep", "hqImport", filename], stdout=subprocess.PIPE)
-            (out, err) = proc.communicate()
-            for line in [b.decode('utf-8') for b in out.split(b"\n")]:
-                if line:
-                    match = re.search(r'hqImport\([\'"]([^\'"]*)[\'"]', line)
-                    if match:
-                        errors.append("{} imported in {}".format(match.group(1), filename))
-                    else:
-                        errors.append("hqImport found in {}: {}".format(filename, line.strip()))
+            has_hqImport = False
+            with open(filename, 'r') as f:
+                line = f.readline()
+                while line:
+                    if re.search(r'hqImport', line):
+                        match = re.search(r'hqImport\([\'"]([^\'"]*)[\'"]', line)
+                        if match:
+                            errors.append("{} imported in {}".format(match.group(1), filename))
+                        else:
+                            errors.append("hqImport found in {}: {}".format(filename, line.strip()))
+                    line = f.readline()
 
         self._run_jobs(test_files, _test_file)
 

--- a/corehq/apps/hqwebapp/tests/test_requirejs.py
+++ b/corehq/apps/hqwebapp/tests/test_requirejs.py
@@ -87,7 +87,6 @@ class TestRequireJS(SimpleTestCase):
                       and not f.endswith("hqwebapp/js/knockout_bindings.ko.js")]
 
         def _test_file(filename):
-            has_hqImport = False
             with open(filename, 'r') as f:
                 line = f.readline()
                 while line:

--- a/corehq/apps/hqwebapp/tests/test_requirejs.py
+++ b/corehq/apps/hqwebapp/tests/test_requirejs.py
@@ -39,9 +39,9 @@ class TestRequireJS(SimpleTestCase):
         proc = subprocess.Popen(["find", prefix, "-name", "*.js"], stdout=subprocess.PIPE)
         (out, err) = proc.communicate()
         cls.js_files = [f for f in [b.decode('utf-8') for b in out.split(b"\n")] if f
-                    and not '/_design/' in f
-                    and not 'couchapps' in f
-                    and not '/vellum/' in f]
+                    and '/_design/' not in f
+                    and 'couchapps' not in f
+                    and '/vellum/' not in f]
 
         cls.hqdefine_files = []
         cls.requirejs_files = []

--- a/corehq/apps/hqwebapp/tests/test_requirejs.py
+++ b/corehq/apps/hqwebapp/tests/test_requirejs.py
@@ -38,13 +38,10 @@ class TestRequireJS(SimpleTestCase):
 
         proc = subprocess.Popen(["find", prefix, "-name", "*.js"], stdout=subprocess.PIPE)
         (out, err) = proc.communicate()
-        design_pattern = re.compile(r'/_design/')
-        couchapps_pattern = re.compile(r'couchapps')
-        vellum_pattern = re.compile(r'/vellum/')
         cls.js_files = [f for f in [b.decode('utf-8') for b in out.split(b"\n")] if f
-                    and not design_pattern.search(f)
-                    and not couchapps_pattern.search(f)
-                    and not vellum_pattern.search(f)]
+                    and not '/_design/' in f
+                    and not 'couchapps' in f
+                    and not '/vellum/' in f]
 
         cls.hqdefine_files = []
         cls.requirejs_files = []


### PR DESCRIPTION
[A recent job](https://travis-ci.org/dimagi/commcare-hq/jobs/565956236) says setup for `test_files_match_modules` takes 20 sec and running takes 10, but it's about 4 times as fast locally. Times in commit messages are based on local testing.