### PR TITLE
Ignore in celery check any blockage under 5 minutes

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -141,7 +141,10 @@ def check_celery():
             except HeartbeatNeverRecorded:
                 blocked_queues.append((queue, 'as long as we can see', threshold))
             else:
-                if blockage_duration > threshold:
+                # We get a lot of self-resolving celery "downtime" under 5 minutes
+                # so to make actionable, we never alert on blockage under 5 minutes
+                # It is still counted as out of SLA for the celery uptime metric in datadog
+                if blockage_duration > max(threshold, datetime.timedelta(minutes=5)):
                     blocked_queues.append((queue, blockage_duration, threshold))
 
     if blocked_queues:


### PR DESCRIPTION
This should reduce the noise without significantly impacting
- our ability to firefight (we currently ignore these unless they are left unresolved for a long time)
- our ability to see how we are doing (the datadog metrics will still show brief "blockages")

Celery is the largest sources of unactionable alerts on production currently, and I think this will go a really long way in reducing noise and only alerting on celery blockages that aren't resolving themselves.