### PR TITLE
Optimize daily feeding form aggregation

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -18,7 +18,6 @@ from custom.icds_reports.tasks import (
 
 STATE_TASKS = {
     'aggregate_gm_forms': _aggregate_gm_forms,
-    'aggregate_df_forms': _aggregate_df_forms,
     'aggregate_cf_forms': _aggregate_cf_forms,
     'aggregate_ccs_cf_forms': _aggregate_ccs_cf_forms,
     'aggregate_child_health_thr_forms': _aggregate_child_health_thr_forms,
@@ -48,6 +47,7 @@ NORMAL_TASKS = {
     'agg_ccs_record': _agg_ccs_record_table,
     'agg_awc_table': _agg_awc_table,
     'aggregate_awc_daily': aggregate_awc_daily,
+    'aggregate_df_forms': _aggregate_df_forms,
 }
 
 

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -374,6 +374,7 @@ def icds_aggregation_task(self, date, func_name, force_citus=False):
             '_agg_ls_table': _agg_ls_table,
             '_update_months_table': _update_months_table,
             '_daily_attendance_table': _daily_attendance_table,
+            '_aggregate_df_forms': _aggregate_df_forms,
             '_agg_child_health_table': _agg_child_health_table,
             '_ccs_record_monthly_table': _ccs_record_monthly_table,
             '_agg_ccs_record_table': _agg_ccs_record_table,
@@ -467,7 +468,7 @@ def _aggregate_gm_forms(state_id, day):
 
 @track_time
 def _aggregate_df_forms(day):
-    AggregateChildHealthDailyFeedingForms.aggregate(day)
+    AggregateChildHealthDailyFeedingForms.aggregate(force_to_date(day))
 
 
 @track_time

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -206,8 +206,9 @@ def move_ucr_data_into_aggregation_tables(date=None, intervals=2, force_citus=Fa
                     for state_id in state_ids
                 ]
                 stage_1_tasks.extend([
-                    icds_state_aggregation_task.si(state_id=state_id, date=monthly_date, func_name='_aggregate_df_forms', force_citus=force_citus)
-                    for state_id in state_ids
+                    icds_aggregation_task.si(
+                        date=calculation_date, func_name='_aggregate_df_forms', force_citus=force_citus
+                    )
                 ])
                 stage_1_tasks.extend([
                     icds_state_aggregation_task.si(state_id=state_id, date=monthly_date, func_name='_aggregate_cf_forms', force_citus=force_citus)
@@ -408,7 +409,6 @@ def icds_state_aggregation_task(self, state_id, date, func_name, force_citus=Fal
     with force_citus_engine(force_citus):
         func = {
             '_aggregate_gm_forms': _aggregate_gm_forms,
-            '_aggregate_df_forms': _aggregate_df_forms,
             '_aggregate_cf_forms': _aggregate_cf_forms,
             '_aggregate_ccs_cf_forms': _aggregate_ccs_cf_forms,
             '_aggregate_child_health_thr_forms': _aggregate_child_health_thr_forms,
@@ -466,8 +466,8 @@ def _aggregate_gm_forms(state_id, day):
 
 
 @track_time
-def _aggregate_df_forms(state_id, day):
-    AggregateChildHealthDailyFeedingForms.aggregate(state_id, day)
+def _aggregate_df_forms(day):
+    AggregateChildHealthDailyFeedingForms.aggregate(day)
 
 
 @track_time

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
@@ -19,17 +19,16 @@ class DailyFeedingFormsChildHealthAggregationDistributedHelper(BaseICDSAggregati
         self.month = transform_day_to_month(month)
 
     def aggregate(self, cursor):
-        drop_query, drop_params = self.drop_table_query()
         agg_query, agg_params = self.aggregation_query()
 
-        cursor.execute(drop_query, drop_params)
-        cursor.execute(agg_query, agg_params)
-
-    def drop_table_query(self):
-        return (
+        cursor.execute(
             f'DELETE FROM "{self.tablename}" WHERE month=%(month)s',
             {'month': month_formatter(self.month)}
         )
+        cursor.execute(agg_query, agg_params)
+
+    def drop_table_query(self):
+        raise NotImplementedError
 
     def aggregation_query(self):
         current_month_start = month_formatter(self.month)

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
@@ -1,13 +1,22 @@
 from dateutil.relativedelta import relativedelta
+
 from custom.icds_reports.const import AGG_DAILY_FEEDING_TABLE
-from custom.icds_reports.utils.aggregation_helpers import month_formatter
-from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
+from custom.icds_reports.utils.aggregation_helpers import (
+    month_formatter,
+    transform_day_to_month,
+)
+from custom.icds_reports.utils.aggregation_helpers.distributed.base import (
+    BaseICDSAggregationDistributedHelper,
+)
 
 
 class DailyFeedingFormsChildHealthAggregationDistributedHelper(BaseICDSAggregationDistributedHelper):
     helper_key = 'daily-feeding-forms-child-health'
     ucr_data_source_id = 'dashboard_child_health_daily_feeding_forms'
     tablename = AGG_DAILY_FEEDING_TABLE
+
+    def __init__(self, month):
+        self.month = transform_day_to_month(month)
 
     def aggregate(self, cursor):
         drop_query, drop_params = self.drop_table_query()
@@ -18,8 +27,8 @@ class DailyFeedingFormsChildHealthAggregationDistributedHelper(BaseICDSAggregati
 
     def drop_table_query(self):
         return (
-            'DELETE FROM "{}" WHERE month=%(month)s AND state_id = %(state)s'.format(self.tablename),
-            {'month': month_formatter(self.month), 'state': self.state_id}
+            f'DELETE FROM "{self.tablename}" WHERE month=%(month)s',
+            {'month': month_formatter(self.month)}
         )
 
     def aggregation_query(self):
@@ -28,35 +37,30 @@ class DailyFeedingFormsChildHealthAggregationDistributedHelper(BaseICDSAggregati
 
         query_params = {
             "month": month_formatter(self.month),
-            "state_id": self.state_id,
             "current_month_start": current_month_start,
             "next_month_start": next_month_start,
         }
 
-        return """
-        INSERT INTO "{tablename}" (
+        return f"""
+        INSERT INTO "{self.tablename}" (
           state_id, supervisor_id, month, case_id, latest_time_end_processed,
           sum_attended_child_ids, lunch_count
         ) (
           SELECT DISTINCT ON (ucr.child_health_case_id)
-            %(state_id)s AS state_id,
+            ucr.state_id AS state_id,
             ucr.supervisor_id,
             %(month)s AS month,
             ucr.child_health_case_id AS case_id,
             MAX(ucr.timeend) OVER w AS latest_time_end_processed,
             SUM(ucr.attended_child_ids) OVER w AS sum_attended_child_ids,
             SUM(ucr.lunch) OVER w AS lunch_count
-          FROM "{ucr_tablename}" ucr INNER JOIN daily_attendance ON (
+          FROM "{self.ucr_tablename}" ucr INNER JOIN daily_attendance ON (
             ucr.doc_id = daily_attendance.doc_id AND
             ucr.supervisor_id = daily_attendance.supervisor_id AND
             daily_attendance.month=%(current_month_start)s
           )
-          WHERE ucr.state_id = %(state_id)s AND
-                ucr.timeend >= %(current_month_start)s AND ucr.timeend < %(next_month_start)s AND
+          WHERE ucr.timeend >= %(current_month_start)s AND ucr.timeend < %(next_month_start)s AND
                 ucr.child_health_case_id IS NOT NULL
           WINDOW w AS (PARTITION BY ucr.supervisor_id, ucr.child_health_case_id)
         )
-        """.format(
-            ucr_tablename=self.ucr_tablename,
-            tablename=self.tablename
-        ), query_params
+        """, query_params

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
@@ -1,12 +1,12 @@
-DELETE FROM "icds_dashboard_daily_feeding_forms" WHERE month=%(month)s AND state_id = %(state)s
-{"month": "2019-01-01", "state": "st1"}
+DELETE FROM "icds_dashboard_daily_feeding_forms" WHERE month=%(month)s
+{"month": "2019-01-01"}
 
         INSERT INTO "icds_dashboard_daily_feeding_forms" (
           state_id, supervisor_id, month, case_id, latest_time_end_processed,
           sum_attended_child_ids, lunch_count
         ) (
           SELECT DISTINCT ON (ucr.child_health_case_id)
-            %(state_id)s AS state_id,
+            ucr.state_id AS state_id,
             ucr.supervisor_id,
             %(month)s AS month,
             ucr.child_health_case_id AS case_id,
@@ -18,10 +18,9 @@ DELETE FROM "icds_dashboard_daily_feeding_forms" WHERE month=%(month)s AND state
             ucr.supervisor_id = daily_attendance.supervisor_id AND
             daily_attendance.month=%(current_month_start)s
           )
-          WHERE ucr.state_id = %(state_id)s AND
-                ucr.timeend >= %(current_month_start)s AND ucr.timeend < %(next_month_start)s AND
+          WHERE ucr.timeend >= %(current_month_start)s AND ucr.timeend < %(next_month_start)s AND
                 ucr.child_health_case_id IS NOT NULL
           WINDOW w AS (PARTITION BY ucr.supervisor_id, ucr.child_health_case_id)
         )
         
-{"current_month_start": "2019-01-01", "month": "2019-01-01", "next_month_start": "2019-02-01", "state_id": "st1"}
+{"current_month_start": "2019-01-01", "month": "2019-01-01", "next_month_start": "2019-02-01"}


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/IIO-472

I've been monitoring the aggregation more closely and found that there are lots of locks due to the way the Citus queries were migrated over. For example `DELETE` queries that aren't dependent on the distribution column happen sequentially (first found/fixed in UCR pillows https://github.com/dimagi/commcare-hq/pull/24640)

Originally (in the monolith setup) these queries were implemented to have a separate task per state because we used table inheritance to have one tale per month & state. We have dropped those partitions because the database is now sharded. This means that a large state query is roughly the same amount of work as a query on all data. For example an explain with Uttar Pradesh (~50k AWCs):

```
                                                                                                                                                    QUERY PLAN                                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Custom Scan (Citus INSERT ... SELECT via coordinator)  (cost=0.00..0.00 rows=0 width=0)
   ->  Unique  (cost=0.00..0.00 rows=0 width=0)
         ->  Sort  (cost=0.00..0.00 rows=0 width=0)
               Sort Key: remote_scan.case_id
               ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
                     Task Count: 64
                     Tasks Shown: One of 64
                     ->  Task
                           Node: host=100.71.184.116 port=5432 dbname=icds_ucr
                           ->  Unique  (cost=77828.71..77829.48 rows=153 width=196)
                                 ->  Sort  (cost=77828.71..77829.10 rows=153 width=196)
                                       Sort Key: ucr.child_health_case_id
                                       ->  WindowAgg  (cost=77819.34..77823.16 rows=153 width=196)
                                             ->  Sort  (cost=77819.34..77819.72 rows=153 width=82)
                                                   Sort Key: ucr.supervisor_id, ucr.child_health_case_id
                                                   ->  Gather  (cost=1001.24..77813.78 rows=153 width=82)
                                                         Workers Planned: 6
                                                         ->  Nested Loop  (cost=1.24..76798.48 rows=26 width=82)
                                                               ->  Parallel Index Only Scan using daily_attendance_pkey_102776 on daily_attendance_102776 daily_attendance  (cost=0.55..34569.34 rows=15116 width=70)
                                                                     Index Cond: (month = '2019-08-01'::date)
                                                               ->  Index Scan using "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_pkey_103098" on "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_103098" ucr  (cost=0.69..2.78 rows=1 width=119)
                                                                     Index Cond: ((supervisor_id = daily_attendance.supervisor_id) AND (doc_id = daily_attendance.doc_id))
                                                                     Filter: ((child_health_case_id IS NOT NULL) AND (timeend >= '2019-08-01 00:00:00'::timestamp without time zone) AND (timeend < '2019-09-01 00:00:00'::timestamp without time zone) AND (state_id = '9051ef4f91d54a89b89c533780857e05'::text))
(23 rows)
```

Without a state_id filter:

```
                                                                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Custom Scan (Citus INSERT ... SELECT via coordinator)  (cost=0.00..0.00 rows=0 width=0)                                                                                                                                                                                  
   ->  Unique  (cost=0.00..0.00 rows=0 width=0)                                         
         ->  Sort  (cost=0.00..0.00 rows=0 width=0)
               Sort Key: remote_scan.case_id       
               ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
                     Task Count: 64                                               
                     Tasks Shown: One of 64
                     ->  Task              
                           Node: host=100.71.184.116 port=5432 dbname=icds_ucr
                           ->  Unique  (cost=78513.86..78529.48 rows=3124 width=131)
                                 ->  Sort  (cost=78513.86..78521.67 rows=3124 width=131)
                                       Sort Key: ucr.child_health_case_id      
                                       ->  WindowAgg  (cost=78254.43..78332.53 rows=3124 width=131)
                                             ->  Sort  (cost=78254.43..78262.24 rows=3124 width=115)
                                                   Sort Key: ucr.supervisor_id, ucr.child_health_case_id
                                                   ->  Gather  (cost=1001.24..78073.09 rows=3124 width=115)
                                                         Workers Planned: 6                           
                                                         ->  Nested Loop  (cost=1.24..76760.69 rows=521 width=115)                                                                                                                                      
                                                               ->  Parallel Index Only Scan using daily_attendance_pkey_102776 on daily_attendance_102776 daily_attendance  (cost=0.55..34569.34 rows=15116 width=70)                                                    
                                                                     Index Cond: (month = '2019-08-01'::date)
                                                               ->  Index Scan using "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_pkey_103098" on "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_103098" ucr  (cost=0.69..2.78 rows=1 width=152)
                                                                     Index Cond: ((supervisor_id = daily_attendance.supervisor_id) AND (doc_id = daily_attendance.doc_id)) 
                                                                     Filter: ((child_health_case_id IS NOT NULL) AND (timeend >= '2019-08-01 00:00:00'::timestamp without time zone) AND (timeend < '2019-09-01 00:00:00'::timestamp without time zone))
(23 rows)
```

Note expected costs on the worker are going from "77829.48" to  "78529.48". A difference of 700, 
< 1%. The benefit here is that instead of doing this 30 times for each state, we're only doing it once. If this scales based on # of AWCs I believe **at our current scale this should be 9x faster**. This would mean going from 50 minutes to 10 minute run time. This won't affect the overall time now because this is run in parallel with many other tasks, but I expect this to be huge once the pattern is applied to those tasks as well

**Further Improvements**

I think we can eventually remove `state_id` from all of these tables once we remove all "state" tasks.

After testing out this query, I would like to create an index on `month` for this table to make the `DELETE` more efficient as well. Its currently doing `# of states` sequential scans at the moment.