### PR TITLE
use contextlib2

### DIFF
--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -31,7 +31,7 @@ monkey.patch_all()
 import os
 import re
 import sys
-from contextlib import ExitStack
+from contextlib2 import ExitStack
 
 import gevent
 import jsonobject


### PR DESCRIPTION
Not sure why it didn't happen for anyone else, may be because i am still using python2.
 But we are using `contextlib2` at other places.