### PR TITLE
Share StaticDataSourceConfiguration between tests

### DIFF
--- a/corehq/apps/userreports/tests/test_static_data_sources.py
+++ b/corehq/apps/userreports/tests/test_static_data_sources.py
@@ -12,7 +12,6 @@ from corehq.util.test_utils import TestFileMixin
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, DataSourceConfiguration
 
 
-@patch('corehq.apps.callcenter.data_source.get_call_center_domains', MagicMock(return_value=[domain_lite('cc1')]))
 class TestStaticDataSource(SimpleTestCase, TestFileMixin):
 
     file_path = ('data', 'static_data_sources')
@@ -21,7 +20,9 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
     @classmethod
     def setUpClass(cls):
         super(TestStaticDataSource, cls).setUpClass()
-        cls.configs = list(StaticDataSourceConfiguration.all())
+        with patch('corehq.apps.callcenter.utils.get_call_center_domains',
+                   MagicMock(return_value=[domain_lite('cc1')])):
+            cls.configs = list(StaticDataSourceConfiguration.all())
 
     def test_wrap(self):
         wrapped = StaticDataSourceConfiguration.wrap(self.get_json('sample_static_data_source'))
@@ -29,24 +30,25 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
 
     def test_get_all(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            self.assertEqual(2 + 3, len(self.configs))
-            example, dimagi = self.configs[:2]
+            all = list(StaticDataSourceConfiguration.all())
+            self.assertEqual(2 + 3, len(all))
+            example, dimagi = all[:2]
             self.assertEqual('example', example.domain)
             self.assertEqual('dimagi', dimagi.domain)
-            for config in self.configs[:2]:
+            for config in all[:2]:
                 self.assertEqual('all_candidates', config.table_id)
 
-            for config in self.configs[2:]:
+            for config in all[2:]:
                 self.assertEqual('cc1', config.domain)
 
     def test_is_static_positive_json(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            example = self.configs[0]
+            example = list(StaticDataSourceConfiguration.all())[0]
             self.assertTrue(example.is_static)
 
     def test_is_static_positive_yaml(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'yaml')]):
-            example = self.configs[0]
+            example = list(StaticDataSourceConfiguration.all())[0]
             self.assertTrue(example.is_static)
 
     def test_is_static_negative(self):
@@ -55,7 +57,7 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
 
     def test_deactivate_noop(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            example = self.configs[0]
+            example = list(StaticDataSourceConfiguration.all())[0]
             # since this is a SimpleTest, this should fail if the call actually hits the DB
             example.deactivate()
 

--- a/corehq/apps/userreports/tests/test_static_data_sources.py
+++ b/corehq/apps/userreports/tests/test_static_data_sources.py
@@ -18,31 +18,35 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
     file_path = ('data', 'static_data_sources')
     root = os.path.dirname(__file__)
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestStaticDataSource, cls).setUpClass()
+        cls.configs = list(StaticDataSourceConfiguration.all())
+
     def test_wrap(self):
         wrapped = StaticDataSourceConfiguration.wrap(self.get_json('sample_static_data_source'))
         self.assertEqual(["example", "dimagi"], wrapped.domains)
 
     def test_get_all(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            all = list(StaticDataSourceConfiguration.all())
-            self.assertEqual(2 + 3, len(all))
-            example, dimagi = all[:2]
+            self.assertEqual(2 + 3, len(self.configs))
+            example, dimagi = self.configs[:2]
             self.assertEqual('example', example.domain)
             self.assertEqual('dimagi', dimagi.domain)
-            for config in all[:2]:
+            for config in self.configs[:2]:
                 self.assertEqual('all_candidates', config.table_id)
 
-            for config in all[2:]:
+            for config in self.configs[2:]:
                 self.assertEqual('cc1', config.domain)
 
     def test_is_static_positive_json(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            example = list(StaticDataSourceConfiguration.all())[0]
+            example = self.configs[0]
             self.assertTrue(example.is_static)
 
     def test_is_static_positive_yaml(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'yaml')]):
-            example = list(StaticDataSourceConfiguration.all())[0]
+            example = self.configs[0]
             self.assertTrue(example.is_static)
 
     def test_is_static_negative(self):
@@ -51,17 +55,16 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
 
     def test_deactivate_noop(self):
         with override_settings(STATIC_DATA_SOURCES=[self.get_path('sample_static_data_source', 'json')]):
-            example = list(StaticDataSourceConfiguration.all())[0]
+            example = self.configs[0]
             # since this is a SimpleTest, this should fail if the call actually hits the DB
             example.deactivate()
 
     def test_production_config(self):
-        for data_source in StaticDataSourceConfiguration.all():
+        for data_source in self.configs:
             data_source.validate()
 
     def test_for_table_id_conflicts(self):
