### PR TITLE
Add future functionality for enforcing child case privileges

### DIFF
--- a/corehq/apps/app_manager/add_ons.py
+++ b/corehq/apps/app_manager/add_ons.py
@@ -245,6 +245,11 @@ def get_dict(request, app, module=None, form=None):
     return {slug: show(slug, request, app, module, form) for slug in _ADD_ONS.keys()}
 
 
+# Get a slug => bool dictionary signifying which add-ons have privileges
+def get_privileges_dict(request):
+    return {slug: _ADD_ONS[slug].has_privilege(request) for slug in _ADD_ONS.keys()}
+
+
 # Get add-ons for display in settings UI
 def get_layout(request):
     all_slugs = set(_ADD_ONS.keys())

--- a/corehq/apps/app_manager/add_ons.py
+++ b/corehq/apps/app_manager/add_ons.py
@@ -8,18 +8,23 @@ from corehq import feature_previews, toggles
 from corehq.apps.app_manager.exceptions import AddOnNotFoundException
 from corehq.apps.app_manager.models import Module, AdvancedModule, ShadowModule
 from corehq.apps.domain.models import Domain
-from corehq.privileges import LOOKUP_TABLES
+from corehq.privileges import (
+    LOOKUP_TABLES,
+    CHILD_CASES,
+)
 
 
 # Similar to feature flags and/or feature previews, but specific to an individual application
 # and with the additional notion of a feature being "in use" in a specific module or form
 # even if the add-on isn't enabled.
 class AddOn(object):
-    def __init__(self, name, description, help_link=None, privilege=None, used_in_module=None, used_in_form=None):
+    def __init__(self, name, description, help_link=None, privilege=None,
+                 used_in_module=None, used_in_form=None, upgrade_text=None):
         self.name = name
         self.description = description
         self.help_link = help_link
         self.privilege = privilege
+        self.upgrade_text = upgrade_text
 
         self.used_in_module = used_in_module if used_in_module else lambda m: False
         self.used_in_form = used_in_form if used_in_form else lambda f: False
@@ -150,6 +155,9 @@ _ADD_ONS = {
         "created them. Available in form settings."),
         help_link="https://confluence.dimagi.com/display/commcarepublic/Child+Cases",
         used_in_form=lambda f: f.form_type != "module_form" or bool(f.actions.subcases),
+        privilege=CHILD_CASES,
+        upgrade_text=_("Child cases are not available on your subscription. "
+                       "This feature is only available on our Pro plan or higher.")
     ),
     "empty_case_lists": AddOn(
         name=_("New Case Lists Created Empty"),
@@ -202,7 +210,7 @@ def show(slug, request, app, module=None, form=None):
     add_on = _ADD_ONS[slug]
 
     # Do not show if there's a required privilege missing
-    if not add_on.has_privilege(request):
+    if not add_on.has_privilege(request) and add_on.upgrade_text is None:
         return False
 
     # Show if flag to enable all toggles is on
@@ -251,7 +259,12 @@ def get_layout(request):
         'name': _ADD_ONS[slug].name,
         'description': _ADD_ONS[slug].description,
         'help_link': _ADD_ONS[slug].help_link,
-    } for slug in section['slugs'] if _ADD_ONS[slug].has_privilege(request)]}, **section) for section in _LAYOUT]
+        'upgrade_text': _ADD_ONS[slug].upgrade_text,
+        'show_upgrade': (not _ADD_ONS[slug].has_privilege(request)
+                         and _ADD_ONS[slug].upgrade_text is not None),
+    } for slug in section['slugs']
+        if _ADD_ONS[slug].has_privilege(request)
+        or _ADD_ONS[slug].upgrade_text is not None]}, **section) for section in _LAYOUT]
 
 
 # Lazily migrate an app that doesn't have any add_ons configured yet.

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -175,6 +175,7 @@
   {% initial_page_data 'post_form_workflow' form.post_form_workflow %}
   {% initial_page_data 'post_form_workflow_fallback' form.post_form_workflow_fallback %}
   {% initial_page_data 'uses_form_workflow' uses_form_workflow %}
+  {% initial_page_data 'add_ons_privileges' add_ons_privileges %}
   {% registerurl "get_form_datums" domain app.id %}
 
   <div class="tabbable appmanager-tabs-container">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -70,7 +70,9 @@
     </div>
     <div class="panel-body">
       <label>
-        <input type="checkbox" data-bind="checked: close_case"/>
+        <input type="checkbox"
+               data-bind="checked: close_case,
+                          disable: !hasPrivilege"/>
         {% trans "Close this case when the form is complete" %}
       </label>
       {% if add_ons.conditional_form_actions %}
@@ -171,6 +173,22 @@
           {% endblocktrans %}
         </p>
 
