### PR TITLE
Make date filters inclusive on SMS Billables Report

### DIFF
--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -160,9 +160,8 @@ class SMSBillablesInterface(GenericTabularReport):
         )
         if DateCreatedFilter.use_filter(self.request):
             selected_billables = selected_billables.filter(
-                date_created__gte=DateCreatedFilter.get_start_date(
-                    self.request),
-                date_created__lte=DateCreatedFilter.get_end_date(self.request),
+                date_created__gte=DateCreatedFilter.get_start_date(self.request),
+                date_created__lt=DateCreatedFilter.get_end_date(self.request) + datetime.timedelta(days=1),
             )
         show_billables = ShowBillablesFilter.get_value(
             self.request, self.domain)

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -155,10 +155,10 @@ class SMSBillablesInterface(GenericTabularReport):
 
     @property
     def sms_billables(self):
-        date_span = DateSpan(DateSentFilter.get_start_date(self.request), DateSentFilter.get_end_date(self.request))
+        datespan = DateSpan(DateSentFilter.get_start_date(self.request), DateSentFilter.get_end_date(self.request))
         selected_billables = SmsBillable.objects.filter(
-            date_sent__gte=date_span.startdate,
-            date_sent__lt=date_span.enddate_adjusted,
+            date_sent__gte=datespan.startdate,
+            date_sent__lt=datespan.enddate_adjusted,
         )
         if DateCreatedFilter.use_filter(self.request):
             date_span = DateSpan(

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import datetime
 from django.db.models.aggregates import Count
+from dimagi.utils.dates import DateSpan
 from corehq.apps.accounting.filters import DateCreatedFilter
 from corehq.apps.reports.datatables import (
     DataTablesColumn,
@@ -154,14 +155,18 @@ class SMSBillablesInterface(GenericTabularReport):
 
     @property
     def sms_billables(self):
+        date_span = DateSpan(DateSentFilter.get_start_date(self.request), DateSentFilter.get_end_date(self.request))
         selected_billables = SmsBillable.objects.filter(
-            date_sent__gte=DateSentFilter.get_start_date(self.request),
-            date_sent__lt=DateSentFilter.get_end_date(self.request) + datetime.timedelta(days=1),
+            date_sent__gte=date_span.startdate,
+            date_sent__lt=date_span.enddate_adjusted,
         )
         if DateCreatedFilter.use_filter(self.request):
+            date_span = DateSpan(
+                DateCreatedFilter.get_start_date(self.request), DateCreatedFilter.get_end_date(self.request)
+            )
             selected_billables = selected_billables.filter(
-                date_created__gte=DateCreatedFilter.get_start_date(self.request),
-                date_created__lt=DateCreatedFilter.get_end_date(self.request) + datetime.timedelta(days=1),
+                date_created__gte=date_span.startdate,
+                date_created__lt=date_span.enddate_adjusted,
             )
         show_billables = ShowBillablesFilter.get_value(
             self.request, self.domain)

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import datetime
 from django.db.models.aggregates import Count
 from dimagi.utils.dates import DateSpan
 from corehq.apps.accounting.filters import DateCreatedFilter

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import datetime
 from django.db.models.aggregates import Count
 from corehq.apps.accounting.filters import DateCreatedFilter
 from corehq.apps.reports.datatables import (
@@ -155,7 +156,7 @@ class SMSBillablesInterface(GenericTabularReport):
     def sms_billables(self):
         selected_billables = SmsBillable.objects.filter(
             date_sent__gte=DateSentFilter.get_start_date(self.request),
-            date_sent__lte=DateSentFilter.get_end_date(self.request),
+            date_sent__lt=DateSentFilter.get_end_date(self.request) + datetime.timedelta(days=1),
         )
         if DateCreatedFilter.use_filter(self.request):
             selected_billables = selected_billables.filter(


### PR DESCRIPTION
Jira Ticket: https://dimagi-dev.atlassian.net/browse/HI-815

Currently, the SMS Billables Report filters for all SMSs sent from the first second of the first date (e.g. July 1 at 00:00) through the first second of the second date (e.g. July 31 at 00:00), effectively filtering out any SMSs sent on the end date. This PR changes the end date to include all billables through the last second of the day

fyi code buddies: @esoergel @calellowitz 