### PR TITLE
Fix payload sent to wrong repeater

### DIFF
--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -168,13 +168,15 @@ class OpenmrsRepeater(CaseRepeater):
             # be forwarded, drop it.
             return False
 
-        repeaters = [repeater for case in cases for repeater in get_case_location_ancestor_repeaters(case)]
-        if repeaters and self not in repeaters:
-            # This repeater points to the wrong OpenMRS server for this
-            # payload. Let the right repeater handle it.
-            return False
+        if not self.location_id:
+            # If this repeater  does not have a location, all payloads
+            # should go to it.
+            return True
 
-        return True
+        repeaters = [repeater for case in cases for repeater in get_case_location_ancestor_repeaters(case)]
+        # If this repeater points to the wrong OpenMRS server for this
+        # payload then let the right repeater handle it.
+        return self in repeaters
 
     def get_payload(self, repeat_record):
         payload = super(OpenmrsRepeater, self).get_payload(repeat_record)


### PR DESCRIPTION
Fixes a bug where a payload that should not be sent to any OpenMRS repeater was being sent.

The current code returns `True` if the `repeaters` list is empty. But the repeaters list is empty if the payload's case(s) should not be sent to any server.

This really deserves a test, but I think that it will take quite a bit of refactoring for tests to be simple. I'd prefer to get this fix in soon, and follow unit tests up in another PR.
