### PR TITLE
Optimize form UCR deletes on Citus

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -276,7 +276,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
             if doc.get('doc_type') in SHARDABLE_DOC_TYPES:
                 # todo only get sharding column's value
                 rows = self.get_all_values(doc)
-                if rows.get(column):
+                if rows and rows[0].get(column):
                     delete = delete.where(table.c.get(column) == rows[column])
             with self.session_context() as session:
                 session.execute(delete)


### PR DESCRIPTION
##### SUMMARY
Found this today since I was about to roll out the combined form pillows.

From the PR description on #24640  I knew this would happen eventually. I think what happened was that when we hit our bandwidth limits, a lot of phones closed their connection to our server before their form submission was fully complete. Then they re-submitted the same form and it was marked as a duplicate. We're currently going through a backlog of duplicate forms