### PR TITLE
Use standard cryptographic padding, take 2

### DIFF
--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -11,7 +11,7 @@ import corehq.motech.utils
 from corehq.motech.utils import (
     b64_aes_decrypt,
     b64_aes_encrypt,
-    pad,
+    simple_pad,
     pformat_json,
 )
 
@@ -20,17 +20,17 @@ class PadTests(SimpleTestCase):
 
     def test_assertion(self):
         with self.assertRaises(AssertionError):
-            pad('xyzzy', 8, b'*')
+            simple_pad('xyzzy', 8, b'*')
 
     def test_ascii_bytestring_default_char(self):
-        padded = pad(b'xyzzy', 8)
+        padded = simple_pad(b'xyzzy', 8)
         self.assertEqual(padded, b'xyzzy   ')
 
     def test_nonascii(self):
         """
         pad should pad a string according to its size in bytes, not its length in letters.
         """
-        padded = pad(b'xy\xc5\xba\xc5\xbay', 8, b'*')
+        padded = simple_pad(b'xy\xc5\xba\xc5\xbay', 8, b'*')
         self.assertEqual(padded, b'xy\xc5\xba\xc5\xbay*')
 
 

--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -56,6 +56,8 @@ class DecryptTests(SimpleTestCase):
         self.assertEqual(plaintext, 'Around you is a forest.')
 
     def test_known_bad_0x80(self):
+        # This test documents behavior of the current implementation, and can
+        # be removed when there are no encrypted passwords padded with spaces.
         password = 'a' * 14 + 'À'
         assert len(password.encode('utf-8')) == AES_BLOCK_SIZE
         ciphertext = self._encrypt_with_simple_padding(password)
@@ -63,6 +65,8 @@ class DecryptTests(SimpleTestCase):
             b64_aes_decrypt(ciphertext)
 
     def test_known_bad_0x00(self):
+        # This test documents behavior of the current implementation, and can
+        # be removed when there are no encrypted passwords padded with spaces.
         password = 'a' + 15 * '\x00'
         assert len(password.encode('utf-8')) == AES_BLOCK_SIZE
         ciphertext = self._encrypt_with_simple_padding(password)
@@ -70,6 +74,8 @@ class DecryptTests(SimpleTestCase):
             b64_aes_decrypt(ciphertext)
 
     def test_known_bad_0x80_0x00(self):
+        # This test documents behavior of the current implementation, and can
+        # be removed when there are no encrypted passwords padded with spaces.
         password = 'aÀ' + 13 * '\x00'
         assert len(password.encode('utf-8')) == AES_BLOCK_SIZE
         ciphertext = self._encrypt_with_simple_padding(password)

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -6,6 +7,8 @@ from base64 import b64decode, b64encode
 
 import six
 from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad as crypto_pad, unpad as crypto_unpad
+from Crypto.Util.py3compat import bord
 from django.conf import settings
 
 from corehq.util.python_compatibility import soft_assert_type_text
@@ -15,12 +18,12 @@ AES_KEY_MAX_LEN = 32  # AES key must be either 16, 24, or 32 bytes long
 PAD_CHAR = b' '
 
 
