### PR TITLE
Diff cases in separate process and reduce memory load

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -32,6 +32,7 @@ from .diff import filter_case_diffs, filter_ledger_diffs
 log = logging.getLogger(__name__)
 
 STATUS_INTERVAL = 300  # 5 minutes
+MAX_FORMS_PER_MEMORIZED_CASE = 20
 
 
 class CaseDiffQueue(object):
@@ -39,12 +40,13 @@ class CaseDiffQueue(object):
 
     Cases in the queue are moved through the following phases:
 
-      - Phase 1: Accumulate cases touched by forms as they are
-        processed. When a sufficiently sized batch of cases that have
-        not been seen before has accumulated, move it to phase 2. Cases
-        that have previously been loaded by phase 2 are updated in this
-        phase, and will be directly enqueued to diff (sent to phase 3)
-        when the last form for a case has been processed.
+      - Phase 0: Receive cases as forms are processed. Accumulate
+        in batches to be processed in phase 1.
+      - Phase 1: Accumulate cases that have not been seen before. When a
+        sufficiently sized batch has accumulated, move it to phase 2.
+        Cases that have previously been loaded by phase 2 are updated in
+        this phase, and will be directly enqueued to diff (sent to phase
+        3) when the last form for a case has been processed.
       - Phase 2: Load full case documents from couch to get the list of
         forms touched by each case. The cases are updated with processed
         forms and enqueued to be diffed when all relevant forms have
@@ -63,20 +65,15 @@ class CaseDiffQueue(object):
     def __init__(self, statedb, status_interval=STATUS_INTERVAL):
         self.statedb = statedb
         self.status_interval = status_interval
-        self.pending_cases = defaultdict(set)  # case id -> processed form ids
+        self.pending_cases = defaultdict(int)  # case id -> processed form count
+        self.pending_loads = defaultdict(int)  # case id -> processed form count
         self.cases_to_diff = {}  # case id -> case doc (JSON)
         self.pool = Pool(5)
         self.case_batcher = BatchProcessor(self.pool)
         self.diff_batcher = BatchProcessor(self.pool)
-
-        # Core data structure: case id -> CaseRecord. Each CaseRecord
-        # maintains a set of unprocessed form ids for each case known
-        # to the migration. Forms are removed from the set as they are
-        # processed. When the set of form ids for a given case becomes
-        # empty it is queued to be diffed and the corresponding
-        # CaseRecord is removed.
         self.cases = {}
         self.num_diffed_cases = 0
+        self._is_flushing = False
 
     def __enter__(self):
         self._load_resume_state()
@@ -88,8 +85,8 @@ class CaseDiffQueue(object):
             if exc_type is None:
                 self.process_remaining_diffs()
         finally:
-            self._stop_status_logger()
             self._save_resume_state()
+            self._stop_status_logger()
 
     def update(self, case_ids, form_id):
         """Update the case diff queue with case ids touched by form
@@ -98,63 +95,92 @@ class CaseDiffQueue(object):
         :param form_id: form id touching case ids.
         """
         log.debug("update: cases=%s form=%s", case_ids, form_id)
-        cases = self.cases
         pending = self.pending_cases
         for case_id in case_ids:
-            if case_id in cases:
-                self._try_to_diff(cases[case_id], [form_id])
-            else:
-                pending[case_id].add(form_id)
-                if len(pending) >= self.BATCH_SIZE:
-                    self._add_pending_cases(pending)
-                    pending = self.pending_cases = defaultdict(set)
+            pending[case_id] += 1
+            if len(pending) >= self.BATCH_SIZE:
+                self._async_enqueue_or_load(pending)
+                pending = self.pending_cases = defaultdict(int)
         task_switch()
 
