### PR TITLE
Improve with_progress_bar update interval

### DIFF
--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -243,14 +243,13 @@ def display_seconds(seconds):
 
 
 def with_progress_bar(iterable, length=None, prefix='Processing', oneline=True,
-                      stream=None, step=timedelta(seconds=10)):
+                      stream=None, step=None):
     """Turns 'iterable' into a generator which prints a progress bar.
 
     :param oneline: Set to False to print each update on a new line.
         Useful if there will be other things printing to the terminal.
         Set to "concise" to use exactly one line for all output.
-    :param step: progress update interval as `timedelta` or `int`
-    (number of items iterated). Defaults to 10 seconds if not specified.
+    :param step: deprecated, not used
     """
     if stream is None:
         stream = sys.stdout
@@ -287,23 +286,43 @@ def with_progress_bar(iterable, length=None, prefix='Processing', oneline=True,
 
     if oneline != "concise":
         print("Started at {:%Y-%m-%d %H:%M:%S}".format(start), file=stream)
-    next_update = datetime.now() - timedelta(hours=1)
-    i = -1
+    should_update = step_calculator(length, granularity)
+    i = 0
     try:
-        for i, x in enumerate(iterable):
+        for i, x in enumerate(iterable, start=1):
             yield x
-            if isinstance(step, int):
-                if i % step == 0:
-                    draw(i)
-            elif datetime.now() > next_update:
+            if should_update(i):
                 draw(i)
-                next_update = datetime.now() + step
     finally:
-        draw(i + 1, done=True)
+        draw(i, done=True)
     if oneline != "concise":
         end = datetime.now()
         print("Finished at {:%Y-%m-%d %H:%M:%S}".format(end), file=stream)
         print("Elapsed time: {}".format(display_seconds((end - start).total_seconds())), file=stream)
+
+
+def step_calculator(length, granularity):
+    """Make a function that caculates when to post progress updates
+
+    Approximates two updates per output granularity (dot) with update
+    interval bounded at 0.1s <= t <= 5m. This assumes a uniform
+    iteration rate. It could be improved to calculate the next wait
+    based on a window of recent iterations, which would yield nicer
+    output for non-uniform iteration rates.
+    """
+    def should_update(i):
+        assert i, "divide by zero protection"
+        nonlocal next_update
+        now = datetime.now()
+        if now > next_update:
+            rate = i / (now - start).total_seconds()  # iterations / second
+            secs = min(max(twice_per_dot / rate, 0.1), 300)  # seconds / dot / 2
+            next_update = now + timedelta(seconds=secs)
+            return True
+        return False
+    twice_per_dot = max(length / granularity, 1) / 2  # iterations / dot / 2
+    start = next_update = datetime.now()
+    return should_update
 
 
 def get_traceback_string():

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -306,9 +306,7 @@ def step_calculator(length, granularity):
 
     Approximates two updates per output granularity (dot) with update
     interval bounded at 0.1s <= t <= 5m. This assumes a uniform
-    iteration rate. It could be improved to calculate the next wait
-    based on a window of recent iterations, which would yield nicer
-    output for non-uniform iteration rates.
+    iteration rate.
     """
     def should_update(i):
         assert i, "divide by zero protection"


### PR DESCRIPTION
I tested this locally with various iteration rates (fast and slow) and lengths (small to large), and the result seems to be good in all tested cases.

The advantage of a self-adjusting time-based updater is that an iteration that hits a very slow section will still update on a reasonably frequent basis (relative to the earlier faster section), assuming items are still iterated. Of course, updates will stall completely if there are no new items yielded, but continuing updates in that scenario would require an even more exotic solution such as a monitor in a separate thread.