### PR TITLE
Location-safe app releases

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -74,6 +74,7 @@ from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.linked_domain.applications import create_linked_app
 from corehq.apps.linked_domain.dbaccessors import is_master_linked_domain
 from corehq.apps.linked_domain.exceptions import RemoteRequestError
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.translations.models import Translation
 from corehq.apps.users.dbaccessors.all_commcare_users import get_practice_mode_mobile_workers
 from corehq.elastic import ESError
@@ -556,6 +557,7 @@ def app_settings(request, domain, app_id=None):
 
 @require_GET
 @require_deploy_apps
+@location_safe
 def view_app(request, domain, app_id=None):
     from corehq.apps.app_manager.views.view_generic import view_generic
     return view_generic(request, domain, app_id, release_manager=True)

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -405,6 +405,7 @@ def delete_copy(request, domain, app_id):
     return json_response({})
 
 
+@location_safe
 def odk_install(request, domain, app_id, with_media=False):
     download_target_version = request.GET.get('download_target_version') == 'true'
     app = get_app(domain, app_id)
@@ -441,6 +442,7 @@ def odk_qr_code(request, domain, app_id):
     return HttpResponse(qr_code, content_type="image/png")
 
 
+@location_safe
 def odk_media_qr_code(request, domain, app_id):
     profile = request.GET.get('profile')
     download_target_version = request.GET.get('download_target_version') == 'true'
@@ -450,12 +452,14 @@ def odk_media_qr_code(request, domain, app_id):
     return HttpResponse(qr_code, content_type="image/png")
 
 
+#@location_safe
 def short_url(request, domain, app_id):
     build_profile_id = request.GET.get('profile')
     short_url = get_app(domain, app_id).get_short_url(build_profile_id=build_profile_id)
     return HttpResponse(short_url)
 
 
+@location_safe
 def short_odk_url(request, domain, app_id, with_media=False):
     build_profile_id = request.GET.get('profile')
     short_url = get_app(domain, app_id).get_short_odk_url(with_media=with_media, build_profile_id=build_profile_id)

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -98,6 +98,7 @@ def _get_error_counts(domain, app_id, version_numbers):
 
 @cache_control(no_cache=True, no_store=True)
 @require_deploy_apps
+@location_safe
 def paginate_releases(request, domain, app_id):
     limit = request.GET.get('limit')
     only_show_released = json.loads(request.GET.get('only_show_released', 'false'))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -240,6 +240,7 @@ class FormplayerPreviewSingleApp(View):
         return render(request, "cloudcare/formplayer_home.html", context)
 
 
+@location_safe
 class PreviewAppView(TemplateView):
     template_name = 'preview_app/base.html'
     urlname = 'preview_app'


### PR DESCRIPTION
[Jira](https://dimagi-dev.atlassian.net/browse/SC-72)

This change allows location-restricted users to deploy an app to their phone using a QR code. This is a requirement of projects in Mozambique.

I'm opening this as a draft PR because the Deploy dialog has a lot of links and async requests for content leading off it, and I think we should talk more about what we want to do with those.

Currently links to pages that aren't location-safe result in a 403 page, and async requests fail silently. I'd love to hear feedback on the experience we'd like location-restricted users to have. @dimagi/product 

Things to consider:
* SMS deploys
* Deploys to Java devices
* "Click here in your mobile browser" on the barcode dialog.
* Feature-flag-hidden functionality on the Releases page and the Deploy dialog (e.g. Open in Web Apps?)
