### PR TITLE
fix knockout logic for data dict description fields

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -247,7 +247,7 @@
           <p class="help-block"
              data-bind="html: validate,
                         visible: validate"></p>
-          <!-- ko if: $data.description && $parent.hasPrivilege -->
+          <!-- ko if: $data.description() && $parent.hasPrivilege() -->
           <inline-edit params="value: $data.description,
                                rows: 3,
                                cols: 30,


### PR DESCRIPTION
##### SUMMARY
this fixes the logic for showing the description fields so that `$data.description` and `$parent.hasPrivilege` don't evaluate to `true` just because they are objects.

##### FEATURE FLAG
none

##### PRODUCT DESCRIPTION
data dict description fields were showing up even when the feature flag was turned off
