### PR TITLE
Bubble up gevent errors to main thread

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
             pool = Pool(10)
             for state in state_ids:
                 pool.spawn(query.func, state, agg_date)
-            pool.join()
+            pool.join(raise_error=True)
         elif query.by_state == NO_STATES:
             query.func(agg_date)
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Gevent swallows errors that are raised in a greenlet by default. This causes an exception in a greenlet to be raised in the main thread, signaling to airflow that the task failed.

This is currently a bit heavy handed as it will retry for all states if one has failed, but its better than silently swallowing.