### PR TITLE
Make case search and unknown user pillows configurable via settings

### DIFF
--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -112,7 +112,9 @@ def get_case_pillow(
         checkpoint=checkpoint, checkpoint_frequency=1000, change_feed=change_feed,
         checkpoint_callback=ucr_processor
     )
-    processors = [case_to_es_processor, case_search_processor, CaseMessagingSyncProcessor()]
+    processors = [case_to_es_processor, CaseMessagingSyncProcessor()]
+    if settings.RUN_CASE_SEARCH_PILLOW:
+        processors.append(case_search_processor)
     if not settings.ENTERPRISE_MODE:
         processors.append(get_case_to_report_es_processor())
     if not skip_ucr:

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -31,7 +31,7 @@ def update_unknown_user_from_form_if_necessary(es, doc_dict):
     if not user_id:
         return
 
-    if not _user_exists_in_couch(user_id):
+    if _user_exists_in_couch(user_id):
         return
 
     if not doc_exists_in_es(USER_INDEX_INFO, user_id):

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -28,8 +28,13 @@ def update_unknown_user_from_form_if_necessary(es, doc_dict):
     if user_id in WEIRD_USER_IDS:
         user_id = None
 
-    if (user_id and not _user_exists(user_id)
-            and not doc_exists_in_es(USER_INDEX_INFO, user_id)):
+    if not user_id:
+        return
+
+    if not _user_exists_in_couch(user_id):
+        return
+
+    if not doc_exists_in_es(USER_INDEX_INFO, user_id):
         doc_type = "AdminUser" if username == "admin" else "UnknownUser"
         doc = {
             "_id": user_id,
@@ -64,7 +69,7 @@ def transform_user_for_elasticsearch(doc_dict):
 
 
 @quickcache(['user_id'])
-def _user_exists(user_id):
+def _user_exists_in_couch(user_id):
     return CouchUser.get_db().doc_exist(user_id)
 
 

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -200,10 +200,9 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
     )
     if ucr_configs:
         ucr_processor.bootstrap(ucr_configs)
-    processors = [
-        xform_to_es_processor,
-        unknown_user_form_processor
-    ]
+    processors = [xform_to_es_processor]
+    if settings.RUN_UNKNOWN_USER_PILLOW:
+        processors.append(unknown_user_form_processor)
     if settings.RUN_FORM_META_PILLOW:
         processors.append(form_meta_processor)
     if not settings.ENTERPRISE_MODE:

--- a/settings.py
+++ b/settings.py
@@ -701,6 +701,7 @@ LOCAL_PILLOWTOPS = {}
 
 RUN_FORM_META_PILLOW = True
 RUN_CASE_SEARCH_PILLOW = True
+RUN_UNKNOWN_USER_PILLOW = True
 
 # Set to True to remove the `actions` and `xform_id` fields from the
 # ES Case index. These fields contribute high load to the shard

--- a/settings.py
+++ b/settings.py
@@ -700,6 +700,7 @@ LOCAL_MIDDLEWARE = ()
 LOCAL_PILLOWTOPS = {}
 
 RUN_FORM_META_PILLOW = True
+RUN_CASE_SEARCH_PILLOW = True
 
 # Set to True to remove the `actions` and `xform_id` fields from the
 # ES Case index. These fields contribute high load to the shard


### PR DESCRIPTION
This makes the case search and unknown user pillow configurable via settings when running the new "combined pillow" processes. Previously we were not running these pillows on ICDS so this was not needed. 

**Why these two pillows**
Case search - We don't currently have any domains under the [(4!) case search feature flags or options](https://github.com/dimagi/commcare-hq/blob/3d08fb4a2140dbe7f255a95785fe4640b8cfcceb/corehq/pillows/case_search.py#L59-L62). This means that no cases are being put into the case search index, but depending on no one (or no script/migration) to touch a feature flag is a fragile process that we've been burnt on before. This allows us to specifically control the environment's ability to have it enabled at all which is useful for enterprise deployments where we need to assess hardware requirements.

Unknown Users Pillow - This creates users when in the UserES index whenever we receive a form with a user_id that does not exist in couch (or isn't a part of system forms). to do this it introduces a couch request that's cached to see if the user_id exists. We've had some recent issues with one of the redis nodes and several of our couch nodes regularly hit ~1 normalized load on a daily basis, so I'm not prepared to make the case that this could be run on ICDS in the short term. perhaps it can be revisited after some more changes long term changes. long term couch issues tracked here: https://dimagi-dev.atlassian.net/browse/IIO-420, there are some similar tickets for redis under https://dimagi-dev.atlassian.net/browse/IIO-142 

**deployment details**
They both default to True and I will write a separate commcare-cloud update to set them to False for ICDS

**Future thoughts** 

Feel free to skip

If I had infinite time or no other commitments I'd probably scrap a lot of the pillow code and re-organize it as a set of classes of `Extractor`s  and `Processor`s with one `CommCareETL` class that could run an `Extractor` and multiple `Processor`s. And then have a default set of  pillows defined in settings (implying you could set all of this in your enviornment's localsettings):

```yaml
etl:
  case:
    extractor: KafkaCaseProcessor
    processors:
      - ESProcessor
      - CaseUCRProcessor
```

But I haven't really thought that through super hard yet. Pillows are almost already structured like this, but have some cruft that has built up over the past 7(?) years. Its also likely I'd just be moving the problems I have with the current code to other places and not solving any core issues. Anyways figured I'd lay that out in case anyone considers rewriting our ETL logic in the future.