### PR TITLE
Added XML mode and search box back to ace

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/base_ace.js
@@ -3,11 +3,15 @@ hqDefine('hqwebapp/js/base_ace', [
     'knockout',
     'ace-builds/src-min-noconflict/ace',
     'ace-builds/src-min-noconflict/mode-json',
+    'ace-builds/src-min-noconflict/mode-xml',
+    'ace-builds/src-min-noconflict/ext-searchbox',
 ], function (
     $,
     ko,
     ace,
-    jsonMode  // eslint-disable-line no-unused-vars
+    jsonMode,  // eslint-disable-line no-unused-vars
+    xmlMode,   // eslint-disable-line no-unused-vars
+    searchBox  // eslint-disable-line no-unused-vars
 ) {
 
     var initAceEditor = function (element, mode, options, value) {


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/24955 - XML mode is used on app manager's View Source Files page. The search box is a nice-to-have for searching only within an ace block.

Feature flag: View Source Files is behind the "Support" flag.