### PR TITLE
On Demand Device Logs

### DIFF
--- a/corehq/apps/ota/admin.py
+++ b/corehq/apps/ota/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.core.exceptions import ValidationError
 
 from .models import DemoUserRestore, MobileRecoveryMeasure, DeviceLogRequest
-from .views import get_recovery_measures_cached
+from .views import get_recovery_measures_cached, get_device_log_requests
 
 
 class DemoUserRestoreAdmin(admin.ModelAdmin):
@@ -68,6 +68,10 @@ class DeviceLogRequestAdmin(admin.ModelAdmin):
     model = DeviceLogRequest
     list_display = ['domain', 'username', 'device_id', 'created_on']
     list_filter = ['domain', 'username']
+
+    def save_model(self, *args, **kwargs):
+        super(DeviceLogRequestAdmin, self).save_model(*args, **kwargs)
+        get_device_log_requests.reset_cache()
 
 
 admin.site.register(DemoUserRestore, DemoUserRestoreAdmin)

--- a/corehq/apps/ota/admin.py
+++ b/corehq/apps/ota/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.core.exceptions import ValidationError
 
 from .models import DemoUserRestore, MobileRecoveryMeasure, DeviceLogRequest
-from .views import get_recovery_measures_cached, get_device_log_requests
+from .views import get_recovery_measures_cached
 
 
 class DemoUserRestoreAdmin(admin.ModelAdmin):
@@ -68,10 +68,6 @@ class DeviceLogRequestAdmin(admin.ModelAdmin):
     model = DeviceLogRequest
     list_display = ['domain', 'username', 'device_id', 'created_on']
     list_filter = ['domain', 'username']
-
-    def save_model(self, *args, **kwargs):
-        super(DeviceLogRequestAdmin, self).save_model(*args, **kwargs)
-        get_device_log_requests.reset_cache()
 
 
 admin.site.register(DemoUserRestore, DemoUserRestoreAdmin)

--- a/corehq/apps/ota/admin.py
+++ b/corehq/apps/ota/admin.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib import admin
 from django.core.exceptions import ValidationError
 
-from .models import DemoUserRestore, MobileRecoveryMeasure
+from .models import DemoUserRestore, MobileRecoveryMeasure, DeviceLogRequest
 from .views import get_recovery_measures_cached
 
 
@@ -64,5 +64,12 @@ class MobileRecoveryMeasureAdmin(admin.ModelAdmin):
         get_recovery_measures_cached.clear(obj.domain, obj.app_id)
 
 
+class DeviceLogRequestAdmin(admin.ModelAdmin):
+    model = DeviceLogRequest
+    list_display = ['domain', 'username', 'device_id', 'created_on']
+    list_filter = ['domain', 'username']
+
+
 admin.site.register(DemoUserRestore, DemoUserRestoreAdmin)
 admin.site.register(MobileRecoveryMeasure, MobileRecoveryMeasureAdmin)
+admin.site.register(DeviceLogRequest, DeviceLogRequestAdmin)

--- a/corehq/apps/ota/migrations/0009_devicelogrequest.py
+++ b/corehq/apps/ota/migrations/0009_devicelogrequest.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ota', '0008_auto_20190108_1808'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DeviceLogRequest',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('domain', models.CharField(max_length=255)),
+                ('username', models.CharField(max_length=255)),
+                ('device_id', models.CharField(max_length=255)),
+                ('created_on', models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+    ]

--- a/corehq/apps/ota/migrations/0009_devicelogrequest.py
+++ b/corehq/apps/ota/migrations/0009_devicelogrequest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.db import migrations, models
 
 
@@ -19,5 +17,9 @@ class Migration(migrations.Migration):
                 ('device_id', models.CharField(max_length=255)),
                 ('created_on', models.DateTimeField(auto_now_add=True)),
             ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='devicelogrequest',
+            unique_together=set([('domain', 'username', 'device_id')]),
         ),
     ]

--- a/corehq/apps/ota/models.py
+++ b/corehq/apps/ota/models.py
@@ -204,6 +204,10 @@ class DeviceLogRequest(models.Model):
     class Meta(object):
         unique_together = ('domain', 'username', 'device_id')
 
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        _all_device_log_requests.reset_cache()
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         _all_device_log_requests.reset_cache()

--- a/corehq/apps/ota/models.py
+++ b/corehq/apps/ota/models.py
@@ -188,3 +188,13 @@ class MobileRecoveryMeasure(models.Model):
             res["app_version_min"] = self.app_version_min
             res["app_version_max"] = self.app_version_max
         return res
+
+
+class DeviceLogRequest(models.Model):
+    """
+    A pending request that a particular device submit their logs
+    """
+    domain = models.CharField(max_length=255)
+    username = models.CharField(max_length=255)
+    device_id = models.CharField(max_length=255)
+    created_on = models.DateTimeField(auto_now_add=True)

--- a/corehq/apps/ota/models.py
+++ b/corehq/apps/ota/models.py
@@ -199,6 +199,9 @@ class DeviceLogRequest(models.Model):
     device_id = models.CharField(max_length=255)
     created_on = models.DateTimeField(auto_now_add=True)
 
