### PR TITLE
 Turn off weekly inactive SMS messages based on warehouse lag

### DIFF
--- a/corehq/warehouse/utils.py
+++ b/corehq/warehouse/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.db import connections
 from django.conf import settings
+from datetime import datetime
 
 from dimagi.utils.chunked import chunked
 
@@ -48,4 +49,6 @@ def get_warehouse_latest_modified_date():
         dag_slug='app_status_batch', completed_on__isnull=False
     ).order_by('completed_on').last()
     # The end_datetime of a batch is used to filter on forms by last_modified (received_on, edited_on, deleted_on)
+    if not last_completed_app_status_batch:
+        return datetime(2000, 1, 1)
     return last_completed_app_status_batch.end_datetime

--- a/corehq/warehouse/utils.py
+++ b/corehq/warehouse/utils.py
@@ -5,8 +5,10 @@ from django.conf import settings
 
 from dimagi.utils.chunked import chunked
 
+from corehq.warehouse.models.meta import Batch
 from corehq.warehouse.const import DJANGO_MAX_BATCH_SIZE
 from corehq.sql_db.routers import db_for_read_write
+from corehq.util.quickcache import quickcache
 
 
 def django_batch_records(cls, record_iter, field_mapping, batch_id):
@@ -35,3 +37,15 @@ def truncate_records_for_cls(cls, cascade=False):
     database = db_for_read_write(cls)
     with connections[database].cursor() as cursor:
         cursor.execute("TRUNCATE {} {}".format(cls._meta.db_table, 'CASCADE' if cascade else ''))
+
+
+@quickcache([], timeout=60 * 60)
+def get_warehouse_latest_modified_date():
+    """
+    Return in minutes how fresh is the data of app_status warehouse model.
+    """
+    last_completed_app_status_batch = Batch.objects.filter(
+        dag_slug='app_status_batch', completed_on__isnull=False
+    ).order_by('completed_on').last()
+    # The end_datetime of a batch is used to filter on forms by last_modified (received_on, edited_on, deleted_on)
+    return last_completed_app_status_batch.end_datetime

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -245,7 +245,7 @@ class AWWSubmissionPerformanceIndicator(AWWIndicator):
         ).aggregate(value=Max("last_form_submission_date"))["value"]
 
     def get_messages(self, language_code=None):
-        ACCEPTABLE_LAG_IN_MINUTES = 60 * 12  # 12 hours
+        ACCEPTABLE_LAG_IN_MINUTES = 60 * 24  # 24 hours
         warehouse_lag = (datetime.utcnow() - get_warehouse_latest_modified_date()).total_seconds() / 60
         if warehouse_lag > ACCEPTABLE_LAG_IN_MINUTES:
             return []

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 import pytz
 
+from django.conf import settings
 from django.db.models import Max
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
@@ -245,9 +246,10 @@ class AWWSubmissionPerformanceIndicator(AWWIndicator):
         ).aggregate(value=Max("last_form_submission_date"))["value"]
 
     def get_messages(self, language_code=None):
-        ACCEPTABLE_LAG_IN_MINUTES = 60 * 24  # 24 hours
+        # default 24 hours
+        ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES = getattr(settings, 'ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES', 60 * 24)
         warehouse_lag = (datetime.utcnow() - get_warehouse_latest_modified_date()).total_seconds() / 60
-        if warehouse_lag > ACCEPTABLE_LAG_IN_MINUTES:
+        if warehouse_lag > ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES:
             return []
 
         more_than_one_week = False

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -28,6 +28,7 @@ from corehq.apps.reports.analytics.esaccessors import (
 )
 from corehq.util.quickcache import quickcache
 from corehq.warehouse.models.facts import ApplicationStatusFact
+from corehq.warehouse.utils import get_warehouse_latest_modified_date
 from custom.icds.const import (
     CHILDREN_WEIGHED_REPORT_ID,
     DAYS_AWC_OPEN_REPORT_ID,
@@ -244,6 +245,11 @@ class AWWSubmissionPerformanceIndicator(AWWIndicator):
         ).aggregate(value=Max("last_form_submission_date"))["value"]
 
     def get_messages(self, language_code=None):
+        ACCEPTABLE_LAG_IN_MINUTES = 60 * 12  # 12 hours
+        warehouse_lag = (datetime.utcnow() - get_warehouse_latest_modified_date()).total_seconds() / 60
+        if warehouse_lag > ACCEPTABLE_LAG_IN_MINUTES:
+            return []
+
         more_than_one_week = False
         more_than_one_month = False
         one_month_ago = datetime.utcnow() - timedelta(days=30)

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -247,7 +247,7 @@ class AWWSubmissionPerformanceIndicator(AWWIndicator):
 
     def get_messages(self, language_code=None):
         # default 24 hours
-        ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES = getattr(settings, 'ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES', 60 * 24)
+        ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES = getattr(settings, 'ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES', 60 * 24 * 2)
         warehouse_lag = (datetime.utcnow() - get_warehouse_latest_modified_date()).total_seconds() / 60
         if warehouse_lag > ACCEPTABLE_WAREHOUSE_LAG_IN_MINUTES:
             return []

