### PR TITLE
Test errors in pillow process

### DIFF
--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -39,6 +39,7 @@ class CasePillowTest(TestCase):
         ensure_index_deleted(CASE_INDEX_INFO.index)
         ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
         FormProcessorTestUtils.delete_all_cases_forms_ledgers(self.domain)
+        PillowError.objects.all().delete()
         super(CasePillowTest, self).tearDown()
 
     @run_with_all_backends
@@ -55,7 +56,7 @@ class CasePillowTest(TestCase):
 
     @run_with_all_backends
     def test_case_pillow_error_in_case_es(self):
-        pillow_errors = PillowError.objects.filter(pillow='case-pillow').count()
+        self.assertEqual(0, PillowError.objects.filter(pillow='case-pillow').count())
         with patch('corehq.pillows.case_search.domain_needs_search_index', return_value=True):
             with patch('corehq.pillows.case.transform_case_for_elasticsearch') as transform_patch:
                 transform_patch.side_effect = Exception()
@@ -69,7 +70,7 @@ class CasePillowTest(TestCase):
         results = CaseES().run()
         self.assertEqual(0, results.total)
 
-        self.assertEqual(pillow_errors + 1, PillowError.objects.filter(pillow='case-pillow').count())
+        self.assertEqual(1, PillowError.objects.filter(pillow='case-pillow').count())
 
     @run_with_all_backends
     def test_case_soft_deletion(self):

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -17,7 +17,7 @@ from corehq.form_processor.tests.utils import (
 )
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
-from corehq.util.elastic import ensure_index_deleted
+from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import create_and_save_a_case, trap_extra_setup
 from testapps.test_pillowtop.utils import process_pillow_changes
 
@@ -34,6 +34,8 @@ class CasePillowTest(TestCase):
             self.elasticsearch = get_es_new()
             initialize_index_and_mapping(self.elasticsearch, CASE_INDEX_INFO)
             initialize_index_and_mapping(self.elasticsearch, CASE_SEARCH_INDEX_INFO)
+        delete_es_index(CASE_INDEX_INFO.index)
+        delete_es_index(CASE_SEARCH_INDEX_INFO.index)
 
     def tearDown(self):
         ensure_index_deleted(CASE_INDEX_INFO.index)

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -1,39 +1,43 @@
-from django.test import TestCase
 import uuid
+from unittest.mock import patch
+
+from django.test import TestCase
 
 from elasticsearch.exceptions import ConnectionError
 
-from corehq.apps.es import CaseES
+from pillow_retry.models import PillowError
+from pillowtop.es_utils import initialize_index_and_mapping
+
+from corehq.apps.es import CaseES, CaseSearchES
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import (
+    FormProcessorTestUtils,
+    run_with_all_backends,
+)
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
-from corehq.util.elastic import delete_es_index, ensure_index_deleted
-from corehq.util.test_utils import trap_extra_setup, create_and_save_a_case
-from pillowtop.es_utils import initialize_index_and_mapping
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import create_and_save_a_case, trap_extra_setup
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 
 class CasePillowTest(TestCase):
-
     domain = 'case-pillowtest-domain'
-
-    @classmethod
-    def setUpClass(cls):
-        super(CasePillowTest, cls).setUpClass()
-        cls.process_case_changes = process_pillow_changes('DefaultChangeFeedPillow')
-        cls.process_case_changes.add_pillow('case-pillow', {'skip_ucr': True})
 
     def setUp(self):
         super(CasePillowTest, self).setUp()
+        self.process_case_changes = process_pillow_changes('DefaultChangeFeedPillow')
+        self.process_case_changes.add_pillow('case-pillow', {'skip_ucr': True})
         FormProcessorTestUtils.delete_all_cases()
         with trap_extra_setup(ConnectionError):
             self.elasticsearch = get_es_new()
             initialize_index_and_mapping(self.elasticsearch, CASE_INDEX_INFO)
-        delete_es_index(CASE_INDEX_INFO.index)
+            initialize_index_and_mapping(self.elasticsearch, CASE_SEARCH_INDEX_INFO)
 
     def tearDown(self):
         ensure_index_deleted(CASE_INDEX_INFO.index)