-    def _add_pending_cases(self, pending_cases):
-        log.debug("add pending cases %s", pending_cases)
-        return self.case_batcher.spawn(self._load_cases, pending_cases)
+    def _async_enqueue_or_load(self, pending):
+        self.case_batcher.spawn(self._enqueue_or_load, pending)
+
+    def _enqueue_or_load(self, pending):
+        """Enqueue or load pending cases
+
+        Update processed form counts and enqueue cases to be diffed when
+        all corresponding forms have been processed. Accumulate a batch
+        of unknown cases and spawn it to be loaded once big enough.
+
+        :param pending: dict `{<case_id>: <processed_form_count>, ...}`
+        """
+        log.debug("enqueue or load %s", pending)
+        to_diff = []
+        batch = self.pending_loads
+        result = self.statedb.add_processed_forms(pending)
+        for case_id, total_forms, processed_forms in result:
+            if total_forms is None:
+                batch[case_id] += pending[case_id]
+                if len(batch) >= self.BATCH_SIZE:
+                    self._async_load_cases(batch)
+                    batch = self.pending_loads = defaultdict(int)
+            elif total_forms <= processed_forms:
+                to_diff.append(case_id)
+        if self._is_flushing and batch:
+            self._load_cases(batch)
+            self.pending_loads = defaultdict(int)
+        if to_diff:
+            self._enqueue_cases(to_diff)
+
+    def _async_load_cases(self, pending):
+        self.case_batcher.spawn(self._load_cases, pending)
 
     def _load_cases(self, pending):
-        """Load cases and try to diff them as forms are processed
+        """Load cases and establish total and processed form counts
 
