### PR TITLE
Skip updating the password if it hasn't changed

### DIFF
--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -144,8 +144,11 @@ class OpenmrsImporterView(BaseProjectSettingsView):
 
     def _update_importer(self, importer, data):
         for key, value in data.items():
-            if key == 'password' and value != PASSWORD_PLACEHOLDER:
-                value = b64_aes_encrypt(value)
+            if key == 'password':
+                if value == PASSWORD_PLACEHOLDER:
+                    continue  # Skip updating the password if it hasn't been changed.
+                else:
+                    value = b64_aes_encrypt(value)
             elif key == 'report_params':
                 value = json.loads(value)
             elif key == 'column_map':


### PR DESCRIPTION
:man_facepalming: A really stupid bug.

If the value of `password` is `PASSWORD_PLACEHOLDER` (which is "****************") then IT OVERWRITES THE REAL PASSWORD WITH THE PLACEHOLDER.

This change fixes that bug by continuing to the next item instead of calling `setattr` on line 154/157.