+    class Meta(object):
+        unique_together = ('domain', 'username', 'device_id')
+
     def save(self, *args, **kwargs):
         from corehq.apps.ota.views import get_device_log_requests
         super().save(*args, **kwargs)

--- a/corehq/apps/ota/models.py
+++ b/corehq/apps/ota/models.py
@@ -222,7 +222,4 @@ class DeviceLogRequest(models.Model):
 def _all_device_log_requests():
     # This is expected to be very small, usually empty, but it's accessed
     # every heartbeat request, so it's memoized to the Django process
-    return {
-        (r.domain, r.username, r.device_id)
-        for r in DeviceLogRequest.objects.all()
-    }
+    return set(DeviceLogRequest.objects.values_list('domain', 'username', 'device_id'))

--- a/corehq/apps/ota/models.py
+++ b/corehq/apps/ota/models.py
@@ -198,3 +198,8 @@ class DeviceLogRequest(models.Model):
     username = models.CharField(max_length=255)
     device_id = models.CharField(max_length=255)
     created_on = models.DateTimeField(auto_now_add=True)
+
+    def save(self, *args, **kwargs):
+        from corehq.apps.ota.views import get_device_log_requests
+        super().save(*args, **kwargs)
+        get_device_log_requests.reset_cache()

--- a/corehq/apps/ota/tests/test_heartbeat.py
+++ b/corehq/apps/ota/tests/test_heartbeat.py
@@ -9,20 +9,22 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 
+from ..models import DeviceLogRequest
+
 
 class HeartbeatTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
         super(HeartbeatTests, cls).setUpClass()
-        cls.domain = create_domain(uuid4().hex)
-        cls.user = CommCareUser.create(cls.domain.name, 'user1', '123')
+        cls.domain_obj = create_domain(uuid4().hex)
+        cls.user = CommCareUser.create(cls.domain_obj.name, 'user1', '123')
         cls.app, cls.build = cls._create_app_and_build()
-        cls.url = reverse('phone_heartbeat', args=[cls.domain.name, cls.build.get_id])
+        cls.url = reverse('phone_heartbeat', args=[cls.domain_obj.name, cls.build.get_id])
 
     @classmethod
     def _create_app_and_build(cls):
-        app = Application.new_app(cls.domain.name, 'app')
+        app = Application.new_app(cls.domain_obj.name, 'app')
         app.save()
         build = app.make_build()
         build.save(increment_version=False)
@@ -30,7 +32,7 @@ class HeartbeatTests(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.domain.delete()
+        cls.domain_obj.delete()
         super(HeartbeatTests, cls).tearDownClass()
 
     def _auth_headers(self, user):
@@ -54,6 +56,7 @@ class HeartbeatTests(TestCase):
             'cc_version': cc_version
         }, **self._auth_headers(user))
         self.assertEqual(resp.status_code, response_code)
+        return resp
 
     def test_heartbeat(self):
         self._do_request(
@@ -91,7 +94,25 @@ class HeartbeatTests(TestCase):
         self.assertIsNone(device.get_meta_for_app(self.app.get_id).last_sync)
 
     def test_bad_app_id(self):
-        url = reverse('phone_heartbeat', args=[self.domain.name, 'bad_id'])
+        url = reverse('phone_heartbeat', args=[self.domain_obj.name, 'bad_id'])
         self._do_request(self.user, device_id='test_bad_app_id', app_id='no-app', url=url, response_code=404)
         device = CommCareUser.get(self.user.get_id).get_device('test_bad_app_id')
         self.assertIsNone(device)
+
+    def test_device_log_request(self):
+        def heartbeat_contains_force_logs():
+            response = self._do_request(self.user, device_id='need-logs')
+            return response.json().get('force_logs', False)
+
+        self.assertFalse(heartbeat_contains_force_logs())
+
+        device_log_request = DeviceLogRequest.objects.create(
+            domain=self.domain_obj.name,
+            username=self.user.username,
+            device_id='need-logs',
+        )
+        self.assertTrue(heartbeat_contains_force_logs())
+
+        # ensure the cache was wiped on delete
+        device_log_request.delete()
+        self.assertFalse(heartbeat_contains_force_logs())

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -27,7 +27,6 @@ from casexml.apps.phone.restore import (
 from dimagi.utils.decorators.profile import profile_prod
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import string_to_utc_datetime
-from memoized import memoized
 
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import (
@@ -368,19 +367,11 @@ def update_user_reporting_data(app_build_id, app_id, couch_user, request):
 
 
 def _should_force_log_submission(request):
-    return (
+    return DeviceLogRequest.is_pending(
         request.domain,
         request.couch_user.username,
         request.GET.get('device_id', ''),
-    ) in get_device_log_requests()
-
-
-@memoized
-def get_device_log_requests():
-    return {
-        (r.domain, r.username, r.device_id)
-        for r in DeviceLogRequest.objects.all()
-    }
+    )
 
 
 @location_safe

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -115,6 +115,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             submit_ip=couchforms.get_submit_ip(request),
             last_sync_token=couchforms.get_last_sync_token(request),
             openrosa_headers=couchforms.get_openrosa_headers(request),
+            force_logs=bool(request.POST.get('force_logs', False)),
         )
 
         try:

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.db import transaction
-from corehq.apps.users.util import format_username
+from dimagi.utils.logging import notify_exception
+from corehq.apps.users.util import format_username, cached_user_id_to_username
 from corehq.apps.users.dbaccessors import get_user_id_by_username
 from .models import UserEntry, DeviceReportEntry, UserErrorEntry, ForceCloseEntry
 from .tasks import send_device_log_to_sumologic
@@ -42,11 +43,13 @@ def _get_logs(form, report_name, report_slug):
 
 
 @transaction.atomic
-def process_device_log(domain, xform):
+def process_device_log(domain, xform, force_logs):
     _process_user_subreport(xform)
     _process_log_subreport(domain, xform)
     _process_user_error_subreport(domain, xform)
     _process_force_close_subreport(domain, xform)
+    if force_logs:
+        clear_device_log_request(domain, xform)
 
 
 def _process_user_subreport(xform):
@@ -277,3 +280,24 @@ class SumoLogicLog(object):
                 device_model=log.get('device_model'),
             ) for log in logs
         ).encode('utf-8'))
