### PR TITLE
Couch to SQL: live migration part 1

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -233,6 +233,7 @@ class CaseDiffQueue(object):
                 self.pending_cases = defaultdict(int)
             join(pool)
             if complete:
+                log.info("Diffing cases with unprocessed forms...")
                 to_diff = self.statedb.iter_cases_with_unprocessed_forms()
                 for chunk in chunked(to_diff, self.BATCH_SIZE, list):
                     self._enqueue_cases(chunk)

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -267,15 +267,16 @@ class CouchSqlDomainMigrator(object):
         except IndexError:
             first_action = CommCareCaseAction()
 
+        opened_on = couch_case.opened_on or first_action.date
         sql_case = CommCareCaseSQL(
             case_id=couch_case.case_id,
             domain=self.domain,
             type=couch_case.type or '',
             name=couch_case.name,
             owner_id=couch_case.owner_id or couch_case.user_id or '',
-            opened_on=couch_case.opened_on or first_action.date,
+            opened_on=opened_on,
             opened_by=couch_case.opened_by or first_action.user_id,
-            modified_on=couch_case.modified_on,
+            modified_on=couch_case.modified_on or opened_on,
             modified_by=couch_case.modified_by or couch_case.user_id or '',
             server_modified_on=couch_case.server_modified_on,
             closed=couch_case.closed,

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -129,6 +129,7 @@ load_ignore_rules = memoized(lambda: {
         ignore_renamed('@date_modified', 'modified_on'),
     ],
     'CommCareCase-Deleted': [
+        Ignore('type', 'modified_on', old=None),
         Ignore('missing', '-deletion_id', old=MISSING, new=None),
         Ignore('missing', 'deletion_id', old=MISSING, new=None),
         Ignore('complex', ('-deletion_id', 'deletion_id'), old=MISSING, new=None),

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -81,25 +81,34 @@ class Command(BaseCommand):
                 reside on an NFS volume for migration state consistency.
                 Can be set in environment: CCHQ_MIGRATION_STATE_DIR
             """)
-        parser.add_argument('--dry-run', action='store_true', default=False,
+        parser.add_argument('--live',
+            dest="live_migrate", action='store_true', default=False,
             help='''
                 Do migration in a way that will not be seen by
                 `any_migrations_in_progress(...)` so it does not block
                 operations like syncs, form submissions, sms activity,
-                etc. Dry-run migrations cannot be committed.
+                etc. A "live" migration will stop when it encounters a
+                form that has been submitted within an hour of the
+                current time. Live migrations can be resumed after
+                interruption or to top off a previous live migration by
+                processing unmigrated forms that are older than one
+                hour. Migration state must be present in the state
+                directory to resume. A live migration may be followed by
+                a normal (non-live) migration, which will commit the
+                result if all goes well.
             ''')
 
     def handle(self, domain, action, **options):
         if should_use_sql_backend(domain):
             raise CommandError('It looks like {} has already been migrated.'.format(domain))
 
-        for opt in ["no_input", "verbose", "state_dir", "dry_run"]:
+        for opt in ["no_input", "verbose", "state_dir", "live_migrate"]:
             setattr(self, opt, options[opt])
 
         if self.no_input and not settings.UNIT_TESTING:
             raise CommandError('--no-input only allowed for unit testing')
-        if action != MIGRATE and self.dry_run:
-            raise CommandError("--dry-run only allowed for `MIGRATE`")
+        if action != MIGRATE and self.live_migrate:
+            raise CommandError("--live only allowed with `MIGRATE`")
         if action != STATS and self.verbose:
             raise CommandError("--verbose only allowed for `stats`")
 
@@ -107,13 +116,21 @@ class Command(BaseCommand):
         getattr(self, "do_" + action)(domain)
 
     def do_MIGRATE(self, domain):
-        path = self.state_dir
-        set_couch_sql_migration_started(domain, self.dry_run)
-        do_couch_to_sql_migration(domain, path, with_progress=not self.no_input)
+        set_couch_sql_migration_started(domain, self.live_migrate)
+        do_couch_to_sql_migration(
+            domain,
+            self.state_dir,
+            with_progress=not self.no_input,
+            live_migrate=self.live_migrate,
+        )
 
-        has_diffs = self.print_stats(domain, short=True, diffs_only=True)
+        if self.live_migrate:
+            print("Live migration completed.")
+            has_diffs = True
+        else:
+            has_diffs = self.print_stats(domain, short=True, diffs_only=True)
         if has_diffs:
-            print("\nRun `diff` or `stats --verbose` for more details.\n")
+            print("\nRun `diff` or `stats [--verbose]` for more details.\n")
 
     def do_reset(self, domain):
         if not self.no_input:

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -97,12 +97,19 @@ class Command(BaseCommand):
                 a normal (non-live) migration, which will commit the
                 result if all goes well.
             ''')
+        parser.add_argument('--no-diff-process',
+            dest='diff_process', action='store_false', default=True,
+            help='''
+                Migrate forms and diff cases in the same process. The
+                case diff queue will run in a separate process if this
+                option is not specified.
+            ''')
 
     def handle(self, domain, action, **options):
         if should_use_sql_backend(domain):
             raise CommandError('It looks like {} has already been migrated.'.format(domain))
 
-        for opt in ["no_input", "verbose", "state_dir", "live_migrate"]:
+        for opt in ["no_input", "verbose", "state_dir", "live_migrate", "diff_process"]:
             setattr(self, opt, options[opt])
 
         if self.no_input and not settings.UNIT_TESTING:
@@ -122,6 +129,7 @@ class Command(BaseCommand):
             self.state_dir,
             with_progress=not self.no_input,
             live_migrate=self.live_migrate,
+            diff_process=self.diff_process,
         )
 
         if self.live_migrate:

--- a/corehq/apps/couch_sql_migration/progress.py
+++ b/corehq/apps/couch_sql_migration/progress.py
@@ -4,11 +4,12 @@ from __future__ import unicode_literals
 from django.conf import settings
 
 from corehq.apps.domain_migration_flags.api import (
+    MigrationStatus,
     get_migration_status,
     set_migration_started,
     set_migration_not_started,
     set_migration_complete,
-    migration_in_progress
+    migration_in_progress,
 )
 from corehq.apps.tzmigration.api import set_tz_migration_complete
 
@@ -19,8 +20,13 @@ def get_couch_sql_migration_status(domain):
     return get_migration_status(domain, COUCH_TO_SQL_SLUG)
 
 
-def set_couch_sql_migration_started(domain, dry_run=False):
-    set_migration_started(domain, COUCH_TO_SQL_SLUG, dry_run)
+def set_couch_sql_migration_started(domain, live_migrate=False):
+    if not live_migrate:
+        # allow live (dry run) migration to be completed
+        if get_couch_sql_migration_status(domain) == MigrationStatus.DRY_RUN:
+            # avoid "Cannot start a migration that is already in state dry_run"
+            set_couch_sql_migration_not_started(domain)
+    set_migration_started(domain, COUCH_TO_SQL_SLUG, dry_run=live_migrate)
 
 
 def set_couch_sql_migration_not_started(domain):

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -131,10 +131,11 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
             domain = self.domain_name
         self.assert_backend("couch", domain)
         options.setdefault("no_input", True)
+        options.setdefault("diff_process", False)
         call_command('migrate_domain_from_couch_to_sql', domain, action, **options)
 
-    def _do_migration_and_assert_flags(self, domain):
-        self._do_migration(domain)
+    def _do_migration_and_assert_flags(self, domain, **options):
+        self._do_migration(domain, **options)
         self.assert_backend("sql", domain)
 
     def _compare_diffs(self, expected_diffs=None, missing=None):
@@ -813,7 +814,7 @@ class MigrationTestCase(BaseMigrationTestCase):
 
     def test_form_with_missing_xml(self):
         create_form_with_missing_xml(self.domain_name)
-        self._do_migration_and_assert_flags(self.domain_name)
+        self._do_migration_and_assert_flags(self.domain_name, diff_process=True)
 
         # This may change in the future: it may be possible to rebuild the
         # XML using parsed form JSON from couch.

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -77,3 +77,7 @@ class XFormLockError(Exception):
 
 class MissingFormXml(Exception):
     pass
+
+
+class FormEditNotAllowed(Exception):
+    pass

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -6,7 +6,8 @@ from contextlib import contextmanager
 from couchdbkit import ResourceNotFound
 from ddtrace import tracer
 
-from corehq.form_processor.exceptions import MissingFormXml
+from corehq.apps.couch_sql_migration.progress import couch_sql_migration_in_progress
+from corehq.form_processor.exceptions import FormEditNotAllowed, MissingFormXml
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import Attachment
@@ -223,6 +224,8 @@ def _handle_duplicate(new_doc):
                 #  - "Deprecate" the old form by making a new document with the same contents
                 #    but a different ID and a doc_type of XFormDeprecated
                 #  - Save the new instance to the previous document to preserve the ID
+                if couch_sql_migration_in_progress(new_doc.domain):
+                    raise FormEditNotAllowed("migration in progress")
                 existing_doc, new_doc = apply_deprecation(existing_doc, new_doc, interface)
                 return new_doc, existing_doc
     else:


### PR DESCRIPTION
This is the first part of the live migration work, which makes it possible to run most of a migration while the domain is still "live" (submitting forms and doing other normal operations). Form edits using the old Edit Forms feature (now deprecated and to-be-removed in September 2019) will be disabled during the migration (https://github.com/dimagi/commcare-hq/commit/0e3ef3a0a59d67da214f2272caa781bd2d24148d). Handling other infrequent operations like un/archive forms and cases is still in progress (not part of this PR).