### PR TITLE
Simplify doctests

### DIFF
--- a/corehq/apps/app_manager/app_schemas/case_properties.py
+++ b/corehq/apps/app_manager/app_schemas/case_properties.py
@@ -80,8 +80,8 @@ class _CaseRelationshipManager(object):
 
     You can also ask "What are all of the case_types a `referral`'s `parent` can be?":
 
-    >>> case_relationship_manager.resolve_expansion(_CaseTypeRef('referral', ('parent',))) == {'patient'}
-    True
+    >>> case_relationship_manager.resolve_expansion(_CaseTypeRef('referral', ('parent',)))
+    {'patient'}
 
     This is read "a `referral`'s parent can only be a `patient`".
 

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -642,10 +642,10 @@ def to_list(value):
     Returns ``value`` as a list if it is iterable and not a string,
     otherwise returns ``value`` in a list.
 
-    >>> to_list(('foo', 'bar', 'baz')) == ['foo', 'bar', 'baz']
-    True
-    >>> to_list('foo bar baz') == ['foo bar baz']
-    True
+    >>> to_list(('foo', 'bar', 'baz'))
+    ['foo', 'bar', 'baz']
+    >>> to_list('foo bar baz')
+    ['foo bar baz']
 
     """
     if hasattr(value, '__iter__') and not isinstance(value, str):

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -80,8 +80,8 @@ def get_patient_uuid(element):
     ...         <![CDATA[/openmrs/ws/rest/v1/patient/e8aa08f6-86cd-42f9-8924-1b3ea021aeb4?v=full]]>
     ...     </content>
     ... </entry>''')
-    >>> get_patient_uuid(element) == 'e8aa08f6-86cd-42f9-8924-1b3ea021aeb4'
-    True
+    >>> get_patient_uuid(element)
+    'e8aa08f6-86cd-42f9-8924-1b3ea021aeb4'
 
     """
     # "./*[local-name()='content']" ignores namespaces and matches all
