### PR TITLE
Add explicit known_first_party in case that is affecting stickler

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,5 @@ include_trailing_comma=true
 
 known_django=django
 known_exsubmodules=auditcare,casexml,couchexport,couchforms,dimagi,fluff,phonelog,pillow_retry,pillowtop,soil,toggle
+known_first_party=corehq,custom
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,EXSUBMODULES,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
This is just a change to the .isort.cfg that affects stickler errors