-        :param pending: dict of processed form id sequences (list
-        or set) by case id.
+        Cases for which all forms have been processed are enqueued to be
+        diffed.
+
+        :param pending: dict `{<case_id>: <processed_form_count>, ...}`
         """
+        log.debug("enqueue or load %s", pending)
         cases = self.cases
         case_ids = list(pending)
-        loaded_case_ids = set()
+        loaded_cases = {}
+        case_records = []
+        enqueued = set()
         stock_forms = get_stock_forms_by_case_id(case_ids)
         for case in CaseAccessorCouch.get_cases(case_ids):
-            loaded_case_ids.add(case.case_id)
-            if case.case_id not in cases:
-                case_stock_forms = stock_forms.get(case.case_id, [])
-                rec = cases[case.case_id] = CaseRecord(case, case_stock_forms)
-            else:
-                # It's unlikley, but possible that the case has already
-                # been loaded by a concurrent invocation of `_load_cases`
-                # in which case we use that one so as not to lose its
-                # processed forms.
-                rec = cases[case.case_id]
-            self._try_to_diff(rec, pending[case.case_id])
-        missing = set(case_ids) - loaded_case_ids
+            loaded_cases[case.case_id] = case
+            case_stock_forms = stock_forms.get(case.case_id, [])
+            rec = CaseRecord(case, case_stock_forms, pending[case.case_id])
+            case_records.append(rec)
+            if rec.should_memorize_case:
+                log.debug("memorize %s", rec)
+                cases[case.case_id] = case
+        if case_records:
+            result = self.statedb.update_cases(case_records)
+            for case_id, total_forms, processed_forms in result:
+                if total_forms <= processed_forms and case_id not in enqueued:
+                    self.enqueue(loaded_cases[case_id].to_json())
+        missing = set(case_ids) - set(loaded_cases)
         if missing:
             log.error("Found %s missing Couch cases", len(missing))
             self.statedb.add_missing_docs("CommCareCase-couch", missing)
 
-    def _try_to_diff(self, rec, processed_form_ids):
-        """Add processed forms to case record and enqueue to diff if possible
-
-        :param rec: CaseRecord
-        :param processed_form_ids: sequence of processed form ids.
-        """
-        log.debug("trying case %s forms %s - %s",
-            rec.id, rec.remaining_forms, processed_form_ids)
-        rec.add_processed(processed_form_ids)
-        if rec.is_unexpected:
-            log.info("case %s unexpectedly updated by %s", rec.id, processed_form_ids)
-            self.statedb.add_unexpected_diff(rec.id)
-        if rec.should_diff:
-            self.enqueue(rec.case.to_json())
+    def _enqueue_cases(self, case_ids):
+        log.debug("enqueue cases %s", case_ids)
+        to_load = []
+        get_case = self.cases.get
+        for case_id in case_ids:
+            case = get_case(case_id)
+            if case is None:
+                to_load.append(case_id)
+            else:
+                self.enqueue(case.to_json())
+        for case in CaseAccessorCouch.get_cases(to_load):
+            self.enqueue(case.to_json())
 
     def enqueue(self, case_doc):
         case_id = case_doc["_id"]
@@ -173,16 +199,7 @@ class CaseDiffQueue(object):
 
     def process_remaining_diffs(self):
         log.debug("process remaining diffs")
-        if self.pending_cases:
-            add_pending = self._add_pending_cases(self.pending_cases)
-            self.pending_cases = defaultdict(set)
-            gevent.joinall([add_pending])
-        for rec in list(self.cases.values()):
-            self.enqueue(rec.case.to_json())
-        self._flush()
-        self._rediff_unexpected()
-        self._flush()
-        assert not self.pending_cases, self.pending_cases
+        self.flush()
         for batcher, action in [
             (self.case_batcher, "loaded"),
             (self.diff_batcher, "diffed"),
@@ -191,29 +208,44 @@ class CaseDiffQueue(object):
                 log.warn("%s batches of cases could not be %s", len(batcher), action)
         self.pool = None
 
-    def _flush(self):
-        pool = self.pool
-        while self.cases_to_diff or pool:
-            if self.cases_to_diff:
-                self._diff_cases()
+    def flush(self, complete=True):
+        """Process cases in the queue
+
+        :param complete: diff cases with unprocessed forms if true (the default)
+        """
+        def join(pool):
             while not pool.join(timeout=10):
                 log.info('Waiting on {} case diff workers'.format(len(pool)))
 
-    def _rediff_unexpected(self):
-        unexpected = self.statedb.iter_unexpected_diffs()
-        for case_ids in chunked(unexpected, self.BATCH_SIZE, list):
-            log.debug("re-diff %s", case_ids)
-            self.statedb.discard_case_diffs(case_ids)
-            self._enqueue_cases(case_ids)
+        log.debug("begin flush")
+        pool = self.pool
+        self._is_flushing = True
+        try:
+            if self.pending_cases:
+                self._enqueue_or_load(self.pending_cases)
+                self.pending_cases = defaultdict(int)
+            join(pool)
+            if complete:
+                to_diff = self.statedb.iter_cases_with_unprocessed_forms()
+                for chunk in chunked(to_diff, self.BATCH_SIZE, list):
+                    self._enqueue_cases(chunk)
+            while self.cases_to_diff or pool:
+                if self.cases_to_diff:
+                    self._diff_cases()
+                join(pool)
+            assert not self.pending_cases, self.pending_cases
+            assert not self.pending_loads, self.pending_loads
+        finally:
+            self._is_flushing = False
+        log.debug("end flush")
 
     def _save_resume_state(self):
         state = {}
-        if self.pending_cases or self.case_batcher or self.cases:
-            recs = ((r.id, list(r.processed_forms)) for r in self.cases.values())
-            pending = defaultdict(list, recs)
-            for batch in chain(self.case_batcher, [self.pending_cases]):
+        if self.pending_cases or self.pending_loads or self.case_batcher:
+            pending = defaultdict(int, self.pending_cases)
+            for batch in chain(self.case_batcher, [self.pending_loads]):
                 for case_id, processed_forms in batch.items():
-                    pending[case_id].extend(processed_forms)
+                    pending[case_id] += processed_forms
             state["pending"] = dict(pending)
         if self.diff_batcher or self.cases_to_diff:
             state["to_diff"] = list(chain.from_iterable(self.diff_batcher))
@@ -230,13 +262,9 @@ class CaseDiffQueue(object):
                 self.diff_batcher.spawn(self._enqueue_cases, chunk)
         if "pending" in state:
             for chunk in chunked(state["pending"].items(), self.BATCH_SIZE, list):
-                self._add_pending_cases(dict(chunk))
+                self._async_load_cases(dict(chunk))
         if "num_diffed_cases" in state:
             self.num_diffed_cases = state["num_diffed_cases"]
-
-    def _enqueue_cases(self, case_ids):
-        for case in CaseAccessorCouch.get_cases(case_ids):
-            self.enqueue(case.to_json())
 
     def run_status_logger(self):
         """Start periodic status logger in a greenlet
