### PR TITLE
Disambiguate page titles, etc.

### DIFF
--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -26,7 +26,7 @@ class Dhis2Repeater(FormRepeater):
         app_label = 'repeaters'
 
     include_app_id_param = False
-    friendly_name = _("Forward to DHIS2")
+    friendly_name = _("Forward Forms to DHIS2 as Anonymous Events")
     payload_generator_classes = (FormRepeaterJsonPayloadGenerator,)
 
     dhis2_config = SchemaProperty(Dhis2Config)

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -224,8 +224,8 @@ class AddOpenmrsRepeaterView(AddCaseRepeaterView):
 class AddDhis2RepeaterView(AddFormRepeaterView):
     urlname = 'new_dhis2_repeater$'
     repeater_form_class = Dhis2RepeaterForm
-    page_title = ugettext_lazy("Forward to DHIS2")
-    page_name = ugettext_lazy("Forward to DHIS2")
+    page_title = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
+    page_name = ugettext_lazy("Forward Forms to DHIS2 as Anonymous Events")
 
     def set_repeater_attr(self, repeater, cleaned_data):
         repeater = super(AddDhis2RepeaterView, self).set_repeater_attr(repeater, cleaned_data)
@@ -314,7 +314,7 @@ class EditOpenmrsRepeaterView(EditRepeaterView, AddOpenmrsRepeaterView):
 
 class EditDhis2RepeaterView(EditRepeaterView, AddDhis2RepeaterView):
     urlname = 'edit_dhis2_repeater'
-    page_title = ugettext_lazy("Edit OpenMRS Repeater")
+    page_title = ugettext_lazy("Edit DHIS2 Anonymous Event Repeater")
 
 
 @require_POST


### PR DESCRIPTION
Fixes `EditDhis2RepeaterView` page title "Edit OpenMRS Repeater". :man_facepalming: 

I took the opportunity to refer to Anonymous Events, because soon we will also have a view with the title "Forward Cases to DHIS2 as Tracked Entities".
