### PR TITLE
Limit memory used by case diff process and other improvements

### DIFF
--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -40,7 +40,9 @@ class AsyncFormProcessor(object):
             else:
                 self.pool.kill()  # stop workers -> reduce chaos in logs
         finally:
-            self.statedb.set_resume_state(type(self).__name__, queue_ids)
+            key = type(self).__name__
+            self.statedb.set_resume_state(key, queue_ids)
+            log.info("saved %s state (%s ids)", key, len(queue_ids))
             self.queues = self.pool = None
 
     def _rebuild_queues(self, form_ids):

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from itertools import chain, count
 
 import gevent
+import gipc
 from gevent.event import Event
 from gevent.pool import Group, Pool
 
@@ -12,7 +13,6 @@ from casexml.apps.case.xform import get_case_ids_from_form
 from casexml.apps.stock.models import StockReport
 from dimagi.utils.chunked import chunked
 
-import gipc
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.tzmigration.timezonemigration import json_diff
 from corehq.form_processor.backends.couch.dbaccessors import (

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import signal
 from collections import defaultdict
 from itertools import chain, count
 
@@ -529,6 +530,15 @@ def run_case_diff_queue(queue_class, calls, stats, state_path, is_rebuild, debug
         else:
             getattr(queue, action)(*args)
 
+    def on_break(signum, frame):
+        nonlocal clean_break
+        if clean_break:
+            raise KeyboardInterrupt
+        log.info("clean break... (Ctrl+C to abort)")
+        clean_break = True
+
+    clean_break = False
+    signal.signal(signal.SIGINT, on_break)
     process_actions = {STATUS: status, TERMINATE: terminate}
     statedb = StateDB.init(state_path)
     statedb.is_rebuild = is_rebuild

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -327,7 +327,7 @@ class CouchSqlDomainMigrator(object):
                 sql_case.deletion_id
             )
         finally:
-            self.case_diff_queue.enqueue(doc)
+            self.case_diff_queue.enqueue(couch_case.case_id)
 
     def _check_for_migration_restrictions(self, domain_name):
         msgs = []

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -60,10 +60,13 @@ class StateDB(DiffDB):
     def init(cls, path):
         is_new_db = not os.path.exists(path)
         db = super(StateDB, cls).init(path)
-        db.is_rebuild = False
         if is_new_db:
             db._set_kv("db_unique_id", datetime.utcnow().strftime("%Y%m%d-%H%M%S.%f"))
         return db
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.is_rebuild = False
 
     def __enter__(self):
         return self

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -60,6 +60,7 @@ class StateDB(DiffDB):
     def init(cls, path):
         is_new_db = not os.path.exists(path)
         db = super(StateDB, cls).init(path)
+        db.is_rebuild = False
         if is_new_db:
             db._set_kv("db_unique_id", datetime.utcnow().strftime("%Y%m%d-%H%M%S.%f"))
         return db
@@ -211,6 +212,8 @@ class StateDB(DiffDB):
             kv = self._get_kv(resume_key, session)
             if kv is None:
                 self._set_kv(resume_key, RESUME_NOT_ALLOWED, session)
+                value = default
+            elif self.is_rebuild:
                 value = default
             elif kv.value == RESUME_NOT_ALLOWED:
                 raise ResumeError("previous session did not save resume state")

--- a/corehq/apps/couch_sql_migration/staterebuilder.py
+++ b/corehq/apps/couch_sql_migration/staterebuilder.py
@@ -25,7 +25,7 @@ def iter_unmigrated_docs(domain, doc_types, migration_id, counter):
     if doc_count:
         log.info("saved count of %s was %s", doc_type, doc_count)
     doc_count = get_doc_count_in_domain_by_type(domain, doc_type, couch_db)
-    add_docs = partial(counter.add, doc_type)
+    add_docs = partial(counter.add, None, doc_type)
     batches = doc_count // iter_id_chunks.chunk_size
     iterable = iter_id_chunks(domain, doc_type, migration_id, couch_db)
     doc_ids = []

--- a/corehq/apps/couch_sql_migration/staterebuilder.py
+++ b/corehq/apps/couch_sql_migration/staterebuilder.py
@@ -1,0 +1,91 @@
+import logging
+
+from django.db import connections
+
+from couchforms.models import XFormInstance
+from dimagi.utils.couch.database import iter_docs
+
+from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_type
+from corehq.form_processor.models import XFormInstanceSQL
+from corehq.sql_db.util import split_list_by_db_partition
+from corehq.util.couch_helpers import NoSkipArgsProvider
+from corehq.util.log import with_progress_bar
+from corehq.util.pagination import ResumableFunctionIterator
+
+log = logging.getLogger(__name__)
+
+
+def iter_unmigrated_docs(domain, doc_types, migration_id):
+    if doc_types != ["XFormInstance"]:
+        raise NotImplementedError(doc_types)
+    [doc_type] = doc_types
+    couch_db = XFormInstance.get_db()
+    doc_count = get_doc_count_in_domain_by_type(domain, doc_type, couch_db)
+    batches = doc_count // iter_id_chunks.chunk_size
+    iterable = iter_id_chunks(domain, doc_type, migration_id, couch_db)
+    doc_ids = []
+    for doc_ids in with_progress_bar(iterable, batches, prefix=doc_type, oneline=False):
+        yield from iter_docs_not_in_sql(doc_ids, couch_db)
+
+
+def iter_id_chunks(domain, doc_type, migration_id, couch_db):
+    def data_function(**view_kwargs):
+        return couch_db.view('by_domain_doc_type_date/view', **view_kwargs)
+    endkey, docid = get_endkey_docid(domain, doc_type, migration_id)
+    args_provider = NoSkipArgsProvider({
+        'startkey': [domain, doc_type],
+        'endkey': endkey,
+        'endkey_docid': docid,
+        'inclusive_end': False,
+        'limit': iter_id_chunks.chunk_size,
+        'include_docs': False,
+        'reduce': False,
+    })
+    args, kwargs = args_provider.get_initial_args()
+    while True:
+        results = list(data_function(*args, **kwargs))
+        results = args_provider.adjust_results(results, args, kwargs)
+        if not results:
+            break
+        yield [r["id"] for r in results]
+        try:
+            args, kwargs = args_provider.get_next_args(results[-1], *args, **kwargs)
+        except StopIteration:
+            break
+
+
+iter_id_chunks.chunk_size = 1000
+
+
+def get_endkey_docid(domain, doc_type, migration_id):
+    resume_key = "%s.%s.%s" % (domain, doc_type, migration_id)
+    state = ResumableFunctionIterator(resume_key, None, None, None).state
+    assert getattr(state, '_rev', None), "rebuild not necessary (no resume state)"
+    assert not state.complete, "iteration is complete"
+    state_json = state.to_json()
+    assert not state_json['args']
+    kwargs = state_json['kwargs']
+    return kwargs['startkey'], kwargs['startkey_docid']
+
+
+def iter_docs_not_in_sql(form_ids, couch_db):
+    def get_missing_form_ids(db, db_form_ids):
+        with db.cursor() as cursor:
+            cursor.execute(sql, [db_form_ids])
+            return [r[0] for r in cursor.fetchall()]
+
+    sql = f"""
+        SELECT id FROM (
+            (
+                SELECT UNNEST(%s) AS id
+            ) EXCEPT (
+                SELECT form_id FROM {XFormInstanceSQL._meta.db_table}
+            )
+        ) AS missing_ids
+    """
+
+    for db_name, db_form_ids in split_list_by_db_partition(form_ids):
+        missing_ids = get_missing_form_ids(connections[db_name], db_form_ids)
+        if missing_ids:
+            log.debug("missing ids: %s", missing_ids)
+            yield from iter_docs(couch_db, missing_ids)

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -142,7 +142,7 @@ class TestCaseDiffQueue(SimpleTestCase):
         with self.assertRaises(Error), self.queue() as queue:
             # HACK mutate queue internal state
             # currently there is no easier way to stop non-empty cases_to_diff
-            queue.cases_to_diff["a"] = self.get_cases("a")[0]
+            queue.cases_to_diff.append("a")
             raise Error("do not process_remaining_diffs")
         self.assertTrue(queue.cases_to_diff)
         with self.queue() as queue:
@@ -414,17 +414,17 @@ class TestCaseDiffProcess(SimpleTestCase):
         with self.process() as proc:
             self.assertEqual(self.get_status(proc), [0, 0, 0])
             proc.update({"case1", "case2"}, "form")
-            proc.enqueue({"case": "data"})
+            proc.enqueue("case")
             self.assertEqual(self.get_status(proc), [2, 1, 0])
 
     def test_process_statedb(self):
         with self.process() as proc1:
             self.assertEqual(self.get_status(proc1), [0, 0, 0])
-            proc1.enqueue({"case": "data"})
+            proc1.enqueue("case")
             self.assertEqual(self.get_status(proc1), [0, 1, 0])
         with self.process() as proc2:
             self.assertEqual(self.get_status(proc2), [0, 1, 0])
-            proc2.enqueue({"case": "data"})
+            proc2.enqueue("case")
             self.assertEqual(self.get_status(proc2), [0, 2, 0])
 
     def test_process_not_allowed(self):
@@ -499,7 +499,7 @@ class FakeCaseDiffQueue(object):
     def update(self, case_ids, form_id):
         self.stats["pending_cases"] += len(case_ids)
 
-    def enqueue(self, case_doc):
+    def enqueue(self, case_id):
         self.stats["pending_diffs"] += 1
 
     def get_status(self):

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -470,7 +470,7 @@ class TestCaseDiffProcess(SimpleTestCase):
     def get_status(proc):
         def log_status(status):
             log.info("status: %s", status)
-            keys = ["pending_cases", "pending_diffs", "diffed_cases"]
+            keys = ["pending_cases", "loaded_cases", "diffed_cases"]
             assert set(keys) == set(status), status
             queue.put([status[k] for k in keys])
 
@@ -485,7 +485,7 @@ class FakeCaseDiffQueue(object):
 
     def __init__(self, statedb, status_interval=None):
         self.statedb = statedb
-        self.stats = {"pending_cases": 0, "pending_diffs": 0, "diffed_cases": 0}
+        self.stats = {"pending_cases": 0, "loaded_cases": 0, "diffed_cases": 0}
 
     def __enter__(self):
         state = self.statedb.pop_resume_state(type(self).__name__, {})
@@ -500,7 +500,7 @@ class FakeCaseDiffQueue(object):
         self.stats["pending_cases"] += len(case_ids)
 
     def enqueue(self, case_id):
-        self.stats["pending_diffs"] += 1
+        self.stats["loaded_cases"] += 1
 
     def get_status(self):
         return self.stats

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -470,7 +470,9 @@ class TestCaseDiffProcess(SimpleTestCase):
     def get_status(proc):
         def log_status(status):
             log.info("status: %s", status)
-            keys = ["pending_cases", "loaded_cases", "diffed_cases"]
+            cached = status.pop("cached")
+            assert cached == "0/0", cached
+            keys = ["pending", "loaded", "diffed"]
             assert set(keys) == set(status), status
             queue.put([status[k] for k in keys])
 
@@ -485,7 +487,7 @@ class FakeCaseDiffQueue(object):
 
     def __init__(self, statedb, status_interval=None):
         self.statedb = statedb
-        self.stats = {"pending_cases": 0, "loaded_cases": 0, "diffed_cases": 0}
+        self.stats = {"pending": 0, "cached": "0/0", "loaded": 0, "diffed": 0}
 
     def __enter__(self):
         state = self.statedb.pop_resume_state(type(self).__name__, {})
@@ -497,10 +499,10 @@ class FakeCaseDiffQueue(object):
         self.statedb.set_resume_state(type(self).__name__, {"stats": self.stats})
 
     def update(self, case_ids, form_id):
-        self.stats["pending_cases"] += len(case_ids)
+        self.stats["pending"] += len(case_ids)
 
     def enqueue(self, case_id):
-        self.stats["loaded_cases"] += 1
+        self.stats["loaded"] += 1
 
     def get_status(self):
         return self.stats

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -1132,13 +1132,13 @@ class MigrationTestCase(BaseMigrationTestCase):
         for i, form_id in enumerate(form_ids):
             self.submit_form(make_test_form(form_id), timedelta(minutes=-90))
         with self.patch_migration_chunk_size(2), self.on_doc("XFormInstance", "form-3", interrupt):
-            self._do_migration(live=True, diff_process=True)
+            self._do_migration(live=True)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), set(form_ids[:4]))
         statedb = init_state_db(self.domain_name, self.state_dir)
         statedb.pop_resume_state("CaseDiffQueue", None)  # simulate failed exit
         clear_local_domain_sql_backend_override(self.domain_name)
