### PR TITLE
Disallow same domain app linking

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -407,7 +407,9 @@ def copy_app(request, domain):
             # Create a new linked application
             # Linked apps can only be created from released versions
             error = None
-            if data['build_id']:
+            if from_domain == to_domain:
+                error = _("You may not create a linked app in the same domain as its master app.")
+            elif data['build_id']:
                 from_app = Application.get(data['build_id'])
                 if not from_app.is_released:
                     error = _("Make sure the version you are copying from is released.")


### PR DESCRIPTION
As discussed in https://dimagi-dev.atlassian.net/browse/QA-666, this is a more strictly-enforced version of https://github.com/dimagi/commcare-hq/pull/22105

Branched off of https://github.com/dimagi/commcare-hq/pull/25003, only the last commit is new.

Feature flag: linked project spaces