### PR TITLE
Removed HQMediaMapItem.output_size

### DIFF
--- a/corehq/apps/accounting/tests/data/app-commcare-icon-build.json
+++ b/corehq/apps/accounting/tests/data/app-commcare-icon-build.json
@@ -4,8 +4,6 @@
    "multimedia_map": {
        "jr://file/commcare/logo/data/hq_logo_android_login.png": {
            "doc_type": "HQMediaMapItem",
-           "output_size": {
-           },
            "version": 7,
            "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
            "media_type": "CommCareImage",
@@ -13,8 +11,6 @@
        },
        "jr://file/commcare/logo/data/hq_logo_android_home.png": {
            "doc_type": "HQMediaMapItem",
-           "output_size": {
-           },
            "version": 7,
            "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
            "media_type": "CommCareImage",

--- a/corehq/apps/accounting/tests/data/app-commcare-icon-standard.json
+++ b/corehq/apps/accounting/tests/data/app-commcare-icon-standard.json
@@ -4,8 +4,6 @@
    "multimedia_map": {
        "jr://file/commcare/logo/data/hq_logo_android_login.png": {
            "doc_type": "HQMediaMapItem",
-           "output_size": {
-           },
            "version": null,
            "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
            "media_type": "CommCareImage",
@@ -13,8 +11,6 @@
        },
        "jr://file/commcare/logo/data/hq_logo_android_home.png": {
            "doc_type": "HQMediaMapItem",
-           "output_size": {
-           },
            "version": null,
            "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
            "media_type": "CommCareImage",

--- a/corehq/apps/app_manager/tests/data/yesno.json
+++ b/corehq/apps/app_manager/tests/data/yesno.json
@@ -303,7 +303,6 @@
             "doc_type": "HQMediaMapItem",
             "media_type": "CommCareImage",
             "multimedia_id": "f9de787a5cb113898c19a0f17d442654",
-            "output_size": {}
         }
     },
     "name": "Yes / No",

--- a/corehq/apps/app_manager/tests/data/yesno.json
+++ b/corehq/apps/app_manager/tests/data/yesno.json
@@ -302,7 +302,7 @@
         "jr://file/commcare/image/data/image.png": {
             "doc_type": "HQMediaMapItem",
             "media_type": "CommCareImage",
-            "multimedia_id": "f9de787a5cb113898c19a0f17d442654",
+            "multimedia_id": "f9de787a5cb113898c19a0f17d442654"
         }
     },
     "name": "Yes / No",

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -447,7 +447,6 @@ class HQMediaMapItem(DocumentSchema):
 
     multimedia_id = StringProperty()
     media_type = StringProperty()
-    output_size = DictProperty()
     version = IntegerProperty()
     unique_id = StringProperty()
 

--- a/corehq/apps/translations/tests/data/bulk_app_translation/moved_module/app.json
+++ b/corehq/apps/translations/tests/data/bulk_app_translation/moved_module/app.json
@@ -67,8 +67,6 @@
   "multimedia_map": {
     "jr:\/\/file\/commcare\/image\/data\/What_does_this_look_like.png": {
       "doc_type": "HQMediaMapItem",
-      "output_size": {
-      },
       "version": null,
       "multimedia_id": "bdee5d5d5619bd3704a2ac4fa8c7be4c",
       "media_type": "CommCareImage",
@@ -76,8 +74,6 @@
     },
     "jr:\/\/file\/commcare\/image\/module0_form0.png": {
       "doc_type": "HQMediaMapItem",
-      "output_size": {
-      },
       "version": null,
       "multimedia_id": "bdee5d5d5619bd3704a2ac4fa84a6cd8",
       "media_type": "CommCareImage",
@@ -85,8 +81,6 @@
     },
     "jr:\/\/file\/commcare\/image\/module0.png": {
       "doc_type": "HQMediaMapItem",
-      "output_size": {
-      },
       "version": null,
       "multimedia_id": "bdee5d5d5619bd3704a2ac4fa84a6cd8",
       "media_type": "CommCareImage",

--- a/corehq/pillows/mappings/app_mapping.json
+++ b/corehq/pillows/mappings/app_mapping.json
@@ -68,10 +68,6 @@
                     "index": "not_analyzed",
                     "type": "string"
                 },
-                "output_size": {
-                    "type": "object",
-                    "dynamic": false
-                },
                 "version": {
                     "type": "long"
                 },

--- a/corehq/pillows/mappings/app_mapping.py
+++ b/corehq/pillows/mappings/app_mapping.py
@@ -4,7 +4,7 @@ from corehq.util.elastic import es_index
 from corehq.pillows.mappings.utils import mapping_from_json
 from pillowtop.es_utils import ElasticsearchIndexInfo
 
-APP_INDEX = es_index("hqapps_2019-01-23")
+APP_INDEX = es_index("hqapps_2019-08-14")
 APP_MAPPING = mapping_from_json('app_mapping.json')
 APP_ES_ALIAS = "hqapps"
 APP_ES_TYPE = "app"

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -87,7 +87,7 @@ EXPECTED_PROD_INDICES = [
     },
     {
         "alias": "hqapps",
-        "index": "test_hqapps_2019-01-23",
+        "index": "test_hqapps_2019-08-14",
         "type": "app",
         "meta": {
             "settings": {

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -9,7 +9,7 @@
     "ApplicationToElasticsearchPillow": {
         "advertised_name": "ApplicationToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "ApplicationToElasticsearchPillow-test_hqapps_2019-01-23",
+        "checkpoint_id": "ApplicationToElasticsearchPillow-test_hqapps_2019-08-14",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "ApplicationToElasticsearchPillow"
     },


### PR DESCRIPTION
It doesn't look like this is used, even back in https://github.com/dimagi/commcare-hq/commit/32a58e484432f066298dee72914f5b5f469f0dea where it was added.