### PR TITLE
validate_phone_datetime supports datetime.date

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_util.py
@@ -13,26 +13,20 @@ class ValidatePhoneDatetimeTests(SimpleTestCase):
     def test_datetime_string(self):
         datetime_string = '2019-08-27T17:50:00.000'
         result = validate_phone_datetime(datetime_string)
-
-        datetime_ = iso8601.parse_date(datetime_string)
-        assert datetime_ == datetime.datetime(
+        self.assertEqual(result, datetime.datetime(
             2019, 8, 27,
             17, 50, 0,
             tzinfo=datetime.timezone.utc
-        )
-        self.assertEqual(result, datetime_)
+        ))
 
     def test_date_string(self):
         date_string = '2019-08-27'
         result = validate_phone_datetime(date_string)
-
-        datetime_ = iso8601.parse_date(date_string)
-        assert datetime_ == datetime.datetime(
+        self.assertEqual(result, datetime.datetime(
             2019, 8, 27,
             0, 0, 0,
             tzinfo=datetime.timezone.utc
-        )
-        self.assertEqual(result, datetime_)
+        ))
 
     def test_datetime(self):
         datetime_ = datetime.datetime(

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_util.py
@@ -2,8 +2,6 @@ import datetime
 
 from django.test import SimpleTestCase
 
-from iso8601 import iso8601
-
 from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.case.util import validate_phone_datetime
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_util.py
@@ -1,0 +1,63 @@
+import datetime
+
+from django.test import SimpleTestCase
+
+from iso8601 import iso8601
+
+from casexml.apps.case.exceptions import PhoneDateValueError
+from casexml.apps.case.util import validate_phone_datetime
+
+
+class ValidatePhoneDatetimeTests(SimpleTestCase):
+
+    def test_datetime_string(self):
+        datetime_string = '2019-08-27T17:50:00.000'
+        result = validate_phone_datetime(datetime_string)
+
+        datetime_ = iso8601.parse_date(datetime_string)
+        assert datetime_ == datetime.datetime(
+            2019, 8, 27,
+            17, 50, 0,
+            tzinfo=datetime.timezone.utc
+        )
+        self.assertEqual(result, datetime_)
+
+    def test_date_string(self):
+        date_string = '2019-08-27'
+        result = validate_phone_datetime(date_string)
+
+        datetime_ = iso8601.parse_date(date_string)
+        assert datetime_ == datetime.datetime(
+            2019, 8, 27,
+            0, 0, 0,
+            tzinfo=datetime.timezone.utc
+        )
+        self.assertEqual(result, datetime_)
+
+    def test_datetime(self):
+        datetime_ = datetime.datetime(
+            2019, 8, 27,
+            17, 50, 0
+        )
+        result = validate_phone_datetime(datetime_)
+        self.assertEqual(result, datetime_)
+
+    def test_date(self):
+        date = datetime.date(2019, 8, 27)
+        result = validate_phone_datetime(date)
+        self.assertEqual(result, datetime.datetime(
+            2019, 8, 27,
+            0, 0, 0
+        ))
+
+    def test_int(self):
+        with self.assertRaises(PhoneDateValueError):
+            validate_phone_datetime(1)
+
+    def test_day_string(self):
+        with self.assertRaises(PhoneDateValueError):
+            validate_phone_datetime('Monday')
+
+    def test_int_string(self):
+        with self.assertRaises(PhoneDateValueError):
+            validate_phone_datetime('1')

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -27,6 +27,13 @@ def validate_phone_datetime(datetime_string, none_ok=False, form_id=None):
     if isinstance(datetime_string, datetime.datetime):
         return datetime_string
 
+    if isinstance(datetime_string, datetime.date):
+        return datetime.datetime(
+            datetime_string.year,
+            datetime_string.month,
+            datetime_string.day
+        )
+
     if none_ok:
         if datetime_string is None:
             return None


### PR DESCRIPTION
Forms (submitted in 2015 and 2016, and probably others) have case blocks whose "date_modified" attributes are `datetime.date` instances. Migrating these forms is raising `PhoneDateValueError`.

This change allows `validate_phone_datetime()` to support `datetime.date` values the same way it supports date string values.