@@ -273,6 +301,7 @@ class CaseDiffQueue(object):
         return {
             "pending_cases": (
                 len(self.pending_cases)
+                + len(self.pending_loads)
                 + sum(len(batch) for batch in self.case_batcher)
                 + len(self.cases)
             ),
@@ -290,34 +319,23 @@ def task_switch():
 
 class CaseRecord(object):
 
-    def __init__(self, case, stock_forms):
-        self.case = case
-        self.remaining_forms = get_case_form_ids(case)
-        self.remaining_forms.update(stock_forms)
-        self.processed_forms = set()
+    def __init__(self, case, stock_forms, processed_forms):
+        self.id = case.case_id
+        case_forms = get_case_form_ids(case)
+        self.total_forms = len(case_forms) + len(stock_forms)
+        self.processed_forms = processed_forms
+
+    def __repr__(self):
+        return "case {id} with {n} of {m} forms processed".format(
+            id=self.id,
+            n=self.processed_forms,
+            m=self.total_forms,
+        )
 
     @property
-    def id(self):
-        return self.case.case_id
-
-    def add_processed(self, form_ids):
-        for form_id in form_ids:
-            try:
-                self.remaining_forms.remove(form_id)
-            except KeyError:
-                pass
-            else:
-                self.processed_forms.add(form_id)
-        if self.is_unexpected:
-            self.remaining_forms.clear()
-
-    @property
-    def should_diff(self):
-        return not self.remaining_forms
-
-    @property
-    def is_unexpected(self):
-        return not self.processed_forms
+    def should_memorize_case(self):
+        # do not keep cases with large history in memory
+        return self.total_forms <= MAX_FORMS_PER_MEMORIZED_CASE
 
 
 def get_case_form_ids(couch_case):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -98,17 +98,17 @@ def setup_logging(log_dir, debug=False):
     log.info("command: %s", " ".join(sys.argv))
 
 
-def do_couch_to_sql_migration(domain, with_progress=True):
+def do_couch_to_sql_migration(domain, state_dir, with_progress=True):
     set_local_domain_sql_backend_override(domain)
-    CouchSqlDomainMigrator(domain, with_progress).migrate()
+    CouchSqlDomainMigrator(domain, state_dir, with_progress).migrate()
 
 
 class CouchSqlDomainMigrator(object):
-    def __init__(self, domain, with_progress=True):
+    def __init__(self, domain, state_dir, with_progress=True):
         self._check_for_migration_restrictions(domain)
         self.with_progress = with_progress
         self.domain = domain
-        self.statedb = init_state_db(domain)
+        self.statedb = init_state_db(domain, state_dir)
         self.case_diff_queue = CaseDiffQueue(self.statedb)
         # exit immediately on uncaught greenlet error
         gevent.get_hub().SYSTEM_ERROR = BaseException

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -22,7 +22,7 @@ from django.db.utils import IntegrityError
 from gevent.pool import Pool
 
 from corehq.apps.couch_sql_migration.asyncforms import AsyncFormProcessor
-from corehq.apps.couch_sql_migration.casediff import CaseDiffQueue
+from corehq.apps.couch_sql_migration.casediff import CaseDiffProcess
 from corehq.apps.couch_sql_migration.diff import filter_form_diffs
 from corehq.apps.couch_sql_migration.statedb import init_state_db
 from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_type
@@ -109,7 +109,7 @@ class CouchSqlDomainMigrator(object):
         self.with_progress = with_progress
         self.domain = domain
         self.statedb = init_state_db(domain, state_dir)
-        self.case_diff_queue = CaseDiffQueue(self.statedb)
+        self.case_diff_queue = CaseDiffProcess(self.statedb)
         # exit immediately on uncaught greenlet error
         gevent.get_hub().SYSTEM_ERROR = BaseException
 

--- a/corehq/apps/couch_sql_migration/lrudict.py
+++ b/corehq/apps/couch_sql_migration/lrudict.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import sys
+from itertools import islice
+
+_native_dict = sys.version_info[:2] >= (3, 6)
+if _native_dict:
+    _dict = dict
+else:
+    from collections import OrderedDict as _dict
+
+
+class LRUDict(_dict):
+    """Least-recently-used dictionary
+
+    Length-limited dictionary that discards least recently "used" items.
+    The definition of "used" in this context means accessed with `get`
+    or `__getitem__` or set by any mutating method.
+    """
+
+    __slots__ = ("max_size",)
+
+    def __init__(self, max_size):
+        super(LRUDict, self).__init__()
+        self.max_size = max_size
+
+    def __getitem__(self, key):
+        if _native_dict:
+            value = self.pop(key)
+        else:
+            value = super(LRUDict, self).__getitem__(key)
+            del self[key]
+        super(LRUDict, self).__setitem__(key, value)
+        return value
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __setitem__(self, key, value):
+        self.pop(key, None)
+        super(LRUDict, self).__setitem__(key, value)
+        self._lru_trim()
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key] = default
+            self._lru_trim()
+            return default
+
+    def update(self, *args, **kw):
+        super(LRUDict, self).update(*args, **kw)
+        self._lru_trim()
+
+    def _lru_trim(self):
+        discard_n = len(self) - self.max_size
+        if discard_n > 0:
+            for key in list(islice(self, discard_n)):
+                del self[key]
+
+    def copy(self):
+        raise NotImplementedError
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        raise NotImplementedError
+
+    if not _native_dict:
+        # OrderedDict defines these methods in a way that never
+        # returns with a mutating __getitem__
+
+        def items(self):
+            get = super(LRUDict, self).__getitem__
+            return [(key, get(key)) for key in self]
+
+        def iteritems(self):
+            get = super(LRUDict, self).__getitem__
+            for k in self:
+                yield (k, get(k))
+
+        def values(self):
+            get = super(LRUDict, self).__getitem__
+            return [get(key) for key in self]
+
+        def itervalues(self):
+            get = super(LRUDict, self).__getitem__
+            for k in self:
+                yield get(k)

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -58,6 +58,9 @@ class StateDB(DiffDB):
         return self
 
     def __exit__(self, *exc_info):
