### PR TITLE
Track submissions that would be rate limited

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -1,0 +1,30 @@
+from corehq.project_limits.rate_limiter import RateDefinition, RateLimiter, \
+    PerUserRateDefinition
+
+# Danny promised in an Aug 2019 email not to enforce limits that were lower than this.
+# If we as a team end up regretting this decision, we'll have to reset expectations
+# with the Dimagi NDoH team.
+rates_promised_not_to_go_lower_than = RateDefinition(
+    per_week=115,
+    per_day=23,
+    per_hour=3,
+    per_minute=0.07,
+    per_second=0.005,
+)
+
+floor_for_small_domain = RateDefinition(
+    per_day=50,
+    per_hour=30,
+    per_minute=10,
+    per_second=1,
+)
+
+test_rates = PerUserRateDefinition(
+    per_user_rate_definition=rates_promised_not_to_go_lower_than.times(2.0),
+    min_rate_definition=floor_for_small_domain,
+)
+
+submission_rate_limiter = RateLimiter(
+    feature_key='submissions',
+    get_rate_limits=test_rates.get_rate_limits
+)

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -12,7 +12,8 @@ class RateLimiter(object):
 
     >>> per_user_rate_def = RateDefinition(per_week=50000, per_day=13000, per_second=.001)
     >>> min_rate_def = RateDefinition(per_second=10)
-    >>> my_feature_rate_limiter = RateLimiter('my_feature', PerUserRateDefinition(per_user_rate_def, min_rate_def).get_rate_limits)
+    >>> per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
+    >>> my_feature_rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
     >>> if my_feature_rate_limiter.allow_usage('my_domain'):
     ...     # ...do stuff...
     ...     my_feature_rate_limiter.report_usage('my_domain')
@@ -41,7 +42,7 @@ class RateLimiter(object):
                    for rate_counter, limit in self.get_rate_limits(*scope))
 
 
-@quickcache(['domain'], memoize_timeout=60, timeout=60*60)
+@quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)
 def get_user_count(domain):
     return CommCareUser.total_by_domain(domain, is_active=True)
 

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -1,35 +1,26 @@
-import functools
+import attr
 
+from corehq.apps.users.models import CommCareUser
 from corehq.project_limits.rate_counter.presets import week_rate_counter, \
     day_rate_counter, hour_rate_counter, minute_rate_counter, second_rate_counter
+from corehq.util.quickcache import quickcache
 
 
 class RateLimiter(object):
     """
     Example usage:
 
-    >>> MyFeatureRateLimiter = RateLimiter.create('my_feature')
-    >>> my_feature_rate_limiter = MyFeatureRateLimiter(per_week=50000, per_day=13000,
-    ...                                                per_second=5)
+    >>> per_user_rate_def = RateDefinition(per_week=50000, per_day=13000, per_second=.001)
+    >>> min_rate_def = RateDefinition(per_second=10)
+    >>> my_feature_rate_limiter = RateLimiter('my_feature', PerUserRateDefinition(per_user_rate_def, min_rate_def).get_rate_limits)
     >>> if my_feature_rate_limiter.allow_usage('my_domain'):
     ...     # ...do stuff...
     ...     my_feature_rate_limiter.report_usage('my_domain')
 
     """
-    def __init__(self, feature_key,
-                 per_week=None, per_day=None, per_hour=None, per_minute=None, per_second=None):
+    def __init__(self, feature_key, get_rate_limits):
         self.feature_key = feature_key
-        self.rate_limits = [(rate_counter, limit) for limit, rate_counter in (
-            (per_week, week_rate_counter),
-            (per_day, day_rate_counter),
-            (per_hour, hour_rate_counter),
-            (per_minute, minute_rate_counter),
-            (per_second, second_rate_counter),
-        ) if limit]
-
-    @classmethod
-    def create(cls, feature_key):
-        return functools.partial(cls, feature_key)
+        self.get_rate_limits = get_rate_limits
 
     def get_normalized_scope(self, scope):
         if isinstance(scope, str):
@@ -37,13 +28,72 @@ class RateLimiter(object):
         elif not isinstance(scope, tuple):
             raise ValueError("scope must be a string or tuple: {!r}".format(scope))
 
-        return (self.feature_key,) + scope
+        return scope
 
     def report_usage(self, scope, delta=1):
         scope = self.get_normalized_scope(scope)
-        for rate_counter, limit in self.rate_limits:
-            rate_counter.increment(scope, delta=delta)
+        for rate_counter, limit in self.get_rate_limits(*scope):
+            rate_counter.increment((self.feature_key,) + scope, delta=delta)
 
     def allow_usage(self, scope):
         scope = self.get_normalized_scope(scope)
