### PR TITLE
Use standard cryptographic padding

### DIFF
--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -11,27 +11,8 @@ import corehq.motech.utils
 from corehq.motech.utils import (
     b64_aes_decrypt,
     b64_aes_encrypt,
-    pad,
     pformat_json,
 )
-
-
-class PadTests(SimpleTestCase):
-
-    def test_assertion(self):
-        with self.assertRaises(AssertionError):
-            pad('xyzzy', 8, b'*')
-
-    def test_ascii_bytestring_default_char(self):
-        padded = pad(b'xyzzy', 8)
-        self.assertEqual(padded, b'xyzzy   ')
-
-    def test_nonascii(self):
-        """
-        pad should pad a string according to its size in bytes, not its length in letters.
-        """
-        padded = pad(b'xy\xc5\xba\xc5\xbay', 8, b'*')
-        self.assertEqual(padded, b'xy\xc5\xba\xc5\xbay*')
 
 
 class PFormatJSONTests(SimpleTestCase):

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -23,7 +23,7 @@ def b64_aes_encrypt(message):
 
     >>> settings.SECRET_KEY = 'xyzzy'
     >>> encrypted = b64_aes_encrypt('Around you is a forest.')
-    >>> encrypted == 'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I='
+    >>> encrypted == 'vhi5JRIioaX6x3zJYPO6x4Y7NxWZ5Nktdhd9ToUh1zM='
     True
 
     """
@@ -48,7 +48,7 @@ def b64_aes_decrypt(message):
     Uses Django SECRET_KEY as AES key.
 
     >>> settings.SECRET_KEY = 'xyzzy'
-    >>> decrypted = b64_aes_decrypt('Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I=')
+    >>> decrypted = b64_aes_decrypt('vhi5JRIioaX6x3zJYPO6x4Y7NxWZ5Nktdhd9ToUh1zM=')
     >>> decrypted == 'Around you is a forest.'
     True
 

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -6,28 +6,13 @@ from base64 import b64decode, b64encode
 
 import six
 from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad, unpad
 from django.conf import settings
 
 from corehq.util.python_compatibility import soft_assert_type_text
 
 AES_BLOCK_SIZE = 16
 AES_KEY_MAX_LEN = 32  # AES key must be either 16, 24, or 32 bytes long
-PAD_CHAR = b' '
-
-
-def pad(bytestring, block_size, char=PAD_CHAR):
-    """
-    Pad `bytestring` to a multiple of `block_size` in length by appending
-    `char`. `char` defaults to space.
-
-    >>> padded = pad(b'xyzzy', 8, b'*')
-    >>> padded == b'xyzzy***'
-    True
-
-    """
-    assert isinstance(bytestring, bytes)
-    padding = ((block_size - len(bytestring)) % block_size) * char
-    return bytestring + padding
 
 
 def b64_aes_encrypt(message):
@@ -77,7 +62,7 @@ def b64_aes_decrypt(message):
 
     ciphertext_bytes = b64decode(message)
     padded_plaintext_bytes = aes.decrypt(ciphertext_bytes)
-    plaintext_bytes = padded_plaintext_bytes.rstrip(PAD_CHAR)
+    plaintext_bytes = unpad(padded_plaintext_bytes, AES_BLOCK_SIZE)
     return plaintext_bytes.decode('utf8')
 
 


### PR DESCRIPTION
Uses [PKCS#7](https://en.wikipedia.org/wiki/Padding_(cryptography)#PKCS#5_and_PKCS#7) padding (instead of appending spaces ... without checking that the plaintext doesn't end in a space :man_facepalming:).