### PR TITLE
Add error logging to calculate_users_in_all_domains

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -1050,3 +1050,8 @@ def calculate_users_in_all_domains(today=None):
             )
         except IntegrityError:
             pass
+        except Exception as e:
+            log_accounting_error(
+                "Exception while creating DomainUserHistory for domain %s: %s" % (domain, e),
+                show_stack_trace=True,
+            )


### PR DESCRIPTION
Related to this issue: https://dimagi-dev.atlassian.net/browse/HI-817

A couple of `DomainUserHistory` objects must have errored out on July 1st, so I added logging to give us some heads up if this happens in the future