### PR TITLE
Replaced generic error with specific one when advanced module referen…

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -31,6 +31,7 @@ from corehq.apps.app_manager.exceptions import (
     LocationXpathValidationError,
     ModuleIdMissingException,
     ModuleNotFoundException,
+    ParentModuleReferenceError,
     PracticeUserException,
     SuiteValidationError,
     UserCaseXPathValidationError,
@@ -87,7 +88,7 @@ class ApplicationBaseValidator(object):
                 'form': ucve.form,
             })
         except (AppEditingError, XFormValidationError, XFormException,
-                PermissionDenied, SuiteValidationError) as e:
+                ParentModuleReferenceError, PermissionDenied, SuiteValidationError) as e:
             errors.append({'type': 'error', 'message': str(e)})
         return errors
 


### PR DESCRIPTION
…ces deleted case list

https://dimagi-dev.atlassian.net/browse/ICDS-822

Referencing the case list of a deleted module will now display this:
![Screen Shot 2019-08-30 at 10 06 34 AM](https://user-images.githubusercontent.com/1486591/64027340-7e45e000-cb0e-11e9-89d9-a232a82f3ee2.png)

@esoergel Perhaps https://github.com/dimagi/commcare-hq/pull/25127/ should either throw a `SuiteValidationError` or else add `SuiteError` to the list caught here, so that the error message is displayed?

Feature flag: advanced modules