### PR TITLE
Use bionic image and don't specify python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+dist: bionic
 sudo: required
 group: edge
 branches:


### PR DESCRIPTION
opening out of curiosity about impact on test speeds. Because we use docker we shouldn't need to specify python version