+        ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
         FormProcessorTestUtils.delete_all_cases_forms_ledgers(self.domain)
         super(CasePillowTest, self).tearDown()
 
@@ -48,6 +52,24 @@ class CasePillowTest(TestCase):
         self.assertEqual(self.domain, case_doc['domain'])
         self.assertEqual(case_id, case_doc['_id'])
         self.assertEqual(case_name, case_doc['name'])
+
+    @run_with_all_backends
+    def test_case_pillow_error_in_case_es(self):
+        pillow_errors = PillowError.objects.filter(pillow='case-pillow').count()
+        with patch('corehq.pillows.case_search.domain_needs_search_index', return_value=True):
+            with patch('corehq.pillows.case.transform_case_for_elasticsearch') as transform_patch:
+                transform_patch.side_effect = Exception()
+                case_id, case_name = self._create_case_and_sync_to_es()
+
+        # confirm change did not make it to case search index
+        results = CaseSearchES().run()
+        self.assertEqual(0, results.total)
+
+        # confirm change did not make it to case index
+        results = CaseES().run()
+        self.assertEqual(0, results.total)
+
+        self.assertEqual(pillow_errors + 1, PillowError.objects.filter(pillow='case-pillow').count())
 
     @run_with_all_backends
     def test_case_soft_deletion(self):
@@ -72,4 +94,5 @@ class CasePillowTest(TestCase):
         with self.process_case_changes:
             create_and_save_a_case(self.domain, case_id, case_name)
         self.elasticsearch.indices.refresh(CASE_INDEX_INFO.index)
+        self.elasticsearch.indices.refresh(CASE_SEARCH_INDEX_INFO.index)
         return case_id, case_name

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -25,6 +25,12 @@ from testapps.test_pillowtop.utils import process_pillow_changes
 class CasePillowTest(TestCase):
     domain = 'case-pillowtest-domain'
 
+    @classmethod
+    def setUpClass(cls):
+        super(CasePillowTest, cls).setUpClass()
+        delete_es_index(CASE_INDEX_INFO.index)
+        delete_es_index(CASE_SEARCH_INDEX_INFO.index)
+
     def setUp(self):
         super(CasePillowTest, self).setUp()
         self.process_case_changes = process_pillow_changes('DefaultChangeFeedPillow')
@@ -34,8 +40,6 @@ class CasePillowTest(TestCase):
             self.elasticsearch = get_es_new()
             initialize_index_and_mapping(self.elasticsearch, CASE_INDEX_INFO)
             initialize_index_and_mapping(self.elasticsearch, CASE_SEARCH_INDEX_INFO)
-        delete_es_index(CASE_INDEX_INFO.index)
-        delete_es_index(CASE_SEARCH_INDEX_INFO.index)
 
     def tearDown(self):
         ensure_index_deleted(CASE_INDEX_INFO.index)

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -17,7 +17,7 @@ from corehq.form_processor.tests.utils import (
 )
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
-from corehq.util.elastic import delete_es_index, ensure_index_deleted
+from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import create_and_save_a_case, trap_extra_setup
 from testapps.test_pillowtop.utils import process_pillow_changes
 
@@ -28,8 +28,8 @@ class CasePillowTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super(CasePillowTest, cls).setUpClass()
-        delete_es_index(CASE_INDEX_INFO.index)
-        delete_es_index(CASE_SEARCH_INDEX_INFO.index)
+        ensure_index_deleted(CASE_INDEX_INFO.index)
+        ensure_index_deleted(CASE_SEARCH_INDEX_INFO.index)
 
     def setUp(self):
         super(CasePillowTest, self).setUp()


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-918

I started some automated tests for pillow errors to verify my understanding of how this works. Something that's really annoying is that errors do stop all processing. By that I mean:

* The case pillow tries to put a document in the "case" index before the "case search" index.
* If the put to case pillow has an error the case is not put in the "case search" index
* A PillowError is added so that the change should be re-queued to the pillow if an error happens anywhere in the process and that if processing is incomplete, it will be retried until it is complete

I think if those three points above are correct, it rules out the possibility of an issue being with the pillow processing code (though I believe that this could be much better tested).

Apologies for adding isort in the same commit.

