### PR TITLE
Tableau / BI Integration: don't include errorred or archived forms

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -1013,7 +1013,7 @@ class ODataFormResource(HqBaseResource, DomainSpecificResourceMixin):
 
     def obj_get_list(self, bundle, domain, **kwargs):
         config = get_document_or_404(FormExportInstance, domain, self.config_id)
-        query = get_form_export_base_query(domain, config.app_id, config.xmlns, include_errors=True)
+        query = get_form_export_base_query(domain, config.app_id, config.xmlns, include_errors=False)
         for filter in config.get_filters():
             query = query.filter(filter.to_es_filter())
         return query


### PR DESCRIPTION
##### SUMMARY
Removes archived and errorred forms from BI Feed

##### FEATURE FLAG
`BI_INTEGRATION_PREVIEW` feature preview

##### PRODUCT DESCRIPTION
only visible in the odata feeds. archived forms will no longer show up
