### PR TITLE
Added compress blocks

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
@@ -1,11 +1,14 @@
+{% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
-<script src="{% static 'xpath/lib/biginteger.js' %}"></script>
-<script src="{% static 'xpath/lib/schemeNumber.js' %}"></script>
-<script src="{% static 'xpath/xpath.js' %}"></script>
-<script src="{% static 'xpath/parser.js' %}"></script>
-<script src="{% static 'app_manager/js/xpathConfig.js' %}"></script>
-<script src="{% static 'app_manager/js/xpathValidator.js' %}"></script>
+{% compress js %}
+  <script src="{% static 'xpath/lib/biginteger.js' %}"></script>
+  <script src="{% static 'xpath/lib/schemeNumber.js' %}"></script>
+  <script src="{% static 'xpath/xpath.js' %}"></script>
+  <script src="{% static 'xpath/parser.js' %}"></script>
+  <script src="{% static 'app_manager/js/xpathConfig.js' %}"></script>
+  <script src="{% static 'app_manager/js/xpathValidator.js' %}"></script>
+{% endcompress %}
 <script type="text/html" id="XPathValidator.template">
   <div class="js-xpath-input-target control-group" data-bind="css: {error: xpathValidator.error}">
     <textarea class="form-control" spellcheck="false"

--- a/corehq/apps/cloudcare/templates/cloudcare/includes/formplayer-inline.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/includes/formplayer-inline.html
@@ -1,26 +1,31 @@
+{% load compress %}
 {% load hq_shared_tags %}
 
 {# touchforms includes #}
-<link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
-<link rel="stylesheet" href="{% static 'cloudcare/css/webforms.css' %}">
-<link rel="stylesheet" href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}">
-<link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}">
+{% compress css %}
+  <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
+  <link rel="stylesheet" href="{% static 'cloudcare/css/webforms.css' %}">
+  <link rel="stylesheet" href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}">
+  <link rel="stylesheet" href="{% static 'At.js/dist/css/jquery.atwho.min.css' %}">
+{% endcompress %}
 
-<script src="{% static 'nprogress/nprogress.js' %}"></script>
-<script src="{% static 'moment/moment.js' %}"></script>
-<script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
+{% compress js %}
+  <script src="{% static 'nprogress/nprogress.js' %}"></script>
+  <script src="{% static 'moment/moment.js' %}"></script>
+  <script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
 
-<script src="{% static 'Caret.js/dist/jquery.caret.js' %}"></script>
-<script src="{% static 'At.js/dist/js/jquery.atwho.js' %}"></script>
+  <script src="{% static 'Caret.js/dist/jquery.caret.js' %}"></script>
+  <script src="{% static 'At.js/dist/js/jquery.atwho.js' %}"></script>
 
-<script src="{% static 'markdown-it/dist/markdown-it.js' %}"></script>
-<script src="{% static 'jquery-tiny-pubsub/dist/ba-tiny-pubsub.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/webformsession.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/formnav-all.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/entrycontrols_full.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/fullform-ui.js' %}"></script>
-<script src="{% static 'cloudcare/js/debugger/debugger.js' %}"></script>
+  <script src="{% static 'markdown-it/dist/markdown-it.js' %}"></script>
+  <script src="{% static 'jquery-tiny-pubsub/dist/ba-tiny-pubsub.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/webformsession.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/formnav-all.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/entrycontrols_full.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/fullform-ui.js' %}"></script>
+  <script src="{% static 'cloudcare/js/debugger/debugger.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/formplayer-inline.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer-inline.js' %}"></script>
+{% endcompress %}
 
 {% include 'form_entry/templates.html' %}

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -1,65 +1,70 @@
+{% load compress %}
 {% load hq_shared_tags %}
 
