### PR TITLE
Removed allow_form_workflow context variable

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -91,34 +91,32 @@ hqDefine("app_manager/js/forms/form_view", function () {
             $('#form-filter').koApplyBindings(formFilterModel());
         }
 
-        if (initialPageData('allow_form_workflow')) {
-            var FormWorkflow = hqImport('app_manager/js/forms/form_workflow').FormWorkflow;
-            var labels = {};
-            labels[FormWorkflow.Values.DEFAULT] = gettext("Home Screen");
-            labels[FormWorkflow.Values.ROOT] = gettext("First Menu");
-            if (initialPageData('module_name')) {
-                labels[FormWorkflow.Values.MODULE] = gettext("Menu: ") + initialPageData('module_name');
-            }
-            if (initialPageData('root_module_name')) {
-                labels[FormWorkflow.Values.PARENT_MODULE] = gettext("Parent Menu: ") + initialPageData('root_module_name');
-            }
-            labels[FormWorkflow.Values.PREVIOUS_SCREEN] = gettext("Previous Screen");
-
-            var options = {
-                labels: labels,
-                workflow: initialPageData('post_form_workflow'),
-                workflow_fallback: initialPageData('post_form_workflow_fallback'),
-            };
-
-            if (hqImport('hqwebapp/js/toggles').toggleEnabled('FORM_LINK_WORKFLOW') || initialPageData('uses_form_workflow')) {
-                labels[FormWorkflow.Values.FORM] = gettext("Link to other form");
-                options.forms = initialPageData('linkable_forms');
-                options.formLinks = initialPageData('form_links');
-                options.formDatumsUrl = hqImport('hqwebapp/js/initial_page_data').reverse('get_form_datums');
-            }
-
-            $('#form-workflow').koApplyBindings(new FormWorkflow(options));
+        var FormWorkflow = hqImport('app_manager/js/forms/form_workflow').FormWorkflow;
+        var labels = {};
+        labels[FormWorkflow.Values.DEFAULT] = gettext("Home Screen");
+        labels[FormWorkflow.Values.ROOT] = gettext("First Menu");
+        if (initialPageData('module_name')) {
+            labels[FormWorkflow.Values.MODULE] = gettext("Menu: ") + initialPageData('module_name');
         }
+        if (initialPageData('root_module_name')) {
+            labels[FormWorkflow.Values.PARENT_MODULE] = gettext("Parent Menu: ") + initialPageData('root_module_name');
+        }
+        labels[FormWorkflow.Values.PREVIOUS_SCREEN] = gettext("Previous Screen");
+
+        var options = {
+            labels: labels,
+            workflow: initialPageData('post_form_workflow'),
+            workflow_fallback: initialPageData('post_form_workflow_fallback'),
+        };
+
+        if (hqImport('hqwebapp/js/toggles').toggleEnabled('FORM_LINK_WORKFLOW') || initialPageData('uses_form_workflow')) {
+            labels[FormWorkflow.Values.FORM] = gettext("Link to other form");
+            options.forms = initialPageData('linkable_forms');
+            options.formLinks = initialPageData('form_links');
+            options.formDatumsUrl = hqImport('hqwebapp/js/initial_page_data').reverse('get_form_datums');
+        }
+
+        $('#form-workflow').koApplyBindings(new FormWorkflow(options));
 
         // Settings > Advanced
         $('#auto-gps-capture').koApplyBindings({

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -66,12 +66,8 @@
     <script src="{% static 'app_manager/js/nav_menu_media_common.js' %}"></script>
     <script src="{% static 'app_manager/js/app_manager_media.js' %}"></script>
     <script src="{% static 'app_manager/js/nav_menu_media.js' %}"></script>
+    <script src="{% static 'app_manager/js/forms/form_workflow.js' %}"></script>
   {% endcompress %}
-  {% if allow_form_workflow %}
-    {% compress js %}
-      <script src="{% static 'app_manager/js/forms/form_workflow.js' %}"></script>
-    {% endcompress %}
-  {% endif %}
   {% if request|toggle_enabled:"CUSTOM_INSTANCES"%}
     {% compress js %}
       <script src="{% static 'app_manager/js/forms/custom_instances.js' %}"></script>
@@ -163,7 +159,6 @@
   {% registerurl "validate_form_for_build" domain app.id form.unique_id %}
 
   {# End of form navigation #}
-  {% initial_page_data 'allow_form_workflow' allow_form_workflow %}
   {% initial_page_data 'form_links' form.form_links %}
   {% initial_page_data 'linkable_forms' linkable_forms %}
   {% if not module.put_in_root %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_tab_settings.html
@@ -63,11 +63,7 @@
             <div class="alert alert-info">{% trans 'Form filtering is disabled for this form' %}</div>
           {% endif %}
 
-          {% if allow_form_workflow %}
-            {% include "app_manager/partials/forms/form_workflow.html" %}
-          {% else %}
-            <div class="alert alert-info">{% trans 'Form workflows are disabled for this form' %}</div>
-          {% endif %}
+          {% include "app_manager/partials/forms/form_workflow.html" %}
         </div>
       </div>
 

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -750,7 +750,6 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
         'xform_validation_missing': xform_validation_missing,
         'allow_form_copy': isinstance(form, (Form, AdvancedForm)),
         'allow_form_filtering': not form_has_schedule,
-        'allow_form_workflow': True,
         'uses_form_workflow': form.post_form_workflow == WORKFLOW_FORM,
         'allow_usercase': allow_usercase,
         'is_usercase_in_use': is_usercase_in_use(request.domain),
@@ -782,7 +781,7 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
     if toggles.COPY_FORM_TO_APP.enabled_for_request(request):
         context['apps_modules'] = get_apps_modules(domain, app.id, module.unique_id)
 
-    if context['allow_form_workflow'] and toggles.FORM_LINK_WORKFLOW.enabled(domain):
+    if toggles.FORM_LINK_WORKFLOW.enabled(domain):
         def qualified_form_name(form, auto_link):
             module_name = trans(module.name, langs)
             form_name = trans(form.name, langs)


### PR DESCRIPTION
Minor. As of https://github.com/dimagi/commcare-hq/pull/17193/ everybody is allowed to use EOF navigation.

Ignore whitespace.