### PR TITLE
Paginate Group API in db

### DIFF
--- a/corehq/apps/api/couch.py
+++ b/corehq/apps/api/couch.py
@@ -1,5 +1,5 @@
-from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
-from corehq.apps.groups.dbaccessors import get_groups_in_domain
+from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class, \
+    get_docs_in_domain_by_class
 from corehq.apps.groups.models import Group
 from corehq.apps.users.analytics import (
     get_active_commcare_users_in_domain,
@@ -42,6 +42,6 @@ class GroupQuerySetAdapter(object):
     def __getitem__(self, item):
         if isinstance(item, slice):
             limit = item.stop - item.start
-            return get_groups_in_domain(self.domain, limit=limit, skip=item.start)
+            return get_docs_in_domain_by_class(self.domain, Group, limit=limit, skip=item.start)
         raise ValueError(
             'Invalid type of argument. Item should be an instance of slice class.')

--- a/corehq/apps/api/couch.py
+++ b/corehq/apps/api/couch.py
@@ -1,3 +1,6 @@
+from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
+from corehq.apps.groups.dbaccessors import get_groups_in_domain
+from corehq.apps.groups.models import Group
 from corehq.apps.users.analytics import (
     get_active_commcare_users_in_domain,
     get_count_of_active_commcare_users_in_domain,
@@ -25,4 +28,20 @@ class UserQuerySetAdapter(object):
                 return get_inactive_commcare_users_in_domain(self.domain, start_at=item.start, limit=limit)
             else:
                 return get_active_commcare_users_in_domain(self.domain, start_at=item.start, limit=limit)
-        raise ValueError('Invalid type of argument. Item should be an instance of slice class.')
+        raise ValueError(
+            'Invalid type of argument. Item should be an instance of slice class.')
+
+
+class GroupQuerySetAdapter(object):
+    def __init__(self, domain):
+        self.domain = domain
+
+    def count(self):
+        return get_doc_count_in_domain_by_class(self.domain, Group)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            limit = item.stop - item.start
+            return get_groups_in_domain(self.domain, limit=limit, skip=item.start)
+        raise ValueError(
+            'Invalid type of argument. Item should be an instance of slice class.')

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -11,6 +11,7 @@ from tastypie.bundle import Bundle
 from tastypie.exceptions import BadRequest
 
 from casexml.apps.case.xform import get_case_updates
+from corehq.apps.api.couch import GroupQuerySetAdapter
 from couchforms.models import doc_types
 
 from corehq.apps.api.es import ElasticAPIQuerySet, XFormES, es_search
@@ -314,8 +315,7 @@ class GroupResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMi
         return get_object_or_not_exist(Group, kwargs['pk'], kwargs['domain'])
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        groups = Group.by_domain(domain)
-        return groups
+        return GroupQuerySetAdapter(domain)
 
     class Meta(CustomResourceMeta):
         authentication = RequirePermissionAuthentication(Permissions.edit_commcare_users)

--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -68,7 +68,7 @@ def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000,
         yield doc['id']
 
 
-def get_docs_in_domain_by_class(domain, doc_class):
+def get_docs_in_domain_by_class(domain, doc_class, limit=None, skip=None):
     """
     Given a domain and doc class, get all docs matching that domain and type
 
@@ -90,12 +90,20 @@ def get_docs_in_domain_by_class(domain, doc_class):
     ]
     doc_type = doc_class.__name__
     assert doc_type in whitelist
+
+    kwargs = {}
+    if limit is not None:
+        kwargs['limit'] = limit
+    if skip is not None:
+        kwargs['skip'] = skip
+
     return doc_class.view(
         'by_domain_doc_type_date/view',
         startkey=[domain, doc_type],
         endkey=[domain, doc_type, {}],
         reduce=False,
         include_docs=True,
+        **kwargs
     ).all()
 
 

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -9,8 +9,24 @@ from corehq.apps.domain.dbaccessors import (
 
 
 def group_by_domain(domain):
+    return get_groups_in_domain(domain)
+
+
+def get_groups_in_domain(domain, limit=None, skip=None):
     from corehq.apps.groups.models import Group
-    return get_docs_in_domain_by_class(domain, Group)
+    kwargs = {}
+    if limit is not None:
+        kwargs['limit'] = limit
+    if skip is not None:
+        kwargs['skip'] = skip
+
+    return Group.view(
+        'groups/by_name',
+        startkey=[domain],
+        endkey=[domain, {}],
+        include_docs=True,
+        **kwargs
+    ).all()
 
 
 def _group_by_name(domain, name, **kwargs):

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -9,24 +9,8 @@ from corehq.apps.domain.dbaccessors import (
 
 
 def group_by_domain(domain):
-    return get_groups_in_domain(domain)
-
-
-def get_groups_in_domain(domain, limit=None, skip=None):
     from corehq.apps.groups.models import Group
-    kwargs = {}
-    if limit is not None:
-        kwargs['limit'] = limit
-    if skip is not None:
-        kwargs['skip'] = skip
-
-    return Group.view(
-        'groups/by_name',
-        startkey=[domain],
-        endkey=[domain, {}],
-        include_docs=True,
-        **kwargs
-    ).all()
+    return get_docs_in_domain_by_class(domain, Group)
 
 
 def _group_by_name(domain, name, **kwargs):


### PR DESCRIPTION
##### SUMMARY
This changes the Group API to paginate in the db instead of pulling all groups in a domain and slicing it in app process memory.

It also changes it so that groups appear in alphabetical order (by group name).

##### PRODUCT DESCRIPTION
Speed improvement for Group API in projects with many groups.