### PR TITLE
Removed testAuditViews

### DIFF
--- a/corehq/ex-submodules/auditcare/tests/auth.py
+++ b/corehq/ex-submodules/auditcare/tests/auth.py
@@ -125,9 +125,3 @@ class AuthenticationTestCase(TestCase):
         response = self.client.post(reverse('auth_login'), {'username': 'mockmock@mockmock.com', 'password': 'wrongwrong'})
         cooled_audit = get_latest_access(['user', 'mockmock@mockmock.com'])
         self.assertEquals(cooled_audit.failures_since_start, 1)
-
-
-
-    def testAuditViews(self):
-        for v in settings.AUDIT_VIEWS:
-            pass


### PR DESCRIPTION
After looking at how `AUDIT_VIEWS` is used in [middleware.py](https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/auditcare/middleware.py), I don't think this test is doing enough to justify its [15 second run time](https://github.com/dimagi/commcare-hq/pull/23874/files#diff-00aa2e3649ea30d6235949a4e047eaacR127).

Added back in 2010: https://github.com/dimagi/commcare-hq/commit/54707a5264e3b776062da2fa41efb0ad8b21c6bb