### PR TITLE
Sk/active users

### DIFF
--- a/corehq/apps/data_analytics/esaccessors.py
+++ b/corehq/apps/data_analytics/esaccessors.py
@@ -52,7 +52,6 @@ def active_mobile_users(domain, start, end, *args):
                   .domain(domain.name)
                   .user_aggregation()
                   .submitted(gte=start, lt=end)
-                  .user_id(user_ids)
                   .size(0)
                   .run()
                   .aggregations.user.counts_by_bucket())

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -67,14 +67,11 @@ def active_mobile_users(domain, *args):
     now = datetime.utcnow()
     then = (now - timedelta(days=30))
 
-    user_ids = get_mobile_users(domain)
-
     form_users = set(
         FormES()
         .domain(domain)
         .user_aggregation()
         .submitted(gte=then)
-        .user_id(user_ids)
         .size(0)
         .run()
         .aggregations.user.keys
@@ -93,7 +90,11 @@ def active_mobile_users(domain, *args):
     )
 
     num_users = len(form_users | sms_users)
-    return num_users if 'inactive' not in args else len(user_ids) - num_users
+
+    if 'inactive' in args:
+        user_ids = get_mobile_users(domain)
+        return len(user_ids) - num_users
+    return num_users
 
 
 def cases(domain, *args):


### PR DESCRIPTION
##### SUMMARY
Follow up on https://github.com/dimagi/commcare-hq/pull/25367 to report active users every minute.

`prod` has ~45K domains in ES and this takes about 1s to run so don't expect it to give any issues.