-<script src="{% static 'backbone-1.3.2/backbone.js' %}"></script>
-<script src="{% static 'backbone.marionette/lib/backbone.marionette.js' %}"></script>
-<script src="{% static 'nprogress/nprogress.js' %}"></script>
-<script src="{% static 'moment/min/moment.min.js' %}"></script>
-<script src="{% static 'jquery-textchange/jquery.textchange.js' %}"></script>
-<script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-<script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
-<script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
-<script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
-<script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.js' %}"></script>
-<script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
-<script src="{% static 'cloudcare/js/util.js' %}"></script>
-<script src="{% static 'Caret.js/dist/jquery.caret.js' %}"></script>
-<script src="{% static 'At.js/dist/js/jquery.atwho.js' %}"></script>
-<script src="{% static 'fast-levenshtein/levenshtein.js' %}"></script>
-<script src="{% static 'clipboard/dist/clipboard.js' %}"></script>
-<script src="{% static 'reports/js/readable_form.js' %}"></script>
+{% compress js %}
+  <script src="{% static 'backbone-1.3.2/backbone.js' %}"></script>
+  <script src="{% static 'backbone.marionette/lib/backbone.marionette.js' %}"></script>
+  <script src="{% static 'nprogress/nprogress.js' %}"></script>
+  <script src="{% static 'moment/min/moment.min.js' %}"></script>
+  <script src="{% static 'jquery-textchange/jquery.textchange.js' %}"></script>
+  <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+  <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
+  <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
+  <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
+  <script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.js' %}"></script>
+  <script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
+  <script src="{% static 'cloudcare/js/util.js' %}"></script>
+  <script src="{% static 'Caret.js/dist/jquery.caret.js' %}"></script>
+  <script src="{% static 'At.js/dist/js/jquery.atwho.js' %}"></script>
+  <script src="{% static 'fast-levenshtein/levenshtein.js' %}"></script>
+  <script src="{% static 'clipboard/dist/clipboard.js' %}"></script>
+  <script src="{% static 'reports/js/readable_form.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/formplayer/utils/util.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/app.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/constants.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/hq.events.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/middleware.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/router.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/utils/util.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/app.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/constants.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/hq.events.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/middleware.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/router.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/debugger/debugger.js' %}"></script>
+  <script src="{% static 'cloudcare/js/debugger/debugger.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/formplayer/layout/views/progress_bar.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/layout/views/settings.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/layout/views/phone_navigation.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/layout/views/progress_bar.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/layout/views/settings.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/layout/views/phone_navigation.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/formplayer/users/models.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/users/collections.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/users/controller.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/users/utils.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/users/views.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/users/models.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/users/collections.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/users/controller.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/users/utils.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/users/views.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/formplayer/apps/api.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/apps/controller.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/apps/views.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/apps/models.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/apps/collections.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/apps/api.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/apps/controller.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/apps/views.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/apps/models.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/apps/collections.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/formplayer/menus/api.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/menus/views.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/menus/views/query.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/menus/controller.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/menus/models.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/menus/collections.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/menus/api.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/menus/views.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/menus/views/query.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/menus/controller.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/menus/models.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/menus/collections.js' %}"></script>
 
-<script src="{% static 'cloudcare/js/formplayer/sessions/api.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/sessions/models.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/sessions/collections.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/sessions/views.js' %}"></script>
-<script src="{% static 'cloudcare/js/formplayer/sessions/controller.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/sessions/api.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/sessions/models.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/sessions/collections.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/sessions/views.js' %}"></script>
+  <script src="{% static 'cloudcare/js/formplayer/sessions/controller.js' %}"></script>
+{% endcompress %}
 
 {% include 'hqwebapp/includes/ui_element_js.html' %}
-<script src="{% static 'markdown-it/dist/markdown-it.js' %}"></script>
-<script src="{% static 'jquery-tiny-pubsub/dist/ba-tiny-pubsub.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/webformsession.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/formnav-all.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/entrycontrols_full.js' %}"></script>
-<script src="{% static 'cloudcare/js/form_entry/fullform-ui.js' %}"></script>
+{% compress js %}
+  <script src="{% static 'markdown-it/dist/markdown-it.js' %}"></script>
+  <script src="{% static 'jquery-tiny-pubsub/dist/ba-tiny-pubsub.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/webformsession.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/formnav-all.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/entrycontrols_full.js' %}"></script>
+  <script src="{% static 'cloudcare/js/form_entry/fullform-ui.js' %}"></script>
+{% endcompress %}

--- a/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
@@ -1,4 +1,5 @@
 {% extends "hqadmin/hqadmin_base_report.html" %}
