### PR TITLE
Remove ghost roles from domain admins

### DIFF
--- a/corehq/apps/users/migrations/0004_rm_role_id_from_admins.py
+++ b/corehq/apps/users/migrations/0004_rm_role_id_from_admins.py
@@ -1,0 +1,46 @@
+from django.db import migrations
+
+from corehq.apps.es import UserES
+from corehq.apps.users.models import WebUser
+from corehq.util.couch import DocUpdate, iter_update
+from corehq.util.django_migrations import skip_on_fresh_install
+from corehq.util.log import with_progress_bar
+
+
+@skip_on_fresh_install
+def fix_users(apps, schema_editor):
+    user_ids = with_progress_bar(_get_admins_with_roles())
+    iter_update(WebUser.get_db(), _remove_role, user_ids, verbose=True)
+
+
+def _get_admins_with_roles():
+    # domain_memberships isn't a nested mapping in ES, so this only checks that
+    # they have a domain membership that's an admin, and one with a role_id,
+    # not that it's both on the same membership
+    return (UserES()
+            .web_users()
+            .term('domain_memberships.is_admin', True)
+            .non_null('domain_memberships.role_id')
+            .get_ids())
+
+
+def _remove_role(user_doc):
+    changed = False
+    for dm in user_doc['domain_memberships']:
+        if dm['is_admin'] and dm['role_id']:
+            dm['role_id'] = None
+            changed = True
+
+    if changed:
+        return DocUpdate(user_doc)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0003_roles_permissions_update'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_users, reverse_code=migrations.RunPython.noop, elidable=True)
+    ]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -720,6 +720,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
         dm.is_admin = False
         if role_qualified_id == "admin":
             dm.is_admin = True
+            dm.role_id = None
         elif role_qualified_id.startswith('user-role:'):
             dm.role_id = role_qualified_id[len('user-role:'):]
         elif role_qualified_id in PERMISSIONS_PRESETS:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-834

##### PRODUCT DESCRIPTION
There's a longstanding bug (2012!) where if you assign a role to a web user, then later promote that user to domain admin, it doesn't actually clear out that role.  This makes the "roles" page think that that user is still assigned to the role, blocking you from deleting the role.

##### SUMMARY
This modifies `set_role` to handle this properly, and migrates all existing users in that situation.  This is complicated somewhat by the fact that the `domain_memberships` subdocument is not mapped as a nested document, so we can't distinguish between a user in this bad state and a user who's an admin on one domain and who has a non-admin role on another (not at query time, anyways).  I believe the migration should be fast enough to roll out during the deploy, here are the counts for the number of users matching that ES query:
* prod - 2432 users
* india - 22 users
* icds - 15 users
