### PR TITLE
Remove soft_assert_type_text() and de-six modules

### DIFF
--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -4,8 +4,6 @@ from django.contrib.auth.signals import user_logged_in
 from django.dispatch import receiver
 from django.urls import reverse
 
-import six
-
 from corehq.apps.accounting.signals import subscription_upgrade_or_downgrade
 from corehq.apps.analytics.tasks import (
     HUBSPOT_COOKIE,
@@ -21,7 +19,6 @@ from corehq.apps.registration.views import ProcessRegistrationView
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.signals import couch_user_post_save
 from corehq.util.decorators import handle_uncaught_exceptions
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.soft_assert import soft_assert
 
 _no_cookie_soft_assert = soft_assert(to=['{}@{}'.format('cellowitz', 'dimagi.com'),
@@ -44,8 +41,7 @@ def user_save_callback(sender, **kwargs):
 @receiver(commcare_domain_post_save)
 @receiver(subscription_upgrade_or_downgrade)
 def domain_save_callback(sender, domain, **kwargs):
-    if isinstance(domain, six.string_types):
-        soft_assert_type_text(domain)
+    if isinstance(domain, str):
         domain_name = domain
     else:
         domain_name = domain.name

--- a/corehq/apps/api/fields.py
+++ b/corehq/apps/api/fields.py
@@ -22,7 +22,8 @@ class AttributeOrCallable(object):
 
     def __call__(self, v):
         if isinstance(self.attribute, str):
-            accessor = lambda v: getattr(v, self.attribute)
+            def accessor(v):
+                return getattr(v, self.attribute)
         else:
             accessor = self.attribute
 

--- a/corehq/apps/api/fields.py
+++ b/corehq/apps/api/fields.py
@@ -1,20 +1,15 @@
 '''
 Fields for use in Tastypie Resources
 '''
-
-import six
 from tastypie.fields import ApiField, CharField
 
 import dimagi.utils.modules
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def get_referenced_class(class_or_str):
     # Simplified from https://github.com/toastdriven/django-tastypie/blob/master/tastypie/fields.py#L519
 
-    if isinstance(class_or_str, six.string_types):
-        soft_assert_type_text(class_or_str)
+    if isinstance(class_or_str, str):
         return dimagi.utils.modules.to_function(class_or_str)
     else:
         return class_or_str
@@ -26,8 +21,7 @@ class AttributeOrCallable(object):
         self.attribute = attribute
 
     def __call__(self, v):
-        if isinstance(self.attribute, six.string_types):
-            soft_assert_type_text(self.attribute)
+        if isinstance(self.attribute, str):
             accessor = lambda v: getattr(v, self.attribute)
         else:
             accessor = self.attribute

--- a/corehq/apps/api/serializers.py
+++ b/corehq/apps/api/serializers.py
@@ -48,7 +48,7 @@ class CommCareCaseSerializer(Serializer):
             else:
                 element = Element('objects')
             for item in data:
-                element.append(self.to_etree(item, options, depth=depth+1))
+                element.append(self.to_etree(item, options, depth=depth + 1))
         elif isinstance(data, dict):
             if depth == 0:
                 element = Element(name or 'response')
@@ -56,24 +56,26 @@ class CommCareCaseSerializer(Serializer):
                 element = Element(name or 'object')
                 element.set('type', 'hash')
             for (key, value) in data.items():
-                element.append(self.to_etree(value, options, name=key, depth=depth+1))
+                element.append(self.to_etree(value, options, name=key, depth=depth + 1))
         elif isinstance(data, Bundle):
-            element = self.bundle_to_etree(data) # <--------------- this is the part that is changed from https://github.com/toastdriven/django-tastypie/blob/master/tastypie/serializers.py
+            # next line is the part that is changed from
+            # https://github.com/toastdriven/django-tastypie/blob/master/tastypie/serializers.py
+            element = self.bundle_to_etree(data)
         elif hasattr(data, 'dehydrated_type'):
-            if getattr(data, 'dehydrated_type', None) == 'related' and data.is_m2m == False:
+            if getattr(data, 'dehydrated_type', None) == 'related' and data.is_m2m is False:
                 if data.full:
-                    return self.to_etree(data.fk_resource, options, name, depth+1)
+                    return self.to_etree(data.fk_resource, options, name, depth + 1)
                 else:
-                    return self.to_etree(data.value, options, name, depth+1)
-            elif getattr(data, 'dehydrated_type', None) == 'related' and data.is_m2m == True:
+                    return self.to_etree(data.value, options, name, depth + 1)
+            elif getattr(data, 'dehydrated_type', None) == 'related' and data.is_m2m is True:
                 if data.full:
                     element = Element(name or 'objects')
                     for bundle in data.m2m_bundles:
-                        element.append(self.to_etree(bundle, options, bundle.resource_name, depth+1))
+                        element.append(self.to_etree(bundle, options, bundle.resource_name, depth + 1))
                 else:
                     element = Element(name or 'objects')
                     for value in data.value:
-                        element.append(self.to_etree(value, options, name, depth=depth+1))
+                        element.append(self.to_etree(value, options, name, depth=depth + 1))
             else:
                 return self.to_etree(data.value, options, name)
         else:

--- a/corehq/apps/api/serializers.py
+++ b/corehq/apps/api/serializers.py
@@ -7,12 +7,9 @@ from django.utils.encoding import force_text
 
 # External imports
 import defusedxml.lxml as lxml
-import six
 from lxml.etree import Element
 from tastypie.bundle import Bundle
 from tastypie.serializers import Serializer, get_type_string
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class CommCareCaseSerializer(Serializer):
@@ -58,7 +55,7 @@ class CommCareCaseSerializer(Serializer):
             else:
                 element = Element(name or 'object')
                 element.set('type', 'hash')
-            for (key, value) in six.iteritems(data):
+            for (key, value) in data.items():
                 element.append(self.to_etree(value, options, name=key, depth=depth+1))
         elif isinstance(data, Bundle):
             element = self.bundle_to_etree(data) # <--------------- this is the part that is changed from https://github.com/toastdriven/django-tastypie/blob/master/tastypie/serializers.py
@@ -88,7 +85,7 @@ class CommCareCaseSerializer(Serializer):
                 element.set('type', get_type_string(simple_data))
 
             if data_type != 'null':
-                if isinstance(simple_data, six.text_type):
+                if isinstance(simple_data, str):
                     element.text = simple_data
                 else:
                     element.text = force_text(simple_data)
@@ -99,8 +96,7 @@ class CommCareCaseSerializer(Serializer):
 class CustomXMLSerializer(Serializer):
 
     def to_etree(self, data, options=None, name=None, depth=0):
-        if isinstance(name, six.string_types):
-            soft_assert_type_text(name)
+        if isinstance(name, str):
             # need to strip any whitespace from xml tag names
             name = name.strip()
         etree = super(CustomXMLSerializer, self).to_etree(data, options, name, depth)

--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -4,12 +4,10 @@ from collections import defaultdict
 
 from django.utils.translation import ugettext, ugettext_noop
 
-import six
 import yaml
 from memoized import memoized
 
 from corehq.apps.app_manager.util import app_doc_types
-from corehq.util.python_compatibility import soft_assert_type_text
 
 PROFILE_SETTINGS_TO_TRANSLATE = [
     'name',
@@ -26,11 +24,9 @@ LAYOUT_SETTINGS_TO_TRANSLATE = [
 
 def _translate_setting(setting, prop):
     value = setting[prop]
-    if not isinstance(value, six.string_types):
+    if not isinstance(value, str):
         return [ugettext(v) for v in value]
     else:
-        if six.PY3:
-            soft_assert_type_text(value)
         return ugettext(value)
 
 

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -5,16 +5,13 @@ from django.core.cache import cache
 from django.http import Http404
 from django.utils.translation import ugettext_lazy as _
 
-import six
 from couchdbkit.exceptions import DocTypeError, ResourceNotFound
-from six.moves import map
 
 from dimagi.utils.couch.database import iter_docs
 
 from corehq.apps.app_manager.exceptions import BuildNotFoundException
 from corehq.apps.es import AppES
 from corehq.apps.es.aggregations import NestedAggregation, TermsAggregation
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 
 AppBuildVersion = namedtuple('AppBuildVersion', ['app_id', 'build_id', 'version', 'comment'])
@@ -276,8 +273,7 @@ def get_app_ids_in_domain(domain):
 def get_apps_by_id(domain, app_ids):
     from .models import Application
     from corehq.apps.app_manager.util import get_correct_app_class
-    if isinstance(app_ids, six.string_types):
-        soft_assert_type_text(app_ids)
+    if isinstance(app_ids, str):
         app_ids = [app_ids]
     docs = iter_docs(Application.get_db(), app_ids)
     return [get_correct_app_class(doc).wrap(doc) for doc in docs]

--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -2,10 +2,6 @@ from distutils.version import LooseVersion, Version
 
 from django.conf import settings
 
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
-
 
 class CommCareFeatureSupportMixin(object):
     # overridden by subclass
@@ -15,9 +11,8 @@ class CommCareFeatureSupportMixin(object):
         if settings.UNIT_TESTING and self.build_version is None:
             return False
         assert isinstance(self.build_version, Version)
-        assert isinstance(minimum_version, six.string_types + (Version,))
-        if isinstance(minimum_version, six.string_types):
-            soft_assert_type_text(minimum_version)
+        assert isinstance(minimum_version, (str, Version))
+        if isinstance(minimum_version, str):
             minimum_version = LooseVersion(minimum_version)
         return self.build_version and self.build_version >= minimum_version
 

--- a/corehq/apps/app_manager/management/commands/migrate_localized_media.py
+++ b/corehq/apps/app_manager/management/commands/migrate_localized_media.py
@@ -1,10 +1,7 @@
-import six
-
 from corehq.apps.app_manager.management.commands.helpers import (
     AppMigrationCommandBase,
 )
 from corehq.apps.app_manager.models import Application
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class Command(AppMigrationCommandBase):
@@ -69,8 +66,7 @@ class Command(AppMigrationCommandBase):
         should_save = False
         for media_attr in ('media_image', 'media_audio'):
             old_media = doc.get(media_attr, None)
-            if old_media and isinstance(old_media, six.string_types):
-                soft_assert_type_text(old_media)
+            if old_media and isinstance(old_media, str):
                 doc[media_attr] = {'default': old_media}
                 should_save = True
 

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -1,7 +1,5 @@
 from collections import defaultdict
 
-import six
-
 from corehq.apps.app_manager import id_strings, models
 from corehq.apps.app_manager.const import (
     MOBILE_UCR_MIGRATING_TO_2,
@@ -28,7 +26,6 @@ from corehq.apps.reports_core.filters import (
     DynamicChoiceListFilter,
 )
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 
 COLUMN_XPATH_TEMPLATE = "column[@id='{}']"
@@ -348,8 +345,7 @@ def _get_data_detail(config, domain, new_mobile_ucr_restore):
                     default_val = "column[@id='{column_id}']"
                 xpath_function = default_val
                 for word, translations in transform['translations'].items():
-                    if isinstance(translations, six.string_types):
-                        soft_assert_type_text(translations)
+                    if isinstance(translations, str):
                         # This is a flat mapping, not per-language translations
                         word_eval = "'{}'".format(translations)
                     else:

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -21,11 +21,9 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 
-import six
 from couchdbkit import ResourceNotFound
 from diff_match_patch import diff_match_patch
 from lxml import etree
-from six.moves import zip
 from unidecode import unidecode
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
@@ -116,7 +114,6 @@ from corehq.apps.domain.decorators import (
 from corehq.apps.programs.models import Program
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.view_utils import set_file_download
 
 
@@ -138,7 +135,7 @@ def delete_form(request, domain, app_id, module_unique_id, form_unique_id):
     try:
         module_id = app.get_module_by_unique_id(module_unique_id).id
     except ModuleNotFoundException as e:
-        messages.error(request, six.text_type(e))
+        messages.error(request, str(e))
         module_id = None
 
     return back_to_main(request, domain, app_id=app_id, module_id=module_id)
@@ -227,8 +224,7 @@ def edit_form_actions(request, domain, app_id, form_unique_id):
         form.actions.load_from_form = old_load_from_form
 
     for condition in (form.actions.open_case.condition, form.actions.close_case.condition):
-        if isinstance(condition.answer, six.string_types):
-            soft_assert_type_text(condition.answer)
+        if isinstance(condition.answer, str):
             condition.answer = condition.answer.strip('"\'')
     form.requires = request.POST.get('requires', form.requires)
     if actions_use_usercase(form.actions):
@@ -270,7 +266,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
         form = app.get_form(form_unique_id)
     except FormNotFoundException as e:
         if ajax:
-            return HttpResponseBadRequest(six.text_type(e))
+            return HttpResponseBadRequest(str(e))
         else:
             messages.error(request, _("There was an error saving, please try again!"))
             return back_to_main(request, domain, app_id=app_id)
@@ -310,7 +306,7 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                 xform = request.POST.get('xform')
             else:
                 try:
-                    xform = six.text_type(xform, encoding="utf-8")
+                    xform = str(xform, encoding="utf-8")
                 except Exception:
                     raise Exception("Error uploading form: Please make sure your form is encoded in UTF-8")
             if request.POST.get('cleanup', False):
@@ -324,17 +320,17 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                 except Exception:
                     pass
             if xform:
-                if isinstance(xform, six.text_type):
+                if isinstance(xform, str):
                     xform = xform.encode('utf-8')
                 save_xform(app, form, xform)
             else:
                 raise Exception("You didn't select a form to upload")
         except Exception as e:
-            notify_exception(request, six.text_type(e))
+            notify_exception(request, str(e))
             if ajax:
-                return HttpResponseBadRequest(six.text_type(e))
+                return HttpResponseBadRequest(str(e))
             else:
-                messages.error(request, six.text_type(e))
+                messages.error(request, str(e))
     if should_edit("references") or should_edit("case_references"):
         form.case_references = _get_case_references(request.POST)
     if should_edit("show_count"):
@@ -684,11 +680,11 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
                 has_case_error = True
                 messages.error(request, "Error in Case Management: %s" % e)
             except XFormException as e:
-                messages.error(request, six.text_type(e))
+                messages.error(request, str(e))
             except Exception as e:
                 if settings.DEBUG:
                     raise
-                logging.exception(six.text_type(e))
+                logging.exception(str(e))
                 messages.error(request, "Unexpected Error: %s" % e)
 
     try:

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -21,11 +21,8 @@ seem to be a good fit.
 import re
 import uuid
 
-import six
 from lxml import etree
 from lxml.builder import E
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 EMPTY_XFORM = """<?xml version="1.0"?>
 <h:html xmlns:h="http://www.w3.org/1999/xhtml"
@@ -133,11 +130,9 @@ class XFormBuilder(object):
         """
         if data_type is not None and data_type not in ODK_TYPES + GROUP_TYPES:
             raise TypeError('Unknown question data type "{}"'.format(data_type))
-        if isinstance(group, six.string_types):
-            soft_assert_type_text(group)
-        if group is not None and not isinstance(group, six.string_types) and not hasattr(group, '__iter__'):
+        if group is not None and not isinstance(group, str) and not hasattr(group, '__iter__'):
             raise TypeError('group parameter needs to be a string or iterable')
-        groups = [group] if isinstance(group, six.string_types) else group
+        groups = [group] if isinstance(group, str) else group
         self._append_to_data(name, groups)
         self._append_to_model(name, data_type, groups, **params)
         if data_type is not None:
@@ -169,15 +164,15 @@ class XFormBuilder(object):
         """
         Builds a text node "id" parameter
 
-        >>> XFormBuilder.get_text_id('foo') if six.PY3 else XFormBuilder.get_text_id('foo').encode('utf-8')
+        >>> XFormBuilder.get_text_id('foo')
         'foo-label'
-        >>> XFormBuilder.get_text_id('foo', ['bar']) if six.PY3 else XFormBuilder.get_text_id('foo', ['bar']).encode('utf-8')
+        >>> XFormBuilder.get_text_id('foo', ['bar'])
         'bar/foo-label'
-        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz']) if six.PY3 else XFormBuilder.get_text_id('foo', ['bar', 'baz']).encode('utf-8')
+        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'])
         'bar/baz/foo-label'
-        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'], 'choice1') if six.PY3 else XFormBuilder.get_text_id('foo', ['bar', 'baz'], 'choice1').encode('utf-8')
+        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'], 'choice1')
         'bar/baz/foo-choice1-label'
-        >>> XFormBuilder.get_text_id('foo', is_hint=True) if six.PY3 else XFormBuilder.get_text_id('foo', is_hint=True).encode('utf-8')
+        >>> XFormBuilder.get_text_id('foo', is_hint=True)
         'foo-hint'
 
         """
@@ -195,11 +190,11 @@ class XFormBuilder(object):
         """
         Returns the reference to the data node of the given question
 
-        >>> XFormBuilder.get_data_ref('foo') if six.PY3 else XFormBuilder.get_data_ref('foo').encode('utf-8')
+        >>> XFormBuilder.get_data_ref('foo')
         '/data/foo'
-        >>> XFormBuilder.get_data_ref('foo', ['bar']) if six.PY3 else XFormBuilder.get_data_ref('foo', ['bar']).encode('utf-8')
+        >>> XFormBuilder.get_data_ref('foo', ['bar'])
         '/data/bar/foo'
-        >>> XFormBuilder.get_data_ref('foo', ['bar', 'baz']) if six.PY3 else XFormBuilder.get_data_ref('foo', ['bar', 'baz']).encode('utf-8')
+        >>> XFormBuilder.get_data_ref('foo', ['bar', 'baz'])
         '/data/bar/baz/foo'
 
         """
@@ -212,9 +207,9 @@ class XFormBuilder(object):
         Return a namespaced parameter/tag name
 
         >>> xform = XFormBuilder()
-        >>> xform.get_namespaced('jr:constraintMsg') if six.PY3 else xform.get_namespaced('jr:constraintMsg').encode('utf-8')
+        >>> xform.get_namespaced('jr:constraintMsg')
         '{http://openrosa.org/javarosa}constraintMsg'
-        >>> xform.get_namespaced('constraint') if six.PY3 else xform.get_namespaced('constraint').encode('utf-8')
+        >>> xform.get_namespaced('constraint')
         'constraint'
 
         """
@@ -357,12 +352,10 @@ class XFormBuilder(object):
                     E.hint({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, is_hint=True))})
                 )
             for choice_name in choices_.keys():
-                if isinstance(choice_name, six.string_types):
-                    soft_assert_type_text(choice_name)
                 node_.append(
                     E.item(
                         E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, choice_name))}),
-                        E.value(choice_name if isinstance(choice_name, six.string_types) else str(choice_name))
+                        E.value(choice_name if isinstance(choice_name, str) else str(choice_name))
                     )
                 )
             return node_

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -5,7 +5,6 @@ from collections import Counter, defaultdict, namedtuple
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
-import six
 from couchdbkit import NoResultFound
 
 from casexml.apps.case.const import CASE_TAG_DATE_OPENED
@@ -24,7 +23,6 @@ from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import format_username
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 from corehq.util.datadog.utils import case_load_counter
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.soft_assert import soft_assert
 
 from . import exceptions
@@ -386,7 +384,7 @@ class _ImportResults(object):
         self._results[row_num] = self.UPDATED
 
     def to_json(self):
-        counts = Counter(six.itervalues(self._results))
+        counts = Counter(self._results.values())
         return {
             'created_count': counts.get(self.CREATED, 0),
             'match_count': counts.get(self.UPDATED, 0),
@@ -397,10 +395,7 @@ class _ImportResults(object):
 
 def _convert_field_value(value):
     # coerce to string unless it's a unicode string then we want that
-    if isinstance(value, six.text_type):
-        return value
-    else:
-        return str(value)
+    return value if isinstance(value, str) else str(value)
 
 
 def _parse_search_id(config, row):
@@ -446,8 +441,7 @@ def _populate_updated_fields(config, row):
             raise exceptions.InvalidCustomFieldNameException(
                 _('Field name "{}" is reserved').format(update_field_name))
 
-        if isinstance(update_value, six.string_types) and update_value.strip() == SCALAR_NEVER_WAS:
-            soft_assert_type_text(update_value)
+        if isinstance(update_value, str) and update_value.strip() == SCALAR_NEVER_WAS:
             # If we find any instances of blanks ('---'), convert them to an
             # actual blank value without performing any data type validation.
             # This is to be consistent with how the case export works.

--- a/corehq/apps/case_search/xpath_functions.py
+++ b/corehq/apps/case_search/xpath_functions.py
@@ -1,12 +1,7 @@
-
 import datetime
 
 from django.utils.dateparse import parse_date
 from django.utils.translation import ugettext as _
-
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class XPathFunctionException(Exception):
@@ -22,8 +17,7 @@ def date(node):
     if isinstance(arg, int):
         return (datetime.date(1970, 1, 1) + datetime.timedelta(days=arg)).strftime("%Y-%m-%d")
 
-    if isinstance(arg, six.string_types):
-        soft_assert_type_text(arg)
+    if isinstance(arg, str):
         try:
             parsed_date = parse_date(arg)
         except ValueError:

--- a/corehq/apps/cleanup/management/commands/pillow_reset.py
+++ b/corehq/apps/cleanup/management/commands/pillow_reset.py
@@ -3,16 +3,12 @@ from datetime import datetime
 
 from django.core.management.base import BaseCommand
 
-import six
 from couchdbkit import ResourceNotFound
-from six.moves import input
 
 from dimagi.ext.jsonobject import JsonObject, ListProperty, StringProperty
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.parsing import json_format_datetime
 from pillowtop.utils import get_pillow_by_name
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class Command(BaseCommand):
@@ -37,8 +33,7 @@ class Command(BaseCommand):
                     continue
 
                 def _fmt(seq_id):
-                    if isinstance(seq_id, six.string_types) and len(seq_id) > 20:
-                        soft_assert_type_text(seq_id)
+                    if isinstance(seq_id, str) and len(seq_id) > 20:
                         return '{}...'.format(seq_id[:20])
                     else:
                         return seq_id

--- a/corehq/apps/cloudcare/touchforms_api.py
+++ b/corehq/apps/cloudcare/touchforms_api.py
@@ -1,10 +1,7 @@
-import six
-
 from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
 from corehq.apps.cloudcare import CLOUDCARE_DEVICE_ID
 from corehq.apps.users.models import CouchUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.util.python_compatibility import soft_assert_type_text
 
 DELEGATION_STUB_CASE_TYPE = "cc_delegation_stub"
 
@@ -52,9 +49,7 @@ class CaseSessionDataHelper(BaseSessionDataHelper):
         super(CaseSessionDataHelper, self).__init__(domain, couch_user)
         self.form = form
         self.app = app
-        if case_id_or_case is None or isinstance(case_id_or_case, six.string_types):
-            if case_id_or_case is not None:
-                soft_assert_type_text(case_id_or_case)
+        if case_id_or_case is None or isinstance(case_id_or_case, str):
             self.case_id = case_id_or_case
             self._case = None
         else:

--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -12,7 +12,6 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 from couchdbkit import ResourceNotFound
 from crispy_forms.bootstrap import (
     FieldWithButtons,
-    FormActions,
     InlineField,
     StrictButton,
 )

--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -9,7 +9,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-import six
 from couchdbkit import ResourceNotFound
 from crispy_forms.bootstrap import (
     FieldWithButtons,
@@ -38,7 +37,6 @@ from corehq.apps.hqwebapp.crispy import HQFormHelper
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es,
 )
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def true_or_false(value):
@@ -51,8 +49,7 @@ def true_or_false(value):
 
 
 def remove_quotes(value):
-    if isinstance(value, six.string_types) and len(value) >= 2:
-        soft_assert_type_text(value)
+    if isinstance(value, str) and len(value) >= 2:
         for q in ("'", '"'):
             if value.startswith(q) and value.endswith(q):
                 return value[1:-1]
@@ -60,9 +57,8 @@ def remove_quotes(value):
 
 
 def is_valid_case_property_name(value):
-    if not isinstance(value, six.string_types):
+    if not isinstance(value, str):
         return False
-    soft_assert_type_text(value)
     try:
         validate_case_property_characters(value)
         return True
@@ -78,9 +74,8 @@ def validate_case_property_characters(value):
 
 
 def validate_case_property_name(value, allow_parent_case_references=True):
-    if not isinstance(value, six.string_types):
+    if not isinstance(value, str):
         raise ValidationError(_("Please specify a case property name."))
-    soft_assert_type_text(value)
 
     value = value.strip()
 
@@ -119,9 +114,8 @@ def hidden_bound_field(field_name, data_value):
 
 
 def validate_case_property_value(value):
-    if not isinstance(value, six.string_types):
+    if not isinstance(value, str):
         raise ValidationError(_("Please specify a case property value."))
-    soft_assert_type_text(value)
 
     value = remove_quotes(value.strip()).strip()
     if not value:

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -86,15 +86,11 @@ AUTO_UPDATE_XMLNS = 'http://commcarehq.org/hq_case_update_rule'
 def _try_date_conversion(date_or_string):
     if isinstance(date_or_string, bytes):
         date_or_string = date_or_string.decode('utf-8')
-    if (
-        isinstance(date_or_string, str) and
-        ALLOWED_DATE_REGEX.match(date_or_string)
-    ):
+    if isinstance(date_or_string, str) and ALLOWED_DATE_REGEX.match(date_or_string):
         try:
             return parse(date_or_string)
         except ValueError:
             pass
-
     return date_or_string
 
 

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -11,7 +11,6 @@ from django.utils.translation import ugettext_lazy
 
 import jsonfield
 import pytz
-import six
 from couchdbkit.exceptions import ResourceNotFound
 from dateutil.parser import parse
 from jsonobject.api import JsonObject
@@ -77,7 +76,6 @@ from corehq.sql_db.util import (
     paginate_query_across_partitioned_databases,
 )
 from corehq.util.log import with_progress_bar
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 from corehq.util.test_utils import unit_testing_only
 
@@ -89,7 +87,7 @@ def _try_date_conversion(date_or_string):
     if isinstance(date_or_string, bytes):
         date_or_string = date_or_string.decode('utf-8')
     if (
-        isinstance(date_or_string, six.text_type) and
+        isinstance(date_or_string, str) and
         ALLOWED_DATE_REGEX.match(date_or_string)
     ):
         try:
@@ -100,7 +98,6 @@ def _try_date_conversion(date_or_string):
     return date_or_string
 
 
-@six.python_2_unicode_compatible
 class AutomaticUpdateRule(models.Model):
     # Used when the rule performs case update actions
     WORKFLOW_CASE_UPDATE = 'CASE_UPDATE'
@@ -138,7 +135,7 @@ class AutomaticUpdateRule(models.Model):
         pass
 
     def __str__(self):
-        return six.text_type("rule: '{s.name}', id: {s.id}, domain: {s.domain}").format(s=self)
+        return f"rule: '{self.name}', id: {self.id}, domain: {self.domain}"
 
     @property
     def references_parent_case(self):
@@ -536,9 +533,8 @@ class AutomaticUpdateRule(models.Model):
             query = query.server_modified_range(lte=boundary_date)
 
         for case_id in query.scroll():
-            if not isinstance(case_id, six.string_types):
+            if not isinstance(case_id, str):
                 raise ValueError("Something is wrong with the query, expected ids only")
-            soft_assert_type_text(case_id)
 
             yield case_id
 
@@ -846,8 +842,7 @@ class MatchPropertyDefinition(CaseRuleCriteriaDefinition):
         for value in values:
             if value is None:
                 continue
-            if isinstance(value, six.string_types) and not value.strip():
-                soft_assert_type_text(value)
+            if isinstance(value, str) and not value.strip():
                 continue
             return True
 
@@ -863,10 +858,7 @@ class MatchPropertyDefinition(CaseRuleCriteriaDefinition):
             return False
 
         for value in self.get_case_values(case):
-            if six.PY2 and isinstance(value, bytes):
-                value = value.decode('utf-8')
-            if isinstance(value, (six.text_type, bytes)):
-                soft_assert_type_text(value)
+            if isinstance(value, str):
                 try:
                     if regex.match(value):
                         return True

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -21,7 +21,6 @@ from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
 from django.views import View
 
-import six
 from django_otp import match_token
 from tastypie.authentication import ApiKeyAuthentication
 from tastypie.http import HttpUnauthorized
@@ -54,7 +53,6 @@ from corehq.toggles import (
     PUBLISH_CUSTOM_REPORTS,
     TWO_FACTOR_SUPERUSER_ROLLOUT,
 )
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.soft_assert import soft_assert
 from django_digest.decorators import httpdigest
 
@@ -520,17 +518,15 @@ def track_domain_request(calculated_prop):
                     len(args) > 2 and
                     isinstance(args[0], View) and
                     isinstance(args[1], HttpRequest) and
-                    isinstance(args[2], six.string_types)
+                    isinstance(args[2], str)
             ):
-                soft_assert_type_text(args[2])
                 # class-based view; args == (self, request, domain, ...)
                 domain = args[2]
             elif (
                     len(args) > 1 and
                     isinstance(args[0], HttpRequest) and
-                    isinstance(args[1], six.string_types)
+                    isinstance(args[1], str)
             ):
-                soft_assert_type_text(args[1])
                 # view function; args == (request, domain, ...)
                 domain = args[1]
             else:

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -515,17 +515,17 @@ def track_domain_request(calculated_prop):
             if 'domain' in kwargs:
                 domain = kwargs['domain']
             elif (
-                    len(args) > 2 and
-                    isinstance(args[0], View) and
-                    isinstance(args[1], HttpRequest) and
-                    isinstance(args[2], str)
+                len(args) > 2
+                and isinstance(args[0], View)
+                and isinstance(args[1], HttpRequest)
+                and isinstance(args[2], str)
             ):
                 # class-based view; args == (self, request, domain, ...)
                 domain = args[2]
             elif (
-                    len(args) > 1 and
-                    isinstance(args[0], HttpRequest) and
-                    isinstance(args[1], str)
+                len(args) > 1
+                and isinstance(args[0], HttpRequest)
+                and isinstance(args[1], str)
             ):
                 # view function; args == (request, domain, ...)
                 domain = args[1]

--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -39,11 +39,7 @@ import re
 from collections import defaultdict, namedtuple
 from copy import deepcopy
 
-import six
-from six.moves import filter
-
 from corehq.elastic import SIZE_LIMIT
-from corehq.util.python_compatibility import soft_assert_type_text
 
 MISSING_KEY = None
 
@@ -442,10 +438,8 @@ class AggregationRange(namedtuple('AggregationRange', 'start end key')):
             if value:
                 if isinstance(value, datetime.date):
                     value = value.isoformat()
-                elif not isinstance(value, six.string_types):
-                    value = six.text_type(value)
-                else:
-                    soft_assert_type_text(value)
+                elif not isinstance(value, str):
+                    value = str(value)
                 range_[key] = value
         return range_
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -24,7 +24,6 @@ from corehq.apps.case_search.const import (
     SYSTEM_PROPERTIES,
     VALUE,
 )
-from corehq.apps.es.aggregations import BucketResult, TermsAggregation
 from corehq.apps.es.cases import CaseES, owner
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_ALIAS
 

--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -14,8 +14,6 @@ from warnings import warn
 
 from django.utils.dateparse import parse_date
 
-import six
-
 from corehq.apps.case_search.const import (
     CASE_PROPERTIES_PATH,
     IDENTIFIER,
@@ -29,7 +27,6 @@ from corehq.apps.case_search.const import (
 from corehq.apps.es.aggregations import BucketResult, TermsAggregation
 from corehq.apps.es.cases import CaseES, owner
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_ALIAS
-from corehq.util.python_compatibility import soft_assert_type_text
 
 from . import filters, queries
 
@@ -121,8 +118,7 @@ class CaseSearchES(CaseES):
     def get_child_cases(self, case_ids, identifier):
         """Returns all cases that reference cases with ids: `case_ids`
         """
-        if isinstance(case_ids, six.string_types):
-            soft_assert_type_text(case_ids)
+        if isinstance(case_ids, str):
             case_ids = [case_ids]
 
         return self.add_query(
@@ -202,7 +198,7 @@ def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lt
     # if its a number, use it
     try:
         # numeric range
-        kwargs = {key: float(value) for key, value in six.iteritems(kwargs) if value is not None}
+        kwargs = {key: float(value) for key, value in kwargs.items() if value is not None}
         return _base_property_query(
             case_property_name,
             queries.range_query("{}.{}.numeric".format(CASE_PROPERTIES_PATH, VALUE), **kwargs)
@@ -213,7 +209,7 @@ def case_property_range_query(case_property_name, gt=None, gte=None, lt=None, lt
     # if its a date, use it
     # date range
     kwargs = {
-        key: parse_date(value) for key, value in six.iteritems(kwargs)
+        key: parse_date(value) for key, value in kwargs.items()
         if value is not None and parse_date(value) is not None
     }
     if not kwargs:
@@ -233,8 +229,7 @@ def reverse_index_case_query(case_ids, identifier=None):
     with identifier `parent`.
 
     """
-    if isinstance(case_ids, six.string_types):
-        soft_assert_type_text(case_ids)
+    if isinstance(case_ids, str):
         case_ids = [case_ids]
 
     if identifier is None:      # some old relationships don't have an identifier specified

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -17,12 +17,6 @@ either ESQuery or HQESQuery, as appropriate (is it an HQ thing?).
 """
 
 
-
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
-
-
 def match_all():
     return {"match_all": {}}
 
@@ -75,9 +69,7 @@ def range_filter(field, gt=None, gte=None, lt=None, lte=None):
 def date_range(field, gt=None, gte=None, lt=None, lte=None):
     """Range filter that accepts datetime objects as arguments"""
     def format_date(date):
-        if isinstance(date, six.string_types):
-            soft_assert_type_text(date)
-        return date if isinstance(date, six.string_types) else date.isoformat()
+        return date if isinstance(date, str) else date.isoformat()
     params = [d if d is None else format_date(d) for d in [gt, gte, lt, lte]]
     return range_filter(field, *params)
 

--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -1,5 +1,3 @@
-
-import six
 from elasticsearch import ElasticsearchException
 
 from corehq.apps.es import CaseES, FormES, GroupES, LedgerES
@@ -9,7 +7,6 @@ from corehq.apps.es.aggregations import (
 )
 from corehq.apps.es.sms import SMSES
 from corehq.elastic import ES_EXPORT_INSTANCE, get_es_new
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def get_form_export_base_query(domain, app_id, xmlns, include_errors):
@@ -46,8 +43,7 @@ def get_groups_user_ids(group_ids):
 
     results = []
     for user_list in q.values_list("users", flat=True):
-        if isinstance(user_list, six.string_types):
-            soft_assert_type_text(user_list)
+        if isinstance(user_list, str):
             results.append(user_list)
         else:
             results.extend(user_list)

--- a/corehq/apps/export/filters.py
+++ b/corehq/apps/export/filters.py
@@ -1,5 +1,3 @@
-import six
-
 from corehq.apps.es import filters as esfilters
 from corehq.apps.es.cases import (
     closed_range,
@@ -15,12 +13,10 @@ from corehq.apps.es.forms import app, submitted, user_id, user_type
 from corehq.apps.es.sms import received as sms_received
 from corehq.apps.export.esaccessors import get_groups_user_ids
 from corehq.pillows.utils import USER_TYPES
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def _assert_user_types(user_types):
-    if isinstance(user_types, six.string_types):
-        soft_assert_type_text(user_types)
+    if isinstance(user_types, str):
         user_types = [user_types]
 
     for type_ in user_types:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1,4 +1,3 @@
-
 import logging
 from collections import OrderedDict, defaultdict, namedtuple
 from copy import copy
@@ -13,7 +12,6 @@ from django.http import Http404
 from django.utils.datastructures import OrderedSet
 from django.utils.translation import ugettext as _
 
-import six
 from couchdbkit import (
     BooleanProperty,
     DictProperty,
@@ -22,7 +20,6 @@ from couchdbkit import (
     SchemaProperty,
 )
 from memoized import memoized
-from six.moves import filter, map, range
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
 from couchexport.models import Format
@@ -118,7 +115,6 @@ from corehq.blobs.util import random_url_id
 from corehq.form_processor.interfaces.dbaccessors import LedgerAccessors
 from corehq.sql_db.util import get_db_alias_for_partitioned_doc
 from corehq.util.global_request import get_request_domain
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.timezones.utils import get_timezone_for_domain
 from corehq.util.view_utils import absolute_reverse
 
@@ -1906,7 +1902,7 @@ class FormExportDataSchema(ExportDataSchema):
             _add_to_group_schema(path, case_attribute, datatype=datatype)
 
         # Add case updates
-        for case_property, case_path in six.iteritems(case_properties):
+        for case_property, case_path in case_properties.items():
             path_suffix = case_property
             path = '{}/case/update/{}'.format(root_path, path_suffix)
             _add_to_group_schema(path, 'update.{}'.format(case_property))
@@ -2112,7 +2108,7 @@ class CaseExportDataSchema(ExportDataSchema):
             last_occurrences={app_id: app_version},
         )
 
-        for case_type, case_properties in six.iteritems(case_property_mapping):
+        for case_type, case_properties in case_property_mapping.items():
 
             for prop in case_properties:
                 group_schema.items.append(ScalarItem(
@@ -2282,13 +2278,13 @@ def _merge_dicts(one, two, resolvefn):
     # keys either in one or two, but not both
     merged = {
         key: one.get(key, two.get(key))
-        for key in six.viewkeys(one) ^ six.viewkeys(two)
+        for key in one.keys() ^ two.keys()
     }
 
     # merge keys that exist in both
     merged.update({
         key: resolvefn(one[key], two[key])
-        for key in six.viewkeys(one) & six.viewkeys(two)
+        for key in one.keys() & two.keys()
     })
     return merged
 
@@ -2335,10 +2331,8 @@ class SplitUserDefinedExportColumn(ExportColumn):
         if self.split_type == PLAIN_USER_DEFINED_SPLIT_TYPE:
             return value
 
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             return [None] * len(self.user_defined_options) + [value]
-        else:
-            soft_assert_type_text(value)
 
         selected = OrderedDict((x, 1) for x in value.split(" "))
         row = []
@@ -2422,10 +2416,8 @@ class SplitGPSExportColumn(ExportColumn):
 
         values = [EMPTY_VALUE] * 4
 
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             return values
-        else:
-            soft_assert_type_text(value)
 
         for index, coordinate in enumerate(value.split(' ')):
             values[index] = coordinate
@@ -2474,11 +2466,9 @@ class SplitExportColumn(ExportColumn):
                 value.append(MISSING_VALUE)
             return value
 
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             unspecified_options = [] if self.ignore_unspecified_options else [value]
             return [EMPTY_VALUE] * len(self.item.options) + unspecified_options
-        else:
-            soft_assert_type_text(value)
 
         selected = OrderedDict((x, 1) for x in value.split(" "))
         row = []
@@ -2526,7 +2516,7 @@ class RowNumberColumn(ExportColumn):
     def get_value(self, domain, doc_id, doc, base_path, transform_dates=False, row_index=None, **kwargs):
         assert row_index, 'There must be a row_index for number column'
         return (
-            [".".join([six.text_type(i) for i in row_index])]
+            [".".join([str(i) for i in row_index])]
             + (list(row_index) if len(row_index) > 1 else [])
         )
 

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -206,7 +206,7 @@ class FixtureDataItem(Document):
                 break
             fields_dict[field] = {
                 "field_list": [{
-                    'field_value': str(field_val) if not isinstance(field_val, (str, bytes)) else field_val,
+                    'field_value': str(field_val) if not isinstance(field_val, str) else field_val,
                     'properties': {}
                 }]
             }

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -4,7 +4,6 @@ from xml.etree import cElementTree as ElementTree
 
 from django.db import models
 
-import six
 from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from memoized import memoized
 
@@ -40,7 +39,6 @@ from corehq.apps.fixtures.utils import (
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import CommCareUser
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.xml_utils import serialize
 
 FIXTURE_BUCKET = 'domain-fixtures'
@@ -66,8 +64,7 @@ class FixtureDataType(QuickCachedDocumentMixin, Document):
         if not obj["doc_type"] == "FixtureDataType":
             raise ResourceNotFound
         # Migrate fixtures without attributes on item-fields to fields with attributes
-        if obj["fields"] and isinstance(obj['fields'][0], six.string_types):
-            soft_assert_type_text(obj['fields'][0])
+        if obj["fields"] and isinstance(obj['fields'][0], str):
             obj['fields'] = [{'field_name': f, 'properties': []} for f in obj['fields']]
 
         # Migrate fixtures without attributes on items to items with attributes
@@ -198,9 +195,7 @@ class FixtureDataItem(Document):
         fields_dict = {}
 
         def _is_new_type(field_val):
-            if isinstance(field_val, six.string_types):
-                soft_assert_type_text(field_val)
-            old_types = (six.string_types, int, float)
+            old_types = (str, int, float)
             return field_val is not None and not isinstance(field_val, old_types)
 
         for field in obj['fields']:
@@ -211,7 +206,7 @@ class FixtureDataItem(Document):
                 break
             fields_dict[field] = {
                 "field_list": [{
-                    'field_value': str(field_val) if not isinstance(field_val, six.string_types) else field_val,
+                    'field_value': str(field_val) if not isinstance(field_val, (str, bytes)) else field_val,
                     'properties': {}
                 }]
             }
@@ -483,8 +478,7 @@ class FixtureDataItem(Document):
 
 
 def _id_from_doc(doc_or_doc_id):
-    if isinstance(doc_or_doc_id, six.string_types):
-        soft_assert_type_text(doc_or_doc_id)
+    if isinstance(doc_or_doc_id, str):
         doc_id = doc_or_doc_id
     else:
         doc_id = doc_or_doc_id.get_id if doc_or_doc_id else None

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -5,7 +5,14 @@ from django.conf import settings
 
 from memoized import memoized
 
-from dimagi.ext.couchdbkit import *
+from dimagi.ext.couchdbkit import (
+    BooleanProperty,
+    DateTimeProperty,
+    DictProperty,
+    ListProperty,
+    SetProperty,
+    StringProperty,
+)
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.undo import (
     DELETED_SUFFIX,
@@ -273,7 +280,8 @@ class Group(QuickCachedDocumentMixin, UndoableDocument):
     def user_in_group(cls, user_id, group_id):
         if not user_id or not group_id:
             return False
-        c = cls.get_db().view('groups/by_user',
+        c = cls.get_db().view(
+            'groups/by_user',
             key=user_id,
             startkey_docid=group_id,
             endkey_docid=group_id

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -3,9 +3,7 @@ from datetime import datetime
 
 from django.conf import settings
 
-import six
 from memoized import memoized
-from six.moves import filter, map, range
 
 from dimagi.ext.couchdbkit import *
 from dimagi.utils.couch.database import iter_docs
@@ -25,7 +23,6 @@ from corehq.apps.groups.dbaccessors import (
 from corehq.apps.groups.exceptions import CantSaveException
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import CommCareUser, CouchUser
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 
 dt_no_Z_re = re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d\d\d\d\d\d)?$')
@@ -94,11 +91,8 @@ class Group(QuickCachedDocumentMixin, UndoableDocument):
         self.ids_by_domain.clear(self.__class__, self.domain)
 
     def add_user(self, couch_user_id, save=True):
-        if not isinstance(couch_user_id, six.string_types):
+        if not isinstance(couch_user_id, str):
             couch_user_id = couch_user_id.user_id
-        else:
-            soft_assert_type_text(couch_user_id)
-        soft_assert_type_text(couch_user_id)
         if couch_user_id not in self.users:
             self.users.append(couch_user_id)
         if couch_user_id in self.removed_users:
@@ -110,11 +104,8 @@ class Group(QuickCachedDocumentMixin, UndoableDocument):
         '''
         Returns True if it removed a user, False otherwise
         '''
-        if not isinstance(couch_user_id, six.string_types):
+        if not isinstance(couch_user_id, str):
             couch_user_id = couch_user_id.user_id
-        else:
-            soft_assert_type_text(couch_user_id)
-        soft_assert_type_text(couch_user_id)
         if couch_user_id in self.users:
             for i in range(0, len(self.users)):
                 if self.users[i] == couch_user_id:

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -7,9 +7,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-import six
 from memoized import memoized
-from six.moves import range
 
 from auditcare.models import NavigationEventAudit
 from auditcare.utils.export import navigation_event_ids_by_user
@@ -55,7 +53,6 @@ from corehq.elastic import (
     fill_mapping_with_facets,
     parse_args_for_es,
 )
-from corehq.util.python_compatibility import soft_assert_type_text
 
 INDICATOR_DATA = {
     "active_domain_count": {
@@ -627,7 +624,7 @@ class AdminFacetedReport(AdminReport, ElasticTabularReport):
     @property
     def shared_pagination_GET_params(self):
         ret = super(AdminFacetedReport, self).shared_pagination_GET_params
-        for param in six.iterlists(self.request.GET):
+        for param in self.request.GET.lists():
             if self.is_custom_param(param[0]):
                 for val in param[1]:
                     ret.append(dict(name=param[0], value=val))
@@ -1261,8 +1258,7 @@ class AdminPhoneNumberReport(PhoneNumberReport):
     @memoized
     def phone_number_filter(self):
         value = RequiredPhoneNumberFilter.get_value(self.request, domain=None)
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             return apply_leniency(value.strip())
 
         return None

--- a/corehq/apps/hqcase/dbaccessors.py
+++ b/corehq/apps/hqcase/dbaccessors.py
@@ -1,10 +1,6 @@
-
-import six
-
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.couch.database import iter_docs
 
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.soft_assert.api import soft_assert
 
 
@@ -16,8 +12,7 @@ def get_case_ids_in_domain(domain, type=None):
             False, 'get_case_ids_in_domain called with typle / list arg for type'
         )
         type_keys = [[t] for t in type]
-    elif isinstance(type, six.string_types):
-        soft_assert_type_text(type)
+    elif isinstance(type, str):
         type_keys = [[type]]
     else:
         raise ValueError(

--- a/corehq/apps/hqcase/esaccessors.py
+++ b/corehq/apps/hqcase/esaccessors.py
@@ -1,7 +1,4 @@
-import six
-
 from corehq.apps.es.cases import CaseES
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def scroll_case_ids_by_domain_and_case_type(domain, case_type, chunk_size=100):
@@ -20,9 +17,8 @@ def scroll_case_ids_by_domain_and_case_type(domain, case_type, chunk_size=100):
     result = []
 
     for case_id in query.scroll():
-        if not isinstance(case_id, six.string_types):
+        if not isinstance(case_id, str):
             raise ValueError("Something is wrong with the query, expected ids only")
-        soft_assert_type_text(case_id)
 
         result.append(case_id)
         if len(result) >= chunk_size:

--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -92,9 +92,9 @@ class Command(BaseCommand):
 
         This may take a while, so don't deploy until all these have reported finishing.
             """ % (
-                settings.EMAIL_SUBJECT_PREFIX,
-                '\n\t'.join(map(str, indices_needing_reindex))
-            )
+            settings.EMAIL_SUBJECT_PREFIX,
+            '\n\t'.join(map(str, indices_needing_reindex))
+        )
 
         mail_admins("Pillow preindexing starting", preindex_message)
         start = datetime.utcnow()

--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -6,9 +6,7 @@ from django.core.mail import mail_admins
 from django.core.management.base import BaseCommand
 
 import gevent
-import six
 from gevent import monkey
-from six.moves import map
 
 from corehq.apps.hqcase.management.commands.ptop_reindexer_v2 import (
     FACTORIES_BY_SLUG,
@@ -17,13 +15,8 @@ from corehq.elastic import get_es_new
 from corehq.pillows.user import add_demo_user_to_user_index
 from corehq.pillows.utils import get_all_expected_es_indices
 from corehq.util.log import get_traceback_string
-from corehq.util.python_compatibility import soft_assert_type_text
 
 monkey.patch_all()
-
-
-
-
 
 
 def get_reindex_commands(alias_name):
@@ -55,8 +48,7 @@ def do_reindex(alias_name, reset):
     print("Starting pillow preindex %s" % alias_name)
     reindex_commands = get_reindex_commands(alias_name)
     for reindex_command in reindex_commands:
-        if isinstance(reindex_command, six.string_types):
-            soft_assert_type_text(reindex_command)
+        if isinstance(reindex_command, str):
             kwargs = {"reset": True} if reset else {}
             FACTORIES_BY_SLUG[reindex_command](**kwargs).build().reindex()
         else:
@@ -90,7 +82,7 @@ class Command(BaseCommand):
             return
 
         print("Reindexing:\n\t", end=' ')
-        print('\n\t'.join(map(six.text_type, indices_needing_reindex)))
+        print('\n\t'.join(map(str, indices_needing_reindex)))
 
         preindex_message = """
         Heads up!
@@ -101,7 +93,7 @@ class Command(BaseCommand):
         This may take a while, so don't deploy until all these have reported finishing.
             """ % (
                 settings.EMAIL_SUBJECT_PREFIX,
-                '\n\t'.join(map(six.text_type, indices_needing_reindex))
+                '\n\t'.join(map(str, indices_needing_reindex))
             )
 
         mail_admins("Pillow preindexing starting", preindex_message)
@@ -134,7 +126,7 @@ class Command(BaseCommand):
                 mail_admins(
                     "Pillow preindexing completed",
                     "Reindexing %s took %s seconds" % (
-                        ', '.join(map(six.text_type, indices_needing_reindex)),
+                        ', '.join(map(str, indices_needing_reindex)),
                         (datetime.utcnow() - start).seconds
                     )
                 )

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -7,8 +7,6 @@ from xml.etree import cElementTree as ElementTree
 from django.core.files.uploadedfile import UploadedFile
 from django.template.loader import render_to_string
 
-import six
-
 from casexml.apps.case import const
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
@@ -23,7 +21,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
     get_cached_case_attachment,
 )
 from corehq.form_processor.utils import should_use_sql_backend
-from corehq.util.python_compatibility import soft_assert_type_text
 
 SYSTEM_FORM_XMLNS = 'http://commcarehq.org/case'
 EDIT_FORM_XMLNS = 'http://commcarehq.org/case/edit'
@@ -61,9 +58,8 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id=None,
     """
     attachments = attachments or {}
     now = json_format_datetime(datetime.datetime.utcnow())
-    if not isinstance(case_blocks, six.string_types):
+    if not isinstance(case_blocks, str):
         case_blocks = ''.join(case_blocks)
-    soft_assert_type_text(case_blocks)
     form_id = form_id or uuid.uuid4().hex
     form_xml = render_to_string('hqcase/xml/case_block.xml', {
         'xmlns': xmlns or SYSTEM_FORM_XMLNS,

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -11,7 +11,6 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 import magic
-import six
 from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from memoized import memoized
 from PIL import Image
@@ -41,7 +40,6 @@ from corehq.apps.domain import SHARED_DOMAIN
 from corehq.apps.domain.models import LICENSE_LINKS, LICENSES
 from corehq.apps.hqmedia.exceptions import BadMediaFileException
 from corehq.blobs.mixin import CODES, BlobMixin
-from corehq.util.python_compatibility import soft_assert_type_text
 
 MULTIMEDIA_PREFIX = "jr://file/"
 LOGO_ARCHIVE_KEY = 'logos'
@@ -469,9 +467,8 @@ class ApplicationMediaReference(object):
                  form_name=None, form_order=None, media_class=None,
                  is_menu_media=False, app_lang=None, use_default_media=False):
 
-        if not isinstance(path, six.string_types):
+        if not isinstance(path, str):
             path = ''
-        soft_assert_type_text(path)
         self.path = path.strip()
 
         if not issubclass(media_class, CommCareMultimedia):
@@ -676,7 +673,7 @@ class ModuleMediaMixin(MediaMixin):
             for column in details.get_columns():
                 if column.format == 'enum-image':
                     for map_item in column.enum:
-                        for lang, icon in six.iteritems(map_item.value):
+                        for lang, icon in map_item.value.items():
                             if icon == old_path:
                                 map_item.value[lang] = new_path
                                 count += 1

--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -7,12 +7,9 @@ from django.contrib.staticfiles import finders
 from django.core import cache
 from django.core.management.base import BaseCommand
 
-import six
 import yaml
 
 from dimagi.utils import gitinfo
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 rcache = cache.caches['redis']
 RESOURCE_PREFIX = '#resource_%s'
@@ -63,12 +60,10 @@ class Command(BaseCommand):
 
         current_sha = self.current_sha()
         existing_resources = rcache.get(RESOURCE_PREFIX % current_sha, None)
-        if existing_resources and not isinstance(existing_resources, six.string_types):
+        if existing_resources and not isinstance(existing_resources, str):
             print("getting resource dict from cache")
             self.output_resources(existing_resources, overwrite=True)
             return
-        if isinstance(existing_resources, six.string_types):
-            soft_assert_type_text(existing_resources)
 
         resources = {}
         for finder in finders.get_finders():

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -2,7 +2,6 @@
 from django.conf import settings
 from django.core.mail import mail_admins, send_mail
 
-import six
 from celery.schedules import crontab
 from celery.task import task
 
@@ -70,10 +69,7 @@ def send_html_email_async(self, subject, recipient, html_content,
                         file_attachments=file_attachments, bcc=bcc,
                         smtp_exception_skip_list=smtp_exception_skip_list)
     except Exception as e:
-        from corehq.util.python_compatibility import soft_assert_type_text
-        if isinstance(recipient, six.string_types):
-            soft_assert_type_text(recipient)
-        recipient = list(recipient) if not isinstance(recipient, six.string_types) else [recipient]
+        recipient = list(recipient) if not isinstance(recipient, str) else [recipient]
         notify_exception(
             None,
             message="Encountered error while sending email",

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -18,9 +18,8 @@ from django.utils.html import conditional_escape, escape
 from django.utils.safestring import mark_safe
 
 import pytz
-import six
 from jsonobject.exceptions import BadValueError
-from six.moves import map, zip_longest
+from itertools import zip_longest
 
 from dimagi.ext.jsonobject import DateProperty
 from dimagi.utils.chunked import chunked
@@ -30,19 +29,13 @@ from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import pretty_doc_info
 from corehq.const import USER_DATE_FORMAT, USER_DATETIME_FORMAT
 from corehq.util.dates import iso_string_to_datetime
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.timezones.conversions import PhoneTime, ServerTime
 
 register = template.Library()
 
 
 def _is_list_like(val):
-    if six.PY2 and isinstance(val, bytes):
-        val = val.decode('utf-8')
-    if isinstance(val, (six.text_type, bytes)):
-        soft_assert_type_text(val)
-    return (isinstance(val, collections.Iterable) and
-            not isinstance(val, six.string_types))
+    return isinstance(val, collections.Iterable) and not isinstance(val, str)
 
 
 def _parse_date_or_datetime(val):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -44,7 +44,6 @@ from django.views.generic.base import View
 
 import httpagentparser
 from couchdbkit import ResourceNotFound
-from djangular.views.mixins import JSONResponseMixin
 from memoized import memoized
 from urllib.parse import urlparse
 from two_factor.forms import AuthenticationTokenForm, BackupTokenForm

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -43,12 +43,10 @@ from django.views.generic import TemplateView
 from django.views.generic.base import View
 
 import httpagentparser
-import six
 from couchdbkit import ResourceNotFound
 from djangular.views.mixins import JSONResponseMixin
 from memoized import memoized
-from six.moves import range
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 from two_factor.views import LoginView
 
@@ -111,7 +109,6 @@ from corehq.util.datadog.const import DATADOG_UNKNOWN
 from corehq.util.datadog.gauges import datadog_counter, datadog_gauge
 from corehq.util.datadog.metrics import JSERROR_COUNT
 from corehq.util.datadog.utils import create_datadog_event, sanitize_url
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.view_utils import reverse
 from no_exceptions.exceptions import Http403
 
@@ -129,19 +126,8 @@ def format_traceback_the_way_python_does(type, exc, tb):
       File "<stdin>", line 2, in <module>
     NameError: name 'name' is not defined
     """
-
-    if six.PY3:
-        exc_message = six.text_type(exc)
-    else:
-        exc_message = exc.message
-        if isinstance(exc_message, bytes):
-            exc_message = exc_message.decode('utf-8')
-
-    return 'Traceback (most recent call last):\n{}{}: {}'.format(
-        ''.join(traceback.format_tb(tb)),
-        type.__name__,
-        exc_message
-    )
+    tb = ''.join(traceback.format_tb(tb))
+    return f'Traceback (most recent call last):\n{tb}{type.__name__}: {exc}'
 
 
 def server_error(request, template_name='500.html'):
@@ -394,8 +380,7 @@ def _login(req, domain_name):
     template_name = 'login_and_password/login.html'
     custom_landing_page = settings.CUSTOM_LANDING_TEMPLATE
     if custom_landing_page:
-        if isinstance(custom_landing_page, six.string_types):
-            soft_assert_type_text(custom_landing_page)
+        if isinstance(custom_landing_page, str):
             template_name = custom_landing_page
         else:
             template_name = custom_landing_page.get(req.get_host())
@@ -1180,7 +1165,7 @@ class MaintenanceAlertsView(BasePageView):
         from corehq.apps.hqwebapp.models import MaintenanceAlert
         return {
             'alerts': [{
-                'created': six.text_type(alert.created),
+                'created': str(alert.created),
                 'active': alert.active,
                 'html': alert.html,
                 'id': alert.id,

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -12,9 +12,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 from django.views.decorators.http import require_http_methods
 
-import six
 from memoized import memoized
-from six.moves import map, range
 
 from dimagi.utils.couch import get_redis_lock, release_lock
 from dimagi.utils.web import json_response
@@ -44,7 +42,6 @@ from corehq.apps.reports.filters.controllers import EmwfOptionsController
 from corehq.apps.users.forms import MultipleSelectionForm
 from corehq.util import reverse
 from corehq.util.files import file_extention_from_filename
-from corehq.util.python_compatibility import soft_assert_type_text
 
 from .analytics import users_have_locations
 from .const import ROOT_LOCATION_TYPE
@@ -304,9 +301,7 @@ class LocationTypesView(BaseDomainView):
         sql_loc_types = {}
 
         def _is_fake_pk(pk):
-            if isinstance(pk, six.string_types):
-                soft_assert_type_text(pk)
-            return isinstance(pk, six.string_types) and pk.startswith("fake-pk-")
+            return isinstance(pk, str) and pk.startswith("fake-pk-")
 
         def mk_loctype(name, parent_type, administrative,
                        shares_cases, view_descendants, pk, code, **kwargs):

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -10,7 +10,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
-import six
 from captcha.fields import CaptchaField
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
@@ -25,9 +24,8 @@ from corehq.apps.locations.forms import LocationSelectWidget
 from corehq.apps.programs.models import Program
 from corehq.apps.users.forms import RoleForm
 from corehq.apps.users.models import CouchUser
-from corehq.util.python_compatibility import soft_assert_type_text
 
-mark_safe_lazy = lazy(mark_safe, six.text_type)
+mark_safe_lazy = lazy(mark_safe, str)
 
 
 class RegisterWebUserForm(forms.Form):
@@ -274,8 +272,7 @@ class RegisterWebUserForm(forms.Form):
 
     def clean(self):
         for field in self.cleaned_data:
-            if isinstance(self.cleaned_data[field], six.string_types):
-                soft_assert_type_text(self.cleaned_data[field])
+            if isinstance(self.cleaned_data[field], str):
                 self.cleaned_data[field] = self.cleaned_data[field].strip()
         return self.cleaned_data
 
@@ -311,8 +308,7 @@ class DomainRegistrationForm(forms.Form):
 
     def clean(self):
         for field in self.cleaned_data:
-            if isinstance(self.cleaned_data[field], six.string_types):
-                soft_assert_type_text(self.cleaned_data[field])
+            if isinstance(self.cleaned_data[field], str):
                 self.cleaned_data[field] = self.cleaned_data[field].strip()
         return self.cleaned_data
 
@@ -387,8 +383,7 @@ class WebUserInvitationForm(NoAutocompleteMixin, DomainRegistrationForm):
 
     def clean(self):
         for field in self.cleaned_data:
-            if isinstance(self.cleaned_data[field], six.string_types):
-                soft_assert_type_text(self.cleaned_data[field])
+            if isinstance(self.cleaned_data[field], str):
                 self.cleaned_data[field] = self.cleaned_data[field].strip()
         return self.cleaned_data
 
@@ -409,8 +404,7 @@ class _BaseForm(object):
 
     def clean(self):
         for field in self.cleaned_data:
-            if isinstance(self.cleaned_data[field], six.string_types):
-                soft_assert_type_text(self.cleaned_data[field])
+            if isinstance(self.cleaned_data[field], str):
                 self.cleaned_data[field] = self.cleaned_data[field].strip()
         return self.cleaned_data
 

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -33,9 +33,7 @@ from corehq.apps.sms.models import Keyword
 from .models import (
     METHOD_SMS,
     METHOD_SMS_SURVEY,
-    RECIPIENT_CASE,
     RECIPIENT_OWNER,
-    RECIPIENT_SURVEY_SAMPLE,
     RECIPIENT_USER_GROUP,
 )
 
@@ -101,7 +99,7 @@ class RecordListWidget(Widget):
         if len(data_dict) > 0:
             for key in sorted(data_dict[input_name]):
                 data_list.append(data_dict[input_name][key])
-        
+
         return data_list
 
     def render(self, name, value, attrs=None):

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -14,7 +14,6 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-import six
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import InlineField
@@ -30,7 +29,6 @@ from corehq.apps.groups.models import Group
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.reminders.util import DotExpandedDict, get_form_list
 from corehq.apps.sms.models import Keyword
-from corehq.util.python_compatibility import soft_assert_type_text
 
 from .models import (
     METHOD_SMS,
@@ -65,10 +63,8 @@ def validate_time(value):
         return value
     error_msg = _("Please enter a valid time from 00:00 to 23:59.")
     time_regex = re.compile(r"^\d{1,2}:\d\d(:\d\d){0,1}$")
-    if not isinstance(value, six.string_types) or time_regex.match(value) is None:
+    if not isinstance(value, str) or time_regex.match(value) is None:
         raise ValidationError(error_msg)
-    if isinstance(value, six.string_types):
-        soft_assert_type_text(value)
     try:
         return parse(value).time()
     except Exception:
@@ -103,7 +99,7 @@ class RecordListWidget(Widget):
         data_dict = DotExpandedDict(raw)
         data_list = []
         if len(data_dict) > 0:
-            for key in sorted(six.iterkeys(data_dict[input_name])):
+            for key in sorted(data_dict[input_name]):
                 data_list.append(data_dict[input_name][key])
         
         return data_list

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -5,7 +5,6 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext
 from django.views.generic.base import View
 
-import six
 from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 
@@ -24,7 +23,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.users.models import AnonymousCouchUser
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 
 datespan_default = datespan_in_request(
@@ -54,10 +52,8 @@ class ReportDispatcher(View):
     map_name = None
 
     def __init__(self, **kwargs):
-        if not self.map_name or not isinstance(self.map_name, six.string_types):
+        if not self.map_name or not isinstance(self.map_name, str):
             raise NotImplementedError("Class property 'map_name' must be a string, and not empty.")
-        if isinstance(self.map_name, six.string_types):
-            soft_assert_type_text(self.map_name)
         super(ReportDispatcher, self).__init__(**kwargs)
 
     @property
@@ -95,7 +91,7 @@ class ReportDispatcher(View):
         if module_name is None:
             custom_reports = ()
         else:
-            module = __import__(module_name, fromlist=['reports' if six.PY3 else b'reports'])
+            module = __import__(module_name, fromlist=['reports'])
             if hasattr(module, 'reports'):
                 reports = getattr(module, 'reports')
                 custom_reports = process(getattr(reports, attr_name, ()))

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -4,10 +4,8 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-import six
 from couchdbkit.exceptions import ResourceNotFound
 from memoized import memoized
-from six.moves import range
 
 from couchforms.analytics import (
     get_all_xmlns_app_id_pairs_submitted_to_in_domain,
@@ -32,7 +30,6 @@ from corehq.apps.reports.filters.base import (
 from corehq.const import MISSING_APP_ID
 from corehq.elastic import ESError
 from corehq.util.context_processors import commcare_hq_names
-from corehq.util.python_compatibility import soft_assert_type_text
 
 PARAM_SLUG_STATUS = 'status'
 PARAM_SLUG_APP_ID = 'app_id'
@@ -413,8 +410,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
 
         If obj is a string, just output that string.
         """
-        if isinstance(obj, six.string_types):
-            soft_assert_type_text(obj)
+        if isinstance(obj, str):
             return obj
         if not obj:
             return _('Untitled')

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -17,7 +17,6 @@ from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
 from django.utils.translation import ugettext
 
-import pytz
 from celery.utils.log import get_task_logger
 from memoized import memoized
 
@@ -42,7 +41,6 @@ from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.reports.util import DatatablesParams, get_report_timezone
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.users.models import CouchUser
-from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 
 from corehq import toggles

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -18,10 +18,8 @@ from django.urls import NoReverseMatch
 from django.utils.translation import ugettext
 
 import pytz
-import six
 from celery.utils.log import get_task_logger
 from memoized import memoized
-from six.moves import range, zip
 
 from couchexport.export import export_from_tables, get_writer
 from couchexport.shortcuts import export_response
@@ -44,7 +42,6 @@ from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.reports.util import DatatablesParams, get_report_timezone
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.users.models import CouchUser
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import absolute_reverse, request_as_dict, reverse
 
@@ -308,8 +305,7 @@ class GenericReportView(object):
         filters = []
         fields = self.fields
         for field in fields or []:
-            if isinstance(field, six.string_types):
-                soft_assert_type_text(field)
+            if isinstance(field, str):
                 klass = to_function(field, failhard=True)
             else:
                 klass = field
@@ -440,9 +436,7 @@ class GenericReportView(object):
         default_config = ReportConfig.default()
 
         def is_editable_datespan(field):
-            if isinstance(field, six.string_types):
-                soft_assert_type_text(field)
-            field_fn = to_function(field) if isinstance(field, six.string_types) else field
+            field_fn = to_function(field) if isinstance(field, str) else field
             return issubclass(field_fn, DatespanFilter) and field_fn.is_editable
 
         has_datespan = any([is_editable_datespan(field) for field in self.fields])
@@ -969,8 +963,7 @@ class GenericTabularReport(GenericReportView):
         # using regex breaks values then we should use a parser instead, and
         # take the knock. Assuming we won't have values with angle brackets,
         # using regex for now.
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             return re.sub('<[^>]*?>', '', value)
         return value
 
@@ -1237,7 +1230,7 @@ class GetParamsMixin(object):
         so as to get sorting working correctly with the context of the GET params
         """
         ret = super(GetParamsMixin, self).shared_pagination_GET_params
-        for k, v in six.iterlists(self.request.GET):
+        for k, v in self.request.GET.lists():
             ret.append(dict(name=k, value=v))
         return ret
 

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_noop
 
 from jsonfield import JSONField
 
-from dimagi.ext.couchdbkit import *
+from dimagi.ext.couchdbkit import IntegerProperty
 
 from corehq.apps.users.models import CommCareUser
 
@@ -80,7 +80,7 @@ class HQToggle(object):
 
     def __repr__(self):
         return "%(klass)s[%(type)s:%(show)s:%(name)s]" % dict(
-            klass = self.__class__.__name__,
+            klass=self.__class__.__name__,
             type=self.type,
             name=self.name,
             show=self.show

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -8,14 +8,11 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 
-import six
 from jsonfield import JSONField
-from six.moves import map, range
 
 from dimagi.ext.couchdbkit import *
 
 from corehq.apps.users.models import CommCareUser
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class HQUserType(object):
@@ -68,7 +65,7 @@ class HQUserType(object):
 
     @classmethod
     def use_filter(cls, ufilter):
-        return [HQUserToggle(i, six.text_type(i) in ufilter) for i in range(cls.count)]
+        return [HQUserToggle(i, str(i) in ufilter) for i in range(cls.count)]
 
 
 class HQToggle(object):
@@ -172,16 +169,13 @@ def ordering_config_validator(value):
     for group in value:
         if not isinstance(group, list) or len(group) != 2:
             raise error
-        if not isinstance(group[0], six.string_types):
+        if not isinstance(group[0], str):
             raise error
-        else:
-            soft_assert_type_text(group[0])
         if not isinstance(group[1], list):
             raise error
         for report in group[1]:
-            if not isinstance(report, six.string_types):
+            if not isinstance(report, str):
                 raise error
-            soft_assert_type_text(report)
 
 
 class ReportsSidebarOrdering(models.Model):

--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -18,7 +18,6 @@ from corehq.apps.reports.datatables import (
 )
 from corehq.apps.reports.util import format_datatables_data
 from corehq.sql_db.connections import DEFAULT_ENGINE_ID, connection_manager
-from corehq.util.soft_assert import soft_assert
 
 
 class SqlReportException(Exception):

--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -4,10 +4,8 @@ from functools import reduce
 
 from django.template.defaultfilters import slugify
 
-import six
 import sqlagg
 from memoized import memoized
-from six.moves import range, zip
 from sqlagg.columns import SimpleColumn
 from sqlagg.filters import RawFilter, SqlFilter
 
@@ -20,7 +18,6 @@ from corehq.apps.reports.datatables import (
 )
 from corehq.apps.reports.util import format_datatables_data
 from corehq.sql_db.connections import DEFAULT_ENGINE_ID, connection_manager
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.soft_assert import soft_assert
 
 
@@ -237,8 +234,7 @@ class SqlData(ReportDataSource):
     @property
     def wrapped_filters(self):
         def _wrap_if_necessary(string_or_filter):
-            if isinstance(string_or_filter, six.string_types):
-                soft_assert_type_text(string_or_filter)
+            if isinstance(string_or_filter, str):
                 filter = RawFilter(string_or_filter)
             else:
                 filter = string_or_filter
@@ -423,7 +419,7 @@ def calculate_total_row(rows):
         num_cols = len(rows[0])
         for i in range(num_cols):
             colrows = [cr[i] for cr in rows if isinstance(cr[i], dict)]
-            columns = [r.get('sort_key') for r in colrows if isinstance(r.get('sort_key'), six.integer_types)]
+            columns = [r.get('sort_key') for r in colrows if isinstance(r.get('sort_key'), int)]
             if len(columns):
                 total_row.append(reduce(lambda x, y: x + y, columns, 0))
             else:

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -12,7 +12,6 @@ from django.utils.html import escape
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-import six
 from couchdbkit import ResourceNotFound
 from memoized import memoized
 
@@ -100,7 +99,6 @@ from corehq.messaging.scheduling.views import (
     EditScheduleView,
 )
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.timezones.conversions import ServerTime, UserTime
 from corehq.util.view_utils import absolute_reverse
 
@@ -658,8 +656,7 @@ class MessagingEventsReport(BaseMessagingEventReport):
     @memoized
     def phone_number_filter(self):
         value = PhoneNumberFilter.get_value(self.request, self.domain)
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             return value.strip()
 
         return None
@@ -1132,8 +1129,7 @@ class PhoneNumberReport(BaseCommConnectLogReport):
     @memoized
     def phone_number_filter(self):
         value = self._filter['phone_number_filter']
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             return apply_leniency(value.strip())
 
         return None

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -11,9 +11,7 @@ from django.utils import html, safestring
 from django.utils.translation import ugettext as _
 
 import pytz
-import six
 from memoized import memoized
-from six.moves import map, range
 
 from couchexport.util import SerializableFunction
 from dimagi.utils.dates import DateSpan
@@ -28,7 +26,6 @@ from corehq.apps.users.permissions import get_extra_permissions
 from corehq.apps.users.util import user_id_to_username
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.log import send_HTML_email
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 from corehq.util.timezones.utils import get_timezone_for_user
 
@@ -161,8 +158,7 @@ def namedtupledict(name, fields):
     cls = namedtuple(name, fields)
 
     def __getitem__(self, item):
-        if isinstance(item, six.string_types):
-            soft_assert_type_text(item)
+        if isinstance(item, str):
             warnings.warn(
                 "namedtuple fields should be accessed as attributes",
                 DeprecationWarning,
@@ -184,7 +180,7 @@ def namedtupledict(name, fields):
 
 
 class SimplifiedUserInfo(
-        namedtupledict(b'SimplifiedUserInfo' if six.PY2 else 'SimplifiedUserInfo', (
+        namedtupledict('SimplifiedUserInfo', (
             'user_id',
             'username_in_report',
             'raw_username',

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -36,11 +36,9 @@ from django.views.generic.base import TemplateView
 
 import csv
 import pytz
-import six
 from couchdbkit.exceptions import ResourceNotFound
 from django_prbac.utils import has_privilege
 from memoized import memoized
-from six.moves import range, zip
 
 from casexml.apps.case import const
 from casexml.apps.case.cleanup import close_case, rebuild_case_from_forms
@@ -151,7 +149,6 @@ from corehq.motech.repeaters.dbaccessors import (
 )
 from corehq.tabs.tabclasses import ProjectReportsTab
 from corehq.util.couch import get_document_or_404
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import (
     get_timezone_for_request,
@@ -708,7 +705,7 @@ class ScheduledReportsView(BaseProjectReportSectionView):
             try:
                 self.report_notification.update_attributes(list(self.scheduled_report_form.cleaned_data.items()))
             except ValidationError as err:
-                kwargs['error'] = six.text_type(err)
+                kwargs['error'] = str(err)
                 messages.error(request, ugettext_lazy(kwargs['error']))
                 return self.get(request, *args, **kwargs)
             time_difference = get_timezone_difference(self.domain)
@@ -1990,7 +1987,7 @@ def _get_data_cleaning_updates(request, old_properties):
         else:
             return val_or_dict
 
-    for prop, value in six.iteritems(properties):
+    for prop, value in properties.items():
         if prop not in old_properties or _get_value(old_properties[prop]) != value:
             updates[prop] = value
     return updates
@@ -2037,11 +2034,9 @@ def resave_form_view(request, domain, instance_id):
 
 # Weekly submissions by xmlns
 def mk_date_range(start=None, end=None, ago=timedelta(days=7), iso=False):
-    if isinstance(end, six.string_types):
-        soft_assert_type_text(end)
+    if isinstance(end, str):
         end = parse_date(end)
-    if isinstance(start, six.string_types):
-        soft_assert_type_text(start)
+    if isinstance(start, str):
         start = parse_date(start)
     if not end:
         end = datetime.utcnow()

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -16,7 +16,6 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_POST
 
 import qrcode
-import six
 from memoized import memoized
 from tastypie.models import ApiKey
 from two_factor.models import PhoneDevice
@@ -58,7 +57,6 @@ from corehq.mobile_flags import (
     ADVANCED_SETTINGS_ACCESS,
     MULTIPLE_APPS_UNLIMITED,
 )
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 
 
@@ -180,10 +178,8 @@ class MyAccountSettingsView(BaseMyAccountView):
         }
 
     def phone_number_is_valid(self):
-        if isinstance(self.phone_number, six.string_types):
-            soft_assert_type_text(self.phone_number)
         return (
-            isinstance(self.phone_number, six.string_types) and
+            isinstance(self.phone_number, str) and
             re.compile(r'^\d+$').match(self.phone_number) is not None
         )
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -179,8 +179,8 @@ class MyAccountSettingsView(BaseMyAccountView):
 
     def phone_number_is_valid(self):
         return (
-            isinstance(self.phone_number, str) and
-            re.compile(r'^\d+$').match(self.phone_number) is not None
+            isinstance(self.phone_number, str)
+            and re.compile(r'^\d+$').match(self.phone_number) is not None
         )
 
     def process_add_phone_number(self):

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -11,7 +11,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-import six
 from couchdbkit.exceptions import ResourceNotFound
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
@@ -42,7 +41,6 @@ from corehq.apps.sms.util import (
     validate_phone_number,
 )
 from corehq.apps.users.models import CommCareUser
-from corehq.util.python_compatibility import soft_assert_type_text
 
 FORWARDING_CHOICES = (
     (FORWARD_ALL, ugettext_noop("All messages")),
@@ -630,8 +628,7 @@ class SettingsForm(Form):
             value = self[field_name].value()
             if field_name in ["restricted_sms_times_json",
                 "sms_conversation_times_json"]:
-                if isinstance(value, six.string_types):
-                    soft_assert_type_text(value)
+                if isinstance(value, str):
                     current_values[field_name] = json.loads(value)
                 else:
                     current_values[field_name] = value

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -626,8 +626,7 @@ class SettingsForm(Form):
         current_values = {}
         for field_name in self.fields.keys():
             value = self[field_name].value()
-            if field_name in ["restricted_sms_times_json",
-                "sms_conversation_times_json"]:
+            if field_name in ["restricted_sms_times_json", "sms_conversation_times_json"]:
                 if isinstance(value, str):
                     current_values[field_name] = json.loads(value)
                 else:

--- a/corehq/apps/sms/mixin.py
+++ b/corehq/apps/sms/mixin.py
@@ -64,7 +64,7 @@ def apply_leniency(contact_phone_number):
     Returns None if an unsupported data type is passed in.
     """
     from corehq.apps.sms.util import strip_plus
-    # Decimal preserves trailing zeroes, so it's ok 
+    # Decimal preserves trailing zeroes, so it's ok
     if isinstance(contact_phone_number, (int, Decimal)):
         contact_phone_number = str(contact_phone_number)
     if isinstance(contact_phone_number, str):

--- a/corehq/apps/sms/mixin.py
+++ b/corehq/apps/sms/mixin.py
@@ -2,12 +2,13 @@ import re
 from collections import namedtuple
 from decimal import Decimal
 
-import six
-
-from dimagi.ext.couchdbkit import *
+from dimagi.ext.couchdbkit import (
+    BooleanProperty,
+    DateTimeProperty,
+    Document,
+    StringProperty,
+)
 from dimagi.utils.couch import CriticalSection
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 phone_number_re = re.compile(r"^\d+$")
 
@@ -64,10 +65,9 @@ def apply_leniency(contact_phone_number):
     """
     from corehq.apps.sms.util import strip_plus
     # Decimal preserves trailing zeroes, so it's ok 
-    if isinstance(contact_phone_number, six.integer_types + (Decimal,)):
-        contact_phone_number = six.text_type(contact_phone_number)
-    if isinstance(contact_phone_number, six.string_types):
-        soft_assert_type_text(contact_phone_number)
+    if isinstance(contact_phone_number, (int, Decimal)):
+        contact_phone_number = str(contact_phone_number)
+    if isinstance(contact_phone_number, str):
         chars = re.compile(r"[()\s\-.]+")
         contact_phone_number = chars.sub("", contact_phone_number)
         contact_phone_number = strip_plus(contact_phone_number)

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -10,7 +10,6 @@ from django.http import Http404
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
 import jsonfield
-import six
 from memoized import memoized
 
 from dimagi.ext.couchdbkit import *
@@ -38,7 +37,6 @@ from corehq.apps.users.models import CouchUser
 from corehq.const import GOOGLE_PLAY_STORE_COMMCARE_URL
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.util.mixin import UUIDGeneratorMixin
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 from corehq.util.view_utils import absolute_reverse
 
@@ -617,9 +615,7 @@ class PhoneNumber(UUIDGeneratorMixin, models.Model):
     @property
     def backend(self):
         from corehq.apps.sms.util import clean_phone_number
-        if isinstance(self.backend_id, six.string_types):
-            soft_assert_type_text(self.backend_id)
-        backend_id = self.backend_id.strip() if isinstance(self.backend_id, six.string_types) else None
+        backend_id = self.backend_id.strip() if isinstance(self.backend_id, str) else None
         if backend_id:
             return SQLMobileBackend.load_by_name(
                 SQLMobileBackend.SMS,
@@ -1864,7 +1860,6 @@ class ActiveMobileBackendManager(models.Manager):
         return super(ActiveMobileBackendManager, self).get_queryset().filter(deleted=False)
 
 
-@six.python_2_unicode_compatible
 class SQLMobileBackend(UUIDGeneratorMixin, models.Model):
     SMS = 'SMS'
     IVR = 'IVR'
@@ -2319,7 +2314,7 @@ class SQLMobileBackend(UUIDGeneratorMixin, models.Model):
         the rest untouched.
         """
         result = self.get_extra_fields()
-        for k, v in six.iteritems(kwargs):
+        for k, v in kwargs.items():
             if k not in self.get_available_extra_fields():
                 raise Exception("Field %s is not an available extra field for %s"
                     % (k, self.__class__.__name__))

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 import jsonfield
 from memoized import memoized
 
-from dimagi.ext.couchdbkit import *
+from dimagi.ext.couchdbkit import Document, StringProperty
 from dimagi.utils.couch import CriticalSection
 
 from corehq.apps.app_manager.dbaccessors import get_app

--- a/corehq/apps/sms/resources/v0_5.py
+++ b/corehq/apps/sms/resources/v0_5.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 from django.http import Http404, HttpResponse
 
-import six
 from tastypie.exceptions import ImmediateHttpResponse
 from tastypie.validation import Validation
 
@@ -16,7 +15,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.sms.mixin import apply_leniency
 from corehq.apps.sms.models import SelfRegistrationInvitation
 from corehq.apps.users.models import Permissions
-from corehq.util.python_compatibility import soft_assert_type_text
 
 FieldDefinition = namedtuple('FieldDefinition', 'name required type')
 
@@ -71,8 +69,7 @@ class SelfRegistrationReinstallInfo(object):
 
     def __init__(self, app_id, reinstall_message=None):
         self.app_id = app_id
-        if isinstance(reinstall_message, six.string_types):
-            soft_assert_type_text(reinstall_message)
+        if isinstance(reinstall_message, str):
             self.reinstall_message = reinstall_message.strip()
         else:
             self.reinstall_message = None
@@ -100,8 +97,6 @@ class BaseUserSelfRegistrationValidation(Validation):
                 )
 
             if field_def.name in data:
-                if isinstance(data[field_def.name], six.string_types):
-                    soft_assert_type_text(data[field_def.name])
                 if not isinstance(data[field_def.name], field_def.type):
                     if isinstance(field_def.type, tuple):
                         if len(field_def.type) > 1:
@@ -133,7 +128,7 @@ class BaseUserSelfRegistrationValidation(Validation):
                 )
 
             self._validate_toplevel_fields(user_info, [
-                FieldDefinition('phone_number', True, six.string_types),
+                FieldDefinition('phone_number', True, (str, bytes)),
                 FieldDefinition('custom_user_data', False, dict),
             ])
 
@@ -156,11 +151,11 @@ class UserSelfRegistrationValidation(BaseUserSelfRegistrationValidation):
 
         try:
             self._validate_toplevel_fields(bundle.data, [
-                FieldDefinition('app_id', True, six.string_types),
+                FieldDefinition('app_id', True, (str, bytes)),
                 FieldDefinition('users', True, list),
                 FieldDefinition('android_only', False, bool),
                 FieldDefinition('require_email', False, bool),
-                FieldDefinition('custom_registration_message', False, six.string_types),
+                FieldDefinition('custom_registration_message', False, (str, bytes)),
             ])
 
             self._validate_app_id(request.domain, bundle.data['app_id'])
@@ -179,9 +174,9 @@ class UserSelfRegistrationReinstallValidation(BaseUserSelfRegistrationValidation
 
         try:
             self._validate_toplevel_fields(bundle.data, [
-                FieldDefinition('app_id', True, six.string_types),
+                FieldDefinition('app_id', True, (str, bytes)),
                 FieldDefinition('users', True, list),
-                FieldDefinition('reinstall_message', False, six.string_types),
+                FieldDefinition('reinstall_message', False, (str, bytes)),
             ])
 
             self._validate_app_id(request.domain, bundle.data['app_id'])
@@ -242,8 +237,7 @@ class UserSelfRegistrationResource(BaseUserSelfRegistrationResource):
         data = bundle.data
 
         custom_registration_message = data.get('custom_registration_message')
-        if isinstance(custom_registration_message, six.string_types):
-            soft_assert_type_text(custom_registration_message)
+        if isinstance(custom_registration_message, str):
             custom_registration_message = custom_registration_message.strip()
             if not custom_registration_message:
                 custom_registration_message = None

--- a/corehq/apps/sms/resources/v0_5.py
+++ b/corehq/apps/sms/resources/v0_5.py
@@ -128,7 +128,7 @@ class BaseUserSelfRegistrationValidation(Validation):
                 )
 
             self._validate_toplevel_fields(user_info, [
-                FieldDefinition('phone_number', True, (str, bytes)),
+                FieldDefinition('phone_number', True, str),
                 FieldDefinition('custom_user_data', False, dict),
             ])
 
@@ -151,11 +151,11 @@ class UserSelfRegistrationValidation(BaseUserSelfRegistrationValidation):
 
         try:
             self._validate_toplevel_fields(bundle.data, [
-                FieldDefinition('app_id', True, (str, bytes)),
+                FieldDefinition('app_id', True, str),
                 FieldDefinition('users', True, list),
                 FieldDefinition('android_only', False, bool),
                 FieldDefinition('require_email', False, bool),
-                FieldDefinition('custom_registration_message', False, (str, bytes)),
+                FieldDefinition('custom_registration_message', False, str),
             ])
 
             self._validate_app_id(request.domain, bundle.data['app_id'])
@@ -174,9 +174,9 @@ class UserSelfRegistrationReinstallValidation(BaseUserSelfRegistrationValidation
 
         try:
             self._validate_toplevel_fields(bundle.data, [
-                FieldDefinition('app_id', True, (str, bytes)),
+                FieldDefinition('app_id', True, str),
                 FieldDefinition('users', True, list),
-                FieldDefinition('reinstall_message', False, (str, bytes)),
+                FieldDefinition('reinstall_message', False, str),
             ])
 
             self._validate_app_id(request.domain, bundle.data['app_id'])

--- a/corehq/apps/sms/tests/test_registration.py
+++ b/corehq/apps/sms/tests/test_registration.py
@@ -624,12 +624,8 @@ class RegistrationAPITestCase(TestCase):
                 {'app_id': 123},
             )
             self.assertEqual(response.status_code, 400)
-            if six.PY3:
-                self.assertEqual(response.content.decode('utf-8'),
-                    '{"sms_user_registration": {"app_id": "Expected type: str"}}')
-            else:
-                self.assertEqual(response.content.decode('utf-8'),
-                    '{"sms_user_registration": {"app_id": "Expected type: basestring"}}')
+            self.assertEqual(response.content.decode('utf-8'),
+                '{"sms_user_registration": {"app_id": "Expected type: str"}}')
 
             response = self.make_api_post(
                 self.domain1,

--- a/corehq/apps/sms/util.py
+++ b/corehq/apps/sms/util.py
@@ -72,8 +72,8 @@ def clean_phone_number(text):
 
 def validate_phone_number(phone_number, error_message=None):
     if (
-        not isinstance(phone_number, str) or
-        not phone_number_plus_re.match(phone_number)
+        not isinstance(phone_number, str)
+        or not phone_number_plus_re.match(phone_number)
     ):
         error_message = error_message or _("Invalid phone number format.")
         raise ValidationError(error_message)

--- a/corehq/apps/sms/util.py
+++ b/corehq/apps/sms/util.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
-import six
 from couchdbkit import ResourceNotFound
 from memoized import memoized
 
@@ -16,7 +15,6 @@ from dimagi.utils.parsing import json_format_datetime
 from corehq.apps.hqcase.utils import submit_case_block_from_template
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.models import CouchUser
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 
 
@@ -55,9 +53,8 @@ def get_date_format(human_readable_format):
 
 
 def strip_plus(phone_number):
-    if (isinstance(phone_number, six.string_types) and len(phone_number) > 0
+    if (isinstance(phone_number, str) and len(phone_number) > 0
             and phone_number[0] == "+"):
-        soft_assert_type_text(phone_number)
         return phone_number[1:]
     else:
         return phone_number
@@ -75,12 +72,11 @@ def clean_phone_number(text):
 
 def validate_phone_number(phone_number, error_message=None):
     if (
-        not isinstance(phone_number, six.string_types) or
+        not isinstance(phone_number, str) or
         not phone_number_plus_re.match(phone_number)
     ):
         error_message = error_message or _("Invalid phone number format.")
         raise ValidationError(error_message)
-    soft_assert_type_text(phone_number)
 
 
 def format_message_list(message_list):

--- a/corehq/apps/sms/verify.py
+++ b/corehq/apps/sms/verify.py
@@ -1,5 +1,3 @@
-import six
-
 from dimagi.utils.couch import CriticalSection
 
 from corehq import privileges
@@ -17,7 +15,6 @@ from corehq.apps.sms.models import (
     SQLMobileBackend,
 )
 from corehq.apps.users.models import CommCareUser
-from corehq.util.python_compatibility import soft_assert_type_text
 
 VERIFICATION__ALREADY_IN_USE = 1
 VERIFICATION__ALREADY_VERIFIED = 2
@@ -147,9 +144,8 @@ def process_verification(v, msg, verification_keywords=None, create_subevent_for
 
 
 def verification_response_ok(text, verification_keywords):
-    if not isinstance(text, six.string_types):
+    if not isinstance(text, str):
         return False
-    soft_assert_type_text(text)
 
     text = text.lower()
     return any([keyword in text for keyword in verification_keywords])

--- a/corehq/apps/sms/verify.py
+++ b/corehq/apps/sms/verify.py
@@ -1,5 +1,3 @@
-from dimagi.utils.couch import CriticalSection
-
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.sms import messages

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -137,7 +137,6 @@ from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
 from corehq.messaging.util import show_messaging_dashboard
 from corehq.util.dates import iso_string_to_datetime
 from corehq.util.quickcache import quickcache
-from corehq.util.soft_assert import soft_assert
 from corehq.util.timezones.conversions import ServerTime, UserTime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.workbook_json.excel import get_single_worksheet

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -24,7 +24,6 @@ from django.utils.translation import ugettext_lazy, ugettext_noop
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
-import six
 from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
 from memoized import memoized
@@ -137,7 +136,6 @@ from corehq.messaging.smsbackends.telerivet.models import SQLTelerivetBackend
 from corehq.messaging.smsbackends.test.models import SQLTestSMSBackend
 from corehq.messaging.util import show_messaging_dashboard
 from corehq.util.dates import iso_string_to_datetime
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 from corehq.util.soft_assert import soft_assert
 from corehq.util.timezones.conversions import ServerTime, UserTime
@@ -1836,9 +1834,8 @@ def upload_sms_translations(request, domain):
                         msg_id = row["property"]
                         if msg_id in msg_ids:
                             val = row[lang]
-                            if not isinstance(val, six.string_types):
-                                val = six.text_type(val)
-                            soft_assert_type_text(val)
+                            if not isinstance(val, str):
+                                val = str(val)
                             val = val.strip()
                             result[lang][msg_id] = val
 

--- a/corehq/apps/translations/app_translations/utils.py
+++ b/corehq/apps/translations/app_translations/utils.py
@@ -2,8 +2,6 @@
 
 from django.utils.translation import ugettext as _
 
-import six
-
 from corehq.apps.app_manager.exceptions import (
     FormNotFoundException,
     ModuleNotFoundException,
@@ -13,7 +11,6 @@ from corehq.apps.translations.const import (
     SINGLE_SHEET_NAME,
 )
 from corehq.apps.translations.generators import EligibleForTransifexChecker
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def get_bulk_app_sheet_headers(app, lang=None, eligible_for_transifex_only=False, by_id=False):
@@ -94,8 +91,7 @@ def get_modules_and_forms_row(row_type, sheet_name, languages, media_image, medi
     assert isinstance(languages, list)
     assert isinstance(media_image, list)
     assert isinstance(media_audio, list)
-    assert isinstance(unique_id, six.string_types)
-    soft_assert_type_text(unique_id)
+    assert isinstance(unique_id, str), type(unique_id)
 
     return [item if item is not None else "" for item in
             ([row_type, sheet_name] +
@@ -190,11 +186,11 @@ def get_unicode_dicts(iterable):
 
     """
     def none_or_unicode(val):
-        return six.text_type(val) if val is not None else val
+        return str(val) if val is not None else val
 
     rows = []
     for row in iterable:
-        rows.append({six.text_type(k): none_or_unicode(v) for k, v in six.iteritems(row)})
+        rows.append({str(k): none_or_unicode(v) for k, v in row.items()})
     return rows
 
 

--- a/corehq/apps/translations/app_translations/utils.py
+++ b/corehq/apps/translations/app_translations/utils.py
@@ -93,10 +93,11 @@ def get_modules_and_forms_row(row_type, sheet_name, languages, media_image, medi
     assert isinstance(media_audio, list)
     assert isinstance(unique_id, str), type(unique_id)
 
-    return [item if item is not None else "" for item in
-            ([row_type, sheet_name] +
-             get_menu_row(languages, media_image, media_audio) +
-             [unique_id])]
+    return [item if item is not None else ""
+            for item in (
+                [row_type, sheet_name]
+                + get_menu_row(languages, media_image, media_audio)
+                + [unique_id])]
 
 
 def get_menu_row(languages, media_image, media_audio):

--- a/corehq/apps/tzmigration/timezonemigration.py
+++ b/corehq/apps/tzmigration/timezonemigration.py
@@ -5,9 +5,7 @@ from itertools import chain
 
 from django.conf import settings
 
-import six
 from couchdbkit import ResourceNotFound
-from six.moves import range
 
 from casexml.apps.case.cleanup import rebuild_case_from_actions
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
@@ -29,7 +27,6 @@ from corehq.form_processor.utils import adjust_datetimes, convert_xform_to_json
 from corehq.form_processor.utils.metadata import scrub_meta
 from corehq.util import eval_lazy
 from corehq.util.dates import iso_string_to_datetime
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def run_timezone_migration_for_domain(domain):
@@ -45,11 +42,6 @@ FormJsonDiff = collections.namedtuple('FormJsonDiff', [
 def _json_diff(obj1, obj2, path, track_list_indices=True):
     obj1 = eval_lazy(obj1)
     obj2 = eval_lazy(obj2)
-    if isinstance(obj1, str):
-        obj1 = six.text_type(obj1)
-    if isinstance(obj2, str):
-        obj2 = six.text_type(obj2)
-
     if obj1 == obj2:
         return
     elif MISSING in (obj1, obj2):
@@ -210,9 +202,8 @@ def prepare_case_json(planning_db):
 
 
 def is_datetime_string(string):
-    if not isinstance(string, six.string_types):
+    if not isinstance(string, str):
         return False
-    soft_assert_type_text(string)
     try:
         iso_string_to_datetime(string, strict=True)
     except (ValueError, OverflowError, TypeError):

--- a/corehq/apps/userreports/app_manager/data_source_meta.py
+++ b/corehq/apps/userreports/app_manager/data_source_meta.py
@@ -2,11 +2,8 @@ from abc import ABCMeta, abstractmethod
 
 from django.utils.translation import ugettext_lazy as _
 
-import six
-
 from corehq.apps.app_manager.models import Form
 from corehq.apps.app_manager.xform import XForm
-from corehq.util.python_compatibility import soft_assert_type_text
 
 DATA_SOURCE_TYPE_CASE = 'case'
 DATA_SOURCE_TYPE_FORM = 'form'
@@ -80,7 +77,7 @@ def get_app_data_source_meta(domain, data_source_type, data_source_id):
         return FormDataSourceMeta(domain, data_source_type, data_source_id)
 
 
-class AppDataSourceMeta(six.with_metaclass(ABCMeta, object)):
+class AppDataSourceMeta(metaclass=ABCMeta):
     """
     Utility base class for interacting with forms/cases inside an app and data sources
     """
@@ -156,8 +153,7 @@ def make_form_meta_block_indicator(spec, column_id=None, root_doc=False):
     form meta field and data type.
     """
     field_name = spec[0]
-    if isinstance(field_name, six.string_types):
-        soft_assert_type_text(field_name)
+    if isinstance(field_name, str):
         field_name = [field_name]
     data_type = spec[1]
     column_id = column_id or field_name[0]

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -1,8 +1,3 @@
-import hashlib
-import json
-
-from django.core.serializers.json import DjangoJSONEncoder
-
 from jsonobject.base_properties import DefaultProperty
 from simpleeval import InvalidExpression
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -3,7 +3,6 @@ import json
 
 from django.core.serializers.json import DjangoJSONEncoder
 
-import six
 from jsonobject.base_properties import DefaultProperty
 from simpleeval import InvalidExpression
 
@@ -37,7 +36,6 @@ from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.util.couch import get_db_by_doc_type
-from corehq.util.python_compatibility import soft_assert_type_text
 
 from .utils import eval_statements
 
@@ -155,7 +153,7 @@ class PropertyPathGetterSpec(JsonObject):
     is specified, "string" will be used.
     """
     type = TypeProperty('property_path')
-    property_path = ListProperty(six.text_type, required=True)
+    property_path = ListProperty(str, required=True)
     datatype = DataTypeProperty(required=False)
 
     def __call__(self, item, context=None):
@@ -615,10 +613,8 @@ class DictExpressionSpec(JsonObject):
 
     def configure(self, compiled_properties):
         for key in compiled_properties:
-            if not isinstance(key, (six.text_type, bytes)):
+            if not isinstance(key, str):
                 raise BadSpecError("Properties in a dict expression must be strings!")
-            if six.PY3:
-                soft_assert_type_text(key)
         self._compiled_properties = compiled_properties
 
     def __call__(self, item, context=None):
@@ -914,9 +910,8 @@ class SplitStringExpressionSpec(JsonObject):
 
     def __call__(self, item, context=None):
         string_value = self._string_expression(item, context)
-        if not isinstance(string_value, six.string_types):
+        if not isinstance(string_value, str):
             return None
-        soft_assert_type_text(string_value)
 
         index_value = None
         if self.index_expression is not None:

--- a/corehq/apps/userreports/mixins.py
+++ b/corehq/apps/userreports/mixins.py
@@ -1,13 +1,11 @@
 
 from collections import OrderedDict
 
-import six
 from sqlagg.columns import SimpleColumn
 
 from corehq.apps.reports.sqlreport import DatabaseColumn
 from corehq.apps.userreports.reports.filters.specs import create_filter_value
 from corehq.apps.userreports.util import get_table_name
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class ConfigurableReportDataSourceMixin(object):
@@ -23,9 +21,8 @@ class ConfigurableReportDataSourceMixin(object):
             self._config = config_or_config_id
             self._config_id = config_or_config_id.id
         else:
-            assert isinstance(config_or_config_id, six.string_types), \
+            assert isinstance(config_or_config_id, str), \
                 '{} is not an allowed type'.format(type(config_or_config_id))
-            soft_assert_type_text(config_or_config_id)
             self._config = None
             self._config_id = config_or_config_id
 

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -1,5 +1,3 @@
-
-import six
 from memoized import memoized
 
 from corehq.apps.userreports.app_manager.data_source_meta import (
@@ -23,7 +21,6 @@ from corehq.apps.userreports.reports.builder.const import (
     UI_AGGREGATIONS,
 )
 from corehq.apps.userreports.sql import get_column_name
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class ColumnOption(object):
@@ -167,8 +164,7 @@ class FormMetaColumnOption(ColumnOption):
         # ui_aggregation parameter is never used because we need not infer the data type
         # self._question_source is a tuple of (identifier, datatype)
         identifier = self._meta_property_spec[0]
-        if isinstance(identifier, six.string_types):
-            soft_assert_type_text(identifier)
+        if isinstance(identifier, str):
             identifier = [identifier]
         identifier = "/".join(identifier)
         column_id = get_column_name(identifier.strip("/"))

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -1,5 +1,3 @@
-import six
-
 from corehq.apps.userreports.const import (
     DATA_SOURCE_TYPE_STANDARD,
     UCR_SQL_BACKEND,
@@ -15,7 +13,6 @@ from corehq.apps.userreports.sql.data_source import (
     ConfigurableReportSqlDataSource,
 )
 from corehq.util.datadog.utils import ucr_load_counter
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class ConfigurableReportDataSource(object):
@@ -35,8 +32,7 @@ class ConfigurableReportDataSource(object):
             self._config = config_or_config_id
             self._config_id = self._config._id
         else:
-            assert isinstance(config_or_config_id, six.string_types)
-            soft_assert_type_text(config_or_config_id)
+            assert isinstance(config_or_config_id, str), type(config_or_config_id)
             self._config = None
             self._config_id = config_or_config_id
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -4,7 +4,6 @@ from datetime import date
 
 from django.utils.translation import ugettext as _
 
-import six
 from jsonobject.base import DefaultProperty
 from jsonobject.exceptions import BadValueError
 from memoized import memoized
@@ -51,7 +50,6 @@ from corehq.apps.userreports.reports.sorting import ASCENDING, DESCENDING
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.transforms.factory import TransformFactory
 from corehq.apps.userreports.util import localize
-from corehq.util.python_compatibility import soft_assert_type_text
 
 SQLAGG_COLUMN_MAP = {
     const.AGGGREGATION_TYPE_AVG: MeanColumn,
@@ -526,8 +524,7 @@ class MultibarChartSpec(ChartSpec):
     def wrap(cls, obj):
         def _convert_columns_to_properly_dicts(cols):
             for column in cols:
-                if isinstance(column, six.string_types):
-                    soft_assert_type_text(column)
+                if isinstance(column, str):
                     yield {'column_id': column, 'display': column}
                 else:
                     yield column

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -2,8 +2,6 @@ from decimal import Decimal
 
 from django.utils.translation import get_language
 
-import six
-
 from dimagi.ext.jsonobject import DictProperty, JsonObject, StringProperty
 
 from corehq.apps.userreports.specs import TypeProperty
@@ -22,7 +20,6 @@ from corehq.apps.userreports.transforms.custom.users import (
     get_user_without_domain_display,
 )
 from corehq.apps.userreports.util import localize
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class Transform(JsonObject):
@@ -84,8 +81,7 @@ class NumberFormatTransform(Transform):
 
         def transform_function(value):
             try:
-                if isinstance(value, six.string_types):
-                    soft_assert_type_text(value)
+                if isinstance(value, str):
                     value = Decimal(value)
                 return self.format_string.format(value)
             except Exception:

--- a/corehq/apps/userreports/ui/fields.py
+++ b/corehq/apps/userreports/ui/fields.py
@@ -3,15 +3,12 @@ import json
 from django import forms
 from django.utils.translation import ugettext as _
 
-import six
-
 from corehq import toggles
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     StaticDataSourceConfiguration,
 )
 from corehq.apps.userreports.ui.widgets import JsonWidget
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class ReportDataSourceField(forms.ChoiceField):
@@ -41,8 +38,7 @@ class JsonField(forms.CharField):
         super(JsonField, self).__init__(*args, **kwargs)
 
     def prepare_value(self, value):
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             try:
                 return json.loads(value)
             except ValueError:

--- a/corehq/apps/userreports/ui/widgets.py
+++ b/corehq/apps/userreports/ui/widgets.py
@@ -2,16 +2,11 @@ import json
 
 from django import forms
 
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
-
 
 class JsonWidget(forms.Textarea):
 
     def render(self, name, value, attrs=None, renderer=None):
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             # It's probably invalid JSON
             return super(JsonWidget, self).render(name, value, attrs, renderer)
 

--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -8,13 +8,11 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.translation import ugettext as _
 
-import six
 from couchdbkit.exceptions import (
     BulkSaveError,
     MultipleResultsFound,
     ResourceNotFound,
 )
-from six.moves import map, range
 
 from couchexport.writers import Excel2007ExportWriter
 from dimagi.utils.chunked import chunked
@@ -35,7 +33,6 @@ from corehq.apps.users.dbaccessors.all_commcare_users import (
     get_existing_usernames,
 )
 from corehq.apps.users.models import UserRole
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.workbook_json.excel import (
     alphanumeric_sort_key,
     flatten_json,
@@ -68,7 +65,7 @@ def check_headers(user_specs):
     headers = set(user_specs.fieldnames)
 
     # Backwards warnings
-    for (old_name, new_name) in six.iteritems(old_headers):
+    for (old_name, new_name) in old_headers.items():
         if old_name in headers:
             messages.append(
                 _("'The column header '{old_name}' is deprecated, please use '{new_name}' instead.").format(
@@ -193,9 +190,8 @@ class GroupMemoizer(object):
 
 
 def _fmt_phone(phone_number):
-    if phone_number and not isinstance(phone_number, six.string_types):
-        phone_number = six.text_type(int(phone_number))
-    soft_assert_type_text(phone_number)
+    if phone_number and not isinstance(phone_number, str):
+        phone_number = str(int(phone_number))
     return phone_number.lstrip("+")
 
 
@@ -266,7 +262,7 @@ def create_or_update_groups(domain, group_specs, log):
     group_names = set()
     for row in group_specs:
         group_id = row.get('id')
-        group_name = six.text_type(row.get('name') or '')
+        group_name = str(row.get('name') or '')
         case_sharing = row.get('case-sharing')
         reporting = row.get('reporting')
         data = row.get('data')
@@ -304,10 +300,9 @@ def create_or_update_groups(domain, group_specs, log):
 
 
 def get_location_from_site_code(site_code, location_cache):
-    if isinstance(site_code, six.string_types):
-        soft_assert_type_text(site_code)
+    if isinstance(site_code, str):
         site_code = site_code.lower()
-    elif isinstance(site_code, six.integer_types):
+    elif isinstance(site_code, int):
         site_code = str(site_code)
     else:
         raise UserUploadError(
@@ -338,7 +333,7 @@ def users_with_duplicate_passwords(rows):
 
     for row in rows:
         username = row.get('username')
-        password = six.text_type(row.get('password'))
+        password = str(row.get('password'))
         if not is_password(password):
             continue
 
@@ -388,7 +383,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, task=None
 
             data = row.get('data')
             email = row.get('email')
-            group_names = list(map(six.text_type, row.get('group') or []))
+            group_names = list(map(str, row.get('group') or []))
             language = row.get('language')
             name = row.get('name')
             password = row.get('password')
@@ -404,9 +399,9 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, task=None
             role = row.get('role', '')
 
             if password:
-                password = six.text_type(password)
+                password = str(password)
             try:
-                username = normalize_username(six.text_type(username), domain)
+                username = normalize_username(str(username), domain)
             except TypeError:
                 username = None
             except ValidationError:
@@ -422,8 +417,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, task=None
             }
 
             is_active = row.get('is_active')
-            if isinstance(is_active, six.string_types):
-                soft_assert_type_text(is_active)
+            if isinstance(is_active, str):
                 try:
                     is_active = string_to_boolean(is_active) if is_active else None
                 except ValueError:
@@ -494,7 +488,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, task=None
                     if phone_number:
                         user.add_phone_number(_fmt_phone(phone_number), default=True)
                     if name:
-                        user.set_full_name(six.text_type(name))
+                        user.set_full_name(str(name))
                     if data:
                         error = custom_data_validator(data)
                         if error:
@@ -564,7 +558,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, task=None
                         group_memoizer.by_name(group_name).add_user(user, save=False)
 
                 except (UserUploadError, CouchUser.Inconsistent) as e:
-                    status_row['flag'] = six.text_type(e)
+                    status_row['flag'] = str(e)
 
             ret["rows"].append(status_row)
     finally:

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -16,7 +16,6 @@ from django.utils.translation import string_concat
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-import six
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import InlineField, StrictButton
@@ -24,7 +23,6 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout, Submit
 from django_countries.data import COUNTRIES
 from memoized import memoized
-from six.moves import range
 
 from dimagi.utils.django.fields import TrimmedCharField
 
@@ -43,10 +41,9 @@ from corehq.apps.locations.permissions import user_can_access_location_id
 from corehq.apps.programs.models import Program
 from corehq.apps.users.models import CouchUser, UserRole
 from corehq.apps.users.util import cc_user_domain, format_username
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
 
-mark_safe_lazy = lazy(mark_safe, six.text_type)
+mark_safe_lazy = lazy(mark_safe, str)
 
 UNALLOWED_MOBILE_WORKER_NAMES = ('admin', 'demo_user')
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -408,6 +408,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
     def preset_permissions_names(cls):
         return {details['name'] for role, details in PERMISSIONS_PRESETS.items()}
 
+
 PERMISSIONS_PRESETS = {
     'edit-apps': {
         'name': 'App Editor',

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -12,12 +12,10 @@ from django.utils.translation import override as override_language
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 
-import six
 from couchdbkit import MultipleResultsFound, ResourceNotFound
 from couchdbkit.exceptions import BadValueError, ResourceConflict
 from dateutil.relativedelta import relativedelta
 from memoized import memoized
-from six.moves import map, range
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.phone.models import OTARestoreCommCareUser, OTARestoreWebUser
@@ -81,7 +79,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.sql_db.routers import db_for_read_write
 from corehq.util.dates import get_timestamp
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 from corehq.util.view_utils import absolute_reverse
 
@@ -400,7 +397,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def get_preset_permission_by_name(cls, name):
-        matches = {k for k, v in six.iteritems(PERMISSIONS_PRESETS) if v['name'] == name}
+        matches = {k for k, v in PERMISSIONS_PRESETS.items() if v['name'] == name}
         return matches.pop() if matches else None
 
     @classmethod
@@ -409,7 +406,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @classmethod
     def preset_permissions_names(cls):
-        return {details['name'] for role, details in six.iteritems(PERMISSIONS_PRESETS)}
+        return {details['name'] for role, details in PERMISSIONS_PRESETS.items()}
 
 PERMISSIONS_PRESETS = {
     'edit-apps': {
@@ -977,7 +974,6 @@ class ReportingMetadata(DocumentSchema):
     last_build_for_user = SchemaProperty(LastBuild)
 
 
-@six.python_2_unicode_compatible
 class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
     """
     A user (for web and commcare)
@@ -1210,9 +1206,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     def add_phone_number(self, phone_number, default=False, **kwargs):
         """ Don't add phone numbers if they already exist """
-        if not isinstance(phone_number, six.string_types):
-            phone_number = six.text_type(phone_number)
-        soft_assert_type_text(phone_number)
+        if not isinstance(phone_number, str):
+            phone_number = str(phone_number)
         self.phone_numbers = _add_to_list(self.phone_numbers, phone_number, default)
 
     def set_default_phone_number(self, phone_number):
@@ -2441,8 +2436,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     def set_location(self, domain, location_object_or_id):
         # set the primary location for user's domain_membership
-        if isinstance(location_object_or_id, six.string_types):
-            soft_assert_type_text(location_object_or_id)
+        if isinstance(location_object_or_id, str):
             location_id = location_object_or_id
         else:
             location_id = location_object_or_id.location_id

--- a/corehq/dbaccessors/couchapps/all_docs.py
+++ b/corehq/dbaccessors/couchapps/all_docs.py
@@ -1,8 +1,6 @@
 from corehq.preindex import get_preindex_plugin
 from corehq.util.couch_helpers import paginate_view
-from corehq.util.python_compatibility import soft_assert_type_text
 from dimagi.utils.chunked import chunked
-import six
 
 
 def _get_all_docs_dbs():
@@ -54,8 +52,7 @@ def get_all_docs_with_doc_types(db, doc_types):
 
     returns doc JSON (not wrapped)
     """
-    if isinstance(doc_types, six.string_types):
-        soft_assert_type_text(doc_types)
+    if isinstance(doc_types, str):
         raise TypeError('get_all_docs_with_doc_types requires doc_types '
                         'to be a sequence of strings, not {!r}'.format(doc_types))
     for doc_type in doc_types:

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -45,9 +45,8 @@ class ESJSONSerializer(object):
 
     def dumps(self, data):
         # don't serialize strings
-        if isinstance(data, (str, bytes)):
+        if isinstance(data, str):
             return data
-
         try:
             return json.dumps(data, cls=CommCareJSONEncoder)
         except (ValueError, TypeError) as e:

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -5,7 +5,7 @@ import copy
 import logging
 import time
 
-from six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 from corehq.util.json import CommCareJSONEncoder
 from dimagi.utils.chunked import chunked
@@ -27,11 +27,8 @@ from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
-from corehq.util.python_compatibility import soft_assert_type_text
 from memoized import memoized
 from pillowtop.processors.elastic import send_to_elasticsearch as send_to_es
-import six
-from six.moves import range
 
 
 class ESJSONSerializer(object):
@@ -48,7 +45,7 @@ class ESJSONSerializer(object):
 
     def dumps(self, data):
         # don't serialize strings
-        if isinstance(data, six.string_types):
+        if isinstance(data, (str, bytes)):
             return data
 
         try:
@@ -117,8 +114,7 @@ def doc_exists_in_es(index_info, doc_id_or_dict):
     """
     Check if a document exists, by ID or the whole document.
     """
-    if isinstance(doc_id_or_dict, six.string_types):
-        soft_assert_type_text(doc_id_or_dict)
+    if isinstance(doc_id_or_dict, str):
         doc_id = doc_id_or_dict
     else:
         assert isinstance(doc_id_or_dict, dict)
@@ -509,7 +505,7 @@ def parse_args_for_es(request, prefix=None):
         return str[:-2] if str.endswith('[]') else str
 
     params, facets = {}, []
-    for attr in six.iterlists(request.GET):
+    for attr in request.GET.lists():
         param, vals = attr[0], attr[1]
         if param == 'facets':
             facets = vals[0].split()
@@ -531,7 +527,7 @@ def generate_sortables_from_facets(results, params=None):
     """
 
     def generate_facet_dict(f_name, ft):
-        if isinstance(ft['term'], six.text_type): #hack to get around unicode encoding issues. However it breaks this specific facet
+        if isinstance(ft['term'], str): #hack to get around unicode encoding issues. However it breaks this specific facet
             ft['term'] = ft['term'].encode('ascii', 'replace')
 
         return {'name': ft["term"],

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -527,7 +527,8 @@ def generate_sortables_from_facets(results, params=None):
     """
 
     def generate_facet_dict(f_name, ft):
-        if isinstance(ft['term'], str): #hack to get around unicode encoding issues. However it breaks this specific facet
+        # hack to get around unicode encoding issues. However it breaks this specific facet
+        if isinstance(ft['term'], str):
             ft['term'] = ft['term'].encode('ascii', 'replace')
 
         return {'name': ft["term"],

--- a/corehq/ex-submodules/casexml/apps/case/xml/parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/parser.py
@@ -8,10 +8,7 @@ import datetime
 from casexml.apps.case import const
 from casexml.apps.case.models import CommCareCaseAction
 from casexml.apps.case.xml import DEFAULT_VERSION, V1, V2, NS_REVERSE_LOOKUP_MAP
-from corehq.util.python_compatibility import soft_assert_type_text
 from dimagi.utils.parsing import string_to_utc_datetime
-import six
-from six.moves import filter
 
 XMLNS_ATTR = "@xmlns"
 KNOWN_PROPERTIES = {
@@ -211,8 +208,7 @@ class CaseAttachmentAction(CaseActionBase):
             return cls(block, attachments)
 
         for id, data in block.items():
-            if isinstance(data, six.string_types):
-                soft_assert_type_text(data)
+            if isinstance(data, str):
                 attachment_src = None
                 attachment_from = None
                 attachment_name = None

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -11,7 +11,6 @@ from datetime import datetime, timedelta
 from wsgiref.util import FileWrapper
 from xml.etree import cElementTree as ElementTree
 
-import six
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
 from django.http import HttpResponse, StreamingHttpResponse
@@ -28,7 +27,6 @@ from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SE
 from casexml.apps.phone.utils import get_cached_items_with_count
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED, LIVEQUERY_SYNC
 from corehq.util.datadog.utils import bucket_value, maybe_add_domain_tag
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.timer import TimingContext
 from corehq.util.datadog.gauges import datadog_counter
 from memoized import memoized
@@ -300,10 +298,8 @@ class RestoreParams(object):
         self.include_item_count = include_item_count
         self.app = app
         self.device_id = device_id
-        if isinstance(openrosa_version, six.string_types):
-            soft_assert_type_text(openrosa_version)
         self.openrosa_version = (LooseVersion(openrosa_version)
-            if isinstance(openrosa_version, six.string_types) else openrosa_version)
+            if isinstance(openrosa_version, str) else openrosa_version)
 
     @property
     def app_id(self):
@@ -574,7 +570,7 @@ class RestoreConfig(object):
                               (type(e).__name__, self.restore_user.username, str(e)))
             is_async = False
             response = get_simple_response_xml(
-                six.text_type(e),
+                str(e),
                 ResponseNature.OTA_RESTORE_ERROR
             )
             response = HttpResponse(response, content_type="text/xml; charset=utf-8",
@@ -675,7 +671,7 @@ class RestoreConfig(object):
             response_or_name = task.get(timeout=self._get_task_timeout(new_task))
             if isinstance(response_or_name, bytes):
                 response_or_name = response_or_name.decode('utf-8')
-            if isinstance(response_or_name, six.text_type):
+            if isinstance(response_or_name, str):
                 response = CachedResponse(response_or_name)
             else:
                 response = response_or_name

--- a/corehq/ex-submodules/couchexport/export.py
+++ b/corehq/ex-submodules/couchexport/export.py
@@ -5,10 +5,6 @@ from couchexport.exceptions import SchemaMismatchException,\
 from django.conf import settings
 from couchexport.models import Format
 from couchexport import writers
-import six
-from six.moves import range
-from six.moves import map
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def get_writer(format):
@@ -98,7 +94,6 @@ def export_raw_to_writer(headers, data, file, format=Format.XLS_2007,
     writer.close()
 
 
-@six.python_2_unicode_compatible
 class Constant(object):
 
     def __init__(self, message):
@@ -106,6 +101,7 @@ class Constant(object):
 
     def __str__(self):
         return self.message
+
 
 SCALAR_NEVER_WAS = settings.COUCHEXPORT_SCALAR_NEVER_WAS \
                     if hasattr(settings, "COUCHEXPORT_SCALAR_NEVER_WAS") \
@@ -174,9 +170,8 @@ def fit_to_schema(doc, schema):
     if schema == "string":
         if not doc:
             doc = ""
-        if not isinstance(doc, six.string_types):
-            doc = six.text_type(doc)
-        soft_assert_type_text(doc)
+        if not isinstance(doc, str):
+            doc = str(doc)
         return doc
 
 
@@ -220,8 +215,7 @@ def _create_intermediate_tables(docs, schema):
         column = []
         id = []
         for k in path:
-            if isinstance(k, six.string_types):
-                soft_assert_type_text(k)
+            if isinstance(k, str):
                 if k:
                     column.append(k)
             else:
@@ -283,18 +277,16 @@ class FormattedRow(object):
 
     @property
     def formatted_id(self):
-        if isinstance(self.id, six.string_types):
-            soft_assert_type_text(self.id)
+        if isinstance(self.id, str):
             return self.id
-        return self.separator.join(map(six.text_type, self.id))
+        return self.separator.join(map(str, self.id))
 
     def include_compound_id(self):
         return len(self.compound_id) > 1
 
     @property
     def compound_id(self):
-        if isinstance(self.id, six.string_types):
-            soft_assert_type_text(self.id)
+        if isinstance(self.id, str):
             return [self.id]
         return self.id
 
@@ -331,8 +323,7 @@ class FormattedRow(object):
             except StopIteration:
                 return rows
             rows = itertools.chain([first_entry], rows)
-            if first_entry and (not hasattr(first_entry, '__iter__') or isinstance(first_entry, six.string_types)):
-                soft_assert_type_text(first_entry)
+            if first_entry and (not hasattr(first_entry, '__iter__') or isinstance(first_entry, str)):
                 # `rows` is actually just a single row, so wrap it
                 return [rows]
             return rows

--- a/corehq/ex-submodules/couchexport/export.py
+++ b/corehq/ex-submodules/couchexport/export.py
@@ -103,13 +103,13 @@ class Constant(object):
         return self.message
 
 
-SCALAR_NEVER_WAS = settings.COUCHEXPORT_SCALAR_NEVER_WAS \
-                    if hasattr(settings, "COUCHEXPORT_SCALAR_NEVER_WAS") \
-                    else "---"
+SCALAR_NEVER_WAS = (settings.COUCHEXPORT_SCALAR_NEVER_WAS
+    if hasattr(settings, "COUCHEXPORT_SCALAR_NEVER_WAS")
+    else "---")
 
-LIST_NEVER_WAS = settings.COUCHEXPORT_LIST_NEVER_WAS \
-                    if hasattr(settings, "COUCHEXPORT_LIST_NEVER_WAS") \
-                    else "this list never existed"
+LIST_NEVER_WAS = (settings.COUCHEXPORT_LIST_NEVER_WAS
+    if hasattr(settings, "COUCHEXPORT_LIST_NEVER_WAS")
+    else "this list never existed")
 
 scalar_never_was = Constant(SCALAR_NEVER_WAS)
 list_never_was = Constant(LIST_NEVER_WAS)
@@ -127,6 +127,7 @@ def render_never_was(schema):
         return list_never_was
     else:
         return scalar_never_was
+
 
 unknown_type = None
 
@@ -359,8 +360,7 @@ def _format_tables(tables, id_label='id', separator='.', include_headers=True,
             id_key = [id_label]
             id_len = len(list(table)[0])  # this is a proxy for the complexity of the ID
             if id_len > 1:
-                id_key += ["{id}__{count}".format(id=id_label, count=i) \
-                           for i in range(id_len)]
+                id_key += ["{id}__{count}".format(id=id_label, count=i) for i in range(id_len)]
             header_vals = [separator.join(key) for key in keys]
             new_table.append(FormattedRow(header_vals, id_key, separator,
                                           is_header_row=True))

--- a/corehq/ex-submodules/couchexport/files.py
+++ b/corehq/ex-submodules/couchexport/files.py
@@ -1,14 +1,9 @@
 import os
 import tempfile
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def Temp(tmp):
-    if isinstance(tmp, six.string_types):
-        soft_assert_type_text(tmp)
-    cls = PathTemp if isinstance(tmp, six.string_types) else StringIOTemp
+    cls = PathTemp if isinstance(tmp, (str, bytes)) else StringIOTemp
     return cls(tmp)
 
 

--- a/corehq/ex-submodules/couchexport/files.py
+++ b/corehq/ex-submodules/couchexport/files.py
@@ -3,7 +3,7 @@ import tempfile
 
 
 def Temp(tmp):
-    cls = PathTemp if isinstance(tmp, (str, bytes)) else StringIOTemp
+    cls = PathTemp if isinstance(tmp, str) else StringIOTemp
     return cls(tmp)
 
 

--- a/corehq/ex-submodules/couchexport/properties.py
+++ b/corehq/ex-submodules/couchexport/properties.py
@@ -1,9 +1,6 @@
 from dateutil.parser import parse
 from dimagi.ext.couchdbkit import DateTimeProperty, Property
 import json
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def parse_date_string(datestring, precise=False):
@@ -41,8 +38,7 @@ class TimeStampProperty(DateTimeProperty):
         super(TimeStampProperty, self).__init__(**kwargs)
 
     def to_python(self, value):
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             try:
                 return parse_date_string(value, self.precise_reads)
             except ValueError as e:

--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -4,14 +4,10 @@ import json
 from dimagi.ext.couchdbkit import Property
 from dimagi.utils.modules import to_function
 from dimagi.utils.web import json_handler
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def force_tag_to_list(export_tag):
-    if isinstance(export_tag, six.string_types):
-        soft_assert_type_text(export_tag)
+    if isinstance(export_tag, str):
         export_tag = [export_tag]
     assert isinstance(export_tag, list)
     return export_tag

--- a/corehq/ex-submodules/dimagi/utils/couch/database.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/database.py
@@ -6,10 +6,6 @@ from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.bulk import get_docs
 from requests.exceptions import RequestException
 from time import sleep
-import six
-from six.moves import range
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class DocTypeMismatchException(Exception):
@@ -154,9 +150,8 @@ class SafeSaveDocument(Document):
 
 
 def safe_delete(db, doc_or_id):
-    if not isinstance(doc_or_id, six.string_types):
+    if not isinstance(doc_or_id, str):
         doc_or_id = doc_or_id._id
-    soft_assert_type_text(doc_or_id)
     db.delete_doc(doc_or_id, **get_safe_write_kwargs())
 
 

--- a/corehq/ex-submodules/dimagi/utils/data/deid_generator.py
+++ b/corehq/ex-submodules/dimagi/utils/data/deid_generator.py
@@ -1,10 +1,9 @@
 import hashlib
-from datetime import datetime
 from functools import reduce
 
 
 def to_number(bytes):
-    return reduce(lambda a, b: a*256 + b, bytes)
+    return reduce(lambda a, b: a * 256 + b, bytes)
 
 
 def to_base(n, b):

--- a/corehq/ex-submodules/dimagi/utils/data/deid_generator.py
+++ b/corehq/ex-submodules/dimagi/utils/data/deid_generator.py
@@ -1,10 +1,6 @@
 import hashlib
 from datetime import datetime
 from functools import reduce
-import six
-from six.moves import range
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def to_number(bytes):
@@ -34,17 +30,12 @@ class DeidGenerator(object):
 
     def _sha1_bytes(self):
         byte_list = hashlib.sha1(self.seed.encode('utf-8')).digest()
-        for b in byte_list[:self.bytes]:
-            if six.PY3:
-                yield b
-            else:
-                yield ord(b)
+        yield from byte_list[:self.bytes]
 
     def digest(self, alphabet="0123456789"):
         b = len(alphabet)
         answer = [alphabet[i] for i in to_base(self.number, b)]
-        if isinstance(alphabet, six.string_types):
-            soft_assert_type_text(alphabet)
+        if isinstance(alphabet, str):
             answer = ''.join(answer)
         return answer
 

--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -1,7 +1,6 @@
 import datetime
 from calendar import month_name
 from django.utils.translation import ugettext_lazy as _
-import logging
 
 try:
     # < 3.0

--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -2,7 +2,6 @@ import datetime
 from calendar import month_name
 from django.utils.translation import ugettext_lazy as _
 import logging
-import six
 
 try:
     # < 3.0
@@ -24,9 +23,7 @@ def force_to_date(val):
         return val.date()
     elif isinstance(val, datetime.date):
         return val
-    elif isinstance(val, six.string_types):
-        from corehq.util.python_compatibility import soft_assert_type_text
-        soft_assert_type_text(val)
+    elif isinstance(val, str):
         return string_to_datetime(val).date()
     else:
         raise ValueError("object must be date or datetime!")
@@ -40,9 +37,7 @@ def force_to_datetime(val):
         return val
     elif isinstance(val, datetime.date):
         return datetime.datetime.combine(val, datetime.time())
-    elif isinstance(val, six.string_types):
-        from corehq.util.python_compatibility import soft_assert_type_text
-        soft_assert_type_text(val)
+    elif isinstance(val, str):
         return string_to_datetime(val)
     else:
         raise ValueError("object must be date or datetime!")

--- a/corehq/ex-submodules/dimagi/utils/decorators/profile.py
+++ b/corehq/ex-submodules/dimagi/utils/decorators/profile.py
@@ -10,9 +10,7 @@ import logging
 from datetime import datetime
 from django.conf import settings
 from corehq.util.decorators import ContextDecorator
-from corehq.util.python_compatibility import soft_assert_type_text
 from dimagi.utils.modules import to_function
-import six
 
 logger = logging.getLogger(__name__)
 
@@ -139,8 +137,7 @@ try:
                     profiler = LineProfiler()
                     profiler.add_function(func)
                     for f in follow:
-                        if isinstance(f, six.string_types):
-                            soft_assert_type_text(f)
+                        if isinstance(f, str):
                             f = to_function(f)
                         profiler.add_function(f)
                     profiler.enable_by_count()

--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -20,7 +20,7 @@ LARGE_FILE_SIZE_ERROR_CODES = [LARGE_FILE_SIZE_ERROR_CODE, LARGE_FILE_SIZE_ERROR
 def send_HTML_email(subject, recipient, html_content, text_content=None,
                     cc=None, email_from=settings.DEFAULT_FROM_EMAIL,
                     file_attachments=None, bcc=None, smtp_exception_skip_list=None):
-    recipient = list(recipient) if not isinstance(recipient, (str, bytes)) else [recipient]
+    recipient = list(recipient) if not isinstance(recipient, str) else [recipient]
 
     if not isinstance(html_content, str):
         html_content = html_content.decode('utf-8')

--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -5,8 +5,6 @@ from django.core.mail import get_connection
 from django.core.mail.message import EmailMultiAlternatives
 from django.utils.translation import ugettext as _
 
-import six
-
 NO_HTML_EMAIL_MESSAGE = """
 Your email client is trying to display the plaintext version of an email that
 is only supported in HTML. Please set your email client to display this message
@@ -22,18 +20,15 @@ LARGE_FILE_SIZE_ERROR_CODES = [LARGE_FILE_SIZE_ERROR_CODE, LARGE_FILE_SIZE_ERROR
 def send_HTML_email(subject, recipient, html_content, text_content=None,
                     cc=None, email_from=settings.DEFAULT_FROM_EMAIL,
                     file_attachments=None, bcc=None, smtp_exception_skip_list=None):
-    from corehq.util.python_compatibility import soft_assert_type_text
-    if isinstance(recipient, six.string_types):
-        soft_assert_type_text(recipient)
-    recipient = list(recipient) if not isinstance(recipient, six.string_types) else [recipient]
+    recipient = list(recipient) if not isinstance(recipient, (str, bytes)) else [recipient]
 
-    if not isinstance(html_content, six.text_type):
+    if not isinstance(html_content, str):
         html_content = html_content.decode('utf-8')
 
     if not text_content:
         text_content = getattr(settings, 'NO_HTML_EMAIL_MESSAGE',
                                NO_HTML_EMAIL_MESSAGE)
-    elif not isinstance(text_content, six.text_type):
+    elif not isinstance(text_content, str):
         text_content = text_content.decode('utf-8')
 
     from_header = {'From': email_from}  # From-header

--- a/corehq/ex-submodules/fluff/indicators.py
+++ b/corehq/ex-submodules/fluff/indicators.py
@@ -27,7 +27,9 @@ class FlatField(schema.StringProperty):
         super(FlatField, self).__init__(*args, **kwargs)
 
     def calculate(self, item):
-        return self.fn(item)
+        result = self.fn(item)
+        assert isinstance(result, str), type(item)
+        return result
 
 
 class AttributeGetter(object):

--- a/corehq/ex-submodules/fluff/indicators.py
+++ b/corehq/ex-submodules/fluff/indicators.py
@@ -3,12 +3,9 @@ from couchdbkit.ext.django import schema
 import datetime
 import sqlalchemy
 
-from corehq.util.python_compatibility import soft_assert_type_text
 from .util import get_indicator_model, default_null_value_placeholder
 from .calculators import Calculator
 from .const import ALL_TYPES, TYPE_STRING
-import six
-from six.moves import zip
 
 
 class FlatField(schema.StringProperty):
@@ -30,10 +27,7 @@ class FlatField(schema.StringProperty):
         super(FlatField, self).__init__(*args, **kwargs)
 
     def calculate(self, item):
-        result = self.fn(item)
-        assert isinstance(result, six.string_types)
-        soft_assert_type_text(result)
-        return result
+        return self.fn(item)
 
 
 class AttributeGetter(object):
@@ -79,7 +73,7 @@ class IndicatorDocumentMeta(schema.DocumentMeta):
         return cls
 
 
-class IndicatorDocument(six.with_metaclass(IndicatorDocumentMeta, schema.Document)):
+class IndicatorDocument(schema.Document, metaclass=IndicatorDocumentMeta):
 
     base_doc = 'IndicatorDocument'
 
@@ -112,8 +106,7 @@ class IndicatorDocument(six.with_metaclass(IndicatorDocumentMeta, schema.Documen
     @property
     def wrapped_group_by(self):
         def _wrap_if_necessary(string_or_attribute_getter):
-            if isinstance(string_or_attribute_getter, six.string_types):
-                soft_assert_type_text(string_or_attribute_getter)
+            if isinstance(string_or_attribute_getter, str):
                 getter = AttributeGetter(string_or_attribute_getter)
             else:
                 getter = string_or_attribute_getter

--- a/corehq/ex-submodules/fluff/indicators.py
+++ b/corehq/ex-submodules/fluff/indicators.py
@@ -28,7 +28,7 @@ class FlatField(schema.StringProperty):
 
     def calculate(self, item):
         result = self.fn(item)
-        assert isinstance(result, str), type(item)
+        assert isinstance(result, str), type(result)
         return result
 
 

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -8,9 +8,6 @@ from pillowtop.exceptions import PillowtopCheckpointReset
 from pillowtop.logger import pillow_logging
 from pillowtop.models import DjangoPillowCheckpoint, KafkaCheckpoint, kafka_seq_to_str, str_to_kafka_seq
 from pillowtop.pillow.interface import ChangeEventHandler
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 MAX_CHECKPOINT_DELAY = 300
 DELAY_SENTINEL = object()
@@ -197,8 +194,7 @@ class KafkaPillowCheckpoint(PillowCheckpoint):
         return kafka_seq_to_str(self.get_current_sequence_as_dict())
 
     def update_to(self, seq, change=None):
-        if isinstance(seq, six.string_types):
-            soft_assert_type_text(seq)
+        if isinstance(seq, str):
             kafka_seq = str_to_kafka_seq(seq)
         else:
             kafka_seq = seq

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -9,12 +9,10 @@ from dimagi.utils.parsing import string_to_utc_datetime
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.users.models import CouchUser, LastSubmission, DeviceAppMeta
 from corehq.pillows.utils import format_form_meta_for_es
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 from corehq.apps.receiverwrapper.util import get_app_version_info
 
 from .interface import PillowProcessor
-import six
 
 
 class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
@@ -102,10 +100,8 @@ def mark_latest_submission(domain, user_id, app_id, build_id, version, metadata,
     last_submission = filter_by_app(user.reporting_metadata.last_submissions, app_id)
 
     if metadata and metadata.get('appVersion'):
-        if not isinstance(metadata['appVersion'], six.string_types):
+        if not isinstance(metadata['appVersion'], str):
             metadata = format_form_meta_for_es(metadata)
-        else:
-            soft_assert_type_text(metadata['appVersion'])
 
     app_version_info = get_app_version_info(
         domain,

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -14,9 +14,6 @@ from dimagi.utils.modules import to_function
 from pillowtop.exceptions import PillowNotFoundError
 from pillowtop.logger import pillow_logging
 from pillowtop.dao.exceptions import DocumentMismatchError, DocumentMissingError
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def _get_pillow_instance(full_class_str):
@@ -89,8 +86,7 @@ class PillowConfig(namedtuple('PillowConfig', ['section', 'name', 'class_name', 
 
 
 def get_pillow_config_from_setting(section, pillow_config_string_or_dict):
-    if isinstance(pillow_config_string_or_dict, six.string_types):
-        soft_assert_type_text(pillow_config_string_or_dict)
+    if isinstance(pillow_config_string_or_dict, str):
         return PillowConfig(
             section,
             pillow_config_string_or_dict.rsplit('.', 1)[1],
@@ -129,11 +125,10 @@ def force_seq_int(seq):
     elif isinstance(seq, dict):
         # multi-topic checkpoints don't support a single sequence id
         return None
-    elif isinstance(seq, six.string_types):
-        soft_assert_type_text(seq)
+    elif isinstance(seq, str):
         return int(seq.split('-')[0])
     else:
-        assert isinstance(seq, int)
+        assert isinstance(seq, int), type(seq)
         return seq
 
 
@@ -261,11 +256,9 @@ def prepare_bulk_payloads(bulk_changes, max_size, chunk_size=100):
     for bulk_chunk in chunked(bulk_changes, chunk_size):
         current_payload = payloads[-1]
         json_bulk_chunks = [
-            json.dumps(obj, cls=CommCareJSONEncoder)
+            json.dumps(obj, cls=CommCareJSONEncoder).encode('utf-8')
             for obj in bulk_chunk
         ]
-        if six.PY3:
-            json_bulk_chunks = [chunk.encode('utf-8') for chunk in json_bulk_chunks]
         payload_chunk = b'\n'.join(json_bulk_chunks) + b'\n'
         appended_payload = current_payload + payload_chunk
         new_payload_size = sys.getsizeof(appended_payload)

--- a/corehq/ex-submodules/soil/__init__.py
+++ b/corehq/ex-submodules/soil/__init__.py
@@ -15,10 +15,8 @@ from django.http import HttpResponse, StreamingHttpResponse
 from django_transfer import TransferHttpResponse
 from soil.progress import get_task_progress, get_multiple_task_progress, set_task_progress
 from corehq.blobs import get_blob_db
-import six
 
 from corehq.const import ONE_DAY
-from corehq.util.python_compatibility import soft_assert_type_text
 
 GLOBAL_RW = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
 
@@ -104,8 +102,7 @@ class DownloadBase(object):
         Sometimes filenames have characters in them which aren't allowed in
         headers and causes the download to fail.
         """
-        if isinstance(content_disposition, six.string_types):
-            soft_assert_type_text(content_disposition)
+        if isinstance(content_disposition, str):
             return re.compile('[\r\n]').sub('', content_disposition)
 
         return content_disposition

--- a/corehq/ex-submodules/soil/views.py
+++ b/corehq/ex-submodules/soil/views.py
@@ -15,14 +15,10 @@ from soil.exceptions import TaskFailedError
 from soil.heartbeat import get_file_heartbeat, get_cache_heartbeat, last_heartbeat
 from soil.tasks import demo_sleep
 from soil.util import get_download_context
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def _parse_date(string):
-    if isinstance(string, six.string_types):
-        soft_assert_type_text(string)
+    if isinstance(string, str):
         return datetime.strptime(string, "%Y-%m-%d").date()
     else:
         return string

--- a/corehq/form_processor/utils/metadata.py
+++ b/corehq/form_processor/utils/metadata.py
@@ -5,8 +5,6 @@ from jsonobject.api import re_date
 
 from dimagi.utils.parsing import json_format_datetime
 from corehq.util.dates import iso_string_to_datetime
-from corehq.util.python_compatibility import soft_assert_type_text
-import six
 
 
 def scrub_meta(xform):
@@ -125,7 +123,8 @@ def _get_text_attribute(node):
     else:
         value = node
 
-    if not isinstance(value, six.string_types):
-        value = six.text_type(value)
-    soft_assert_type_text(value)
+    if isinstance(value, bytes):
+        value = value.decode('utf-8')
+    elif not isinstance(value, str):
+        value = str(value)
     return value

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -3,14 +3,12 @@ from lxml import etree
 
 import iso8601
 import pytz
-import six
 
 import xml2json
 from corehq.apps.tzmigration.api import phone_timezones_should_be_processed
 from corehq.form_processor.interfaces.processor import XFormQuestionValueIterator
 from corehq.form_processor.models import Attachment
 from corehq.form_processor.exceptions import XFormQuestionValueNotFound
-from corehq.util.python_compatibility import soft_assert_type_text
 from dimagi.ext import jsonobject
 from dimagi.utils.parsing import json_format_datetime
 
@@ -198,10 +196,9 @@ def adjust_datetimes(data, parent=None, key=None, process_timezones=None):
     process_timezones = process_timezones or phone_timezones_should_be_processed()
     # this strips the timezone like we've always done
     # todo: in the future this will convert to UTC
-    if isinstance(data, six.string_types) and jsonobject.re_loose_datetime.match(data):
-        soft_assert_type_text(data)
+    if isinstance(data, str) and jsonobject.re_loose_datetime.match(data):
         try:
-            parent[key] = six.text_type(json_format_datetime(
+            parent[key] = str(json_format_datetime(
                 adjust_text_to_datetime(data, process_timezones=process_timezones)
             ))
         except (iso8601.ParseError, ValueError):

--- a/corehq/messaging/smsbackends/mach/models.py
+++ b/corehq/messaging/smsbackends/mach/models.py
@@ -1,11 +1,10 @@
 import binascii
-import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
+import urllib.request
+import urllib.parse
+import urllib.error
 from django.conf import settings
-import six.moves.urllib.request, six.moves.urllib.error, six.moves.urllib.parse
 from corehq.apps.sms.models import SQLSMSBackend, SMS
 from corehq.messaging.smsbackends.mach.forms import MachBackendForm
-from corehq.util.python_compatibility import soft_assert_type_text
-import six
 
 MACH_URL = "http://smsgw.a2p.mme.syniverse.com/sms.php"
 
@@ -67,12 +66,11 @@ class SQLMachBackend(SQLSMSBackend):
         )
 
     def handle_response(self, msg, response):
-        if not isinstance(response, six.string_types):
+        if not isinstance(response, str):
             raise SyniverseException(
                 "Unrecognized response received from Syniverse "
                 "backend %s" % self.pk
             )
-        soft_assert_type_text(response)
 
         response = response.strip().upper()
         if response.startswith('+OK'):
@@ -100,7 +98,7 @@ class SQLMachBackend(SQLSMSBackend):
         except UnicodeEncodeError:
             params['msg'] = binascii.hexlify(msg.text.encode('utf-16-be'))
             params['encoding'] = 'ucs'
-        url = '%s?%s' % (MACH_URL, six.moves.urllib.parse.urlencode(params))
-        resp = six.moves.urllib.request.urlopen(url, timeout=settings.SMS_GATEWAY_TIMEOUT).read().decode('utf-8')
+        url = '%s?%s' % (MACH_URL, urllib.parse.urlencode(params))
+        resp = urllib.request.urlopen(url, timeout=settings.SMS_GATEWAY_TIMEOUT).read().decode('utf-8')
         self.handle_response(msg, resp)
         return resp

--- a/corehq/messaging/smsbackends/starfish/views.py
+++ b/corehq/messaging/smsbackends/starfish/views.py
@@ -2,9 +2,6 @@ from corehq.apps.sms.api import incoming
 from corehq.apps.sms.views import IncomingBackendView
 from corehq.messaging.smsbackends.starfish.models import StarfishBackend
 from django.http import JsonResponse, HttpResponseBadRequest
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class StarfishIncomingView(IncomingBackendView):
@@ -15,8 +12,7 @@ class StarfishIncomingView(IncomingBackendView):
         return StarfishBackend
 
     def clean_value(self, value):
-        if isinstance(value, six.string_types):
-            soft_assert_type_text(value)
+        if isinstance(value, str):
             return value.strip()
         return value
 

--- a/corehq/motech/dhis2/dhis2_config.py
+++ b/corehq/motech/dhis2/dhis2_config.py
@@ -1,6 +1,3 @@
-
-import six
-
 from dimagi.ext.couchdbkit import (
     DocumentSchema,
     ListProperty,
@@ -14,7 +11,6 @@ from corehq.motech.dhis2.const import (
     DHIS2_EVENT_STATUSES,
 )
 from corehq.motech.value_source import ValueSource
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class FormDataValueMap(DocumentSchema):
@@ -35,8 +31,7 @@ class Dhis2FormConfig(DocumentSchema):
 
     @classmethod
     def wrap(cls, data):
-        if isinstance(data.get('org_unit_id'), six.string_types):
-            soft_assert_type_text(data.get('org_unit_id'))
+        if isinstance(data.get('org_unit_id'), str):
             # Convert org_unit_id from a string to a ConstantString
             data['org_unit_id'] = {
                 'doc_type': 'ConstantString',

--- a/corehq/motech/openmrs/finders_utils.py
+++ b/corehq/motech/openmrs/finders_utils.py
@@ -1,11 +1,8 @@
 
 from datetime import timedelta
 
-import six
 from dateutil.parser import parse as parse_date
 from Levenshtein import distance
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def le_days_diff(max_days, date1, date2):
@@ -22,11 +19,9 @@ def le_days_diff(max_days, date1, date2):
     False
 
     """
-    if isinstance(date1, six.string_types):
-        soft_assert_type_text(date1)
+    if isinstance(date1, str):
         date1 = parse_date(date1)
-    if isinstance(date2, six.string_types):
-        soft_assert_type_text(date2)
+    if isinstance(date2, str):
         date2 = parse_date(date2)
     return abs(date1 - date2) <= timedelta(max_days)
 

--- a/corehq/motech/openmrs/serializers.py
+++ b/corehq/motech/openmrs/serializers.py
@@ -3,7 +3,6 @@
 import datetime
 import re
 
-import six
 from dateutil import parser as dateutil_parser
 
 from corehq.motech.const import (
@@ -16,7 +15,6 @@ from corehq.motech.openmrs.const import (
     OPENMRS_DATA_TYPE_DATETIME,
 )
 from corehq.motech.serializers import serializers
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def to_omrs_date(value):
@@ -27,8 +25,7 @@ def to_omrs_date(value):
     True
 
     """
-    if isinstance(value, six.string_types):
-        soft_assert_type_text(value)
+    if isinstance(value, str):
         if not re.match(r'\d{4}-\d{2}-\d{2}', value):
             raise ValueError('"{}" is not recognised as a date or a datetime'.format(value))
         value = dateutil_parser.parse(value)
@@ -44,8 +41,7 @@ def to_omrs_datetime(value):
     True
 
     """
-    if isinstance(value, six.string_types):
-        soft_assert_type_text(value)
+    if isinstance(value, str):
         if not re.match(r'\d{4}-\d{2}-\d{2}', value):
             raise ValueError('"{}" is not recognised as a date or a datetime'.format(value))
         value = dateutil_parser.parse(value)
@@ -56,10 +52,7 @@ def to_omrs_datetime(value):
 
 
 def to_omrs_boolean(value):
-    if (
-        isinstance(value, six.string_types)
-        and value.lower() in ('false', '0')
-    ):
+    if isinstance(value, str) and value.lower() in ('false', '0'):
         return False
     return bool(value)
 

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -44,7 +44,6 @@ from corehq.motech.openmrs.models import POSIX_MILLISECONDS
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.requests import Requests
 from corehq.motech.utils import b64_aes_decrypt
-from corehq.util.python_compatibility import soft_assert_type_text
 
 RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
 LOCATION_OPENMRS = 'openmrs_uuid'  # The location metadata key that maps to its corresponding OpenMRS location UUID
@@ -60,7 +59,6 @@ def parse_params(params, location=None):
     parsed = {}
     for key, value in params.items():
         if isinstance(value, str) and '{{' in value:
-            soft_assert_type_text(value)
             template = Template(value)
             value = template.render(today=today, location=location_uuid)
         parsed[key] = value

--- a/corehq/motech/serializers.py
+++ b/corehq/motech/serializers.py
@@ -13,15 +13,11 @@ Serializer functions accept a value in `from_data_type`, and return a
 value in `to_data_type`.
 
 """
-
-import six
-
 from corehq.motech.const import (
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_INTEGER,
     COMMCARE_DATA_TYPE_TEXT,
 )
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def to_decimal(value):
@@ -41,9 +37,8 @@ def to_integer(value):
 def to_text(value):
     if value is None:
         return ''
-    if not isinstance(value, six.string_types):
-        return six.text_type(value)
-    soft_assert_type_text(value)
+    if not isinstance(value, str):
+        return str(value)
     return value
 
 

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -3,13 +3,10 @@ from base64 import b64decode, b64encode
 
 from django.conf import settings
 
-import six
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad as crypto_pad
 from Crypto.Util.Padding import unpad as crypto_unpad
 from Crypto.Util.py3compat import bord
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 AES_BLOCK_SIZE = 16
 AES_KEY_MAX_LEN = 32  # AES key must be either 16, 24, or 32 bytes long
@@ -121,9 +118,7 @@ def pformat_json(data):
     if data is None:
         return ''
     try:
-        if isinstance(data, six.string_types):
-            soft_assert_type_text(data)
-        json_data = json.loads(data) if isinstance(data, six.string_types) else data
+        json_data = json.loads(data) if isinstance(data, str) else data
         return json.dumps(json_data, indent=2, sort_keys=True)
     except ValueError:
         return data

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -1,7 +1,6 @@
 
 import datetime
 
-import six
 from django.conf import settings
 from django.http import Http404
 from django.urls import resolve, reverse
@@ -13,7 +12,6 @@ from corehq.apps.analytics import ab_tests
 from corehq.apps.accounting.models import BillingAccount
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
-from corehq.util.python_compatibility import soft_assert_type_text
 
 COMMCARE = 'commcare'
 COMMTRACK = 'commtrack'
@@ -180,8 +178,7 @@ def emails(request=None):
 
 def _get_cc_name(request, var):
     value = getattr(settings, var)
-    if isinstance(value, six.string_types):
-        soft_assert_type_text(value)
+    if isinstance(value, str):
         return value
 
     if request is None:

--- a/corehq/util/python_compatibility.py
+++ b/corehq/util/python_compatibility.py
@@ -1,23 +1,6 @@
+import pickle
 
-import six
 from django_redis.serializers.pickle import PickleSerializer
-
-from corehq.util.soft_assert import soft_assert
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
-
-_soft_assert_type_text = soft_assert(
-    exponential_backoff=True,
-)
-
-
-# After PY3 migration: remove
-def soft_assert_type_text(value):
-    _soft_assert_type_text(isinstance(value, six.text_type), 'expected unicode, got: %s' % type(value))
 
 
 class Py3PickleSerializer(PickleSerializer):

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -2,7 +2,6 @@
 import datetime
 import dateutil
 import pytz
-import six
 from functools import reduce
 from memoized import memoized
 
@@ -11,7 +10,6 @@ from django.core.exceptions import ValidationError
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CouchUser, WebUser, AnonymousCouchUser
 from corehq.util.global_request import get_request
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.soft_assert import soft_assert
 from corehq.util.dates import iso_string_to_datetime
 
@@ -58,8 +56,7 @@ def get_timezone_for_user(couch_user_or_id, domain):
         if isinstance(couch_user_or_id, CouchUser):
             requesting_user = couch_user_or_id
         else:
-            assert isinstance(couch_user_or_id, six.string_types)
-            soft_assert_type_text(couch_user_or_id)
+            assert isinstance(couch_user_or_id, str), type(couch_user_or_id)
             try:
                 requesting_user = WebUser.get_by_user_id(couch_user_or_id)
             except CouchUser.AccountTypeError:

--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -4,12 +4,8 @@ from zipfile import BadZipfile
 from tempfile import NamedTemporaryFile
 import openpyxl
 from openpyxl.utils.exceptions import InvalidFileException
-import six
-from six.moves import zip
 from django.core.files.uploadedfile import UploadedFile
 from django.utils.translation import ugettext as _
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 class InvalidExcelFileException(Exception):
@@ -73,9 +69,8 @@ class IteratorJSONReader(object):
     def get_fieldnames(self):
         obj = {}
         for field, value in zip(self.headers, [''] * len(self.headers)):
-            if not isinstance(field, six.string_types):
+            if not isinstance(field, str):
                 raise HeaderValueError('Field %s is not a string.' % field)
-            soft_assert_type_text(field)
             self.set_field_value(obj, field, value)
         return list(obj)
 
@@ -83,7 +78,7 @@ class IteratorJSONReader(object):
     def set_field_value(cls, obj, field, value):
         if isinstance(value, bytes):
             value = value.decode('utf-8')
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             value = value.strip()
         # try dict
         try:
@@ -236,12 +231,7 @@ class WorksheetJSONReader(IteratorJSONReader):
 class WorkbookJSONReader(object):
 
     def __init__(self, file_or_filename):
-        if six.PY3:
-            check_types = (UploadedFile, io.RawIOBase, io.BufferedIOBase)
-        else:
-            from types import FileType
-            check_types = (UploadedFile, FileType, io.BytesIO)
-
+        check_types = (UploadedFile, io.RawIOBase, io.BufferedIOBase)
         if isinstance(file_or_filename, check_types):
             tmp = NamedTemporaryFile(mode='wb', suffix='.xlsx', delete=False)
             file_or_filename.seek(0)
@@ -251,7 +241,7 @@ class WorkbookJSONReader(object):
         try:
             self.wb = openpyxl.load_workbook(file_or_filename, read_only=True, data_only=True)
         except (BadZipfile, InvalidFileException, KeyError) as e:
-            raise InvalidExcelFileException(six.text_type(e))
+            raise InvalidExcelFileException(str(e))
         self.worksheets_by_title = {}
         self.worksheets = []
 
@@ -301,11 +291,10 @@ def format_header(path, value):
     # pretty sure making a string-builder would be slower than concatenation
     s = path[0]
     for p in path[1:]:
-        if isinstance(p, six.string_types):
-            soft_assert_type_text(p)
-            s += ': %s' % p
+        if isinstance(p, str):
+            s += f': {p}'
         elif isinstance(p, int):
-            s += ' %s' % (p + 1)
+            s += f' {p + 1}'
     if isinstance(value, bool):
         s += '?'
         value = 'yes' if value else 'no'
@@ -332,11 +321,10 @@ def alphanumeric_sort_key(key):
 
 
 def enforce_string_type(value):
-    if isinstance(value, six.string_types):
-        soft_assert_type_text(value)
+    if isinstance(value, str):
         return value
 
-    if isinstance(value, six.integer_types):
+    if isinstance(value, int):
         return str(value)
 
     # Don't try to guess for decimal types how they should be converted to string

--- a/custom/_legacy/pact/models.py
+++ b/custom/_legacy/pact/models.py
@@ -17,10 +17,6 @@ from pact.enums import (
     REGIMEN_CHOICES,
 )
 from pact.regimen import regimen_string_from_doc
-import six
-from six.moves import range
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 
 def make_uuid():
@@ -419,7 +415,6 @@ class CDotWeeklySchedule(OldDocument):
 ADDENDUM_NOTE_STRING = "[AddendumEntry]"
 
 
-@six.python_2_unicode_compatible
 class CObservation(OldDocument):
     doc_id = StringProperty()
     patient = StringProperty()  # case id
@@ -459,8 +454,7 @@ class CObservation(OldDocument):
         ints = ['dose_number', 'total_doses', 'day_index', 'day_slot']
         for prop_name in ints:
             val = obj.get(prop_name)
-            if val and isinstance(val, six.string_types):
-                soft_assert_type_text(val)
+            if val and isinstance(val, str):
                 obj[prop_name] = int(val)
         return super(CObservation, cls).wrap(obj)
 

--- a/custom/apps/wisepill/models.py
+++ b/custom/apps/wisepill/models.py
@@ -1,19 +1,23 @@
-from dimagi.ext.couchdbkit import *
 from memoized import memoized
-import six
 
-from corehq.util.python_compatibility import soft_assert_type_text
+from dimagi.ext.couchdbkit import (
+    BooleanProperty,
+    DateTimeProperty,
+    Document,
+    StringProperty,
+)
 
 
 class WisePillDeviceEvent(Document):
     """
-    One DeviceEvent is created each time a device sends data that is 
+    One DeviceEvent is created each time a device sends data that is
     forwarded to the CommCareHQ WisePill API (/wisepill/device/).
     """
     domain = StringProperty()
     data = StringProperty()
     received_on = DateTimeProperty()
-    case_id = StringProperty() # Document _id of the case representing the device that sent this data in
+    # Document _id of the case representing the device that sent this data in
+    case_id = StringProperty()  
     processed = BooleanProperty()
 
     @property
@@ -23,8 +27,7 @@ class WisePillDeviceEvent(Document):
         Convert 'a=b,c=d' to {'a': 'b', 'c': 'd'}
         """
         result = {}
-        if isinstance(self.data, six.string_types):
-            soft_assert_type_text(self.data)
+        if isinstance(self.data, str):
             items = self.data.strip().split(',')
             for item in items:
                 parts = item.partition('=')
@@ -41,8 +44,7 @@ class WisePillDeviceEvent(Document):
     @property
     def timestamp(self):
         raw = self.data_as_dict.get('T', None)
-        if isinstance(raw, six.string_types) and len(raw) == 12:
-            soft_assert_type_text(raw)
+        if isinstance(raw, str) and len(raw) == 12:
             return "20%s-%s-%s %s:%s:%s" % (
                 raw[4:6],
                 raw[2:4],

--- a/custom/apps/wisepill/models.py
+++ b/custom/apps/wisepill/models.py
@@ -17,7 +17,7 @@ class WisePillDeviceEvent(Document):
     data = StringProperty()
     received_on = DateTimeProperty()
     # Document _id of the case representing the device that sent this data in
-    case_id = StringProperty()  
+    case_id = StringProperty()
     processed = BooleanProperty()
 
     @property

--- a/custom/ewsghana/reports/maps.py
+++ b/custom/ewsghana/reports/maps.py
@@ -8,10 +8,8 @@ from corehq.apps.reports.commtrack.data_sources import StockStatusBySupplyPointD
 from corehq.apps.reports.commtrack.maps import StockStatusMapReport
 from corehq.apps.reports.standard import CustomProjectReport
 from corehq.apps.hqwebapp.decorators import use_maps
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.ewsghana.utils import get_country_id, filter_slugs_by_role
 from memoized import memoized
-import six
 
 
 class EWSStockStatusBySupplyPointDataSource(StockStatusBySupplyPointDataSource):
@@ -40,8 +38,7 @@ class EWSStockStatusBySupplyPointDataSource(StockStatusBySupplyPointDataSource):
             include_self=True
         ).filter(location_type__administrative=False).exclude(is_archived=True)
         if 'loc_type' in self.config and self.config['loc_type']:
-            if isinstance(self.config['loc_type'], six.string_types):
-                soft_assert_type_text(self.config['loc_type'])
+            if isinstance(self.config['loc_type'], str):
                 self.config['loc_type'] = [self.config['loc_type']]
             locations = locations.filter(location_type__pk__in=self.config['loc_type'])
         return locations
@@ -147,8 +144,8 @@ class EWSMapReport(CustomProjectReport, StockStatusMapReport):
             loader = getattr(self, '_get_data_%s' % adapter)
         except AttributeError:
             raise RuntimeError('unknown adapter [%s]' % adapter)
-        config = dict(six.iterlists(self.request.GET))
-        for k, v in six.iteritems(config):
+        config = dict(self.request.GET.lists())
+        for k, v in config.items():
             if len(v) == 1:
                 config[k] = v[0]
         data = loader(self.data_source, config)

--- a/custom/icds/rules/util.py
+++ b/custom/icds/rules/util.py
@@ -1,22 +1,18 @@
 import pytz
 import re
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
-from corehq.util.timezones.conversions import ServerTime
 from datetime import datetime, date
+
+from corehq.util.timezones.conversions import ServerTime
 
 
 def get_date(value):
     if isinstance(value, date):
         if isinstance(value, datetime):
             return value.date()
-
         return value
 
-    if not isinstance(value, six.string_types):
+    if not isinstance(value, str):
         raise TypeError("Expected date, datetime, or string")
-    soft_assert_type_text(value)
 
     if not re.match(r'^\d{4}-\d{2}-\d{2}', value):
         raise ValueError("Expected a date string")

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -33,7 +33,6 @@ from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSo
 from corehq.blobs.mixin import safe_id
 from corehq.const import ONE_DAY
 from corehq.util.datadog.gauges import datadog_histogram
-from corehq.util.python_compatibility import soft_assert_type_text
 from corehq.util.quickcache import quickcache
 from corehq.util.timer import TimingContext
 from custom.icds_reports import const
@@ -44,12 +43,9 @@ from couchexport.export import export_from_tables
 from dimagi.utils.dates import DateSpan
 from django.db.models import Case, When, Q, F, IntegerField, Max, Min
 from django.db.utils import OperationalError
-import six
 import uuid
-from six.moves import range
 from sqlagg.filters import EQ, NOT
 from pillowtop.models import KafkaCheckpoint
-from six.moves import zip
 
 
 OPERATORS = {
@@ -252,8 +248,7 @@ class ICDSMixin(object):
                     op = column['condition']['operator']
 
                     def check_condition(v):
-                        if isinstance(v, six.string_types):
-                            soft_assert_type_text(v)
+                        if isinstance(v, str):
                             fil_v = str(value)
                         elif isinstance(v, int):
                             fil_v = int(value)
@@ -606,7 +601,7 @@ def generate_data_for_map(data, loc_level, num_prop, denom_prop, fill_key_lower,
         data_for_map[on_map_name][denom_prop] += valid
         data_for_map[on_map_name]['original_name'].append(name)
 
-    for data_for_location in six.itervalues(data_for_map):
+    for data_for_location in data_for_map.values():
         value = data_for_location[num_prop] * 100 / (data_for_location[denom_prop] or 1)
         fill_format = '%s%%-%s%%'
         if value < fill_key_lower:
@@ -1027,7 +1022,7 @@ def create_aww_performance_excel_file(excel_data, data_type, month, state, distr
             widths[columns[column_index]],
             max(
                 len(row[column_index].decode('utf-8') if isinstance(row[column_index], bytes)
-                    else six.text_type(row[column_index])
+                    else str(row[column_index])
                     )
                 for row in excel_data[1:]) * 4 // 3 if len(excel_data) >= 2 else 0
         )
@@ -1207,7 +1202,7 @@ def create_thr_report_excel_file(excel_data, data_type, month, aggregation_level
             widths[columns[column_index]],
             max(
                 len(row[column_index].decode('utf-8') if isinstance(row[column_index], bytes)
-                    else six.text_type(row[column_index])
+                    else str(row[column_index])
                     )
                 for row in excel_data[1:]) * 4 // 3 if len(excel_data) >= 2 else 0
         )
@@ -1457,7 +1452,7 @@ def create_lady_supervisor_excel_file(excel_data, data_type, month, aggregation_
             widths[columns[column_index]],
             max(
                 len(row[column_index].decode('utf-8') if isinstance(row[column_index], bytes)
-                    else six.text_type(row[column_index])
+                    else str(row[column_index])
                     )
                 for row in excel_data[1:]) * 4 // 3 if len(excel_data) >= 2 else 0
         )

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -1,16 +1,11 @@
-
-import six
 from dateutil.relativedelta import relativedelta
 
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
-from six.moves import map
 
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.const import AGG_CCS_RECORD_CF_TABLE, AGG_THR_V2_TABLE
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
-from six.moves import range
 
 
 class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
@@ -592,7 +587,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
             ('usage_num_add_person',),
             ('usage_num_add_pregnancy',),
             ('is_launched', "'yes'"),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('num_launched_states', lambda col: _launched_col(col)),
             ('num_launched_districts', lambda col: _launched_col(col)),
             ('num_launched_blocks', lambda col: _launched_col(col)),
@@ -646,8 +641,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
@@ -1,12 +1,5 @@
-
-import six
-
-from six.moves import map
-
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
-from six.moves import range
 
 
 class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelper):
@@ -151,7 +144,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
             ('block_id', lambda col: col if aggregation_level > 2 else "'All'"),
             ('supervisor_id', lambda col: col if aggregation_level > 3 else "'All'"),
             ('awc_id', lambda col: col if aggregation_level > 4 else "'All'"),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('date', 'date'),
             ('cases_household',),
             ('cases_person',),
@@ -201,8 +194,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_ccs_record.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_ccs_record.py
@@ -1,12 +1,5 @@
-
-import six
-
-from six.moves import map
-
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
-from six.moves import range
 
 
 class AggCcsRecordAggregationDistributedHelper(BaseICDSAggregationDistributedHelper):
@@ -228,7 +221,7 @@ class AggCcsRecordAggregationDistributedHelper(BaseICDSAggregationDistributedHel
             ('counsel_immediate_conception', ),
             ('counsel_accessible_postpartum_fp', ),
             ('has_aadhar_id', ),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('valid_all_registered_in_month', ),
             ('institutional_delivery_in_month', ),
             ('lactating_all', ),
@@ -259,8 +252,7 @@ class AggCcsRecordAggregationDistributedHelper(BaseICDSAggregationDistributedHel
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
@@ -1,12 +1,5 @@
-
-import six
-
-from six.moves import map
-
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
-from six.moves import range
 
 
 class AggChildHealthAggregationDistributedHelper(BaseICDSAggregationDistributedHelper):
@@ -268,7 +261,7 @@ class AggChildHealthAggregationDistributedHelper(BaseICDSAggregationDistributedH
             ('fully_immunized_on_time', ),
             ('fully_immunized_late', ),
             ('has_aadhar_id', ),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('pnc_eligible', ),
             ('height_eligible', ),
             ('wasting_moderate', ),
@@ -317,8 +310,7 @@ class AggChildHealthAggregationDistributedHelper(BaseICDSAggregationDistributedH
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/icds_reports/utils/aggregation_helpers/monolith/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/monolith/agg_awc.py
@@ -1,16 +1,11 @@
-
-import six
 from dateutil.relativedelta import relativedelta
-from six.moves import map
 
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.const import AGG_CCS_RECORD_CF_TABLE, AGG_THR_V2_TABLE
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month, \
     month_formatter
 from custom.icds_reports.utils.aggregation_helpers.monolith.base import BaseICDSAggregationHelper
-from six.moves import range
 
 
 class AggAwcHelper(BaseICDSAggregationHelper):
@@ -556,7 +551,7 @@ class AggAwcHelper(BaseICDSAggregationHelper):
             ('usage_num_add_person',),
             ('usage_num_add_pregnancy',),
             ('is_launched', "'yes'"),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('num_launched_states', lambda col: _launched_col(col)),
             ('num_launched_districts', lambda col: _launched_col(col)),
             ('num_launched_blocks', lambda col: _launched_col(col)),
@@ -610,8 +605,7 @@ class AggAwcHelper(BaseICDSAggregationHelper):
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/icds_reports/utils/aggregation_helpers/monolith/agg_awc_daily.py
+++ b/custom/icds_reports/utils/aggregation_helpers/monolith/agg_awc_daily.py
@@ -1,11 +1,5 @@
-
-import six
-from six.moves import map
-
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.monolith.base import BaseICDSAggregationHelper
-from six.moves import range
 
 
 class AggAwcDailyAggregationHelper(BaseICDSAggregationHelper):
@@ -148,7 +142,7 @@ class AggAwcDailyAggregationHelper(BaseICDSAggregationHelper):
             ('block_id', lambda col: col if aggregation_level > 2 else "'All'"),
             ('supervisor_id', lambda col: col if aggregation_level > 3 else "'All'"),
             ('awc_id', lambda col: col if aggregation_level > 4 else "'All'"),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('date', 'date'),
             ('cases_household',),
             ('cases_person',),
@@ -198,8 +192,7 @@ class AggAwcDailyAggregationHelper(BaseICDSAggregationHelper):
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/icds_reports/utils/aggregation_helpers/monolith/agg_ccs_record.py
+++ b/custom/icds_reports/utils/aggregation_helpers/monolith/agg_ccs_record.py
@@ -1,5 +1,3 @@
-from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
-from corehq.apps.userreports.util import get_table_name
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.monolith.base import BaseICDSAggregationHelper
 

--- a/custom/icds_reports/utils/aggregation_helpers/monolith/agg_ccs_record.py
+++ b/custom/icds_reports/utils/aggregation_helpers/monolith/agg_ccs_record.py
@@ -1,13 +1,7 @@
-
-import six
-from six.moves import map
-
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.monolith.base import BaseICDSAggregationHelper
-from six.moves import range
 
 
 class AggCcsRecordAggregationHelper(BaseICDSAggregationHelper):
@@ -215,7 +209,7 @@ class AggCcsRecordAggregationHelper(BaseICDSAggregationHelper):
             ('counsel_immediate_conception', ),
             ('counsel_accessible_postpartum_fp', ),
             ('has_aadhar_id', ),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('valid_all_registered_in_month', ),
             ('institutional_delivery_in_month', ),
             ('lactating_all', ),
@@ -246,8 +240,7 @@ class AggCcsRecordAggregationHelper(BaseICDSAggregationHelper):
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/icds_reports/utils/aggregation_helpers/monolith/agg_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/monolith/agg_child_health.py
@@ -1,11 +1,5 @@
-
-import six
-from six.moves import map
-
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.monolith.base import BaseICDSAggregationHelper
-from six.moves import range
 
 
 class AggChildHealthAggregationHelper(BaseICDSAggregationHelper):
@@ -258,7 +252,7 @@ class AggChildHealthAggregationHelper(BaseICDSAggregationHelper):
             ('fully_immunized_on_time', ),
             ('fully_immunized_late', ),
             ('has_aadhar_id', ),
-            ('aggregation_level', six.text_type(aggregation_level)),
+            ('aggregation_level', str(aggregation_level)),
             ('pnc_eligible', ),
             ('height_eligible', ),
             ('wasting_moderate', ),
@@ -307,8 +301,7 @@ class AggChildHealthAggregationHelper(BaseICDSAggregationHelper):
 
             if len(column_tuple) == 2:
                 agg_col = column_tuple[1]
-                if isinstance(agg_col, six.string_types):
-                    soft_assert_type_text(agg_col)
+                if isinstance(agg_col, str):
                     return column_tuple
                 elif callable(agg_col):
                     return (column, agg_col(column))

--- a/custom/m4change/user_calcs/immunization_hmis_report_calcs.py
+++ b/custom/m4change/user_calcs/immunization_hmis_report_calcs.py
@@ -1,10 +1,9 @@
 import fluff
 
-from corehq.util.python_compatibility import soft_assert_type_text
-from custom.m4change.constants import PNC_CHILD_IMMUNIZATION_AND_REG_HOME_DELIVERED_FORMS, \
-    BOOKED_AND_UNBOOKED_DELIVERY_FORMS
-import six
-
+from custom.m4change.constants import (
+    BOOKED_AND_UNBOOKED_DELIVERY_FORMS,
+    PNC_CHILD_IMMUNIZATION_AND_REG_HOME_DELIVERED_FORMS,
+)
 
 FULL_IMMUNIZATION_VALUES = [
     'bcg',
@@ -53,9 +52,7 @@ class PncFullImmunizationCalculator(fluff.Calculator):
         if form.xmlns in PNC_CHILD_IMMUNIZATION_AND_REG_HOME_DELIVERED_FORMS:
             all_passed = True
             for value in FULL_IMMUNIZATION_VALUES:
-                if isinstance(value, six.string_types):
-                    soft_assert_type_text(value)
-                passed = value in form.form.get("immunization_given", "") if isinstance(value, six.string_types)\
+                passed = value in form.form.get("immunization_given", "") if isinstance(value, str)\
                     else _check_immunization_value_tuple(form, "immunization_given", value)
                 if not passed:
                     all_passed = False

--- a/custom/succeed/utils.py
+++ b/custom/succeed/utils.py
@@ -4,9 +4,6 @@ from corehq.apps.app_manager.dbaccessors import get_latest_build_id, get_latest_
 from corehq.apps.domain.models import Domain
 from datetime import timedelta
 from pytz import timezone
-import six
-
-from corehq.util.python_compatibility import soft_assert_type_text
 
 EMPTY_FIELD = "---"
 SUCCEED_DOMAIN = 'succeed'
@@ -79,8 +76,7 @@ def format_date(date_string, OUTPUT_FORMAT, localize=None):
             or isinstance(date_string, (int, float)):
         return ''
 
-    if isinstance(date_string, six.string_types):
-        soft_assert_type_text(date_string)
+    if isinstance(date_string, str):
         try:
             date_string = dateutil.parser.parse(date_string)
         except (AttributeError, ValueError):

--- a/custom/zipline/views.py
+++ b/custom/zipline/views.py
@@ -2,7 +2,6 @@ import json
 import re
 from corehq.apps.api.decorators import api_user_basic_auth
 from corehq.apps.domain.views.base import DomainViewMixin
-from corehq.util.python_compatibility import soft_assert_type_text
 from custom.zipline.api import get_order_update_critical_section_key, ProductQuantity
 from custom.zipline.models import (EmergencyOrder, EmergencyOrderStatusUpdate,
     update_product_quantity_json_field, EmergencyOrderPackage)
@@ -14,7 +13,6 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.utils.decorators import method_decorator
-import six
 
 
 ZIPLINE_PERMISSION = 'ZIPLINE'
@@ -104,17 +102,15 @@ class BaseZiplineStatusUpdateView(View, DomainViewMixin):
         value = data.get(field_name)
         error_msg = "Field '{}' is required and expected to be a string".format(field_name)
 
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             raise OrderStatusValidationError(error_msg)
-        soft_assert_type_text(value)
 
     def validate_and_clean_time(self, data, field_name):
         value = data.get(field_name)
         error_msg = "Field '{}' is required and expected to be a 24-hour time string HH:MM".format(field_name)
 
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             raise OrderStatusValidationError(error_msg)
-        soft_assert_type_text(value)
 
         if not re.match(r'^\d\d?:\d\d$', value):
             raise OrderStatusValidationError(error_msg)
@@ -130,9 +126,8 @@ class BaseZiplineStatusUpdateView(View, DomainViewMixin):
         value = data.get(field_name)
         error_msg = "Field '{}' is required and expected to be a numeric string".format(field_name)
 
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             raise OrderStatusValidationError(error_msg)
-        soft_assert_type_text(value)
 
         try:
             Decimal(value)
@@ -250,7 +245,7 @@ class BaseZiplineStatusUpdateView(View, DomainViewMixin):
                 'package_id': dispatched_status.package_id,
                 'vehicle_id': dispatched_status.vehicle_id,
                 'products': [ProductQuantity(code, data.get('quantity'))
-                             for code, data in six.iteritems(dispatched_status.products)],
+                             for code, data in dispatched_status.products.items()],
             }
         else:
             return {}


### PR DESCRIPTION
In which @millerdev learns that `six.string_types == str,` in Python 3. Always thought it was `(str, bytes)` in both Python 2 and 3. Therefore `soft_assert_type_text(value)` was usually a no-op on Python 3 since `value` could never be anything but text (`str`) in the most common usage pattern:
```py
if isinstance(value, six.string_types):
    soft_assert_type_text(value)  # value is always a str here
```

@dimagi/py3 