### PR TITLE
Fix the way responses are handled when a payload has nothing to send

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -67,13 +67,28 @@ class Dhis2Repeater(FormRepeater):
         return json.loads(payload)
 
     def send_request(self, repeat_record, payload):
+        """
+        Sends API request and returns response if ``payload`` is a form
+        that is configured to be forwarded to DHIS2.
+
+        If ``payload`` is a form that isn't configured to be forwarded,
+        returns True.
+        """
         for form_config in self.dhis2_config.form_configs:
             if form_config.xmlns == payload['form']['@xmlns']:
+                requests = Requests(
+                    self.domain,
+                    self.url,
+                    self.username,
+                    self.plaintext_password,
+                    verify=self.verify,
+                )
                 return send_data_to_dhis2(
-                    Requests(self.domain, self.url, self.username, self.plaintext_password, verify=self.verify),
+                    requests,
                     form_config,
                     payload,
                 )
+        return True
 
 
 def create_dhis_repeat_records(sender, xform, **kwargs):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -320,7 +320,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
         if isinstance(result, Exception):
             attempt = repeat_record.handle_exception(result)
             self.generator.handle_exception(result, repeat_record)
-        elif 200 <= result.status_code < 300:
+        elif result is True or 200 <= result.status_code < 300:
             attempt = repeat_record.handle_success(result)
             self.generator.handle_success(result, self.payload_doc(repeat_record), repeat_record)
         else:
@@ -722,23 +722,34 @@ class RepeatRecord(Document):
 
     @staticmethod
     def _format_response(response):
+        if not _is_response(response):
+            return None
         return '{}: {}.\n{}'.format(
             response.status_code, response.reason, getattr(response, 'content', None))
 
     def handle_success(self, response):
-        """Do something with the response if the repeater succeeds
+        """
+        Log success in Datadog and return a success RepeatRecordAttempt.
+
+        ``response`` can be a Requests response instance, or True if the
+        payload did not result in an API call.
         """
         now = datetime.utcnow()
-        log_repeater_success_in_datadog(
-            self.domain,
-            response.status_code if response else None,
-            self.repeater_type
-        )
+        if _is_response(response):
+            # ^^^ Don't bother logging success in Datadog if the payload
+            # did not need to be sent. (This can happen with DHIS2 if
+            # the form that triggered the forwarder doesn't contain data
+            # for a DHIS2 Event.)
+            log_repeater_success_in_datadog(
+                self.domain,
+                response.status_code,
+                self.repeater_type
+            )
         return RepeatRecordAttempt(
             cancelled=False,
             datetime=now,
             failure_reason=None,
-            success_response=self._format_response(response) if response else None,
+            success_response=self._format_response(response),
             next_check=None,
             succeeded=True,
             info=self.get_attempt_info(),
@@ -809,6 +820,14 @@ class RepeatRecord(Document):
         self.failure_reason = ''
         self.overall_tries = 0
         self.next_check = datetime.utcnow()
+
+
+def _is_response(duck):
+    """
+    Returns True if ``duck`` has the attributes of a Requests response
+    instance that this module uses, otherwise False.
+    """
+    return hasattr(duck, 'status_code') and hasattr(duck, 'reason')
 
 
 # import signals

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -724,8 +724,9 @@ class RepeatRecord(Document):
     def _format_response(response):
         if not _is_response(response):
             return None
+        response_body = getattr(response, "text", "")
         return '{}: {}.\n{}'.format(
-            response.status_code, response.reason, getattr(response, 'content', None))
+            response.status_code, response.reason, response_body)
 
     def handle_success(self, response):
         """

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -320,7 +320,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
         if isinstance(result, Exception):
             attempt = repeat_record.handle_exception(result)
             self.generator.handle_exception(result, repeat_record)
-        elif result is True or 200 <= result.status_code < 300:
+        elif _is_response(result) and 200 <= result.status_code < 300 or result is True:
             attempt = repeat_record.handle_success(result)
             self.generator.handle_success(result, self.payload_doc(repeat_record), repeat_record)
         else:

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -938,7 +939,7 @@ class TestRepeaterDeleted(BaseRepeaterTest):
 
 
 @attr.s
-class Response:
+class Response(object):
     status_code = attr.ib()
     reason = attr.ib()
     content = attr.ib(default=None)
@@ -946,7 +947,7 @@ class Response:
 
     @property
     def text(self):
-        return '' if self.content is None else str(self.content, self.encoding, errors='replace')
+        return '' if self.content is None else self.content.decode(self.encoding, errors='replace')
 
 
 class HandleResponseTests(SimpleTestCase):


### PR DESCRIPTION
Dhis2Repeater forwards forms to DHIS2 as "Events" by mapping form question values to event attributes. But not all forms are mapped. Forms that are not mapped are ignored.

When a payload doesn't include a mapped form, Dhis2Repeater has nothing to send to DHIS2, and the `send_payload()` method returns `None`. This `None` result causes problems downstream. 

This PR resolves those problems by returning `True` instead, and treating a `True` result as a kind of success.

Probably easier to :blowfish: 
