### PR TITLE
Renamed location widgets

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/select_2_ajax_widget.js
@@ -4,7 +4,7 @@ hqDefine("hqwebapp/js/select_2_ajax_widget", [
     'select2/dist/js/select2.full.min',
 ], function ($, _) {
     $(function () {
-        $(".hqwebapp-select2-ajax-v4").each(function () {
+        $(".hqwebapp-select2-ajax").each(function () {
             var $select = $(this),
                 htmlData = $select.data();
 

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -78,7 +78,7 @@ class Select2Ajax(_Select2AjaxMixin, forms.Select):
 
     def render(self, name, value, attrs=None):
         attrs.update({
-            'class': 'form-control hqwebapp-select2-ajax-v4',
+            'class': 'form-control hqwebapp-select2-ajax',
             'data-initial': json.dumps(self._initial if self._initial is not None else self._clean_initial(value)),
             'data-endpoint': self.url,
             'data-page-size': self.page_size,

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -16,7 +16,7 @@ hqDefine("locations/js/widgets", [
     }
 
     $(function () {
-        $(".locations-widget-autocomplete-v4").each(function () {
+        $(".locations-widget-autocomplete").each(function () {
             var $select = $(this),
                 options = $select.data();
             $select.select2({
@@ -60,7 +60,7 @@ hqDefine("locations/js/widgets", [
             $select.trigger('select-ready');
         });
 
-        $(".locations-widget-primary-v4").each(function () {
+        $(".locations-widget-primary").each(function () {
             var $select = $(this),
                 $source = $('#' + $select.data("sourceCssId")),
                 value = $select.data("initial");

--- a/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html
@@ -1,6 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
-<select id="{{ id }}" class="locations-widget-autocomplete-v4 form-control" name="{{ name }}" value="{{ value }}" style="width: 30em;"
+<select id="{{ id }}" class="locations-widget-autocomplete form-control" name="{{ name }}" value="{{ value }}" style="width: 30em;"
   {% if attrs.disabled %}
         disabled="disabled"
   {% endif %}

--- a/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/drilldown_location_widget.html
@@ -1,6 +1,6 @@
 {% load hq_shared_tags %}
 
-<select class="locations-widget-primary-v4 form-control" id="{{ css_id }}" name="{{ name }}" style="width: 30em;"
+<select class="locations-widget-primary form-control" id="{{ css_id }}" name="{{ name }}" style="width: 30em;"
   {% if attrs.disabled %}
         disabled="disabled"
   {% endif %}


### PR DESCRIPTION
Minor. Now that select2 is fully migrated, the `v4` suffixes are just confusing.