### PR TITLE
Make form metadata optional for combined pillow

### DIFF
--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -199,8 +199,11 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
     )
     if ucr_configs:
         ucr_processor.bootstrap(ucr_configs)
-    processors = [xform_to_es_processor,
-        form_meta_processor, unknown_user_form_processor]
+    processors = [
+        xform_to_es_processor,
+        form_meta_processor,
+        unknown_user_form_processor
+    ]
     if not settings.ENTERPRISE_MODE:
         xform_to_report_es_processor = ElasticProcessor(
             elasticsearch=get_es_new(),
@@ -208,9 +211,9 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
             doc_prep_fn=transform_xform_for_report_forms_index,
             doc_filter_fn=report_xform_filter
         )
-        processors = [xform_to_report_es_processor] + processors
+        processors.append(xform_to_report_es_processor)
     if not skip_ucr:
-        processors = [ucr_processor] + processors
+        processors.append(ucr_processor)
     return ConstructedPillow(
         name=pillow_id,
         change_feed=change_feed,

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -201,9 +201,10 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         ucr_processor.bootstrap(ucr_configs)
     processors = [
         xform_to_es_processor,
-        form_meta_processor,
         unknown_user_form_processor
     ]
+    if settings.RUN_FORM_META_PILLOW:
+        processors.append(form_meta_processor)
     if not settings.ENTERPRISE_MODE:
         xform_to_report_es_processor = ElasticProcessor(
             elasticsearch=get_es_new(),

--- a/settings.py
+++ b/settings.py
@@ -699,6 +699,8 @@ LOCAL_APPS = ()
 LOCAL_MIDDLEWARE = ()
 LOCAL_PILLOWTOPS = {}
 
+RUN_FORM_META_PILLOW = True
+
 # Set to True to remove the `actions` and `xform_id` fields from the
 # ES Case index. These fields contribute high load to the shard
 # databases.


### PR DESCRIPTION
Doing this so that we can remove the form metadata pillow in the future (or run it separately if we really want to). This pillow will be able to be removed once the app status work is complete.