### PR TITLE
Use active_objects to filter archived products

### DIFF
--- a/corehq/apps/commtrack/consumption.py
+++ b/corehq/apps/commtrack/consumption.py
@@ -18,7 +18,7 @@ def recalculate_domain_consumption(domain):
         domain_name=domain,
         doc_type='CommCareCase',
     ).values_list('doc_id', flat=True)
-    product_ids = SQLProduct.objects.filter(domain=domain).product_ids()
+    product_ids = SQLProduct.active_objects.filter(domain=domain).product_ids()
     for supply_point_id in found_doc_ids:
         for product_id in product_ids:
             try:

--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -120,7 +120,7 @@ class ConsumptionForm(forms.Form):
         self.helper.field_class = 'col-sm-4 col-md-5 col-lg-3'
 
         layout = []
-        products = SQLProduct.objects.filter(domain=domain)
+        products = SQLProduct.active_objects.filter(domain=domain)
         for product in products:
             field_name = 'default_%s' % product.product_id
             display = _('Default %(product_name)s') % {'product_name': product.name}

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -192,7 +192,7 @@ class CommtrackConfig(QuickCachedDocumentMixin, Document):
         from casexml.apps.phone.restore import StockSettings
         default_product_ids = []
         if self.ota_restore_config.use_dynamic_product_list:
-            default_product_ids = SQLProduct.objects.filter(domain=self.domain).product_ids()
+            default_product_ids = SQLProduct.active_objects.filter(domain=self.domain).product_ids()
         case_filter = lambda stub: stub.type in set(self.ota_restore_config.force_consumption_case_types)
         return StockSettings(
             section_to_consumption_types=self.ota_restore_config.section_to_consumption_types,

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -34,7 +34,7 @@ def all_sms_codes(domain):
     config = CommtrackConfig.for_domain(domain)
 
     actions = {action.keyword: action for action in config.actions}
-    products = {p.code: p for p in SQLProduct.by_domain(domain)}
+    products = {p.code: p for p in SQLProduct.active_objects.filter(domain=domain)}
 
     ret = {}
     for action_key, action in actions.items():

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -83,7 +83,7 @@ class ProductFixturesProvider(FixtureProvider):
             return []
 
         data = list(
-            SQLProduct.objects
+            SQLProduct.active_objects
             .filter(domain=restore_user.domain)
             .order_by('code')
             .all()

--- a/corehq/apps/products/forms.py
+++ b/corehq/apps/products/forms.py
@@ -66,7 +66,7 @@ class ProductForm(forms.Form):
         name = self.cleaned_data['name']
 
         num_other_products_with_name = (
-            SQLProduct.objects
+            SQLProduct.active_objects
             .filter(domain=self.product.domain, name=name)
             .exclude(product_id=self.product._id)
         ).count()


### PR DESCRIPTION
Found this when finishing up the product migration. This was an issue with https://github.com/dimagi/commcare-hq/pull/25157.

I missed this because [`SQLProduct.by_domain`](https://github.com/dimagi/commcare-hq/blob/ff92105443e987ee27407630945f7f019556f96c/corehq/apps/products/models.py#L342-L344) has a different implementation than [`Product.by_domain`](https://github.com/dimagi/commcare-hq/blob/ff92105443e987ee27407630945f7f019556f96c/corehq/apps/products/models.py#L168-L172)