### PR TITLE
Process fewer apps at a time in migration

### DIFF
--- a/corehq/apps/app_manager/migrations/0006_multi_master_linked_apps.py
+++ b/corehq/apps/app_manager/migrations/0006_multi_master_linked_apps.py
@@ -14,7 +14,7 @@ from corehq.util.log import with_progress_bar
 def _populate_linked_app_fields(apps, schema_editor):
     app_ids = (get_doc_ids_by_class(LinkedApplication)
                + get_deleted_doc_ids_by_class(LinkedApplication))
-    iter_update(LinkedApplication.get_db(), _add_fields, with_progress_bar(app_ids))
+    iter_update(LinkedApplication.get_db(), _add_fields, with_progress_bar(app_ids), chunksize=5)
 
 
 def _add_fields(app_doc):

--- a/corehq/apps/app_manager/migrations/0006_multi_master_linked_apps.py
+++ b/corehq/apps/app_manager/migrations/0006_multi_master_linked_apps.py
@@ -14,7 +14,7 @@ from corehq.util.log import with_progress_bar
 def _populate_linked_app_fields(apps, schema_editor):
     app_ids = (get_doc_ids_by_class(LinkedApplication)
                + get_deleted_doc_ids_by_class(LinkedApplication))
-    iter_update(LinkedApplication.get_db(), _add_fields, with_progress_bar(app_ids), chunksize=5)
+    iter_update(LinkedApplication.get_db(), _add_fields, with_progress_bar(app_ids), chunksize=1)
 
 
 def _add_fields(app_doc):

--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -262,7 +262,7 @@ def send_keys_to_couch(db, keys):
     return r.json()['rows']
 
 
-def iter_update(db, fn, ids, max_retries=3, verbose=False):
+def iter_update(db, fn, ids, max_retries=3, verbose=False, chunksize=100):
     """
     Map `fn` over every doc in `db` matching `ids`
 
@@ -304,8 +304,8 @@ def iter_update(db, fn, ids, max_retries=3, verbose=False):
         return updated_doc_id
 
     def _iter_update(doc_ids, try_num):
-        with IterDB(db, chunksize=100) as iter_db:
-            for chunk in chunked(set(doc_ids), 100):
+        with IterDB(db, chunksize=chunksize) as iter_db:
+            for chunk in chunked(set(doc_ids), chunksize):
                 for res in send_keys_to_couch(db, keys=chunk):
                     raw_doc = res.get('doc')
                     doc_id = res.get('id', None)


### PR DESCRIPTION
##### SUMMARY
100 ICDS apps at once is too many.  Tried running this migration on India and it ran out of memory.  Swapping it for something smaller.