### PR TITLE
Pull celery from dimagi/celery instead of nickpell/celery

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -17,7 +17,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -15,7 +15,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -14,7 +14,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -16,7 +16,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -17,7 +17,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -15,7 +15,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9
 cffi==1.12.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,8 @@ jsonobject==0.9.9
 jsonobject-couchdbkit~=0.9
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+# originally changes were made on nickpell/celery, but this was moved to dimagi/celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 # required by django-digest
 decorator==4.0.11
 django>=1.11.22  # security update

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,7 +14,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -16,7 +16,7 @@ boto3==1.9.143
 botocore==1.12.143        # via boto3, s3transfer
 cairocffi==0.9.0          # via cairosvg, weasyprint
 cairosvg==1.0.22          # via weasyprint
-git+git://github.com/nickpell/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests


### PR DESCRIPTION
##### SUMMARY
Still on my list to get back on mainline celery. For now, I at least forked nickpell/celery to https://github.com/dimagi/celery and pointed our requirements file to that instead.