### PR TITLE
Set the value of 3rd row height

### DIFF
--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -1000,6 +1000,7 @@ def create_aww_performance_excel_file(excel_data, data_type, month, state, distr
     title_row = worksheet.row_dimensions[2]
     title_row.height = 23
     worksheet.row_dimensions[table_header_position_row].height = 46
+    worksheet.row_dimensions[3].height = 32
     widths = {}
     widths_columns = ['A']
     widths_columns.extend(columns)


### PR DESCRIPTION
This fixes this issue: https://dimagi-dev.atlassian.net/browse/ICDS-841
This is happening now because we switched to python3
this fixes this error which prevented xlsx formation:
```
/home/cchq/www/icds/releases/2019-08-26_15.23/python_env-3.6/lib/python3.6/site-packages/celery/local.py in __call__(self, *a, **kw)
    191 
    192     def __call__(self, *a, **kw):
--> 193         return self._get_current_object()(*a, **kw)
    194 
    195     def __len__(self):

/home/cchq/www/icds/releases/2019-08-26_15.23/python_env-3.6/lib/python3.6/site-packages/celery/app/task.py in __call__(self, *args, **kwargs)
    377             if self.__self__ is not None:
    378                 return self.run(self.__self__, *args, **kwargs)
--> 379             return self.run(*args, **kwargs)
    380         finally:
    381             self.pop_request()

/home/cchq/www/icds/releases/2019-08-26_15.23/custom/icds_reports/tasks.py in build_incentive_files(location, month, file_format, aggregation_level, state, district)
   1236             state_name,
   1237             district_name,
-> 1238             block_name
   1239         )
   1240     else:

/home/cchq/www/icds/releases/2019-08-26_15.23/custom/icds_reports/utils/__init__.py in create_aww_performance_excel_file(excel_data, data_type, month, state, district, block)
   1026             worksheet.row_dimensions[3].height = max(
   1027                 16 * ((widths[column] // 25) + 1),
-> 1028                 worksheet.row_dimensions[3].height
   1029             )
   1030             widths[column] = 25

TypeError: '>' not supported between instances of 'NoneType' and 'int'```