-        counts = Counter((ds.table_id, ds.domain) for ds in
-                         StaticDataSourceConfiguration.all())
+        counts = Counter((ds.table_id, ds.domain) for ds in self.configs)
         duplicates = [k for k, v in counts.items() if v > 1]
         msg = "The following data source configs have duplicate table_ids on the same domains:\n{}".format(
             "\n".join("table_id: {}, domain: {}".format(table_id, domain) for table_id, domain in duplicates)

--- a/corehq/apps/userreports/tests/test_static_data_sources.py
+++ b/corehq/apps/userreports/tests/test_static_data_sources.py
@@ -20,7 +20,7 @@ class TestStaticDataSource(SimpleTestCase, TestFileMixin):
     @classmethod
     def setUpClass(cls):
         super(TestStaticDataSource, cls).setUpClass()
-        with patch('corehq.apps.callcenter.utils.get_call_center_domains',
+        with patch('corehq.apps.callcenter.data_source.get_call_center_domains',
                    MagicMock(return_value=[domain_lite('cc1')])):
             cls.configs = list(StaticDataSourceConfiguration.all())
 

--- a/corehq/apps/userreports/tests/test_static_reports.py
+++ b/corehq/apps/userreports/tests/test_static_reports.py
@@ -20,7 +20,8 @@ class TestStaticReportConfig(SimpleTestCase, TestFileMixin):
     @classmethod
     def setUpClass(cls):
         super(TestStaticReportConfig, cls).setUpClass()
-        with patch('corehq.apps.callcenter.data_source.get_call_center_domains', MagicMock(return_value=[domain_lite('cc1')])):
+        with patch('corehq.apps.callcenter.data_source.get_call_center_domains',
+                   MagicMock(return_value=[domain_lite('cc1')])):
             cls.configs = list(StaticDataSourceConfiguration.all())
 
     def setUp(self):

--- a/corehq/apps/userreports/tests/test_static_reports.py
+++ b/corehq/apps/userreports/tests/test_static_reports.py
@@ -17,6 +17,11 @@ class TestStaticReportConfig(SimpleTestCase, TestFileMixin):
     file_path = ('data', 'static_reports')
     root = os.path.dirname(__file__)
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestStaticReportConfig, cls).setUpClass()
+        cls.configs = list(StaticDataSourceConfiguration.all())
+
     def setUp(self):
         super(TestStaticReportConfig, self).setUp()
         StaticReportConfiguration.by_id_mapping.reset_cache(StaticReportConfiguration.__class__)
@@ -27,31 +32,28 @@ class TestStaticReportConfig(SimpleTestCase, TestFileMixin):
 
     def test_get_all_json(self):
         with override_settings(STATIC_UCR_REPORTS=[self.get_path('static_report_config', 'json')]):
-            all = list(StaticReportConfiguration.all())
-            self.assertEqual(2, len(all))
-            example, dimagi = all
+            self.assertEqual(2, len(self.configs))
+            example, dimagi = self.configs
             self.assertEqual('example', example.domain)
             self.assertEqual('dimagi', dimagi.domain)
-            for config in all:
+            for config in self.configs:
                 self.assertEqual('Custom Title', config.title)
 
     def test_get_all_yaml(self):
         with override_settings(STATIC_UCR_REPORTS=[self.get_path('static_report_config', 'yaml')]):
-            all = list(StaticReportConfiguration.all())
-            self.assertEqual(2, len(all))
-            example, dimagi = all
+            self.assertEqual(2, len(self.configs))
+            example, dimagi = self.configs
             self.assertEqual('example', example.domain)
             self.assertEqual('dimagi', dimagi.domain)
-            for config in all:
+            for config in self.configs:
                 self.assertEqual('Custom Title', config.title)
 
     def test_production_config(self):
-        for report_config in StaticReportConfiguration.all():
+        for report_config in self.configs:
             report_config.validate()
 
     def test_for_report_id_conflicts(self):
-        counts = Counter(rc.get_id for rc in
-                         StaticReportConfiguration.all())
+        counts = Counter(rc.get_id for rc in self.configs)
         duplicates = [k for k, v in counts.items() if v > 1]
         msg = "The following report configs have duplicate generated report_ids:\n{}".format(
             "\n".join("report_id: {}".format(report_id) for report_id in duplicates)
@@ -70,8 +72,7 @@ class TestStaticReportConfig(SimpleTestCase, TestFileMixin):
             available_data_sources = data_sources_on_domain[report_config.domain]
             return report_config.config_id not in available_data_sources
 
-        all_configs = StaticReportConfiguration.all()
-        configs_missing_data_source = list(filter(has_no_data_source, all_configs))
+        configs_missing_data_source = list(filter(has_no_data_source, self.configs))
 
         msg = ("There are {} report configs which reference data sources that "
                "don't exist (or which don't exist on that domain):\n{}".format(


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/23874/files#diff-922e9297b3c8138d87abebf772e70923R64

Pulling all `StaticDataSourceConfiguration` is surprisingly (to me) slow; it takes a couple of seconds. This shares it among all of the tests in each class, which only ever read from it.