### PR TITLE
Test FormUserAncestorLocationField, simplify metadata

### DIFF
--- a/corehq/motech/dhis2/tests/test_events_helpers.py
+++ b/corehq/motech/dhis2/tests/test_events_helpers.py
@@ -7,10 +7,10 @@ from fakecouch import FakeCouchDb
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.apps.users.models import WebUser
-from corehq.motech.dhis2.const import DHIS2_DATA_TYPE_DATE
+from corehq.motech.dhis2.const import DHIS2_DATA_TYPE_DATE, LOCATION_DHIS_ID
 from corehq.motech.dhis2.dhis2_config import Dhis2FormConfig
-from corehq.motech.dhis2.forms import Dhis2ConfigForm
 from corehq.motech.dhis2.events_helpers import get_event
+from corehq.motech.dhis2.forms import Dhis2ConfigForm
 from corehq.motech.dhis2.repeaters import Dhis2Repeater
 
 DOMAIN = "dhis2-test"
@@ -31,7 +31,8 @@ class TestDhisHandler(TestCase):
             domain=domain.name,
             name='test location',
             location_id='test_location',
-            location_type=location_type
+            location_type=location_type,
+            metadata={LOCATION_DHIS_ID: "dhis2_location_id"},
         )
 
         cls.user = WebUser.create(domain.name, 'test', 'passwordtest')
