### PR TITLE
Python 3.7 applies PEP-479

### DIFF
--- a/corehq/util/itertools.py
+++ b/corehq/util/itertools.py
@@ -23,13 +23,7 @@ def zip_with_gaps(all_items, some_items, all_items_key=None, some_items_key=None
 
     all_iterable = iter(all_items)
     for s_item in some_items:
-        try:
-            a_item = next(all_iterable)
-        except StopIteration:
-            return
-        while some_items_key(s_item) != all_items_key(a_item):
-            try:
-                a_item = next(all_iterable)
-            except StopIteration:
-                return
-        yield (a_item, s_item)
+        for a_item in all_iterable:
+            if some_items_key(s_item) == all_items_key(a_item):
+                yield (a_item, s_item)
+                break

--- a/corehq/util/itertools.py
+++ b/corehq/util/itertools.py
@@ -23,7 +23,13 @@ def zip_with_gaps(all_items, some_items, all_items_key=None, some_items_key=None
 
     all_iterable = iter(all_items)
     for s_item in some_items:
-        a_item = next(all_iterable)
-        while some_items_key(s_item) != all_items_key(a_item):
+        try:
             a_item = next(all_iterable)
+        except StopIteration:
+            return
+        while some_items_key(s_item) != all_items_key(a_item):
+            try:
+                a_item = next(all_iterable)
+            except StopIteration:
+                return
         yield (a_item, s_item)


### PR DESCRIPTION
##### SUMMARY
Python 3.7 changes the behaviour of `StopIteration` inside generators. ([PEP-479](https://www.python.org/dev/peps/pep-0479/))

This PR anticipates HQ on Python > 3.6, and allows the `zip_with_gaps()` iterator to continue to work.

Thanks for the heads-up, @esoergel 

