### PR TITLE
prepend Copy of to name when copying odata feed

### DIFF
--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -236,6 +236,7 @@ class ODataFeedMixin(object):
         clean_odata_columns(export_instance)
         export_instance.is_odata_config = True
         export_instance.transform_dates = False
+        export_instance.name = _("Copy of {}").format(export_instance.name)
         return export_instance
 
 


### PR DESCRIPTION
##### SUMMARY
this prepends "Copy of" to the name of the odata feed when making a copy

##### FEATURE FLAG
`BI_INTEGRATION_PREVIEW` feature preview