-def pad(bytestring, block_size, char=PAD_CHAR):
+def simple_pad(bytestring, block_size, char=PAD_CHAR):
     """
     Pad `bytestring` to a multiple of `block_size` in length by appending
     `char`. `char` defaults to space.
 
-    >>> padded = pad(b'xyzzy', 8, b'*')
+    >>> padded = simple_pad(b'xyzzy', 8, b'*')
     >>> padded == b'xyzzy***'
     True
 
@@ -46,11 +49,11 @@ def b64_aes_encrypt(message):
         secret_key_bytes = settings.SECRET_KEY
     else:
         secret_key_bytes = settings.SECRET_KEY.encode('ascii')
-    aes_key = pad(secret_key_bytes, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
+    aes_key = simple_pad(secret_key_bytes, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
     aes = AES.new(aes_key, AES.MODE_ECB)
 
     message_bytes = message if isinstance(message, bytes) else message.encode('utf8')
-    plaintext_bytes = pad(message_bytes, AES_BLOCK_SIZE)
+    plaintext_bytes = simple_pad(message_bytes, AES_BLOCK_SIZE)
     ciphertext_bytes = aes.encrypt(plaintext_bytes)
     b64ciphertext_bytes = b64encode(ciphertext_bytes)
     return b64ciphertext_bytes.decode('ascii')
@@ -72,13 +75,40 @@ def b64_aes_decrypt(message):
         secret_key_bytes = settings.SECRET_KEY
     else:
         secret_key_bytes = settings.SECRET_KEY.encode('ascii')
-    aes_key = pad(secret_key_bytes, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
+    aes_key = simple_pad(secret_key_bytes, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
     aes = AES.new(aes_key, AES.MODE_ECB)
 
     ciphertext_bytes = b64decode(message)
     padded_plaintext_bytes = aes.decrypt(ciphertext_bytes)
-    plaintext_bytes = padded_plaintext_bytes.rstrip(PAD_CHAR)
+    plaintext_bytes = unpad(padded_plaintext_bytes)
     return plaintext_bytes.decode('utf8')
+
+
+def unpad(bytestring):
+    """
+    Unpad will remove padding from the right of a string that has been
+    padded by ``simple_pad()`` or by ``crypto_pad()``.
+
+    ``crypto_pad()`` uses `ISO 7816-4 <iso7816>`_, which will result in
+    the string ending in a byte with a decimal value of either 0 or 128
+    (hex 0x00 or 0x80).
+
+     ``simple_pad()`` pads with PAD_CHAR (an ASCII space character) if
+     the original length is not a multiple of AES_BLOCK_SIZE, otherwise
+     it does not pad.
+
+     If ``bytestring`` ends in 0x00 or 0x80, it could have been padded
+     with ``crypto_pad()``, or it could padded with ``simple_pad()``
+     and whose last character is multi-byte non-ASCII UTF-8 character
+     whose last byte is 0x00 or 0x80 (e.g. b'0xC3\0x80', "À" (capital
+     A-grave)). Because the second possibility is far less likely than
+     the first, ``unpad()`` uses ``crypto_unpad()`` in this case.
+
+    .. _iso7816: https://en.wikipedia.org/wiki/Padding_(cryptography)#ISO/IEC_7816-4
+    """
+    if bord(bytestring[-1]) in (0, 128):
+        return crypto_unpad(bytestring, AES_BLOCK_SIZE, style='iso7816')
+    return bytestring.rstrip(PAD_CHAR)
 
 
 def pformat_json(data):

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -41,7 +41,7 @@ def b64_aes_encrypt(message):
 
     >>> settings.SECRET_KEY = 'xyzzy'
     >>> encrypted = b64_aes_encrypt('Around you is a forest.')
-    >>> encrypted == 'Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I='
+    >>> encrypted == 'Vh2Tmlnr5+out2PQDefkudZ2frfze5onsAlUGTLv3Oc='
     True
 
     """
@@ -50,10 +50,12 @@ def b64_aes_encrypt(message):
     else:
         secret_key_bytes = settings.SECRET_KEY.encode('ascii')
     aes_key = simple_pad(secret_key_bytes, AES_BLOCK_SIZE)[:AES_KEY_MAX_LEN]
+    # We never need to unpad the key, so simple_pad() is fine (and
+    # allows us to decrypt old values).
     aes = AES.new(aes_key, AES.MODE_ECB)
 
     message_bytes = message if isinstance(message, bytes) else message.encode('utf8')
-    plaintext_bytes = simple_pad(message_bytes, AES_BLOCK_SIZE)
+    plaintext_bytes = crypto_pad(message_bytes, AES_BLOCK_SIZE, style='iso7816')
     ciphertext_bytes = aes.encrypt(plaintext_bytes)
     b64ciphertext_bytes = b64encode(ciphertext_bytes)
     return b64ciphertext_bytes.decode('ascii')


### PR DESCRIPTION
Encrypts passwords using cryptographic padding standard [ISO 7816-4](https://en.wikipedia.org/wiki/Padding_(cryptography)#ISO/IEC_7816-4), and decrypts new and existing passwords.

Resolves the problem with PR #25092 which could not decrypt existing passwords.
