### PR TITLE
Multiple master apps for linked apps

### DIFF
--- a/corehq/apps/app_manager/_design/views/saved_app/map.js
+++ b/corehq/apps/app_manager/_design/views/saved_app/map.js
@@ -23,8 +23,6 @@ function(doc){
             build_profiles: doc.build_profiles,
             vellum_case_management: !!doc.vellum_case_management,
             target_commcare_flavor: doc.target_commcare_flavor,
-
-            // fields related to LinkedApplications
             family_id: doc.family_id,
             // In legacy linked apps, the linked and master versions correspond, but newer linked apps stored the pulled master version
             upstream_version: doc.doc_type == 'LinkedApplication' ? doc.upstream_version : null,

--- a/corehq/apps/app_manager/_design/views/saved_app/map.js
+++ b/corehq/apps/app_manager/_design/views/saved_app/map.js
@@ -27,8 +27,8 @@ function(doc){
             // fields related to LinkedApplications
             family_id: doc.family_id,
             // In legacy linked apps, the linked and master versions correspond, but newer linked apps stored the pulled master version
-            upstream_version: doc.doc_type == 'LinkedApplication' ? doc.upstream_version || doc.version : null,
-            upstream_app_id: doc.doc_type == 'LinkedApplication' ? doc.upstream_app_id || doc.master : null
+            upstream_version: doc.doc_type == 'LinkedApplication' ? doc.upstream_version : null,
+            upstream_app_id: doc.doc_type == 'LinkedApplication' ? doc.upstream_app_id : null
         });
     }
 }

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -52,6 +52,22 @@ def get_latest_released_app(domain, app_id):
     return None
 
 
+def get_latest_released_app_versions_by_app_id(domain):
+    """
+    Gets a dict of all apps in domain that have released at least one build
+    and the version of their most recently released build. Note that keys
+    are the app ids, not build ids.
+    """
+    from .models import Application
+    results = Application.get_db().view(
+        'app_manager/applications',
+        startkey=['^ReleasedApplications', domain],
+        endkey=['^ReleasedApplications', domain, {}],
+        include_docs=False,
+    ).all()
+    return {r['key'][2]: r['key'][3] for r in results}
+
+
 def get_latest_released_build_id(domain, app_id):
     """Get the latest starred build id for an application"""
     app = _get_latest_released_build_view_result(domain, app_id)

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -65,6 +65,7 @@ def get_latest_released_app_versions_by_app_id(domain):
         endkey=['^ReleasedApplications', domain, {}],
         include_docs=False,
     ).all()
+    # key[3] will be latest released version since view is ordered by app_id, version asc
     return {r['key'][2]: r['key'][3] for r in results}
 
 

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -52,6 +52,7 @@ def get_latest_released_app(domain, app_id):
     return None
 
 
