### PR TITLE
Pull multimedia asynchronously

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5580,6 +5580,7 @@ class LinkedApplication(Application):
     # from a bug years ago. These should be fixed when mobile can handle the change
     # https://manage.dimagi.com/default.asp?283410
     uses_master_app_form_ids = BooleanProperty(default=False)
+    multimedia_pulled = False
 
     @property
     @memoized

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -86,6 +86,12 @@ def update_linked_app_and_notify_task(domain, app_id, user_id, email):
     update_linked_app_and_notify(domain, app_id, user_id, email)
 
 
+@task(queue='background_queue')
+def pull_missing_multimedia_for_app_and_notify_task(domain, app_id, email=None):
+    from corehq.apps.app_manager.views.utils import pull_missing_multimedia_for_app_and_notify
+    pull_missing_multimedia_for_app_and_notify(domain, app_id, email)
+
+
 @task
 def load_appcues_template_app(domain, username, app_slug):
     from corehq.apps.app_manager.views.apps import load_app_from_slug

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -274,6 +274,28 @@
           </div>
         {% endif %}
       {% endif %}
+      {% if app.master_is_remote and not app.multimedia_pulled %}
+        <div class="panel panel-appmanager panel-appmanager-form">
+          <form action="{% url "pull_missing_multimedia" domain app.id %}" method="POST">
+            {% csrf_token %}
+            <legend>
+              {% trans "Pull missing multimedia" %}
+            </legend>
+            <div class="panel-body">
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" name="notify">
+                  {% trans "Email when finished (recommended for applications with large number of multimedia files or heavy files)" %}
+                </label>
+              </div>
+              <button type="submit" class="btn btn-primary">
+                <i class="fa fa-arrow-down"></i>
+                {% trans "Pull missing multimedia" %}
+              </button>
+            </div>
+          </form>
+        </div>
+      {% endif %}
       <div class="panel panel-appmanager panel-appmanager-form panel-appmanager-form-danger">
         <legend>{% trans "Delete Application" %}</legend>
         <div class="panel-body">

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -29,6 +29,7 @@ from corehq.apps.app_manager.views import (
     odk_media_qr_code, odk_install, short_url, short_odk_url, save_copy, revert_to_copy, delete_copy, list_apps,
     direct_ccz, download_index, download_file, get_form_questions, pull_master_app, edit_add_ons,
     update_linked_whitelist, overwrite_module_case_list, app_settings, toggle_build_profile,
+    pull_missing_multimedia,
 )
 from corehq.apps.app_manager.views.apps import move_child_modules_after_parents
 from corehq.apps.app_manager.views.modules import ExistingCaseTypesView
@@ -103,6 +104,8 @@ urlpatterns = [
         new_form, name='new_form'),
     url(r'^drop_user_case/(?P<app_id>[\w-]+)/$', drop_user_case, name='drop_user_case'),
     url(r'^pull_master/(?P<app_id>[\w-]+)/$', pull_master_app, name='pull_master_app'),
+    url(r'^pull_missing_multimedia/(?P<app_id>[\w-]+)/$', pull_missing_multimedia,
+        name='pull_missing_multimedia'),
     url(r'^linked_whitelist/(?P<app_id>[\w-]+)/$', update_linked_whitelist, name='update_linked_whitelist'),
 
     url(r'^delete_app/(?P<app_id>[\w-]+)/$', delete_app, name='delete_app'),

--- a/corehq/apps/app_manager/views/__init__.py
+++ b/corehq/apps/app_manager/views/__init__.py
@@ -30,6 +30,7 @@ from corehq.apps.app_manager.views.apps import (
     validate_language,
     view_app,
     pull_master_app,
+    pull_missing_multimedia,
     update_linked_whitelist,
 )
 from corehq.apps.app_manager.views.cli import (

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -45,7 +45,10 @@ from corehq.apps.app_manager.models import (
     load_app_template,
 )
 from corehq.apps.app_manager.models import import_app as import_app_util
-from corehq.apps.app_manager.tasks import update_linked_app_and_notify_task
+from corehq.apps.app_manager.tasks import (
+    update_linked_app_and_notify_task,
+    pull_missing_multimedia_for_app_and_notify_task,
+)
 from corehq.apps.app_manager.util import (
     get_settings_values,
     app_doc_types,
@@ -74,6 +77,7 @@ from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.linked_domain.applications import create_linked_app
 from corehq.apps.linked_domain.dbaccessors import is_master_linked_domain
 from corehq.apps.linked_domain.exceptions import RemoteRequestError
+from corehq.apps.linked_domain.remote_accessors import pull_missing_multimedia_for_app
 from corehq.apps.translations.models import Translation
 from corehq.apps.users.dbaccessors.all_commcare_users import get_practice_mode_mobile_workers
 from corehq.elastic import ESError
@@ -943,6 +947,18 @@ def pull_master_app(request, domain, app_id):
         messages.success(request, _('Your linked application was successfully updated to the latest version.'))
     track_workflow(request.couch_user.username, "Linked domain: master app pulled")
     return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[domain, app_id]))
