### PR TITLE
Remove py3k linter

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -6,7 +6,6 @@ linters:
   flake8:
     max-line-length: 115
     ignore: E128,E265,F403,W503,W1618  # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
-  py3k: {}
   eslint:
     config: ./.eslintrc.js
     install_plugins: true


### PR DESCRIPTION
No longer necessary now that we're on Python 3