### PR TITLE
use citus for sqldata requests as well

### DIFF
--- a/custom/icds_reports/sqldata/base.py
+++ b/custom/icds_reports/sqldata/base.py
@@ -8,12 +8,14 @@ from django.core.serializers.json import DjangoJSONEncoder
 from sqlalchemy.dialects import postgresql
 
 from corehq.apps.reports.sqlreport import DatabaseColumn, SqlData
+from corehq.sql_db.connections import ICDS_UCR_CITUS_ENGINE_ID, ICDS_UCR_ENGINE_ID
+from corehq.sql_db.routers import forced_citus
 from corehq.toggles import ICDS_COMPARE_QUERIES_AGAINST_CITUS, NAMESPACE_OTHER
 from custom.icds_reports.utils.tasks import call_citus_experiment
 
 
 class IcdsSqlData(SqlData):
-    engine_id = 'icds-ucr'
+    engine_id = ICDS_UCR_CITUS_ENGINE_ID if forced_citus() else ICDS_UCR_ENGINE_ID
 
     def get_data(self, start=None, limit=None):
         query_context = self.query_context()


### PR DESCRIPTION
it looks like the data reliant on `sqldata` functions (mostly fact sheets but potentially mpr too) were not using citus