### PR TITLE
Eliminate multi-process shared state db

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -27,6 +27,7 @@ from corehq.form_processor.exceptions import MissingFormXml
 
 from .diff import filter_case_diffs, filter_ledger_diffs
 from .lrudict import LRUDict
+from .statedb import StateDB
 
 log = logging.getLogger(__name__)
 
@@ -78,6 +79,7 @@ class CaseDiffQueue(object):
         self._is_flushing = False
 
     def __enter__(self):
+        self.statedb.set(ProcessNotAllowed.__name__, True)
         self._load_resume_state()
         self._stop_status_logger = self.run_status_logger()
         return self
@@ -433,7 +435,11 @@ class CaseDiffProcess(object):
     """Run CaseDiffQueue in a separate process"""
 
     def __init__(self, statedb, status_interval=STATUS_INTERVAL, queue_class=CaseDiffQueue):
+        if statedb.get(ProcessNotAllowed.__name__):
+            raise ProcessNotAllowed(f"{statedb.db_filepath} was previously "
+                "used directly by CaseDiffQueue")
         self.statedb = statedb
+        self.state_path = get_casediff_state_path(statedb.db_filepath)
         self.status_interval = status_interval
         self.queue_class = queue_class
 
@@ -444,7 +450,7 @@ class CaseDiffProcess(object):
         calls, self.calls = self.calls_pipe.__enter__()
         self.stats, stats = self.stats_pipe.__enter__()
         debug = log.isEnabledFor(logging.DEBUG)
-        args = (self.queue_class, calls, stats, self.statedb, debug)
+        args = (self.queue_class, calls, stats, self.state_path, debug)
         self.process = gipc.start_process(target=run_case_diff_queue, args=args)
         self.status_logger = gevent.spawn(self.run_status_logger)
         return self
@@ -459,6 +465,7 @@ class CaseDiffProcess(object):
         self.calls.put((TERMINATE, is_error))
         self.status_logger.join(timeout=30)
         self.process.join(timeout=30)
+        self.statedb.clone_casediff_data_from(self.state_path)
         self.stats_pipe.__exit__(*exc_info)
         self.calls_pipe.__exit__(*exc_info)
 
@@ -498,7 +505,13 @@ STATUS = "status"
 TERMINATE = "terminate"
 
 
-def run_case_diff_queue(queue_class, calls, stats, statedb, debug):
+def get_casediff_state_path(path):
+    assert os.path.exists(os.path.dirname(path)), path
+    assert path.endswith(".db"), path
+    return path[:-3] + "-casediff.db"
+
+
+def run_case_diff_queue(queue_class, calls, stats, state_path, debug):
     def status():
         stats.put((STATUS, queue.get_status()))
 
@@ -513,7 +526,8 @@ def run_case_diff_queue(queue_class, calls, stats, statedb, debug):
             getattr(queue, action)(*args)
 
     process_actions = {STATUS: status, TERMINATE: terminate}
-    setup_logging(statedb, debug)
+    statedb = StateDB.init(state_path)
+    setup_logging(state_path, debug)
     with calls, stats:
         try:
             with queue_class(statedb, status_interval=0) as queue:
@@ -533,9 +547,9 @@ def run_case_diff_queue(queue_class, calls, stats, statedb, debug):
             stats.put((TERMINATE, status_))
 
 
-def setup_logging(statedb, debug):
+def setup_logging(state_path, debug):
     from .couchsqlmigration import setup_logging
-    log_dir = os.path.dirname(statedb.db_filepath)
+    log_dir = os.path.dirname(state_path)
     if os.path.basename(log_dir) == "db":
         # unfortunately coupled to _get_state_db_filepath, which adds /db/
         log_dir = os.path.dirname(log_dir)
@@ -547,6 +561,10 @@ class GracefulExit(Exception):
 
 
 class ParentError(Exception):
+    pass
+
+
+class ProcessNotAllowed(Exception):
     pass
 
 

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -19,8 +19,7 @@ from sqlalchemy import (
     or_,
 )
 
-from corehq.apps.tzmigration.planning import Base, DiffDB
-from corehq.apps.tzmigration.planning import PlanningDiff as Diff
+from corehq.apps.tzmigration.planning import Base, DiffDB, PlanningDiff as Diff
 from corehq.apps.tzmigration.timezonemigration import json_diff
 
 from .diff import filter_form_diffs
