### PR TITLE
Bump up limits for small projects

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -27,7 +27,7 @@ floor_for_small_domain = RateDefinition(
 
 test_rates = PerUserRateDefinition(
     per_user_rate_definition=rates_promised_not_to_go_lower_than.times(2.0),
-    min_rate_definition=floor_for_small_domain,
+    constant_rate_definition=floor_for_small_domain,
 )
 
 submission_rate_limiter = RateLimiter(

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -19,6 +19,7 @@ rates_promised_not_to_go_lower_than = RateDefinition(
 )
 
 floor_for_small_domain = RateDefinition(
+    per_week=100,
     per_day=50,
     per_hour=30,
     per_minute=10,

--- a/corehq/project_limits/tests/test_rate_definition.py
+++ b/corehq/project_limits/tests/test_rate_definition.py
@@ -139,6 +139,19 @@ def test_rate_definition_against_fixed_user_table():
 
     rows = tab_delimited_table.strip().splitlines()[1:]
     table = [[int(cell.replace(',', '')) for cell in row.split()] for row in rows]
+
+    def check(n_users, per_second, per_minute, per_hour, per_day, per_week):
+        testil.eq(
+            per_user_rate.times(n_users).plus(floor_rate).map(int),
+            RateDefinition(
+                per_week=per_week,
+                per_day=per_day,
+                per_hour=per_hour,
+                per_minute=per_minute,
+                per_second=per_second,
+            ),
+        )
+
     per_user_rate = RateDefinition(
         per_week=115,
         per_day=23,
@@ -154,13 +167,4 @@ def test_rate_definition_against_fixed_user_table():
         per_second=1,
     )
     for n_users, per_second, per_minute, per_hour, per_day, per_week in table:
-        testil.eq(
-            per_user_rate.times(n_users).plus(floor_rate).map(int),
-            RateDefinition(
-                per_week=per_week,
-                per_day=per_day,
-                per_hour=per_hour,
-                per_minute=per_minute,
-                per_second=per_second,
-            ),
-        )
+        yield check, n_users, per_second, per_minute, per_hour, per_day, per_week

--- a/corehq/project_limits/tests/test_rate_definition.py
+++ b/corehq/project_limits/tests/test_rate_definition.py
@@ -129,12 +129,12 @@ def _get_random_rate_def():
 def test_rate_definition_against_fixed_user_table():
     tab_delimited_table = """
     # of users  second  minute  hour    day       week
-    1           1       10      33      73        115
-    10          1       10      60      280       1,150
-    100         1       17      330     2,350     11,500
-    1000        6       80      3,030   23,050    115,000
-    10000       51      710     30,030  230,050   1,150,000
-    100000      501     7,010   300,030 2,300,050 11,500,000
+    1           1       10      33      73        215
+    10          1       10      60      280       1,250
+    100         1       17      330     2,350     11,600
+    1000        6       80      3,030   23,050    115,100
+    10000       51      710     30,030  230,050   1,150,100
+    100000      501     7,010   300,030 2,300,050 11,500,100
     """
 
     rows = tab_delimited_table.strip().splitlines()[1:]
@@ -147,6 +147,7 @@ def test_rate_definition_against_fixed_user_table():
         per_second=0.005,
     )
     floor_rate = RateDefinition(
+        per_week=100,
         per_day=50,
         per_hour=30,
         per_minute=10,


### PR DESCRIPTION
##### SUMMARY
This PR includes two different changes that both have the effect of giving small domains a bit more leeway in submission rate. Can review commit by commit

As a recap, we're currently never rejecting requests, but we are delaying would-be rate-limited requests up to a max_wait (currently 30s) before processing them (in the same request).

In the coming weeks before switching to a harder form of rate limiting, I'll be iterating on our various thresholds and logic to better target potential problem causers without significantly affecting "normal", non-problematic using.