+        {% if not add_ons_privileges.subcases %}
+          <div class="well well-sm">
+            <p>
+              <i class="fa fa-info-circle"></i>
+              {% blocktrans %}
+                <strong>Child Cases</strong> are not available in your subscription.
+                This feature is only available on our <strong>Pro</strong> plan or higher.
+                This configuration will remain un-editable until you upgrade.
+              {% endblocktrans %}
+            </p>
+            <p>
+              {% include 'hqwebapp/partials/generic_feature_upgrade.html' %}
+            </p>
+          </div>
+        {% endif %}
+
         <div data-bind="foreach: subcases">
           <div class="panel panel-appmanager panel-case-actions">
             <div class="panel-heading">
@@ -181,11 +199,13 @@
               </h4>
             </div>
             <div class="panel-case-actions-actions">
-              <a href="#"
-                 class="case-action-remove btn btn-purple"
-                 data-bind="openModal: 'remove-subcase-modal-template'">
-                <i class="fa fa-trash"></i>
-              </a>
+              {% if add_ons_privileges.subcases %}
+                <a href="#"
+                   class="case-action-remove btn btn-purple"
+                   data-bind="openModal: 'remove-subcase-modal-template'">
+                  <i class="fa fa-trash"></i>
+                </a>
+              {% endif %}
             </div>
             <div class="panel-body">
               <div class="panel panel-appmanager">
@@ -199,6 +219,7 @@
                   <span class="form-group"
                         data-bind="css: {'has-warning': !case_type()}">
                     <select class="form-control"
+                            {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
                             data-bind="options: $parent.caseTypes,
                                        optionsText: $parent.getCaseTypeLabel,
                                        value: case_type,
@@ -211,6 +232,7 @@
                         {% trans "Override reference id: " %}
                       </label>
                       <input type="text"
+                             {% if not add_ons_privileges.subcases %}disabled="disabled"{% endif %}
                              class="form-control"
                              data-bind="value: reference_id"/>
                     {% endif %}
@@ -221,13 +243,14 @@
             </div>
           </div>
         </div>
-
-        <a href="#"
-           class="btn btn-default"
-           data-bind="click: addSubCase">
-          <i class="fa fa-plus"></i>
-          {% trans "Add a Child Case to open a case for a different Case List..." %}
-        </a>
+        {% if add_ons_privileges.subcases %}
+          <a href="#"
+             class="btn btn-default"
+             data-bind="click: addSubCase">
+            <i class="fa fa-plus"></i>
+            {% trans "Add a Child Case to open a case for a different Case List..." %}
+          </a>
+        {% endif %}
         <!--/ko-->
       {% endif %}
     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -1,19 +1,30 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-<script type="text/html" id="remove-subcase-modal-template">
+<script type="text/html"
+        id="remove-subcase-modal-template">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
         <a href="#" class="close" data-dismiss="modal">×</a>
-        <h4 class="modal-title">{% trans "Remove Child Case?" %}</h4>
+        <h4 class="modal-title">
+          {% trans "Remove Child Case?" %}
+        </h4>
       </div>
       <div class="modal-body">
-        <p>{% trans "Are you sure you want to remove this Child Case?" %}</p>
+        <p>
+          {% trans "Are you sure you want to remove this Child Case?" %}
+        </p>
       </div>
       <div class="modal-footer">
-        <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</a>
-        <a class="btn btn-danger" href="#" data-bind="click: $parent.removeSubCase" data-dismiss="modal">
+        <a href="#" class="btn btn-default"
+           data-dismiss="modal">
+          {% trans "Cancel" %}
+        </a>
+        <a class="btn btn-danger"
+           href="#"
+           data-bind="click: $parent.removeSubCase"
+           data-dismiss="modal">
           {% trans "Remove Child Case" %}
         </a>
       </div>
@@ -21,9 +32,12 @@
   </div>
 </script>
 
-<script type="text/html" id="case-config:case-transaction">
+<script type="text/html"
+        id="case-config:case-transaction">
+
   {% if add_ons.conditional_form_actions %}
-    <div class="panel panel-appmanager" data-bind="visible: allow.condition()">
+    <div class="panel panel-appmanager"
+         data-bind="visible: allow.condition()">
       <div class="panel-heading">
         <h4 class="panel-title panel-title-nolink">
           {% trans "Open Case Condition" %}
@@ -31,20 +45,23 @@
       </div>
       <div class="panel-body">
         <div data-bind="template: {
-                                name: 'case-config:condition',
-                                data: {condition: condition, config: $data}
-                            }"></div>
+                          name: 'case-config:condition',
+                          data: {condition: condition, config: $data}
+                        }"></div>
       </div>
     </div>
   {% endif %}
+
   <div data-bind="if: allow.case_preload()">
     <div class="panel panel-appmanager case-properties wide-select2s"
          data-bind="template: 'case-config:case-transaction:case-properties'"></div>
   </div>
+
   <div data-bind="if: !allow.case_preload()">
     <div class="panel panel-appmanager"
          data-bind="template: 'case-config:case-transaction:case-properties'"></div>
   </div>
