### PR TITLE
Added DatespanMixin to ASHAReports to replace old NRHMDatespanMixin

### DIFF
--- a/custom/up_nrhm/reports/asha_reports.py
+++ b/custom/up_nrhm/reports/asha_reports.py
@@ -2,7 +2,7 @@ import calendar
 from corehq.apps.reports.filters.dates import DatespanFilter
 from corehq.apps.reports.filters.select import YearFilter
 from corehq.apps.reports.generic import GenericTabularReport
-from corehq.apps.reports.standard import CustomProjectReport
+from corehq.apps.reports.standard import CustomProjectReport, DatespanMixin
 from corehq.apps.users.models import CommCareUser
 from corehq.util.translation import localize
 from custom.up_nrhm.reports import LangMixin
@@ -26,7 +26,7 @@ def total_rows(report):
     return {}
 
 
-class ASHAReports(GenericTabularReport, CustomProjectReport, LangMixin):
+class ASHAReports(GenericTabularReport, DatespanMixin, CustomProjectReport, LangMixin):
     fields = [SampleFormatFilter, LanguageFilter,
               DatespanFilter, DrillDownOptionFilter,
               ASHAMonthFilter, YearFilter]


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1204713211

Followup for https://github.com/dimagi/commcare-hq/pull/25239/commits/ca0646a53b8c23bcc2efed491eafa94b1734e26c

Same idea as https://github.com/dimagi/commcare-hq/pull/25239/commits/bf15f230f7804fa6aa2503eeee4560d9611de099 - when deleting `NRHMDatespanMixin` its usages should have been replaced with its superclass instead of being removed altogether.