### PR TITLE
Disable unsafe operations during couch-to-SQL migration

### DIFF
--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -52,6 +52,7 @@ load_ignore_rules = memoized(lambda: {
         ignore_renamed('uid', 'instanceID'),
     ],
     'XFormInstance-Deleted': [
+        Ignore('missing', 'deletion_id', old=MISSING, new=None),
         ignore_renamed('-deletion_id', 'deletion_id'),
         ignore_renamed('-deletion_date', 'deleted_on'),
     ],

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -48,7 +48,6 @@ from corehq.form_processor.backends.sql.dbaccessors import (
 )
 from corehq.form_processor.exceptions import (
     CaseNotFound,
-    FormEditNotAllowed,
     MissingFormXml,
     NotAllowed,
 )
@@ -754,7 +753,7 @@ class MigrationTestCase(BaseMigrationTestCase):
 
         clear_local_domain_sql_backend_override(self.domain_name)
         self.assert_backend("couch")
-        with self.assertRaises(FormEditNotAllowed):
+        with self.assertRaises(NotAllowed):
             self.submit_form(make_test_form("test-1", age=30))
 
         self._do_migration_and_assert_flags(self.domain_name)

--- a/corehq/apps/hqadmin/management/commands/delete_related_cases.py
+++ b/corehq/apps/hqadmin/management/commands/delete_related_cases.py
@@ -8,6 +8,7 @@ from six.moves import input
 
 from corehq.apps.receiverwrapper.util import get_app_version_info
 from corehq.apps.users.util import cached_owner_id_to_display
+from corehq.form_processor.exceptions import NotAllowed
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -23,6 +24,7 @@ class Command(BaseCommand):
         parser.add_argument('--filename', dest='filename', default='case-delete-info.csv')
 
     def handle(self, domain, case_id, **options):
+        NotAllowed.check(domain)
         case_accessor = CaseAccessors(domain=domain)
         case = case_accessor.get_case(case_id)
         if not case.is_deleted and input('\n'.join([

--- a/corehq/apps/hqcase/tasks.py
+++ b/corehq/apps/hqcase/tasks.py
@@ -18,6 +18,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.ota.utils import get_restore_user
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL
+from corehq.form_processor.exceptions import NotAllowed
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -145,6 +146,7 @@ def delete_exploded_case_task(domain, explosion_id):
 
 
 def delete_exploded_cases(domain, explosion_id, task=None):
+    NotAllowed.check(domain)
     if task:
         DownloadBase.set_progress(delete_exploded_case_task, 0, 0)
     query = (CaseSearchES()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -73,7 +73,7 @@ from corehq.apps.users.util import (
     user_location_data,
     username_to_user_id,
 )
-from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.exceptions import CaseNotFound, NotAllowed
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -1810,6 +1810,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         - It will not restore the user's phone numbers
         - It will not restore reminders for cases
         """
+        NotAllowed.check(self.domain)
         by_username = self.get_db().view('users/by_username', key=self.username, reduce=False).first()
         if by_username and by_username['id'] != self._id:
             return False, "A user with the same username already exists in the system"
@@ -1827,6 +1828,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return True, None
 
     def retire(self):
+        NotAllowed.check(self.domain)
         suffix = DELETED_SUFFIX
         deletion_id = uuid4().hex
         deletion_date = datetime.utcnow()

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -43,6 +43,9 @@ hqDefine('users/js/edit_commcare_user', function () {
             self.signOff = ko.observable('');
             self.formDeleteUserSent = ko.observable(false);
             self.disabled = function () {
+                if (!initialPageData.get('is_delete_allowed')) {
+                    return true;
+                }
                 var understand = self.signOff().toLowerCase() === initialPageData.get('couch_user_username');
                 return self.formDeleteUserSent() || !understand;
             };

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -23,7 +23,7 @@ from soil import DownloadBase
 
 from corehq import toggles
 from corehq.apps.domain.models import Domain
-from corehq.form_processor.exceptions import CaseNotFound
+from corehq.form_processor.exceptions import CaseNotFound, NotAllowed
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -97,6 +97,7 @@ def bulk_download_users_async(domain, download_id, user_filters):
 def tag_cases_as_deleted_and_remove_indices(domain, case_ids, deletion_id, deletion_date):
     from corehq.apps.sms.tasks import delete_phone_numbers_for_owners
     from corehq.messaging.scheduling.tasks import delete_schedule_instances_for_cases
+    NotAllowed.check(domain)
     CaseAccessors(domain).soft_delete_cases(list(case_ids), deletion_date, deletion_id)
     _remove_indices_from_deleted_cases_task.delay(domain, case_ids)
     delete_phone_numbers_for_owners.delay(case_ids)

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -162,7 +162,7 @@ class RetireUserTestCase(TestCase):
         self.assertEqual(1, len(child.xform_ids))
 
         # simulate parent deletion
-        parent.soft_delete()
+        CaseAccessors(self.domain).soft_delete_cases([parent_id])
 
         # call the remove index task
         remove_indices_from_deleted_cases(self.domain, [parent_id])

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -183,6 +183,11 @@ class EditCommCareUserView(BaseEditUserView):
         return self.editable_user_id == self.couch_user._id
 
     @property
+    def is_delete_allowed(self):
+        from corehq.apps.couch_sql_migration.progress import couch_sql_migration_in_progress
+        return not couch_sql_migration_in_progress(self.domain)
+
+    @property
     @memoized
     def reset_password_form(self):
         return SetUserPasswordForm(self.request.project, self.editable_user_id, user="")
@@ -244,6 +249,7 @@ class EditCommCareUserView(BaseEditUserView):
             'group_form': self.group_form,
             'reset_password_form': self.reset_password_form,
             'is_currently_logged_in_user': self.is_currently_logged_in_user,
+            'is_delete_allowed': self.is_delete_allowed,
             'data_fields_form': self.form_user_update.custom_data.form,
             'can_use_inbound_sms': domain_has_privilege(self.domain, privileges.INBOUND_SMS),
             'can_create_groups': (

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -292,10 +292,6 @@ class CommCareCase(DeferredBlobMixin, SafeSaveDocument, IndexHoldingMixIn,
     def deletion_date(self):
         return getattr(self, '-deletion_date', None)
 
-    def soft_delete(self):
-        self.doc_type += DELETED_SUFFIX
-        self.save()
-
     def to_api_json(self, lite=False):
         ret = {
             # actions excluded here

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -163,9 +163,11 @@ class CaseBugTest(TestCase, TestFileMixin):
         xform, [case] = post_case_blocks([
             CaseBlock(create=True, case_id=case_id, user_id='whatever',
                 update={'foo': 'bar'}).as_xml()
-        ])
-        case.soft_delete()
+        ], domain="test-domain")
+        cases = CaseAccessors("test-domain")
+        cases.soft_delete_cases([case_id])
 
+        case = cases.get_case(case_id)
         self.assertEqual('bar', case.dynamic_case_properties()['foo'])
         self.assertTrue(case.is_deleted)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -811,7 +811,7 @@ class SyncDeletedCasesTest(BaseSyncTest):
     def test_deleted_case_doesnt_sync(self):
         case_id = uuid.uuid4().hex
         self.device.post_changes(case_id=case_id, create=True)
-        CaseAccessors(self.project.name).get_case(case_id).soft_delete()
+        CaseAccessors(self.project.name).soft_delete_cases([case_id])
         self.assertNotIn(case_id, self.device.sync().cases)
 
     def test_deleted_parent_doesnt_sync(self):
@@ -829,7 +829,7 @@ class SyncDeletedCasesTest(BaseSyncTest):
                 )],
             )
         )
-        CaseAccessors().get_case(parent_id).soft_delete()
+        CaseAccessors(self.project.name).soft_delete_cases([parent_id])
         self.assertEqual(set(self.device.sync().cases), {child_id})
         # todo: in the future we may also want to purge the child
 

--- a/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
+++ b/corehq/ex-submodules/couchforms/management/commands/purge_forms_and_cases.py
@@ -5,6 +5,7 @@ from django.http import Http404
 
 from corehq.apps.app_manager.models import Application
 from casexml.apps.case.xform import get_case_ids_from_form
+from corehq.form_processor.exceptions import NotAllowed
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors
 from corehq.apps.app_manager.dbaccessors import get_app
 from dimagi.utils.django.management import are_you_sure
@@ -51,6 +52,7 @@ though deletion would be re-confirmed so dont panic
         self.case_accessors = CaseAccessors(self.domain)
 
     def ensure_prerequisites(self, domain, app_id, version_number, test_run):
+        NotAllowed.check(domain)
         self.domain = domain
         self.app_id = app_id
         self.version_number = version_number

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -30,7 +30,11 @@ from lxml.etree import XMLSyntaxError
 
 from corehq.blobs.mixin import DeferredBlobMixin, CODES
 from corehq.form_processor.abstract_models import AbstractXFormInstance
-from corehq.form_processor.exceptions import XFormNotFound, MissingFormXml
+from corehq.form_processor.exceptions import (
+    MissingFormXml,
+    NotAllowed,
+    XFormNotFound,
+)
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.utils import clean_metadata
 
@@ -272,6 +276,7 @@ class XFormInstance(DeferredBlobMixin, SafeSaveDocument,
         return safe_index(self, path.split("/"))
 
     def soft_delete(self):
+        NotAllowed.check(self.domain)
         self.doc_type += DELETED_SUFFIX
         self.save()
 

--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -27,7 +27,11 @@ from corehq.dbaccessors.couchapps.cases_by_server_date.by_owner_server_modified_
     get_case_ids_modified_with_owner_since
 from corehq.dbaccessors.couchapps.cases_by_server_date.by_server_modified_on import \
     get_last_modified_dates
-from corehq.form_processor.exceptions import AttachmentNotFound, LedgerValueNotFound
+from corehq.form_processor.exceptions import (
+    AttachmentNotFound,
+    LedgerValueNotFound,
+    NotAllowed,
+)
 from corehq.form_processor.interfaces.dbaccessors import (
     AbstractCaseAccessor, AbstractFormAccessor, AttachmentContent,
     AbstractLedgerAccessor)
@@ -125,12 +129,14 @@ class FormAccessorCouch(AbstractFormAccessor):
     def soft_delete_forms(domain, form_ids, deletion_date=None, deletion_id=None):
         def _form_delete(doc):
             doc['server_modified_on'] = json_format_datetime(datetime.utcnow())
+        NotAllowed.check(domain)
         return _soft_delete(XFormInstance.get_db(), form_ids, deletion_date, deletion_id, _form_delete)
 
     @staticmethod
     def soft_undelete_forms(domain, form_ids):
         def _form_undelete(doc):
             doc['server_modified_on'] = json_format_datetime(datetime.utcnow())
+        NotAllowed.check(domain)
         return _soft_undelete(XFormInstance.get_db(), form_ids, _form_undelete)
 
     @staticmethod

--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -277,6 +277,7 @@ class CaseAccessorCouch(AbstractCaseAccessor):
 
     @staticmethod
     def soft_undelete_cases(domain, case_ids):
+        NotAllowed.check(domain)
         return _soft_undelete(CommCareCase.get_db(), case_ids)
 
     @staticmethod

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -13,6 +13,7 @@ from casexml.apps.case.util import get_case_xform_ids
 from casexml.apps.case.xform import get_case_updates
 from corehq.blobs.mixin import bulk_atomic_blobs
 from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
+from corehq.form_processor.exceptions import NotAllowed
 from corehq.form_processor.interfaces.processor import XFormQuestionValueIterator
 from corehq.form_processor.utils import extract_meta_instance_id
 from corehq.util.datadog.utils import case_load_counter, form_load_counter
@@ -80,6 +81,7 @@ class FormProcessorCouch(object):
 
     @classmethod
     def hard_delete_case_and_forms(cls, domain, case, xforms):
+        NotAllowed.check(domain)
         docs = [case._doc] + [f._doc for f in xforms]
         case.get_db().bulk_delete(docs)
 

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -34,7 +34,9 @@ from corehq.form_processor.exceptions import (
     AttachmentNotFound,
     CaseSaveError,
     LedgerSaveError,
-    LedgerValueNotFound)
+    LedgerValueNotFound,
+    NotAllowed,
+)
 from corehq.form_processor.interfaces.dbaccessors import (
     AbstractCaseAccessor,
     AbstractFormAccessor,
@@ -498,6 +500,7 @@ class FormAccessorSQL(AbstractFormAccessor):
     @staticmethod
     def hard_delete_forms(domain, form_ids, delete_attachments=True):
         assert isinstance(form_ids, list)
+        NotAllowed.check(domain)
 
         deleted_count = 0
         for db_name, split_form_ids in split_list_by_db_partition(form_ids):
@@ -527,6 +530,7 @@ class FormAccessorSQL(AbstractFormAccessor):
         from corehq.form_processor.change_publishers import publish_form_saved
 
         assert isinstance(form_ids, list)
+        NotAllowed.check(domain)
         problem = 'Restored on {}'.format(datetime.utcnow())
         with get_cursor(XFormInstanceSQL) as cursor:
             cursor.execute(
@@ -559,6 +563,7 @@ class FormAccessorSQL(AbstractFormAccessor):
     def soft_delete_forms(domain, form_ids, deletion_date=None, deletion_id=None):
         from corehq.form_processor.change_publishers import publish_form_deleted
         assert isinstance(form_ids, list)
+        NotAllowed.check(domain)
         deletion_date = deletion_date or datetime.utcnow()
         with get_cursor(XFormInstanceSQL) as cursor:
             cursor.execute(

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -888,6 +888,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
     @staticmethod
     def hard_delete_cases(domain, case_ids):
         assert isinstance(case_ids, list)
+        NotAllowed.check(domain)
         with get_cursor(CommCareCaseSQL) as cursor:
             cursor.execute('SELECT hard_delete_cases(%s, %s) as deleted_count', [domain, case_ids])
             results = fetchall_as_namedtuple(cursor)
@@ -1134,6 +1135,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         from corehq.form_processor.change_publishers import publish_case_saved
 
         assert isinstance(case_ids, list)
+        NotAllowed.check(domain)
 
         with get_cursor(CommCareCaseSQL) as cursor:
             cursor.execute(

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -77,5 +77,15 @@ class MissingFormXml(Exception):
     pass
 
 
+class DeleteNotAllowed(Exception):
+
+    @classmethod
+    def check(cls, domain):
+        from corehq.apps.couch_sql_migration.progress import \
+            couch_sql_migration_in_progress
+        if couch_sql_migration_in_progress(domain):
+            raise cls("couch-to-SQL migration in progress")
+
+
 class FormEditNotAllowed(Exception):
     pass

--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -77,7 +77,7 @@ class MissingFormXml(Exception):
     pass
 
 
-class DeleteNotAllowed(Exception):
+class NotAllowed(Exception):
 
     @classmethod
     def check(cls, domain):
@@ -85,7 +85,3 @@ class DeleteNotAllowed(Exception):
             couch_sql_migration_in_progress
         if couch_sql_migration_in_progress(domain):
             raise cls("couch-to-SQL migration in progress")
-
-
-class FormEditNotAllowed(Exception):
-    pass

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -770,11 +770,6 @@ class CommCareCaseSQL(PartitionedModel, models.Model, RedisLockableMixIn,
     def user_id(self, value):
         self.modified_by = value
 
-    def soft_delete(self):
-        from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-        CaseAccessorSQL.soft_delete_cases(self.domain, [self.case_id])
-        self.deleted = True
-
     @property
     def is_deleted(self):
         return self.deleted

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -4,8 +4,7 @@ from contextlib import contextmanager
 from couchdbkit import ResourceNotFound
 from ddtrace import tracer
 
-from corehq.apps.couch_sql_migration.progress import couch_sql_migration_in_progress
-from corehq.form_processor.exceptions import FormEditNotAllowed, MissingFormXml
+from corehq.form_processor.exceptions import MissingFormXml, NotAllowed
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.models import Attachment
@@ -222,8 +221,7 @@ def _handle_duplicate(new_doc):
                 #  - "Deprecate" the old form by making a new document with the same contents
                 #    but a different ID and a doc_type of XFormDeprecated
                 #  - Save the new instance to the previous document to preserve the ID
-                if couch_sql_migration_in_progress(new_doc.domain):
-                    raise FormEditNotAllowed("migration in progress")
+                NotAllowed.check(new_doc.domain)
                 existing_doc, new_doc = apply_deprecation(existing_doc, new_doc, interface)
                 return new_doc, existing_doc
     else:

--- a/corehq/form_processor/tests/test_kafka.py
+++ b/corehq/form_processor/tests/test_kafka.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
 from corehq.util.test_utils import create_and_save_a_case, create_and_save_a_form
 from pillowtop.pillow.interface import ConstructedPillow
@@ -79,7 +79,7 @@ class KafkaPublishingTest(TestCase):
     def test_case_deletions(self):
         case = create_and_save_a_case(self.domain, case_id=uuid.uuid4().hex, case_name='test case')
         with self.process_case_changes:
-            case.soft_delete()
+            CaseAccessors(self.domain).soft_delete_cases([case.case_id])
 
         self.assertEqual(1, len(self.processor.changes_seen))
         change_meta = self.processor.changes_seen[0].metadata


### PR DESCRIPTION
Things that are disabled

- un/delete form (hard and soft)
- un/retire mobile user
- un/delete case (hard and soft in most places)

🐡 Review by commit.

@orangejenny please review commit https://github.com/dimagi/commcare-hq/commit/e814c4cd1c7df3ec4ce233c0c94691a22c84ca5e, esp. the UI changes.