+
   <div class="panel panel-appmanager">
     <div class="panel-heading">
       <h4 class="panel-title panel-title-nolink">
@@ -58,19 +75,23 @@
       </label>
       {% if add_ons.conditional_form_actions %}
         <div data-bind="template: {
-                name: 'case-config:condition',
-                data: {condition: $data.close_condition, config: $data},
-                if: $data.close_condition
-            }"></div>
+                          name: 'case-config:condition',
+                          data: {
+                            condition: $data.close_condition,
+                            config: $data
+                          },
+                          if: $data.close_condition
+                        }"></div>
       {% endif %}
     </div>
   </div>
+
 </script>
 
 <div id="case-config-ko">
 
-
-  <div class="refresh-form-questions-container" data-bind="template: 'case-config:refresh-form-questions'"></div>
+  <div class="refresh-form-questions-container"
+       data-bind="template: 'case-config:refresh-form-questions'"></div>
   <div data-bind="saveButton: saveButton"></div>
 
   <div data-bind="with: caseConfigViewModel">
@@ -86,13 +107,13 @@
           <p class="lead">
             {% blocktrans %}
               <span data-bind="visible: showLeadRegistration">
-                            This is a <strong><i class="fcc fcc-app-createform"></i> Registration</strong> form.
-                            Use the Registration form to add new cases to your <strong><i class="fa fa-bars"></i> Case List</strong>.
-                        </span>
+                This is a <strong><i class="fcc fcc-app-createform"></i> Registration</strong> form.
+                Use the Registration form to add new cases to your <strong><i class="fa fa-bars"></i> Case List</strong>.
+              </span>
               <span data-bind="visible: showLeadFollowup">
-                            This is a <strong><i class="fcc fcc-app-updateform"></i> Followup</strong> form.
-                            Use Followup forms to update cases in your <strong><i class="fa fa-bars"></i> Case List</strong>.
-                        </span>
+                This is a <strong><i class="fcc fcc-app-updateform"></i> Followup</strong> form.
+                Use Followup forms to update cases in your <strong><i class="fa fa-bars"></i> Case List</strong>.
+              </span>
               <br />
               <span><strong>Cases</strong> give you a way to track patients, farms, and other entities over time.</span>
             {% endblocktrans %}
@@ -100,22 +121,40 @@
 
           {% trans "Registration: This form opens a new case" as registers_case %}
           {% trans "Followup: This form loads a case and may then update or close it" as updates_case %}
-          <select class="form-control" id="case-action-select" data-bind="
-                        optstr: [{value: 'open', label: '{{ registers_case|escapejs }}'},
-                                 {value: 'update', label: '{{ updates_case|escapejs }}'}],
-                        value: actionType,
-                        event: { change: function() { hqImport('analytix/js/google').track.event('Case Management', 'Form Level', 'Case Action'); } }
-                    "></select>
+          <select class="form-control"
+                  id="case-action-select"
+                  data-bind="optstr: [
+                               {
+                                 value: 'open',
+                                 label: '{{ registers_case|escapejs }}'
+                               },
+                               {
+                                 value: 'update',
+                                 label: '{{ updates_case|escapejs }}'
+                               }
+                             ],
+                             value: actionType,
+                             event: {
+                               change: function() {
+                                 hqImport('analytix/js/google').track.event('Case Management', 'Form Level', 'Case Action');
+                               }
+                             }"></select>
         </div>
       </div>
     </div>
 
     {% if form.source %}
       <!--ko if: actionType() === 'update' -->
-      <div data-bind="template: {name: 'case-config:case-transaction', data: case_transaction}"></div>
+      <div data-bind="template: {
+                        name: 'case-config:case-transaction',
+                        data: case_transaction
+                      }"></div>
       <!--/ko-->
       <!--ko if: actionType() === 'open' -->
-      <div data-bind="template: {name: 'case-config:case-transaction', data: case_transaction}"></div>
+      <div data-bind="template: {
+                        name: 'case-config:case-transaction',
+                        data: case_transaction
+                      }"></div>
       <!--/ko-->
       {% if add_ons.subcases %}
         <!--ko if: actionType() !== 'none'-->
@@ -159,18 +198,23 @@
                   {% trans "This Form opens a Child Case in the Case List" %}&nbsp;
                   <span class="form-group"
                         data-bind="css: {'has-warning': !case_type()}">
-                                        <select class="form-control" data-bind="
-                                            options: $parent.caseTypes,
-                                            optionsText: $parent.getCaseTypeLabel,
-                                            value: case_type,
-                                            optionsCaption: 'Choose a Module...'
-                                        "></select>
-                                        <span class="help-block" data-bind="visible: !case_type()">{% trans "Required" %}</span>
+                    <select class="form-control"
+                            data-bind="options: $parent.caseTypes,
+                                       optionsText: $parent.getCaseTypeLabel,
+                                       value: case_type,
+                                       optionsCaption: 'Choose a Module...'"></select>
+                    <span class="help-block" data-bind="visible: !case_type()">
+                      {% trans "Required" %}
+                    </span>
                     {% if show_custom_ref %}
