### PR TITLE
Institute soft rate limiting through brief delays

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -1,21 +1,15 @@
-import random
-import time
-from functools import wraps
-
-from django.conf import settings
-
 from corehq.project_limits.rate_limiter import RateDefinition, RateLimiter, \
     PerUserRateDefinition
 
-# Danny promised in an Aug 2019 email not to enforce limits that were lower than this.
-# If we as a team end up regretting this decision, we'll have to reset expectations
-# with the Dimagi NDoH team.
 from corehq.util.datadog.gauges import datadog_counter
 from corehq.util.datadog.utils import bucket_value
 from corehq.util.decorators import silence_and_report_error, enterprise_skip
 from corehq.util.timer import TimingContext
-from dimagi.utils.logging import notify_exception
 
+
+# Danny promised in an Aug 2019 email not to enforce limits that were lower than this.
+# If we as a team end up regretting this decision, we'll have to reset expectations
+# with the Dimagi NDoH team.
 rates_promised_not_to_go_lower_than = RateDefinition(
     per_week=115,
     per_day=23,

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -1,9 +1,14 @@
+from django.conf import settings
+
 from corehq.project_limits.rate_limiter import RateDefinition, RateLimiter, \
     PerUserRateDefinition
 
 # Danny promised in an Aug 2019 email not to enforce limits that were lower than this.
 # If we as a team end up regretting this decision, we'll have to reset expectations
 # with the Dimagi NDoH team.
+from corehq.util.datadog.gauges import datadog_counter
+from dimagi.utils.logging import notify_exception
+
 rates_promised_not_to_go_lower_than = RateDefinition(
     per_week=115,
     per_day=23,
@@ -28,3 +33,23 @@ submission_rate_limiter = RateLimiter(
     feature_key='submissions',
     get_rate_limits=test_rates.get_rate_limits
 )
+
+
+def rate_limit_submission_noop(domain):
+    if not settings.ENTERPRISE_MODE:
+        try:
+            if not submission_rate_limiter.allow_usage(domain):
+                datadog_counter('commcare.xform_submissions.rate_limited.test', tags=[
+                    'domain:{}'.format(domain),
+                ])
+            submission_rate_limiter.report_usage(domain)
+        except Exception:
+            # Prevent rate limiting logic from ever blocking as submission if it errors
+            # until it is proven to be a stable and essential part of our system.
+            # Instead, report the issue to sentry and track the overall count on datadog
+            notify_exception(request, "Exception raised in the rate limiter")
+            datadog_counter('commcare.xform_submissions.rate_limiter_errors', tags=[
+                'domain:{}'.format(domain),
+            ])
+            if settings.UNIT_TESTING:
+                raise

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-from django.conf import settings
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
@@ -36,7 +35,7 @@ from corehq.apps.receiverwrapper.auth import (
     WaivedAuthContext,
     domain_requires_auth,
 )
-from corehq.apps.receiverwrapper.rate_limiter import submission_rate_limiter
+from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission_noop
 from corehq.apps.receiverwrapper.util import (
     DEMO_SUBMIT_MODE,
     from_demo_user,
@@ -66,23 +65,8 @@ PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 @profile_prod('commcare_receiverwapper_process_form.prof', probability=PROFILE_PROBABILITY, limit=PROFILE_LIMIT)
 def _process_form(request, domain, app_id, user_id, authenticated,
                   auth_cls=AuthContext):
-    if not settings.ENTERPRISE_MODE:
-        try:
-            if not submission_rate_limiter.allow_usage(domain):
-                datadog_counter('commcare.xform_submissions.rate_limited.test', tags=[
-                    'domain:{}'.format(domain),
-                ])
-            submission_rate_limiter.report_usage(domain)
-        except Exception:
-            # Prevent rate limiting logic from ever blocking as submission if it errors
-            # until it is proven to be a stable and essential part of our system.
-            # Instead, report the issue to sentry and track the overall count on datadog
-            notify_exception(request, "Exception raised in the rate limiter")
-            datadog_counter('commcare.xform_submissions.rate_limiter_errors', tags=[
-                'domain:{}'.format(domain),
-            ])
-            if settings.UNIT_TESTING:
-                raise
+
+    rate_limit_submission_noop(domain)
 
     metric_tags = [
         'backend:sql' if should_use_sql_backend(domain) else 'backend:couch',

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -66,7 +66,7 @@ PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 def _process_form(request, domain, app_id, user_id, authenticated,
                   auth_cls=AuthContext):
 
-    rate_limit_submission_by_delaying(domain, max_wait=30)
+    rate_limit_submission_by_delaying(domain, max_wait=15)
 
     metric_tags = [
         'backend:sql' if should_use_sql_backend(domain) else 'backend:couch',

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -35,7 +35,7 @@ from corehq.apps.receiverwrapper.auth import (
     WaivedAuthContext,
     domain_requires_auth,
 )
-from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission_noop
+from corehq.apps.receiverwrapper.rate_limiter import rate_limit_submission_by_delaying
 from corehq.apps.receiverwrapper.util import (
     DEMO_SUBMIT_MODE,
     from_demo_user,
@@ -66,7 +66,7 @@ PROFILE_LIMIT = int(PROFILE_LIMIT) if PROFILE_LIMIT is not None else 1
 def _process_form(request, domain, app_id, user_id, authenticated,
                   auth_cls=AuthContext):
 
-    rate_limit_submission_noop(domain)
+    rate_limit_submission_by_delaying(domain, max_wait=30)
 
     metric_tags = [
         'backend:sql' if should_use_sql_backend(domain) else 'backend:couch',

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -44,8 +44,7 @@ class RateLimiter(object):
         return all(rate_counter.get((self.feature_key,) + scope) < limit
                    for rate_counter, limit in self.get_rate_limits(*scope))
 
-    def wait(self, scope, timeout=None):
-        assert timeout
+    def wait(self, scope, timeout):
         start = time.time()
         target_end = start + timeout
         delay = 0

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -1,3 +1,6 @@
+import random
+import time
+
 import attr
 
 from corehq.apps.users.models import CommCareUser
@@ -40,6 +43,26 @@ class RateLimiter(object):
         scope = self.get_normalized_scope(scope)
         return all(rate_counter.get((self.feature_key,) + scope) < limit
                    for rate_counter, limit in self.get_rate_limits(*scope))
+
+    def wait(self, scope, timeout=None):
+        assert timeout
+        start = time.time()
+        target_end = start + timeout
+        delay = 0
+        while True:
+            if self.allow_usage(scope):
+                return True
+            # add a random amount between 100ms and 500ms to the last delay
+            # so that the delays get a bit longer each time
+            # and different requests don't have exactly the same schedule
+            delay += random.uniform(0.1, 0.5)
+            # if the delay would bring us past the timeout
+            # rescheduled for right at the timeout instead
+            delay = min(delay, target_end - time.time())
+            if delay < 0.01:
+                return False
+            else:
+                time.sleep(delay)
 
 
 @quickcache(['domain'], memoize_timeout=60, timeout=60 * 60)

--- a/corehq/util/datadog/gauges.py
+++ b/corehq/util/datadog/gauges.py
@@ -1,9 +1,9 @@
 import time
+from contextlib import ContextDecorator
 from functools import wraps
 
 from celery.task import periodic_task
 from corehq.util.datadog import statsd, datadog_logger
-from corehq.util.decorators import ContextDecorator
 from corehq.util.soft_assert import soft_assert
 from corehq.util.datadog.utils import bucket_value
 from corehq.util.timer import TimingContext

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -1,5 +1,5 @@
 import inspect
-from contextlib import contextmanager
+from contextlib import contextmanager, ContextDecorator
 
 from celery.task import task
 from functools import wraps
@@ -10,20 +10,6 @@ from corehq.util.datadog.gauges import datadog_counter
 from corehq.util.global_request import get_request
 from dimagi.utils.logging import notify_exception
 from django.conf import settings
-
-
-class ContextDecorator(object):
-    """
-    A base class that enables a context manager to also be used as a decorator.
-    https://docs.python.org/3/library/contextlib.html#contextlib.ContextDecorator
-    """
-
-    def __call__(self, fn):
-        @wraps(fn)
-        def decorated(*args, **kwds):
-            with self:
-                return fn(*args, **kwds)
-        return decorated
 
 
 def handle_uncaught_exceptions(mail_admins=True):


### PR DESCRIPTION
##### SUMMARY
I want to be careful about how we roll out rate limiting, and I think the safest place to start is to continue processing all form submission requests, but for those that "would be" rate limited, we delay and recheck every few seconds until we hit a timeout, a maxium amount we're willing to delay form submission request processing by. If the timeout is hit, we just give up waiting and process the request; if before the timeout is through we check and we're no long over the limit, we process it right away.

This functionality is still skipped in `ENTERPRISE_MODE`.
