### PR TITLE
use celery not gevent for mbt

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -10,7 +10,7 @@ from custom.icds_reports.tasks import (
     _aggregate_child_health_thr_forms, _aggregate_ccs_record_thr_forms, _aggregate_child_health_pnc_forms,
     _aggregate_ccs_record_pnc_forms, _aggregate_delivery_forms, _aggregate_bp_forms,
     _aggregate_awc_infra_forms, _agg_ls_awc_mgt_form, _agg_ls_vhnd_form,
-    _agg_beneficiary_form, create_mbt_for_month, setup_aggregation, _agg_ls_table,
+    _agg_beneficiary_form, create_all_mbt, setup_aggregation, _agg_ls_table,
     _update_months_table, _daily_attendance_table, _agg_child_health_table,
     _ccs_record_monthly_table, _agg_ccs_record_table, _agg_awc_table,
     aggregate_awc_daily, _child_health_monthly_aggregation
@@ -32,11 +32,11 @@ STATE_TASKS = {
     'agg_ls_awc_mgt_form': _agg_ls_awc_mgt_form,
     'agg_ls_vhnd_form': _agg_ls_vhnd_form,
     'agg_beneficiary_form': _agg_beneficiary_form,
-    'create_mbt_for_month': create_mbt_for_month
 }
 
 ALL_STATES_TASKS = {
     'child_health_monthly': _child_health_monthly_aggregation,
+    'create_mbt_for_month': create_all_mbt,
 }
 
 NORMAL_TASKS = {

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -1247,6 +1247,11 @@ def build_incentive_files(location, month, file_format, aggregation_level, state
         create_excel_file(excel_data, data_type, file_format, blob_key, timeout=None)
 
 
+def create_all_mbt(month, state_ids):
+    for state_id in state_ids:
+        create_mbt_for_month.delay(state_id, month)
+
+
 @task(queue='icds_dashboard_reports_queue')
 def create_mbt_for_month(state_id, month, force_citus=False):
     with force_citus_engine(force_citus):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
You apparently cant use copy with gevent in psycopg. When we switched gevent to bubble up errors this came to light and likely has been failing for a while. This switches it back to being run on celery. Not ideal, but the only way to make it parallel without gevent that I could figure out