-                      <label>{% trans "Override reference id: " %}</label>
-                      <input type="text" class="form-control" data-bind="value: reference_id"/>
+                      <label>
+                        {% trans "Override reference id: " %}
+                      </label>
+                      <input type="text"
+                             class="form-control"
+                             data-bind="value: reference_id"/>
                     {% endif %}
-                                    </span>
+                  </span>
                 </div>
               </div>
               <div data-bind="template: 'case-config:case-transaction'"></div>
@@ -178,7 +222,9 @@
           </div>
         </div>
 
-        <a href="#" class="btn btn-default" data-bind="click: addSubCase">
+        <a href="#"
+           class="btn btn-default"
+           data-bind="click: addSubCase">
           <i class="fa fa-plus"></i>
           {% trans "Add a Child Case to open a case for a different Case List..." %}
         </a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -1,11 +1,17 @@
 {% load i18n %}
 
-<script type="text/html" id="case-config:condition">
+<script type="text/html"
+        id="case-config:condition">
   <!--ko with: condition -->
   <span data-bind="text: $parent.actionType"></span>
 
   <div data-bind="visible: type() === 'always'">
-    <a href="#" class="btn btn-default" data-bind="click: function () {type('if')}"><i class="fa fa-plus"></i> {% trans "Only if the answer to..." %}</a>
+    <a href="#"
+       class="btn btn-default"
+       data-bind="click: function () {type('if')}">
+      <i class="fa fa-plus"></i>
+      {% trans "Only if the answer to..." %}
+    </a>
   </div>
 
   <div class="row" data-bind="visible: type() === 'if'">
@@ -13,35 +19,39 @@
       {% trans "Only if the answer to" %}
     </div>
     <div class="col-sm-4">
-      <select class="form-control" data-bind="
-                questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
-                value: question,
-            "></select>
+      <select class="form-control"
+              data-bind="questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
+                         value: question"></select>
     </div>
     <div class="col-sm-2">
-      <select class="form-control" data-bind="
-                    optstr: [
-                        {label:'{% trans "is" %}', value:'='},
-                        {label:'{% trans "has selected" %}', value:'selected'},
-                        {label:'{% trans "is true" %}', value:'boolean_true'}
-                    ],
-                    value: operator"></select>
+      <select class="form-control"
+              data-bind="optstr: [
+                           {label:'{% trans "is" %}', value:'='},
+                           {label:'{% trans "has selected" %}', value:'selected'},
+                           {label:'{% trans "is true" %}', value:'boolean_true'}
+                         ],
+                         value: operator"></select>
     </div>
     <!-- Input for question's answer -->
-    <div class="col-sm-4" data-bind="visible: operator() != 'boolean_true'">
+    <div class="col-sm-4"
+         data-bind="visible: operator() != 'boolean_true'">
       <!-- Select question: answer is a dropdown -->
       <span data-bind="if: $root.getAnswers({question: question()}).length">
-                <select class="form-control" data-bind="
-                    optstr: $root.getAnswers({question: question()}),
-                    value: answer"></select>
-            </span>
+        <select class="form-control"
+                data-bind="optstr: $root.getAnswers({question: question()}),
+                           value: answer"></select>
+      </span>
       <!-- Non-select question: answer is a text box -->
       <span data-bind="if: !$root.getAnswers({question: question()}).length">
-                <input type="text" class="form-control" data-bind="value: answer"/>
-            </span>
+        <input type="text"
+               class="form-control"
+               data-bind="value: answer"/>
+      </span>
     </div>
     <div class="col-sm-1">
-      <a href="#" class="btn btn-default" data-bind="click: function () {type('always')}">
+      <a href="#"
+         class="btn btn-default"
+         data-bind="click: function () {type('always')}">
         <i class="fa fa-remove"></i>
       </a>
     </div>
@@ -49,164 +59,222 @@
   <!--/ko-->
 </script>
 
-<script type="text/html" id="case-config:case-properties:question">
-  <select class="form-control" data-bind="
-        questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
-        value: path,
-        event: { change: function(view, e) {
-            if (e.target.closest('#case-config-ko')) {
-                var action = e.target.closest('.case-preload') ? 'Load' : 'Save';
-                hqImport('analytix/js/google').track.event('Case Management', 'Form Level', action + ' Property (add/edit)');
-            }
-        } }
-    "></select>
-  <p class="help-block" data-bind="visible: required() && !path()">{% trans "Required" %}</p>
-  <p class="help-block" data-bind="visible: !required() && !path() && key()">{% trans "Not assigned" %}</p>
+<script type="text/html"
+        id="case-config:case-properties:question">
+  <select class="form-control"
+          data-bind="questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
+                     value: path,
+                     event: {
+                       change: function(view, e) {
+                         if (e.target.closest('#case-config-ko')) {
+                           var action = e.target.closest('.case-preload') ? 'Load' : 'Save';
+                           hqImport('analytix/js/google').track.event('Case Management', 'Form Level', action + ' Property (add/edit)');
+                         }
+                       }
+                     }"></select>
+  <p class="help-block"
+     data-bind="visible: required() && !path()">
+    {% trans "Required" %}
+  </p>
+  <p class="help-block"
+     data-bind="visible: !required() && !path() && key()">
+    {% trans "Not assigned" %}
+  </p>
 </script>
 
