### PR TITLE
Add indexes to speed up form aggregation

### DIFF
--- a/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
@@ -278,6 +278,11 @@
       },
       "primary_key": ["supervisor_id","doc_id","repeat_iteration"]
     },
+    "sql_column_indexes": [
+      {
+        "column_ids": ["state_id", "timeend"]
+      }
+    ],
     "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
@@ -393,6 +393,9 @@
       },
       {
         "column_ids": ["state_id", "muac_grading"]
+      },
+      {
+        "column_ids": ["state_id", "timeend"]
       }
     ],
     "disable_destructive_rebuild": true


### PR DESCRIPTION
##### SUMMARY
This adds a composite index on `(state_id, timeend)` for the two slowest "stage 1" tasks in the aggregation. I think that this could/should be added to all of them, but I have not investigated very much.

Growth monitoring query: https://github.com/dimagi/commcare-hq/blob/af21e70235a810fd8804dd5e3ba5c4d510de7d49/custom/icds_reports/utils/aggregation_helpers/distributed/growth_monitoring_forms.py#L82-L83

Daily feeding form query: https://github.com/dimagi/commcare-hq/blob/af21e70235a810fd8804dd5e3ba5c4d510de7d49/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py#L54-L56

Currently I believe that these queries must load all data from these tables during every aggregation. This was not the case on the monolith because we used table inheritance with CHECK constraints to efficiently filter queries on timeend. At some point during the Citus work we decided not to do that to simplify the rollout and custom code (and if we did, we'd probably have changed it to use postgres's new native partitioning features). 

##### Rollout

These should be added concurrently before this is merged