### PR TITLE
Replaced assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/corehq/apps/app_manager/tests/test_extension_case.py
+++ b/corehq/apps/app_manager/tests/test_extension_case.py
@@ -229,7 +229,7 @@ class CaseBlockIndexRelationshipTest(SimpleTestCase, TestXmlMixin):
         """
         CaseBlock index relationship should only allow valid values
         """
-        with self.assertRaisesRegexp(CaseError,
+        with self.assertRaisesRegex(CaseError,
                                      'Valid values for an index relationship are'):
             self.subcase_block.add_index_ref(
                 'host',

--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -127,7 +127,7 @@ class TagTest(SimpleTestCase):
 
     def test_requirejs_main_multiple_tags(self):
         msg = r"multiple 'requirejs_main' tags not allowed \(\"requirejs/two\"\)"
-        with self.assertRaisesRegexp(TemplateSyntaxError, msg):
+        with self.assertRaisesRegex(TemplateSyntaxError, msg):
             self.render("""
                 {% load hq_shared_tags %}
                 {% requirejs_main "requirejs/one" %}
@@ -136,7 +136,7 @@ class TagTest(SimpleTestCase):
 
     def test_requirejs_main_too_short(self):
         msg = r"bad 'requirejs_main' argument: '"
-        with self.assertRaisesRegexp(TemplateSyntaxError, msg):
+        with self.assertRaisesRegex(TemplateSyntaxError, msg):
             self.render("""
                 {% load hq_shared_tags %}
                 {% requirejs_main ' %}
@@ -144,7 +144,7 @@ class TagTest(SimpleTestCase):
 
     def test_requirejs_main_bad_string(self):
         msg = r"bad 'requirejs_main' argument: \.'"
-        with self.assertRaisesRegexp(TemplateSyntaxError, msg):
+        with self.assertRaisesRegex(TemplateSyntaxError, msg):
             self.render("""
                 {% load hq_shared_tags %}
                 {% requirejs_main .' %}
@@ -152,7 +152,7 @@ class TagTest(SimpleTestCase):
 
     def test_requirejs_main_mismatched_delimiter(self):
         msg = r"bad 'requirejs_main' argument: 'x\""
-        with self.assertRaisesRegexp(TemplateSyntaxError, msg):
+        with self.assertRaisesRegex(TemplateSyntaxError, msg):
             self.render("""
                 {% load hq_shared_tags %}
                 {% requirejs_main 'x" %}

--- a/corehq/apps/tzmigration/tests/test_timezonemigration.py
+++ b/corehq/apps/tzmigration/tests/test_timezonemigration.py
@@ -125,7 +125,7 @@ class TimeZoneMigrationTest(TestCase, TestFileMixin):
     def test_pause(self):
         xform = self.get_xml('form')
         set_tz_migration_started(self.domain)
-        with self.assertRaisesRegexp(LocalSubmissionError, 'status code 503'):
+        with self.assertRaisesRegex(LocalSubmissionError, 'status code 503'):
             submit_form_locally(xform, self.domain)
         _run_timezone_migration_for_domain(self.domain)
         set_tz_migration_complete(self.domain)

--- a/corehq/apps/userreports/tests/test_data_source_validaton.py
+++ b/corehq/apps/userreports/tests/test_data_source_validaton.py
@@ -34,7 +34,7 @@ class DataSourceValidationTest(SimpleTestCase):
 
         sample_doc['is_starred'] = 'what is a star?'
 
-        with self.assertRaisesRegexp(ValidationError, "is_starred has unexpected value"):
+        with self.assertRaisesRegex(ValidationError, "is_starred has unexpected value"):
             self.config.validate_document(sample_doc)
 
     def test_multiple_validations(self):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -266,7 +266,7 @@ class CaseBlockIndexRelationshipTests(SimpleTestCase):
         """
         CaseBlock index relationship should only allow valid values
         """
-        with self.assertRaisesRegexp(CaseBlockError,
+        with self.assertRaisesRegex(CaseBlockError,
                                      'Valid values for an index relationship are "child" and "extension"'):
             CaseBlock(
                 case_id='abcdef',

--- a/corehq/ex-submodules/dimagi/utils/tests/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/dates.py
@@ -148,5 +148,5 @@ class DateSpanValidationTests(SimpleTestCase):
                          "You are limited to a span of 90 days, but this date range spans 181 days")
 
     def test_negative_max_days(self):
-        with self.assertRaisesRegexp(ValueError, 'max_days cannot be less than 0'):
+        with self.assertRaisesRegex(ValueError, 'max_days cannot be less than 0'):
             DateSpan(datetime(2015, 1, 1), datetime(2015, 4, 1), max_days=-1)

--- a/corehq/form_processor/tests/test_ledger_dbaccessor.py
+++ b/corehq/form_processor/tests/test_ledger_dbaccessor.py
@@ -176,13 +176,13 @@ class LedgerAccessorErrorTests(TestCase):
         super(LedgerAccessorErrorTests, cls).tearDownClass()
 
     def test_delete_ledger_values_raise_error_case_section_entry(self):
-        with self.assertRaisesRegexp(LedgerSaveError, '.*still has transactions.*'):
+        with self.assertRaisesRegex(LedgerSaveError, '.*still has transactions.*'):
             LedgerAccessorSQL.delete_ledger_values(self.case.case_id, 'stock', self.product._id)
 
     def test_delete_ledger_values_raise_error_case_section(self):
-        with self.assertRaisesRegexp(LedgerSaveError, '.*still has transactions.*'):
+        with self.assertRaisesRegex(LedgerSaveError, '.*still has transactions.*'):
             LedgerAccessorSQL.delete_ledger_values(self.case.case_id, 'stock')
 
     def test_delete_ledger_values_raise_error_case(self):
-        with self.assertRaisesRegexp(LedgerSaveError, '.*still has transactions.*'):
+        with self.assertRaisesRegex(LedgerSaveError, '.*still has transactions.*'):
             LedgerAccessorSQL.delete_ledger_values(self.case.case_id)


### PR DESCRIPTION
Minor - get this warning out of the travis logs.

https://docs.python.org/3/library/unittest.html#deprecated-aliases