### PR TITLE
Encrypt and decrypt functions must return Unicode

### DIFF
--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -1,10 +1,19 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+# encoding: utf-8
+from __future__ import absolute_import, unicode_literals
+
 import doctest
-import six
+
 from django.test import SimpleTestCase
+
+import six
+
 import corehq.motech.utils
-from corehq.motech.utils import pad, pformat_json
+from corehq.motech.utils import (
+    b64_aes_decrypt,
+    b64_aes_encrypt,
+    pad,
+    pformat_json,
+)
 
 
 class PadTests(SimpleTestCase):
@@ -54,6 +63,26 @@ class PFormatJSONTests(SimpleTestCase):
             pformat_json(None),
             ''
         )
+
+
+class EncryptionTests(SimpleTestCase):
+
+    def assert_message_equals_plaintext(self, message):
+        assert isinstance(message, six.text_type)
+        ciphertext = b64_aes_encrypt(message)
+        plaintext = b64_aes_decrypt(ciphertext)
+        self.assertEqual(plaintext, message)
+        self.assertIsInstance(ciphertext, six.text_type)
+        self.assertIsInstance(plaintext, six.text_type)
+
+    def test_encrypt_decrypt_ascii(self):
+        message = 'Around you is a forest.'
+        self.assert_message_equals_plaintext(message)
+
+    def test_encrypt_decrypt_utf8(self):
+        message = 'आपके आसपास एक जंगल है'
+        self.assert_message_equals_plaintext(message)
+
 
 class DocTests(SimpleTestCase):
 

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -38,7 +38,7 @@ def b64_aes_encrypt(message):
 
     >>> settings.SECRET_KEY = 'xyzzy'
     >>> encrypted = b64_aes_encrypt('Around you is a forest.')
-    >>> encrypted == b'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I='
+    >>> encrypted == 'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I='
     True
 
     """
@@ -49,7 +49,8 @@ def b64_aes_encrypt(message):
     message_bytes = message if isinstance(message, bytes) else message.encode('utf8')
     plaintext = pad(message_bytes, AES_BLOCK_SIZE)
     ciphertext = aes.encrypt(plaintext)
-    return b64encode(ciphertext)
+    b64bytestring = b64encode(ciphertext)
+    return str(b64bytestring)
 
 
 def b64_aes_decrypt(message):
@@ -59,8 +60,8 @@ def b64_aes_decrypt(message):
     Uses Django SECRET_KEY as AES key.
 
     >>> settings.SECRET_KEY = 'xyzzy'
-    >>> decrypted = b64_aes_decrypt(b'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I=')
-    >>> decrypted == b'Around you is a forest.'
+    >>> decrypted = b64_aes_decrypt('Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I=')
+    >>> decrypted == 'Around you is a forest.'
     True
 
     """
@@ -69,8 +70,9 @@ def b64_aes_decrypt(message):
     aes = AES.new(secret, AES.MODE_ECB)
 
     ciphertext = b64decode(message)
-    plaintext = aes.decrypt(ciphertext)
-    return plaintext.rstrip(PAD_CHAR)
+    padded_plaintext = aes.decrypt(ciphertext)
+    plaintext = padded_plaintext.rstrip(PAD_CHAR)
+    return str(plaintext)
 
 
 def pformat_json(data):

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -42,15 +42,18 @@ def b64_aes_encrypt(message):
     True
 
     """
-    key = settings.SECRET_KEY if isinstance(settings.SECRET_KEY, bytes) else settings.SECRET_KEY.encode('ascii')
-    secret = pad(key, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
-    aes = AES.new(secret, AES.MODE_ECB)
+    if isinstance(settings.SECRET_KEY, bytes):
+        secret_key_bytes = settings.SECRET_KEY
+    else:
+        secret_key_bytes = settings.SECRET_KEY.encode('ascii')
+    aes_key = pad(secret_key_bytes, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
+    aes = AES.new(aes_key, AES.MODE_ECB)
 
     message_bytes = message if isinstance(message, bytes) else message.encode('utf8')
-    plaintext = pad(message_bytes, AES_BLOCK_SIZE)
-    ciphertext = aes.encrypt(plaintext)
-    b64bytestring = b64encode(ciphertext)
-    return str(b64bytestring)
+    plaintext_bytes = pad(message_bytes, AES_BLOCK_SIZE)
+    ciphertext_bytes = aes.encrypt(plaintext_bytes)
+    b64ciphertext_bytes = b64encode(ciphertext_bytes)
+    return b64ciphertext_bytes.decode('ascii')
 
 
 def b64_aes_decrypt(message):
@@ -65,14 +68,17 @@ def b64_aes_decrypt(message):
     True
 
     """
-    key = settings.SECRET_KEY if isinstance(settings.SECRET_KEY, bytes) else settings.SECRET_KEY.encode('ascii')
-    secret = pad(key, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
-    aes = AES.new(secret, AES.MODE_ECB)
+    if isinstance(settings.SECRET_KEY, bytes):
+        secret_key_bytes = settings.SECRET_KEY
+    else:
+        secret_key_bytes = settings.SECRET_KEY.encode('ascii')
+    aes_key = pad(secret_key_bytes, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
+    aes = AES.new(aes_key, AES.MODE_ECB)
 
-    ciphertext = b64decode(message)
-    padded_plaintext = aes.decrypt(ciphertext)
-    plaintext = padded_plaintext.rstrip(PAD_CHAR)
-    return str(plaintext)
+    ciphertext_bytes = b64decode(message)
+    padded_plaintext_bytes = aes.decrypt(ciphertext_bytes)
+    plaintext_bytes = padded_plaintext_bytes.rstrip(PAD_CHAR)
+    return plaintext_bytes.decode('utf8')
 
 
 def pformat_json(data):


### PR DESCRIPTION
This resolves a bug related to changing passwords for remote servers. This is a result of the switch to Python 3, because:

Py2:
```python
>>> json.dumps({u'hello': b'world'})
'{"hello": "world"}'
```

Py3:
```python
>>> json.dumps({u'hello': b'world'})
Traceback (most recent call last):
  ...
TypeError: Object of type 'bytes' is not JSON serializable
```
