### PR TITLE
Removed caching from resource_static

### DIFF
--- a/corehq/apps/hqwebapp/exceptions.py
+++ b/corehq/apps/hqwebapp/exceptions.py
@@ -1,2 +1,6 @@
 class AlreadyRenderedException(Exception):
     pass
+
+
+class ResourceVersionsNotFoundException(Exception):
+    pass

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -11,6 +11,7 @@ from django.conf import settings
 
 import yaml
 
+from corehq.apps.hqwebapp.exceptions import ResourceVersionsNotFoundException
 from corehq.apps.hqwebapp.management.commands.resource_static import \
     Command as ResourceStaticCommand
 
@@ -45,11 +46,11 @@ class Command(ResourceStaticCommand):
         if local:
             _confirm_or_exit()
 
-        try:
-            from get_resource_versions import get_resource_versions
-            resource_versions = get_resource_versions()
-        except (ImportError, SyntaxError):
-            resource_versions = {}
+        # During deploy, resource_static should already have run and populated resource_versions
+        from get_resource_versions import get_resource_versions
+        resource_versions = get_resource_versions()
+        if (not resource_versions):
+            raise ResourceVersionsNotFoundException()
 
         config, local_js_dirs = _r_js(local=local, no_optimize=no_optimize)
 

--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -95,7 +95,7 @@ class Command(ResourceStaticCommand):
             }, indent=2))
         resource_versions["hqwebapp/js/resource_versions.js"] = self.get_hash(filename)
 
-        self.update_resources(resource_versions, overwrite=False)
+        self.output_resources(resource_versions, overwrite=False)
 
 
 def _confirm_or_exit():

--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -4,34 +4,19 @@ import os
 
 from django.conf import settings
 from django.contrib.staticfiles import finders
-from django.core import cache
 from django.core.management.base import BaseCommand
 
 import yaml
 
 from dimagi.utils import gitinfo
 
-rcache = cache.caches['redis']
-RESOURCE_PREFIX = '#resource_%s'
-
 
 class Command(BaseCommand):
-    help = "Prints the paths of all the static files"
+    help = """
+        Hashes the contents of all static files and stores the results in resource_versions.yaml.
+    """
 
     root_dir = settings.FILEPATH
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--clear',
-            action='store_true',
-            default=False,
-        )
-
-    def current_sha(self):
-        current_snapshot = gitinfo.get_project_snapshot(self.root_dir, submodules=False)
-        sha = current_snapshot['commits'][0]['sha']
-        print("Current commit SHA: %s" % sha)
-        return sha
 
     def output_resources(self, resources, overwrite=True, path=None):
         if not overwrite:
@@ -45,25 +30,8 @@ class Command(BaseCommand):
             fout.write(yaml.dump([{'name': name, 'version': version}
                                   for name, version in resources.items()]))
 
-    def update_resources(self, resources, sha=None, overwrite=True):
-        if not sha:
-            sha = self.current_sha()
-        rcache.set(RESOURCE_PREFIX % sha, resources, 86400)
-        self.output_resources(resources, overwrite=overwrite)
-
     def handle(self, **options):
         prefix = os.getcwd()
-
-        if options['clear']:
-            print("clearing resource cache")
-            rcache.delete_pattern(RESOURCE_PREFIX % '*')
-
-        current_sha = self.current_sha()
-        existing_resources = rcache.get(RESOURCE_PREFIX % current_sha, None)
-        if existing_resources and not isinstance(existing_resources, str):
-            print("getting resource dict from cache")
-            self.output_resources(existing_resources, overwrite=True)
-            return
 
         resources = {}
         for finder in finders.get_finders():
@@ -76,7 +44,8 @@ class Command(BaseCommand):
                     url = os.path.join(storage.prefix, path)
                 filename = os.path.join(storage.location, path)
                 resources[url] = self.get_hash(filename)
-        self.update_resources(resources, sha=current_sha)
+
+        self.output_resources(resources)
 
     def get_hash(self, filename):
         with open(filename, 'rb') as f:

--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -8,8 +8,6 @@ from django.core.management.base import BaseCommand
 
 import yaml
 
-from dimagi.utils import gitinfo
-
 
 class Command(BaseCommand):
     help = """


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-865

During deploy, resource_versions should be
1. Cleared
1. Populated with hashes for all static files, which happens during `resource_static`
1. Appended with hashes for RequireJS bundles, which happens during `build_requirejs`

https://github.com/dimagi/commcare-hq/pull/24938 updated this logic to deal with an issue where resource_versions contained only the requirejs bundles. It did so by updating the logic in `resource_static`. However, this is confounded by 1) commands during the deploy process that `rm` resource_versions.yaml and 2) caching of resource_versions.

This PR removes the resource_versions cache. The cache lasts a day, so at best it's useful when deploying one server multiple times a day without any static files changes. I'm guessing that given frequent high-priority ICDS bugs lately, india and TCL have been more likely to be deployed multiple times a day and this is why this issue has popped up more often on those servers. To further complicate recent behavior, between the release of https://github.com/dimagi/commcare-hq/pull/24938 and the release of https://github.com/dimagi/commcare-cloud/pull/3148/ and https://github.com/dimagi/commcare-cloud/pull/3186/, there was a stretch when neither of the deploy `rm`s was doing anything, then a stretch when only one of them was doing something.

I'm removing the deploy `rm` commands in https://github.com/dimagi/commcare-cloud/pull/3222 so that all logic about removing/overwriting resource_versions is contained in the `resource_static` command.