### PR TITLE
Email upon table upload

### DIFF
--- a/corehq/apps/fixtures/tasks.py
+++ b/corehq/apps/fixtures/tasks.py
@@ -1,12 +1,12 @@
 import datetime
 
+from django.conf import settings
+from django.template.loader import render_to_string
+
 from celery.task import task
 
 from dimagi.utils.chunked import chunked
 from soil import DownloadBase
-
-from django.conf import settings
-from django.template.loader import render_to_string
 
 from corehq.apps.fixtures.download import prepare_fixture_download
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureOwnership

--- a/corehq/apps/fixtures/tasks.py
+++ b/corehq/apps/fixtures/tasks.py
@@ -1,29 +1,57 @@
+import datetime
 
 from celery.task import task
 
 from dimagi.utils.chunked import chunked
 from soil import DownloadBase
 
+from django.conf import settings
+from django.template.loader import render_to_string
+
 from corehq.apps.fixtures.download import prepare_fixture_download
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureOwnership
 from corehq.apps.fixtures.upload import upload_fixture_file
+from corehq.apps.hqwebapp.tasks import send_html_email_async
 
 
 @task
-def fixture_upload_async(domain, download_id, replace, skip_orm):
+def fixture_upload_async(domain, download_id, replace, skip_orm, user_email=None):
     task = fixture_upload_async
     DownloadBase.set_progress(task, 0, 100)
     download_ref = DownloadBase.get(download_id)
+    time_start = datetime.datetime.now()
     result = upload_fixture_file(domain, download_ref.get_filename(), replace, task, skip_orm)
+    time_end = datetime.datetime.now()
     DownloadBase.set_progress(task, 100, 100)
-    return {
-        'messages': {
-            'success': result.success,
-            'messages': result.messages,
-            'errors': result.errors,
-            'number_of_fixtures': result.number_of_fixtures,
-        },
+    messages = {
+        'success': result.success,
+        'messages': result.messages,
+        'errors': result.errors,
+        'number_of_fixtures': result.number_of_fixtures
     }
+    if user_email:
+        send_upload_fixture_complete_email(user_email, domain, time_start, time_end, messages)
+    return {
+        'messages': messages,
+    }
+
+
+def send_upload_fixture_complete_email(email, domain, time_start, time_end, messages):
+    context = {
+        "username": email,
+        "domain": domain,
+        "time_start": time_start,
+        "time_end": time_end,
+        "messages": messages
+    }
+    send_html_email_async.delay(
+        "Your fixture upload is complete!",
+        email,
+        render_to_string('fixtures/upload_complete.html', context),
+        render_to_string('fixtures/upload_complete.txt', context),
+        email_from=settings.DEFAULT_FROM_EMAIL
+    )
+    return
 
 
 @task(serializer='pickle')

--- a/corehq/apps/fixtures/templates/fixtures/upload_complete.html
+++ b/corehq/apps/fixtures/templates/fixtures/upload_complete.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+<p>
+  {% blocktrans %}
+    Dear {{ username }},
+  {% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}
+    The fixture upload for {{ domain }} you started has finished.
+  {% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}
+    Upload start time: {{ time_start }}
+  {% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}
+    Upload end time: {{ time_end }}
+  {% endblocktrans %}
+</p>
+
+<p>
+  {% blocktrans %}
+    Upload messages: {{ messages }}
+  {% endblocktrans %}
+</p>

--- a/corehq/apps/fixtures/templates/fixtures/upload_complete.txt
+++ b/corehq/apps/fixtures/templates/fixtures/upload_complete.txt
@@ -1,0 +1,9 @@
+{% load i18n %}
+{% blocktrans %}
+Dear {{ username }},
+
+The fixture upload for {{ domain }} you started has finished.
+
+Upload start time: {{ time_start }}
+Upload end time: {{ time_end }}
+Upload messages: {{ messages }}

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -514,7 +514,8 @@ def _upload_fixture_api(request, domain):
                     domain,
                     download_id,
                     replace,
-                    skip_orm
+                    skip_orm,
+                    user_email=email
                 )
                 file_ref.set_task(task)
 

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -67,6 +67,7 @@ from corehq.apps.reports.util import format_datatables_data
 from corehq.apps.users.models import Permissions
 from corehq.toggles import SKIP_ORM_FIXTURE_UPLOAD
 from corehq.util.files import file_extention_from_filename
+from corehq import toggles
 
 
 def strip_json(obj, disallow_basic=None, disallow=None):
@@ -571,8 +572,10 @@ def _get_fixture_upload_args_from_request(request, domain):
             replace = True
         elif replace.lower() == "false":
             replace = False
-        user_email = request.couch_user.email if request.couch_user.email is not None \
-            else request.couch_user.username
+        user_email = None
+        if toggles.SUPPORT.enabled(request.couch_user.username):
+            user_email = request.couch_user.email if request.couch_user.email is not None \
+                else request.couch_user.username
     except Exception:
         raise FixtureAPIRequestError(
             "Invalid post request."

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -496,7 +496,7 @@ def fixture_api_upload_status(request, domain, download_id, **kwargs):
 
 def _upload_fixture_api(request, domain):
     try:
-        excel_file, replace, is_async, skip_orm = _get_fixture_upload_args_from_request(request, domain)
+        excel_file, replace, is_async, skip_orm, email = _get_fixture_upload_args_from_request(request, domain)
     except FixtureAPIRequestError as e:
         return UploadFixtureAPIResponse('fail', six.text_type(e))
 
@@ -570,6 +570,8 @@ def _get_fixture_upload_args_from_request(request, domain):
             replace = True
         elif replace.lower() == "false":
             replace = False
+        user_email = request.couch_user.email if request.couch_user.email is not None \
+            else request.couch_user.username
     except Exception:
         raise FixtureAPIRequestError(
             "Invalid post request."
@@ -586,7 +588,7 @@ def _get_fixture_upload_args_from_request(request, domain):
     if request.POST.get('skip_orm') == 'true' and SKIP_ORM_FIXTURE_UPLOAD.enabled(domain):
         skip_orm = True
 
-    return _excel_upload_file(upload_file), replace, is_async, skip_orm
+    return _excel_upload_file(upload_file), replace, is_async, skip_orm, user_email
 
 
 @login_and_domain_required


### PR DESCRIPTION
QA is testing large lookup table uploads for INDDEX, and they wanted a way to record the upload's start and end times so testers don't have to babysit the status page

Relevant QA tickets:
https://dimagi-dev.atlassian.net/browse/QA-703
https://dimagi-dev.atlassian.net/browse/QA-652