### PR TITLE
Ignore absolute_import warning [ci skip]

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -5,7 +5,7 @@ files:
 linters:
   flake8:
     max-line-length: 115
-    ignore: E128,E265,F403,W503  # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+    ignore: E128,E265,F403,W503,W1618  # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
   py3k: {}
   eslint:
     config: ./.eslintrc.js


### PR DESCRIPTION
W1618 import missing `from __future__ import absolute_import`