### PR TITLE
Add "rewind" feature to couch to SQL forms iteration

### DIFF
--- a/corehq/apps/couch_sql_migration/asyncforms.py
+++ b/corehq/apps/couch_sql_migration/asyncforms.py
@@ -30,8 +30,8 @@ class AsyncFormProcessor(object):
     def __enter__(self):
         self.pool = Pool(POOL_SIZE)
         self.queues = PartiallyLockingQueue()
-        form_ids = self.statedb.pop_resume_state(type(self).__name__, [])
-        self._rebuild_queues(form_ids)
+        with self.statedb.pop_resume_state(type(self).__name__, []) as form_ids:
+            self._rebuild_queues(form_ids)
         self.stop_status_logger = run_status_logger(
             log_status,
             self.queues.get_status,

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -285,7 +285,7 @@ class CaseDiffQueue(object):
         if "num_diffed_cases" in state:
             self.num_diffed_cases = state["num_diffed_cases"]
         if "to_diff" in state:
-            for case_id in state["to_diff"]:
+            for case_id in set(state["to_diff"]):
                 self.enqueue(case_id)
         if "pending" in state:
             for chunk in chunked(state["pending"].items(), self.BATCH_SIZE, list):

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -99,6 +99,7 @@ class CaseDiffQueue(object):
         try:
             if exc_type is None:
                 self.process_remaining_diffs()
+            log.info("preparing to save resume state... DO NOT BREAK!")
         finally:
             self._save_resume_state()
             self._stop_status_logger()

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -90,7 +90,8 @@ class CaseDiffQueue(object):
 
     def __enter__(self):
         self.statedb.set(ProcessNotAllowed.__name__, True)
-        self._load_resume_state()
+        with self.statedb.pop_resume_state(type(self).__name__, {}) as state:
+            self._load_resume_state(state)
         self._stop_status_logger = run_status_logger(
             log_status, self.get_status, self.status_interval)
         return self
@@ -283,8 +284,7 @@ class CaseDiffQueue(object):
         }
         log.info("saved %s state: %s", type(self).__name__, log_state)
 
-    def _load_resume_state(self):
-        state = self.statedb.pop_resume_state(type(self).__name__, {})
+    def _load_resume_state(self, state):
         if "num_diffed_cases" in state:
             self.num_diffed_cases = state["num_diffed_cases"]
         if "to_diff" in state:

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -303,7 +303,12 @@ class CaseDiffQueue(object):
             ),
             "cached": "%s/%s" % tuple(cache_hits),
             "loaded": (
-                len(self.cases) + sum(len(batch) for batch in self.diff_batcher)
+                len(self.cases)
+                + sum(len(batch) for batch in self.diff_batcher)
+                # subtract diff_spawner jobs because it blocks until
+                # diff_batcher starts the job; during that time
+                # batches will appear in both
+                - sum(len(batch) for batch in self.diff_spawner)
             ),
             "diffed": self.num_diffed_cases,
         }

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -403,7 +403,7 @@ class BatchProcessor(object):
                 if self._should_retry(key):
                     log.warn("retrying batch on error: %s: %s",
                         type(err).__name__, err)
-                    self._process_batch(process, key)
+                    gevent.spawn(self._process_batch, process, key)
                 else:
                     log.exception("batch processing error: %s: %s",
                         type(err).__name__, err)

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -653,7 +653,8 @@ def diff_ledgers(case_ids, statedb):
     }
     for ledger_value in LedgerAccessorSQL.get_ledger_values_for_cases(case_ids):
         couch_state = couch_state_map.get(ledger_value.ledger_reference, None)