+        self.close()
+
+    def close(self):
         self.engine.dispose()
         if self._connection is not None:
             self._connection.close()

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -18,18 +18,21 @@ from sqlalchemy import func, Column, Index, Integer, String, Text
 from corehq.apps.tzmigration.planning import Base, DiffDB, PlanningDiff as Diff
 
 
-def init_state_db(domain):
-    db_filepath = _get_state_db_filepath(domain)
+def init_state_db(domain, state_dir):
+    db_filepath = _get_state_db_filepath(domain, state_dir)
+    db_dir = os.path.dirname(db_filepath)
+    if os.path.isdir(state_dir) and not os.path.isdir(db_dir):
+        os.mkdir(db_dir)
     return StateDB.init(db_filepath)
 
 
-def open_state_db(domain):
-    db_filepath = _get_state_db_filepath(domain)
+def open_state_db(domain, state_dir):
+    db_filepath = _get_state_db_filepath(domain, state_dir)
     return StateDB.open(db_filepath)
 
 
-def delete_state_db(domain):
-    db_filepath = _get_state_db_filepath(domain)
+def delete_state_db(domain, state_dir):
+    db_filepath = _get_state_db_filepath(domain, state_dir)
     try:
         os.remove(db_filepath)
     except OSError as e:
@@ -37,9 +40,8 @@ def delete_state_db(domain):
             raise
 
 
-def _get_state_db_filepath(domain):
-    return os.path.join(settings.SHARED_DRIVE_CONF.tzmigration_planning_dir,
-                        '{}-tzmigration.db'.format(domain))
+def _get_state_db_filepath(domain, state_dir):
+    return os.path.join(state_dir, "db", '{}-couch-sql.db'.format(domain))
 
 
 class StateDB(DiffDB):

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import logging
 from collections import defaultdict
 from contextlib import contextmanager
+from copy import deepcopy
 try:
     from inspect import signature
 except ImportError:
@@ -16,9 +17,10 @@ from django.test import SimpleTestCase
 from gevent.event import Event
 from gevent.queue import Queue
 from mock import patch
-from testil import tempdir
+from testil import Config, tempdir
 
 from corehq.apps.tzmigration.timezonemigration import FormJsonDiff
+from corehq.form_processor.parsers.ledgers.helpers import UniqueLedgerReference
 
 from .. import casediff as mod
 from ..statedb import delete_state_db, init_state_db, StateDB
@@ -504,6 +506,136 @@ class TestBatchProcessor(SimpleTestCase):
         with silence_expected_errors(), self.assertRaises(Error):
             flush(self.proc.pool)
         self.assertEqual(len(tries), 3)