+@quickcache(['domain'], timeout=1 * 60 * 60)
 def get_latest_released_app_versions_by_app_id(domain):
     """
     Gets a dict of all apps in domain that have released at least one build

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -80,6 +80,7 @@ from corehq.apps.app_manager.dbaccessors import (
     domain_has_apps,
     get_app,
     get_build_by_version,
+    get_build_ids,
     get_latest_build_doc,
     get_latest_released_app_doc,
     wrap_app,
@@ -159,7 +160,7 @@ from corehq.apps.hqmedia.models import (
 from corehq.apps.integration.models import ApplicationIntegrationMixin
 from corehq.apps.linked_domain.applications import (
     get_latest_master_app_release,
-    get_master_app_version,
+    get_master_app_briefs,
 )
 from corehq.apps.linked_domain.exceptions import ActionNotPermitted
 from corehq.apps.locations.models import SQLLocation
@@ -5577,20 +5578,26 @@ class LinkedApplication(Application):
             return get_master_app_briefs(self.domain_link)
         return []
 
-    def get_master_version(self):
-        if self.domain_link:
-            return get_master_app_version(self.domain_link, self.master)
-
     @property
     def master_is_remote(self):
         if self.domain_link:
             return self.domain_link.is_remote
 
-    def get_latest_master_release(self):
+    def get_latest_master_release(self, master_app_id):
         if self.domain_link:
-            return get_latest_master_app_release(self.domain_link, self.master)
-        else:
-            raise ActionNotPermitted
+            return get_latest_master_app_release(self.domain_link, master_app_id)
+        raise ActionNotPermitted
+
+    @memoized
+    def get_previous_version(self, master_app_id=None):
+        if master_app_id is None:
+            master_app_id = self.upstream_app_id
+        build_ids = get_build_ids(self.domain, self.master_id)
+        for build_id in build_ids:
+            build_doc = Application.get_db().get(build_id)
+            if build_doc.get('upstream_app_id') == master_app_id:
+                return self.wrap(build_doc)
+        return None
 
     def reapply_overrides(self):
         # Used by app_manager.views.utils.update_linked_app()

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4488,7 +4488,7 @@ class ApplicationBase(LazyBlobDoc, SnapshotMixin,
             cache.delete('app_build_cache_{}_{}'.format(self.domain, self.get_id))
 
         if increment_version is None:
-            increment_version = not self.copy_of and not is_linked_app(self)
+            increment_version = not self.copy_of
         if increment_version:
             self.version = self.version + 1 if self.version else 1
         super(ApplicationBase, self).save(**params)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5549,7 +5549,6 @@ class LinkedApplication(Application):
     """
     An app that can pull changes from an app in a different domain.
     """
-    master = StringProperty()  # Legacy, should be removed once all linked apps support multiple masters
     upstream_app_id = StringProperty()  # ID of the app that was most recently pulled
     upstream_version = IntegerProperty()  # Version of the app that was most recently pulled
 
@@ -5571,6 +5570,12 @@ class LinkedApplication(Application):
     def domain_link(self):
         from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
         return get_domain_master_link(self.domain)
+
+    @memoized
+    def get_master_app_briefs(self):
+        if self.domain_link:
+            return get_master_app_briefs(self.domain_link)
+        return []
 
     def get_master_version(self):
         if self.domain_link:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -160,6 +160,7 @@ from corehq.apps.hqmedia.models import (
 from corehq.apps.integration.models import ApplicationIntegrationMixin
 from corehq.apps.linked_domain.applications import (
     get_latest_master_app_release,
+    get_latest_master_releases_versions,
     get_master_app_briefs,
 )
 from corehq.apps.linked_domain.exceptions import ActionNotPermitted
@@ -5587,6 +5588,11 @@ class LinkedApplication(Application):
         if self.domain_link:
             return get_latest_master_app_release(self.domain_link, master_app_id)
         raise ActionNotPermitted
+
+    def get_latest_master_releases_versions(self):
+        if self.domain_link:
+            return get_latest_master_releases_versions(self.domain_link)
+        return {}
 
     @memoized
     def get_previous_version(self, master_app_id=None):

--- a/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/app_view_release_manager.js
@@ -1,4 +1,3 @@
-/* globals hqDefine hqImport django */
 hqDefine("app_manager/js/releases/app_view_release_manager", function () {
     var initial_page_data = hqImport("hqwebapp/js/initial_page_data").get;
 
@@ -11,6 +10,8 @@ hqDefine("app_manager/js/releases/app_view_release_manager", function () {
         recipient_contacts: initial_page_data('sms_contacts'),
         download_modal_id: '#download-zip-modal',
         latestReleasedVersion: initial_page_data('latestReleasedVersion'),
+        masterBriefs: initial_page_data('master_briefs'),
+        upstreamUrl: initial_page_data('upstream_url'),
     };
     var el = $('#releases-table');
     if (el.length) {

--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -43,6 +43,24 @@ hqDefine('app_manager/js/releases/releases', function () {
             return profiles;
         };
 
+        self.upstream_app_name = ko.computed(function () {
+            if (self.doc_type() !== "LinkedApplication") {
+                return "";
+            }
+            var brief = releasesMain.masterBriefsById[self.upstream_app_id()] || {};
+            return brief.name || gettext("Unknown App");
+        });
+
+        self.upstream_app_url = ko.computed(function () {
+            if (self.doc_type() !== "LinkedApplication") {
+                return "";
+            }
+            if (self.upstream_app_id()) {
+                return releasesMain.upstreamUrl.replace('---', self.upstream_app_id());
+            }
+            return '';
+        });
+
         self.track_deploy_type = function (type) {
             hqImport('analytix/js/google').track.event('App Manager', 'Deploy Type', type);
         };
@@ -232,6 +250,8 @@ hqDefine('app_manager/js/releases/releases', function () {
         self.latestReleasedVersion = ko.observable(self.options.latestReleasedVersion);
         self.lastAppVersion = ko.observable();
         self.buildComment = ko.observable();
+        self.masterBriefsById = _.indexBy(self.options.masterBriefs, '_id');
+        self.upstreamUrl = self.options.upstreamUrl;
 
         self.download_modal = $(self.options.download_modal_id);
         self.async_downloader = asyncDownloader(self.download_modal);

--- a/corehq/apps/app_manager/tasks.py
+++ b/corehq/apps/app_manager/tasks.py
@@ -82,9 +82,9 @@ def prune_auto_generated_builds(domain, app_id):
 
 
 @task(serializer='pickle', queue='background_queue', ignore_result=True)
-def update_linked_app_and_notify_task(domain, app_id, user_id, email):
+def update_linked_app_and_notify_task(domain, app_id, master_app_id, user_id, email):
     from corehq.apps.app_manager.views.utils import update_linked_app_and_notify
-    update_linked_app_and_notify(domain, app_id, user_id, email)
+    update_linked_app_and_notify(domain, app_id, master_app_id, user_id, email)
 
 
 @task

--- a/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_release_manager.html
@@ -31,6 +31,8 @@
   {% initial_page_data 'build_profiles' app.build_profiles %}
   {% initial_page_data 'latest_version_for_build_profiles' latest_version_for_build_profiles %}
   {% initial_page_data 'latestReleasedVersion' latest_released_version %}
+  {% initial_page_data 'master_briefs' master_briefs %}{# linked apps only #}
+  {% initial_page_data 'multiple_masters' multiple_masters %}{# linked apps only #}
   {% initial_page_data 'practice_users' practice_users %}
   {% initial_page_data 'enable_practice_users' app.enable_practice_users %}
   {% initial_page_data 'intro_only' intro_only %}
@@ -38,6 +40,7 @@
   {% initial_page_data 'latest_build_id' latest_build_id %}
   {% initial_page_data 'sms_contacts' sms_contacts %}
   {% initial_page_data 'confirm' confirm %}
+  {% initial_page_data 'upstream_url' upstream_url_template %}
   {% registerurl "app_data_json" app.domain '---' %}
   {% registerurl "app_form_summary_diff" domain '---' '---' %}
   {% registerurl "paginate_releases" domain app.id %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -159,7 +159,11 @@
           <!--/ko-->
         </div>
         <h4 class="panel-release-title">
-          <strong>{% trans "Version" %} <span data-bind="text: version"></span></strong> |
+          <strong>{% trans "Version" %} <span data-bind="text: version"></span></strong>
+          <span data-bind="if: doc_type() == 'LinkedApplication'">
+            (master v<span data-bind="text: upstream_version"></span>)
+          </span>
+          |
           <span data-bind="text: built_on_date"></span> <span data-bind="text: built_on_time"></span> {% trans 'by' %}
           <span data-bind="text: comment_user_name"></span>
           <!--ko if: menu_item_label() -->

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -161,7 +161,8 @@
         <h4 class="panel-release-title">
           <strong>{% trans "Version" %} <span data-bind="text: version"></span></strong>
           <span data-bind="if: doc_type() == 'LinkedApplication'">
-            (master v<span data-bind="text: upstream_version"></span>)
+            (<a data-bind="text: upstream_app_name(), attr: {href: upstream_app_url()}"></a>
+              v<span data-bind="text: upstream_version"></span>)
           </span>
           |
           <span data-bind="text: built_on_date"></span> <span data-bind="text: built_on_time"></span> {% trans 'by' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -188,33 +188,54 @@
           <form action="{% url "pull_master_app" domain app.id %}" method="POST">
             {% csrf_token %}
             <legend>
-              {% if upstream_url %}
-                {% blocktrans %}Update from <a href="{{ upstream_url }}">master application</a>{% endblocktrans %}
-              {% else %}
-                {% trans "Update from master application" %}
-              {% endif %}
+              {% trans "Update from master application" %}
             </legend>
             <div class="panel-body">
               <p>
-                {% blocktrans with version=app.upstream_version %}
-                  Your app was last pulled from master version {{ version }}.
+                {% blocktrans with upstream_name=upstream_brief.name upstream_version=app.upstream_version %}
+                  Your app was last pulled from
+                  <a href='{{ upstream_url }}'>{{ upstream_name }}</a>,
+                  version {{ upstream_version }}.
                 {% endblocktrans %}
-                {% if master_version %}
-                  {% blocktrans %}The master app is at version {{ master_version }}.{% endblocktrans %}
-                {% else %}
-                  {% trans "Unable to get master version." %}
-                {% endif %}
               </p>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" name="notify">
-                  {% trans "Email when finished (recommended for large applications)" %}
-                </label>
+              <div class="form-horizontal">
+                {% if multiple_masters %}
+                  <div class="form-group">
+                    <div class="{% css_field_class %}">
+                      <select name="master_app_id" class="form-control hqwebapp-select2"
+                              data-placeholder="{% trans_html_attr "Select a master app to pull" %}">
+                        <option value="">{% trans "Select a master app to pull" %}</option>
+                        {% for brief in master_briefs %}
+                          <option value="{{ brief.id }}">
+                            {{ brief.name }}
+                            {% if brief.version %} ({% trans "version" %} {{ brief.version }}){% endif %}
+                          </option>
+                        {% endfor %}
+                      </select>
+                    </div>
+                  </div>
+                {% else %}
+                  <input name="master_app_id" type="hidden" value="{{ upstream_brief.get_id }}" />
+                {% endif %}
+                <div class="form-group">
+                  <div class="{% css_field_class %}">
+                    <div class="checkbox">
+                      <label>
+                        <input type="checkbox" name="notify">
+                        {% trans "Email when finished (recommended for large applications)" %}
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <div class="{% css_field_class %}">
+                    <button type="submit" class="btn btn-primary">
+                      <i class="fa fa-arrow-up"></i>
+                      {% trans "Update" %}
+                    </button>
+                  </div>
+                </div>
               </div>
-              <button type="submit" class="btn btn-primary">
-                <i class="fa fa-arrow-up"></i>
-                {% trans "Update" %}
-              </button>
             </div>
           </form>
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -195,7 +195,10 @@
               {% endif %}
             </legend>
             <div class="panel-body">
-              <p>{% blocktrans with version=app.version %}Your app is at version {{ version }}.{% endblocktrans %}
+              <p>
+                {% blocktrans with version=app.upstream_version %}
+                  Your app was last pulled from master version {{ version }}.
+                {% endblocktrans %}
                 {% if master_version %}
                   {% blocktrans %}The master app is at version {{ master_version }}.{% endblocktrans %}
                 {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/app_settings.html
@@ -206,10 +206,8 @@
                               data-placeholder="{% trans_html_attr "Select a master app to pull" %}">
                         <option value="">{% trans "Select a master app to pull" %}</option>
                         {% for brief in master_briefs %}
-                          <option value="{{ brief.id }}">
-                            {{ brief.name }}
-                            {% if brief.version %} ({% trans "version" %} {{ brief.version }}){% endif %}
-                          </option>
+                          {# Poor readability because any whitespace within the option will also appear in the title attribute and therefore on hover #}
+                          <option value="{{ brief.id }}">{{ brief.name }}{% for id, version in master_versions_by_id.items %}{% if id == brief.id %} ({% blocktrans with v=version %}version {{ v }}{% endblocktrans %}){% endif %}{% endfor %}</option>
                         {% endfor %}
                       </select>
                     </div>

--- a/corehq/apps/app_manager/tests/test_apps.py
+++ b/corehq/apps/app_manager/tests/test_apps.py
@@ -170,10 +170,12 @@ class AppManagerTest(TestCase, TestXmlMixin):
                 old_config_ids = {config.uuid for config in old_module.report_configs}
                 new_config_ids = {config.uuid for config in new_module.report_configs}
                 self.assertEqual(old_config_ids.intersection(new_config_ids), set())
+        return new_app
 
     def testImportApp_from_id(self):
         self.assertTrue(self.app.blobs)
-        self._test_import_app(self.app.id)
+        imported_app = self._test_import_app(self.app.id)
+        self.assertEqual(imported_app.family_id, self.app.id)
 
     @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
     @patch('corehq.apps.app_manager.models.ReportAppConfig.report')

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -226,15 +226,21 @@ class TestAppGetters(TestCase):
         ).to_json()
         app = Application.wrap(app_doc)  # app is v1
 
+        # Make builds v1 - v5. Builds v2 and v4 are released.
         app.save()  # app is v2
         cls.v2_build = app.make_build()
         cls.v2_build.is_released = True
-        cls.v2_build.save()  # There is a starred build at v2
+        cls.v2_build.save()
 
         app.save()  # app is v3
-        app.make_build().save()  # There is a build at v3
+        app.make_build().save()
 
         app.save()  # app is v4
+        cls.v4_build = app.make_build()
+        cls.v4_build.is_released = True
+        cls.v4_build.save()
+
+        app.save()  # app is v5
         cls.app_id = app._id
 
     @classmethod
@@ -244,31 +250,31 @@ class TestAppGetters(TestCase):
 
     def test_get_app_current(self):
         app = get_app(self.domain, self.app_id)
-        self.assertEqual(app.version, 4)
+        self.assertEqual(app.version, 5)
 
     def test_get_current_app(self):
         app_doc = get_current_app(self.domain, self.app_id)
-        self.assertEqual(app_doc['version'], 4)
+        self.assertEqual(app_doc['version'], 5)
 
     def test_latest_saved_from_build(self):
         app_doc = get_app(self.domain, self.v2_build._id, latest=True, target='save')
-        self.assertEqual(app_doc['version'], 4)
+        self.assertEqual(app_doc['version'], 5)
 
     def test_get_app_latest_released_build(self):
         app = get_app(self.domain, self.app_id, latest=True)
-        self.assertEqual(app.version, 2)
+        self.assertEqual(app.version, 4)
 
     def test_get_latest_released_app_doc(self):
         app_doc = get_latest_released_app_doc(self.domain, self.app_id)
-        self.assertEqual(app_doc['version'], 2)
+        self.assertEqual(app_doc['version'], 4)
 
     def test_get_app_latest_build(self):
         app = get_app(self.domain, self.app_id, latest=True, target='build')
-        self.assertEqual(app.version, 3)
+        self.assertEqual(app.version, 4)
 
     def test_get_latest_build_doc(self):
         app_doc = get_latest_build_doc(self.domain, self.app_id)
-        self.assertEqual(app_doc['version'], 3)
+        self.assertEqual(app_doc['version'], 4)
 
     def test_get_specific_version(self):
         app_doc = get_build_doc_by_version(self.domain, self.app_id, version=2)
@@ -277,14 +283,14 @@ class TestAppGetters(TestCase):
     def test_get_apps_by_id(self):
         apps = get_apps_by_id(self.domain, [self.app_id])
         self.assertEqual(1, len(apps))
-        self.assertEqual(apps[0].version, 4)
+        self.assertEqual(apps[0].version, 5)
 
     def test_get_latest_released_app_version(self):
         version = get_latest_released_app_version(self.domain, self.app_id)
-        self.assertEqual(version, 2)
+        self.assertEqual(version, 4)
 
     def test_get_latest_released_app_versions_by_app_id(self):
         versions = get_latest_released_app_versions_by_app_id(self.domain)
         self.assertEqual(versions, {
-            self.app_id: 2,
+            self.app_id: 4,
         })

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -7,8 +7,8 @@ from corehq.apps.app_manager.dbaccessors import (
     get_all_app_ids,
     get_all_built_app_ids_and_versions,
     get_app,
-    get_app_ids_in_domain,
     get_apps_by_id,
+    get_app_ids_in_domain,
     get_apps_in_domain,
     get_brief_app,
     get_brief_apps_in_domain,
@@ -22,6 +22,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_build_doc,
     get_latest_released_app_doc,
     get_latest_released_app_version,
+    get_latest_released_app_versions_by_app_id,
 )
 from corehq.apps.app_manager.models import Application, Module, RemoteApp
 from corehq.apps.domain.models import Domain
@@ -281,3 +282,9 @@ class TestAppGetters(TestCase):
     def test_get_latest_released_app_version(self):
         version = get_latest_released_app_version(self.domain, self.app_id)
         self.assertEqual(version, 2)
+
+    def test_get_latest_released_app_versions_by_app_id(self):
+        versions = get_latest_released_app_versions_by_app_id(self.domain)
+        self.assertEqual(versions, {
+            self.app_id: 2,
+        })

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -158,7 +158,7 @@ class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
         self._assertMediaSuiteResourcesEqual(self.get_xml('form_media_suite_hin'), suites['hin'])
         self._assertMediaSuiteResourcesEqual(self.get_xml('form_media_suite_all'), suites['all'])
 
-    @patch('corehq.apps.app_manager.models.ApplicationBase.get_latest_build')
+    @patch('corehq.apps.app_manager.models.ApplicationBase._get_version_comparison_build')
     def test_update_image_id(self, get_latest_build):
         """
         When an image is updated, change only version number, not resource id

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -301,7 +301,10 @@ def get_app_view_context(request, app):
     if is_linked_app(app):
         context['upstream_url'] = _get_upstream_url(app, request.couch_user)
         try:
