### PR TITLE
Scope automatic instance declarations to the app

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -630,7 +630,7 @@ class ReportModuleValidator(ModuleBaseValidator):
         from corehq.apps.app_manager.suite_xml.features.mobile_ucr import get_uuids_by_instance_id
         duplicate_instance_ids = {
             instance_id
-            for instance_id, uuids in get_uuids_by_instance_id(self.module.get_app().domain).items()
+            for instance_id, uuids in get_uuids_by_instance_id(self.module.get_app()).items()
             if len(uuids) > 1
         }
         return any(report_config.instance_id in duplicate_instance_ids

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1185,7 +1185,7 @@ class FormBase(DocumentSchema):
         xform.normalize_itext()
         xform.strip_vellum_ns_attributes()
         xform.set_version(self.get_version())
-        xform.add_missing_instances(app.domain)
+        xform.add_missing_instances(app)
 
     def render_xform(self, build_profile_id=None):
         xform = XForm(self.source)

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -458,20 +458,17 @@ def is_valid_mobile_select_filter_type(ui_filter):
     return isinstance(ui_filter, DynamicChoiceListFilter) or isinstance(ui_filter, ChoiceListFilter)
 
 
-@quickcache(['domain'])
-def get_uuids_by_instance_id(domain):
+def get_uuids_by_instance_id(app):
     """
     map ReportAppConfig.uuids list to user-defined ReportAppConfig.instance_ids
 
     This is per-domain, since registering instances (like
     commcare_reports_fixture_instances) is per-domain
     """
-    apps = get_apps_in_domain(domain)
     config_ids = defaultdict(list)
-    for app in apps:
-        if app.mobile_ucr_restore_version in (MOBILE_UCR_MIGRATING_TO_2, MOBILE_UCR_VERSION_2):
-            for module in app.modules:
-                if module.module_type == 'report':
-                    for report_config in module.report_configs:
-                        config_ids[report_config.instance_id].append(report_config.uuid)
+    if app.mobile_ucr_restore_version in (MOBILE_UCR_MIGRATING_TO_2, MOBILE_UCR_VERSION_2):
+        for module in app.modules:
+            if module.module_type == 'report':
+                for report_config in module.report_configs:
+                    config_ids[report_config.instance_id].append(report_config.uuid)
     return config_ids

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -474,7 +474,7 @@ def get_instances_for_module(app, module, additional_xpaths=None):
     for detail_id in detail_ids:
         xpaths.update(details_by_id[detail_id].get_all_xpaths())
 
-    instances, _ = get_all_instances_referenced_in_xpaths(app.domain, xpaths)
+    instances, _ = get_all_instances_referenced_in_xpaths(app, xpaths)
     return instances
 
 

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -76,7 +76,7 @@ class RemoteRequestFactory(object):
         claim_relevant_xpaths = [self.module.search_config.relevant]
 
         instances, unknown_instances = get_all_instances_referenced_in_xpaths(
-            self.domain,
+            self.app,
             query_xpaths + claim_relevant_xpaths
         )
         # we use the module's case list/details view to select the datum so also

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -105,7 +105,7 @@ class FormPreparationV2Test(SimpleTestCase, TestXmlMixin):
     def test_instance_check(self):
         xml = self.get_xml('missing_instances')
         with self.assertRaises(XFormValidationError) as cm:
-            XForm(xml).add_missing_instances(self.domain)
+            XForm(xml).add_missing_instances(self.app)
         exception_message = str(cm.exception)
         self.assertIn('casebd', exception_message)
         self.assertIn('custom2', exception_message)

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -27,7 +27,6 @@ from corehq.apps.app_manager.models import (
     _filter_by_user_id,
     _get_auto_filter_function,
 )
-from corehq.apps.app_manager.suite_xml.features.mobile_ucr import get_uuids_by_instance_id
 from corehq.apps.app_manager.tests.mocks.mobile_ucr import (
     mock_report_configuration_get,
     mock_report_configurations,
@@ -415,9 +414,6 @@ class TestReportConfigInstances(TestCase, TestXmlMixin):
     file_path = ('data',)
     domain = 'test_report_config_instances'
 
-    def tearDown(self):
-        get_uuids_by_instance_id.clear(self.domain)
-
     def test_autogenerate_instance_declaration(self):
         app = self._make_app("Untitled Application")
         report_app_config = self._make_report_app_config("my_report")
@@ -439,6 +435,18 @@ class TestReportConfigInstances(TestCase, TestXmlMixin):
 
         errors = module2.validate_for_build()
         self.assertEqual('report config id duplicated', errors[0]['type'])
+
+    def test_allow_duplicates_on_different_apps(self):
+        app1 = self._make_app("Untitled Application")
+        report_app_config1 = self._make_report_app_config("duplicate")
+        module1 = self._add_report_module(app1, report_app_config1)
+
+        app2 = self._make_app("Untitled Application")
+        report_app_config2 = self._make_report_app_config("duplicate")
+        module2 = self._add_report_module(app2, report_app_config2)
+
+        errors = module2.validate_for_build()
+        self.assertEqual([], errors)
 
     def _make_app(self, app_name):
         app = Application.new_app(self.domain, app_name)

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -1,30 +1,62 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import os
 from collections import OrderedDict
 from xml.etree import cElementTree as ElementTree
-from django.test import SimpleTestCase, TestCase
-import mock
-from casexml.apps.phone.tests.utils import create_restore_user, call_fixture_generator
-from corehq.apps.app_manager.fixtures import report_fixture_generator
-from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
-from corehq.apps.app_manager.models import ReportAppConfig, Application, ReportModule, \
-    GraphConfiguration, GraphSeries, MobileSelectFilter, _get_auto_filter_function, _filter_by_user_id
-from corehq.apps.app_manager.tests.mocks.mobile_ucr import mock_report_configurations, \
-    mock_report_configuration_get, mock_report_data
+from django.test import SimpleTestCase, TestCase
+
+import mock
+import six
+
+from casexml.apps.phone.tests.utils import (
+    call_fixture_generator,
+    create_restore_user,
+)
+
+from corehq.apps.app_manager.const import MOBILE_UCR_VERSION_2
+from corehq.apps.app_manager.fixtures import report_fixture_generator
+from corehq.apps.app_manager.models import (
+    Application,
+    GraphConfiguration,
+    GraphSeries,
+    MobileSelectFilter,
+    Module,
+    ReportAppConfig,
+    ReportModule,
+    _filter_by_user_id,
+    _get_auto_filter_function,
+)
+from corehq.apps.app_manager.suite_xml.features.mobile_ucr import get_uuids_by_instance_id
+from corehq.apps.app_manager.tests.mocks.mobile_ucr import (
+    mock_report_configuration_get,
+    mock_report_configurations,
+    mock_report_data,
+)
 from corehq.apps.app_manager.tests.util import TestXmlMixin
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.reports_core.filters import Choice
 from corehq.apps.userreports.models import ReportConfiguration, ReportMeta
-from corehq.apps.userreports.reports.filters.choice_providers import ChoiceProvider
-from corehq.apps.userreports.reports.filters.specs import DynamicChoiceListFilterSpec, ChoiceListFilterSpec, \
-    FilterChoice
-from corehq.apps.userreports.reports.specs import FieldColumn, MultibarChartSpec, \
-    GraphDisplayColumn
-from corehq.apps.userreports.tests.utils import mock_datasource_config
+from corehq.apps.userreports.reports.filters.choice_providers import (
+    ChoiceProvider,
+)
+from corehq.apps.userreports.reports.filters.specs import (
+    ChoiceListFilterSpec,
+    DynamicChoiceListFilterSpec,
+    FilterChoice,
+)
+from corehq.apps.userreports.reports.specs import (
+    FieldColumn,
+    GraphDisplayColumn,
+    MultibarChartSpec,
+)
+from corehq.apps.userreports.tests.utils import (
+    get_sample_report_config,
+    mock_datasource_config,
+)
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.toggles import MOBILE_UCR, NAMESPACE_DOMAIN
-import six
+from corehq.util.test_utils import flag_enabled
 
 
 class ReportAppConfigTest(SimpleTestCase):
@@ -376,3 +408,60 @@ class TestReportAutoFilters(SimpleTestCase):
     def test_get_filter_function(self):
         fn = _get_auto_filter_function('user_id')
         self.assertEqual(fn, _filter_by_user_id)
+
+
+@flag_enabled('MOBILE_UCR')
+class TestReportConfigInstances(TestCase, TestXmlMixin):
+    file_path = ('data',)
+    domain = 'test_report_config_instances'
+
+    def tearDown(self):
+        get_uuids_by_instance_id.clear(self.domain)
+
+    def test_autogenerate_instance_declaration(self):
+        app = self._make_app("Untitled Application")
+        report_app_config = self._add_report(app, "my_report")
+        form = self._add_form_with_report_reference(app, report_app_config)
+
+        expected_declaration = ("""<instance id="commcare-reports:{}" src="jr://fixture/commcare-reports:{}"/>"""
+                                .format(report_app_config.report_slug, report_app_config.uuid))
+        self.assertIn(expected_declaration, self._render_form(app, form))
+
+    def _make_app(self, app_name):
+        app = Application.new_app(self.domain, app_name)
+        app.mobile_ucr_restore_version = MOBILE_UCR_VERSION_2
+        app.save()
+        self.addCleanup(app.delete)
+        return app
+
+    def _add_report(self, app, report_slug):
+        report = get_sample_report_config()
+        report.domain = self.domain
+        report.save()
+        self.addCleanup(report.delete)
+        report_app_config = ReportAppConfig(
+            report_id=report._id,
+            report_slug=report_slug,
+        )
+        report_app_config._report = report
+
+        report_module = app.add_module(ReportModule.new_module('Reports', None))
+        report_module.report_configs = [report_app_config]
+        app.save()
+        return report_app_config
+
+    def _add_form_with_report_reference(self, app, report_app_config):
+        other_module = app.add_module(Module.new_module('m0', None))
+        form = other_module.new_form('f0', None)
+        report_reference = "instance('commcare-reports:{}')/rows/row[0]/@index".format(report_app_config.report_slug)
+        form.source = self.get_xml('very_simple_form').decode('utf-8')
+        form.source = form.source.replace(
+            """<bind nodeset="/data/question1" type="xsd:string"/>""",
+            """<bind nodeset="/data/question1" type="xsd:string" calculate="{}"/>""".format(report_reference),
+        )
+        app.save()
+        return form
+
+    def _render_form(self, app, form):
+        with mock.patch('corehq.apps.app_manager.suite_xml.features.mobile_ucr.get_apps_in_domain', lambda d: [app]):
+            return form.render_xform().decode('utf-8')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -279,7 +279,7 @@ def _get_report_module_context(app, module):
             'autoFilterChoices': auto_filter_choices,
             'dateRangeOptions': [choice._asdict() for choice in get_simple_dateranges()],
         },
-        'uuids_by_instance_id': get_uuids_by_instance_id(app.domain),
+        'uuids_by_instance_id': get_uuids_by_instance_id(app),
     }
     return context
 