@@ -90,6 +89,16 @@ class StateDB(DiffDB):
     def unique_id(self):
         with self.session() as session:
             return self._get_kv("db_unique_id", session).value
+
+    def get(self, name, default=None):
+        with self.session() as session:
+            kv = self._get_kv(f"kv-{name}", session)
+            if kv is None:
+                return default
+            return json.loads(kv.value)
+
+    def set(self, name, value):
+        self._upsert(KeyValue, KeyValue.key, f"kv-{name}", json.dumps(value))
 
     def update_cases(self, case_records):
         """Update case total and processed form counts
@@ -296,6 +305,68 @@ class StateDB(DiffDB):
             .filter(MissingDoc.kind == doc_type)
         }
 
+    def clone_casediff_data_from(self, casediff_state_path):
+        """Copy casediff state into this state db
+
+        model analysis
+        - CaseForms - casediff r/w
+        - Diff - casediff w (case and stock kinds), main r/w
+        - KeyValue - casediff r/w, main r/w (different keys)
+        - DocCount - casediff w, main r
+        - MissingDoc - casediff w, main r
+        - NoActionCaseForm - main r/w
+        - ProblemForm - main r/w
+        """
+        def quote(value):
+            assert isinstance(value, str) and "'" not in value, repr(value)
+            return f"'{value}'"
+
+        def quotelist(values):
+            return f"({', '.join(quote(v) for v in values)})"
+
+        def is_id(column):
+            return column.key == "id" and isinstance(column.type, Integer)
+
+        def copy(model, session, where_expr=None):
+            where = f"WHERE {where_expr}" if where_expr else ""
+            fields = ", ".join(c.key for c in model.__table__.columns if not is_id(c))
+            session.execute(f"DELETE FROM main.{model.__tablename__} {where}")
+            session.execute(f"""
+                INSERT INTO main.{model.__tablename__} ({fields})
+                SELECT {fields} FROM cddb.{model.__tablename__} {where}
+            """)
+
+        casediff_db = type(self).open(casediff_state_path)
+        with casediff_db.session() as cddb:
+            expect_casediff_kinds = {
+                "CommCareCase",
+                "CommCareCase-Deleted",
+                "stock state",
+            }
+            casediff_kinds = {k for k, in cddb.query(Diff.kind).distinct()}
+            assert not casediff_kinds - expect_casediff_kinds, casediff_kinds
+
+            resume_keys = [
+                key for key, in cddb.query(KeyValue.key)
+                .filter(KeyValue.key.startswith("resume-"))
+            ]
+            assert all("Case" in key for key in resume_keys), resume_keys
+
+            count_kinds = [k for k, in cddb.query(DocCount.kind).distinct()]
+            assert all("CommCareCase" in k for k in count_kinds), count_kinds
+
+            missing_kinds = [m for m, in cddb.query(MissingDoc.kind).distinct()]
+            assert all("CommCareCase" in k for k in missing_kinds), missing_kinds
+        casediff_db.close()
+
+        with self.session() as session:
+            session.execute(f"ATTACH DATABASE {quote(casediff_state_path)} AS cddb")
+            copy(CaseForms, session)
+            copy(Diff, session, f"kind IN {quotelist(expect_casediff_kinds)}")
+            copy(KeyValue, session, f"key IN {quotelist(resume_keys)}")
+            copy(DocCount, session)
+            copy(MissingDoc, session)
+
 
 class ResumeError(Exception):
     pass
@@ -342,12 +413,6 @@ class NoActionCaseForm(Base):
 
 class ProblemForm(Base):
     __tablename__ = "problemform"
-
-    id = Column(String(50), nullable=False, primary_key=True)
-
-
-class UnexpectedCaseUpdate(Base):
-    __tablename__ = "unexpectedcaseupdate"
 
     id = Column(String(50), nullable=False, primary_key=True)
 

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -15,6 +15,7 @@ from ..statedb import (
     diff_doc_id_idx,
     init_state_db,
 )
+from .. import statedb as mod
 
 
 def setup_module():
@@ -27,14 +28,14 @@ def teardown_module():
     _tmp.__exit__(None, None, None)
 
 
-def init_db(memory=True):
+def init_db(name="test", memory=True):
     if memory:
         return StateDB.init(":memory:")
-    return init_state_db("test", state_dir)
+    return init_state_db(name, state_dir)
 
 
-def delete_db():
-    delete_state_db("test", state_dir)
+def delete_db(name="test"):
+    delete_state_db(name, state_dir)
 
 
 @with_setup(teardown=delete_db)
@@ -139,9 +140,6 @@ def test_resume_state():
 
 
 def test_replace_case_diffs():
-    def make_diff(id):
-        return JsonDiff("type", "path/%s" % id, "old%s" % id, "new%s" % id)
-
     with init_db() as db:
         case_id = "865413246874321"
         # add old diffs
@@ -189,3 +187,82 @@ def test_pickle():
         assert isinstance(other, type(db)), (other, db)
         assert other is not db
         eq(db.unique_id, other.unique_id)
+
+
+def test_clone_casediff_data_from():
+    diffs = [make_diff(i) for i in range(3)]
+    try:
+        with init_db("main", memory=False) as main:
+            uid = main.unique_id
+            with init_db("cddb", memory=False) as cddb:
+                main.add_problem_form("problem")
+                main.save_form_diffs({"doc_type": "XFormInstance", "_id": "form"}, {})
+                cddb.add_processed_forms({"case": 1})
+                cddb.update_cases([
+                    Config(id="case", total_forms=1, processed_forms=1),
+                    Config(id="a", total_forms=2, processed_forms=1),
+                    Config(id="b", total_forms=2, processed_forms=1),
+                    Config(id="c", total_forms=2, processed_forms=1),
+                ])
+                cddb.add_missing_docs("CommCareCase-couch", ["missing"])
+                cddb.replace_case_diffs("CommCareCase", "a", [diffs[0]])
+                cddb.replace_case_diffs("CommCareCase-Deleted", "b", [diffs[1]])
+                cddb.add_diffs("stock state", "c/ledger", [diffs[2]])
+                cddb.increment_counter("CommCareCase", 3)           # case, a, c
+                cddb.increment_counter("CommCareCase-Deleted", 1)   # b
+                cddb.increment_counter("CommCareCase-couch", 1)     # missing
+                main.add_no_action_case_form("no-action")
+                main.set_resume_state("FormState", ["form"])
+                cddb.set_resume_state("CaseState", ["case"])
+            cddb.close()
+            main.clone_casediff_data_from(cddb.db_filepath)
+        main.close()
+
+        with StateDB.open(main.db_filepath) as db:
+            eq(list(db.iter_cases_with_unprocessed_forms()), ["a", "b", "c"])
+            eq(list(db.iter_problem_forms()), ["problem"])
+            eq(db.get_no_action_case_forms(), {"no-action"})
+            eq(db.pop_resume_state("CaseState", "nope"), ["case"])
+            eq(db.pop_resume_state("FormState", "fail"), ["form"])
+            eq(db.unique_id, uid)
+    finally:
+        delete_db("main")
+        delete_db("cddb")
+
+
+def test_clone_casediff_data_from_tables():
+    from corehq.apps.tzmigration.planning import (
+        PlanningForm,
+        PlanningCase,
+        PlanningCaseAction,
+        PlanningStockReportHelper,
+    )
+    # Any time a model is added to this list it must be analyzed for usage
+    # by the case diff process. StateDB.clone_casediff_data_from() may need
+    # to be updated.
+    eq(set(mod.Base.metadata.tables), {m.__tablename__ for m in [
+        mod.CaseForms,
+        mod.Diff,
+        mod.KeyValue,
+        mod.DocCount,
+        mod.MissingDoc,
+        mod.NoActionCaseForm,
+        mod.ProblemForm,
+        # models not used by couch-to-sql migration
+        PlanningForm,
+        PlanningCase,
+        PlanningCaseAction,
+        PlanningStockReportHelper,
+    ]})
+
+
+def test_get_set():
+    with init_db() as db:
+        eq(db.get("key"), None)
+        eq(db.get("key", "default"), "default")
+        db.set("key", True)
+        eq(db.get("key"), True)
+
+
+def make_diff(id):
+    return JsonDiff("type", "path/%s" % id, "old%s" % id, "new%s" % id)


### PR DESCRIPTION
Address `OperationalError: database is locked` caused by concurrent writes from multiple processes.