### PR TITLE
BI Integration: Fix Filtering, small text change

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -925,7 +925,10 @@ class ODataCaseResource(HqBaseResource, DomainSpecificResourceMixin):
 
     def obj_get_list(self, bundle, domain, **kwargs):
         config = get_document_or_404(CaseExportInstance, domain, self.config_id)
-        return get_case_export_base_query(domain, config.case_type)
+        query = get_case_export_base_query(domain, config.case_type)
+        for filter in config.get_filters():
+            query = query.filter(filter.to_es_filter())
+        return query
 
     def detail_uri_kwargs(self, bundle_or_obj):
         # Not sure why this is required but the feed 500s without it
@@ -974,7 +977,10 @@ class ODataFormResource(HqBaseResource, DomainSpecificResourceMixin):
 
     def obj_get_list(self, bundle, domain, **kwargs):
         config = get_document_or_404(FormExportInstance, domain, self.config_id)
-        return get_form_export_base_query(domain, config.app_id, config.xmlns, include_errors=True)
+        query = get_form_export_base_query(domain, config.app_id, config.xmlns, include_errors=True)
+        for filter in config.get_filters():
+            query = query.filter(filter.to_es_filter())
+        return query
 
     def detail_uri_kwargs(self, bundle_or_obj):
         # Not sure why this is required but the feed 500s without it

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -56,7 +56,9 @@
         {% elif not is_odata %}
           {% trans 'Edit' %}
         {% else %}
-          {% trans 'Copy' %}
+          {% blocktrans %}
+            Copy &amp; Edit
+          {% endblocktrans %}
         {% endif %}
       </th>
       <th class="col-sm-1">

--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -19,7 +19,7 @@
 
     <th class="col-sm-1">
       {% if export_filter_form %}
-        {% if has_edit_permissions and not is_odata %}
+        {% if has_edit_permissions %}
           {% trans "Edit Filters" %}
         {% endif %}
       {% else %}
@@ -416,7 +416,7 @@
          class="btn btn-primary">
         {{ export_type_caps }}
       </a>
-      {% if has_edit_permissions and not is_odata %}
+      {% if has_edit_permissions %}
         <a class="btn btn-default"
            data-bind="visible: showSavedFilters && isLocationSafeForUser(),
                       click: function (model) {


### PR DESCRIPTION
filters were broken in odata. This adds filtering to the feed and unhides the Edit Filters button in the odata exports feed.

cc @dimagi/product 