+
+
+@require_can_edit_apps
+def pull_missing_multimedia(request, domain, app_id):
+    async_update = request.POST.get('notify') == 'on'
+    if async_update:
+        pull_missing_multimedia_for_app_and_notify_task.delay(domain, app_id, request.user.email)
+        messages.success(request,
+                         _('Your request has been submitted. We will notify you via email once completed.'))
+    else:
+        pull_missing_multimedia_for_app(domain, app_id)
+    return HttpResponseRedirect(reverse('app_settings', args=[domain, app_id]))
 
 
 @no_conflict_require_POST

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -934,7 +934,8 @@ def drop_user_case(request, domain, app_id):
 def pull_master_app(request, domain, app_id):
     async_update = request.POST.get('notify') == 'on'
     if async_update:
-        update_linked_app_and_notify_task.delay(domain, app_id, request.couch_user.get_id, request.couch_user.email)
+        update_linked_app_and_notify_task.delay(domain, app_id, request.couch_user.get_id,
+                                                request.couch_user.email)
         messages.success(request,
                          _('Your request has been submitted. We will notify you via email once completed.'))
     else:

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -283,9 +283,13 @@ def save_copy(request, domain, app_id):
     See VersionedDoc.save_copy
 
     """
+    app = get_app(domain, app_id)
+    if app.doc_type == "LinkedApplication" and not app.multimedia_pulled:
+        return JsonResponse({
+            'error': _("Multimedia yet to be pulled for the app.")
+        }, status=400)
     track_built_app_on_hubspot.delay(request.couch_user)
     comment = request.POST.get('comment')
-    app = get_app(domain, app_id)
     try:
         errors = app.validate_app()
     except ModuleIdMissingException:

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -373,18 +373,13 @@ def update_linked_app(app, user_id):
                 ).format(ucr_id=str(e))
             )
 
-    if app.master_is_remote:
-        try:
-            pull_missing_multimedia_for_app(app)
-        except RemoteRequestError:
-            raise AppLinkError(_(
-                'Error fetching multimedia from remote server. Please try again later.'
-            ))
-
     app.domain_link.update_last_pull('app', user_id, model_details=AppLinkDetail(app_id=app._id))
 
     # reapply linked application specific data
     app.reapply_overrides()
+
+    if app.master_is_remote:
+        pull_missing_multimedia_for_app.delay(app.domain, app.get_id)
 
 
 def clear_xmlns_app_id_cache(domain):

--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import requests
-import json
+
 from couchdbkit.exceptions import ResourceNotFound
 from django.urls.base import reverse
 from requests import ConnectionError
@@ -17,7 +17,7 @@ from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.apps.linked_domain.auth import ApiKeyAuth
 from corehq.apps.linked_domain.exceptions import RemoteRequestError, RemoteAuthError, ActionNotPermitted
 from corehq.util.view_utils import absolute_reverse
-from corehq.util.soft_assert import soft_assert
+
 from dimagi.utils.logging import notify_exception
 from django.utils.translation import ugettext as _
 


### PR DESCRIPTION
It came to attention that pulling multimedia files can be a long running process.
For ex: it took 14 mins to just find the multimedia that can be possibly missing for AWW app on ICDS.
```
In [47]: with TimingContext() as timer:
    ...:     missing_media = _get_missing_multimedia(app)
    ...:

In [48]: timer.duration
Out[48]: 830.3005919456482

In [49]: timer.duration/60
Out[49]: 13.838343199094137
```
Users can be left clueless about where the process is at.

This PR 
1. extracts multimedia pull as a separate asynchronous process performed
2. let the user pull missing mm in case of failure
3. stops user from creating a new version until mm is pulled so that the CCZ can eventually have all mm.