-<script type="text/html" id="case-config:case-properties:property">
+<script type="text/html"
+        id="case-config:case-properties:property">
   <span data-bind="visible: !property.required()">
-        <input type="text" class="form-control" data-bind="
-            valueDefault: property.key,
-            default: property.defaultKey,
-            casePropertyAutocomplete: suggestedProperties
-        "/>
+    <input type="text"
+           class="form-control"
+           data-bind="valueDefault: property.key,
+                      default: property.defaultKey,
+                      casePropertyAutocomplete: suggestedProperties"/>
     </span>
   <span data-bind="visible: property.required()">
-        <code data-bind="text: property.key"></code>
-    </span>
+    <code data-bind="text: property.key"></code>
+  </span>
 </script>
 
-<script type="text/html" id="case-config:case-transaction:case-preload">
+<script type="text/html"
+        id="case-config:case-transaction:case-preload">
   <div class="panel-heading">
     <h4 class="panel-title panel-title-nolink">
-      <i class="fa fa-arrow-right"></i><i class="fa fa-file-o"></i> {% trans "Load the following properties into the form questions" %}
+      <i class="fa fa-arrow-right"></i><i class="fa fa-file-o"></i>
+      {% trans "Load the following properties into the form questions" %}
     </h4>
   </div>
   <div class="panel-body">
-    <table class="table table-savecaseprops" data-bind="visible: case_preload().length">
+    <table class="table table-savecaseprops"
+           data-bind="visible: case_preload().length">
       <thead>
       <tr>
         <th></th>
-        <th>{% trans "Property" %}</th>
+        <th>
+          {% trans "Property" %}
+        </th>
         <th></th>
-        <th>{% trans "Question" %}</th>
+        <th>
+          {% trans "Question" %}
+        </th>
       </tr>
       </thead>
 
       <tbody data-bind="foreach: case_preload">
-      <tr class="form-group" data-bind="css: {'has-error': validateProperty || validateQuestion}">
+      <tr class="form-group"
+          data-bind="css: {
+                       'has-error': validateProperty || validateQuestion,
+                     }">
         <td class="col-sm-1 text-center">
-          <a href="#" class="btn btn-danger" data-bind="
-                            click: $parent.removePreload,
-                            visible: !(isBlank() && $index() === $parent.case_preload().length - 1)">
+          <a href="#"
+             class="btn btn-danger"
+             data-bind="click: $parent.removePreload,
+                        visible: !(isBlank() && $index() === $parent.case_preload().length - 1)">
             <i class="fa fa-remove"></i>
           </a>
         </td>
         <td class="col-sm-5">
-          <div class="full-width-select2" data-bind="template: {
+          <div class="full-width-select2"
+               data-bind="template: {
                             name: 'case-config:case-properties:property',
-                            data: {'property': $data, 'suggestedProperties': case_transaction.suggestedPreloadProperties}
-                        }"></div>
-          <p class="help-block" data-bind="html: validateProperty, visible: validateProperty"></p>
+                            data: {
+                              'property': $data,
+                              'suggestedProperties': case_transaction.suggestedPreloadProperties
+                            }
+                          }"></div>
+          <p class="help-block"
+             data-bind="html: validateProperty,
+                        visible: validateProperty"></p>
         </td>
         <td class="col-sm-1 text-center">
           <i class="fa fa-arrow-right"></i><i class="fa fa-file-o"></i>
         </td>
         <td class="col-sm-5">
-          <div class="full-width-select2" data-bind="template: 'case-config:case-properties:question'"></div>
-          <p class="help-block" data-bind="html: validateQuestion, visible: validateQuestion"></p>
+          <div class="full-width-select2"
+               data-bind="template: 'case-config:case-properties:question'"></div>
+          <p class="help-block"
+             data-bind="html: validateQuestion,
+                        visible: validateQuestion"></p>
         </td>
       </tr>
       </tbody>
     </table>
-    <div class="alert alert-block alert-info" data-bind="visible: !case_preload().length">
+    <div class="alert alert-block alert-info"
+         data-bind="visible: !case_preload().length">
       {% trans "No properties will be loaded" %}
     </div>
