### PR TITLE
Better ICDS Dashboard static file management

### DIFF
--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -6,7 +6,6 @@
 <html>
 <head>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'bootstrap/dist/css/bootstrap.css' %}"/>
-        <link type="text/css" rel="stylesheet" media="all" href="{% static 'bootstrap/dist/css/bootstrap.css' %}"/>
         <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css"/>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'ui-select/dist/select.css' %}"/>
         <link type="text/css"

--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -5,15 +5,11 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css"/>
 {% compress css %}
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'bootstrap/dist/css/bootstrap.css' %}"/>
-        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css"/>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'ui-select/dist/select.css' %}"/>
-        <link type="text/css"
-              rel="stylesheet"
-              media="all"
-              href="{% static 'font-awesome/css/font-awesome.css' %}"/>
-
+        <link type="text/css" rel="stylesheet" media="all" href="{% static 'font-awesome/css/font-awesome.css' %}"/>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'nvd3-1.8.6/build/nv.d3.css' %}">
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'angular-datatables/dist/css/angular-datatables.min.css' %}">
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'angular-datatables/dist/plugins/bootstrap/datatables.bootstrap.min.css' %}">
@@ -52,14 +48,18 @@
         <script src="{% static 'angular-leaflet-directive/dist/angular-leaflet-directive.js' %}"></script>
         <script src="{% static 'perfect-scrollbar/js/perfect-scrollbar.jquery.min.js' %}"></script>
         <script src="{% static 'angular-perfect-scrollbar/src/angular-perfect-scrollbar.js' %}"></script>
-
         <script src="{% static 'topojson/topojson.js' %}"></script>
         <script src="{% static 'datamaps/dist/datamaps.ind.js' %}"></script>
 
         <script src="{% static 'js/topojsons/states_v2.topojson.js' %}"></script>
         <script src="{% static 'js/topojsons/districts_v2.topojson.js' %}"></script>
         <script src="{% static 'js/topojsons/blocks_v3.topojson.js' %}"></script>
-
+{% endcompress %}
+{% comment %}
+For some odd reason if we include the entire block in a single compres tag we get javascript errors
+related to angular not being defined. But if we split it here it works fine.
+{% endcomment %}
+{% compress js %}
         <script src="{% static 'angular-datamaps/dist/angular-datamaps.js' %}"></script>
         <script src="{% static 'angular-bootstrap/ui-bootstrap-tpls.min.js' %}"></script>
 

--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -5,6 +5,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+{% compress css %}
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'bootstrap/dist/css/bootstrap.css' %}"/>
         <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css"/>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'ui-select/dist/select.css' %}"/>
@@ -20,6 +21,8 @@
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'angular-busy/dist/angular-busy.min.css' %}"/>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'perfect-scrollbar/css/perfect-scrollbar.min.css' %}"/>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'css/icds_dashboard.css' %}"/>
+{% endcompress %}
+
         {% include 'analytics/google.html' %}
         {% javascript_libraries underscore=True hq=True %}
         <script src="{% static 'autotrack/autotrack.js' %}"></script>
@@ -28,6 +31,7 @@
             window.ga('require', 'outboundLinkTracker');
             window.ga('require', 'urlChangeTracker');
         </script>
+{% compress js %}
         <script src="{% static 'd3-3.5.17/d3.js' %}"></script>
         <script src="{% static 'datatables/media/js/jquery.dataTables.min.js'%}"></script>
         <script src="{% static 'datatables-fixedcolumns/js/dataTables.fixedColumns.js'%}"></script>
@@ -116,6 +120,7 @@
         <script src="{% static 'js/directives/cas-export/cas-export.directive.js' %}"></script>
         <script src="{% static 'js/directives/access-denied/access-denied.directive.js' %}"></script>
         <script src="{% static 'js/directives/info-message/info-message.directive.js' %}"></script>
+{% endcompress %}
 </head>
 <body>
 

--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -56,7 +56,7 @@
         <script src="{% static 'js/topojsons/blocks_v3.topojson.js' %}"></script>
 {% endcompress %}
 {% comment %}
-For some odd reason if we include the entire block in a single compres tag we get javascript errors
+For some odd reason if we include the entire block in a single compress tag we get javascript errors
 related to angular not being defined. But if we split it here it works fine.
 {% endcomment %}
 {% compress js %}

--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -5,7 +5,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css"/>
 {% compress css %}
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'bootstrap/dist/css/bootstrap.css' %}"/>
         <link type="text/css" rel="stylesheet" media="all" href="{% static 'ui-select/dist/select.css' %}"/>


### PR DESCRIPTION
Related to: https://dimagi-dev.atlassian.net/browse/ICDS-761

I believe the root cause of the bug is a yet-to-be-fully-understood issue related to our static versioning code, but I think this should also fix it for this page (since `compress` should re-generate the file and hash if anything changes.

This also reduces the number of requests from a comical 128 to a still not great but much more reasonable 36.

I ran `compress` locally and it succeeded. And I also verified there were no JS errors on the pages and navigation worked properly using [on the fly compression](https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/static-files.md#2-on-the-fly-server-side-compression-with-the-cache-refreshed-as-changes-are-made).