### PR TITLE
Add ES backend for Group API

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -5,7 +5,7 @@ from tastypie.exceptions import BadRequest
 
 from dimagi.utils.parsing import string_to_boolean
 
-from corehq.apps.api.couch import UserQuerySetAdapter
+from corehq.apps.api.query_adapters import UserQuerySetAdapter
 from corehq.apps.api.resources import (
     CouchResourceMixin,
     DomainSpecificResourceMixin,

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -11,7 +11,8 @@ from tastypie.bundle import Bundle
 from tastypie.exceptions import BadRequest
 
 from casexml.apps.case.xform import get_case_updates
-from corehq.apps.api.couch import GroupQuerySetAdapter
+from corehq import toggles
+from corehq.apps.api.query_adapters import GroupQuerySetAdapterCouch, GroupQuerySetAdapterES
 from couchforms.models import doc_types
 
 from corehq.apps.api.es import ElasticAPIQuerySet, XFormES, es_search
@@ -315,7 +316,10 @@ class GroupResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMi
         return get_object_or_not_exist(Group, kwargs['pk'], kwargs['domain'])
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        return GroupQuerySetAdapter(domain)
+        if toggles.GROUP_API_USE_ES_BACKEND.enabled(domain):
+            return GroupQuerySetAdapterES(domain)
+        else:
+            return GroupQuerySetAdapterCouch(domain)
 
     class Meta(CustomResourceMeta):
         authentication = RequirePermissionAuthentication(Permissions.edit_commcare_users)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1803,3 +1803,11 @@ DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK = StaticToggle(
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN]
 )
+
+
+GROUP_API_USE_ES_BACKEND = StaticToggle(
+    'group_api_use_es_backend',
+    'Use ES backend for Group API',
+    TAG_PRODUCT,
+    [NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
##### SUMMARY

This adds an experimental group API backend that uses ES instead of CouchDB for bulk gets.

The only known difference as of now is that it sorts by name instead of by group `_id`. (The ES index we're using doesn't sort by `_id`, so there's no easy way to do that.)

##### FEATURE FLAG
GROUP_API_USE_ES_BACKEND

