### PR TITLE
Fix payloads when PatientFinder is not configured

### DIFF
--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -81,9 +81,10 @@ class PatientFinder(DocumentSchema):
             }
 
         if cls is PatientFinder:
-            return {
+            subclass = {
                 sub._doc_type: sub for sub in recurse_subclasses(cls)
-            }[data['doc_type']].wrap(data)
+            }.get(data['doc_type'])
+            return subclass.wrap(data) if subclass else None
         else:
             return super(PatientFinder, cls).wrap(data)
 

--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -73,8 +73,7 @@ class PatientFinder(DocumentSchema):
 
     @classmethod
     def wrap(cls, data):
-
-        if 'create_missing' in data and data['create_missing'] in (True, False):
+        if 'create_missing' in data and isinstance(data['create_missing'], bool):
             data['create_missing'] = {
                 'doc_type': 'ConstantString',
                 'external_data_type': OPENMRS_DATA_TYPE_BOOLEAN,

--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -11,8 +11,6 @@ from functools import partial
 from operator import eq
 from pprint import pformat
 
-import six
-
 from dimagi.ext.couchdbkit import (
     DecimalProperty,
     DocumentSchema,
@@ -77,7 +75,7 @@ class PatientFinder(DocumentSchema):
             data['create_missing'] = {
                 'doc_type': 'ConstantString',
                 'external_data_type': OPENMRS_DATA_TYPE_BOOLEAN,
-                'value': six.text_type(data['create_missing'])
+                'value': str(data['create_missing'])
             }
 
         if cls is PatientFinder:
@@ -218,7 +216,7 @@ class WeightedPropertyPatientFinder(PatientFinder):
                 case.name, case.get_id, pformat(patient, indent=2),
             )
             return [patient]
-        patients_scores = sorted(six.itervalues(candidates), key=lambda candidate: candidate.score, reverse=True)
+        patients_scores = sorted(candidates.values(), key=lambda candidate: candidate.score, reverse=True)
         if patients_scores[0].score / patients_scores[1].score > 1 + self.confidence_margin:
             # There is more than a `confidence_margin` difference
             # (defaults to 10%) in score between the best-ranked

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -1,6 +1,5 @@
-
 import re
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 
 from lxml import html
 from six.moves import zip
@@ -33,8 +32,6 @@ from corehq.motech.requests import Requests
 from corehq.motech.value_source import CaseTriggerInfo
 from corehq.util.quickcache import quickcache
 from requests import RequestException
-
-OpenmrsResponse = namedtuple('OpenmrsResponse', 'status_code reason content')
 
 
 def get_case_location(case):
@@ -359,6 +356,8 @@ def generate_identifier(requests, identifier_type):
 def find_or_create_patient(requests, domain, info, openmrs_config):
     case = CaseAccessors(domain).get_case(info.case_id)
     patient_finder = PatientFinder.wrap(openmrs_config.case_config.patient_finder)
+    if patient_finder is None:
+        return
     patients = patient_finder.find_patients(requests, case, openmrs_config.case_config)
     if len(patients) == 1:
         patient, = patients

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
+import attr
 import six
 from memoized import memoized
 
@@ -29,7 +30,6 @@ from corehq.motech.openmrs.const import ATOM_FEED_NAME_PATIENT, XMLNS_OPENMRS
 from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.openmrs_config import OpenmrsConfig
 from corehq.motech.openmrs.repeater_helpers import (
-    OpenmrsResponse,
     get_case_location_ancestor_repeaters,
     get_patient,
     get_relevant_case_updates_from_form_json,
@@ -56,6 +56,17 @@ from corehq.motech.value_source import (
     get_form_question_values,
 )
 from corehq.toggles import OPENMRS_INTEGRATION
+
+
+@attr.s
+class OpenmrsResponse:
+    """
+    Ducktypes an HTTP response for Repeater.handle_response(),
+    RepeatRecord.handle_success() and RepeatRecord.handle_failure()
+    """
+    status_code = attr.ib()
+    reason = attr.ib()
+    text = attr.ib(default="")
 
 
 class AtomFeedStatus(DocumentSchema):
@@ -213,17 +224,19 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
     want to do. Each workflow task has a rollback task. If a task fails, all previous tasks are rolled back in
     reverse order.
 
-    :return: A response-like object that can be used by Repeater.handle_response
+    :return: A response-like object that can be used by Repeater.handle_response(),
+             RepeatRecord.handle_success() and RepeatRecord.handle_failure()
 
 
     .. _OpenMRS REST Web Services: https://wiki.openmrs.org/display/docs/REST+Web+Services+API+For+Clients
     """
+    warnings = []
     errors = []
     for info in case_trigger_infos:
         assert isinstance(info, CaseTriggerInfo)
         patient = get_patient(requests, domain, info, openmrs_config)
         if patient is None:
-            errors.append('Warning: CommCare case "{}" was not found in OpenMRS'.format(info.case_id))
+            warnings.append(f"CommCare case '{info.case_id}' was not found in OpenMRS.")
             continue
 
         # case_trigger_infos are info about all of the cases
@@ -266,9 +279,13 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
         # have succeeded, but don't say everything was OK if any
         # workflows failed. (Of course most forms will only involve one
         # case, so one workflow.)
-        return OpenmrsResponse(400, 'Bad Request', pformat_json([str(e) for e in errors]))
-    else:
-        return OpenmrsResponse(200, 'OK', '')
+        return OpenmrsResponse(400, 'Bad Request', "Errors: " + pformat_json([str(e) for e in errors]))
+
+    if warnings:
+        logger.warning("Warnings encountered sending OpenMRS data: %s", warnings)
+        return OpenmrsResponse(201, "Accepted", "Warnings: " + pformat_json([str(e) for e in warnings]))
+
+    return OpenmrsResponse(200, "OK")
 
 
 def create_openmrs_repeat_records(sender, xform, **kwargs):

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -236,7 +236,10 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
         assert isinstance(info, CaseTriggerInfo)
         patient = get_patient(requests, domain, info, openmrs_config)
         if patient is None:
-            warnings.append(f"CommCare case '{info.case_id}' was not found in OpenMRS.")
+            warnings.append(
+                f"CommCare case '{info.case_id}' was not matched to a "
+                f"patient in OpenMRS instance '{requests.base_url}'."
+            )
             continue
 
         # case_trigger_infos are info about all of the cases

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -47,6 +47,7 @@ class ValueSource(DocumentSchema):
 
     def __eq__(self, other):
         return (
+            isinstance(other, ValueSource) and
             self.doc_type == other.doc_type and
             self.external_data_type == other.external_data_type and
             self.commcare_data_type == other.commcare_data_type and

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -47,11 +47,11 @@ class ValueSource(DocumentSchema):
 
     def __eq__(self, other):
         return (
-            isinstance(other, ValueSource) and
-            self.doc_type == other.doc_type and
-            self.external_data_type == other.external_data_type and
-            self.commcare_data_type == other.commcare_data_type and
-            self.direction == other.direction
+            isinstance(other, ValueSource)
+            and self.doc_type == other.doc_type
+            and self.external_data_type == other.external_data_type
+            and self.commcare_data_type == other.commcare_data_type
+            and self.direction == other.direction
         )
 
     @classmethod


### PR DESCRIPTION
This fixes a bug in OpenMRS integration when MOTECH is not configured to find a patient in OpenMRS that corresponds to the case in the Repeater payload.

It also changes the way warnings (like "case not found in OpenMRS") are treated. Previously they were passed to `RepeatRecord.handle_failure()` which would retry a payload that had actually been sent (or not sent) correctly the first time.

Probably easier :blowfish: :fish: :tropical_fish: 