+
+
+class TestDiffCases(SimpleTestCase):
+
+    def setUp(self):
+        super(TestDiffCases, self).setUp()
+        self.patches = [
+            patch(
+                "corehq.form_processor.backends.sql.dbaccessors.CaseAccessorSQL.get_cases",
+                self.get_sql_cases,
+            ),
+            patch(
+                "corehq.form_processor.backends.sql.dbaccessors"
+                ".LedgerAccessorSQL.get_ledger_values_for_cases",
+                self.get_sql_ledgers,
+            ),
+            patch(
+                "corehq.apps.commtrack.models.StockState.objects.filter",
+                self.get_stock_states,
+            ),
+            patch(
+                "corehq.form_processor.backends.couch.processor"
+                ".FormProcessorCouch.hard_rebuild_case",
+                self.hard_rebuild_case,
+            ),
+        ]
+
+        for patcher in self.patches:
+            patcher.start()
+        self.statedb = StateDB.init(":memory:")
+        self.sql_cases = {}
+        self.sql_ledgers = {}
+        self.couch_cases = {}
+        self.couch_ledgers = {}
+
+    def tearDown(self):
+        for patcher in self.patches:
+            patcher.stop()
+        self.statedb.close()
+        super(TestDiffCases, self).tearDown()
+
+    def test_clean(self):
+        self.add_case("a")
+        mod.diff_cases(self.couch_cases, self.statedb)
+        self.assert_diffs()
+
+    def test_diff(self):
+        couch_json = self.add_case("a", prop=1)
+        couch_json["prop"] = 2
+        mod.diff_cases(self.couch_cases, self.statedb)
+        self.assert_diffs([Diff("a", path=["prop"], old=2, new=1)])
+
+    def test_replace_diff(self):
+        self.add_case("a", prop=1)
+        different_cases = deepcopy(self.couch_cases)
+        different_cases["a"]["prop"] = 2
+        mod.diff_cases(different_cases, self.statedb)
+        self.assert_diffs([Diff("a", path=["prop"], old=2, new=1)])
+        mod.diff_cases(self.couch_cases, self.statedb)
+        self.assert_diffs()
+
+    def test_replace_ledger_diff(self):
+        self.add_case("a")
+        stock = self.add_ledger("a", x=1)
+        stock.values["x"] = 2
+        mod.diff_cases(self.couch_cases, self.statedb)
+        self.assert_diffs([Diff("a/stock/a", "stock state", path=["x"], old=2, new=1)])
+        stock.values["x"] = 1
+        mod.diff_cases(self.couch_cases, self.statedb)
+        self.assert_diffs()
+
+    def assert_diffs(self, expected=None):
+        actual = [
+            Diff(diff.doc_id, diff.kind, *diff.json_diff)
+            for diff in self.statedb.get_diffs()
+        ]
+        self.assertEqual(actual, expected or [])
+
+    def add_case(self, case_id, **props):
+        assert case_id not in self.sql_cases, self.sql_cases[case_id]
+        assert case_id not in self.couch_cases, self.couch_cases[case_id]
+        props.setdefault("doc_type", "CommCareCase")
+        self.sql_cases[case_id] = Config(
+            case_id=case_id,
+            props=props,
+            to_json=lambda: dict(props, case_id=case_id),
+            is_deleted=False,
+        )
+        self.couch_cases[case_id] = couch_case = dict(props, case_id=case_id)
+        return couch_case
+
+    def add_ledger(self, case_id, **values):
+        ref = UniqueLedgerReference(case_id, "stock", case_id)
+        self.sql_ledgers[case_id] = Config(
+            ledger_reference=ref,
+            values=values,
+            to_json=lambda: dict(values, ledger_reference=ref.as_id()),
+        )
+        couch_values = dict(values)
+        stock = Config(
+            ledger_reference=ref,
+            values=couch_values,
+            to_json=lambda: dict(couch_values, ledger_reference=ref.as_id()),
+        )
+        self.couch_ledgers[case_id] = stock
+        return stock
+
+    def get_sql_cases(self, case_ids):
+        return [self.sql_cases[c] for c in case_ids]
+
+    def get_sql_ledgers(self, case_ids):
+        ledgers = self.sql_ledgers
+        return [ledgers[c] for c in case_ids if c in ledgers]
+
+    def get_stock_states(self, case_id__in):
+        ledgers = self.couch_ledgers
+        return [ledgers[c] for c in case_id__in if c in ledgers]
+
+    def hard_rebuild_case(self, domain, case_id, *args, **kw):
+        return Config(to_json=lambda: self.couch_cases[case_id])
+
+
+@attr.s
+class Diff(object):
+    doc_id = attr.ib()
+    kind = attr.ib(default="CommCareCase")
+    type = attr.ib(default="diff")
+    path = attr.ib(factory=list)
+    old = attr.ib(default=None)
+    new = attr.ib(default=None)
 
 
 @attr.s

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -440,7 +440,7 @@ class TestCaseDiffProcess(SimpleTestCase):
         def log_status(status):
             log.info("status: %s", status)
             keys = ["pending_cases", "pending_diffs", "diffed_cases"]
