### PR TITLE
Extend timeout for OpenMRS Reporting API

### DIFF
--- a/corehq/motech/const.py
+++ b/corehq/motech/const.py
@@ -2,8 +2,8 @@
 
 PASSWORD_PLACEHOLDER = '*' * 16
 
-# If any remote service does not respond within 10 minutes, time out
-REQUEST_TIMEOUT = 600
+# If any remote service does not respond within 5 minutes, time out
+REQUEST_TIMEOUT = 5 * 60
 
 ALGO_AES = 'aes'
 

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -46,7 +46,10 @@ from corehq.motech.requests import Requests
 from corehq.motech.utils import b64_aes_decrypt
 
 RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
-LOCATION_OPENMRS = 'openmrs_uuid'  # The location metadata key that maps to its corresponding OpenMRS location UUID
+# REQUEST_TIMEOUT is 5 minutes, but reports can take up to an hour
+REPORT_REQUEST_TIMEOUT = 60 * 60
+# The location metadata key that maps to its corresponding OpenMRS location UUID
+LOCATION_OPENMRS = 'openmrs_uuid'
 
 
 def parse_params(params, location=None):
@@ -71,7 +74,8 @@ def get_openmrs_patients(requests, importer, location=None):
     """
     endpoint = f'/ws/rest/v1/reportingrest/reportdata/{importer.report_uuid}'
     params = parse_params(importer.report_params, location)
-    response = requests.get(endpoint, params=params, raise_for_status=True)
+    response = requests.get(endpoint, params=params, raise_for_status=True,
+                            timeout=REPORT_REQUEST_TIMEOUT)
     data = response.json()
     return data['dataSets'][0]['rows']  # e.g. ...
     #     [{u'familyName': u'Hornblower', u'givenName': u'Horatio', u'personId': 2},

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -1,4 +1,3 @@
-
 import json
 
 from django.test import SimpleTestCase
@@ -6,6 +5,8 @@ from django.test import SimpleTestCase
 from mock import Mock, patch
 
 import requests
+
+from corehq.motech.const import REQUEST_TIMEOUT
 from corehq.motech.requests import Requests
 
 TEST_API_URL = 'http://localhost:9080/api/'
@@ -39,7 +40,7 @@ class RequestsTests(SimpleTestCase):
                 allow_redirects=True,
                 headers={'Accept': 'application/json'},
                 auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
-                timeout=600,
+                timeout=REQUEST_TIMEOUT,
             )
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json()['code'], TEST_API_USERNAME)
@@ -69,7 +70,7 @@ class RequestsTests(SimpleTestCase):
                 json=payload,
                 headers={'Content-type': 'application/json', 'Accept': 'application/json'},
                 auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
-                timeout=600,
+                timeout=REQUEST_TIMEOUT,
             )
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json()['status'], 'SUCCESS')
@@ -87,7 +88,7 @@ class RequestsTests(SimpleTestCase):
                 allow_redirects=True,
                 headers={'Accept': 'application/json'},
                 auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
-                timeout=600,
+                timeout=REQUEST_TIMEOUT,
                 verify=False
             )
 


### PR DESCRIPTION
... and reduce timeout to a more reasonable value for all other requests.
