### PR TITLE
Add very basic static UCRs for QA

### DIFF
--- a/custom/ccqa/ucr/data_sources/patients.json
+++ b/custom/ccqa/ucr/data_sources/patients.json
@@ -1,0 +1,72 @@
+{
+  "domains": [
+    "ccqa",
+    "ccqa-downstream"
+  ],
+  "server_environment": [
+    "localdev",
+    "production",
+    "staging",
+    "india"
+  ],
+  "config": {
+    "table_id": "patients",
+    "display_name": "Patients",
+    "referenced_doc_type": "CommCareCase",
+    "description": "Example static UCR for testing, operates on 'patient' cases",
+    "base_item_expression": {},
+    "configured_filter": {
+      "operator": "eq",
+      "type": "boolean_expression",
+      "expression": {
+        "type": "property_name",
+        "property_name": "type"
+      },
+      "property_value": "patient"
+    },
+    "validations": [],
+    "configured_indicators": [
+      {
+        "column_id": "name",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "name"
+        },
+        "datatype": "string"
+      },
+      {
+        "column_id": "dob",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "dob"
+        },
+        "datatype": "date"
+      },
+      {
+        "column_id": "favorite_color",
+        "type": "expression",
+        "expression": {
+          "type": "property_name",
+          "property_name": "favorite_color"
+        },
+        "datatype": "string"
+      },
+      {
+        "column_id": "opened_on",
+        "datatype": "datetime",
+        "type": "raw",
+        "property_name": "opened_on"
+      },
+      {
+        "column_id": "closed_on",
+        "datatype": "datetime",
+        "type": "raw",
+        "property_name": "closed_on"
+      }
+    ],
+    "named_expressions": {},
+    "named_filters": {}
+  }
+}

--- a/custom/ccqa/ucr/reports/patients.json
+++ b/custom/ccqa/ucr/reports/patients.json
@@ -1,0 +1,71 @@
+{
+  "domains": [
+    "ccqa",
+    "ccqa-downstream"
+  ],
+  "server_environment": [
+    "localdev",
+    "production",
+    "staging",
+    "india"
+  ],
+  "report_id": "patients",
+  "data_source_table": "patients",
+  "config": {
+    "title": "Patients",
+    "description": "Example static UCR for testing, operates on 'patient' cases",
+    "visible": true,
+    "aggregation_columns": [
+      "doc_id"
+    ],
+    "filters": [
+      {
+        "display": "Date of Birth",
+        "slug": "dob",
+        "type": "date",
+        "field": "dob",
+        "datatype": "date"
+      }
+    ],
+    "columns": [
+      {
+        "display": "Name",
+        "column_id": "name",
+        "type": "field",
+        "field": "name",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Date of Birth",
+        "column_id": "dob",
+        "type": "field",
+        "field": "dob",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Favorite Color",
+        "column_id": "favorite_color",
+        "type": "field",
+        "field": "favorite_color",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Date Opened",
+        "column_id": "opened_on",
+        "type": "field",
+        "field": "opened_on",
+        "aggregation": "simple"
+      },
+      {
+        "display": "Date Closed",
+        "column_id": "closed_on",
+        "type": "field",
+        "field": "closed_on",
+        "aggregation": "simple"
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  },
+  "doc_type": "ReportConfiguration"
+}

--- a/settings.py
+++ b/settings.py
@@ -361,6 +361,8 @@ HQ_APPS = (
     'custom.hki',
     'custom.champ',
     'custom.aaa',
+
+    'custom.ccqa',
 )
 
 # any built-in management commands we want to override should go in hqscripts
@@ -1807,6 +1809,7 @@ STATIC_UCR_REPORTS = [
     os.path.join('custom', 'icds_reports', 'ucr', 'reports', 'other', '*.json'),
     os.path.join('custom', 'echis_reports', 'ucr', 'reports', '*.json'),
     os.path.join('custom', 'aaa', 'ucr', 'reports', '*.json'),
+    os.path.join('custom', 'ccqa', 'ucr', 'reports', 'patients.json'),  # For testing static UCRs
 ]
 
 
@@ -1875,6 +1878,7 @@ STATIC_DATA_SOURCES = [
 
     os.path.join('custom', 'echis_reports', 'ucr', 'data_sources', '*.json'),
     os.path.join('custom', 'aaa', 'ucr', 'data_sources', '*.json'),
+    os.path.join('custom', 'ccqa', 'ucr', 'data_sources', 'patients.json'),  # For testing static UCRs
 ]
 
 STATIC_DATA_SOURCE_PROVIDERS = [
@@ -2022,6 +2026,8 @@ DOMAIN_MODULE_MAP = {
     'vectorlink-uganda': 'custom.abt',
     'vectorlink-zambia': 'custom.abt',
     'vectorlink-zimbabwe': 'custom.abt',
+
+    'ccqa': 'custom.ccqa',
 }
 
 THROTTLE_SCHED_REPORTS_PATTERNS = (


### PR DESCRIPTION
There have been a few instances recently where I've wanted to do testing either locally or on staging involving static UCRs (in particular for UCR references in linked or copied apps).  This seems like an easy way of making that happen.

I added a report and a data source to the `ccqa` domain and one called `ccqa-downstream`.  These operate on a case type called `patient`, and deal with three fields - `name`, `dob`, and `favorite_color`.