### PR TITLE
Added more validation for parameters in CCUI bulk translations

### DIFF
--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -47,11 +47,13 @@ class BulkUiTranslation(SimpleTestCase):
         # They were replaced by other randomly selected strings in that file.
         # Leaving this note here in case this issue comes up again. --B
         data = (('key.manage.title', 'wobble', ''),
-                ('bulk.send.dialog.progress', 'wabble', ''),
+                ('bulk.send.dialog.progress', 'wabble ${0}', ''),
                 ('connection.test.access.settings', '', 'wibble'),
-                ('bulk.send.dialog.progress', '', 'wubble'),
+                ('bulk.send.dialog.progress', '', 'wubble ${0}'),
                 ('home.start.demo', 'Ding', 'Dong'),
-                ('unknown_string', 'Ding', 'Dong'))
+                ('unknown_string', 'Ding', 'Dong'),
+                ('updates.found', 'I am missing a parameter', 'I have ${0} an ${1} extra ${2} parameter'),
+                ('sync.progress', 'It is fine to ${1} reorder ${0} parameters', 'But they need ${x0} correct syntax $ {1}'))
 
         f = self._build_translation_download_file(headers, data)
         translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
@@ -61,20 +63,30 @@ class BulkUiTranslation(SimpleTestCase):
             {
                 'en': {
                     'key.manage.title': 'wobble',
-                    'bulk.send.dialog.progress': 'wabble',
+                    'bulk.send.dialog.progress': 'wabble ${0}',
                     'home.start.demo': 'Ding',
                     'unknown_string': 'Ding',
+                    'updates.found': 'I am missing a parameter',
+                    'sync.progress': 'It is fine to ${1} reorder ${0} parameters',
                 },
                 'fra': {
                     'connection.test.access.settings': 'wibble',
-                    'bulk.send.dialog.progress': 'wubble',
+                    'bulk.send.dialog.progress': 'wubble ${0}',
                     'home.start.demo': 'Dong',
                     'unknown_string': 'Dong',
+                    'updates.found': 'I have ${0} an ${1} extra ${2} parameter',
+                    'sync.progress': 'But they need ${x0} correct syntax $ {1}',
                 }
             }
 
         )
-        self.assertEqual(len(error_properties), 0)
+        self.assertEqual(len(error_properties), 4)
+        self.assertEqual([e.strip() for e in error_properties], [
+            "Property updates.found should contain ${0}, ${1} but en value contains no parameters.",
+            "Property updates.found should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
+            "Could not understand '${x0}' in fra value of sync.progress.",
+            "Could not understand '$ {1}' in fra value of sync.progress.",
+        ])
         # There should be a warning that 'unknown_string' is not a CommCare string
         self.assertEqual(len(warnings), 1, warnings)
 

--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -53,7 +53,7 @@ class BulkUiTranslation(SimpleTestCase):
                 ('home.start.demo', 'Ding', 'Dong'),
                 ('unknown_string', 'Ding', 'Dong'),
                 ('updates.found', 'I am missing a parameter', 'I have ${0} an ${1} extra ${2} parameter'),
-                ('sync.progress', 'It is fine to ${1} reorder ${0} parameters', 'But they need ${x0} correct syntax $ {1}'))
+                ('sync.progress', 'It is fine to ${1} reorder ${0} params', 'But use ${x0} correct syntax $ {1}'))
 
         f = self._build_translation_download_file(headers, data)
         translations, error_properties, warnings = process_ui_translation_upload(self.app, f)
@@ -67,7 +67,7 @@ class BulkUiTranslation(SimpleTestCase):
                     'home.start.demo': 'Ding',
                     'unknown_string': 'Ding',
                     'updates.found': 'I am missing a parameter',
-                    'sync.progress': 'It is fine to ${1} reorder ${0} parameters',
+                    'sync.progress': 'It is fine to ${1} reorder ${0} params',
                 },
                 'fra': {
                     'connection.test.access.settings': 'wibble',
@@ -75,7 +75,7 @@ class BulkUiTranslation(SimpleTestCase):
                     'home.start.demo': 'Dong',
                     'unknown_string': 'Dong',
                     'updates.found': 'I have ${0} an ${1} extra ${2} parameter',
-                    'sync.progress': 'But they need ${x0} correct syntax $ {1}',
+                    'sync.progress': 'But use ${x0} correct syntax $ {1}',
                 }
             }
 

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -58,7 +58,15 @@ def process_ui_translation_upload(app, trans_file):
     def _get_params_text(params):
         if not params:
             return "no parameters"
-        return ", ".join(["${{{}}}".format(num) for num in sorted({re.sub(r'\D', '', p) for p in params})])
+
+        # Reduce parameter list to the numbers alone, a set like {'0', '1', '2'}
+        numbers = {re.sub(r'\D', '', p) for p in params}
+
+        # Sort numbers, so that re-ordering parameters doesn't trigger error
+        numbers = sorted(numbers)
+
+        # Re-join numbers into a string for display
+        return ", ".join(["${{{}}}".format(num) for num in numbers])
 
     for row in translations:
         if row["property"] not in commcare_ui_strings:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-846

CCUI translations already validates bad syntax, like `$ {0}` instead of `${0}`. This PR adds validation that the uploaded translation contains the same parameters as the default translation.

<img width="1370" alt="Screen Shot 2019-08-30 at 2 46 32 PM" src="https://user-images.githubusercontent.com/1486591/64045088-6e41f680-cb36-11e9-86b0-287adf061c3e.png">
