### PR TITLE
Added back in 'Tracks Stock' header in locations table

### DIFF
--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -104,6 +104,19 @@
                                           {% endblocktrans %}">
                                     </span>
               </th>
+              {% if commtrack_enabled %}
+                <th>
+                  {% trans "Tracks Stock" %}
+                  <span class="hq-help-template"
+                        data-title="{% trans "Tracks Stock" %}"
+                        data-content="{% blocktrans %}
+                                        Does this location keep inventory and track stock?
+                                        Note that changing this property will update all
+                                        locations of this level accordingly.
+                                      {% endblocktrans %}">
+                  </span>
+                </th>
+              {% endif %}
               <th>
                 {% trans "Owns Cases" %}
                 <span class="hq-help-template"


### PR DESCRIPTION
The column headers aren't on the right columns...the first column stock tracking, the second is case sharing , and the third is child data.

Introduced in https://github.com/dimagi/commcare-hq/commit/42a1a26190ec0b579d9e81998c41b7a16f1e1824

![Screen Shot 2019-08-20 at 11 20 23 AM](https://user-images.githubusercontent.com/1486591/63360765-f822e000-c33c-11e9-9299-7db809a06bb9.png)

Feature flag: commtrack