### PR TITLE
Make arg required and rename to disambiguate

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5635,13 +5635,11 @@ class LinkedApplication(Application):
         return {}
 
     @memoized
-    def get_previous_version(self, master_app_id=None):
-        if master_app_id is None:
-            master_app_id = self.upstream_app_id
+    def get_latest_build_from_upstream(self, upstream_app_id):
         build_ids = get_build_ids(self.domain, self.master_id)
         for build_id in build_ids:
             build_doc = Application.get_db().get(build_id)
-            if build_doc.get('upstream_app_id', build_doc['master']) == master_app_id:
+            if build_doc.get('upstream_app_id', build_doc['master']) == upstream_app_id:
                 return self.wrap(build_doc)
         return None
 
@@ -5652,7 +5650,7 @@ class LinkedApplication(Application):
             # If there's no previous version, check for a previous version in the same family.
             # This allows projects using multiple masters to copy a master app and start pulling
             # from that copy without resetting the form and multimedia versions.
-            previous_version = self.get_previous_version(master_app_id=self.progenitor_app_id)
+            previous_version = self.get_latest_build_from_upstream(self.progenitor_app_id)
         return previous_version
 
     @classmethod

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -195,7 +195,7 @@ def overwrite_app(app, master_build, report_map=None):
     form_ids_by_xmlns = {}
     master_app_briefs = app.get_master_app_briefs()
     for brief in master_app_briefs:
-        previous_app = app.get_previous_version(master_app_id=brief.master_id)
+        previous_app = app.get_latest_build_from_upstream(brief.master_id)
         if previous_app:
             form_ids_by_xmlns.update(_get_form_ids_by_xmlns(previous_app))
     # Add in any forms from the current linked app, before the source is overwritten.
@@ -371,7 +371,7 @@ def update_linked_app(app, master_app_id, user_id):
             'Unable to pull latest master from remote CommCare HQ. Please try again later.'
         ))
 
-    previous = app.get_previous_version(master_app_id)
+    previous = app.get_latest_build_from_upstream(master_app_id)
     if previous is None or latest_released_master_build.version > previous.upstream_version:
         report_map = get_static_report_mapping(latest_released_master_build.domain, app['domain'])
         try:

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -309,7 +309,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.assertEqual(self.linked_app.upstream_app_id, self.master2.get_id)
         self.assertEqual(self.linked_app.upstream_version, original_master2_version + 3)
 
-    def test_get_previous_version(self):
+    def test_get_latest_build_from_upstream(self):
         # Make build of master1, pull linked app, and make linked app build
         self._make_master1_build()
         self._pull_linked_app(self.master1.get_id)
@@ -325,11 +325,11 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self._pull_linked_app(self.master2.get_id)
         linked_build3 = self._make_linked_build()
 
-        previous_master2_version = linked_build3.get_previous_version()
+        previous_master2_version = linked_build3.get_latest_build_from_upstream(self.master2.get_id)
         self.assertEqual(previous_master2_version.upstream_app_id, self.master2.get_id)
         self.assertEqual(previous_master2_version.get_id, linked_build2.get_id)
 
-        previous_master1_version = linked_build3.get_previous_version(master_app_id=self.master1.get_id)
+        previous_master1_version = linked_build3.get_latest_build_from_upstream(self.master1.get_id)
         self.assertEqual(previous_master1_version.upstream_app_id, self.master1.get_id)
         self.assertEqual(previous_master1_version.get_id, linked_build1.get_id)
 


### PR DESCRIPTION
I just merged master to the linked apps PR.  There were a bunch of conflicts, but I think I resolved them properly.  This change felt different enough to warrant a separate commit.  `get_previous_version` was renamed `get_latest_build`.  This usage was a bit different anyways, so I renamed and made the arg requried.