### PR TITLE
fix for selecting multiple choice values in a UCR / report builder report

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -120,7 +120,8 @@ def query_dict_to_dict(query_dict, domain, string_type_params):
     # json.loads casts strings 'true'/'false' to booleans, so undo it
     for key in string_type_params:
         if key in query_dict:
-            request_dict[key] = query_dict[key]  # json_request converts keys to strings
+            # json_request converts keys to strings, this returns them to their original strings
+            request_dict[key] = query_dict[key]
     return request_dict
 
 

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -225,10 +225,8 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             for filter in self.filters
             if getattr(filter, 'datatype', 'string') == "string"
         ]
-        if self.request.method == 'GET':
-            return query_dict_to_dict(self.request.GET, self.domain, string_type_params)
-        elif self.request.method == 'POST':
-            return query_dict_to_dict(self.request.POST, self.domain, string_type_params)
+        query_dict = self.request.GET if self.request.method == 'GET' else self.request.POST
+        return query_dict_to_dict(query_dict, self.domain, string_type_params)
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -119,9 +119,8 @@ def query_dict_to_dict(query_dict, domain, string_type_params):
 
     # json.loads casts strings 'true'/'false' to booleans, so undo it
     for key in string_type_params:
-        u_key = str(key)  # QueryDict's key/values are unicode strings
-        if u_key in query_dict:
-            request_dict[key] = query_dict[u_key]  # json_request converts keys to strings
+        if key in query_dict:
+            request_dict[key] = query_dict[key]  # json_request converts keys to strings
     return request_dict
 
 


### PR DESCRIPTION
(review by commit)

##### SUMMARY

https://dimagi-dev.atlassian.net/browse/HI-878

Selecting multiple values in a choice list filter should filter on all of them, but was arbitrarily choosing one. This fixes that behavior. Though I'm not thrilled with the implementation (details below).

##### TECHNICAL DETAILS

my best guess is that this was introduced in https://github.com/dimagi/commcare-hq/commit/8e086c1a752f84a1e87a83f7eac496273fbc54ab or somewhere nearby during the select2 migration.

For these multiselects there is code that kind of looks like it’s supposed to take a choice list and convert it to a string separated by the `u001F` character. But it doesn’t appear that’s working correctly. This causes the value to be a list in django’s request dict, which then gets converted to the first value in the list because of django’s behavior: https://code.djangoproject.com/ticket/1130

This PR goes through the process of fixing the backend to handle the list format, and then re-parse it into the string format previously used by the front-end. Which is pretty ugly, but does fix the bug.

I fixed it this way because it wasn't until I was basically done that I realized the backend was expecting a delimited string all along. And then I ran out of time/steam to dig into the front end approach (or refactor the backend to expect lists).

@orangejenny i’d be curious to get your thoughts on this and whether you think the above sounds plausible (and if so whether we should try a fix on the front end instead of this one).

##### FEATURE FLAG

Affects the UCR feature flag, but also report builder reports.

##### PRODUCT DESCRIPTION

Selecting multiple options in a filter will properly include all of them.