-            context['master_version'] = app.get_master_version()
+            context.update({
+                'master_version': app.get_master_version(),
+                'upstream_version': app.upstream_version,
+            })
         except RemoteRequestError:
             pass
     return context

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -299,18 +299,30 @@ def get_app_view_context(request, app):
         'is_remote_app': is_remote_app(app),
     })
     if is_linked_app(app):
-        context['upstream_url'] = _get_upstream_url(app, request.couch_user)
         try:
-            context.update({
-                'master_version': app.get_master_version(),
-                'upstream_version': app.upstream_version,
-            })
+            master_versions_by_id = app.get_latest_master_releases_versions()
+            master_briefs = [brief for brief in app.get_master_app_briefs() if brief.id in master_versions_by_id]
         except RemoteRequestError:
-            pass
+            messages.error(request, "Unable to reach remote master server. Please try again later.")
+            master_versions_by_id = {}
+            master_briefs = []
+        upstream_brief = {}
+        for b in master_briefs:
+            if b.id == app.upstream_app_id:
+                upstream_brief = b
+        context.update({
+            'master_briefs': master_briefs,
+            'master_versions_by_id': master_versions_by_id,
+            'multiple_masters': len(master_briefs) > 1 and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(app.domain),
+            'upstream_version': app.upstream_version,
+            'upstream_brief': upstream_brief,
+            'upstream_url': _get_upstream_url(app, request.couch_user),
+            'upstream_url_template': _get_upstream_url(app, request.couch_user, master_app_id='---'),
+        })
     return context
 
 
-def _get_upstream_url(app, request_user):
+def _get_upstream_url(app, request_user, master_app_id=None):
     """Get the upstream url if the user has access"""
     if (
             app.domain_link and (
@@ -320,7 +332,9 @@ def _get_upstream_url(app, request_user):
                 )
             )
     ):
-        url = reverse('view_app', args=[app.domain_link.master_domain, app.master])
+        if master_app_id is None:
+            master_app_id = app.upstream_app_id
+        url = reverse('view_app', args=[app.domain_link.master_domain, master_app_id])
         if app.domain_link.is_remote:
             url = '{}{}'.format(app.domain_link.remote_base_url, url)
         return url

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -470,7 +470,7 @@ def _create_linked_app(request, app_id, build_id, from_domain, to_domain, link_a
 
     linked_app = create_linked_app(from_domain, from_app.master_id, to_domain, link_app_name)
     try:
-        update_linked_app(linked_app, request.couch_user.get_id, master_build=from_app)
+        update_linked_app(linked_app, from_app, request.couch_user.get_id)
     except AppLinkError as e:
         linked_app.delete()
         messages.error(request, str(e))
@@ -978,15 +978,21 @@ def drop_user_case(request, domain, app_id):
 
 @require_can_edit_apps
 def pull_master_app(request, domain, app_id):
+    master_app_id = request.POST.get('master_app_id')
+    if not master_app_id:
+        messages.error(request, _("Please select a master app."))
+        return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[domain, app_id]))
+
     async_update = request.POST.get('notify') == 'on'
     if async_update:
-        update_linked_app_and_notify_task.delay(domain, app_id, request.couch_user.get_id, request.couch_user.email)
+        update_linked_app_and_notify_task.delay(domain, app_id, master_app_id,
+                                                request.couch_user.get_id, request.couch_user.email)
         messages.success(request,
                          _('Your request has been submitted. We will notify you via email once completed.'))
     else:
         app = get_current_app(domain, app_id)
         try:
-            update_linked_app(app, request.couch_user.get_id)
+            update_linked_app(app, master_app_id, request.couch_user.get_id)
         except AppLinkError as e:
             messages.error(request, str(e))
             return HttpResponseRedirect(reverse_util('app_settings', params={}, args=[domain, app_id]))

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -38,6 +38,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_build_id,
     get_latest_build_version,
     get_latest_released_app_version,
+    get_latest_released_app_versions_by_app_id,
 )
 from corehq.apps.app_manager.decorators import (
     avoid_parallel_build_request,
@@ -257,6 +258,7 @@ def release_build(request, domain, app_id, saved_app_id):
     saved_app.is_released = is_released
     saved_app.is_auto_generated = False
     saved_app.save(increment_version=False)
+    get_latest_released_app_versions_by_app_id.clear(domain)
     from corehq.apps.app_manager.signals import app_post_release
     app_post_release.send(Application, application=saved_app)
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -174,7 +174,6 @@ def overwrite_app(app, master_build, report_map=None):
     # and compare those to the XMLNSes present in this app.
     unknown_xmlnses = {form.xmlns for form in app.get_forms()}
     form_ids_by_xmlns = {}
-    unknown_xmlnses = unknown_xmlnses.difference(form_ids_by_xmlns.keys())
     for brief in app.get_master_app_briefs():
         if len(unknown_xmlnses):
             previous_app = app.get_latest_build_from_upstream(brief.master_id)
@@ -184,9 +183,7 @@ def overwrite_app(app, master_build, report_map=None):
     # Add in any forms from the current linked app, before the source is overwritten.
     # This is particularly important if there's no previous version.
     if len(unknown_xmlnses):
-        for module in app['modules']:
-            for form in module['forms']:
-                form_ids_by_xmlns[form.xmlns] = form['unique_id']
+        form_ids_by_xmlns.update(_get_form_ids_by_xmlns(app))
 
     for key, value in master_json.items():
         if key not in excluded_fields:

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -202,6 +202,12 @@ def overwrite_app(app, master_build, report_map=None):
                 raise AppEditingError(config.report_id)
 
     wrapped_app = _update_form_ids(wrapped_app, master_build, form_ids_by_xmlns)
+
+    # Multimedia versions should be set based on the linked app's versions, not those of the master app.
+    for path in wrapped_app.multimedia_map.keys():
+        wrapped_app.multimedia_map[path].version = None
+    wrapped_app.set_media_versions()
+
     enable_usercase_if_necessary(wrapped_app)
     return wrapped_app
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -167,7 +167,22 @@ def overwrite_app(app, master_build, report_map=None):
     ])
     master_json = master_build.to_json()
     app_json = app.to_json()
-    form_ids_by_xmlns = _get_form_ids_by_xmlns(app_json)  # do this before we change the source
+
+    # Corresponding forms in a master app and linked app need to have the same XMLNS but different unique ids,
+    # so the linked app needs to know if there are any new forms and, if so, assign those forms new unique ids.
+    # To do this lookup, get the XMLNSes from the the most recent versions of this app pulled from each master
+    # and compare those to the XMLNSes present in this app.
+    form_ids_by_xmlns = {}
+    master_app_briefs = app.get_master_app_briefs()
+    for brief in master_app_briefs:
+        previous_app = app.get_previous_version(master_app_id=brief.master_id)
+        if previous_app:
+            form_ids_by_xmlns.update(_get_form_ids_by_xmlns(previous_app))
+    # Add in any forms from the current linked app, before the source is overwritten.
+    # This is particularly important if there's no previous version.
+    for module in app['modules']:
+        for form in module['forms']:
+            form_ids_by_xmlns[form.xmlns] = form['unique_id']
 
     for key, value in master_json.items():
         if key not in excluded_fields:
@@ -191,14 +206,6 @@ def overwrite_app(app, master_build, report_map=None):
     return wrapped_app
 
 
-def _get_form_ids_by_xmlns(app):
-    id_map = {}
-    for module in app['modules']:
-        for form in module['forms']:
-            id_map[form['xmlns']] = form['unique_id']
-    return id_map
-
-
 def _update_form_ids(app, master_app, form_ids_by_xmlns):
 
     _attachments = master_app.get_attachments()
@@ -213,6 +220,14 @@ def _update_form_ids(app, master_app, form_ids_by_xmlns):
     new_wrapped_app = wrap_app(updated_source)
     save = partial(new_wrapped_app.save, increment_version=False)
     return new_wrapped_app.save_attachments(attachments, save)
+
+
+def _get_form_ids_by_xmlns(app):
+    id_map = {}
+    for module in app.get_modules():
+        for form in module.get_forms():
+            id_map[form.xmlns] = form.unique_id
+    return id_map
 
 
 def get_practice_mode_configured_apps(domain, mobile_worker_id=None):

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -175,7 +175,7 @@ def overwrite_app(app, master_build, report_map=None):
     form_ids_by_xmlns = {}
     master_app_briefs = app.get_master_app_briefs()
     for brief in master_app_briefs:
-        previous_app = app.get_previous_version(master_app_id=brief.master_id)
+        previous_app = app.get_latest_build_from_upstream(brief.master_id)
         if previous_app:
             form_ids_by_xmlns.update(_get_form_ids_by_xmlns(previous_app))
     # Add in any forms from the current linked app, before the source is overwritten.
@@ -361,7 +361,7 @@ def update_linked_app(app, master_app_id_or_build, user_id):
         master_build = master_app_id_or_build
     master_app_id = master_build.master_id
 
-    previous = app.get_previous_version(master_app_id)
+    previous = app.get_latest_build_from_upstream(master_app_id)
     if previous is None or master_build.version > previous.upstream_version:
         old_multimedia_ids = set([media_info.multimedia_id for path, media_info in app.multimedia_map.items()])
         report_map = get_static_report_mapping(master_build.domain, app['domain'])

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -159,7 +159,7 @@ def get_default_followup_form_xml(context):
     return render_to_string("app_manager/default_followup_form.xml", context=context)
 
 
-def overwrite_app(app, master_build, report_map=None, version=None):
+def overwrite_app(app, master_build, report_map=None):
     excluded_fields = set(Application._meta_fields).union([
         'date_created', 'build_profiles', 'copy_history', 'copy_of',
         'name', 'comment', 'doc_type', '_LAZY_ATTACHMENTS', 'practice_mobile_worker_id',
@@ -172,7 +172,7 @@ def overwrite_app(app, master_build, report_map=None, version=None):
     for key, value in master_json.items():
         if key not in excluded_fields:
             app_json[key] = value
-    app_json['version'] = master_json['version']
+    app_json['version'] = app_json.get('version', 1)
     app_json['upstream_version'] = master_json['version']
     app_json['upstream_app_id'] = master_json['copy_of']
     wrapped_app = wrap_app(app_json)
@@ -292,11 +292,11 @@ def handle_custom_icon_edits(request, form_or_module, lang):
             form_or_module.custom_icons = []
 
 
-def update_linked_app_and_notify(domain, app_id, user_id, email):
+def update_linked_app_and_notify(domain, app_id, master_app_id, user_id, email):
     app = get_current_app(domain, app_id)
     subject = _("Update Status for linked app %s") % app.name
     try:
-        update_linked_app(app, user_id)
+        update_linked_app(app, master_app_id, user_id)
     except (AppLinkError, MultimediaMissingError) as e:
         message = str(e)
     except Exception:
@@ -312,49 +312,41 @@ def update_linked_app_and_notify(domain, app_id, user_id, email):
     send_html_email_async.delay(subject, email, message)
 
 
-def update_linked_app(app, user_id, master_build=None):
+def update_linked_app(app, master_app_id_or_build, user_id):
     if not app.domain_link:
         raise AppLinkError(_(
             'This project is not authorized to update from the master application. '
             'Please contact the maintainer of the master app if you believe this is a mistake. '
         ))
 
-    if master_build:
-        master_version = master_build.version
-    else:
+    if isinstance(master_app_id_or_build, str):
         try:
-            master_version = app.get_master_version()
+            master_build = app.get_latest_master_release(master_app_id_or_build)
+        except ActionNotPermitted:
+            raise AppLinkError(_(
+                'This project is not authorized to update from the master application. '
+                'Please contact the maintainer of the master app if you believe this is a mistake. '
+            ))
+        except RemoteAuthError:
+            raise AppLinkError(_(
+                'Authentication failure attempting to pull latest master from remote CommCare HQ.'
+                'Please verify your authentication details for the remote link are correct.'
+            ))
         except RemoteRequestError:
             raise AppLinkError(_(
                 'Unable to pull latest master from remote CommCare HQ. Please try again later.'
             ))
+    else:
+        master_build = master_app_id_or_build
+    master_app_id = master_build.master_id
 
-    if app.version is None or master_version > app.version:
-        if not master_build:
-            try:
-                master_build = app.get_latest_master_release()
-            except ActionNotPermitted:
-                raise AppLinkError(_(
-                    'This project is not authorized to update from the master application. '
-                    'Please contact the maintainer of the master app if you believe this is a mistake. '
-                ))
-            except RemoteAuthError:
-                raise AppLinkError(_(
-                    'Authentication failure attempting to pull latest master from remote CommCare HQ.'
-                    'Please verify your authentication details for the remote link are correct.'
-                ))
-            except RemoteRequestError:
-                raise AppLinkError(_(
-                    'Unable to pull latest master from remote CommCare HQ. Please try again later.'
-                ))
-
+    previous = app.get_previous_version(master_app_id)
+    if previous is None or master_build.version > previous.upstream_version:
         old_multimedia_ids = set([media_info.multimedia_id for path, media_info in app.multimedia_map.items()])
         report_map = get_static_report_mapping(master_build.domain, app['domain'])
 
         try:
-            new_version = app.version if app.version else 1
-            app = overwrite_app(app, master_build, report_map, version=new_version)
-            app.upstream_version = master_build.version
+            app = overwrite_app(app, master_build, report_map)
         except AppEditingError as e:
             raise AppLinkError(
                 _(

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -159,7 +159,7 @@ def get_default_followup_form_xml(context):
     return render_to_string("app_manager/default_followup_form.xml", context=context)
 
 
-def overwrite_app(app, master_build, report_map=None):
+def overwrite_app(app, master_build, report_map=None, version=None):
     excluded_fields = set(Application._meta_fields).union([
         'date_created', 'build_profiles', 'copy_history', 'copy_of',
         'name', 'comment', 'doc_type', '_LAZY_ATTACHMENTS', 'practice_mobile_worker_id',
@@ -352,7 +352,9 @@ def update_linked_app(app, user_id, master_build=None):
         report_map = get_static_report_mapping(master_build.domain, app['domain'])
 
         try:
-            app = overwrite_app(app, master_build, report_map)
+            new_version = app.version if app.version else 1
+            app = overwrite_app(app, master_build, report_map, version=new_version)
+            app.upstream_version = master_build.version
         except AppEditingError as e:
             raise AppLinkError(
                 _(

--- a/corehq/apps/linked_domain/README.md
+++ b/corehq/apps/linked_domain/README.md
@@ -39,7 +39,7 @@ Linked applications predate linked domains. Now that linked domains exist, when 
 A linked app can be pulled if its master app has a higher released version than the current version of the linked app. Pulling a linked app is similar but not identical to copying an app.
 
 When a linked/downstream app is pulled from its master/upstream app:
-- The linked app's version will be set to the master app's version.
+- The linked app's version will be incremented.
 - The two apps will have **different** ids.
 - Corresponding modules in the master and linked app will have the **same** unique ids.
 - Corresponding forms in the master and linked app will have **different** unique ids.
@@ -49,8 +49,4 @@ When a linked/downstream app is pulled from its master/upstream app:
 A few fields are **not** copied from the master app to the linked app. They include basic metadata (doc type, name, date created, comment, etc) and some build-related fields (build profiles and practice mobile workers). For the full list, see [excluded_fields in overwrite_app](https://github.com/dimagi/commcare-hq/blob/47b197378fc196ff25a88dc5b2c56a389aaec85f/corehq/apps/app_manager/views/utils.py#L165-L169).
 
 ## Overrides
-A small number of settings can be overridden in a linked app. App settings can be tagged with the `supports_linked_app` flag to make them appear on the linked app's settings page. However, because linked app versions are tied to master versions, linked app versions do not increment on their own when a change is made. This makes the following workflow necessary for settings overrides:
-- Pull master app
-- Make any changes to linked app
-- Make build of linked app
-Once the build is made, even after making additional changes, it's no longer possible to make a new build of the linked app until the next pull from master.
+A small number of settings can be overridden in a linked app. App settings can be tagged with the `supports_linked_app` flag to make them appear on the linked app's settings page.

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -12,11 +12,14 @@ from corehq.apps.linked_domain.remote_accessors import (
 )
 
 
-def get_master_app_briefs(domain_link):
+def get_master_app_briefs(domain_link, family_id):
     if domain_link.is_remote:
         apps = get_brief_apps(domain_link.master_domain, domain_link.remote_details)
     else:
         apps = get_brief_apps_in_domain(domain_link.master_domain, include_remote=False)
+
+    apps = [app for app in apps if family_id in [app._id, app.family_id]]
+
     # Ignore deleted, linked and remote apps
     return [app for app in apps if app.doc_type == 'Application']
 

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -1,13 +1,13 @@
 from corehq.apps.app_manager.dbaccessors import (
-    get_app,
     get_brief_apps_in_domain,
     get_latest_released_app,
-    get_latest_released_app_version,
+    get_latest_released_app_versions_by_app_id,
 )
 from corehq.apps.linked_domain.exceptions import ActionNotPermitted
 from corehq.apps.linked_domain.models import DomainLink
 from corehq.apps.linked_domain.remote_accessors import (
     get_brief_apps,
+    get_latest_released_versions_by_app_id,
     get_released_app,
 )
 
@@ -28,6 +28,13 @@ def get_latest_master_app_release(domain_link, app_id):
         return get_released_app(master_domain, app_id, linked_domain, domain_link.remote_details)
     else:
         return get_latest_released_app(master_domain, app_id)
+
+
+def get_latest_master_releases_versions(domain_link):
+    if domain_link.is_remote:
+        return get_latest_released_versions_by_app_id(domain_link)
+    else:
+        return get_latest_released_app_versions_by_app_id(domain_link.master_domain)
 
 
 def create_linked_app(master_domain, master_id, target_domain, target_name, remote_details=None):

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -19,7 +19,7 @@ def get_master_app_briefs(domain_link, family_id):
         apps = get_brief_apps_in_domain(domain_link.master_domain, include_remote=False)
 
     # Ignore deleted, linked and remote apps
-    apps = [app for app in apps if family_id in [app._id, app.family_id] and app.doc_type == 'Application']
+    return [app for app in apps if family_id in [app._id, app.family_id] and app.doc_type == 'Application']
 
 
 def get_latest_master_app_release(domain_link, app_id):

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -18,10 +18,8 @@ def get_master_app_briefs(domain_link, family_id):
     else:
         apps = get_brief_apps_in_domain(domain_link.master_domain, include_remote=False)
 
-    apps = [app for app in apps if family_id in [app._id, app.family_id]]
-
     # Ignore deleted, linked and remote apps
-    return [app for app in apps if app.doc_type == 'Application']
+    apps = [app for app in apps if family_id in [app._id, app.family_id] and app.doc_type == 'Application']
 
 
 def get_latest_master_app_release(domain_link, app_id):

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -1,11 +1,13 @@
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
+    get_brief_apps_in_domain,
     get_latest_released_app,
     get_latest_released_app_version,
 )
 from corehq.apps.linked_domain.exceptions import ActionNotPermitted
 from corehq.apps.linked_domain.models import DomainLink
 from corehq.apps.linked_domain.remote_accessors import (
+    get_brief_apps,
     get_released_app,
     get_released_app_version,
 )
@@ -16,6 +18,15 @@ def get_master_app_version(domain_link, app_id):
         return get_released_app_version(domain_link.master_domain, app_id, domain_link.remote_details)
     else:
         return get_latest_released_app_version(domain_link.master_domain, app_id)
+
+
+def get_master_app_briefs(domain_link):
+    if domain_link.is_remote:
+        apps = get_brief_apps(domain_link.master_domain, domain_link.remote_details)
+    else:
+        apps = get_brief_apps_in_domain(domain_link.master_domain, include_remote=False)
+    # Ignore deleted, linked and remote apps
+    return [app for app in apps if app.doc_type == 'Application']
 
 
 def get_latest_master_app_release(domain_link, app_id):
@@ -39,7 +50,6 @@ def create_linked_app(master_domain, master_id, target_domain, target_name, remo
 def link_app(linked_app, master_domain, master_id, remote_details=None):
     DomainLink.link_domains(linked_app.domain, master_domain, remote_details)
 
-    linked_app.master = master_id
     linked_app.family_id = master_id
     linked_app.doc_type = 'LinkedApplication'
     linked_app.save()

--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -9,15 +9,7 @@ from corehq.apps.linked_domain.models import DomainLink
 from corehq.apps.linked_domain.remote_accessors import (
     get_brief_apps,
     get_released_app,
-    get_released_app_version,
 )
-
-
-def get_master_app_version(domain_link, app_id):
-    if domain_link.is_remote:
-        return get_released_app_version(domain_link.master_domain, app_id, domain_link.remote_details)
-    else:
-        return get_latest_released_app_version(domain_link.master_domain, app_id)
 
 
 def get_master_app_briefs(domain_link):

--- a/corehq/apps/linked_domain/management/commands/link_apps.py
+++ b/corehq/apps/linked_domain/management/commands/link_apps.py
@@ -29,4 +29,4 @@ class Command(BaseCommand):
         linked_app = LinkedApplication.get(linked_id)
 
         link_app(linked_app, master_app.domain, master_id)
-        update_linked_app(linked_app, 'system')
+        update_linked_app(linked_app, master_id, 'system')

--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -40,12 +40,6 @@ def get_case_search_config(domain_link):
     return _do_simple_request('linked_domain:case_search_config', domain_link)
 
 
-def get_released_app_version(master_domain, app_id, remote_details):
-    url = reverse('current_app_version', args=[master_domain, app_id])
-    response = _do_request_to_remote_hq_json(url, remote_details, None)
-    return response.get('latestReleasedBuild')
-
-
 def get_released_app(master_domain, app_id, linked_domain, remote_details):
     url = reverse('linked_domain:latest_released_app_source', args=[master_domain, app_id])
     response = _do_request_to_remote_hq_json(url, remote_details, linked_domain)

--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -32,6 +32,10 @@ def get_user_roles(domain_link):
     return _do_simple_request('linked_domain:user_roles', domain_link)['user_roles']
 
 
+def get_brief_apps(domain_link):
+    return _do_simple_request('linked_domain:brief_apps', domain_link)['brief_apps']
+
+
 def get_case_search_config(domain_link):
     return _do_simple_request('linked_domain:case_search_config', domain_link)
 

--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -46,6 +46,10 @@ def get_released_app(master_domain, app_id, linked_domain, remote_details):
     return _convert_app_from_remote_linking_source(response)
 
 
+def get_latest_released_versions_by_app_id(domain_link):
+    return _do_simple_request('linked_domain:released_app_versions', domain_link)['versions']
+
+
 def _convert_app_from_remote_linking_source(app_json):
     attachments = app_json.pop('_LAZY_ATTACHMENTS', {})
     app = wrap_app(app_json)

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -49,10 +49,14 @@ class BaseLinkedAppsTest(TestCase, TestXmlMixin):
             ReportAppConfig(report_id='master_report_id', header={'en': 'CommBugz'}),
         ]
 
-        cls.master1 = Application.new_app(cls.domain, "Master Application")
         cls.linked_domain = 'domain-2'
+        cls.master1 = Application.new_app(cls.domain, "First Master Application")
         cls.master1.linked_whitelist = [cls.linked_domain]
         cls.master1.save()
+
+        cls.master2 = Application.new_app(cls.domain, "Second Master Application")
+        cls.master2.linked_whitelist = [cls.linked_domain]
+        cls.master2.save()
 
         cls.linked_app = LinkedApplication.new_app(cls.linked_domain, "Linked Application")
         cls.linked_app.save()
@@ -63,6 +67,7 @@ class BaseLinkedAppsTest(TestCase, TestXmlMixin):
     def tearDownClass(cls):
         cls.linked_app.delete()
         cls.master1.delete()
+        cls.master2.delete()
         cls.domain_link.delete()
         super(BaseLinkedAppsTest, cls).tearDownClass()
 
@@ -74,6 +79,9 @@ class BaseLinkedAppsTest(TestCase, TestXmlMixin):
 class TestLinkedApps(BaseLinkedAppsTest):
     def _make_master1_build(self, release):
         return self._make_build(self.master1, release)
+
+    def _make_master2_build(self, release):
+        return self._make_build(self.master2, release)
 
     def _make_build(self, app, release):
         app.save()  # increment version number
@@ -134,6 +142,48 @@ class TestLinkedApps(BaseLinkedAppsTest):
         latest_master_release = self.linked_app.get_latest_master_release()
         self.assertEqual(copy1.get_id, latest_master_release.get_id)
         self.assertEqual(copy1._rev, latest_master_release._rev)
+
+    def test_incremental_versioning(self):
+        self.linked_app.master = self.master1.get_id
+        original_master_version = self.master1.version or 0
+        original_linked_version = self.linked_app.version or 0
+
+        # Make a few versions of master app
+        self._make_master1_build(True)
+        self._make_master1_build(True)
+        self._make_master1_build(True)
+        current_master = self._make_master1_build(True)
+
+        # Pull linked app and refresh from database
+        update_linked_app(self.linked_app, 'test_incremental_versioning')
+        self.linked_app = LinkedApplication.get(self.linked_app._id)
+
+        self.assertEqual(current_master.version, original_master_version + 4)
+        self.assertEqual(self.linked_app.version, original_linked_version + 1)
+
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    def test_multi_master_fields(self, *args):
+        original_master1_version = self.master1.version or 0
+        original_master2_version = self.master2.version or 0
+
+        # Make a few versions of master apps
+        self._make_master1_build(True)
+        self._make_master1_build(True)
+        self._make_master1_build(True)
+        self._make_master1_build(True)
+        self._make_master2_build(True)
+        self._make_master2_build(True)
+        self._make_master2_build(True)
+
+        # Pull linked app from first master and refresh from database
+        update_linked_app(self.linked_app, self.master1.get_id, 'test_incremental_versioning')
+        self.linked_app = LinkedApplication.get(self.linked_app._id)
+        self.assertEqual(self.linked_app.upstream_version, original_master1_version + 4)
+
+        # Pull linked app from other master and refresh from database
+        update_linked_app(self.linked_app, self.master2.get_id, 'test_incremental_versioning')
+        self.linked_app = LinkedApplication.get(self.linked_app._id)
+        self.assertEqual(self.linked_app.upstream_version, original_master2_version + 3)
 
     def test_get_latest_master_release_not_permitted(self):
         self.linked_app.master = self.master1.get_id

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -91,8 +91,8 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.addCleanup(copy.delete)
         return copy
 
-    def _pull_linked_app(self):
-        update_linked_app(self.linked_app, 'TestLinkedApps user')
+    def _pull_linked_app(self, upstream_app_id):
+        update_linked_app(self.linked_app, upstream_app_id, 'TestLinkedApps user')
         self.linked_app = LinkedApplication.get(self.linked_app._id)
 
     def test_missing_ucrs(self):
@@ -120,29 +120,24 @@ class TestLinkedApps(BaseLinkedAppsTest):
             _get_form_ids_by_xmlns(LinkedApplication.get(self.linked_app._id))
         )
 
-    def test_get_master_version(self):
-        self.linked_app.master = self.master1.get_id
-
-        self.assertIsNone(self.linked_app.get_master_version())
-        self._make_master1_build(False)
-        self.assertIsNone(self.linked_app.get_master_version())
-
-        copy1 = self._make_master1_build(True)
-        self.assertEqual(copy1.version, self.linked_app.get_master_version())
-
     def test_get_latest_master_release(self):
-        master_id = self.master1.get_id
-
-        self.assertIsNone(self.linked_app.get_latest_master_release())
+        self.assertIsNone(self.linked_app.get_latest_master_release(self.master1.get_id))
 
         self._make_master1_build(False)
+        self.assertIsNone(self.linked_app.get_latest_master_release(self.master1.get_id))
 
-        self.assertIsNone(self.linked_app.get_latest_master_release())
+        self._make_master1_build(True)
+        master1_copy2 = self._make_master1_build(True)
 
-        copy1 = self._make_master1_build(True)
-        latest_master_release = self.linked_app.get_latest_master_release()
-        self.assertEqual(copy1.get_id, latest_master_release.get_id)
-        self.assertEqual(copy1._rev, latest_master_release._rev)
+        latest_master_release = self.linked_app.get_latest_master_release(self.master1.get_id)
+        self.assertEqual(master1_copy2.get_id, latest_master_release.get_id)
+        self.assertEqual(master1_copy2._rev, latest_master_release._rev)
+
+        master2_copy1 = self._make_master2_build(True)
+        latest_master1_release = self.linked_app.get_latest_master_release(self.master1.get_id)
+        latest_master2_release = self.linked_app.get_latest_master_release(self.master2.get_id)
+        self.assertEqual(master1_copy2.get_id, latest_master1_release.get_id)
+        self.assertEqual(master2_copy1.get_id, latest_master2_release.get_id)
 
     def test_incremental_versioning(self):
         original_master_version = self.master1.version or 0
@@ -154,10 +149,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self._make_master1_build(True)
         current_master = self._make_master1_build(True)
 
-        # Pull linked app and refresh from database
-        update_linked_app(self.linked_app, 'test_incremental_versioning')
-        self.linked_app = LinkedApplication.get(self.linked_app._id)
-
+        self._pull_linked_app(self.master1.get_id)
         self.assertEqual(current_master.version, original_master_version + 4)
         self.assertEqual(self.linked_app.version, original_linked_version + 1)
 
@@ -175,21 +167,17 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self._make_master2_build(True)
         self._make_master2_build(True)
 
-        # Pull linked app from first master and refresh from database
-        update_linked_app(self.linked_app, self.master1.get_id, 'test_incremental_versioning')
-        self.linked_app = LinkedApplication.get(self.linked_app._id)
+        self._pull_linked_app(self.master1.get_id)
         self.assertEqual(self.linked_app.upstream_app_id, self.master1.get_id)
         self.assertEqual(self.linked_app.upstream_version, original_master1_version + 4)
 
-        # Pull linked app from other master and refresh from database
-        update_linked_app(self.linked_app, self.master2.get_id, 'test_incremental_versioning')
-        self.linked_app = LinkedApplication.get(self.linked_app._id)
+        self._pull_linked_app(self.master2.get_id)
         self.assertEqual(self.linked_app.upstream_app_id, self.master2.get_id)
         self.assertEqual(self.linked_app.upstream_version, original_master2_version + 3)
 
     def test_get_latest_master_release_not_permitted(self):
         release = self._make_master1_build(True)
-        latest_master_release = self.linked_app.get_latest_master_release()
+        latest_master_release = self.linked_app.get_latest_master_release(self.master1.get_id)
         self.assertEqual(release.get_id, latest_master_release.get_id)
 
         self.domain_link.linked_domain = 'other'
@@ -204,9 +192,10 @@ class TestLinkedApps(BaseLinkedAppsTest):
 
         with self.assertRaises(ActionNotPermitted):
             # re-fetch to bust memoize cache
-            LinkedApplication.get(self.linked_app._id).get_latest_master_release()
+            LinkedApplication.get(self.linked_app._id).get_latest_master_release(self.master1.get_id)
 
-    def test_override_translations(self):
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    def test_override_translations(self, *args):
         translations = {'en': {'updates.check.begin': 'update?'}}
 
         self._make_master1_build(True)
@@ -216,15 +205,15 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.linked_app.save()
         self.assertEqual(self.linked_app.translations, {})
 
-        self._pull_linked_app()
+        self._pull_linked_app(self.master1.get_id)
         self.linked_app = LinkedApplication.get(self.linked_app._id)
-
         self.assertEqual(self.master1.translations, {})
         self.assertEqual(self.linked_app.linked_app_translations, translations)
         self.assertEqual(self.linked_app.translations, translations)
 
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
     @patch('corehq.apps.app_manager.models.get_and_assert_practice_user_in_domain', lambda x, y: None)
-    def test_overrides(self):
+    def test_overrides(self, *args):
         self.master1.practice_mobile_worker_id = "123456"
         self.master1.save()
         image_data = _get_image_data()
@@ -264,7 +253,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.linked_app.practice_mobile_worker_id = 'abc123456def'
         self.assertEqual(self.linked_app.logo_refs, {})
 
-        self._pull_linked_app()
+        self._pull_linked_app(self.master1.get_id)
         self.assertEqual(self.master1.logo_refs, {})
         self.assertEqual(self.linked_app.linked_app_logo_refs, logo_refs)
         self.assertEqual(self.linked_app.logo_refs, logo_refs)
@@ -297,9 +286,8 @@ class TestLinkedApps(BaseLinkedAppsTest):
         master_app.save()  # increment version number
         self._make_build(master_app, True)
 
-        update_linked_app(linked_app, 'test_update_from_specific_build', master_build=copy1)
+        update_linked_app(linked_app, copy1, 'test_update_from_specific_build')
         linked_app = LinkedApplication.get(linked_app._id)
-
         self.assertEqual(len(linked_app.modules), 1)
         self.assertEqual(linked_app.version, copy1.version)
 

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -131,11 +131,12 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.assertEqual(copy1.version, self.linked_app.get_master_version())
 
     def test_get_latest_master_release(self):
-        self.linked_app.master = self.master1.get_id
+        master_id = self.master1.get_id
 
         self.assertIsNone(self.linked_app.get_latest_master_release())
 
         self._make_master1_build(False)
+
         self.assertIsNone(self.linked_app.get_latest_master_release())
 
         copy1 = self._make_master1_build(True)
@@ -144,7 +145,6 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.assertEqual(copy1._rev, latest_master_release._rev)
 
     def test_incremental_versioning(self):
-        self.linked_app.master = self.master1.get_id
         original_master_version = self.master1.version or 0
         original_linked_version = self.linked_app.version or 0
 
@@ -178,16 +178,16 @@ class TestLinkedApps(BaseLinkedAppsTest):
         # Pull linked app from first master and refresh from database
         update_linked_app(self.linked_app, self.master1.get_id, 'test_incremental_versioning')
         self.linked_app = LinkedApplication.get(self.linked_app._id)
+        self.assertEqual(self.linked_app.upstream_app_id, self.master1.get_id)
         self.assertEqual(self.linked_app.upstream_version, original_master1_version + 4)
 
         # Pull linked app from other master and refresh from database
         update_linked_app(self.linked_app, self.master2.get_id, 'test_incremental_versioning')
         self.linked_app = LinkedApplication.get(self.linked_app._id)
+        self.assertEqual(self.linked_app.upstream_app_id, self.master2.get_id)
         self.assertEqual(self.linked_app.upstream_version, original_master2_version + 3)
 
     def test_get_latest_master_release_not_permitted(self):
-        self.linked_app.master = self.master1.get_id
-
         release = self._make_master1_build(True)
         latest_master_release = self.linked_app.get_latest_master_release()
         self.assertEqual(release.get_id, latest_master_release.get_id)
@@ -208,8 +208,6 @@ class TestLinkedApps(BaseLinkedAppsTest):
 
     def test_override_translations(self):
         translations = {'en': {'updates.check.begin': 'update?'}}
-
-        self.linked_app.master = self.master1.get_id
 
         self._make_master1_build(True)
         self._make_master1_build(True)
@@ -252,8 +250,6 @@ class TestLinkedApps(BaseLinkedAppsTest):
             },
         }
 
-        self.linked_app.master = self.master1.get_id
-
         self._make_master1_build(True)
         self._make_master1_build(True)
 
@@ -291,7 +287,6 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.addCleanup(master_app.delete)
 
         linked_app = LinkedApplication.new_app(self.linked_domain, "Linked Application")
-        linked_app.master = master_app.get_id
         linked_app.save()
         self.addCleanup(linked_app.delete)
 

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -21,7 +21,11 @@ from corehq.apps.app_manager.views.utils import (
     update_linked_app,
     _get_form_ids_by_xmlns,
 )
-from corehq.apps.hqmedia.models import CommCareImage, CommCareMultimedia
+from corehq.apps.hqmedia.models import (
+    CommCareAudio,
+    CommCareImage,
+    CommCareMultimedia,
+)
 from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
 from corehq.apps.linked_domain.exceptions import ActionNotPermitted
 from corehq.apps.linked_domain.models import DomainLink, RemoteLinkDetails
@@ -126,11 +130,29 @@ class TestLinkedApps(BaseLinkedAppsTest):
             _get_form_ids_by_xmlns(LinkedApplication.get(self.linked_app._id))
         )
 
-    def test_multi_master_form_attributes(self):
-        # Add single module and form to both master1 and master2
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    def test_multi_master_form_attributes_and_media_versions(self, *args):
+        '''
+        This tests a few things related to pulling a linked app from multiple master apps,
+        particularly interleaving pulls (pulling master A, then master B, then master A again):
+        - Form versions should not change unless the form content changed
+        - Form unique ids should be different from the master they came from but consistent across
+          versions of the linked app that come from that master.
+        - If a new form is added to multiple masters, that form's unique id should be the same
+          across all versions of the linked app that pull from any of those masters - that is,
+          each XMLNS in the linked app should correspond to one and only one form unique id.
+        - Multimedia versions should not change, but should be consistent with the version
+          of the linked app where they were introduced.
+        '''
+
+        # Add single module and form to both master1 and master2.
+        # The module in master1 will also be used for multimedia testing.
         master1_module = self.master1.add_module(Module.new_module('Module for master1', None))
         master1_module.new_form('Form for master1', 'en', get_blank_form_xml('Form for master1'))
         master1_map = _get_form_ids_by_xmlns(self.master1)
+        image_path = 'jr://file/commcare/photo.jpg'
+        self.master1.create_mapping(CommCareImage(_id='123'), image_path)
+        self.master1.get_module(0).set_icon('en', image_path)
         self._make_master1_build(True)
         master2_module = self.master2.add_module(Module.new_module('Module for master2', None))
         master2_module.new_form('Form for master2', 'en', get_blank_form_xml('Form for master2'))
@@ -144,6 +166,8 @@ class TestLinkedApps(BaseLinkedAppsTest):
         linked_master1_map = _get_form_ids_by_xmlns(self.linked_app)
         self.assertEqual(set(master1_map.keys()), set(linked_master1_map.keys()))
         self.assertNotEqual(set(master1_map.values()), set(linked_master1_map.values()))
+        original_image_version = linked_master1_build1.multimedia_map[image_path].version
+        self.assertEqual(original_image_version, linked_master1_build1.version)
 
         # Pull master2, so linked app now has other form. Verify that form xmlnses match but unique ids do not.
         self._pull_linked_app(self.master2.get_id)
@@ -165,9 +189,14 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.assertEqual(linked_master1_build1_form.get_version(), linked_master1_build2_form.get_version())
 
         # Update form in master1 and make new linked build, which should update form version
+        # Also add audio. The new audio should get the new build version, but the old image should retain
+        # the version of the old app.
         wrapped = self.master1.get_module(0).get_form(0).wrapped_xform()
         wrapped.set_name("Updated form for master1")
         self.master1.get_module(0).get_form(0).source = etree.tostring(wrapped.xml, encoding="unicode")
+        audio_path = 'jr://file/commcare/scream.mp3'
+        self.master1.create_mapping(CommCareAudio(_id='345'), audio_path)
+        self.master1.get_module(0).set_audio('en', audio_path)
         self._make_master1_build(True)
         self._pull_linked_app(self.master1.get_id)
         linked_master1_build3 = self._make_linked_build()
@@ -175,6 +204,8 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.assertEqual(linked_master1_build2_form.xmlns, linked_master1_build3_form.xmlns)
         self.assertEqual(linked_master1_build2_form.unique_id, linked_master1_build3_form.unique_id)
         self.assertLess(linked_master1_build2_form.get_version(), linked_master1_build3_form.get_version())
+        self.assertEqual(self.linked_app.multimedia_map[image_path].version, original_image_version)
+        self.assertGreater(self.linked_app.multimedia_map[audio_path].version, original_image_version)
 
         # Add another form to both master1 and master2. When master1 is pulled, that form should be assigned a
         # new unique id, and when master2 is pulled, it should retain that id since it has the same xmlns.

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -13,6 +13,7 @@ from corehq.apps.app_manager.models import (
     Module,
     ReportAppConfig,
     ReportModule,
+    import_app,
 )
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.views.utils import (
@@ -222,6 +223,44 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self.assertEqual(_get_form_ids_by_xmlns(linked_master1_build4)[xmlns],
                          _get_form_ids_by_xmlns(linked_master2_build2)[xmlns])
 
+    @patch('corehq.apps.app_manager.models.validate_xform', return_value=None)
+    def test_multi_master_copy_master(self, *args):
+        '''
+        This tests that when a master app A is copied to A' and the linked app is pulled from A',
+        the linked app's form unique ids remain consistent, and form and multimedia versions
+        do NOT increment just because of the copy.
+        '''
+
+        # Add single module and form, with image, to master, and pull linked app.
+        master1_module = self.master1.add_module(Module.new_module('Module for master', None))
+        master1_module.new_form('Form for master', 'en', get_blank_form_xml('Form for master'))
+        image_path = 'jr://file/commcare/photo.jpg'
+        self.master1.create_mapping(CommCareImage(_id='123'), image_path)
+        self.master1.get_module(0).set_icon('en', image_path)
+        self._make_master1_build(True)
+        self.linked_app.family_id = self.master1.get_id
+        self.linked_app.save()
+        self._pull_linked_app(self.master1.get_id)
+        build1 = self._make_linked_build()
+
+        # Make a copy of master and pull it.
+        master_copy = import_app(self.master1.get_id, self.master1.domain)
+        self._make_build(master_copy, True)
+        self._pull_linked_app(master_copy.get_id)
+        build2 = self._make_linked_build()
+
+        # Verify form XMLNS, form unique id, form version, and multimedia version all match.
+        form1 = build1.get_module(0).get_form(0)
+        form2 = build2.get_module(0).get_form(0)
+        self.assertEqual(form1.xmlns, form2.xmlns)
+        self.assertEqual(form1.unique_id, form2.unique_id)
+        self.assertNotEqual(build1.version, build2.version)
+        self.assertEqual(form1.get_version(), form2.get_version())
+        map_item1 = build1.multimedia_map[image_path]
+        map_item2 = build2.multimedia_map[image_path]
+        self.assertEqual(map_item1.unique_id, map_item2.unique_id)
+        self.assertEqual(map_item1.version, map_item2.version)
+
     def test_get_latest_master_release(self):
         self.assertIsNone(self.linked_app.get_latest_master_release(self.master1.get_id))
 
@@ -276,6 +315,30 @@ class TestLinkedApps(BaseLinkedAppsTest):
         self._pull_linked_app(self.master2.get_id)
         self.assertEqual(self.linked_app.upstream_app_id, self.master2.get_id)
         self.assertEqual(self.linked_app.upstream_version, original_master2_version + 3)
+
+    def test_get_latest_build_from_upstream(self):
+        # Make build of master1, pull linked app, and make linked app build
+        self._make_master1_build(True)
+        self._pull_linked_app(self.master1.get_id)
+        linked_build1 = self._make_linked_build()
+
+        # Make several builds of master2, each also pulled to linked app and built there
+        self._make_master2_build(True)
+        self._make_master2_build(True)
+        self._pull_linked_app(self.master2.get_id)
+        linked_build2 = self._make_linked_build()
+        self._make_master2_build(True)
+        self._make_master2_build(True)
+        self._pull_linked_app(self.master2.get_id)
+        linked_build3 = self._make_linked_build()
+
+        previous_master2_version = linked_build3.get_latest_build_from_upstream(self.master2.get_id)
+        self.assertEqual(previous_master2_version.upstream_app_id, self.master2.get_id)
+        self.assertEqual(previous_master2_version.get_id, linked_build2.get_id)
+
+        previous_master1_version = linked_build3.get_latest_build_from_upstream(self.master1.get_id)
+        self.assertEqual(previous_master1_version.upstream_app_id, self.master1.get_id)
+        self.assertEqual(previous_master1_version.get_id, linked_build1.get_id)
 
     def test_get_latest_master_release_not_permitted(self):
         release = self._make_master1_build(True)

--- a/corehq/apps/linked_domain/tests/test_linked_apps.py
+++ b/corehq/apps/linked_domain/tests/test_linked_apps.py
@@ -16,9 +16,10 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.views.utils import (
-    _get_form_ids_by_xmlns,
+    get_blank_form_xml,
     overwrite_app,
     update_linked_app,
+    _get_form_ids_by_xmlns,
 )
 from corehq.apps.hqmedia.models import CommCareImage, CommCareMultimedia
 from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
@@ -32,6 +33,8 @@ from corehq.apps.linked_domain.util import (
     _get_missing_multimedia,
     convert_app_for_remote_linking,
 )
+from lxml import etree
+
 from corehq.util.test_utils import flag_enabled, softer_assert
 
 
@@ -83,6 +86,9 @@ class TestLinkedApps(BaseLinkedAppsTest):
     def _make_master2_build(self, release):
         return self._make_build(self.master2, release)
 
+    def _make_linked_build(self):
+        return self._make_build(self.linked_app, True)
+
     def _make_build(self, app, release):
         app.save()  # increment version number
         copy = app.make_build()
@@ -105,7 +111,7 @@ class TestLinkedApps(BaseLinkedAppsTest):
         linked_app = Application.get(self.linked_app._id)
         self.assertEqual(linked_app.modules[0].report_configs[0].report_id, 'mapped_id')
 
-    def test_overwrite_app_maintain_ids(self):
+    def test_overwrite_app_maintain_form_unique_ids(self):
         module = self.master1.add_module(Module.new_module('M1', None))
         module.new_form('f1', None, self.get_xml('very_simple_form').decode('utf-8'))
 
@@ -119,6 +125,71 @@ class TestLinkedApps(BaseLinkedAppsTest):
             id_map_before,
             _get_form_ids_by_xmlns(LinkedApplication.get(self.linked_app._id))
         )
+
+    def test_multi_master_form_attributes(self):
+        # Add single module and form to both master1 and master2
+        master1_module = self.master1.add_module(Module.new_module('Module for master1', None))
+        master1_module.new_form('Form for master1', 'en', get_blank_form_xml('Form for master1'))
+        master1_map = _get_form_ids_by_xmlns(self.master1)
+        self._make_master1_build(True)
+        master2_module = self.master2.add_module(Module.new_module('Module for master2', None))
+        master2_module.new_form('Form for master2', 'en', get_blank_form_xml('Form for master2'))
+        master2_map = _get_form_ids_by_xmlns(self.master2)
+        self._make_master2_build(True)
+
+        # Pull master1, so linked app now has a form. Verify that form xmlnses match but unique ids do not.
+        self._pull_linked_app(self.master1.get_id)
+        linked_master1_build1 = self._make_linked_build()
+        linked_master1_build1_form = linked_master1_build1.get_module(0).get_form(0)
+        linked_master1_map = _get_form_ids_by_xmlns(self.linked_app)
+        self.assertEqual(set(master1_map.keys()), set(linked_master1_map.keys()))
+        self.assertNotEqual(set(master1_map.values()), set(linked_master1_map.values()))
+
+        # Pull master2, so linked app now has other form. Verify that form xmlnses match but unique ids do not.
+        self._pull_linked_app(self.master2.get_id)
+        linked_master2_build1 = self._make_linked_build()
+        linked_master2_map = _get_form_ids_by_xmlns(self.linked_app)
+        linked_master2_build1_form = linked_master2_build1.get_module(0).get_form(0)
+        self.assertEqual(set(master2_map.keys()), set(linked_master2_map.keys()))
+        self.assertNotEqual(set(master2_map.values()), set(linked_master2_map.values()))
+        self.assertNotEqual(linked_master1_build1_form.unique_id, linked_master2_build1_form.unique_id)
+
+        # Re-pull master1, so linked app is back to the first form, with same xmlns, unique id, and version
+        linked_master1_build1 = self._make_master1_build(True)
+        self._pull_linked_app(self.master1.get_id)
+        linked_master1_build2 = self._make_linked_build()
+        linked_master1_build2_form = linked_master1_build2.get_module(0).get_form(0)
+        self.assertEqual(linked_master1_map, _get_form_ids_by_xmlns(self.linked_app))
+        self.assertEqual(linked_master1_build1_form.xmlns, linked_master1_build2_form.xmlns)
+        self.assertEqual(linked_master1_build1_form.unique_id, linked_master1_build2_form.unique_id)
+        self.assertEqual(linked_master1_build1_form.get_version(), linked_master1_build2_form.get_version())
+
+        # Update form in master1 and make new linked build, which should update form version
+        wrapped = self.master1.get_module(0).get_form(0).wrapped_xform()
+        wrapped.set_name("Updated form for master1")
+        self.master1.get_module(0).get_form(0).source = etree.tostring(wrapped.xml, encoding="unicode")
+        self._make_master1_build(True)
+        self._pull_linked_app(self.master1.get_id)
+        linked_master1_build3 = self._make_linked_build()
+        linked_master1_build3_form = linked_master1_build3.get_module(0).get_form(0)
+        self.assertEqual(linked_master1_build2_form.xmlns, linked_master1_build3_form.xmlns)
+        self.assertEqual(linked_master1_build2_form.unique_id, linked_master1_build3_form.unique_id)
+        self.assertLess(linked_master1_build2_form.get_version(), linked_master1_build3_form.get_version())
+
+        # Add another form to both master1 and master2. When master1 is pulled, that form should be assigned a
+        # new unique id, and when master2 is pulled, it should retain that id since it has the same xmlns.
+        self.master1.get_module(0).new_form('Twin form', None, self.get_xml('very_simple_form').decode('utf-8'))
+        self._make_master1_build(True)
+        self._pull_linked_app(self.master1.get_id)
+        xmlns = self.master1.get_module(0).get_form(1).xmlns
+        self.master2.get_module(0).new_form('Twin form', None, self.get_xml('very_simple_form').decode('utf-8'))
+        linked_master1_build4 = self._make_linked_build()
+        self._make_master2_build(True)
+        self._pull_linked_app(self.master2.get_id)
+        linked_master2_build2 = self._make_linked_build()
+        self.assertEqual(xmlns, self.master2.get_module(0).get_form(1).xmlns)
+        self.assertEqual(_get_form_ids_by_xmlns(linked_master1_build4)[xmlns],
+                         _get_form_ids_by_xmlns(linked_master2_build2)[xmlns])
 
     def test_get_latest_master_release(self):
         self.assertIsNone(self.linked_app.get_latest_master_release(self.master1.get_id))

--- a/corehq/apps/linked_domain/tests/test_update_roles.py
+++ b/corehq/apps/linked_domain/tests/test_update_roles.py
@@ -10,7 +10,6 @@ class TestUpdateRoles(BaseLinkedAppsTest):
     @classmethod
     def setUpClass(cls):
         super(TestUpdateRoles, cls).setUpClass()
-        cls.linked_app.master = cls.master1.get_id
         cls.linked_app.save()
 
         cls.role = UserRole(
@@ -18,9 +17,6 @@ class TestUpdateRoles(BaseLinkedAppsTest):
             name='test',
             permissions=Permissions(
                 edit_data=True,
-                view_web_apps_list=[
-                    cls.master1.get_id
-                ],
                 view_report_list=[
                     'corehq.reports.DynamicReportmaster_report_id'
                 ]
@@ -38,7 +34,7 @@ class TestUpdateRoles(BaseLinkedAppsTest):
             role.delete()
         super(TestUpdateRoles, self).tearDown()
 
-    def test_update_web_apps_list(self):
+    def test_update_report_list(self):
         self.assertEqual([], UserRole.by_domain(self.linked_domain))
 
         report_mapping = {'master_report_id': 'linked_report_id'}
@@ -47,5 +43,4 @@ class TestUpdateRoles(BaseLinkedAppsTest):
 
         roles = UserRole.by_domain(self.linked_domain)
         self.assertEqual(1, len(roles))
-        self.assertEqual(roles[0].permissions.view_web_apps_list, [self.linked_app._id])
         self.assertEqual(roles[0].permissions.view_report_list, [get_ucr_class_name('linked_report_id')])

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -99,7 +99,6 @@ def update_user_roles(domain_link):
     else:
         master_results = local_get_user_roles(domain_link.master_domain)
 
-    _convert_web_apps_permissions(domain_link, master_results)
     _convert_reports_permissions(domain_link, master_results)
 
     local_roles = UserRole.view(
@@ -143,26 +142,6 @@ def update_case_search_config(domain_link):
 
     if query_addition:
         CaseSearchQueryAddition.create_from_json(domain_link.linked_domain, query_addition)
-
-
-def _convert_web_apps_permissions(domain_link, master_results):
-    """Mutates the master result docs to convert web app permissions.
-    """
-    linked_apps_by_master = {
-        app.master: app._id
-        for app in get_docs_in_domain_by_class(domain_link.linked_domain, LinkedApplication)
-    }
-    for role_def in master_results:
-        view_web_apps_list = []
-        for app_id in role_def['permissions']['view_web_apps_list']:
-            master_app_id = get_app(domain_link.master_domain, app_id).master_id
-            try:
-                linked_app_id = linked_apps_by_master[master_app_id]
-            except KeyError:
-                continue
-            view_web_apps_list.append(linked_app_id)
-
-        role_def['permissions']['view_web_apps_list'] = view_web_apps_list
 
 
 def _convert_reports_permissions(domain_link, master_results):

--- a/corehq/apps/linked_domain/urls.py
+++ b/corehq/apps/linked_domain/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from corehq.apps.linked_domain.views import (
     DomainLinkRMIView,
+    brief_apps,
     case_search_config,
     custom_data_models,
     get_latest_released_app_source,
@@ -13,11 +14,12 @@ app_name = 'linked_domain'
 
 
 urlpatterns = [
-    url(r'^toggles/$', toggles_and_previews, name='toggles'),
-    url(r'^custom_data_models/$', custom_data_models, name='custom_data_models'),
-    url(r'^user_roles/$', user_roles, name='user_roles'),
+    url(r'^brief_apps/$', custom_data_models, name='brief_apps'),
     url(r'^case_search_config/$', case_search_config, name='case_search_config'),
+    url(r'^custom_data_models/$', custom_data_models, name='custom_data_models'),
+    url(r'^toggles/$', toggles_and_previews, name='toggles'),
     url(r'^release_source/(?P<app_id>[\w-]+)/$', get_latest_released_app_source,
         name='latest_released_app_source'),
     url(r'^service/$', DomainLinkRMIView.as_view(), name=DomainLinkRMIView.urlname),
+    url(r'^user_roles/$', user_roles, name='user_roles'),
 ]

--- a/corehq/apps/linked_domain/urls.py
+++ b/corehq/apps/linked_domain/urls.py
@@ -6,6 +6,7 @@ from corehq.apps.linked_domain.views import (
     case_search_config,
     custom_data_models,
     get_latest_released_app_source,
+    released_app_versions,
     toggles_and_previews,
     user_roles,
 )
@@ -18,6 +19,7 @@ urlpatterns = [
     url(r'^case_search_config/$', case_search_config, name='case_search_config'),
     url(r'^custom_data_models/$', custom_data_models, name='custom_data_models'),
     url(r'^toggles/$', toggles_and_previews, name='toggles'),
+    url(r'^released_app_versions/$', released_app_versions, name='released_app_versions'),
     url(r'^release_source/(?P<app_id>[\w-]+)/$', get_latest_released_app_source,
         name='latest_released_app_source'),
     url(r'^service/$', DomainLinkRMIView.as_view(), name=DomainLinkRMIView.urlname),

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -84,6 +84,12 @@ def user_roles(request, domain):
 
 @login_or_api_key
 @require_linked_domain
+def brief_apps(request, domain):
+    return JsonResponse({'brief_apps': get_brief_apps_in_domain(domain, include_remote=False)})
+
+
+@login_or_api_key
+@require_linked_domain
 def case_search_config(request, domain):
     try:
         config = CaseSearchConfig.objects.get(domain=domain).to_json()

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -16,6 +16,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_app,
     get_brief_apps_in_domain,
     get_latest_released_app,
+    get_latest_released_app_versions_by_app_id,
 )
 from corehq.apps.app_manager.decorators import require_can_edit_apps
 from corehq.apps.app_manager.util import is_linked_app
@@ -86,6 +87,12 @@ def user_roles(request, domain):
 @require_linked_domain
 def brief_apps(request, domain):
     return JsonResponse({'brief_apps': get_brief_apps_in_domain(domain, include_remote=False)})
+
+
+@login_or_api_key
+@require_linked_domain
+def released_app_versions(request, domain):
+    return JsonResponse({'versions': get_latest_released_app_versions_by_app_id(domain, include_remote=False)})
 
 
 @login_or_api_key

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1506,6 +1506,13 @@ LINKED_DOMAINS = StaticToggle(
     notification_emails=['aking'],
 )
 
+MULTI_MASTER_LINKED_DOMAINS = StaticToggle(
+    'multi_master_linked_domains',
+    "Allow linked apps to pull from multiple master apps in the upstream domain",
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)
+
 SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(
     'sumologic_logs',
     'Send logs to sumologic',


### PR DESCRIPTION
Rebased version of https://github.com/dimagi/commcare-hq/pull/24602

Branched off of https://github.com/dimagi/commcare-hq/pull/24820, first new commit is "Divorced linked app versions from master versions."

Opening for tests, no need to review right now.

Feature flag: linked project spaces