@@ -934,7 +934,6 @@ def edit_report_module(request, domain, app_id, module_unique_id):
         )
         return HttpResponseBadRequest(_("There was a problem processing your request."))
 
-    get_uuids_by_instance_id.clear(domain)
     return json_response('success')
 
 

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -813,12 +813,12 @@ class XForm(WrappedNode):
                 if key.startswith(vellum_ns):
                     del node.attrib[key]
 
-    def add_missing_instances(self, domain):
+    def add_missing_instances(self, app):
         from corehq.apps.app_manager.suite_xml.post_process.instances import get_all_instances_referenced_in_xpaths
         instance_declarations = self._get_instance_ids()
         missing_unknown_instances = set()
         instances, unknown_instance_ids = get_all_instances_referenced_in_xpaths(
-            domain, [self.render().decode('utf-8')])
+            app, [self.render().decode('utf-8')])
         for instance_id in unknown_instance_ids:
             if instance_id not in instance_declarations:
                 missing_unknown_instances.add(instance_id)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-777
Had a hell of a time getting these tests set up, but the change is pretty straightforward.  It makes it so multiple applications on the same domain can use the same aliases for their mobile ucr v2 configs (previously they had to be unique on the domain).  This is necessary to allow projects (ie, ICDS) to copy applications with UCR references to the same domain.

Feature flag: Mobile UCR
@orangejenny @gbova @calellowitz 