-        self._do_migration(live=True, rebuild_state=True, diff_process=True)
+        self._do_migration(live=True, rebuild_state=True)
         self.assertEqual(self._get_form_ids(), set(form_ids))
         self._compare_diffs([])
 

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -1125,6 +1125,23 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assertEqual(self._get_form_ids("XFormArchived"), {"arch"})
         self._compare_diffs([])
 
+    def test_rebuild_state(self):
+        def interrupt():
+            os.kill(os.getpid(), SIGINT)
+        form_ids = [f"form-{n}" for n in range(7)]
+        for i, form_id in enumerate(form_ids):
+            self.submit_form(make_test_form(form_id), timedelta(minutes=-90))
+        with self.patch_migration_chunk_size(2), self.on_doc("XFormInstance", "form-3", interrupt):
+            self._do_migration(live=True, diff_process=True)
+        self.assert_backend("sql")
+        self.assertEqual(self._get_form_ids(), set(form_ids[:4]))
+        statedb = init_state_db(self.domain_name, self.state_dir)
+        statedb.pop_resume_state("CaseDiffQueue", None)  # simulate failed exit
+        clear_local_domain_sql_backend_override(self.domain_name)
+        self._do_migration(live=True, rebuild_state=True, diff_process=True)
+        self.assertEqual(self._get_form_ids(), set(form_ids))
+        self._compare_diffs([])
+
     def test_case_forms_list_order(self):
         SERVER_DATES = [
             datetime.strptime("2015-07-13T11:21:00.639795Z", ISO_DATETIME_FORMAT),

--- a/corehq/apps/tzmigration/planning.py
+++ b/corehq/apps/tzmigration/planning.py
@@ -93,6 +93,10 @@ class BaseDB(object):
         self.engine = create_engine("sqlite://", creator=connect)
         self.Session = sessionmaker(bind=self.engine)
 
+    def __repr__(self):
+        readonly = ", readonly=True" if self.readonly else ""
+        return f"{type(self).__name__}({self.db_filepath!r}{readonly})"
+
     def __getstate__(self):
         return self.db_filepath
 


### PR DESCRIPTION
Other improvements:
- [Option to rebuild migration state](https://github.com/dimagi/commcare-hq/commit/6a0839faa9ea7581859d3488e129d402d07b7816) if the migration crashes and state is lost. Some state ~may still be lost~, such as un-diffed cases, cannot be rebuilt.
- [Signal handler for case diff process](https://github.com/dimagi/commcare-hq/commit/ad7acf25772f1af2ea0f3b922816727cfff1277a) so it is not killed abruptly on keyboard interrupt.
- [Persistent doc counts](https://github.com/dimagi/commcare-hq/commit/b57e946097645f4356604baf2eaf80abeabdfa68) so migration progress does not reset on resumed migrations.

🐡 review by commit