### PR TITLE
Fetch param from GET data, not POST

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -119,7 +119,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             submit_ip=couchforms.get_submit_ip(request),
             last_sync_token=couchforms.get_last_sync_token(request),
             openrosa_headers=couchforms.get_openrosa_headers(request),
-            force_logs=bool(request.POST.get('force_logs', False)),
+            force_logs=bool(request.GET.get('force_logs', False)),
         )
 
         try:


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-716
Just like the title says.  I thought this parameter would be sent as POST data, but that was incorrect.