-        diffs = json_diff(couch_state.to_json(), ledger_value.to_json(), track_list_indices=False)
+        couch_json = couch_state.to_json() if couch_state is not None else {}
+        diffs = json_diff(couch_json, ledger_value.to_json(), track_list_indices=False)
         statedb.add_diffs(
             'stock state', ledger_value.ledger_reference.as_id(),
             filter_ledger_diffs(diffs)

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -695,11 +695,10 @@ class Stopper:
 
     def __exit__(self, exc_type, exc, tb):
         signal.signal(signal.SIGINT, signal.default_int_handler)
-        if self.clean_break:
-            # raise keyboard interrupt to signal early termination to
-            # __exit__ and exception handlers further up the stack
-            # (CaseDiffQueue will not diff cases with unprocessed forms)
-            raise KeyboardInterrupt
+        # the case diff queue can safely be stopped with ^C at this
+        # point, although proceed with care so as not to interrupt it at
+        # a point where it is saving resume state. There will be a log
+        # message indicating "DO NOT BREAK" just before it saves state.
 
     def on_break(self, signum, frame):
         if self.clean_break:

--- a/corehq/apps/couch_sql_migration/rewind.py
+++ b/corehq/apps/couch_sql_migration/rewind.py
@@ -1,0 +1,130 @@
+import logging
+import re
+import sys
+from datetime import datetime, timedelta
+
+import attr
+
+from couchforms.models import XFormInstance
+
+from corehq.util.couch_helpers import NoSkipArgsProvider
+from corehq.util.pagination import ResumableFunctionIterator
+
+from .asyncforms import get_case_ids
+
+log = logging.getLogger(__name__)
+
+
+def rewind_iteration_state(statedb, domain, move_to):
+    doc_type = "XFormInstance"
+    status_interval = timedelta(minutes=1)
+    next_status = datetime.utcnow() - status_interval
+    rw = Rewinder(statedb, domain, doc_type, move_to)
+    if rw.offset:
+        offset = rw.offset
+        for n, item in enumerate(rw, start=1):
+            if n > offset:
+                rw.save_state(item)
+                break
+            if datetime.utcnow() > next_status:
+                log.info("scanned %s docs", n)
+                next_status = datetime.utcnow() + status_interval
+
+
+@attr.s
+class Rewinder:
+    statedb = attr.ib()
+    domain = attr.ib()
+    doc_type = attr.ib()
+    move_to = attr.ib()
+
+    def __attrs_post_init__(self):
+        for method, regex in [
+            ("case_rewind", r"^case-(\d+)$"),
+            ("resume_rewind", r"^resume-"),
+        ]:
+            match = re.search(regex, self.move_to)
+            if match:
+                getattr(self, method)(match)
+                break
+        else:
+            raise NotImplementedError(self.move_to)
+        migration_id = self.statedb.unique_id
+        resume_key = "%s.%s.%s" % (self.domain, self.doc_type, migration_id)
+        self.itr = ResumableFunctionIterator(resume_key, None, None, None)
+
+    def resume_rewind(self, match):
+        self.offset = None
+        new_state = self.statedb.get(self.move_to)
+        if new_state is None:
+            sys.exit(1, "resume state not found")
+        old_state = self.itr.state
+        self._save_resume_state(old_state.to_json())
+        log.info("restoring iteration state: %s", new_state)
+        self.itr._save_state_json(new_state)
+
+    def case_rewind(self, match):
+        self.offset = int(match.group(1))
+
+    def __iter__(self):
+        def data_function(**view_kwargs):
+            return couch_db.view('by_domain_doc_type_date/view', **view_kwargs)
+
+        log.info("preparing to rewind: %s", self.move_to)
+        state_json = self.itr.state.to_json()
+        self._save_resume_state(state_json)
+        couch_db = XFormInstance.get_db()
+        args_provider = NoSkipArgsProvider({
+            'startkey': state_json["kwargs"]["startkey"],
+            'startkey_docid': state_json["kwargs"]["startkey_docid"],
+            'endkey': [self.domain, self.doc_type],
+            'descending': True,
+            'limit': 1000,
+            'include_docs': True,
+            'reduce': False,
+        })
+        args, kwargs = args_provider.get_initial_args()
+        while True:
+            results = list(data_function(*args, **kwargs))
+            results = args_provider.adjust_results(results, args, kwargs)
+            if not results:
+                break
+            for result in results:
+                yield from iter_case_items(result["doc"])
+            try:
+                args, kwargs = args_provider.get_next_args(results[-1], *args, **kwargs)
+            except StopIteration:
+                break
+
+    def save_state(self, item):
+        state = self.itr.state
+        startkey = state.kwargs["startkey"]
+        assert len(startkey) == 3, startkey
+        startkey[-1] = item.form.received_on
+        assert state.kwargs["startkey"] is startkey, (state.kwargs, startkey)
+        state.kwargs.pop("startkey_docid")
+        state.timestamp = datetime.utcnow()
+        self._save_resume_state(state.to_json())
+
+    def _save_resume_state(self, state_json):
+        assert isinstance(state_json, dict), state_json
+        key = f"resume-{state_json['timestamp']}"
+        log.info("saving resume state. restore with: rewind --to=%s\n%s",
+                 key, state_json)
+        old = self.statedb.get(key)
+        if old is None:
+            self.statedb.set(key, state_json)
+        elif old != state_json:
+            log.warn("NOT SAVED! refusing to overwrite:\n%s", old)
+
+
+def iter_case_items(doc):
+    form = XFormInstance.wrap(doc)
+    for case_id in get_case_ids(form):
+        yield CaseItem(form, case_id)
+
+
+@attr.s
+class CaseItem:
+    form = attr.ib()
+    case_id = attr.ib()

--- a/corehq/apps/couch_sql_migration/rewind.py
+++ b/corehq/apps/couch_sql_migration/rewind.py
@@ -50,6 +50,9 @@ class Rewinder:
     move_to = attr.ib()
 
     def __attrs_post_init__(self):
+        migration_id = self.statedb.unique_id
+        resume_key = "%s.%s.%s" % (self.domain, self.doc_type, migration_id)
+        self.itr = ResumableFunctionIterator(resume_key, None, None, None)
         for method, regex in [
             ("case_rewind", r"^case-(\d+)$"),
             ("resume_rewind", r"^resume-"),
@@ -60,9 +63,6 @@ class Rewinder:
                 break
         else:
             raise NotImplementedError(self.move_to)
-        migration_id = self.statedb.unique_id
-        resume_key = "%s.%s.%s" % (self.domain, self.doc_type, migration_id)
-        self.itr = ResumableFunctionIterator(resume_key, None, None, None)
 
     def resume_rewind(self, match):
         self.offset = None

--- a/corehq/apps/couch_sql_migration/rewind.py
+++ b/corehq/apps/couch_sql_migration/rewind.py
@@ -126,6 +126,7 @@ class Rewinder:
                  key, state_json)
         old = self.statedb.get(key)
         if old is None:
+            log.info("saved.")
             self.statedb.set(key, state_json)
         elif old != state_json:
             log.warn("NOT SAVED! refusing to overwrite:\n%s", old)

--- a/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
+++ b/corehq/apps/couch_sql_migration/tests/test_asyncforms.py
@@ -29,8 +29,8 @@ class TestAsyncFormProcessor(SimpleTestCase):
             # pool.spawn(...) will block in _finish_processing_queues
 
         self.assertEqual(migrated, forms)
-        unprocessed = statedb.pop_resume_state(type(queue).__name__, None)
-        self.assertEqual(unprocessed, [])
+        with statedb.pop_resume_state(type(queue).__name__, None) as unprocessed:
+            self.assertEqual(unprocessed, [])
 
 
 class TestLockingQueues(SimpleTestCase):

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -481,9 +481,9 @@ class FakeCaseDiffQueue(object):
         self.stats = {"pending": 0, "cached": "0/0", "loaded": 0, "diffed": 0}
 
     def __enter__(self):
-        state = self.statedb.pop_resume_state(type(self).__name__, {})
-        if "stats" in state:
-            self.stats = state["stats"]
+        with self.statedb.pop_resume_state(type(self).__name__, {}) as state:
+            if "stats" in state:
+                self.stats = state["stats"]
         return self
 
     def __exit__(self, *exc_info):

--- a/corehq/apps/tzmigration/planning.py
+++ b/corehq/apps/tzmigration/planning.py
@@ -89,6 +89,7 @@ class BaseDB(object):
         def connect():
             return sqlite3.connect(f"file:{db_filepath}{mode}", uri=True)
         mode = "?mode=ro" if readonly else ""
+        self.readonly = readonly
         self.db_filepath = db_filepath
         self.engine = create_engine("sqlite://", creator=connect)
         self.Session = sessionmaker(bind=self.engine)

--- a/corehq/util/pagination.py
+++ b/corehq/util/pagination.py
@@ -336,6 +336,10 @@ class ResumableFunctionIterator(object):
     def _save_state(self):
         self.state.timestamp = datetime.utcnow()
         state_json = self.state.to_json()
+        self._save_state_json(state_json)
+        self._state = ResumableIteratorState(state_json)
+
+    def _save_state_json(self, state_json):
         for x in range(5):
             try:
                 self.couch_db.save_doc(state_json)
@@ -345,7 +349,6 @@ class ResumableFunctionIterator(object):
                     continue
                 raise
             break
-        self._state = ResumableIteratorState(state_json)
 
     def discard_state(self):
         try:


### PR DESCRIPTION
Add a new feature making it possible to rewind the main forms iteration state so it can be resumed from an earlier point. This makes it possible to diff forms or cases that were processed, but then the resume state was lost due to a crash.

Also fix a few errors found along the way. Notably https://github.com/dimagi/commcare-hq/commit/e25326ac29f38ccce24f23eafd4540beab526a64: errors encountered while loading resume state should no longer cause that state to be lost.

🐡 Review by commit.