### PR TITLE
Refactor async form processing queue

### DIFF
--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -193,8 +193,6 @@ class PartiallyLockingQueue(object):
         queue_by_lock_id = self.queue_by_lock_id
         lock_ids_by_queue_id = self.lock_ids_by_queue_id
         for queue in queue_by_lock_id.values():
-            if not queue:
-                continue
             queue_id = queue[0]
             lock_ids = lock_ids_by_queue_id[queue_id]
             if all(is_first(queue_id, x) for x in lock_ids) and self._set_lock(lock_ids):
@@ -246,7 +244,11 @@ class PartiallyLockingQueue(object):
         queue_by_lock_id = self.queue_by_lock_id
         for lock_id in lock_ids:
             queue = queue_by_lock_id[lock_id]
-            queue.popleft()
+            assert queue[0] == queued_obj_id, (queue[0], queued_obj_id)
+            if len(queue) == 1:
+                queue_by_lock_id.pop(lock_id)
+            else:
+                queue.popleft()
         return self.queue_objs_by_queue_id.pop(queued_obj_id)
 
     def _is_any_locked(self, lock_ids):

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -176,10 +176,14 @@ class PartiallyLockingQueue(object):
         Returns :boolean: True if it acquired the lock, False if it was added to queue
         """
         queue_obj_id = self.get_queue_obj_id(queue_obj)
-        if not lock_ids or self._set_lock(lock_ids):
-            self.processing[queue_obj_id] = lock_ids
-            return True
         queue_by_lock_id = self.queue_by_lock_id
+        for lock_id in lock_ids:
+            if queue_by_lock_id.get(lock_id):
+                break  # wait behind other object(s) in the queue for this lock
+        else:
+            if not lock_ids or self._set_lock(lock_ids):
+                self.processing[queue_obj_id] = lock_ids
+                return True
         for lock_id in lock_ids:
             queue_by_lock_id[lock_id].append(queue_obj_id)
         self.objs_by_queue_id[queue_obj_id] = (queue_obj, lock_ids)

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -240,18 +240,12 @@ class PartiallyLockingQueue(object):
 
         :queue_obj_id string: An id of an object of the type in the queues
 
-        Assumes the obj is the first in every queue it inhabits. This seems reasonable
-        for the intended use case, as this function should only be used by `.get_next`.
-
-        Raises UnexpectedObjectException if this assumption doesn't hold
+        Assumes the obj is the first in every queue it inhabits.
         """
-        lock_ids = self.lock_ids_by_queue_id.get(queued_obj_id)
+        lock_ids = self.lock_ids_by_queue_id[queued_obj_id]
+        queue_by_lock_id = self.queue_by_lock_id
         for lock_id in lock_ids:
-            queue = self.queue_by_lock_id[lock_id]
-            if queue[0] != queued_obj_id:
-                raise UnexpectedObjectException("This object shouldn't be removed")
-        for lock_id in lock_ids:
-            queue = self.queue_by_lock_id[lock_id]
+            queue = queue_by_lock_id[lock_id]
             queue.popleft()
         return self.queue_objs_by_queue_id.pop(queued_obj_id)
 
@@ -271,10 +265,6 @@ class PartiallyLockingQueue(object):
 
     def _release_lock(self, lock_ids):
         self.currently_locked.difference_update(lock_ids)
-
-
-class UnexpectedObjectException(Exception):
-    pass
 
 
 def _fix_replacement_form_problem_in_couch(doc):

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -168,7 +168,7 @@ class PartiallyLockingQueue(object):
         if not lock_ids:
             self._add_item(lock_ids, queue_obj, to_queue=False)
             return True
-        if self._check_lock(lock_ids):  # if it's currently locked, it can't acquire the lock
+        if self._is_any_locked(lock_ids):
             self._add_item(lock_ids, queue_obj)
             return False
         for lock_id in lock_ids:  # if other objs are waiting for the same locks, it has to wait
@@ -254,15 +254,16 @@ class PartiallyLockingQueue(object):
             queue.popleft()
         return self.queue_objs_by_queue_id.pop(queued_obj_id)
 
-    def _check_lock(self, lock_ids):
-        return any(lock_id in self.currently_locked for lock_id in lock_ids)
+    def _is_any_locked(self, lock_ids):
+        locked = self.currently_locked
+        return any(lock_id in locked for lock_id in lock_ids)
 
     def _set_lock(self, lock_ids):
         """ Tries to set locks for given lock ids
 
         If already locked, returns false. If acquired, returns True
         """