--- a/custom/icds/tests/test_aww_no_submissions.py
+++ b/custom/icds/tests/test_aww_no_submissions.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime, timedelta
 from django.test import TestCase
+import mock
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.tests.util import make_loc, setup_location_types
@@ -11,6 +12,7 @@ from custom.icds.messaging.custom_content import run_indicator_for_user
 from custom.icds.messaging.indicators import AWWSubmissionPerformanceIndicator
 
 
+@mock.patch('custom.icds.messaging.indicators.get_warehouse_latest_modified_date', return_value=datetime.utcnow())
 class TestAWWSubmissionPerformanceIndicator(TestCase):
     domain = 'domain'
 

--- a/custom/icds/tests/test_aww_no_submissions.py
+++ b/custom/icds/tests/test_aww_no_submissions.py
@@ -70,47 +70,47 @@ class TestAWWSubmissionPerformanceIndicator(TestCase):
     def now(self):
         return datetime.utcnow()
 
-    def test_form_sent_today(self):
+    def test_form_sent_today(self, patch):
         self.app_fact.last_form_submission_date = self.now
         self.app_fact.save()
         messages = run_indicator_for_user(self.user, AWWSubmissionPerformanceIndicator, language_code='en')
         self.assertEqual(len(messages), 0)
 
-    def test_form_sent_just_under_seven_days_ago(self):
+    def test_form_sent_just_under_seven_days_ago(self, patch):
         self.app_fact.last_form_submission_date = self.now - timedelta(days=6, hours=23)
         self.app_fact.save()
         messages = run_indicator_for_user(self.user, AWWSubmissionPerformanceIndicator, language_code='en')
         self.assertEqual(len(messages), 0)
 
-    def test_form_sent_eight_days_ago(self):
+    def test_form_sent_eight_days_ago(self, patch):
         self.app_fact.last_form_submission_date = self.now - timedelta(days=8)
         self.app_fact.save()
         messages = run_indicator_for_user(self.user, AWWSubmissionPerformanceIndicator, language_code='en')
         self.assertEqual(len(messages), 1)
         self.assertIn('one week', messages[0])
 
-    def test_form_sent_thirty_days_ago(self):
+    def test_form_sent_thirty_days_ago(self, patch):
         self.app_fact.last_form_submission_date = self.now - timedelta(days=29, hours=23)
         self.app_fact.save()
         messages = run_indicator_for_user(self.user, AWWSubmissionPerformanceIndicator, language_code='en')
         self.assertEqual(len(messages), 1)
         self.assertIn('one week', messages[0])
 
-    def test_form_sent_thirty_one_days_ago(self):
+    def test_form_sent_thirty_one_days_ago(self, patch):
         self.app_fact.last_form_submission_date = self.now - timedelta(days=31)
         self.app_fact.save()
         messages = run_indicator_for_user(self.user, AWWSubmissionPerformanceIndicator, language_code='en')
         self.assertEqual(len(messages), 1)
         self.assertIn('one month', messages[0])
 
-    def test_no_last_form_submission(self):
+    def test_no_last_form_submission(self, patch):
         self.app_fact.last_form_submission_date = None
         self.app_fact.save()
         messages = run_indicator_for_user(self.user, AWWSubmissionPerformanceIndicator, language_code='en')
         self.assertEqual(len(messages), 1)
         self.assertIn('one month', messages[0])
 
-    def test_no_app_status_fact(self):
+    def test_no_app_status_fact(self, patch):
         messages = run_indicator_for_user(
             self.user_sans_app_status,
             AWWSubmissionPerformanceIndicator,


### PR DESCRIPTION
@calellowitz @snopoke 

This is the PR for the ICDS Inactive SMS P1 ticket https://dimagi-dev.atlassian.net/browse/ICDS-741

Cal, can you validate the way I did lag calculation please. This is how my thinking was. 

Any successful  run on airflow will create a `Batch` object that records `completed_on` and the date range for the data considered for that batch via the attributes `start_datetime` and `end_datetime`. The form_staging table uses this `end_datetime` (via `corehq.warehouse.dbaccessors.get_forms_by_last_modified`) to fetch forms of a given range. So the latest form data available in the warehouse (for the complete app_status_fact) is the latest Batch's `end_datetime`.

I did some stats on existing batch runs below, and the batch duration is mostly within 24 hours (except the one that's still running now). This will be the minimum lag seen by the SMS trigger task.
```
In [14]: bl = list(Batch.objects.filter(dag_slug='app_status_batch', completed_on__isnull=False).order_by('-completed
    ...: _on'))

In [15]: [(b.completed_on-b.end_datetime).total_seconds()/(60*60) for b in bl[0:20]]
Out[15]: # In hours
[11.661836730833333,
 12.504099592777777,
 22.453406085555557,
 7.658533924166667,
 19.97456774611111,
 17.549148881111112,
 7.290091748055556,
 21.39826220111111,
 23.25774011888889,
 24.297149540833335,
 9.092858160555556,
 21.462363166666666,
 5.543469443055556,
 22.549744259166665,
 10.066691982222222,
 7.8351759238888885,
 3.4097954291666666,
 8.06512696361111,
 5.656455826111111,
 5.636946606944445]
```