### PR TITLE
Batch unsharded deletes in UCR

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -300,8 +300,9 @@ class IndicatorSqlAdapter(IndicatorAdapter):
                     delete = delete.where(table.c.get(column) == sharded_column_value[0])
                     with self.session_context() as session:
                         session.execute(delete)
+                    continue  # skip adding doc ID into doc_ids_to_delete
 
-            doc_ids_to_delete.append(tmp_doc['_id'])
+            doc_ids_to_delete.append(doc['_id'])
 
         if doc_ids_to_delete:
             delete = table.delete().where(table.c.doc_id.in_(doc_ids_to_delete))

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -289,11 +289,15 @@ class IndicatorSqlAdapter(IndicatorAdapter):
 
                 tmp_doc = doc.copy()
                 tmp_doc['doc_type'] = 'XFormInstance'
-                # todo only get sharding column's value
                 rows = self.get_all_values(tmp_doc)
-                if rows and rows[0].get(column):
+                first_row = rows[0]
+                sharded_column_value = [
+                    i.value for i in first_row
+                    if i.column.database_column_name.decode('utf-8') == column
+                ]
+                if sharded_column_value:
                     delete = table.delete().where(table.c.doc_id == doc['_id'])
-                    delete = delete.where(table.c.get(column) == rows[column])
+                    delete = delete.where(table.c.get(column) == sharded_column_value[0])
                     with self.session_context() as session:
                         session.execute(delete)
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -276,6 +276,8 @@ class IndicatorSqlAdapter(IndicatorAdapter):
         blocked on deletes.
         """
 
+        # these doc types were blocking the queue but the approach could be applied
+        # more generally with some more testing
         SHARDABLE_DOC_TYPES = ('XFormArchived', 'XFormDuplicate')
         table = self.get_table()
         doc_ids_to_delete = []


### PR DESCRIPTION
##### SUMMARY
This PR batches the deletes that need to be run on all Citus nodes.

Follow up on https://github.com/dimagi/commcare-hq/pull/25334. I wanted to follow that up by batching deletes by the sharded column but I began implementing it and realized it was adding non-trivial complexity to it (was first using `itertools.groupby`).

Then I realized that grouping by sharded column does not give us very much. The slowness in this path is caused by performing a distributed lock around multiple databases. When we have the sharded column this operation is already very fast and non-locking because it is routed to only one node. By batching these 'unsharded' deletes, we should be reducing the time in coordination locks and therefore be able to process real forms faster.