-        if self._check_lock(lock_ids):
+        if self._is_any_locked(lock_ids):
             return False
         self.currently_locked.update(lock_ids)
         return True

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -228,8 +228,9 @@ class PartiallyLockingQueue(object):
         """
         queue_obj_id = self.get_queue_obj_id(queue_obj)
         if to_queue:
+            queue_by_lock_id = self.queue_by_lock_id
             for lock_id in lock_ids:
-                self.queue_by_lock_id[lock_id].append(queue_obj_id)
+                queue_by_lock_id[lock_id].append(queue_obj_id)
             self.queue_objs_by_queue_id[queue_obj_id] = queue_obj
         self.lock_ids_by_queue_id[queue_obj_id] = lock_ids
 

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -149,7 +149,7 @@ class PartiallyLockingQueue(object):
     def queue_ids(self):
         """Return a list of queue object ids
 
-        Queue state can be ruilt using this list by looking up each
+        Queue state can be rebuilt using this list by looking up each
         queue object and lock ids and passing them to `try_obj()`.
         """
         return list(self.lock_ids_by_queue_id)
@@ -207,16 +207,11 @@ class PartiallyLockingQueue(object):
         """ Releases all locks for an object in the queue
 
         :queue_obj obj: An object of the type in the queues
-
-        At some point in the future it might raise an exception if it trys
-        releasing a lock that isn't held
         """
         queue_obj_id = self.get_queue_obj_id(queue_obj)
         lock_ids = self.lock_ids_by_queue_id.pop(queue_obj_id, None)
         if lock_ids:
             self._release_lock(lock_ids)
-            return True
-        return False
 
     def __len__(self):
         """Return the number of objects in the queue"""
@@ -263,7 +258,7 @@ class PartiallyLockingQueue(object):
         return any(lock_id in self.currently_locked for lock_id in lock_ids)
 
     def _set_lock(self, lock_ids):
-        """ Trys to set locks for given lock ids
+        """ Tries to set locks for given lock ids
 
         If already locked, returns false. If acquired, returns True
         """

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -186,13 +186,17 @@ class PartiallyLockingQueue(object):
         def is_first(queue_id, lock_id):
             return queue_by_lock_id[lock_id][0] == queue_id
 
+        seen = set()
         queue_by_lock_id = self.queue_by_lock_id
         objs_by_queue_id = self.objs_by_queue_id
         for queue in queue_by_lock_id.values():
             queue_id = queue[0]
+            if queue_id in seen:
+                continue
             lock_ids = objs_by_queue_id[queue_id][1]
             if all(is_first(queue_id, x) for x in lock_ids) and self._set_lock(lock_ids):
                 return self._pop_queue_obj(queue_id)
+            seen.add(queue_id)
         return None, None
 
     def _pop_queue_obj(self, queued_obj_id):

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -171,9 +171,9 @@ class PartiallyLockingQueue(object):
         if self._is_any_locked(lock_ids):
             self._add_item(lock_ids, queue_obj)
             return False
+        queue_by_lock_id = self.queue_by_lock_id
         for lock_id in lock_ids:  # if other objs are waiting for the same locks, it has to wait
-            queue = self.queue_by_lock_id[lock_id]
-            if queue:
+            if queue_by_lock_id.get(lock_id):
                 self._add_item(lock_ids, queue_obj)
                 return False
         self._add_item(lock_ids, queue_obj, to_queue=False)

--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -177,7 +177,8 @@ class PartiallyLockingQueue(object):
                 self._add_item(lock_ids, queue_obj)
                 return False
         self._add_item(lock_ids, queue_obj, to_queue=False)
-        self._set_lock(lock_ids)
+        locked = self._set_lock(lock_ids)
+        assert locked, len(lock_ids)
         return True
 
     def pop(self):
@@ -201,7 +202,10 @@ class PartiallyLockingQueue(object):
         return None, None
 
     def release_lock_for_queue_obj(self, queue_obj):