@@ -80,8 +81,8 @@ class TestDhisHandler(TestCase):
                     'external_data_type': DHIS2_DATA_TYPE_DATE
                 },
                 'org_unit_id': {
-                    'doc_type': 'ConstantString',
-                    'value': 'dhis2_location_id'
+                    'doc_type': 'FormUserAncestorLocationField',
+                    'location_field': LOCATION_DHIS_ID
                 },
                 'datavalue_maps': [
                     {

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -3,7 +3,6 @@ import doctest
 import json
 import os
 import uuid
-import warnings
 
 from django.test import SimpleTestCase, TestCase
 
@@ -41,7 +40,6 @@ from corehq.motech.openmrs.repeaters import OpenmrsRepeater
 from corehq.motech.value_source import (
     CaseTriggerInfo,
     get_case_location,
-    get_form_question_values,
 )
 from corehq.util.test_utils import TestFileMixin, _create_case
 
@@ -253,58 +251,6 @@ class GetPatientByUuidTests(SimpleTestCase):
     def test_valid_uuid(self):
         patient = get_patient_by_uuid(self.requests, uuid='c83d9989-585f-4db3-bf55-ca1d0ee7c0af')
         self.assertEqual(patient, self.patient)
-
-
-class GetFormQuestionValuesTests(SimpleTestCase):
-
-    def test_unicode_answer(self):
-        value = get_form_question_values({'form': {'foo': {'bar': 'b\u0105z'}}})
-        self.assertEqual(value, {'/data/foo/bar': 'b\u0105z'})
-
-    def test_utf8_answer(self):
-        value = get_form_question_values({'form': {'foo': {'bar': b'b\xc4\x85z'}}})
-        self.assertEqual(value, {'/data/foo/bar': b'b\xc4\x85z'})
-
-    def test_unicode_question(self):
-        value = get_form_question_values({'form': {'foo': {'b\u0105r': 'baz'}}})
-        self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
-
-    def test_utf8_question(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UnicodeWarning)
-            value = get_form_question_values({'form': {'foo': {b'b\xc4\x85r': 'baz'}}})
-        self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
-
-    def test_received_on(self):
-        value = get_form_question_values({
-            'form': {
-                'foo': {'bar': 'baz'},
-            },
-            'received_on': '2018-11-06T18:30:00.000000Z',
-        })
-        self.assertDictEqual(value, {
-            '/data/foo/bar': 'baz',
-            '/metadata/received_on': '2018-11-06T18:30:00.000000Z',
-        })
-
-    def test_metadata(self):
-        value = get_form_question_values({
-            'form': {
-                'foo': {'bar': 'baz'},
-                'meta': {
-                    'timeStart': '2018-11-06T18:00:00.000000Z',
-                    'timeEnd': '2018-11-06T18:15:00.000000Z',
-                    'spam': 'ham',
-                },
-            },
-            'received_on': '2018-11-06T18:30:00.000000Z',
-        })
-        self.assertDictEqual(value, {
-            '/data/foo/bar': 'baz',
-            '/metadata/timeStart': '2018-11-06T18:00:00.000000Z',
-            '/metadata/timeEnd': '2018-11-06T18:15:00.000000Z',
-            '/metadata/received_on': '2018-11-06T18:30:00.000000Z',
-        })
 
 
 class ExportOnlyTests(SimpleTestCase):

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -1,8 +1,10 @@
 import doctest
+import warnings
 
 from django.test import SimpleTestCase
 
 import corehq.motech.value_source
+from corehq.motech.value_source import get_form_question_values
 
 
 class DocTests(SimpleTestCase):
@@ -10,3 +12,56 @@ class DocTests(SimpleTestCase):
     def test_doctests(self):
         results = doctest.testmod(corehq.motech.value_source)
         self.assertEqual(results.failed, 0)
+
+
+class GetFormQuestionValuesTests(SimpleTestCase):
+
+    def test_unicode_answer(self):
+        value = get_form_question_values({'form': {'foo': {'bar': 'b\u0105z'}}})
+        self.assertEqual(value, {'/data/foo/bar': 'b\u0105z'})
+
+    def test_utf8_answer(self):
+        value = get_form_question_values({'form': {'foo': {'bar': b'b\xc4\x85z'}}})
+        self.assertEqual(value, {'/data/foo/bar': b'b\xc4\x85z'})
+
+    def test_unicode_question(self):
+        value = get_form_question_values({'form': {'foo': {'b\u0105r': 'baz'}}})
+        self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
+
+    def test_utf8_question(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UnicodeWarning)
+            value = get_form_question_values({'form': {'foo': {b'b\xc4\x85r': 'baz'}}})
+        self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
+
+    def test_received_on(self):
+        value = get_form_question_values({
+            'form': {
+                'foo': {'bar': 'baz'},
+            },
+            'received_on': '2018-11-06T18:30:00.000000Z',
+        })
+        self.assertDictEqual(value, {
+            '/data/foo/bar': 'baz',
+            '/metadata/received_on': '2018-11-06T18:30:00.000000Z',
+        })
+
+    def test_metadata(self):
+        value = get_form_question_values({
+            'form': {
+                'foo': {'bar': 'baz'},
+                'meta': {
+                    'timeStart': '2018-11-06T18:00:00.000000Z',
+                    'timeEnd': '2018-11-06T18:15:00.000000Z',
+                    'spam': 'ham',
+                },
+            },
+            'received_on': '2018-11-06T18:30:00.000000Z',
+        })
+        self.assertDictEqual(value, {
+            '/data/foo/bar': 'baz',
+            '/metadata/timeStart': '2018-11-06T18:00:00.000000Z',
+            '/metadata/timeEnd': '2018-11-06T18:15:00.000000Z',
+            '/metadata/spam': 'ham',
+            '/metadata/received_on': '2018-11-06T18:30:00.000000Z',
+        })

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -290,6 +290,7 @@ class FormUserAncestorLocationField(ValueSource):
     where the metadata value is set.
     """
     location_field = StringProperty()
+
     def _get_commcare_value(self, case_trigger_info):
         user_id = case_trigger_info.form_question_values.get('/metadata/userID')
         location = get_owner_location(case_trigger_info.domain, user_id)
@@ -335,12 +336,7 @@ def get_form_question_values(form_json):
 
     metadata = {}
     if 'meta' in form_json[TAG_FORM]:
-        if 'timeStart' in form_json[TAG_FORM][TAG_META]:
-            metadata['timeStart'] = form_json[TAG_FORM][TAG_META]['timeStart']
-        if 'timeEnd' in form_json[TAG_FORM][TAG_META]:
-            metadata['timeEnd'] = form_json[TAG_FORM][TAG_META]['timeEnd']
-        if 'userID' in form_json[TAG_FORM][TAG_META]:
-            metadata['userID'] = form_json[TAG_FORM][TAG_META]
+        metadata.update(form_json[TAG_FORM][TAG_META])
     if 'received_on' in form_json:
         metadata['received_on'] = form_json['received_on']
     if metadata:


### PR DESCRIPTION
##### SUMMARY
Modifies a test to test FormUserAncestorLocationField. Simplifies the way form metadata is added to CaseTriggerInfo.form_question_values
