### PR TITLE
Fixed inability to delete non-last load action in advanced form settings

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -468,16 +468,12 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                         potential_child;
                     self.load_update_cases.remove(action);
 
-                    // remove references to deleted action in other load actions
+                    // remove references to deleted action in subsequent load actions
                     var loadUpdateCases = self.caseConfig.caseConfigViewModel.load_update_cases();
                     for (var i = index; i < loadUpdateCases.length; i++) {
-                        potential_child = loadUpdateCases[i];
-                        for (var j = 0; j < potential_child.parents.length; j++) {
-                            var caseIndex = potential_child.parents[i];
-                            if (caseIndex.tag() === action.case_tag()) {
-                                caseIndex.tag('');
-                            }
-
+                        var caseIndex = loadUpdateCases[i].case_index;
+                        if (caseIndex.tag() === action.case_tag()) {
+                            caseIndex.tag('');
                         }
                     }
                 }


### PR DESCRIPTION
Julia reported this as we've been investigating https://dimagi-dev.atlassian.net/browse/HI-676

So far as I can tell this is a minor oversight from way back in https://github.com/dimagi/commcare-hq/pull/7749/commits/74f56e30ecd557da7ac802a294bad83070c9e1d1

Feature flag: advanced modules