### PR TITLE
Continue live migration

### DIFF
--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -18,7 +18,10 @@ log = logging.getLogger(__name__)
 
 def set_migration_started(domain, slug, dry_run=False):
     progress, _ = DomainMigrationProgress.objects.get_or_create(domain=domain, migration_slug=slug)
-    if progress.migration_status == MigrationStatus.NOT_STARTED:
+    if (
+        progress.migration_status == MigrationStatus.NOT_STARTED
+        or progress.migration_status == MigrationStatus.DRY_RUN
+    ):
         progress.migration_status = MigrationStatus.DRY_RUN if dry_run else MigrationStatus.IN_PROGRESS
         progress.started_on = datetime.utcnow()
         progress.save()

--- a/corehq/apps/domain_migration_flags/tests/test_domain_migration_progress.py
+++ b/corehq/apps/domain_migration_flags/tests/test_domain_migration_progress.py
@@ -61,6 +61,23 @@ class DomainMigrationProgressTest(TestCase):
         self.assertIsNotNone(progress.started_on)
         self.assertLessEqual(progress.started_on, datetime.utcnow())
 
+    def test_continue_live_migration(self):
+        set_migration_started('yellow', self.slug, dry_run=True)
+        self.assertFalse(migration_in_progress('yellow', self.slug))
+        self.assertTrue(migration_in_progress('yellow', self.slug, include_dry_runs=True))
+        # Live migration finishes ... and is continued later
+        set_migration_started('yellow', self.slug, dry_run=True)
+        self.assertFalse(migration_in_progress('yellow', self.slug))
+        self.assertTrue(migration_in_progress('yellow', self.slug, include_dry_runs=True))
+
+    def test_migration_after_live_migration(self):
+        set_migration_started('yellow', self.slug, dry_run=True)
+        self.assertFalse(migration_in_progress('yellow', self.slug))
+        self.assertTrue(migration_in_progress('yellow', self.slug, include_dry_runs=True))
+        # Live migration finishes ... and is completed with normal migration
+        set_migration_started('yellow', self.slug)
+        self.assertTrue(migration_in_progress('yellow', self.slug))
+
     def test_complete(self):
         set_migration_complete('green', self.slug)
         self.assertEqual(get_migration_status('green', self.slug),


### PR DESCRIPTION
According to help text for the `--live` option of migration commands:

> Live migrations can be resumed after
> interruption or to top off a previous live migration by
> processing unmigrated forms that are older than one
> hour.

This change makes that true.
