### PR TITLE
cap thr values

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/thr_forms_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/thr_forms_child_health.py
@@ -44,7 +44,7 @@ class THRFormsChildHealthAggregationDistributedHelper(BaseICDSAggregationDistrib
             %(month)s AS month,
             child_health_case_id AS case_id,
             MAX(timeend) over w AS latest_time_end_processed,
-            SUM(days_ration_given_child) over w AS days_ration_given_child
+            CASE WHEN SUM(days_ration_given_child) over w < 32767 THEN SUM(days_ration_given_child) over w ELSE 32767 END AS days_ration_given_child
           FROM "{ucr_tablename}"
           WHERE state_id = %(state_id)s AND
                 timeend >= %(current_month_start)s AND timeend < %(next_month_start)s AND

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/thr-forms-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/thr-forms-child-health.distributed.txt
@@ -10,7 +10,7 @@ DELETE FROM "icds_dashboard_child_health_thr_forms" WHERE month=%(month)s AND st
             %(month)s AS month,
             child_health_case_id AS case_id,
             MAX(timeend) over w AS latest_time_end_processed,
-            SUM(days_ration_given_child) over w AS days_ration_given_child
+            CASE WHEN SUM(days_ration_given_child) over w < 32767 THEN SUM(days_ration_given_child ELSE 32767 END AS days_ration_given_child
           FROM "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea"
           WHERE state_id = %(state_id)s AND
                 timeend >= %(current_month_start)s AND timeend < %(next_month_start)s AND

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/thr-forms-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/thr-forms-child-health.distributed.txt
@@ -10,7 +10,7 @@ DELETE FROM "icds_dashboard_child_health_thr_forms" WHERE month=%(month)s AND st
             %(month)s AS month,
             child_health_case_id AS case_id,
             MAX(timeend) over w AS latest_time_end_processed,
-            CASE WHEN SUM(days_ration_given_child) over w < 32767 THEN SUM(days_ration_given_child ELSE 32767 END AS days_ration_given_child
+            CASE WHEN SUM(days_ration_given_child) over w < 32767 THEN SUM(days_ration_given_child) over w ELSE 32767 END AS days_ration_given_child
           FROM "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea"
           WHERE state_id = %(state_id)s AND
                 timeend >= %(current_month_start)s AND timeend < %(next_month_start)s AND


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
THRs given to an individual in a month should be between 0 and 30. Sometimes people fill out forms in very wrong ways. This makes sure if that happens that we dont overflow our smallint column.