### PR TITLE
Updated up_nhrm js to happen on ajax completion instead of document r…

### DIFF
--- a/custom/up_nrhm/static/up_nrhm/js/main.js
+++ b/custom/up_nrhm/static/up_nrhm/js/main.js
@@ -27,7 +27,13 @@ hqDefine("up_nrhm/js/main", function () {
         }
     }
 
-    $(function () {
+    $(document).on("ajaxComplete", function (e, xhr, options) {
+        var fragment = "async/",
+            pageUrl = window.location.href.split('?')[0],
+            ajaxUrl = options.url.split('?')[0];
+        if (ajaxUrl.indexOf(fragment) === -1 || !pageUrl.endsWith(ajaxUrl.replace(fragment, ''))) {
+            return;
+        }
         if (hqImport("hqwebapp/js/initial_page_data").get("rendered_as") === "print") {
             if (!$('#report_filter_sf').val()) {
                 document.body.style.zoom="80%";


### PR DESCRIPTION
…eady

##### SUMMARY
Followup for https://github.com/dimagi/commcare-hq/pull/25344

[This line](https://github.com/dimagi/commcare-hq/blob/00f8d7c28a01740eb04fe3bae5d1a09d2824320f/custom/up_nrhm/static/up_nrhm/js/main.js#L57) is currently erroring saying that `$datespan.data("start-date")` is undefined. I think the filters are being rendered as part of the report's ajax request rather than the initial page load, so it isn't safe to run this code on document ready.