### PR TITLE
Remove pip-tools from base requirements

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -216,4 +216,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via django-websocket-redis, ipdb, ipython, python-levenshtein, python-termstyle, sphinx
+# setuptools==41.1.0        # via django-websocket-redis, ipdb, ipython, python-levenshtein, python-termstyle, sphinx

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -19,7 +19,6 @@ git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#eg
 certifi==2019.3.9
 cffi==1.12.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
-click==7.0                # via pip-tools
 cloudant==2.12.0          # via jsonobject-couchdbkit
 commcaretranslationchecker==0.9.3.5
 concurrent-log-handler==0.9.12
@@ -111,7 +110,6 @@ pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
 pillow==6.0.0
-pip-tools==4.0.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prompt-toolkit==1.0.16    # via ipython

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -18,7 +18,6 @@ git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#eg
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
-click==7.0                # via pip-tools
 cloudant==2.12.0          # via jsonobject-couchdbkit
 commcaretranslationchecker==0.9.3.5
 concurrent-log-handler==0.9.12
@@ -100,7 +99,6 @@ pbr==5.2.0                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.10
 pillow==6.0.0
-pip-tools==4.0.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1
@@ -163,4 +161,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via django-websocket-redis, python-levenshtein
+# setuptools==41.1.0        # via django-websocket-redis, python-levenshtein

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -179,4 +179,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via django-websocket-redis, python-levenshtein
+# setuptools==41.1.0        # via django-websocket-redis, python-levenshtein

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -137,7 +137,7 @@ pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
 pillow==6.0.0
-pip-tools==3.8.0
+pip-tools==4.0.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prompt-toolkit==1.0.16    # via ipython
@@ -226,4 +226,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via django-websocket-redis, ipdb, ipython, python-levenshtein, python-termstyle, sphinx
+# setuptools==41.1.0        # via django-websocket-redis, ipdb, ipython, python-levenshtein, python-termstyle, sphinx

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,7 +28,6 @@ kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 mock==2.0.0
 Pillow~=6.0
-pip-tools>=4.0.0
 phonenumberslite~=8.8
 psycopg2~=2.7.7
 psycogreen~=1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -166,4 +166,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via django-websocket-redis, python-levenshtein
+# setuptools==41.1.0        # via django-websocket-redis, python-levenshtein

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -6,7 +6,7 @@ git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 fakecouch==0.0.15
 nose==1.3.7
 nose-exclude==0.5.0
-pip-tools>=3.8
+pip-tools>=4.0.0
 testil
 unittest2
 requests-mock

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -116,7 +116,7 @@ pbr==5.2.0                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.10
 pillow==6.0.0
-pip-tools==3.8.0
+pip-tools==4.0.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1
@@ -185,4 +185,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via django-websocket-redis, python-levenshtein
+# setuptools==41.1.0        # via django-websocket-redis, python-levenshtein


### PR DESCRIPTION
I missed this in https://github.com/dimagi/commcare-hq/pull/24968

* Removed pip-tools from requirements.in
* Updated the pip-tools version in test-requirements.in
* Ran make requirements in both a py2 and py3 environment