### PR TITLE
Report mobile worker counts to datadog

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -16,6 +16,7 @@ from six.moves import filter, map
 from unidecode import unidecode
 
 from casexml.apps.case.xform import extract_case_blocks
+from corehq.util.datadog.gauges import datadog_gauge
 from couchforms.analytics import app_has_been_submitted_to_in_last_30_days
 from dimagi.utils.logging import notify_exception
 from soil import DownloadBase
@@ -76,6 +77,7 @@ def _update_calculated_properties():
     ).fields(["name", "_id"]).run().hits
 
     all_stats = all_domain_stats()
+    datadog_report_user_stats(commcare_users_by_domain=all_stats['commcare_users'])
     for r in results:
         dom = r["name"]
         domain_obj = Domain.get_by_name(dom)
@@ -93,6 +95,35 @@ def _update_calculated_properties():
             send_to_elasticsearch("domains", props, es_merge_update=True)
         except Exception as e:
             notify_exception(None, message='Domain {} failed on stats calculations with {}'.format(dom, e))
+
+
+def datadog_report_user_stats(commcare_users_by_domain):
+    commcare_users_by_domain = summarize_user_counts(commcare_users_by_domain, n=50)
+    for domain, user_count in commcare_users_by_domain.items():
+        datadog_gauge('commcare.mobile_workers.count', user_count, tags=[
+            'domain:{}'.format('_other' if domain is () else domain)
+        ])
+
+
+def summarize_user_counts(commcare_users_by_domain, n):
+    """
+    Reduce (domain => user_count) to n entries, with all other entries summed to a single one
+
+    This allows us to report individual domain data to datadog for the domains that matter
+    and report a single number that combines the users for all other domains.
+
+    :param commcare_users_by_domain: the source data
+    :param n: number of domains to reduce the map to
+    :return: (domain => user_count) of top domains
+             with a single entry under () for all other domains
+    """
+    user_counts = sorted((user_count, domain) for domain, user_count in commcare_users_by_domain.items())
+    if n:
+        top_domains, other_domains = user_counts[-n:], user_counts[:-n]
+    else:
+        top_domains, other_domains = [], user_counts[:]
+    other_entry = (sum(user_count for user_count, _ in other_domains), ())
+    return {domain: user_count for user_count, domain in top_domains + [other_entry]}
 
 
 def get_domains_to_update_es_filter():

--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import os
 from django.test import SimpleTestCase
 
+from corehq.apps.reports.tasks import summarize_user_counts
 from corehq.apps.reports.util import validate_xform_for_edit
 from corehq.apps.reports.exceptions import EditFormValidationError
 from corehq.apps.app_manager.xform import XForm
@@ -21,3 +22,27 @@ class TestValidateXFormForEdit(SimpleTestCase, TestFileMixin):
         xform = XForm(source)
         with self.assertRaises(EditFormValidationError):
             validate_xform_for_edit(xform)
+
+
+class TestSummarizeUserCounts(SimpleTestCase):
+    def test_summarize_user_counts(self):
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=0),
+            {(): 13},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=1),
+            {'b': 10, (): 3},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=2),
+            {'b': 10, 'c': 2, (): 1},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=3),
+            {'a': 1, 'b': 10, 'c': 2, (): 0},
+        )
+        self.assertEqual(
+            summarize_user_counts({'a': 1, 'b': 10, 'c': 2}, n=4),
+            {'a': 1, 'b': 10, 'c': 2, (): 0},
+        )


### PR DESCRIPTION
Some upcoming rate limiting will likely be based on mobile worker counts, so I wanted to just start collecting this data so we have another way to validate some numbers. It's also just seems like a useful thing to be able to track user count over time in datadog.