### PR TITLE
Daily Saved Exports -- move isFeed check to ko if tag, not visible

### DIFF
--- a/corehq/apps/export/templates/export/partials/table.html
+++ b/corehq/apps/export/templates/export/partials/table.html
@@ -297,26 +297,26 @@
               <i class="fa fa-cloud-download"></i>
               {% trans "Download" %}
             </a>
-
-            <div class="input-group"
-                 data-bind="visible: isFeed">
-              <!-- ko with: feedUrl -->
-              <span data-bind="css: {
-                                 'input-group-btn': showLink
-                               },
-                               click: copyLinkRequested">
-                <a class="btn btn-default btn-sm">
-                  <i class="fa fa-clipboard"></i>
-                  {% trans "Copy Dashboard Feed Link" %}
-                </a>
-              </span>
-              <input data-bind="visible: showLink,
-                                value: url"
-                     type="text"
-                     class="form-control input-sm"
-                     readonly />
-              <!-- /ko -->
-            </div>
+            <!-- ko if: isFeed -->
+              <div class="input-group">
+                <!-- ko with: feedUrl -->
+                <span data-bind="css: {
+                                   'input-group-btn': showLink
+                                 },
+                                 click: copyLinkRequested">
+                  <a class="btn btn-default btn-sm">
+                    <i class="fa fa-clipboard"></i>
+                    {% trans "Copy Dashboard Feed Link" %}
+                  </a>
+                </span>
+                <input data-bind="visible: showLink,
+                                  value: url"
+                       type="text"
+                       class="form-control input-sm"
+                       readonly />
+                <!-- /ko -->
+              </div>
+            <!-- /ko -->
           </div>
 
           <div data-bind="if: isLocationSafeForUser">


### PR DESCRIPTION
This was working fine when I tested it locally, but it appears to be throwing errors now. My guess is that `isVisible` is a soft hide, so knockout still tries to parse the other `data-bind` tags in the child elements.

fixes https://dimagi-dev.atlassian.net/browse/HI-825