### PR TITLE
Released multimedia integrity check

### DIFF
--- a/corehq/apps/app_manager/tests/test_ccz.py
+++ b/corehq/apps/app_manager/tests/test_ccz.py
@@ -51,7 +51,6 @@ class CCZTest(TestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn('forms.m0f0', errors[0])
 
-    @flag_enabled('CAUTIOUS_MULTIMEDIA')
     def test_multimedia_integrity(self):
         icon_path = 'jr://file/commcare/icon.png'
         self.module.set_icon('en', icon_path)

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -288,9 +288,6 @@ def find_missing_locale_ids_in_ccz(file_cache):
 
 # Check that all media files present in media_suite.xml were added to the zip
 def check_ccz_multimedia_integrity(domain, fpath):
-    if not toggles.CAUTIOUS_MULTIMEDIA.enabled(domain):
-        return []
-
     errors = []
 
     with open(fpath, 'rb') as tmp:


### PR DESCRIPTION
Releases the check added in https://github.com/dimagi/commcare-hq/pull/23287/ which has been live for ICDS for quite some time now and has had its kinks smoothed out.

@dimagi/product This adds a step when making a CCZ that verifies that all of the multimedia expected to be in the application is indeed included in the CCZ. It won't complain if there's "known" missing multimedia - that is, if you added a multimedia reference without uploading a file, that's fine. It will only complain if HQ should have a multimedia file but does not, which indicates a bug in HQ and which means the CCZ will fail to install on the phone - so this just surfaces the error earlier and in a more user-friendly fashion. Looks like this:

![b6482333-a8b4-4eb6-b14c-2108ed805ba1](https://user-images.githubusercontent.com/1486591/62802662-6acaca80-bab6-11e9-8b15-4cefebbdcc94.png)
