### PR TITLE
Remove eventlet from requirements and uninstall

### DIFF
--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -67,7 +67,6 @@ errand-boy==0.3.8
 et-xmlfile==1.0.1         # via openpyxl
 ethiopian-date-converter==0.1.5
 eulxml==1.1.3
-eventlet==0.24.1          # via errand-boy
 faker==0.8.15
 flower==0.9.2
 funcsigs==1.0.2
@@ -99,7 +98,6 @@ mako==1.0.9               # via alembic
 markdown==2.2.1
 markupsafe==1.1.1         # via jinja2, mako
 mock==2.0.0
-monotonic==1.5            # via eventlet
 msgpack-python==0.5.6     # via ddtrace
 ndg-httpsclient==0.5.1
 openpyxl==2.6.2

--- a/requirements-python3/uninstall-requirements.txt
+++ b/requirements-python3/uninstall-requirements.txt
@@ -14,3 +14,4 @@ ConcurrentLogHandler
 xhtml2pdf
 celery  # Remove once we are back to regular celery releases
 subprocess32
+eventlet

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -67,7 +67,6 @@ errand-boy==0.3.8
 et-xmlfile==1.0.1         # via openpyxl
 ethiopian-date-converter==0.1.5
 eulxml==1.1.3
-eventlet==0.24.1          # via errand-boy
 faker==0.8.15
 flower==0.9.2
 funcsigs==1.0.2
@@ -99,7 +98,6 @@ mako==1.0.9               # via alembic
 markdown==2.2.1
 markupsafe==1.1.1         # via jinja2, mako
 mock==2.0.0
-monotonic==1.5            # via eventlet
 msgpack-python==0.5.6     # via ddtrace
 ndg-httpsclient==0.5.1
 openpyxl==2.6.2

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -14,3 +14,4 @@ ConcurrentLogHandler
 xhtml2pdf
 celery  # Remove once we are back to regular celery releases
 subprocess32
+eventlet

--- a/scripts/pip-post-compile.sh
+++ b/scripts/pip-post-compile.sh
@@ -8,6 +8,16 @@ function clean_file {
     TEMP_FILE=${FILE_PATH}.tmp
     grep -v '^appnope==' ${FILE_PATH} > ${TEMP_FILE}
     mv ${TEMP_FILE} ${FILE_PATH}
+    grep -v '^eventlet==.*\# via errand-boy$' ${FILE_PATH} > ${TEMP_FILE}
+    mv ${TEMP_FILE} ${FILE_PATH}
+    grep -v '# via eventlet$' ${FILE_PATH} > ${TEMP_FILE}
+    mv ${TEMP_FILE} ${FILE_PATH}
+    grep '^eventlet==' ${FILE_PATH} && {
+        echo "The dependency chain contains eventlet, a library that clashes with gevent:"
+        echo "https://github.com/gevent/gevent/issues/577."
+        echo "Specifically, we have had problems with this on the sms_queue celery processor."
+        exit -1
+    } || :;
 }
 
 for i in "$@"; do


### PR DESCRIPTION
##### SUMMARY
We believe the presence of eventlet has been the cause of the sms_queue issues in
https://dimagi-dev.atlassian.net/browse/PLAT-188. As noted there, I have tested that
errand-boy, the only thing that has an eventlet dependency, continues to work when eventlet
is uninstalled, and confirmed that it appears to just be a testing dependency from the codebase.

##### PRODUCT DESCRIPTION
Should (hopefully) fix some recent daily delays in sms processing (UPDATE: by itself this PR didn't have the desired effect)
