### PR TITLE
Fixed relevancy of child menus using display-only forms

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3550,10 +3550,10 @@ class ReportModule(ModuleBase):
         from corehq.apps.app_manager.suite_xml.features.mobile_ucr import ReportModuleSuiteHelper
         return ReportModuleSuiteHelper(self).get_custom_entries()
 
-    def get_menus(self, supports_module_filter=False, build_profile_id=None):
+    def get_menus(self, build_profile_id=None):
         from corehq.apps.app_manager.suite_xml.utils import get_module_enum_text, get_module_locale_id
         kwargs = {}
-        if supports_module_filter:
+        if self.get_app().enable_module_filtering and module.module_filter:
             kwargs['relevant'] = interpolate_xpath(self.module_filter)
 
         menu = suite_models.LocalizedMenu(

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3553,7 +3553,7 @@ class ReportModule(ModuleBase):
     def get_menus(self, build_profile_id=None):
         from corehq.apps.app_manager.suite_xml.utils import get_module_enum_text, get_module_locale_id
         kwargs = {}
-        if self.get_app().enable_module_filtering and module.module_filter:
+        if self.get_app().enable_module_filtering and self.module_filter:
             kwargs['relevant'] = interpolate_xpath(self.module_filter)
 
         menu = suite_models.LocalizedMenu(

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -136,7 +136,8 @@ class MenuContributor(SuiteContributorByModule):
                                     XPath(id_module.root_module.module_filter).paren(force=True)))
                             else:
                                 relevancy = id_module.root_module.module_filter
