### PR TITLE
Removed logic to propagate web apps permissions to linked apps

### DIFF
--- a/corehq/apps/linked_domain/tests/test_update_roles.py
+++ b/corehq/apps/linked_domain/tests/test_update_roles.py
@@ -11,7 +11,6 @@ class TestUpdateRoles(BaseLinkedAppsTest):
     @classmethod
     def setUpClass(cls):
         super(TestUpdateRoles, cls).setUpClass()
-        cls.linked_app.master = cls.master1.get_id
         cls.linked_app.save()
 
         cls.role = UserRole(
@@ -19,9 +18,6 @@ class TestUpdateRoles(BaseLinkedAppsTest):
             name='test',
             permissions=Permissions(
                 edit_data=True,
-                view_web_apps_list=[
-                    cls.master1.get_id
-                ],
                 view_report_list=[
                     'corehq.reports.DynamicReportmaster_report_id'
                 ]
@@ -39,7 +35,7 @@ class TestUpdateRoles(BaseLinkedAppsTest):
             role.delete()
         super(TestUpdateRoles, self).tearDown()
 
-    def test_update_web_apps_list(self):
+    def test_update_report_list(self):
         self.assertEqual([], UserRole.by_domain(self.linked_domain))
 
         report_mapping = {'master_report_id': 'linked_report_id'}
@@ -48,5 +44,4 @@ class TestUpdateRoles(BaseLinkedAppsTest):
 
         roles = UserRole.by_domain(self.linked_domain)
         self.assertEqual(1, len(roles))
-        self.assertEqual(roles[0].permissions.view_web_apps_list, [self.linked_app._id])
         self.assertEqual(roles[0].permissions.view_report_list, [get_ucr_class_name('linked_report_id')])

--- a/corehq/apps/linked_domain/updates.py
+++ b/corehq/apps/linked_domain/updates.py
@@ -100,7 +100,6 @@ def update_user_roles(domain_link):
     else:
         master_results = local_get_user_roles(domain_link.master_domain)
 
-    _convert_web_apps_permissions(domain_link, master_results)
     _convert_reports_permissions(domain_link, master_results)
 
     local_roles = UserRole.view(
@@ -144,26 +143,6 @@ def update_case_search_config(domain_link):
 
     if query_addition:
         CaseSearchQueryAddition.create_from_json(domain_link.linked_domain, query_addition)
-
-
-def _convert_web_apps_permissions(domain_link, master_results):
-    """Mutates the master result docs to convert web app permissions.
-    """
-    linked_apps_by_master = {
-        app.master: app._id
-        for app in get_docs_in_domain_by_class(domain_link.linked_domain, LinkedApplication)
-    }
-    for role_def in master_results:
-        view_web_apps_list = []
-        for app_id in role_def['permissions']['view_web_apps_list']:
-            master_app_id = get_app(domain_link.master_domain, app_id).master_id
-            try:
-                linked_app_id = linked_apps_by_master[master_app_id]
-            except KeyError:
-                continue
-            view_web_apps_list.append(linked_app_id)
-
-        role_def['permissions']['view_web_apps_list'] = view_web_apps_list
 
 
 def _convert_reports_permissions(domain_link, master_results):


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/25107

See discussion on https://dimagi-dev.atlassian.net/browse/ICDS-604 - this removes the logic that automatically grants linked apps web apps permissions to users who have permissions to view the corresponding master apps.