### PR TITLE
Add new controller class for reassign case

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -21,6 +21,7 @@ from corehq.apps.reports.filters.controllers import (
     EmwfOptionsController,
     MobileWorkersOptionsController,
     CaseListFilterOptionsController,
+    ReassignCaseOptionsController
 )
 
 from phonelog.models import DeviceReportEntry
@@ -121,19 +122,10 @@ class CaseListFilterOptions(EmwfOptionsView):
 
 @location_safe
 class ReassignCaseOptions(CaseListFilterOptions):
-
     @property
-    def data_sources(self):
-        """
-        Includes case-sharing groups but not reporting groups
-        """
-        sources = []
-        if self.request.can_access_all_locations:
-            sources.append((self.get_sharing_groups_size, self.get_sharing_groups))
-        sources.append((self.get_locations_size, self.get_locations))
-        sources.append((self.get_all_users_size, self.get_all_users))
-        return sources
-
+    @memoized
+    def options_controller(self):
+        return ReassignCaseOptionsController(self.request, self.domain, self.search)
 
 
 class DeviceLogFilter(LoginAndDomainMixin, JSONResponseMixin, View):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -299,6 +299,21 @@ class CaseListFilterOptionsController(EmwfOptionsController):
         return self.group_es_query(query, group_type="case_sharing").count()
 
 
+class ReassignCaseOptionsController(CaseListFilterOptionsController):
+
+    @property
+    def data_sources(self):
+        """
+        Includes case-sharing groups but not reporting groups
+        """
+        sources = []
+        if self.request.can_access_all_locations:
+            sources.append((self.get_sharing_groups_size, self.get_sharing_groups))
+        sources.append((self.get_locations_size, self.get_locations))
+        sources.append((self.get_all_users_size, self.get_all_users))
+        return sources
+
+
 class LocationGroupOptionsController(EmwfOptionsController):
 
     @property


### PR DESCRIPTION
fixes this https://dimagi-dev.atlassian.net/browse/HI-696.
Currently ReassignCaseOptions.data_source method is not being called at the first place which it is always calling the data_sources method in CaseListFilterOptionsController. 
and ReassignCaseOptions.data_source is not being used/called anywhere else in the code base. 
This code change makes a sub controller class for  ReassignCaseOptions to call the correct datasource.

