### PR TITLE
last submission should be based on received_on?

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -53,9 +53,9 @@ def get_last_submission_time_for_users(domain, user_ids, datespan, es_instance_a
             TermsAggregation('user_id', 'form.meta.userID').aggregation(
                 TopHitsAggregation(
                     'top_hits_last_form_submissions',
-                    'form.meta.timeEnd',
+                    'received_on',
                     is_ascending=False,
-                    include='form.meta.timeEnd',
+                    include='received_on',
                 )
             )
         )
@@ -66,7 +66,7 @@ def get_last_submission_time_for_users(domain, user_ids, datespan, es_instance_a
     buckets_dict = aggregations.user_id.buckets_dict
     result = {}
     for user_id, bucket in six.iteritems(buckets_dict):
-        result[user_id] = convert_to_date(bucket.top_hits_last_form_submissions.hits[0]['form']['meta']['timeEnd'])
+        result[user_id] = convert_to_date(bucket.top_hits_last_form_submissions.hits[0]['received_on'])
     return result
 
 


### PR DESCRIPTION
Mostly open for discussion, and open for merge if we agree.

There is an issue with this function where if a form submission was made with future completion time, that form gets shown as the latest form submission which is wrong. For e.g. see [this form](https://www.icds-cas.gov.in/a/icds-cas/reports/form_data/c4531341-55c5-473c-a2a7-48273c9c9553/#form-metadata) that I Idiscovered an edge case with this when I was writing another [similar function](https://github.com/dimagi/commcare-hq/pull/25125) for warehouse.

This function is used for Worker Activity Report and LS Performance indicators.  The mistake in LS indicators would be that users who have submitted buggy forms with future completion date (say Aug 2019) long ago (say in 2017), would be counted as performing correctly.

@snopoke  