-        return all(rate_counter.get(scope) < limit for rate_counter, limit in self.rate_limits)
+        return all(rate_counter.get((self.feature_key,) + scope) < limit
+                   for rate_counter, limit in self.get_rate_limits(*scope))
+
+
+@quickcache(['domain'], memoize_timeout=60, timeout=60*60)
+def get_user_count(domain):
+    return CommCareUser.total_by_domain(domain, is_active=True)
+
+
+class PerUserRateDefinition(object):
+    def __init__(self, per_user_rate_definition, min_rate_definition=None):
+        self.per_user_rate_definition = per_user_rate_definition
+        self.min_rate_definition = min_rate_definition or RateDefinition()
+
+    def get_rate_limits(self, domain):
+        n_users = get_user_count(domain)
+        return self.per_user_rate_definition.times(n_users).with_minimum(self.min_rate_definition).rate_limits
+
+
+@attr.s
+class RateDefinition(object):
+    per_week = attr.ib(default=None)
+    per_day = attr.ib(default=None)
+    per_hour = attr.ib(default=None)
+    per_minute = attr.ib(default=None)
+    per_second = attr.ib(default=None)
+
+    def times(self, multiplier):
+        return self.map(lambda value: value * multiplier if value is not None else value)
+
+    def with_minimum(self, other):
+        return self.map(lambda value, other_value:
+                        None if value is None else max(value, other_value or 0), other)
+
+    def map(self, math_func, other=None):
+        """
+        Create new rate definition object with math_func applied to each value of self
+
+        This is essentially RateDefinition(per_week=math_func(self.per_week), ...)
+        but deals better with None values and uses meta-programming to avoid copy-paste errors.
+        """
+        kwargs = {}
+        for attribute in self.__attrs_attrs__:
+            value = getattr(self, attribute.name)
+            if other:
+                other_value = getattr(other, attribute.name)
+                kwargs[attribute.name] = math_func(value, other_value)
+            else:
+                kwargs[attribute.name] = math_func(value)
+        return self.__class__(**kwargs)
+
+    @property
+    def rate_limits(self):
+        return [(rate_counter, limit) for limit, rate_counter in (
+            (self.per_week, week_rate_counter),
+            (self.per_day, day_rate_counter),
+            (self.per_hour, hour_rate_counter),
+            (self.per_minute, minute_rate_counter),
+            (self.per_second, second_rate_counter),
+        ) if limit]

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -1,11 +1,17 @@
-from corehq.project_limits.rate_limiter import RateLimiter
+from mock import mock
+
+from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
+    PerUserRateDefinition
 
 
-def test_create_rate_limiter():
+@mock.patch('corehq.project_limits.rate_limiter.get_user_count', lambda domain: 10)
+def test_rate_limit_interface():
     """
-    Just test that very basic usage at least doesn't error
+    Just test that very basic usage doesn't error
     """
-    MyFeatureRateLimiter = RateLimiter.create('my_feature')
-    my_feature_rate_limiter = MyFeatureRateLimiter(per_week=50000, per_day=13000, per_second=5)
+    per_user_rate_def = RateDefinition(per_week=50000, per_day=13000, per_second=.001)
+    min_rate_def = RateDefinition(per_second=10)
+    my_feature_rate_limiter = RateLimiter('my_feature', PerUserRateDefinition(per_user_rate_def, min_rate_def).get_rate_limits)
     if my_feature_rate_limiter.allow_usage('my_domain'):
+        # ...do stuff...
         my_feature_rate_limiter.report_usage('my_domain')

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -11,7 +11,8 @@ def test_rate_limit_interface():
     """
     per_user_rate_def = RateDefinition(per_week=50000, per_day=13000, per_second=.001)
     min_rate_def = RateDefinition(per_second=10)
-    my_feature_rate_limiter = RateLimiter('my_feature', PerUserRateDefinition(per_user_rate_def, min_rate_def).get_rate_limits)
+    per_user_rate_def = PerUserRateDefinition(per_user_rate_def, min_rate_def)
+    my_feature_rate_limiter = RateLimiter('my_feature', per_user_rate_def.get_rate_limits)
     if my_feature_rate_limiter.allow_usage('my_domain'):
         # ...do stuff...
         my_feature_rate_limiter.report_usage('my_domain')


### PR DESCRIPTION
##### SUMMARY

Get the system in place for rate limiting submissions, but for now
instead of actually blocking usage, just report to datadog that a
submission would have been blocked.

The rate limiting is based on the domain-wide per-user rate, and is
given both a minimum usage to allow (e.g. for a domain with very few
users) and a per user rate for projects that have enough users.