### PR TITLE
more changes to pillow error queue

### DIFF
--- a/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
+++ b/corehq/apps/hqpillow_retry/management/commands/run_pillow_retry_queue.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+from datetime import datetime
+
 from django.conf import settings
 from psycopg2._psycopg import InterfaceError
 import pytz
+
+from corehq.sql_db.util import handle_connection_failure
 from hqscripts.generic_queue import GenericEnqueuingOperation, QueueItem
 from pillow_retry.const import PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT
 from pillow_retry.models import PillowError
@@ -23,11 +28,12 @@ class PillowRetryEnqueuingOperation(GenericEnqueuingOperation):
     def get_enqueuing_timeout(self):
         return PILLOW_RETRY_QUEUE_ENQUEUING_TIMEOUT
 
-    def _get_items(self, utcnow):
-        errors = PillowError.get_errors_to_process(utcnow=utcnow, limit=10000)
-        items = [QueueItem(id=e.id, key=e.date_next_attempt, object=e) for e in errors]
-        self._errors_in_queue = bool(items)
-        return items
+    @handle_connection_failure()
+    def populate_queue(self):
+        utcnow = datetime.utcnow()
+        items = self.get_items_to_be_processed(utcnow)
+        for item in items:
+            process_pillow_retry(item.object)
 
     def get_items_to_be_processed(self, utcnow):
         # We're just querying for ids here, so no need to limit
@@ -38,11 +44,14 @@ class PillowRetryEnqueuingOperation(GenericEnqueuingOperation):
             db.connection.close()
             return self._get_items(utcnow)
 
+    def _get_items(self, utcnow):
+        errors = PillowError.get_errors_to_process(utcnow=utcnow, limit=10000)
+        items = [QueueItem(id=e.id, key=e.date_next_attempt, object=e) for e in errors]
+        self._errors_in_queue = bool(items)
+        return items
+
     def use_queue(self):
         return settings.PILLOW_RETRY_QUEUE_ENABLED
-
-    def enqueue_item(self, item):
-        process_pillow_retry(item.object)
 
 
 class Command(PillowRetryEnqueuingOperation):

--- a/corehq/ex-submodules/pillow_retry/api.py
+++ b/corehq/ex-submodules/pillow_retry/api.py
@@ -6,7 +6,7 @@ import sys
 from memoized import memoized
 
 from corehq.apps.change_feed.data_sources import get_document_store
-from corehq.apps.change_feed.producer import producer
+from corehq.apps.change_feed.producer import producer as kafka_producer
 from corehq.apps.change_feed.topics import get_topic_for_doc_type
 from dimagi.utils.logging import notify_error
 from pillow_retry import const
@@ -21,7 +21,8 @@ def _get_pillow(pillow_name_or_class):
     return get_pillow_by_name(pillow_name_or_class)
 
 
-def process_pillow_retry(error_doc):
+def process_pillow_retry(error_doc, producer=None):
+    producer = producer or kafka_producer
     pillow_name_or_class = error_doc.pillow
     try:
         pillow = _get_pillow(pillow_name_or_class)

--- a/corehq/ex-submodules/pillow_retry/api.py
+++ b/corehq/ex-submodules/pillow_retry/api.py
@@ -74,16 +74,10 @@ def _process_couch_change(pillow, change):
 
 def _process_kafka_change(producer, change):
     change_metadata = change.metadata
-    if change_metadata.data_source_type in ('couch', 'sql'):
-        data_source_type = change_metadata.data_source_type
-    else:
-        # legacy metadata will have other values for non-sql
-        # can remove this once all legacy errors have been processed
-        data_source_type = 'sql'
     producer.send_change(
         get_topic_for_doc_type(
             change_metadata.document_type,
-            data_source_type
+            change_metadata.data_source_type
         ),
         change_metadata
     )

--- a/corehq/ex-submodules/pillow_retry/api.py
+++ b/corehq/ex-submodules/pillow_retry/api.py
@@ -43,31 +43,10 @@ def process_pillow_retry(error_doc):
     change = error_doc.change_object
     delete_all_for_doc = False
     try:
-        change_metadata = change.metadata
         if isinstance(pillow.get_change_feed(), CouchChangeFeed):
-            if change_metadata:
-                document_store = get_document_store(
-                    data_source_type=change_metadata.data_source_type,
-                    data_source_name=change_metadata.data_source_name,
-                    domain=change_metadata.domain,
-                    load_source="pillow_retry",
-                )
-                change.document_store = document_store
-            pillow.process_change(change)
+            _process_couch_change(pillow, change)
         else:
-            if change_metadata.data_source_type in ('couch', 'sql'):
-                data_source_type = change_metadata.data_source_type
-            else:
-                # legacy metadata will have other values for non-sql
-                # can remove this once all legacy errors have been processed
-                data_source_type = 'sql'
-            producer.send_change(
-                get_topic_for_doc_type(
-                    change_metadata.document_type,
-                    data_source_type
-                ),
-                change_metadata
-            )
+            _process_kafka_change(producer, change)
             delete_all_for_doc = True
     except Exception:
         ex_type, ex_value, ex_tb = sys.exc_info()
