### PR TITLE
Set mobile UCR slugs when copying app

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -444,10 +444,18 @@ def update_form_unique_ids(app_source, form_ids_by_xmlns=None):
 
 
 def update_report_module_ids(app_source):
+    """Make new report UUIDs so they stay unique
+
+    Otherwise there would be multiple reports in the restore with the same UUID
+    Set the report slug to the old UUID so any xpath expressions referencing
+    the report by ID continue to work, if only in mobile UCR v2
+    """
     app_source = deepcopy(app_source)
     for module in app_source['modules']:
         if module['module_type'] == 'report':
             for config in module['report_configs']:
+                if not config.get('report_slug'):
+                    config['report_slug'] = config['uuid']
                 config['uuid'] = uuid.uuid4().hex
     return app_source
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-778

##### SUMMARY
When copying apps with mobile UCRs, the report config UUIDs are updated automatically to prevent report ID conflicts in the restore.  The drawback of this is that any xpath references to those config IDs will break with this change.  Mobile UCRv2 allows you to use cusom aliases in your expressions rather than hardcoding that UUID everywhere:
![image](https://user-images.githubusercontent.com/2367539/65550257-36d42900-deed-11e9-88fe-dc75c5bb11ac.png)
Using aliases is a great workaround to this issue, since the aliases don't need to change.  For any report configs that _don't_ have a custom alias defined, this PR will set the alias to the original ID when the app is copied, so existing references will continue to work.

##### FEATURE FLAG
Mobile UCR

##### PRODUCT DESCRIPTION
See summary
