### PR TITLE
Fixed js error on admin report User List

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/faceted_report.html
@@ -6,7 +6,7 @@
 {% block view-tabs %}
 {% endblock %}
 
-{% block js %}{{ block.super }}
+{% block js %}
   {% include 'reports/partials/filters_js.html' %}
   {% compress js %}
     <script src="{% static 'reports/js/hq_report.js' %}"></script>
@@ -15,6 +15,8 @@
     <script src="{% static 'appstore/js/facet_sidebar.js' %}"></script>
     <script src="{% static 'reports/js/standard_hq_report.js' %}"></script>
   {% endcompress %}
+  {# The scripts above must be loaded before the parent's scripts, specifically reports/js/standard_hq_report #}
+  {{ block.super }}
 {% endblock %}
 
 {% block page_navigation %}


### PR DESCRIPTION
##### SUMMARY
Introduced in https://github.com/dimagi/commcare-hq/pull/25374

Necessary because now that more of the reports js is migrated to use requirejs, the ordering of script tags is more important on *non*-requirejs pages. See the [troubleshooting guide](https://github.com/dimagi/commcare-hq/blob/master/docs/js-guide/migrating.md#troubleshooting) for detail (ctrl+F "tags are ordered").