### PR TITLE
Remove FF for metadata in UCR excel

### DIFF
--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -1,15 +1,9 @@
-from datetime import datetime
-
-from django.utils.translation import ugettext as _
-
 from memoized import memoized
 
 from couchexport.export import export_from_tables
 
 from corehq.apps.userreports.columns import get_expanded_column_config
 from corehq.apps.userreports.models import get_report_config
-from corehq.toggles import INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS
-from corehq.util.timezones.utils import get_timezone_for_domain
 
 
 def get_expanded_columns(column_configs, data_source_config):
@@ -91,15 +85,5 @@ class ReportExport(object):
                 [headers] + rows + total_rows
             ]
         ]
-
-        if INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS.enabled(self.domain):
-            time_zone = get_timezone_for_domain(self.domain)
-            export_table.append([
-                'metadata',
-                [
-                    [_('Report Name'), self.title],
-                    [_('Generated On'), datetime.now(time_zone).strftime('%Y-%m-%d %H:%M')],
-                ] + list(self._get_filter_values())
-            ])
 
         return export_table

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -503,22 +503,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             else:
                 return str(filter_value)
 
-    def _get_filter_values(self):
-        slug_to_filter = {
-            ui_filter.name: ui_filter
-            for ui_filter in self.filters
-        }
-
-        filters_without_prefilters = {
-            filter_slug: filter_value
-            for filter_slug, filter_value in self.filter_values.items()
-            if not isinstance(slug_to_filter[filter_slug], PreFilter)
-        }
-
-        for filter_slug, filter_value in filters_without_prefilters.items():
-            label = slug_to_filter[filter_slug].label
-            yield label, self._get_filter_export_format(filter_value)
-
     @property
     @memoized
     def report_export(self):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1328,13 +1328,6 @@ SORT_CALCULATION_IN_CASE_LIST = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-INCLUDE_METADATA_IN_UCR_EXCEL_EXPORTS = StaticToggle(
-    'include_metadata_in_ucr_excel_exports',
-    'Include metadata in UCR excel exports',
-    TAG_SOLUTIONS_CONDITIONAL,
-    [NAMESPACE_DOMAIN]
-)
-
 VIEW_APP_CHANGES = StaticToggle(
     'app-changes-with-improved-diff',
     'Improved app changes view',


### PR DESCRIPTION
##### SUMMARY
Removes a broken feature flag.

I found this while debugging some UCR exports for interrupt and thought "oh what a useful feature" except its not useful since it breaks the entire export and I'd need to enable it for the entire domain (this export happens in celery, and the user doesn't get passed into it).

Also this being solutions was a lie. It should have been enikshay/custom https://github.com/dimagi/commcare-hq/pull/14970

##### FEATURE FLAG
Include metadata in UCR excel exports

##### PRODUCT DESCRIPTION
This removes "Include metadata in UCR excel exports" which has been broken for some time (estimated for 1.5 years since https://github.com/dimagi/commcare-hq/pull/20117/)