-            assert keys == list(status), status
+            assert set(keys) == set(status), status
             queue.put([status[k] for k in keys])
 
         queue = Queue()

--- a/corehq/apps/couch_sql_migration/tests/test_lrudict.py
+++ b/corehq/apps/couch_sql_migration/tests/test_lrudict.py
@@ -1,0 +1,67 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from nose.plugins.skip import SkipTest
+from testil import assert_raises, eq
+
+from ..lrudict import LRUDict
+
+
+def test_getitem():
+    lru = LRUDict(3)
+    for x in range(4):
+        lru[x] = x * 2
+        eq(lru[0], 0, "x: %s" % x)
+    with assert_raises(KeyError):
+        lru[-1]
+    assert_items_equal(lru, [(2, 4), (3, 6), (0, 0)])
+
+
+def test_get():
+    lru = LRUDict(3)
+    for x in range(4):
+        lru[x] = x * 2
+        eq(lru.get(0), 0, "x: %s" % x)
+    eq(lru.get(-1, -2), -2)
+    assert_items_equal(lru, [(2, 4), (3, 6), (0, 0)])
+
+
+def test_setitem():
+    lru = LRUDict(3)
+    for x in range(4):
+        lru[x] = x * 2
+    lru[2] = 5
+    assert_items_equal(lru, [(1, 2), (3, 6), (2, 5)])
+
+
+def test_setdefault():
+    lru = LRUDict(3)
+    for x in range(4):
+        lru.setdefault(x, x * 2)
+        lru.setdefault(0, 1000)
+    assert_items_equal(lru, [(2, 4), (3, 6), (0, 0)])
+
+
+def test_update():
+    lru = LRUDict(3)
+    lru.update((x, x * 2) for x in range(4))
+    assert_items_equal(lru, [(1, 2), (2, 4), (3, 6)])
+
+
+def test_update_with_duplicate_keys():
+    raise SkipTest("broken edge case")
+    lru = LRUDict(3)
+    lru.update((x, x) for x in [0, 1, 2, 3, 0])
+    assert_items_equal(lru, [(2, 4), (3, 6), (0, 0)])
+
+
+def assert_items_equal(lru, items):
+    keys = [k for k, v in items]
+    values = [v for k, v in items]
+    eq(list(lru.items()), items)
+    eq(list(lru), keys)
+    eq(list(lru.keys()), keys)
+    eq(list(lru.values()), values)
+    if hasattr(lru, "iterkeys"):
+        eq(list(lru.iterkeys()), keys)
+        eq(list(lru.itervalues()), values)

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import pickle
 import re
 
 from sqlalchemy.exc import OperationalError
@@ -111,3 +112,11 @@ def test_diff_doc_id_idx_exists():
     msg = re.compile("index diff_doc_id_idx already exists")
     with init_db() as db, assert_raises(OperationalError, msg=msg):
         diff_doc_id_idx.create(db.engine)
+
+
+def test_pickle():
+    with init_db() as db:
+        other = pickle.loads(pickle.dumps(db))
+        assert isinstance(other, type(db)), (other, db)
+        assert other is not db
+        eq(db.unique_id, other.unique_id)

