### PR TITLE
Added isort to stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -7,6 +7,7 @@ linters:
     python: 3
     max-line-length: 115
     ignore: E128,E265,F403,W503,W1618  # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+    isort: true
   eslint:
     config: ./.eslintrc.js
     install_plugins: true


### PR DESCRIPTION
##### SUMMARY
This was just added to stickler. We already have an [isort config](https://github.com/dimagi/commcare-hq/blob/master/.isort.cfg) and have already run isort on a large part of the codebase.