### PR TITLE
move join out of the loop

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -1320,7 +1320,7 @@ def _child_health_monthly_aggregation(day, state_ids):
     pool = Pool(10)
     for query, params in helper.pre_aggregation_queries():
         pool.spawn(_child_health_helper, query, params)
-        pool.join()
+    pool.join()
 
     with transaction.atomic(using=db_for_read_write(ChildHealthMonthly)):
         ChildHealthMonthly.aggregate(state_ids, force_to_date(day))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move join outside the loop, so the pool is allowed to fill up. Otherwise, it empties the pool each time an element is added (so it just executes sequentially)