### PR TITLE
Citus should use local table for awc_location agg

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/location.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/location.distributed.txt
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS "tmp_awc_location"
+DROP TABLE IF EXISTS "tmp_awc_location_local"
 {}
-CREATE TABLE "tmp_awc_location" (LIKE "awc_location" INCLUDING INDEXES)
+CREATE TABLE "tmp_awc_location_local" (LIKE "awc_location_local" INCLUDING INDEXES)
 {}


### PR DESCRIPTION
@calellowitz I accidentally hurt Citus performance considerably with the locations change. I believe that the check for missing locations is very inefficient because it uses a subquery with a distributed table. I think that can be fixed with this PR where I swap usages of distributed and local tables