### PR TITLE
[Vectorlink] Add Date of Inspection column to supervisory report

### DIFF
--- a/custom/abt/reports/data_sources/supervisory_v2019.json
+++ b/custom/abt/reports/data_sources/supervisory_v2019.json
@@ -183,6 +183,23 @@
                 "type": "expression"
             },
             {
+                "column_id": "inspection_date",
+                "datatype": "datetime",
+                "display_name": "inspection_date",
+                "expression": {
+                    "expression": {
+                        "datatype": null,
+                        "property_name": "date",
+                        "type": "property_name"
+                    },
+                    "type": "root_doc"
+                },
+                "is_nullable": true,
+                "is_primary_key": false,
+                "transform": {},
+                "type": "expression"
+            },
+            {
                 "column_id": "country",
                 "datatype": "string",
                 "display_name": "country",

--- a/custom/abt/reports/data_sources/supervisory_v2019.json
+++ b/custom/abt/reports/data_sources/supervisory_v2019.json
@@ -182,15 +182,18 @@
                 "transform": {},
                 "type": "expression"
             },
-            {
+             {
                 "column_id": "inspection_date",
                 "datatype": "datetime",
                 "display_name": "inspection_date",
                 "expression": {
                     "expression": {
                         "datatype": null,
-                        "property_name": "date",
-                        "type": "property_name"
+                        "property_path": [
+                            "form",
+                            "date"
+                        ],
+                        "type": "property_path"
                     },
                     "type": "root_doc"
                 },

--- a/custom/abt/reports/supervisory_report_v2019.json
+++ b/custom/abt/reports/supervisory_report_v2019.json
@@ -85,6 +85,22 @@
             },
             {
                 "compare_as_string": false,
+                "datatype": "string",
+                "required": false,
+                "slug": "inspection_date",
+                "field": "inspection_date",
+                "type": "date",
+                "display": {
+                    "fra": "Date d'inspection",
+                    "frm": "Date d'inspection",
+                    "en": "Date of inspection",
+                    "sw": "Date of inspection",
+                    "kin": "Date of inspection",
+                    "por": "Data de inspe\u00e7\u00e3o"
+                }
+            },
+            {
+                "compare_as_string": false,
                 "show_all": true,
                 "datatype": "string",
                 "required": false,
@@ -182,6 +198,28 @@
             "created_by_builder": false
         },
         "columns": [
+            {
+                "description": null,
+                "field": "inspection_date",
+                "format": "default",
+                "transform": {
+                    "type": "date_format",
+                    "format": "%Y-%m-%d %H:%M"
+                },
+                "column_id": "inspection_date",
+                "alias": null,
+                "calculate_total": false,
+                "type": "field",
+                "display": {
+                    "fra": "Date d'inspection",
+                    "frm": "Date d'inspection",
+                    "en": "Date of inspection",
+                    "sw": "Date of inspection",
+                    "kin": "Date of inspection",
+                    "por": "Data de inspe\u00e7\u00e3o"
+                },
+                "aggregation": "simple"
+            },
             {
                 "description": null,
                 "field": "received_on",

--- a/custom/abt/reports/supervisory_report_v2019.json
+++ b/custom/abt/reports/supervisory_report_v2019.json
@@ -46,6 +46,10 @@
                 "order": "DESC"
             },
             {
+                "field": "inspection_date",
+                "order": "DESC"
+            },
+            {
                 "field": "level_1",
                 "order": "ASC"
             },


### PR DESCRIPTION
Hi,
I've added additional column to supervisory report 2019 with date of inspection.
TICKET: https://dimagi-dev.atlassian.net/browse/SL-169

Need QA: no
Environment: Vectorlink
locally tested: yes