-    <a href="#" class="firstProperty btn btn-default" data-bind="click: addPreload, visible: !case_preload().length">
+    <a href="#"
+       class="firstProperty btn btn-default"
+       data-bind="click: addPreload,
+                  visible: !case_preload().length">
       <i class="fa fa-plus"></i>
       {% trans "Load properties" %}
     </a>
   </div>
 </script>
 
-<script type="text/html" id="case-config:case-transaction:case-properties">
+<script type="text/html"
+        id="case-config:case-transaction:case-properties">
   <div class="panel-heading">
     <h4 class="panel-title panel-title-nolink">
-      <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i> {% trans "Save Questions to Case Properties" %}
+      <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
+      {% trans "Save Questions to Case Properties" %}
     </h4>
   </div>
   <div class="panel-body">
-    <table class="table table-savecaseprops" data-bind="visible: case_properties().length">
+    <table class="table table-savecaseprops"
+           data-bind="visible: case_properties().length">
       <thead>
       <tr>
         <th class="col-sm-1"></th>
-        <th class="col-sm-5">{% trans "Question" %}</th>
+        <th class="col-sm-5">
+          {% trans "Question" %}
+        </th>
         <th class="col-sm-1"></th>
-        <th class="col-sm-5">{% trans "Case Property" %}</th>
+        <th class="col-sm-5">
+          {% trans "Case Property" %}
+        </th>
       </tr>
       </thead>
 
       <tbody data-bind="foreach: case_properties">
-      <tr class="form-group" data-bind="css: {'has-error': validate, warning: (!validate() && required() && !path()) || (!validate() && !required() && !path() && key())}">
+      <tr class="form-group"
+          data-bind="css: {
+                      'has-error': validate,
+                      warning: (!validate() && required() && !path()) || (!validate() && !required() && !path() && key())
+                    }">
         <td class="col-sm-1 text-center">
-          <a href="#" class="btn btn-danger" data-bind="
-                            click: $parent.removeProperty,
-                            visible: !required() && !(isBlank() && $index() === $parent.case_properties().length - 1)
-                        ">
+          <a href="#"
+             class="btn btn-danger"
+             data-bind="click: $parent.removeProperty,
+                        visible: !required() && !(isBlank() && $index() === $parent.case_properties().length - 1)">
             <i class="fa fa-remove"></i>
           </a>
         </td>
         <td class="col-sm-5">
-          <div class="full-width-select2" data-bind="template: 'case-config:case-properties:question'"></div>
+          <div class="full-width-select2"
+               data-bind="template: 'case-config:case-properties:question'"></div>
         </td>
         <td class="text-center col-sm-1">
           <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
         </td>
         <td class="col-sm-5">
-          <div class="full-width-select2" data-bind="template: {
+          <div class="full-width-select2"
+               data-bind="template: {
                             name: 'case-config:case-properties:property',
-                            data: {property: $data, suggestedProperties: case_transaction.suggestedSaveProperties},
+                            data: {
+                              property: $data,
+                              suggestedProperties: case_transaction.suggestedSaveProperties
+                            },
                             afterRender: $root.makePopover
-                        }"></div>
-          <p class="help-block" data-bind="html: validate, visible: validate"></p>
+                          }"></div>
+          <p class="help-block"
+             data-bind="html: validate,
+                        visible: validate"></p>
           <!-- ko if: $data.description -->
-          <inline-edit params="
-                            value: $data.description,
-                            rows: 3,
-                            cols: 30,
-                            placeholder: '{% trans "Click here to add a description" %}',
-                            url: '{% url "update_property_description" domain %}',
-                            saveParams: {'caseType': $data.caseType, 'name':  $data.key},
-                            saveValueName: 'description',
-                            errorMessage: '{% trans "Error updating description. Please try again." %}',
-                            readOnlyClass: 'property-description',
-                            readOnlyAttrs: {'data-content': $data.description},
-                            afterRenderFunc: $root.makePopover,
-                        "></inline-edit>
+          <inline-edit params="value: $data.description,
+                               rows: 3,
+                               cols: 30,
+                               placeholder: '{% trans "Click here to add a description" %}',
+                               url: '{% url "update_property_description" domain %}',
+                               saveParams: {
+                                 'caseType': $data.caseType,
+                                 'name':  $data.key
+                               },
+                               saveValueName: 'description',
+                               errorMessage: '{% trans "Error updating description. Please try again." %}',
+                               readOnlyClass: 'property-description',
+                               readOnlyAttrs: {
+                                 'data-content': $data.description
+                               },
+                               afterRenderFunc: $root.makePopover"></inline-edit>
           <!-- /ko -->
         </td>
       </tr>
       </tbody>
     </table>
-    <div class="alert alert-block alert-info" data-bind="visible: !case_properties().length">
+    <div class="alert alert-block alert-info"
+         data-bind="visible: !case_properties().length">
       {% trans "No properties will be saved" %}
     </div>
