### PR TITLE
Remove domain design doc from irrelevant couch dbs

### DIFF
--- a/corehq/apps/domain/__init__.py
+++ b/corehq/apps/domain/__init__.py
@@ -1,13 +1,2 @@
-from django.conf import settings
-
-from corehq.preindex import ExtraPreindexPlugin
-
-ExtraPreindexPlugin.register('domain', __file__, (
-    settings.NEW_DOMAINS_DB,
-    settings.NEW_USERS_GROUPS_DB,
-    settings.NEW_FIXTURES_DB,
-    'meta',
-))
-
 SHARED_DOMAIN = "<shared>"
 UNKNOWN_DOMAIN = "<unknown>"


### PR DESCRIPTION
##### SUMMARY
It used to contain views that were relevant to users, fixtures, and meta dbs,
but these have since been removed. Currently all views in the domain design doc
emit absolutely nothing in those domains
