### PR TITLE
Ensure present domain can be copied to

### DIFF
--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -246,16 +246,16 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
     })
 
     # Pass form for Copy Application to template
-    domain_names = [
+    domain_names = {
         d.name for d in Domain.active_for_user(request.couch_user)
         if not (is_linked_domain(request.domain)
                 and get_domain_master_link(request.domain).master_domain == d.name)
-    ]
-    domain_names.sort()
+    }
+    domain_names.add(request.domain)
     if copy_app_form is None:
         copy_app_form = CopyApplicationForm(domain, app)
         context.update({
-            'domain_names': domain_names,
+            'domain_names': sorted(domain_names),
         })
     linked_domains_enabled = toggles.LINKED_DOMAINS.enabled(domain)
     context.update({


### PR DESCRIPTION
Superusers often aren't members of the domains they work on.  This ensures the present domain always appears in the dropdown of domains to copy an app to.

@calellowitz @orangejenny 