### PR TITLE
Fix intermittent test failures due to quickcache collisions

### DIFF
--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -43,13 +43,11 @@ from dimagi.utils.couch.cache.cache_core import get_redis_client
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
-from flaky import flaky
 from mock import patch
 from six.moves.urllib.parse import urlencode
 from six.moves import range
 
 
-@flaky
 class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
     @classmethod

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -330,7 +330,7 @@ class CommCareCase(DeferredBlobMixin, SafeSaveDocument, IndexHoldingMixIn,
         try:
             return super(CommCareCase, cls).get(id, **kwargs)
         except ResourceNotFound:
-            raise CaseNotFound
+            raise CaseNotFound(id)
 
     @classmethod
     def get_wrap_class(cls, data):

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -1,12 +1,13 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-import warnings
-import hashlib
-from quickcache.django_quickcache import get_django_quickcache
-from quickcache import ForceSkipCache
-from celery._state import get_current_task
-from corehq.util.global_request import get_request
+from __future__ import absolute_import, unicode_literals
 
+import os
+from base64 import b64encode
+
+from celery._state import get_current_task
+from quickcache import ForceSkipCache
+from quickcache.django_quickcache import get_django_quickcache
+
+from corehq.util.global_request import get_request
 from corehq.util.soft_assert import soft_assert
 
 quickcache_soft_assert = soft_assert(
@@ -20,27 +21,25 @@ def get_session_key():
     """
     returns a 7 character string that varies with the current "session" (task or request)
     """
-    session_id = None
     current_task = get_current_task()
-    if current_task:
-        # at least in tests, current_task may have the same id between different tasks!
-        session_id = current_task.request.id
-    if not session_id:
-        request = get_request()
-        if request:
-            session_id = str(id(get_request()))
-        else:
-            session_id = None
+    if current_task is not None:
+        return _quickcache_id(current_task.request)
+    request = get_request()
+    if request is not None:
+        return _quickcache_id(request)
+    # quickcache catches this and skips the cache
+    # this happens during tests (outside a fake task/request context)
+    # and during management commands
+    raise ForceSkipCache("Not part of a session")
 
-    if session_id:
-        session_id = session_id.encode('utf-8')
-        # hash it so that similar numbers end up very different (esp. because we're truncating)
-        return hashlib.md5(session_id).hexdigest()[:7]
-    else:
-        # quickcache catches this and skips the cache
-        # this happens during tests (outside a fake task/request context)
-        # and during management commands
-        raise ForceSkipCache("Not part of a session")
+
+def _quickcache_id(obj):
+    try:
+        value = obj.__quickcache_id
+    except AttributeError:
+        value = b64encode(os.urandom(5)).decode("ascii").rstrip("=\n")
+        obj.__quickcache_id = value
+    return value
 
 
 quickcache = get_django_quickcache(timeout=5 * 60, memoize_timeout=10,

--- a/corehq/util/tests/test_quickcache.py
+++ b/corehq/util/tests/test_quickcache.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, unicode_literals
+
+from testil import eq
+
+from ..quickcache import _quickcache_id
+
+
+def test_quickcache_id():
+    class Request(object):
+        pass
+
+    # 2 collisions routinely occur with a sample size of 1M
+    SAMPLE_SIZE = 1000
+    requests = [Request() for x in range(SAMPLE_SIZE)]
+    ids = [_quickcache_id(r) for r in requests]
+    eq(ids, [_quickcache_id(r) for r in requests])
+    eq({len(id) for id in ids}, {7})
+    # safe sanity check, 1% is NOT a reasonable collision rate
+    assert len(set(ids)) > SAMPLE_SIZE * .99, (len(set(ids)), SAMPLE_SIZE)


### PR DESCRIPTION
Should fix intermittent failures in `corehq.apps.sms.tests.test_backends`. May fix others as well.

Explanation of the fix: `LocMemCache` is not always cleared as expected because multiple session ids may be used within a single test if the test calls celery tasks and/or makes requests using a test client (this is unresolved). Additionally, session ids returned by `get_session_key()` had frequent collisions (resolved). The result is that previously cached values were resurfacing in other tests.

Additional context for why the `session_function` was introduced: https://github.com/dimagi/quickcache/pull/8

While this is a pragmatic fix to resolve intermittent test failures, I'm not leaving `corehq/util/quickcache.py` in a state that I'm happy with. There are things in there (use of global request and private/internal celery function) that seem like bad practices that should not be part of such a widely used component. Hacks like that make the system hard to understand and reason about. However, coming up with better solutions (e.g., Giovanni's proposal to set `memoize_timeout=0`) is likely to take careful thought and may require lots of refactoring, which is out of scope here.

@dannyroberts @snopoke buddy @calellowitz 