### PR TITLE
Removed unnecessary js from m4change base report

### DIFF
--- a/custom/m4change/templates/m4change/report.html
+++ b/custom/m4change/templates/m4change/report.html
@@ -8,8 +8,6 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'case/js/cheapxml.js' %}"></script>
-    <script src="{% static 'case/js/casexml.js' %}"></script>
     <script src="{% static 'm4change/javascripts/daterangepicker.js' %}"></script>
     <script src="{% static 'm4change/javascripts/mcct_project_review_page_management.js' %}"></script>
     <script src="{% static 'm4change/javascripts/main.js' %}"></script>


### PR DESCRIPTION
##### SUMMARY
Followup for https://github.com/dimagi/commcare-hq/pull/25245/ - these scripts are already in the grandparent template, `reports/standard/base_template.html`, causing a javascript error. I'm guessing this was already erroring when you repeatedly click "Apply", ~~but now it's erroring on page load which is worse~~. EDIT: the reports seem to work despite the js error, but I'd still like to clean it up.