-                        menu_kwargs['relevant'] = interpolate_xpath(relevancy)
+                        if relevancy:
+                            menu_kwargs['relevant'] = interpolate_xpath(relevancy)
 
                     if self.app.enable_localized_menu_media:
                         module_custom_icon = module.custom_icon

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -26,6 +26,7 @@ from corehq.apps.app_manager.util import (
 from corehq.apps.app_manager.xpath import (
     CaseIDXPath,
     QualifiedScheduleFormXPath,
+    XPath,
     interpolate_xpath,
     session_var,
 )
@@ -90,17 +91,14 @@ class MenuContributor(SuiteContributorByModule):
             if hasattr(module, 'case_list') and module.case_list.show:
                 yield Command(id=id_strings.case_list_command(module))
 
-        supports_module_filter = self.app.enable_module_filtering and module.module_filter
-
         menus = []
         if hasattr(module, 'get_menus'):
-            for menu in module.get_menus(supports_module_filter=supports_module_filter,
-                                         build_profile_id=self.build_profile_id):
+            for menu in module.get_menus(build_profile_id=self.build_profile_id):
                 menus.append(menu)
         else:
             from corehq.apps.app_manager.models import ShadowModule
-            id_modules = [module]
-            root_modules = []
+            id_modules = [module]       # the current module and all of its shadows
+            root_modules = []           # the current module's parent and all of that parent's shadows
 
             shadow_modules = [m for m in self.app.get_modules()
                               if isinstance(m, ShadowModule) and m.source_module_id]
@@ -127,8 +125,18 @@ class MenuContributor(SuiteContributorByModule):
                         suffix = id_strings.menu_id(root_module) if isinstance(root_module, ShadowModule) else ""
                     menu_kwargs.update({'id': id_strings.menu_id(id_module, suffix)})
 
-                    if supports_module_filter:
-                        menu_kwargs['relevant'] = interpolate_xpath(module.module_filter)
+                    # Determine relevancy
+                    if self.app.enable_module_filtering:
+                        relevancy = id_module.module_filter
+                        # If module has a parent, incorporate the parent's relevancy.
+                        # This is only necessary when the child uses display only forms.
+                        if id_module.put_in_root and id_module.root_module and id_module.root_module.module_filter:
+                            if relevancy:
+                                relevancy = str(XPath.and_(XPath(relevancy).paren(force=True),
+                                    XPath(id_module.root_module.module_filter).paren(force=True)))
+                            else:
+                                relevancy = id_module.root_module.module_filter
+                        menu_kwargs['relevant'] = interpolate_xpath(relevancy)
 
                     if self.app.enable_localized_menu_media:
                         module_custom_icon = module.custom_icon

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -19,7 +19,7 @@ class ModuleAsChildTestBase(TestXmlMixin):
     child_module_class = None
 
     def setUp(self):
-        self.factory = AppFactory(build_version='2.9.0', domain=DOMAIN)
+        self.factory = AppFactory(build_version='2.20.0', domain=DOMAIN)
         self.module_0, _ = self.factory.new_basic_module('parent', 'gold-fish')
         self.module_1, _ = self.factory.new_module(self.child_module_class, 'child', 'guppy', parent_module=self.module_0)
 
@@ -275,6 +275,32 @@ class BasicModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
         </partial>
         """
         self.assertXmlPartialEqual(XML, self.app.create_suite(), "./menu[@id='m1']")
+
+    def test_menu_display_conditions(self):
+        """
+        If child uses display only forms, suite should incorporate parent's display condition.
+        """
+        self.module_0.module_filter = "int(double(now())) mod 2 = 0"
+        self.module_1.module_filter = "int(double(now())) mod 3 = 0"
+        self.module_1.put_in_root = True
+
+        XML = """
+        <partial>
+          <menu id="m0" relevant="int(double(now())) mod 2 = 0">
+            <text>
+              <locale id="modules.m0"/>
+            </text>
+            <command id="m0-f0"/>
+          </menu>
+          <menu id="m0" relevant="(int(double(now())) mod 3 = 0) and (int(double(now())) mod 2 = 0)">
+            <text>
+              <locale id="modules.m0"/>
+            </text>
+            <command id="m1-f0"/>
+          </menu>
+        </partial>
+        """
+        self.assertXmlPartialEqual(XML, self.app.create_suite(), "./menu")
 
     def test_child_module_no_forms_show_case_list(self):
         m0f0 = self.module_0.get_form(0)


### PR DESCRIPTION
##### SUMMARY
Fixes https://dimagi-dev.atlassian.net/browse/HI-827

You have an app with two menus: m1 and m2. m1 is the parent of m2, and they both use display conditions.

If m2 uses "display menu, then forms", the suite file looks like this: an m1 menu with its forms, and then an m2 menu with `root="m1"`, which tells mobile to nest it inside of m1.
```
  <menu id="m1" relevant="<display condition for m1>">
    ...
    <command id="m1-f0"/>
  </menu>
  <menu id="m2" root="m1" relevant="<display condition for m2>">
    ...
    <command id="m2-f0"/>
  </menu>
```
If m1 is hidden (display condition is false), mobile takes care of also hiding any menus with m1 as their root, so m2 is also hidden.

Switch m2 to "display only forms" and the suite file looks like this: the second menu now has id m1 and no root attribute. This tells the phone to concatenate these two menus, so the m1 and m2 commands will all be displayed on the same screen.
```
  <menu id="m1" relevant="<display condition for m1>">
    ...
    <command id="m1-f0"/>
  </menu>
  <menu id="m1" relevant="<display condition for m2>">
    ...
    <command id="m2-f0"/>
  </menu>
```
The problem is that here, when m1 is hidden, the phone hides the first menu but it doesn't have any indicator that it should hide the second.

This PR makes it so that in the second example, the beginning of the child menu:
```
<menu id="m1" relevant="<display condition for m2>">
```
becomes
```
<menu id="m1" relevant="(<display condition for m1>) and (<display condition for m2>)">
```
so that it doesn't show if its parent isn't showing.

##### PRODUCT DESCRIPTION
This fixes a bug where apps that use child menus with "display only forms" set, when the parent menu is hidden due to a display condition, the child menu's forms were still displaying in the root menu.