### PR TITLE
Use pip-compile --allow-unsafe throughout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,18 @@ endif
 
 requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 requirements:
-	pip-compile -o $(REQUIREMENTS_TXT_DIR)/requirements.txt requirements/requirements.in
+	pip-compile -o $(REQUIREMENTS_TXT_DIR)/requirements.txt requirements/requirements.in --allow-unsafe
 	pip-compile -o $(REQUIREMENTS_TXT_DIR)/prod-requirements.txt requirements/prod-requirements.in --allow-unsafe
-	pip-compile -o $(REQUIREMENTS_TXT_DIR)/test-requirements.txt requirements/test-requirements.in
-	pip-compile -o $(REQUIREMENTS_TXT_DIR)/dev-requirements.txt requirements/dev-requirements.in
+	pip-compile -o $(REQUIREMENTS_TXT_DIR)/test-requirements.txt requirements/test-requirements.in --allow-unsafe
+	pip-compile -o $(REQUIREMENTS_TXT_DIR)/dev-requirements.txt requirements/dev-requirements.in --allow-unsafe
 	scripts/pip-post-compile.sh $(REQUIREMENTS_TXT_DIR)/*requirements.txt
 
 upgrade-requirements: export CUSTOM_COMPILE_COMMAND=`make requirements` or `make upgrade-requirements`
 upgrade-requirements:
-	pip-compile --upgrade -o $(REQUIREMENTS_TXT_DIR)/requirements.txt requirements/requirements.in
+	pip-compile --upgrade -o $(REQUIREMENTS_TXT_DIR)/requirements.txt requirements/requirements.in --allow-unsafe
 	pip-compile --upgrade -o $(REQUIREMENTS_TXT_DIR)/prod-requirements.txt requirements/prod-requirements.in --allow-unsafe
-	pip-compile --upgrade -o $(REQUIREMENTS_TXT_DIR)/test-requirements.txt requirements/test-requirements.in
-	pip-compile --upgrade -o $(REQUIREMENTS_TXT_DIR)/dev-requirements.txt requirements/dev-requirements.in
+	pip-compile --upgrade -o $(REQUIREMENTS_TXT_DIR)/test-requirements.txt requirements/test-requirements.in --allow-unsafe
+	pip-compile --upgrade -o $(REQUIREMENTS_TXT_DIR)/dev-requirements.txt requirements/dev-requirements.in --allow-unsafe
 	scripts/pip-post-compile.sh $(REQUIREMENTS_TXT_DIR)/*requirements.txt
 
 docs:

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -216,4 +216,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via django-websocket-redis, ipdb, ipython, python-levenshtein, python-termstyle, sphinx
+setuptools==41.2.0        # via django-websocket-redis, ipdb, ipython, python-levenshtein, python-termstyle, sphinx

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -161,4 +161,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via django-websocket-redis, python-levenshtein
+setuptools==41.2.0        # via django-websocket-redis, python-levenshtein

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -179,4 +179,4 @@ xlrd==1.0.0
 xlwt==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via django-websocket-redis, python-levenshtein
+setuptools==41.2.0        # via django-websocket-redis, python-levenshtein


### PR DESCRIPTION
to avoid test failures because of inconsistent setuptools version in comment,
as discussed in https://github.com/dimagi/commcare-hq/pull/25128#issuecomment-523619277