### PR TITLE
more explicit handling of `excluded_states`

### DIFF
--- a/custom/icds_reports/sqldata/exports/beneficiary.py
+++ b/custom/icds_reports/sqldata/exports/beneficiary.py
@@ -19,10 +19,8 @@ class BeneficiaryExport(ExportableMixin, IcdsSqlData):
         config.update({
             '5_years': 60,
         })
-        self.config = config
-        self.loc_level = loc_level
-        self.show_test = show_test
-        self.beta = beta
+        super(BeneficiaryExport, self).__init__(config, loc_level, show_test, beta,
+                                                use_excluded_states=False)
 
     @property
     def group_by(self):

--- a/custom/icds_reports/sqldata/exports/beneficiary.py
+++ b/custom/icds_reports/sqldata/exports/beneficiary.py
@@ -19,8 +19,7 @@ class BeneficiaryExport(ExportableMixin, IcdsSqlData):
         config.update({
             '5_years': 60,
         })
-        super(BeneficiaryExport, self).__init__(config, loc_level, show_test, beta,
-                                                use_excluded_states=False)
+        super().__init__(config, loc_level, show_test, beta, use_excluded_states=False)
 
     @property
     def group_by(self):

--- a/custom/icds_reports/tests/__init__.py
+++ b/custom/icds_reports/tests/__init__.py
@@ -123,6 +123,16 @@ def setUpModule():
         location_id='st7',
         location_type=state_location_type
     )
+    # exercise the logic that excludes test states by creating one
+    test_state = SQLLocation.objects.create(
+        domain=domain.name,
+        name='test_state',
+        location_id='test_state',
+        location_type=state_location_type,
+        metadata={
+            'is_test_location': 'test',
+        }
+    )
 
     supervisor_location_type = LocationType.objects.create(
         domain=domain.name,

--- a/custom/icds_reports/tests/test_citus_comparison.py
+++ b/custom/icds_reports/tests/test_citus_comparison.py
@@ -88,6 +88,7 @@ class TestSqlData(TestCase):
                 'age_60': '60',
                 'age_0': '0',
                 'aggregation_level': 1,
+                'excluded_states_0': 'test_state',
                 'age_6': '6'
             },
         )

--- a/custom/icds_reports/utils/mixins.py
+++ b/custom/icds_reports/utils/mixins.py
@@ -38,12 +38,14 @@ FILTER_BY_LIST = {
 
 
 class ExportableMixin(object):
-    def __init__(self, config=None, loc_level=1, show_test=False, beta=False):
+    def __init__(self, config=None, loc_level=1, show_test=False, beta=False, use_excluded_states=True):
         self.config = config
         self.loc_level = loc_level
-        self.excluded_states = get_test_state_locations_id(self.domain)
-        self.config['excluded_states'] = self.excluded_states
-        clean_IN_filter_value(self.config, 'excluded_states')
+        self.use_excluded_states = use_excluded_states
+        if use_excluded_states:
+            self.excluded_states = get_test_state_locations_id(self.domain)
+            self.config['excluded_states'] = self.excluded_states
+            clean_IN_filter_value(self.config, 'excluded_states')
         self.show_test = show_test
         self.beta = beta
 
@@ -61,7 +63,10 @@ class ExportableMixin(object):
     @property
     def filters(self):
         filters = []
-        infilter_params = get_INFilter_bindparams('excluded_states', self.excluded_states)
+        if self.use_excluded_states:
+            infilter_params = get_INFilter_bindparams('excluded_states', self.excluded_states)
+        else:
+            infilter_params = tuple()
 
         if not self.show_test:
             filters.append(NOT(IN('state_id', infilter_params)))


### PR DESCRIPTION
##### SUMMARY

https://sentry.io/organizations/dimagi/issues/1204534920/?project=136860

This is an alternative fix to https://github.com/dimagi/commcare-hq/pull/25278 that I prefer since

1. it has tests
2. subclasses should generally be able to call their superclass `__init__` functions without breaking things...

##### FEATURE FLAG

n/a

##### PRODUCT DESCRIPTION

n/a
