### PR TITLE
Include filter columns in reports with custom backends

### DIFF
--- a/corehq/apps/app_manager/tests/test_filters.py
+++ b/corehq/apps/app_manager/tests/test_filters.py
@@ -327,7 +327,7 @@ class AutoFilterTests(TestCase):
         self.assertEqual(ancestor_state_value, ui_filter.default_value())
 
 
-class NumericFilterTests(TestCase):
+class NumericFilterTests(SimpleTestCase):
 
     def test_numeric_filter(self):
         self.assertEqual(

--- a/corehq/apps/userreports/custom/data_source.py
+++ b/corehq/apps/userreports/custom/data_source.py
@@ -25,9 +25,8 @@ class ConfigurableReportCustomDataSource(ConfigurableReportDataSourceMixin, Repo
         self._provider = to_function(provider_string, failhard=True)(self)
 
     @property
-    def columns(self):
-        db_columns = [c for conf in self.column_configs for c in conf.columns]
-        return db_columns
+    def _db_columns(self):
+        return [c for conf in self.column_configs for c in conf.columns]
 
     @memoized
     @method_decorator(catch_and_raise_exceptions)

--- a/corehq/apps/userreports/mixins.py
+++ b/corehq/apps/userreports/mixins.py
@@ -1,11 +1,14 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 from collections import OrderedDict
 
+import six
+from sqlagg.columns import SimpleColumn
+
+from corehq.apps.reports.sqlreport import DatabaseColumn
 from corehq.apps.userreports.reports.filters.specs import create_filter_value
 from corehq.apps.userreports.util import get_table_name
 from corehq.util.python_compatibility import soft_assert_type_text
-import six
 
 
 class ConfigurableReportDataSourceMixin(object):
@@ -73,6 +76,16 @@ class ConfigurableReportDataSourceMixin(object):
         return [
             inner_col for col in self.top_level_columns
             for inner_col in col.get_column_config(self.config, self.lang).columns
+        ]
+
+    @property
+    def columns(self):
+        fields = {c.slug for c in self._db_columns}
+
+        return self._db_columns + [
+            DatabaseColumn('', SimpleColumn(field))
+            for field in self._defer_fields
+            if field not in fields
         ]
 
     @property

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -1,16 +1,14 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import numbers
 
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext
 
 from memoized import memoized
-
-from sqlagg.columns import SimpleColumn
 from sqlagg.sorting import OrderBy
 
-from corehq.apps.reports.sqlreport import SqlData, DatabaseColumn
+from corehq.apps.reports.sqlreport import SqlData
 from corehq.apps.userreports.decorators import catch_and_raise_exceptions
 from corehq.apps.userreports.exceptions import InvalidQueryColumn
 from corehq.apps.userreports.mixins import ConfigurableReportDataSourceMixin
@@ -61,16 +59,9 @@ class ConfigurableReportSqlDataSource(ConfigurableReportDataSourceMixin, SqlData
         return []
 
     @property
-    def columns(self):
+    def _db_columns(self):
         # This explicitly only includes columns that resolve to database queries.
-        # The name is a bit confusing but is hard to change due to its dependency in SqlData
-        db_columns = [c for c in self.inner_columns if not isinstance(c, CalculatedColumn)]
-        fields = {c.slug for c in db_columns}
-
-        return db_columns + [
-            DatabaseColumn('', SimpleColumn(field))
-            for field in self._defer_fields
-            if field not in fields]
+        return [c for c in self.inner_columns if not isinstance(c, CalculatedColumn)]
 
     @memoized
     @method_decorator(catch_and_raise_exceptions)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-760
The "Pregnancy & Delivery Deaths" report used in ICDS mobile UCRs uses a `MobileSelectFilter` to select owner ID.  In order for the filtering to work, this property must be included in the report data. (Filter options are [populated from it](https://github.com/dimagi/commcare-hq/blob/63320e3a4a51889e6f7ed411070895dbc327c744/corehq/apps/app_manager/fixtures/mobile_ucr.py#L224-L224), and I assume mobile needs it anyways).

However, this report uses a custom backend (`MPR2BIPregDeliveryDeathList`), which means the `data_source.data_source` wrapper is `ConfigurableReportCustomDataSource` instead of `ConfigurableReportSqlDataSource`.  That wrapper doesn't currently insert filter-only fields, which causes this failure.

Gonna try this out in a shell session before merging (it's really hard to get an appropriate environment to test this).

@emord 
@calellowitz @gbova buddies