### PR TITLE
Removed link to mm reference checker from mm download zip area

### DIFF
--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -14,18 +14,6 @@
         This application is missing references, so this zip will be incomplete.
       {% endblocktrans %}
     </p>
-    {% if not is_multimedia_reference_checker %}
-      <p>
-        {% url "hqmedia_references" domain app.get_id as checker_url %}
-        {% blocktrans %}
-          Visit the <a href='{{ checker_url }}' target= '_blank'>
-          Multimedia Reference Checker
-          <i class='fa fa-external-link'></i>
-        </a>
-          to upload any missing multimedia.
-        {% endblocktrans %}
-      </p>
-    {% endif %}
   </div>
 {% endif %}
 

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -56,7 +56,7 @@
       </div>
       <div class="col-sm-5" data-bind="visible: totals().length">
         <div class="well">
-          {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True is_multimedia_reference_checker=True %}
+          {% include "hqmedia/partials/multimedia_zip_notice.html" with include_modal=True %}
           <ul class="list-unstyled" data-bind="foreach: totals">
             <li class="media-totals" data-bind="event: {refMediaAdded: $parent.incrementTotals}">
               <i data-bind="attr: {class: icon_class}"></i>


### PR DESCRIPTION
This removes this link to the multimedia reference checker in the publish modal:

<img width="612" alt="Screen Shot 2019-08-06 at 3 01 07 PM" src="https://user-images.githubusercontent.com/1486591/62568408-17107500-b85b-11e9-993a-c9acd9a7b9b9.png">

which was added in https://github.com/dimagi/commcare-hq/commit/70658a2ca4731782dd912dda39299d9ce118bae1 

The intent was to let users know how to deal with missing multimedia. But for builds, this isn't actually a fixable problem. You can add multimedia to the current app, but you can't retroactively add it to old builds.