### PR TITLE
Fix a bit of jankiness in the builds menu page

### DIFF
--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -24,9 +24,6 @@
   {% initial_page_data 'doc' doc %}
   {% initial_page_data 'available_versions' all_versions %}
   {% initial_page_data 'j2me_enabled_versions' j2me_enabled_versions %}
-  {% if success %}
-    <div class="alert alert-success">Your changes have been saved</div>
-  {% endif %}
   <div class="alert alert-info"><strong>{% trans "Editing" %} {{ doc.ID }}</strong></div>
 
 


### PR DESCRIPTION
##### SUMMARY
The cache was only cleared when the page was initially loaded, instead of after changes were made.  This meant it wouldn't be reflected elsewhere on the site unless you refreshed.  Also, since it didn't do a redirect on successful POST, refreshing would attempt to resubmit the same form, which would give a resource conflict.
