### PR TITLE
Add check that custom case detail xml id matches

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -67,6 +67,11 @@ class DetailContributor(SectionContributor):
                                 detail.custom_xml,
                                 xmlclass=Detail
                             )
+                            expected = id_strings.detail(module, detail_type)
+                            if not id_strings.is_custom_app_string(d.id) and d.id != expected:
+                                raise SuiteError("Module {} uses custom case list xml, the "
+                                                 "specified detail ID is '{}', expected '{}'"
+                                                 .format(module.id, d.id, expected))
                             r.append(d)
                         else:
                             detail_column_infos = get_detail_column_infos(

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -9,7 +9,7 @@ from memoized import memoized
 from corehq import toggles
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.const import RETURN_TO
-from corehq.apps.app_manager.exceptions import SuiteError
+from corehq.apps.app_manager.exceptions import SuiteError, SuiteValidationError
 from corehq.apps.app_manager.id_strings import callout_header_locale
 from corehq.apps.app_manager.suite_xml.const import FIELD_TYPE_LEDGER
 from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
@@ -69,9 +69,11 @@ class DetailContributor(SectionContributor):
                             )
                             expected = id_strings.detail(module, detail_type)
                             if not id_strings.is_custom_app_string(d.id) and d.id != expected:
-                                raise SuiteError("Module {} uses custom case list xml, the "
-                                                 "specified detail ID is '{}', expected '{}'"
-                                                 .format(module.id, d.id, expected))
+                                raise SuiteValidationError(
+                                    "Module {} uses custom case list xml, the "
+                                    "specified detail ID is '{}', expected '{}'"
+                                    .format(module.id, d.id, expected)
+                                )
                             r.append(d)
                         else:
                             detail_column_infos = get_detail_column_infos(

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -10,7 +10,6 @@ import commcare_translations
 from corehq.apps.app_manager.exceptions import (
     DuplicateInstanceIdError,
     SuiteValidationError,
-    SuiteError,
 )
 from corehq.apps.app_manager.models import (
     AdvancedModule,
@@ -1000,7 +999,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         module, form = factory.new_advanced_module("my_module", "person")
         # This should be 'm0_case_short'
         module.case_details.short.custom_xml = '<detail id="m1_case_short"></detail>'
-        with self.assertRaises(SuiteError):
+        with self.assertRaises(SuiteValidationError):
             factory.app.create_suite()
 
     def test_subcase_repeat_mixed(self):

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -10,6 +10,7 @@ import commcare_translations
 from corehq.apps.app_manager.exceptions import (
     DuplicateInstanceIdError,
     SuiteValidationError,
+    SuiteError,
 )
 from corehq.apps.app_manager.models import (
     AdvancedModule,
@@ -993,6 +994,14 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             suite,
             "entry/session/datum"
         )
+
+    def test_custom_xml_with_wrong_module_index(self):
+        factory = AppFactory()
+        module, form = factory.new_advanced_module("my_module", "person")
+        # This should be 'm0_case_short'
+        module.case_details.short.custom_xml = '<detail id="m1_case_short"></detail>'
+        with self.assertRaises(SuiteError):
+            factory.app.create_suite()
 
     def test_subcase_repeat_mixed(self):
         app = Application.new_app(None, "Untitled Application")


### PR DESCRIPTION
Feature flag: CASE_LIST_CUSTOM_XML

Custom XML for case details hardcodes the module ID like `m32_case_short`.  This adds a simple check to make sure that it's the ID we expect, and if not, fails when building the app.

@orangejenny 
@calellowitz buddy