@@ -106,8 +106,8 @@ def get_encounter_uuid(element):
     ...         <![CDATA[/openmrs/ws/rest/v1/bahmnicore/bahmniencounter/0f54fe40-89af-4412-8dd4-5eaebe8684dc?includeAll=true]]>
     ...     </content>
     ... </entry>''')
-    >>> get_encounter_uuid(element) == '0f54fe40-89af-4412-8dd4-5eaebe8684dc'
-    True
+    >>> get_encounter_uuid(element)
+    '0f54fe40-89af-4412-8dd4-5eaebe8684dc'
 
     """
     content = element.xpath("./*[local-name()='content']")

--- a/corehq/motech/openmrs/serializers.py
+++ b/corehq/motech/openmrs/serializers.py
@@ -21,8 +21,8 @@ def to_omrs_date(value):
     """
     Drop the time and timezone to export date-only values
 
-    >>> to_omrs_date('2017-06-27T12:00:00+0530') == '2017-06-27'
-    True
+    >>> to_omrs_date('2017-06-27T12:00:00+0530')
+    '2017-06-27'
 
     """
     if isinstance(value, str):
@@ -37,8 +37,8 @@ def to_omrs_datetime(value):
     """
     Converts CommCare dates and datetimes to OpenMRS datetimes.
 
-    >>> to_omrs_datetime('2017-06-27') == '2017-06-27T00:00:00.000+0000'
-    True
+    >>> to_omrs_datetime('2017-06-27')
+    '2017-06-27T00:00:00.000+0000'
 
     """
     if isinstance(value, str):
@@ -61,8 +61,8 @@ def omrs_datetime_to_date(value):
     """
     Converts an OpenMRS datetime to a CommCare date
 
-    >>> omrs_datetime_to_date('2017-06-27T00:00:00.000+0000') == '2017-06-27'
-    True
+    >>> omrs_datetime_to_date('2017-06-27T00:00:00.000+0000')
+    '2017-06-27'
 
     """
     if value and 'T' in value:

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -18,9 +18,8 @@ def simple_pad(bytestring, block_size, char=PAD_CHAR):
     Pad `bytestring` to a multiple of `block_size` in length by appending
     `char`. `char` defaults to space.
 
-    >>> padded = simple_pad(b'xyzzy', 8, b'*')
-    >>> padded == b'xyzzy***'
-    True
+    >>> simple_pad(b'xyzzy', 8, b'*')
+    b'xyzzy***'
 
     """
     assert isinstance(bytestring, bytes)
@@ -35,9 +34,8 @@ def b64_aes_encrypt(message):
     Uses Django SECRET_KEY as AES key.
 
     >>> settings.SECRET_KEY = 'xyzzy'
-    >>> encrypted = b64_aes_encrypt('Around you is a forest.')
-    >>> encrypted == 'Vh2Tmlnr5+out2PQDefkudZ2frfze5onsAlUGTLv3Oc='
-    True
+    >>> b64_aes_encrypt('Around you is a forest.')
+    'Vh2Tmlnr5+out2PQDefkudZ2frfze5onsAlUGTLv3Oc='
 
     """
     if isinstance(settings.SECRET_KEY, bytes):
@@ -63,9 +61,8 @@ def b64_aes_decrypt(message):
     Uses Django SECRET_KEY as AES key.
 
     >>> settings.SECRET_KEY = 'xyzzy'
-    >>> decrypted = b64_aes_decrypt('Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I=')
-    >>> decrypted == 'Around you is a forest.'
-    True
+    >>> b64_aes_decrypt('Vh2Tmlnr5+out2PQDefkuS9+9GtIsiEX8YBA0T/V87I=')
+    'Around you is a forest.'
 
     """
     if isinstance(settings.SECRET_KEY, bytes):

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -248,9 +248,8 @@ def get_form_question_values(form_json):
     """
     Returns question-value pairs to result where questions are given as "/data/foo/bar"
 
-    >>> values = get_form_question_values({'form': {'foo': {'bar': 'baz'}}})
-    >>> values == {'/data/foo/bar': 'baz'}
-    True
+    >>> get_form_question_values({'form': {'foo': {'bar': 'baz'}}})
+    {'/data/foo/bar': 'baz'}
 
     """
     _reserved_keys = ('@uiVersion', '@xmlns', '@name', '#type', 'case', 'meta', '@version')

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -246,7 +246,10 @@ class FormQuestionMap(FormQuestion):
 
 def get_form_question_values(form_json):
     """
-    Returns question-value pairs to result where questions are given as "/data/foo/bar"
+    Given form JSON, returns question-value pairs, where questions are
+    formatted "/data/foo/bar".
+
+    e.g. Question "bar" in group "foo" has value "baz":
 
     >>> get_form_question_values({'form': {'foo': {'bar': 'baz'}}})
     {'/data/foo/bar': 'baz'}

--- a/corehq/util/itertools.py
+++ b/corehq/util/itertools.py
@@ -12,10 +12,8 @@ def zip_with_gaps(all_items, some_items, all_items_key=None, some_items_key=None
 
     >>> long_list = ['Alice', 'Apple', 'Bengal', 'Carrot', 'Daring', 'Danger', 'Dakar', 'Electric']
     >>> short_list = ['Cabernet', 'Daedalus', 'Daimler', 'Dog']
-    >>> list(zip_with_gaps(long_list, short_list, lambda x: x[0], lambda x: x[0])) == [
-    ...    ('Carrot', 'Cabernet'), ('Daring', 'Daedalus'), ('Danger', 'Daimler'), ('Dakar', 'Dog')
-    ... ]
-    True
+    >>> list(zip_with_gaps(long_list, short_list, lambda x: x[0], lambda x: x[0]))
+    [('Carrot', 'Cabernet'), ('Daring', 'Daedalus'), ('Danger', 'Daimler'), ('Dakar', 'Dog')]
 
     """
     if all_items_key is None:


### PR DESCRIPTION
##### SUMMARY

Doctests had to deal with string values awkwardly in order to pass in both Python 2 and Python 3. We don't have to do that any more.