+
+
+def clear_device_log_request(domain, xform):
+    from corehq.apps.ota.models import DeviceLogRequest
+    device_id = xform.form_data.get('device_id')
+    username = cached_user_id_to_username(xform.user_id)
+    try:
+        if not (username and device_id):
+            raise DeviceLogRequest.DoesNotExist()
+        log_request = DeviceLogRequest.objects.get(
+            domain=domain,
+            username=username,
+            device_id=device_id,
+        )
+    except DeviceLogRequest.DoesNotExist:
+        msg = "Forced log submission, but no corresponding request found."
+        notify_exception(None, msg, details={
+            'domain': domain, 'device_id': device_id, 'username': username
+        })
+    else:
+        log_request.delete()

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -284,8 +284,10 @@ class SumoLogicLog(object):
 
 def clear_device_log_request(domain, xform):
     from corehq.apps.ota.models import DeviceLogRequest
+    user_subreport = _get_logs(xform.form_data, 'user_subreport', 'user')
+    username = (user_subreport[0].get('username') if user_subreport
+                else cached_user_id_to_username(xform.user_id))
     device_id = xform.form_data.get('device_id')
-    username = cached_user_id_to_username(xform.user_id)
     try:
         if not (username and device_id):
             raise DeviceLogRequest.DoesNotExist()

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -66,7 +66,7 @@ class SubmissionPost(object):
                  domain=None, app_id=None, build_id=None, path=None,
                  location=None, submit_ip=None, openrosa_headers=None,
                  last_sync_token=None, received_on=None, date_header=None,
-                 partial_submission=False, case_db=None):
+                 partial_submission=False, case_db=None, force_logs=False):
         assert domain, "'domain' is required"
         assert instance, instance
         assert not isinstance(instance, HttpRequest), instance
@@ -92,6 +92,7 @@ class SubmissionPost(object):
         self.case_db = case_db
         if case_db:
             assert case_db.domain == domain
+        self.force_logs = force_logs
 
         self.is_openrosa_version3 = self.openrosa_headers.get(OPENROSA_VERSION_HEADER, '') == OPENROSA_VERSION_3
         self.track_load = form_load_counter("form_submission", domain)
@@ -487,7 +488,7 @@ class SubmissionPost(object):
     def process_device_log(self, device_log_form):
         self._conditionally_send_device_logs_to_sumologic(device_log_form)
         ignore_device_logs = settings.SERVER_ENVIRONMENT in settings.NO_DEVICE_LOG_ENVS
-        if not ignore_device_logs:
+        if self.force_logs or not ignore_device_logs:
             try:
                 process_device_log(self.domain, device_log_form)
             except Exception as e:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -490,7 +490,7 @@ class SubmissionPost(object):
         ignore_device_logs = settings.SERVER_ENVIRONMENT in settings.NO_DEVICE_LOG_ENVS
         if self.force_logs or not ignore_device_logs:
             try:
-                process_device_log(self.domain, device_log_form)
+                process_device_log(self.domain, device_log_form, self.force_logs)
             except Exception as e:
                 notify_exception(None, "Error processing device log", details={
                     'xml': self.instance,


### PR DESCRIPTION
##### SUMMARY
https://docs.google.com/document/d/1lkgq-w_olxPPaKBYb8_pbIHCOpSai3LVwoxcbvgzZbA/edit

Going through the commits should make the most sense.  This is the HQ side of the following workflow:

1. A tech team member creates a DeviceLogRequest using the Django admin
1. Next time a heartbeat request comes in which matches the request, the heartbeat response notifies mobile to submit "forced" device logs
1. Mobile submits device logs, but with an additional param indicating this was forced
1. When processing mobile device logs with that parameter present, HQ _will_ store the logs, even if normally they would be discarded
1. HQ then deletes the open request

I've got a couple questions for @shubham1g5 before merging this - will add comments to the PR