### PR TITLE
Remove links to old admin reports

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -582,15 +582,6 @@ class AdminFacetedReport(AdminReport, ElasticTabularReport):
 
     @property
     def template_context(self):
-        msg = """
-        WARNING! This page will soon be deleted. As part of an effort to
-        upgrade elasticsearch, we are removing several admin reports which rely
-        on deprecated functionality. This page will be removed on August 16th.
-        Comparable reports are available in salesforce. If you rely on this
-        report, please contact product@dimagi.com to discuss as soon as
-        possible.
-        """
-        messages.add_message(self.request, messages.ERROR, msg)
         ctxt = super(AdminFacetedReport, self).template_context
 
         self.run_query(0)

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -15,8 +15,6 @@ from corehq.apps.hqadmin.views.reports import (
     DimagisphereView,
     DownloadGIRView,
     DownloadMALTView,
-    admin_reports_stats_data,
-    stats_data,
     top_five_projects_by_country,
 )
 from corehq.apps.hqadmin.views.system import (
@@ -61,8 +59,6 @@ urlpatterns = [
     url(r'^phone/restore/$', AdminRestoreView.as_view(), name="admin_restore"),
     url(r'^phone/restore/(?P<app_id>[\w-]+)/$', AdminRestoreView.as_view(), name='app_aware_admin_restore'),
     url(r'^app_build_timings/$', AppBuildTimingsView.as_view(), name="app_build_timings"),
-    url(r'^stats_data/$', stats_data, name="admin_stats_data"),
-    url(r'^admin_reports_stats_data/$', admin_reports_stats_data, name="admin_reports_stats_data"),
     url(r'^do_pillow_op/$', pillow_operation_api, name="pillow_operation_api"),
     url(r'^web_user_lookup/$', web_user_lookup, name='web_user_lookup'),
     url(r'^disable_two_factor/$', DisableTwoFactorView.as_view(), name=DisableTwoFactorView.urlname),

--- a/corehq/apps/hqadmin/views/utils.py
+++ b/corehq/apps/hqadmin/views/utils.py
@@ -15,7 +15,7 @@ from corehq.util import reverse
 
 @require_superuser
 def default(request):
-    return HttpResponseRedirect(reverse('admin_report_dispatcher', args=('domains',)))
+    return HttpResponseRedirect(reverse('admin_report_dispatcher', args=('user_list',)))
 
 
 def get_hqadmin_base_context(request):

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -7,15 +7,9 @@ from corehq import privileges
 from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_class
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqadmin.reports import (
-    AdminDomainStatsReport,
-    AdminAppReport,
     AdminPhoneNumberReport,
     AdminUserReport,
-    RealProjectSpacesReport,
-    CommConnectProjectSpacesReport,
-    CommTrackProjectSpacesReport,
     DeviceLogSoftAssertReport,
-    CommCareVersionReport,
     UserAuditReport)
 from corehq.apps.hqpillow_retry.views import PillowErrorsReport
 from corehq.apps.linked_domain.views import DomainLinkHistoryReport
@@ -349,15 +343,9 @@ BASIC_REPORTS = (
 
 ADMIN_REPORTS = (
     (_('Domain Stats'), (
-        AdminDomainStatsReport,
         AdminUserReport,
-        AdminAppReport,
         PillowErrorsReport,
-        RealProjectSpacesReport,
-        CommConnectProjectSpacesReport,
-        CommTrackProjectSpacesReport,
         DeviceLogSoftAssertReport,
-        CommCareVersionReport,
         AdminPhoneNumberReport,
         UserAuditReport,
     )),

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -24,9 +24,7 @@ from corehq.apps.domain.views.releases import (
     ManageReleasesByLocation,
     ManageReleasesByAppProfile,
 )
-from corehq.apps.hqadmin.reports import RealProjectSpacesReport, \
-    CommConnectProjectSpacesReport, CommTrackProjectSpacesReport, \
-    DeviceLogSoftAssertReport, UserAuditReport
+from corehq.apps.hqadmin.reports import DeviceLogSoftAssertReport, UserAuditReport
 from corehq.apps.hqwebapp.models import GaTracker
 from corehq.apps.hqwebapp.view_permissions import user_can_view_reports
 from corehq.apps.linked_domain.dbaccessors import is_linked_domain
@@ -2052,20 +2050,14 @@ class AdminTab(UITab):
             ] + admin_operations
         sections = [
             (_('Administrative Reports'), [
-                {'title': _('Project Space List'),
-                 'url': reverse('admin_report_dispatcher', args=('domains',))},
                 {'title': _('Submission Map'),
                  'url': reverse('dimagisphere')},
                 {'title': _('User List'),
                  'url': reverse('admin_report_dispatcher', args=('user_list',))},
-                {'title': _('Application List'),
-                 'url': reverse('admin_report_dispatcher', args=('app_list',))},
                 {'title': _('Download Malt table'),
                  'url': reverse('download_malt')},
                 {'title': _('Download Global Impact Report'),
                  'url': reverse('download_gir')},
-                {'title': _('CommCare Version'),
-                 'url': reverse('admin_report_dispatcher', args=('commcare_version', ))},
                 {'title': _('Admin Phone Number Report'),
                  'url': reverse('admin_report_dispatcher', args=('phone_number_report',))},
             ]),
@@ -2085,13 +2077,7 @@ class AdminTab(UITab):
                     url=reverse('admin_report_dispatcher', args=(report.slug,)),
                     params="?{}".format(urlencode(report.default_params)) if report.default_params else ""
                 )
-            } for report in [
-                RealProjectSpacesReport,
-                CommConnectProjectSpacesReport,
-                CommTrackProjectSpacesReport,
-                DeviceLogSoftAssertReport,
-                UserAuditReport,
-            ]
+            } for report in [DeviceLogSoftAssertReport, UserAuditReport]
         ]))
         return sections
 


### PR DESCRIPTION
Keeping the user list report around for the short term until @biyeun 's replacement is ready.

We'll soon be killing all of these faceted admin reports, including the user list, so I'm waiting for that before actually deleting those views.

Here's the PR with that change:
https://github.com/dimagi/commcare-hq/pull/25105/

@biyeun @calellowitz @gbova 