### PR TITLE
botocore is raising HTTPClientError

### DIFF
--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -178,7 +178,7 @@ class BlobStream(RawIOBase):
         return self._blob_db()
 
 
-def is_not_found(err, not_found_codes=["NoSuchKey", "NoSuchBucket", "404"]):
+def is_not_found(err, not_found_codes=("NoSuchKey", "NoSuchBucket", "404")):
     return (err.response["Error"]["Code"] in not_found_codes or
         err.response.get("Errors", {}).get("Error", {}).get("Code") in not_found_codes)
 

--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -13,7 +13,7 @@ from dimagi.utils.chunked import chunked
 
 import boto3
 from botocore.client import Config
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, HTTPClientError
 from botocore.utils import fix_s3_host
 
 DEFAULT_S3_BUCKET = "blobdb"
@@ -210,7 +210,7 @@ def get_file_size(fileobj):
 def maybe_not_found(throw=None):
     try:
         yield
-    except ClientError as err:
+    except (ClientError, HTTPClientError) as err:
         if not is_not_found(err):
             raise
         datadog_counter('commcare.blobdb.notfound')


### PR DESCRIPTION
##### SUMMARY
An exception is bubbling up that should be caught.

##### CONTEXT
When we fetch a form attachment using [`S3BlobDB.get()`](https://github.com/dimagi/commcare-hq/blob/9ca0e799b78efde26103eafcb2b8f54d8ac98417/corehq/blobs/s3db.py#L80), we wrap that request with the `maybe_not_found` context manager.

Requests to S3 are sent using `botocore`. Currently `maybe_not_found` catches exceptions that extend `botocore.exceptions.ClientError` but from the traceback below it seems it's throwing `HTTPClientError`, which does not extend `ClientError`.

This PR is to catch both errors.

Tests to follow.

```
Traceback
...
  File ".../corehq/blobs/mixin.py", line 192, in fetch_attachment
    blob = db.get(key=key)
  File ".../corehq/blobs/s3db.py", line 80, in get
    resp = self._s3_bucket().Object(key).get()
  File ".../python_env-3.6/lib/python3.6/site-packages/boto3/resources/factory.py", line 520, in do_action
    response = action(self, *args, **kwargs)
  File ".../python_env-3.6/lib/python3.6/site-packages/boto3/resources/action.py", line 83, in __call__
    response = getattr(parent.meta.client, operation_name)(**params)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/client.py", line 648, in _make_api_call
    operation_model, request_dict, request_context)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/client.py", line 667, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/endpoint.py", line 102, in make_request
    return self._send_request(request_dict, operation_model)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/endpoint.py", line 137, in _send_request
    success_response, exception):
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/endpoint.py", line 231, in _needs_retry
    caught_exception=caught_exception, request_dict=request_dict)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/hooks.py", line 356, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/retryhandler.py", line 183, in __call__
    if self._checker(attempts, response, caught_exception):
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/retryhandler.py", line 251, in __call__
    caught_exception)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/retryhandler.py", line 269, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/retryhandler.py", line 317, in __call__
    caught_exception)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/retryhandler.py", line 223, in __call__
    attempt_number, caught_exception)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/retryhandler.py", line 359, in _check_caught_exception
    raise caught_exception
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/endpoint.py", line 200, in _do_get_response
    http_response = self._send(request)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/endpoint.py", line 244, in _send
    return self.http_session.send(request)
  File ".../python_env-3.6/lib/python3.6/site-packages/botocore/httpsession.py", line 294, in send
    raise HTTPClientError(error=e)
botocore.exceptions.HTTPClientError: An HTTP Client raised and unhandled exception: 0123456789abcdef0123456789abcdef
```