### PR TITLE
[VectorLink] Changed name of New Supervisory Report to Supervisory Report 2018 (old)

### DIFF
--- a/custom/abt/reports/supervisory_report_v2.json
+++ b/custom/abt/reports/supervisory_report_v2.json
@@ -35,7 +35,7 @@
         "doc_type": "ReportConfiguration",
         "domain": "airs",
         "description": "",
-        "title": "New Supervisory Report",
+        "title": "Supervisory Report 2018 (old)",
         "sort_expression": [
             {
                 "field": "received_on",


### PR DESCRIPTION
##### SUMMARY
Changed name of New Supervisory Report to Supervisory Report 2018 (old)
TICKET: https://dimagi-dev.atlassian.net/browse/SL-260
