### PR TITLE
Cmdline copy app with report references

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5614,13 +5614,12 @@ def import_app(app_id_or_source, domain, source_properties=None, request=None):
         source = get_app(None, app_id)
         source_domain = source['domain']
         source = source.export_json(dump_json=False)
-        report_map = get_static_report_mapping(source_domain, domain)
     else:
         cls = get_correct_app_class(app_id_or_source)
         # Don't modify original app source
         app = cls.wrap(deepcopy(app_id_or_source))
+        source_domain = app['domain']
         source = app.export_json(dump_json=False)
-        report_map = {}
     try:
         attachments = source['_attachments']
     except KeyError:
@@ -5639,6 +5638,7 @@ def import_app(app_id_or_source, domain, source_properties=None, request=None):
     app.date_created = datetime.datetime.utcnow()
     app.cloudcare_enabled = domain_has_privilege(domain, privileges.CLOUDCARE)
 
+    report_map = get_static_report_mapping(source_domain, domain)
     if report_map:
         for module in app.get_report_modules():
             for config in module.report_configs:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5635,6 +5635,7 @@ def import_app(app_id_or_source, domain, source_properties=None, request=None):
     if 'build_spec' in source:
         del source['build_spec']
     app = cls.from_source(source, domain)
+    app.convert_build_to_app()
     app.date_created = datetime.datetime.utcnow()
     app.cloudcare_enabled = domain_has_privilege(domain, privileges.CLOUDCARE)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -89,6 +89,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_build_doc,
     get_latest_released_app_doc,
     get_build_by_version,
+    wrap_app,
 )
 from corehq.apps.app_manager.util import (
     get_latest_app_release_by_location,
@@ -5610,16 +5611,11 @@ class LinkedApplication(Application):
 def import_app(app_id_or_source, domain, source_properties=None, request=None):
     if isinstance(app_id_or_source, six.string_types):
         soft_assert_type_text(app_id_or_source)
-        app_id = app_id_or_source
-        source = get_app(None, app_id)
-        source_domain = source['domain']
-        source = source.export_json(dump_json=False)
+        source_app = get_app(None, app_id_or_source)
     else:
-        cls = get_correct_app_class(app_id_or_source)
-        # Don't modify original app source
-        app = cls.wrap(deepcopy(app_id_or_source))
-        source_domain = app['domain']
-        source = app.export_json(dump_json=False)
+        source_app = wrap_app(app_id_or_source)
+    source_domain = source_app.domain
+    source = source_app.export_json(dump_json=False)
     try:
         attachments = source['_attachments']
     except KeyError:

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -428,7 +428,6 @@ def copy_app(request, domain):
         else:
             # Copy application
             from_app = Application.get(data['build_id'] or app_id)
-            from_app.convert_build_to_app()
             app_source = from_app.export_json(dump_json=False)
             return _copy_app_helper(request, app_source, to_domain, data['name'])
 

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -404,27 +404,7 @@ def copy_app(request, domain):
 
         linked = data.get('linked')
         if linked:
-            # Create a new linked application
-            # Linked apps can only be created from released versions
-            error = None
-            if from_domain == to_domain:
-                error = _("You may not create a linked app in the same domain as its master app.")
-            elif data['build_id']:
-                from_app = Application.get(data['build_id'])
-                if not from_app.is_released:
-                    error = _("Make sure the version you are copying from is released.")
-            else:
-                from_app = get_latest_released_app(from_domain, app_id)
-                if not from_app:
-                    error = _("Unable to get latest released version of your app."
-                              " Make sure you have at least one released build.")
-
-            if error:
-                messages.error(request, _("Creating linked app failed. {}").format(error))
-                return HttpResponseRedirect(reverse_util('app_settings', params={},
-                                                         args=[from_domain, app_id]))
-
-            return _create_linked_app(request, from_app, to_domain, data['name'])
+            return _create_linked_app(request, app_id, data['build_id'], from_domain, to_domain, data['name'])
         else:
             return _copy_app_helper(request, data['build_id'] or app_id, to_domain, data['name'])
 
@@ -433,19 +413,36 @@ def copy_app(request, domain):
     return login_and_domain_required(_inner)(request, form.cleaned_data['domain'], form.cleaned_data)
 
 
-def _create_linked_app(request, master_build, link_domain, link_app_name):
-    master_domain = master_build.domain
-    linked_app = create_linked_app(master_domain, master_build.master_id, link_domain, link_app_name)
+def _create_linked_app(request, app_id, build_id, from_domain, to_domain, link_app_name):
+    # Linked apps can only be created from released versions
+    error = None
+    if from_domain == to_domain:
+        error = _("You may not create a linked app in the same domain as its master app.")
+    elif build_id:
+        from_app = Application.get(build_id)
+        if not from_app.is_released:
+            error = _("Make sure the version you are copying from is released.")
+    else:
+        from_app = get_latest_released_app(from_domain, app_id)
+        if not from_app:
+            error = _("Unable to get latest released version of your app."
+                      " Make sure you have at least one released build.")
+
+    if error:
+        messages.error(request, _("Creating linked app failed. {}").format(error))
+        return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[from_domain, app_id]))
+
+    linked_app = create_linked_app(from_domain, from_app.master_id, to_domain, link_app_name)
     try:
-        update_linked_app(linked_app, request.couch_user.get_id, master_build=master_build)
+        update_linked_app(linked_app, request.couch_user.get_id, master_build=from_app)
     except AppLinkError as e:
         linked_app.delete()
         messages.error(request, str(e))
         return HttpResponseRedirect(reverse_util('app_settings', params={},
-                                                 args=[master_domain, master_build.master_id]))
+                                                 args=[from_domain, from_app.master_id]))
 
     messages.success(request, _('Application successfully copied and linked.'))
-    return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[link_domain, linked_app.get_id]))
+    return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[to_domain, linked_app.get_id]))
 
 
 def _copy_app_helper(request, from_app_id, to_domain, to_app_name):

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -426,10 +426,7 @@ def copy_app(request, domain):
 
             return _create_linked_app(request, from_app, to_domain, data['name'])
         else:
-            # Copy application
-            from_app = Application.get(data['build_id'] or app_id)
-            app_source = from_app.export_json(dump_json=False)
-            return _copy_app_helper(request, app_source, to_domain, data['name'])
+            return _copy_app_helper(request, data['build_id'] or app_id, to_domain, data['name'])
 
     # having login_and_domain_required validates that the user
     # has access to the domain we're copying the app to
@@ -451,9 +448,9 @@ def _create_linked_app(request, master_build, link_domain, link_app_name):
     return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[link_domain, linked_app.get_id]))
 
 
-def _copy_app_helper(request, from_app_source, to_domain, to_app_name):
+def _copy_app_helper(request, from_app_id, to_domain, to_app_name):
     extra_properties = {'name': to_app_name}
-    app_copy = import_app_util(from_app_source, to_domain, extra_properties, request)
+    app_copy = import_app_util(from_app_id, to_domain, extra_properties, request)
     return back_to_main(request, app_copy.domain, app_id=app_copy._id)
 
 

--- a/custom/icds/management/commands/copy_icds_app.py
+++ b/custom/icds/management/commands/copy_icds_app.py
@@ -23,3 +23,18 @@ class Command(BaseCommand):
         old_app = wrap_app(old_app)
         old_app.convert_build_to_app()
         new_app = import_app(old_app.to_json(), domain, source_properties={'name': new_name})
+
+        old_to_new = get_old_to_new_config_ids(old_app, new_app)
+        for form in new_app.get_forms():
+            for old_id, new_id in old_to_new:
+                form.source = form.source.replace(old_id, new_id)
+
+        new_app.save()
+
+
+def get_old_to_new_config_ids(old_app, new_app):
+    return [
+        (old_config.uuid, new_config.uuid)
+        for old_module, new_module in zip(old_app.get_report_modules(), new_app.get_report_modules())
+        for old_config, new_config in zip(old_module.report_configs, new_module.report_configs)
+    ]

