### PR TITLE
Catch all errors/exceptions when creating DomainUserHistory objects

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -1049,7 +1049,7 @@ def calculate_users_in_all_domains(today=None):
                 num_users=num_users,
                 record_date=record_date
             )
-        except _ as e:
+        except Exception as e:
             log_accounting_error(
                 "Something went wrong while creating DomainUserHistory for domain %s: %s" % (domain, e),
                 show_stack_trace=True,

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -1049,10 +1049,8 @@ def calculate_users_in_all_domains(today=None):
                 num_users=num_users,
                 record_date=record_date
             )
-        except IntegrityError:
-            pass
-        except Exception as e:
+        except _ as e:
             log_accounting_error(
-                "Exception while creating DomainUserHistory for domain %s: %s" % (domain, e),
+                "Something went wrong while creating DomainUserHistory for domain %s: %s" % (domain, e),
                 show_stack_trace=True,
             )


### PR DESCRIPTION
##### SUMMARY
I'm changing the error handling in `calculate_users_in_all_domains` to catch and log all errors, because we've been having problems recently with `DomainUserHistory` objects not getting created on the first of the month. This in turn prevents invoices from getting created ([we need these objects to exist in order to bill clients for user charges](https://github.com/dimagi/commcare-hq/blob/11dc7307a10e2405b9f0468d9b583422d8ce1b3d/corehq/apps/accounting/invoicing.py#L661)). Right now, we are not catching any of the failures so I don't know why this is happening.

##### FEATURE FLAG
None

##### PRODUCT DESCRIPTION
None

(ps @orangejenny I'm loving the new template!)