### PR TITLE
Propogate hard deletes in Couch to Kafka

### DIFF
--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -88,6 +88,16 @@ def change_meta_from_doc_meta_and_document(doc_meta, document, data_source_type,
     )
 
 
+def change_meta_from_hard_delete(document, data_source_type, data_source_name):
+    return ChangeMeta(
+        document_id=document['_id'],
+        document_rev=document.get('_rev', None),
+        data_source_type=data_source_type,
+        data_source_name=data_source_name,
+        is_deletion=True,
+    )
+
+
 def _get_domain(document):
     return document.get('domain', None)
 

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -7,7 +7,7 @@ from pillowtop.feed.couch import CouchChangeFeed, populate_change_metadata
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
 
-from corehq.apps.change_feed import data_sources
+from corehq.apps.change_feed import data_sources, topics
 from corehq.apps.change_feed.producer import ChangeProducer
 from corehq.apps.change_feed.topics import get_topic_for_doc_type
 from corehq.apps.domain.models import Domain
@@ -20,16 +20,17 @@ class KafkaProcessor(PillowProcessor):
     Processor that pushes changes to Kafka
     """
 
-    def __init__(self, data_source_type, data_source_name):
+    def __init__(self, data_source_type, data_source_name, default_topic):
         self._producer = ChangeProducer()
         self._data_source_type = data_source_type
         self._data_source_name = data_source_name
+        self._default_topic = default_topic
 
     def process_change(self, change):
         populate_change_metadata(change, self._data_source_type, self._data_source_name)
         if change.metadata:
             change_meta = change.metadata
-            topic = get_topic_for_doc_type(change_meta.document_type, self._data_source_type)
+            topic = get_topic_for_doc_type(change_meta.document_type, self._data_source_type, self._default_topic)
             # change.deleted is used for hard deletions whereas change_meta.is_deletion is for soft deletions.
             # from the consumer's perspective both should be counted as deletions so just "or" them
             # note: it is strange and hard to reproduce that the couch changes feed is providing a "doc"
@@ -39,25 +40,29 @@ class KafkaProcessor(PillowProcessor):
 
 
 def get_default_couch_db_change_feed_pillow(pillow_id, **kwargs):
-    return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
+    return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db(), topics.CASE)
 
 
 def get_user_groups_db_kafka_pillow(pillow_id, **kwargs):
-    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(CommCareUser))
+    return get_change_feed_pillow_for_db(
+        pillow_id, couch_config.get_db_for_class(CommCareUser), topics.COMMCARE_USER
+    )
 
 
 def get_domain_db_kafka_pillow(pillow_id, **kwargs):
-    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Domain))
+    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Domain), topics.DOMAIN)
 
 
 def get_application_db_kafka_pillow(pillow_id, **kwargs):
     from corehq.apps.app_manager.models import Application
-    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Application))
+    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Application), topics.APP)
 
 
-def get_change_feed_pillow_for_db(pillow_id, couch_db):
+def get_change_feed_pillow_for_db(pillow_id, couch_db, default_topic=None):
     processor = KafkaProcessor(
-        data_source_type=data_sources.SOURCE_COUCH, data_source_name=couch_db.dbname
+        data_source_type=data_sources.SOURCE_COUCH,
+        data_source_name=couch_db.dbname,
+        default_topic=default_topic,
     )
     change_feed = CouchChangeFeed(couch_db)
     checkpoint = PillowCheckpoint(pillow_id, change_feed.sequence_format)

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -43,7 +43,7 @@ ALL = (
 )
 
 
-def get_topic_for_doc_type(doc_type, data_source_type=None):
+def get_topic_for_doc_type(doc_type, data_source_type=None, default_topic=None):
     from corehq.apps.change_feed import document_types
     from corehq.apps.locations.document_store import LOCATION_DOC_TYPE
 
@@ -73,6 +73,8 @@ def get_topic_for_doc_type(doc_type, data_source_type=None):
         return LOCATION
     elif doc_type in ALL:  # for docs that don't have a doc_type we use the Kafka topic
         return doc_type
+    elif default_topic:
+        return default_topic
     else:
         # at some point we may want to make this more granular
         return META  # note this does not map to the 'meta' Couch database

--- a/corehq/ex-submodules/pillowtop/feed/couch.py
+++ b/corehq/ex-submodules/pillowtop/feed/couch.py
@@ -58,14 +58,22 @@ def change_from_couch_row(couch_change, document_store=None):
 
 def populate_change_metadata(change, data_source_type, data_source_name):
     from corehq.apps.change_feed.exceptions import MissingMetaInformationError
-    from corehq.apps.change_feed.document_types import get_doc_meta_object_from_document
-    from corehq.apps.change_feed.document_types import change_meta_from_doc_meta_and_document
+    from corehq.apps.change_feed.document_types import (
+        change_meta_from_doc_meta_and_document,
+        change_meta_from_hard_delete,
+        get_doc_meta_object_from_document,
+    )
 
     if change.metadata:
         return
 
+    document = change.get_document()
+
+    if change.deleted:
+        change.metadata = change_meta_from_hard_delete(document, data_source_type, data_source_name)
+        return
+
     try:
-        document = change.get_document()
         doc_meta = get_doc_meta_object_from_document(document)
         change_meta = change_meta_from_doc_meta_and_document(
             doc_meta=doc_meta,

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -71,13 +71,14 @@ class AppPillowTest(TestCase):
         self.assertEqual(app['_id'], app_doc['_id'])
         self.assertEqual(app_name, app_doc['name'])
 
-    def _create_app(self, name):
+    def _create_app(self, name, cleanup=True):
         factory = AppFactory(domain=self.domain, name=name, build_version='2.11.0')
         module1, form1 = factory.new_basic_module('open_case', 'house')
         factory.form_opens_case(form1)
         app = factory.app
         app.save()
-        self.addCleanup(app.delete)
+        if cleanup:
+            self.addCleanup(app.delete)
         return app
 
     def refresh_elasticsearch(self, kafka_seq, couch_seq):
@@ -119,3 +120,46 @@ class AppPillowTest(TestCase):
         self.refresh_elasticsearch(kafka_seq, couch_seq)
         build_ids_in_es = AppES().domain(self.domain).is_build().values_list('_id', flat=True)
         self.assertItemsEqual(build_ids_in_es, [build1._id, build3._id])
+
+    def test_hard_delete_app(self):
+        consumer = get_test_kafka_consumer(topics.APP)
+        # have to get the seq id before the change is processed
+        kafka_seq = get_topic_offset(topics.APP)
+        couch_seq = get_current_seq(Application.get_db())
+
+        app = self._create_app('test_hard_deleted_app', cleanup=False)
+        app_db_pillow = get_application_db_kafka_pillow('test_app_db_pillow')
+        app_db_pillow.process_changes(couch_seq, forever=False)
+
+        # confirm change made it to kafka
+        message = next(consumer)
+        change_meta = change_meta_from_kafka_message(message.value)
+        self.assertEqual(app._id, change_meta.document_id)
+        self.assertEqual(self.domain, change_meta.domain)
+
+        # send to elasticsearch
+        app_pillow = get_app_to_elasticsearch_pillow()
+        app_pillow.process_changes(since=kafka_seq, forever=False)
+        self.es.indices.refresh(APP_INDEX_INFO.index)
+
+        # confirm change made it to elasticserach
+        results = AppES().run()
+        self.assertEqual(1, results.total)
+
+        couch_seq = get_current_seq(Application.get_db())
+        kafka_seq = get_topic_offset(topics.APP)
+
+        app.delete()
+        app_db_pillow.process_changes(couch_seq, forever=False)
+
+        # confirm change made it to kafka. Would raise StopIteration otherwise
+        next(consumer)
+
+        # send to elasticsearch
+        app_pillow = get_app_to_elasticsearch_pillow()
+        app_pillow.process_changes(since=kafka_seq, forever=False)
+        self.es.indices.refresh(APP_INDEX_INFO.index)
+
+        # confirm deletion made it to elasticserach
+        results = AppES().run()
+        self.assertEqual(0, results.total)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-838

When you run `Doc.delete()`, the pillow can't get the document because it no longer exists, so those deletions are not propagated through to ES. There were several places where it was assumed that the document exists

Note this only affects the pillows that are CouchDB -> Kafka