### PR TITLE
Search for billing accounts in Trigger Customer Invoice view

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -237,7 +237,7 @@ class Select2InvoiceTriggerHandler(BaseSelect2AsyncHandler):
         domain_names = [domain['key'] for domain in Domain.get_all(include_docs=False)]
         if self.search_string:
             search_string = self.search_string.lower()
-            domain_names = [x for x in domain_names if x.lower().startswith(search_string)]
+            domain_names = [x for x in domain_names if search_string in x.lower()]
         return [(d, d) for d in domain_names]
 
 
@@ -252,7 +252,7 @@ class Select2CustomerInvoiceTriggerHandler(BaseSelect2AsyncHandler):
         accounts = BillingAccount.objects.filter(is_customer_billing_account=True).values_list('name', flat=True)
         if self.search_string:
             search_string = self.search_string.lower()
-            accounts = [x for x in accounts if x.lower().startswith(search_string)]
+            accounts = [x for x in accounts if search_string in x.lower()]
         return [(n, n) for n in accounts]
 
 

--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -250,7 +250,7 @@ class Select2CustomerInvoiceTriggerHandler(BaseSelect2AsyncHandler):
     @property
     def customer_account_response(self):
         accounts = BillingAccount.objects.filter(is_customer_billing_account=True).values_list('name', flat=True)
-        if self. search_string:
+        if self.search_string:
             search_string = self.search_string.lower()
             accounts = [x for x in accounts if x.lower().startswith(search_string)]
         return [(n, n) for n in accounts]

--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -250,6 +250,9 @@ class Select2CustomerInvoiceTriggerHandler(BaseSelect2AsyncHandler):
     @property
     def customer_account_response(self):
         accounts = BillingAccount.objects.filter(is_customer_billing_account=True).values_list('name', flat=True)
+        if self. search_string:
+            search_string = self.search_string.lower()
+            accounts = [x for x in accounts if x.lower().startswith(search_string)]
         return [(n, n) for n in accounts]
 
 


### PR DESCRIPTION
##### SUMMARY
The billing account search bar on the [Trigger Customer Invoice page](https://www.commcarehq.org/hq/accounting/trigger_customer_invoice/) isn't actually capable of searching through accounts. I've modeled the `Select2CustomerInvoiceTriggerHandler` search functionality after the handler in the [Trigger Invoice page](https://www.commcarehq.org/hq/accounting/trigger_invoice/) page to fix this issue.

##### FEATURE FLAG

##### PRODUCT DESCRIPTION