--- a/corehq/apps/tzmigration/planning.py
+++ b/corehq/apps/tzmigration/planning.py
@@ -88,6 +88,12 @@ class BaseDB(object):
             'sqlite+pysqlite:///{}'.format(db_filepath), module=sqlite)
         self.Session = sessionmaker(bind=self.engine)
 
+    def __getstate__(self):
+        return self.db_filepath
+
+    def __setstate__(self, db_filepath):
+        self.__init__(db_filepath)
+
     @classmethod
     def init(cls, db_filepath):
         self = cls(db_filepath)

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -80,9 +80,11 @@ faker==0.8.15
 fixture==1.5.11
 flaky==3.6.0
 freezegun==0.3.11
+funcsigs==1.0.2
 future==0.17.1            # via commonmark
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 gnureadline==6.3.8
 graphviz==0.7
 greenlet==0.4.15

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -72,8 +72,10 @@ eulxml==1.1.3
 eventlet==0.24.1          # via errand-boy
 faker==0.8.15
 flower==0.9.2
+funcsigs==1.0.2
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -67,8 +67,10 @@ et-xmlfile==1.0.1         # via openpyxl
 ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 faker==0.8.15
+funcsigs==1.0.2
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -74,8 +74,10 @@ fakecouch==0.0.15
 faker==0.8.15
 flaky==3.6.0
 freezegun==0.3.11
+funcsigs==1.0.2
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -85,11 +85,12 @@ faker==0.8.15
 fixture==1.5.11
 flaky==3.6.0
 freezegun==0.3.11
-funcsigs==1.0.2           # via mock
+funcsigs==1.0.2
 future==0.17.1            # via commonmark
 futures==3.2.0            # via s3transfer, tinys3
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 gnureadline==6.3.8
 graphviz==0.7
 greenlet==0.4.15

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -74,10 +74,11 @@ eulxml==1.1.3
 eventlet==0.24.1          # via errand-boy
 faker==0.8.15
 flower==0.9.2
-funcsigs==1.0.2           # via mock
+funcsigs==1.0.2
 futures==3.2.0            # via flower, s3transfer, tinys3
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -50,6 +50,8 @@ simplejson~=3.11
 sh==1.09
 gevent==1.4.0
 greenlet==0.4.15
+gipc~=1.0.1  # for gevent+multiprocessing, used by Couch to SQL migration
+funcsigs>=1.0.2  # can be removed after Python 3 upgrade
 openpyxl~=2.6
 six~=1.11
 socketpool==0.5.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -69,10 +69,11 @@ et-xmlfile==1.0.1         # via openpyxl
 ethiopian-date-converter==0.1.5
 eulxml==1.1.3
 faker==0.8.15
-funcsigs==1.0.2           # via mock
+funcsigs==1.0.2
 futures==3.2.0            # via s3transfer, tinys3
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -78,10 +78,11 @@ fakecouch==0.0.15
 faker==0.8.15
 flaky==3.6.0
 freezegun==0.3.11
-funcsigs==1.0.2           # via mock
+funcsigs==1.0.2
 futures==3.2.0            # via s3transfer, tinys3
 gevent==1.4.0
 ghdiff==0.4
+gipc==1.0.1
 greenlet==0.4.15
 gunicorn==19.9.0
 hiredis==0.2.0


### PR DESCRIPTION
- The state directory has been moved away from the shared drive because NFS is not a safe place to store SQLite db files that are shred between multiple processes.
- The `gipc` library was added because gevent doesn't play nicely with Python's built-in multiprocessing library.
- The algorithm for determining when a case should be diffed has changed: forms are counted for each case as they are processed, and the count is compared to the total number of forms that update the case. A case is diffed when the number of processed forms is greater than or equal to the number of forms expected to update it. This greatly reduces the memory requirements and makes it easier to persist the migration state incrementally as forms are processed. This new algorithm enabled use of an LRU cache for cases kept in memory to further limit memory usage.

This is getting close to being ready for prime time. The remaining tasks are

- Track operations that are not reflected as new forms (archives, deletes, etc.) to allow the migration to be safely stopped and resumed while the domain is online.
- Review and document process for full migration. Two options:
  - Complete migration in one go with downtime
  - Multi-step migration for large domains: livemigrate first, then finish with downtime.

🐡 Review by commit.