-    <a href="#" class="firstProperty btn btn-default" data-bind="click: addProperty, visible: !case_properties().length">
+    <a href="#" class="firstProperty btn btn-default"
+       data-bind="click: addProperty,
+                  visible: !case_properties().length">
       <i class="fa fa-plus"></i>
       {% trans "Save properties" %}
     </a>
   </div>
 </script>
 
-<script type="text/html" id="case-config:refresh-form-questions">
+<script type="text/html"
+        id="case-config:refresh-form-questions">
   <p class="pull-right">
     <button class="btn btn-default refresh-form-questions"
             type="button"
             data-bind="click: function(data, event){
-                        refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{form.unique_id}}', event);
-                        hqImport('analytix/js/google').track.event('Refresh case management', 'Button Clicked');
-                        }">
+                         refreshQuestions('{% url 'get_form_questions' domain app.id %}', '{{form.unique_id}}', event);
+                         hqImport('analytix/js/google').track.event('Refresh case management', 'Button Clicked');
+                       }">
       <i class="fa fa-refresh"></i>
     </button>
   </p>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -5,13 +5,19 @@
   <!--ko with: condition -->
   <span data-bind="text: $parent.actionType"></span>
 
-  <div data-bind="visible: type() === 'always'">
+  <div data-bind="visible: type() === 'always' && $parent.config.hasPrivilege">
     <a href="#"
        class="btn btn-default"
        data-bind="click: function () {type('if')}">
       <i class="fa fa-plus"></i>
       {% trans "Only if the answer to..." %}
     </a>
+  </div>
+
+  <div data-bind="visible: type() === 'always' && !$parent.config.hasPrivilege">
+    {% blocktrans %}
+      Configuration no longer allowed.
+    {% endblocktrans %}
   </div>
 
   <div class="row" data-bind="visible: type() === 'if'">
@@ -21,6 +27,7 @@
     <div class="col-sm-4">
       <select class="form-control"
               data-bind="questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
+                         disable: !$parent.config.hasPrivilege,
                          value: question"></select>
     </div>
     <div class="col-sm-2">
@@ -30,6 +37,7 @@
                            {label:'{% trans "has selected" %}', value:'selected'},
                            {label:'{% trans "is true" %}', value:'boolean_true'}
                          ],
+                         disable: !$parent.config.hasPrivilege,
                          value: operator"></select>
     </div>
     <!-- Input for question's answer -->
@@ -39,21 +47,24 @@
       <span data-bind="if: $root.getAnswers({question: question()}).length">
         <select class="form-control"
                 data-bind="optstr: $root.getAnswers({question: question()}),
+                           disable: !$parent.config.hasPrivilege,
                            value: answer"></select>
       </span>
       <!-- Non-select question: answer is a text box -->
       <span data-bind="if: !$root.getAnswers({question: question()}).length">
         <input type="text"
                class="form-control"
-               data-bind="value: answer"/>
+               data-bind="value: answer,
+                          disable: !$parent.config.hasPrivilege"/>
       </span>
     </div>
-    <div class="col-sm-1">
-      <a href="#"
-         class="btn btn-default"
-         data-bind="click: function () {type('always')}">
-        <i class="fa fa-remove"></i>
-      </a>
+    <div class="col-sm-1"
+         data-bind="if: $parent.config.hasPrivilege">
+        <a href="#"
+           class="btn btn-default"
+           data-bind="click: function () {type('always')}">
+          <i class="fa fa-remove"></i>
+        </a>
     </div>
   </div>
   <!--/ko-->
@@ -64,6 +75,7 @@
   <select class="form-control"
           data-bind="questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
                      value: path,
+                     disable: !$parent.hasPrivilege,
                      event: {
                        change: function(view, e) {
                          if (e.target.closest('#case-config-ko')) {
@@ -89,6 +101,7 @@
            class="form-control"
            data-bind="valueDefault: property.key,
                       default: property.defaultKey,
+                      disable: isDisabled,
                       casePropertyAutocomplete: suggestedProperties"/>
     </span>
   <span data-bind="visible: property.required()">
@@ -139,7 +152,7 @@
                             name: 'case-config:case-properties:property',
                             data: {
                               'property': $data,
-                              'suggestedProperties': case_transaction.suggestedPreloadProperties
+                              'suggestedProperties': case_transaction.suggestedPreloadProperties,
                             }
                           }"></div>
           <p class="help-block"
@@ -203,7 +216,8 @@
                       'has-error': validate,
                       warning: (!validate() && required() && !path()) || (!validate() && !required() && !path() && key())
                     }">
-        <td class="col-sm-1 text-center">
+        <td class="col-sm-1 text-center"
+            data-bind="if: $parent.hasPrivilege">
           <a href="#"
              class="btn btn-danger"
              data-bind="click: $parent.removeProperty,
@@ -224,14 +238,15 @@
                             name: 'case-config:case-properties:property',
                             data: {
                               property: $data,
-                              suggestedProperties: case_transaction.suggestedSaveProperties
+                              suggestedProperties: case_transaction.suggestedSaveProperties,
+                              'isDisabled': !$parent.hasPrivilege,
                             },
                             afterRender: $root.makePopover
                           }"></div>
           <p class="help-block"
              data-bind="html: validate,
                         visible: validate"></p>
