### PR TITLE
Import patients in their own task

### DIFF
--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from dimagi.ext.couchdbkit import (
     DictProperty,
     Document,
@@ -9,7 +11,9 @@ from dimagi.ext.couchdbkit import (
 
 from corehq.motech.openmrs.const import (
     IMPORT_FREQUENCY_CHOICES,
+    IMPORT_FREQUENCY_DAILY,
     IMPORT_FREQUENCY_MONTHLY,
+    IMPORT_FREQUENCY_WEEKLY,
 )
 
 # Supported values for ColumnMapping.data_type
@@ -74,3 +78,17 @@ class OpenmrsImporter(Document):
 
     def __str__(self):
         return self.server_url
+
+    def should_import_today(self):
+        today = datetime.today()
+        return (
+            self.import_frequency == IMPORT_FREQUENCY_DAILY
+            or (
+                self.import_frequency == IMPORT_FREQUENCY_WEEKLY
+                and today.weekday() == 1  # Tuesday
+            )
+            or (
+                self.import_frequency == IMPORT_FREQUENCY_MONTHLY
+                and today.day == 1
+            )
+        )

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -189,9 +189,8 @@ def import_patients_to_domain(domain_name, force=False):
     :param force: Import regardless of the configured import frequency / today's date
     """
     for importer in get_openmrs_importers_by_domain(domain_name):
-        if not _should_import_today(importer) and not force:
-            continue
-        import_patients_with_importer.delay(importer.to_json())
+        if _should_import_today(importer) or force:
+            import_patients_with_importer.delay(importer.to_json())
 
 @task(serializer='pickle', queue='background_queue')
 def import_patients_with_importer(importer_json):

--- a/corehq/motech/openmrs/tests/test_importer.py
+++ b/corehq/motech/openmrs/tests/test_importer.py
@@ -1,0 +1,60 @@
+import datetime
+
+from django.test import SimpleTestCase
+
+from mock import patch
+
+from corehq.motech.openmrs.const import (
+    IMPORT_FREQUENCY_DAILY,
+    IMPORT_FREQUENCY_MONTHLY,
+    IMPORT_FREQUENCY_WEEKLY,
+)
+from corehq.motech.openmrs.models import OpenmrsImporter
+
+domain_name = 'test-domain'
+
+
+class ImporterTests(SimpleTestCase):
+
+    def test_import_daily(self):
+        importer = OpenmrsImporter(
+            domain=domain_name,
+            import_frequency=IMPORT_FREQUENCY_DAILY,
+        )
+        self.assertTrue(importer.should_import_today())
+
+    def test_import_weekly_tuesday(self):
+        with patch('corehq.motech.openmrs.models.datetime') as datetime_mock:
+            datetime_mock.today.return_value = datetime.date(2019, 9, 17)
+            importer = OpenmrsImporter(
+                domain=domain_name,
+                import_frequency=IMPORT_FREQUENCY_WEEKLY,
+            )
+            self.assertTrue(importer.should_import_today())
+
+    def test_import_weekly_not_tuesday(self):
+        with patch('corehq.motech.openmrs.models.datetime') as datetime_mock:
+            datetime_mock.today.return_value = datetime.date(2019, 9, 16)
+            importer = OpenmrsImporter(
+                domain=domain_name,
+                import_frequency=IMPORT_FREQUENCY_WEEKLY,
+            )
+            self.assertFalse(importer.should_import_today())
+
+    def test_import_monthly_first(self):
+        with patch('corehq.motech.openmrs.models.datetime') as datetime_mock:
+            datetime_mock.today.return_value = datetime.date(2019, 9, 1)
+            importer = OpenmrsImporter(
+                domain=domain_name,
+                import_frequency=IMPORT_FREQUENCY_MONTHLY,
+            )
+            self.assertTrue(importer.should_import_today())
+
+    def test_import_monthly_not_first(self):
+        with patch('corehq.motech.openmrs.models.datetime') as datetime_mock:
+            datetime_mock.today.return_value = datetime.date(2019, 9, 2)
+            importer = OpenmrsImporter(
+                domain=domain_name,
+                import_frequency=IMPORT_FREQUENCY_MONTHLY,
+            )
+            self.assertFalse(importer.should_import_today())

--- a/corehq/motech/openmrs/views.py
+++ b/corehq/motech/openmrs/views.py
@@ -130,7 +130,7 @@ def openmrs_test_fire(request, domain, repeater_id, record_id):
 @login_and_domain_required
 @require_http_methods(['POST'])
 def openmrs_import_now(request, domain):
-    import_patients_to_domain.delay(request.domain, True)
+    import_patients_to_domain(request.domain, force=True)
     return JsonResponse({'status': 'Accepted'}, status=202)
 
 


### PR DESCRIPTION
##### SUMMARY
Instead of using a task per domain, use a task per OpenMRS Importer. 

OpenMRS Importers fetch patient data from OpenMRS reports, and create/update CommCare cases with that data. The motivation behind this change is that some OpenMRS reports can take a very long time, so importing patients in parallel makes more sense.

:tropical_fish: 

##### FEATURE FLAG
OpenMRS Integration

##### PRODUCT DESCRIPTION
This change allows domains to import patients from different OpenMRS servers in parallel.
