### PR TITLE
Report user counts every minute (with caching)

### DIFF
--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -346,7 +346,7 @@ def all_domain_stats():
     commcare_counts = defaultdict(int)
 
     for row in CouchUser.get_db().view('users/by_domain', startkey=["active"],
-                             endkey=["active", {}], group_level=3).all():
+                                       endkey=["active", {}], group_level=3).all():
         _, domain, doc_type = row['key']
         value = row['value']
         {

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -340,7 +340,7 @@ def dom_calc(calc_tag, dom, extra_arg=''):
     return ans
 
 
-@quickcache(timeout=60 * 60)
+@quickcache([], timeout=60 * 60)
 def all_domain_stats():
     webuser_counts = defaultdict(lambda: 0)
     commcare_counts = defaultdict(lambda: 0)

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 
 from dateutil.relativedelta import relativedelta
 
+from corehq.util.quickcache import quickcache
 from couchforms.analytics import (
     domain_has_submission_in_last_30_days,
     get_first_form_submission_received,
@@ -339,6 +340,7 @@ def dom_calc(calc_tag, dom, extra_arg=''):
     return ans
 
 
+@quickcache(timeout=60 * 60)
 def all_domain_stats():
     webuser_counts = defaultdict(lambda: 0)
     commcare_counts = defaultdict(lambda: 0)

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -342,8 +342,8 @@ def dom_calc(calc_tag, dom, extra_arg=''):
 
 @quickcache([], timeout=60 * 60)
 def all_domain_stats():
-    webuser_counts = defaultdict(lambda: 0)
-    commcare_counts = defaultdict(lambda: 0)
+    webuser_counts = defaultdict(int)
+    commcare_counts = defaultdict(int)
 
     for row in CouchUser.get_db().view('users/by_domain', startkey=["active"],
                              endkey=["active", {}], group_level=3).all():

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -91,7 +91,7 @@ def _update_calculated_properties():
             notify_exception(None, message='Domain {} failed on stats calculations with {}'.format(dom, e))
 
 
-@periodic_task(run_every=timedelta(hours=6), queue='background_queue')
+@periodic_task(run_every=timedelta(minutes=1), queue='background_queue')
 def run_datadog_user_stats():
     all_stats = all_domain_stats()
     datadog_report_user_stats(commcare_users_by_domain=all_stats['commcare_users'])


### PR DESCRIPTION
The sparse data makes it hard to use in calculations on datadog.
So as silly as it is, I think we should just cache the work and report the same
thing every minute.

Basically I want to make this graph more granular and use it to get insight into peak per-user submission rates for domains, which I can use to inform the choices in rate limiting.