### PR TITLE
Fixed shadow forms erroring out while updating multimedia paths in bulk

### DIFF
--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -725,7 +725,9 @@ class FormMediaMixin(MediaMixin):
         count = 0
 
         count += self.rename_menu_media(self, old_path, new_path)
-        count += self.memoized_xform().rename_media(old_path, new_path)
+
+        if self.form_type != 'shadow_form':
+            count += self.memoized_xform().rename_media(old_path, new_path)
 
         return count
 

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext as _
 
 import magic
 from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
+from lxml import etree
 from memoized import memoized
 from PIL import Image
 
@@ -722,14 +723,15 @@ class FormMediaMixin(MediaMixin):
         return media
 
     def rename_media(self, old_path, new_path):
-        count = 0
+        menu_count = self.rename_menu_media(self, old_path, new_path)
 
-        count += self.rename_menu_media(self, old_path, new_path)
-
+        xform_count = 0
         if self.form_type != 'shadow_form':
-            count += self.memoized_xform().rename_media(old_path, new_path)
+            xform_count = self.memoized_xform().rename_media(old_path, new_path)
+            if xform_count:
+                self.source = etree.tostring(self.memoized_xform().xml).decode('utf-8')
 
-        return count
+        return menu_count + xform_count
 
 
 class ApplicationMediaMixin(Document, MediaMixin):

--- a/corehq/apps/hqmedia/view_helpers.py
+++ b/corehq/apps/hqmedia/view_helpers.py
@@ -72,21 +72,13 @@ def validate_multimedia_paths_rows(app, rows):
 def update_multimedia_paths(app, paths):
     # Update module and form references
     success_counts = defaultdict(lambda: 0)
-    dirty_xform_ids = set()
     for old_path, new_path in paths.items():
         for module in app.modules:
             success_counts[module.unique_id] += module.rename_media(old_path, new_path)
             for form in module.get_forms():
                 update_count = form.rename_media(old_path, new_path)
                 if update_count:
-                    dirty_xform_ids.add(form.unique_id)
                     success_counts[form.unique_id] += update_count
-
-    # Update any form xml that changed
-    for module in app.modules:
-        for form in module.get_forms():
-            if form.unique_id in dirty_xform_ids and form.form_type != 'shadow_form':
-                form.source = etree.tostring(form.memoized_xform().xml).decode('utf-8')
 
     # Update app's master map of multimedia
     for old_path, new_path in paths.items():

--- a/corehq/apps/hqmedia/view_helpers.py
+++ b/corehq/apps/hqmedia/view_helpers.py
@@ -76,7 +76,7 @@ def update_multimedia_paths(app, paths):
     for old_path, new_path in paths.items():
         for module in app.modules:
             success_counts[module.unique_id] += module.rename_media(old_path, new_path)
-            for form in module.forms:
+            for form in module.get_forms():
                 update_count = form.rename_media(old_path, new_path)
                 if update_count:
                     dirty_xform_ids.add(form.unique_id)
@@ -84,8 +84,8 @@ def update_multimedia_paths(app, paths):
 
     # Update any form xml that changed
     for module in app.modules:
-        for form in module.forms:
-            if form.unique_id in dirty_xform_ids:
+        for form in module.get_forms():
+            if form.unique_id in dirty_xform_ids and form.form_type != 'shadow_form':
                 form.source = etree.tostring(form.memoized_xform().xml).decode('utf-8')
 
     # Update app's master map of multimedia


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-859

##### FEATURE FLAG
"Bulk multimedia path management" and "Advanced Module in App-Builder"

##### PRODUCT DESCRIPTION
This fixes a bug where HQ would error when using bulk multimedia path management to update media for a form that is used as a source for a shadow form.
