### PR TITLE
gevent monkey-patching must happen before requests

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -61,7 +61,7 @@ def init_hq_python_path():
     _set_source_root(os.path.join('custom', '_legacy'))
 
 
-def _patch_gevent_if_reqd(args, gevent_commands):
+def _patch_gevent_if_required(args, gevent_commands):
     if len(args) <= 1:
         return
     for gevent_command in gevent_commands:

--- a/manage.py
+++ b/manage.py
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         GeventCommand('run_aggregation_query'),
         GeventCommand('send_pillow_retry_queue_through_pillows'),
     )
-    _patch_gevent_if_reqd(sys.argv, GEVENT_COMMANDS)
+    _patch_gevent_if_required(sys.argv, GEVENT_COMMANDS)
 
     init_hq_python_path()
     run_patches()


### PR DESCRIPTION
This reverts commit 463602b5678e1f31e08b4e554e1a14ea0fbc440e, which is the revert of my dumb commit straight onto master.

This commit resolves the following warning, and the Recursion Error that it mentions.

> ./manage.py:198: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including Recursion Error on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016.

The warning is shown because currently gevent monkey-patching happens after Requests is imported, and Requests imports `urllib3.contrib.pyopenssl` in Python 3.

This change patches before importing Requests.