--- a/custom/icds/management/commands/copy_icds_app.py
+++ b/custom/icds/management/commands/copy_icds_app.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.core.management import BaseCommand
+
+from corehq.apps.app_manager.dbaccessors import get_build_doc_by_version, wrap_app
+from corehq.apps.app_manager.models import import_app
+
+
+class Command(BaseCommand):
+    help = "Make a copy of a specific version of an application on the same domain"
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('app_id')
+        parser.add_argument('version')
+        parser.add_argument('new_name')
+
+    def handle(self, domain, app_id, version, new_name, **options):
+        old_app = get_build_doc_by_version(domain, app_id, version)
+        if not old_app:
+            raise Exception("No app found with id '{}' and version '{}', on '{}'"
+                            .format(app_id, version, domain))
+        old_app = wrap_app(old_app)
+        old_app.convert_build_to_app()
+        new_app = import_app(old_app.to_json(), domain, source_properties={'name': new_name})

--- a/custom/icds/management/commands/copy_icds_app.py
+++ b/custom/icds/management/commands/copy_icds_app.py
@@ -4,6 +4,7 @@ from django.core.management import BaseCommand
 
 from corehq.apps.app_manager.dbaccessors import get_build_doc_by_version, wrap_app
 from corehq.apps.app_manager.models import import_app
+from corehq.util.view_utils import absolute_reverse
 
 
 class Command(BaseCommand):
@@ -30,6 +31,9 @@ class Command(BaseCommand):
                 form.source = form.source.replace(old_id, new_id)
 
         new_app.save()
+        print("App succesfully copied, you can view it at\n{}".format(
+            absolute_reverse('view_app', args=[domain, new_app.get_id])
+        ))
 
 
 def get_old_to_new_config_ids(old_app, new_app):

--- a/custom/icds/management/commands/copy_icds_app.py
+++ b/custom/icds/management/commands/copy_icds_app.py
@@ -17,11 +17,7 @@ class Command(BaseCommand):
         parser.add_argument('new_name')
 
     def handle(self, domain, app_id, version, new_name, **options):
-        old_app = get_build_doc_by_version(domain, app_id, version)
-        if not old_app:
-            raise Exception("No app found with id '{}' and version '{}', on '{}'"
-                            .format(app_id, version, domain))
-        old_app = wrap_app(old_app)
+        old_app = get_app_by_version(domain, app_id, version)
         old_app.convert_build_to_app()
         new_app = import_app(old_app.to_json(), domain, source_properties={'name': new_name})
 
@@ -34,6 +30,14 @@ class Command(BaseCommand):
         print("App succesfully copied, you can view it at\n{}".format(
             absolute_reverse('view_app', args=[domain, new_app.get_id])
         ))
+
+
+def get_app_by_version(domain, app_id, version):
+    app = get_build_doc_by_version(domain, app_id, version)
+    if not app:
+        raise Exception("No app found with id '{}' and version '{}', on '{}'"
+                        .format(app_id, version, domain))
+    return wrap_app(app)
 
 
 def get_old_to_new_config_ids(old_app, new_app):

--- a/custom/icds/management/commands/copy_icds_app.py
+++ b/custom/icds/management/commands/copy_icds_app.py
@@ -18,7 +18,6 @@ class Command(BaseCommand):
 
     def handle(self, domain, app_id, version, new_name, **options):
         old_app = get_app_by_version(domain, app_id, version)
-        old_app.convert_build_to_app()
         new_app = import_app(old_app.to_json(), domain, source_properties={'name': new_name})
 
         old_to_new = get_old_to_new_config_ids(old_app, new_app)


### PR DESCRIPTION
Copying an app changes report config UUIDs, which breaks any references to those reports by UUID in the app's forms.  This management command makes a copy of the application and performs a naive substitution of old to new UUIDs.  It's intended to be used for ICDS until we get them on a better long-term approach to copying apps that doesn't require switching IDs (that is, mobile UCRv2 with aliased report references).

@orangejenny this is PR'd into https://github.com/dimagi/commcare-hq/pull/25003 since it builds off of that work.
@gbova @calellowitz buddies