### PR TITLE
use real location hierarchy in ICDS dashboard tests

### DIFF
--- a/custom/icds_reports/tests/__init__.py
+++ b/custom/icds_reports/tests/__init__.py
@@ -134,6 +134,32 @@ def setUpModule():
         }
     )
 
+    district_location_type = LocationType.objects.create(
+        domain=domain.name,
+        name='district',
+        parent_type=state_location_type,
+    )
+    d1 = SQLLocation.objects.create(
+        domain=domain.name,
+        name='d1',
+        location_id='d1',
+        location_type=district_location_type,
+        parent=st1
+    )
+
+    block_location_type = LocationType.objects.create(
+        domain=domain.name,
+        name='block',
+        parent_type=district_location_type,
+    )
+    b1 = SQLLocation.objects.create(
+        domain=domain.name,
+        name='b1',
+        location_id='b1',
+        location_type=block_location_type,
+        parent=d1
+    )
+
     supervisor_location_type = LocationType.objects.create(
         domain=domain.name,
         name='supervisor',
@@ -144,31 +170,20 @@ def setUpModule():
         name='s1',
         location_id='s1',
         location_type=supervisor_location_type,
-        parent=st1
-    )
-
-    block_location_type = LocationType.objects.create(
-        domain=domain.name,
-        name='block',
-        parent_type=supervisor_location_type,
-    )
-    b1 = SQLLocation.objects.create(
-        domain=domain.name,
-        name='b1',
-        location_id='b1',
-        location_type=block_location_type,
-        parent=s1
+        parent=b1,
     )
 
     awc_location_type = LocationType.objects.create(
         domain=domain.name,
         name='awc',
+        parent_type=supervisor_location_type,
     )
     a7 = SQLLocation.objects.create(
         domain=domain.name,
         name='a7',
         location_id='a7',
-        location_type=awc_location_type
+        location_type=awc_location_type,
+        parent=s1,
     )
 
     with override_settings(SERVER_ENVIRONMENT='icds'):

--- a/custom/icds_reports/tests/test_export_data.py
+++ b/custom/icds_reports/tests/test_export_data.py
@@ -15,6 +15,7 @@ from custom.icds_reports.sqldata.exports.system_usage import SystemUsageExport
 from custom.icds_reports.reports.incentive import IncentiveReport
 from custom.icds_reports.reports.take_home_ration import TakeHomeRationExport
 
+
 class TestExportData(TestCase):
     maxDiff = None
 
@@ -59,8 +60,8 @@ class TestExportData(TestCase):
                         'State',
                         'st1'],
                     [
-                        'Supervisor',
-                        's1'],
+                        'District',
+                        'd1'],
                     [
                         "Block",
                         "b1"
@@ -543,7 +544,7 @@ class TestExportData(TestCase):
                     [
                         ['Generated at', '16:21:11 15 November 2017'],
                         ['State', 'st1'],
-                        ['Supervisor', 's1'],
+                        ['District', 'd1'],
                         ['Block', 'b1']
                     ]
                 ]
@@ -680,7 +681,7 @@ class TestExportData(TestCase):
                 ['Export Info', [
                     ['Generated at', '16:21:11 15 November 2017'],
                     ['State', 'st1'],
-                    ['Supervisor', 's1'],
+                    ['District', 'd1'],
                     ['Block', 'b1'],
                     ['Month', 'May'],
                     ['Year', 2017]
@@ -776,7 +777,7 @@ class TestExportData(TestCase):
                 ['Export Info', [
                     ['Generated at', '16:21:11 15 November 2017'],
                     ['State', 'st1'],
-                    ['Supervisor', 's1'],
+                    ['District', 'd1'],
                     ['Block', 'b1'],
                     ['Grouped By', 'AWC'],
                     ['Month', 'May'],
@@ -1097,8 +1098,8 @@ class TestExportData(TestCase):
                             'st1'
                         ],
                         [
-                            'Supervisor',
-                            's1'
+                            'District',
+                            'd1'
                         ],
                         [
                             "Block",
@@ -2081,6 +2082,22 @@ class TestExportData(TestCase):
                             "16:21:11 15 November 2017"
                         ],
                         [
+                            'State',
+                            'st1'
+                        ],
+                        [
+                            'District',
+                            'd1'
+                        ],
+                        [
+                            'Block',
+                            'b1'
+                        ],
+                        [
+                            'Supervisor',
+                            's1'
+                        ],
+                        [
                             "Awc",
                             "a7"
                         ],
@@ -2292,7 +2309,7 @@ class TestExportData(TestCase):
              ['Export Info', [
                  ['Generated at', india_now()],
                  ['State', 'st1'],
-                 ['Supervisor', 's1'],
+                 ['District', 'd1'],
                  ['Block', 'b1'],
                  ['Month', 'May'],
                  ['Year', 2017]]


### PR DESCRIPTION
##### SUMMARY

This switches tests to use the same location hierarchy as the production environment. Which should hopefully make things a bit more consistent in our test setup and pave the way for future cleanup.