-        """ Releases all locks for an object in the queue
+        """Release locks for a locked object
+
+        The object should have been previously popped from the queue or
+        `.try_obj()` should have returned `True`.
 
         :queue_obj obj: An object of the type in the queues
         """

--- a/corehq/apps/couch_sql_migration/status.py
+++ b/corehq/apps/couch_sql_migration/status.py
@@ -1,0 +1,29 @@
+import gevent
+from gevent.event import Event
+
+
+def run_status_logger(log_status, get_status, status_interval):
+    """Start a status logger loop in a greenlet
+
+    Log status every `status_interval` seconds unless it evaluates to
+    false, in which case the loop is not started.
+
+    :param log_status: a status logging function.
+    :param get_status: a function returning a status object to be logged.
+    :param status_interval: number of seconds between status logging.
+    :returns: A function that stops the logger loop.
+    """
+    def status_logger():
+        while not exit.wait(timeout=status_interval):
+            log_status(get_status())
+        log_status(get_status())
+
+    def stop():
+        exit.set()
+        loop.join()
+
+    if status_interval:
+        exit = Event()
+        loop = gevent.spawn(status_logger)
+        return stop
+    return lambda: None

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -154,6 +154,16 @@ class TestLockingQueues(SimpleTestCase):
         self.assertTrue(self.queues.try_obj(["tooth", "tail"], obj))
         self.assertFalse(self.queues.queue_by_lock_id)
 
+    def test_pop_should_discard_empty_queues(self):
+        tiger = DummyObject('tiger')
+        beaver = DummyObject('beaver')
+        self.assertTrue(self.queues.try_obj(["tooth", "claw"], tiger))
+        self.assertFalse(self.queues.try_obj(["tooth", "tail"], beaver))
+        self.queues.release_lock_for_queue_obj(tiger)
+        obj, lock_ids = self.queues.pop()
+        self.assertEqual(obj, beaver)
+        self.assertFalse(self.queues.queue_by_lock_id)
+
     def test_max_size(self):
         self.assertEqual(-1, self.queues.max_size)
         self.assertFalse(self.queues.full)  # not full when no max size set

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -95,6 +95,19 @@ class TestLockingQueues(SimpleTestCase):
         self._check_locks(['grapefruit_sculpin'], lock_set=True)
         self._check_locks(['wrought_iron'], lock_set=False)
 
+    def test_try_obj_should_make_obj_wait_in_line(self):
+        tiger = DummyObject('tiger')
+        beaver = DummyObject('beaver')
+        monkey = DummyObject('monkey')
+        self.assertTrue(self.queues.try_obj(["tooth", "claw"], tiger))
+        self.assertFalse(self.queues.try_obj(["tooth", "tail"], beaver))
+        self.assertFalse(self.queues.try_obj(["tail"], monkey))
+        self.queues.release_lock(tiger)
+        self.assertEqual(self.queues.pop()[0], beaver)
+        self.assertEqual(self.queues.pop()[0], None)
+        self.queues.release_lock(beaver)
+        self.assertEqual(self.queues.pop()[0], monkey)
+
     def test_pop(self):
         # nothing returned if nothing in queues
         self.assertEqual((None, None), self.queues.pop())

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -123,16 +123,10 @@ class TestLockingQueues(SimpleTestCase):
         self._check_locks(final_lock_ids)
 
     def test_release_locks(self):
+        queue_obj = DummyObject('kancamagus')
         lock_ids = ['rubaeus', 'dirty_bastard', 'red\'s_rye']
         self._check_locks(lock_ids, lock_set=False)
-        self.queues._set_lock(lock_ids)
-        self._check_locks(lock_ids, lock_set=True)
-        self.queues._release_lock(lock_ids)
-        self._check_locks(lock_ids, lock_set=False)
-
-        queue_obj = DummyObject('kancamagus')
-        self.queues._add_item(lock_ids, queue_obj, to_queue=False)
-        self.queues._set_lock(lock_ids)
+        self.assertTrue(self.queues.try_obj(lock_ids, queue_obj))
         self._check_locks(lock_ids, lock_set=True)
         self.queues.release_lock_for_queue_obj(queue_obj)
         self._check_locks(lock_ids, lock_set=False)

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -137,6 +137,18 @@ class TestLockingQueues(SimpleTestCase):
         self.queues.release_lock_for_queue_obj(queue_obj)
         self._check_locks(lock_ids, lock_set=False)
 
+    def test_release_obj_with_no_locks(self):
+        obj = DummyObject('blanch')
+        self.assertTrue(self.queues.try_obj([], obj))
+        self.assertFalse(self.queues)
+        self.queues.release_lock_for_queue_obj(obj)
+
+    def test_release_locked_obj(self):
+        obj = DummyObject('beaver')
+        self.assertTrue(self.queues.try_obj(["tooth", "tail"], obj))
+        self.assertFalse(self.queues)
+        self.queues.release_lock_for_queue_obj(obj)
+
     def test_max_size(self):
         self.assertEqual(-1, self.queues.max_size)
         self.assertFalse(self.queues.full)  # not full when no max size set

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -149,6 +149,11 @@ class TestLockingQueues(SimpleTestCase):
         self.assertFalse(self.queues)
         self.queues.release_lock_for_queue_obj(obj)
 
+    def test_try_obj_should_not_create_queues_unnecessarily(self):
+        obj = DummyObject('beaver')
+        self.assertTrue(self.queues.try_obj(["tooth", "tail"], obj))
+        self.assertFalse(self.queues.queue_by_lock_id)
+
     def test_max_size(self):
         self.assertEqual(-1, self.queues.max_size)
         self.assertFalse(self.queues.full)  # not full when no max size set

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -60,7 +60,7 @@ class TestLockingQueues(SimpleTestCase):
         self.assertItemsEqual(lock_ids, self.queues.lock_ids_by_queue_id[queue_obj_id])
 
     def _check_locks(self, lock_ids, lock_set=True):
-        self.assertEqual(lock_set, self.queues._check_lock(lock_ids))
+        self.assertEqual(lock_set, self.queues._is_any_locked(lock_ids))
 
     def test_has_next(self):
         self.assertFalse(self.queues)

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -90,36 +90,36 @@ class TestLockingQueues(SimpleTestCase):
         self._check_locks(['grapefruit_sculpin'], lock_set=True)
         self._check_locks(['wrought_iron'], lock_set=False)
 
-    def test_get_next(self):
+    def test_pop(self):
         # nothing returned if nothing in queues
-        self.assertEqual((None, None), self.queues.get_next())
+        self.assertEqual((None, None), self.queues.pop())
 
         # first obj in queues will be returned if nothing blocking
         lock_ids = ['old_chub', 'dales_pale', 'little_yella']
         queue_obj_id = 'moosilauke'
         self._add_to_queues(queue_obj_id, lock_ids)
-        self.assertEqual(queue_obj_id, self.queues.get_next()[0].id)
+        self.assertEqual(queue_obj_id, self.queues.pop()[0].id)
         self._check_locks(lock_ids, lock_set=True)
 
         # next object will not be returned if anything locks are held
         new_lock_ids = ['old_chub', 'ten_fidy']
         new_queue_obj_id = 'flume'
         self._add_to_queues(new_queue_obj_id, new_lock_ids)
-        self.assertEqual((None, None), self.queues.get_next())
+        self.assertEqual((None, None), self.queues.pop())
         self._check_locks(['ten_fidy'], lock_set=False)
 
         # next object will not be returned if not first in all queues
         next_lock_ids = ['ten_fidy', 'death_by_coconut']
         next_queue_obj_id = 'liberty'
         self._add_to_queues(next_queue_obj_id, next_lock_ids)
-        self.assertEqual((None, None), self.queues.get_next())
+        self.assertEqual((None, None), self.queues.pop())
         self._check_locks(next_lock_ids, lock_set=False)
 
         # will return something totally orthogonal though
         final_lock_ids = ['fugli', 'pinner']
         final_queue_obj_id = 'sandwich'
         self._add_to_queues(final_queue_obj_id, final_lock_ids)
-        self.assertEqual(final_queue_obj_id, self.queues.get_next()[0].id)
+        self.assertEqual(final_queue_obj_id, self.queues.pop()[0].id)
         self._check_locks(final_lock_ids)
 
     def test_release_locks(self):

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -63,9 +63,9 @@ class TestLockingQueues(SimpleTestCase):
         self.assertEqual(lock_set, self.queues._check_lock(lock_ids))
 
     def test_has_next(self):
-        self.assertFalse(self.queues.has_next())
+        self.assertFalse(self.queues)
         self._add_to_queues('monadnock', ['heady_topper', 'sip_of_sunshine', 'focal_banger'])
-        self.assertTrue(self.queues.has_next())
+        self.assertTrue(self.queues)
 
     def test_try_obj(self):
         # first object is fine


### PR DESCRIPTION
Migrations have been slowing down considerably over time, and the async form processing queue seems like a probable culprit. The results of this refactor seem fruitful since the internal logic in the queue is now quite a bit simpler and hopefully easier follow. Critical operations like `try_obj()` are doing far less work than before with the same end result.

Possibly the most important changes here are https://github.com/dimagi/commcare-hq/commit/1989e9602a02fd41b9aa1a41f77e3c19178d09e0 and https://github.com/dimagi/commcare-hq/commit/c71eb07c194f0b391a5cd767e90495f620bef483, which were causing new `deque` objects (and corresponding dict entries) to be created for every case ever seen by the migration, and they were never cleaned up. A portion (in some cases all) of these unneeded queue items were visited in an ever-lengthening iteration every time an item was popped from the queue. I expect this will have a dramatic effect in queue performance.

It may be possible to simplify the queue even more and also reduce the amount of work being done in operations like `pop()`. However, at this point it seems better to try out these changes rather than continuing to polish this cannonball.

🐡 Review by commit.