@@ -78,3 +57,33 @@ def process_pillow_retry(error_doc):
             PillowError.objects.filter(doc_id=error_doc.doc_id).delete()
         else:
             error_doc.delete()
+
+
+def _process_couch_change(pillow, change):
+    change_metadata = change.metadata
+    if change_metadata:
+        document_store = get_document_store(
+            data_source_type=change_metadata.data_source_type,
+            data_source_name=change_metadata.data_source_name,
+            domain=change_metadata.domain,
+            load_source="pillow_retry",
+        )
+        change.document_store = document_store
+    pillow.process_change(change)
+
+
+def _process_kafka_change(producer, change):
+    change_metadata = change.metadata
+    if change_metadata.data_source_type in ('couch', 'sql'):
+        data_source_type = change_metadata.data_source_type
+    else:
+        # legacy metadata will have other values for non-sql
+        # can remove this once all legacy errors have been processed
+        data_source_type = 'sql'
+    producer.send_change(
+        get_topic_for_doc_type(
+            change_metadata.document_type,
+            data_source_type
+        ),
+        change_metadata
+    )

--- a/corehq/ex-submodules/pillow_retry/management/commands/send_pillow_retry_queue_through_pillows.py
+++ b/corehq/ex-submodules/pillow_retry/management/commands/send_pillow_retry_queue_through_pillows.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
+
+import time
 from datetime import datetime
 
 from django.core.management.base import BaseCommand
-
-from pillow_retry.models import PillowError
+from gevent.pool import Pool
 
 from corehq.apps.change_feed.producer import producer
+from pillow_retry.models import PillowError
 
 
 class Command(BaseCommand):
@@ -15,18 +17,16 @@ class Command(BaseCommand):
         parser.add_argument('pillow')
 
     def handle(self, pillow, **options):
+        self.pool = Pool(10)
         self.pillow = pillow
+        self.count = 0
+        self.start = time.time()
+
         for errors in self.get_next_errors():
-            for error in errors:
-                if error.change_object.metadata:
-                    producer.send_change(
-                        error.change_object.metadata.data_source_type,
-                        error.change_object.metadata
-                    )
+            self.pool.spawn(self._process_errors, errors)
 
     def get_next_errors(self):
         num_retrieved = 1
-        count = 0
 
         while num_retrieved > 0:
             pillow_errors = (
@@ -38,9 +38,28 @@ class Command(BaseCommand):
             num_retrieved = len(pillow_errors)
             yield pillow_errors
 
-            print("deleting")
-            doc_ids = [error.doc_id for error in pillow_errors]
-            PillowError.objects.filter(doc_id__in=doc_ids).delete()
-            count += num_retrieved
-            print(count)
-            print(datetime.utcnow())
+            while not self.pool.wait_available(timeout=10):
+                time.sleep(1)
+
+        while not self.pool.join(timeout=10):
+            print('Waiting for tasks to complete')
+
+    def _process_errors(self, errors):
+        for error in errors:
+            if error.change_object.metadata:
+                producer.send_change(
+                    error.change_object.metadata.data_source_name,
+                    error.change_object.metadata
+                )
+
+        self._delete_errors(errors)
+        self.count += 1000
+        duration = time.time() - self.start
+        print('Processed {} in {}s: {} per s'.format(
+            self.count, duration, self.count / duration if duration else self.count)
+        )
+        print(datetime.utcnow())
+
+    def _delete_errors(self, errors):
+        doc_ids = [error.doc_id for error in errors]
+        PillowError.objects.filter(doc_id__in=doc_ids).delete()

--- a/corehq/ex-submodules/pillow_retry/management/commands/send_pillow_retry_queue_through_pillows.py
+++ b/corehq/ex-submodules/pillow_retry/management/commands/send_pillow_retry_queue_through_pillows.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
                     error.change_object.metadata.data_source_name,
                     error.change_object.metadata
                 )
-            self.producer.flush()
+        self.producer.flush()
 
         self._delete_errors(errors)
         self.count += 1000

--- a/corehq/ex-submodules/pillow_retry/management/commands/send_pillow_retry_queue_through_pillows.py
+++ b/corehq/ex-submodules/pillow_retry/management/commands/send_pillow_retry_queue_through_pillows.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
 
 import time
 from datetime import datetime

--- a/manage.py
+++ b/manage.py
@@ -194,6 +194,7 @@ if __name__ == "__main__":
         GeventCommand('migrate_domain_from_couch_to_sql', http_adapter_pool_size=32),
         GeventCommand('migrate_multiple_domains_from_couch_to_sql', http_adapter_pool_size=32),
         GeventCommand('run_aggregation_query'),
+        GeventCommand('send_pillow_retry_queue_through_pillows'),
     )
     if len(sys.argv) > 1 and _should_patch_gevent(sys.argv, GEVENT_COMMANDS):
         from gevent.monkey import patch_all; patch_all(subprocess=True)


### PR DESCRIPTION
* only flush kafka producer once per batch instead of on every change
* update `send_pillow_retry_queue_through_pillows` to use gevent

can review by commit

I was hoping to be able to get the gevent / batch processing into the pillow error queue process having to split the errors by pillow makes that much harder.