### PR TITLE
Fix SMS form handling of deleted groups

### DIFF
--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -773,6 +773,8 @@ class SettingsForm(Form):
             group = Group.get(object_id)
             if group.doc_type == 'Group' and group.domain == self._cchq_domain and group.case_sharing:
                 return group
+            elif group.is_deleted():
+                return None
         except ResourceNotFound:
             pass
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-800

https://sentry.io/organizations/dimagi/issues/1135181391/?project=136860&query=is%3Aunresolved&statsPeriod=14d

There's a similar clause return `None` in the `get_user` function. This is failing at the moment because groups and users are in the same DB