-          <!-- ko if: $data.description -->
+          <!-- ko if: $data.description && $parent.hasPrivilege -->
           <inline-edit params="value: $data.description,
                                rows: 3,
                                cols: 30,
@@ -249,6 +264,9 @@
                                },
                                afterRenderFunc: $root.makePopover"></inline-edit>
           <!-- /ko -->
+          <!-- ko if: $data.description -->
+            <p data-bind="text: $data.description"></p>
+          <!-- /ko -->
         </td>
       </tr>
       </tbody>
@@ -257,12 +275,20 @@
          data-bind="visible: !case_properties().length">
       {% trans "No properties will be saved" %}
     </div>
-    <a href="#" class="firstProperty btn btn-default"
+    <a href="#"
+       class="firstProperty btn btn-default"
        data-bind="click: addProperty,
-                  visible: !case_properties().length">
+                  visible: !case_properties().length && $parent.hasPrivilege">
       <i class="fa fa-plus"></i>
       {% trans "Save properties" %}
     </a>
+    <!-- ko if: !case_properties().length && !$parent.hasPrivilege -->
+      <p>
+        {% blocktrans %}
+          You no longer have permission to save case properties.
+        {% endblocktrans %}
+      </p>
+    <!-- /ko -->
   </div>
 </script>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/add_ons.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/add_ons.html
@@ -51,12 +51,42 @@
         <div class="panel-body" data-bind="foreach: add_ons">
           <div class="checkbox">
             <label>
-              <input type="checkbox" data-bind="attr: {name: slug, id: 'check-' + slug}, checked: $root.addOns[slug], event: {change: $root.update}" />
+              <input type="checkbox"
+                     data-bind="attr: {
+                                  name: slug,
+                                  id: 'check-' + slug,
+                                },
+                                disable: show_upgrade,
+                                checked: $root.addOns[slug],
+                                event: {change: $root.update}" />
               <span data-bind="text: name, attr: {for: 'check-' + slug}" class="clickable"></span>
               <div class="help-block">
                 <span data-bind="text: description"></span>
                 <a target="_blank" data-bind="if: help_link, attr:{href: help_link}">{% trans "Learn more." %}</a>
               </div>
+              <!-- ko if: show_upgrade -->
+                <div class="well well-sm">
+                  <p>
+                    <i class="fa fa-info-circle"></i>
+                    <span data-bind="text: upgrade_text"></span>
+                    {% include 'hqwebapp/partials/generic_feature_upgrade.html' %}
+                  </p>
+
+                  <!-- ko if: $root.addOns[slug] -->
+                    <p>
+                      {% blocktrans %}
+                        You have previously enabled this feature in your app, but have since lost access
+                        to it.
+                      {% endblocktrans %}
+                      <br />
+                      {% blocktrans %}
+                        Your application will continue to function in places that utilized this feature, but
+                        you will not be able to edit any related functionality until you upgrade.
+                      {% endblocktrans %}
+                    </p>
+                  <!-- /ko -->
+                </div>
+              <!-- /ko -->
             </label>
           </div>
         </div>

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -143,6 +143,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
     if app and not app.is_remote_app():
         context.update({
             'add_ons': add_ons.get_dict(request, app, module, form),
+            'add_ons_privileges': add_ons.get_privileges_dict(request),
             'add_ons_layout': add_ons.get_layout(request),
         })
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/generic_feature_upgrade.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/generic_feature_upgrade.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+{% url 'domain_subscription_view' domain as sub_url %}
+{% blocktrans %}
+  <a href="{{ sub_url }}">Click here</a> to upgrade or reach
+  out to us at <a href="mailto:sales@dimagi.com">sales@dimagi.com</a>
+  to learn more!
+{% endblocktrans %}


### PR DESCRIPTION
**NOTE:** will not show up yet to any existing domains, as the privilege `CHILD_CASES` has been grandfathered to all current plans.

**What it looks like on a domain (eventually new community / standard plans) that can't access `CHILD_CASES`:**

Add Ons page:
![Screen Shot 2019-08-02 at 4 40 29 PM](https://user-images.githubusercontent.com/716573/62401506-20db6500-b549-11e9-83db-9841ea0cc61e.png)

**Experience for domains that have been downgraded but had Child Cases enabled on an app:**

Add Ons page:
![Screen Shot 2019-08-02 at 4 38 27 PM](https://user-images.githubusercontent.com/716573/62401567-613ae300-b549-11e9-87d0-17a9cda29800.png)

On the case config page:
![Screen Shot 2019-08-02 at 4 38 14 PM](https://user-images.githubusercontent.com/716573/62401543-4a948c00-b549-11e9-94f2-b7fbeae581a6.png)

cc @dimagi/product 