+{% load compress %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
@@ -6,15 +7,14 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-  <script src="{% static 'reports/js/hq_report.js' %}"></script>
-  <script src="{% static 'reports/js/reports.util.js' %}"></script>
   {% include 'reports/partials/filters_js.html' %}
-  <script src="{% static 'reports/js/reports.async.js' %}"></script>
-{% endblock %}
-
-{% block js-inline %}{{ block.super }}
-  <script src="{% static 'appstore/js/facet_sidebar.js' %}"></script>
-  <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
+  {% compress js %}
+    <script src="{% static 'reports/js/hq_report.js' %}"></script>
+    <script src="{% static 'reports/js/reports.util.js' %}"></script>
+    <script src="{% static 'reports/js/reports.async.js' %}"></script>
+    <script src="{% static 'appstore/js/facet_sidebar.js' %}"></script>
+    <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block page_navigation %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -406,10 +406,12 @@
 
     {% if requirejs_main %}
       <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
-      <script src="{% static 'requirejs/require.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/requirejs_config.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/resource_versions.js' %}"></script>
+      {% compress js %}
+        <script src="{% static 'requirejs/require.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/requirejs_config.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/resource_versions.js' %}"></script>
+      {% endcompress %}
       <script>
         requirejs.config({
           deps: ['knockout', 'ko.mapping'],
@@ -449,8 +451,10 @@
     {# JavaScript Display Logic Libaries #}
 
     {% if request.couch_user and not requirejs_main %}
-      <script src="{% static 'notifications/js/notifications_service.js' %}"></script>
-      <script src="{% static 'notifications/js/notifications_service_main.js' %}"></script>
+      {% compress js %}
+        <script src="{% static 'notifications/js/notifications_service.js' %}"></script>
+        <script src="{% static 'notifications/js/notifications_service_main.js' %}"></script>
+      {% endcompress %}
     {% endif %}
 
     {% if not requirejs_main %}
@@ -525,8 +529,10 @@
     {% endif %}
 
     {% if request.use_ko_validation and not requirejs_main %}
-      <script src="{% static 'knockout-validation/dist/knockout.validation.min.js' %}"></script>
-      <script src="{% static 'hqwebapp/js/validators.ko.js' %}"></script>
+      {% compress js %}
+        <script src="{% static 'knockout-validation/dist/knockout.validation.min.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/validators.ko.js' %}"></script>
+      {% endcompress %}
     {% endif %}
 
     {% if is_demo_visible %}

--- a/corehq/apps/reports/templates/reports/partials/filters_js.html
+++ b/corehq/apps/reports/templates/reports/partials/filters_js.html
@@ -1,23 +1,24 @@
+{% load compress %}
 {% load hq_shared_tags %}
 
-{# This file may be compressed; it should contain only script tags #}
+{% compress js %}
+  <script src="{% static 'reports/js/filters/button_group.js' %}"></script>
+  <script src="{% static 'reports/js/filters/select2s.js' %}"></script>
+  <script src="{% static 'reports/js/filters/phone_number.js' %}"></script>
+  <script src="{% static 'reports/js/filters/schedule_instance.js' %}"></script>
 
-<script src="{% static 'reports/js/filters/button_group.js' %}"></script>
-<script src="{% static 'reports/js/filters/select2s.js' %}"></script>
-<script src="{% static 'reports/js/filters/phone_number.js' %}"></script>
-<script src="{% static 'reports/js/filters/schedule_instance.js' %}"></script>
+  <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+  <script src="{% static 'ace-builds/src-min-noconflict/ext-language_tools.js' %}"></script>
+  <script src="{% static 'ace-builds/src-min-noconflict/mode-xquery.js' %}"></script>
+  <script src="{% static 'Caret.js/dist/jquery.caret.min.js' %}"></script>
+  <script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
+  <script src="{% static 'hqwebapp/js/atwho.js' %}"></script>
+  <script src="{% static 'reports/js/filters/case_list_explorer_knockout_bindings.js' %}"></script>
+  <script src="{% static 'reports/js/filters/case_list_explorer.js' %}"></script>
 
-<script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-<script src="{% static 'ace-builds/src-min-noconflict/ext-language_tools.js' %}"></script>
-<script src="{% static 'ace-builds/src-min-noconflict/mode-xquery.js' %}"></script>
-<script src="{% static 'Caret.js/dist/jquery.caret.min.js' %}"></script>
-<script src="{% static 'At.js/dist/js/jquery.atwho.min.js' %}"></script>
-<script src="{% static 'hqwebapp/js/atwho.js' %}"></script>
-<script src="{% static 'reports/js/filters/case_list_explorer_knockout_bindings.js' %}"></script>
-<script src="{% static 'reports/js/filters/case_list_explorer.js' %}"></script>
+  <script src="{% static 'locations/js/location_drilldown.js' %}"></script>
+  <script src="{% static 'reports/js/filters/drilldown_options.js' %}"></script>
+  <script src="{% static 'reports/js/filters/advanced_forms_options.js' %}"></script>
 
-<script src="{% static 'locations/js/location_drilldown.js' %}"></script>
-<script src="{% static 'reports/js/filters/drilldown_options.js' %}"></script>
-<script src="{% static 'reports/js/filters/advanced_forms_options.js' %}"></script>
-
-<script src="{% static 'reports/js/filters/main.js' %}"></script>
+  <script src="{% static 'reports/js/filters/main.js' %}"></script>
+{% endcompress %}

--- a/corehq/apps/reports/templates/reports/partials/graphs/charts_js.html
+++ b/corehq/apps/reports/templates/reports/partials/graphs/charts_js.html
@@ -1,6 +1,8 @@
+{% load compress %}
 {% load hq_shared_tags %}
-{# This file may be compressed; it should contain only script tags #}
 
-<script src="{% static 'reports/js/charts/pie_chart.js' %}"></script>
-<script src="{% static 'reports/js/charts/multibar_chart.js' %}"></script>
-<script src="{% static 'reports/js/charts/main.js' %}"></script>
+{% compress js %}
+  <script src="{% static 'reports/js/charts/pie_chart.js' %}"></script>
+  <script src="{% static 'reports/js/charts/multibar_chart.js' %}"></script>
+  <script src="{% static 'reports/js/charts/main.js' %}"></script>
+{% endcompress %}

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -19,8 +19,10 @@
     <script src="{% static 'reports/js/reports.async.js' %}"></script>
     <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
-    {% include 'reports/partials/filters_js.html' %}
-    {% include 'reports/partials/graphs/charts_js.html' %}
+  {% endcompress %}
+  {% include 'reports/partials/filters_js.html' %}
+  {% include 'reports/partials/graphs/charts_js.html' %}
+  {% compress js %}
     <script src="{% static 'case/js/cheapxml.js' %}"></script>
     <script src="{% static 'case/js/casexml.js' %}"></script>
     <script src="{% static 'reports/js/tabular.js' %}"></script>

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -11,14 +11,16 @@
 {% endblock stylesheets %}
 
 {% block js %}{{ block.super }}
-  <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
-  <script src="{% static 'reports/js/config.dataTables.bootstrap.js' %}"></script>
-  <script src="{% static 'reports_core/js/choice_list_utils.js' %}"></script>
-  <script src="{% static 'reports_core/js/charts.js' %}"></script>
-  <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
-  <script src="{% static 'reports/js/maps_utils.js' %}"></script><!-- depends on leaflet -->
-  <script src="{% static 'reports_core/js/maps.js' %}"></script>
-  <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
+  {% compress js %}
+    <script src="{% static 'hqwebapp/js/select2_knockout_bindings.ko.js' %}"></script>
+    <script src="{% static 'reports/js/config.dataTables.bootstrap.js' %}"></script>
+    <script src="{% static 'reports_core/js/choice_list_utils.js' %}"></script>
+    <script src="{% static 'reports_core/js/charts.js' %}"></script>
+    <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
+    <script src="{% static 'reports/js/maps_utils.js' %}"></script><!-- depends on leaflet -->
+    <script src="{% static 'reports_core/js/maps.js' %}"></script>
+    <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
+  {% endcompress %}
   {% include 'reports/partials/filters_js.html' %}
   {% include 'reports/partials/graphs/charts_js.html' %}
   <script src="{% static 'reports_core/js/base_template_new.js' %}"></script>

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -1,14 +1,17 @@
 {% extends "reports_core/base_template_new.html" %}
+{% load compress %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
 {% block js %}{{ block.super }}
-  <script src="{% static 'reports/js/reports.util.js' %}"></script>
-  <script src="{% static 'reports/js/hq_report.js' %}"></script>
-  <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
-  <script src="{% static 'reports/js/report_config_models.js' %}"></script>
-  <script src="{% static 'userreports/js/configurable_report.js' %}"></script>
-  <script src="{% static 'userreports/js/build_in_progress_warning.js' %}"></script>
+  {% compress js %}
+    <script src="{% static 'reports/js/reports.util.js' %}"></script>
+    <script src="{% static 'reports/js/hq_report.js' %}"></script>
+    <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
+    <script src="{% static 'reports/js/report_config_models.js' %}"></script>
+    <script src="{% static 'userreports/js/configurable_report.js' %}"></script>
+    <script src="{% static 'userreports/js/build_in_progress_warning.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block report_alerts %}

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -1,4 +1,5 @@
 {% extends "userreports/base_report_builder.html" %}
+{% load compress %}
 {% load i18n %}
 {% load hq_shared_tags %}
 
@@ -12,12 +13,14 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-  <script src="{% static 'app_manager/js/forms/case_knockout_bindings.js' %}"></script>
-  <script src="{% static 'userreports/js/constants.js' %}"></script>
-  <script src="{% static 'userreports/js/builder_view_models.js' %}"></script>
-  <script src="{% static 'userreports/js/report_config.js' %}"></script>
-  <script src="{% static 'userreports/js/utils.js' %}"></script>
-  <script src="{% static 'userreports/js/configure_report.js' %}"></script>
+  {% compress js %}
+    <script src="{% static 'app_manager/js/forms/case_knockout_bindings.js' %}"></script>
+    <script src="{% static 'userreports/js/constants.js' %}"></script>
+    <script src="{% static 'userreports/js/builder_view_models.js' %}"></script>
+    <script src="{% static 'userreports/js/report_config.js' %}"></script>
+    <script src="{% static 'userreports/js/utils.js' %}"></script>
+    <script src="{% static 'userreports/js/configure_report.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block pre_page_content %}{% endblock %}{# Avoid the spacer #}

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -1,13 +1,16 @@
 {% extends "hqwebapp/base_section.html" %}
+{% load compress %}
 {% load i18n %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% block js %}{{ block.super }}
-  <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
-  <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
-  <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
-  <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
-  <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
+  {% compress js %}
+    <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
+    <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
+    <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
+    <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block page_navigation %}

--- a/corehq/motech/dhis2/templates/dhis2/edit_config.html
+++ b/corehq/motech/dhis2/templates/dhis2/edit_config.html
@@ -1,15 +1,18 @@
 {% extends 'hqwebapp/two_column.html' %}
+{% load compress %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% block title %}Edit Config : DHIS2 :: {% endblock %}
 {% block js %}{{ block.super }}
+  {% compress js %}
     <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
     <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block page_content %}
-{% crispy form %}
+  {% crispy form %}
 {% endblock %}

--- a/corehq/motech/openmrs/templates/openmrs/edit_config.html
+++ b/corehq/motech/openmrs/templates/openmrs/edit_config.html
@@ -1,15 +1,18 @@
 {% extends 'hqwebapp/two_column.html' %}
+{% load compress %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% block title %}Edit Config : OpenMRS :: {% endblock %}
 {% block js %}{{ block.super }}
+  {% compress js %}
     <script src="{% static 'ace-builds/src-min-noconflict/ace.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/mode-json.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/mode-xml.js' %}"></script>
     <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
     <script src="{% static 'hqwebapp/js/base_ace.js' %}"></script>
+  {% endcompress %}
 {% endblock %}
 
 {% block page_content %}
-{% crispy form %}
+  {% crispy form %}
 {% endblock %}


### PR DESCRIPTION
While investigating https://dimagi-dev.atlassian.net/browse/HI-865 I wrote a script to find files affected by the issue - that is, HTML files that contain `<script>` tags that are not inside a `{% compress %}` block - and there were many more than I expected, about 80 files.

In general, using compress blocks is a good practice, so this PR adds them to the files that have the most uncompressed js.

Marking don't merge pending sanity testing on staging.