### PR TITLE
Ce/month filter

### DIFF
--- a/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
@@ -35,8 +35,9 @@ function MonthModalController($location, $uibModalInstance) {
     }
 
     if (vm.selectedYear === new Date().getFullYear()) {
+        var month_offset = new Date().getDate() < 3 ? 0 : 1;
         vm.months = _.filter(vm.monthsCopy, function (month) {
-            return month.id <= new Date().getMonth() + 1;
+            return month.id <= new Date().getMonth() + month_offset;
         });
 
         if (startDate === 2019) {

--- a/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
@@ -8,7 +8,7 @@ function MonthModalController($location, $uibModalInstance) {
     vm.monthsCopy = [];
     vm.showMessage = false;
     var isSDD =  $location.path().indexOf('service_delivery_dashboard') !== -1;
-    var startDate = $location.path().indexOf('service_delivery_dashboard') === -1 ? 2017 : 2019;
+    var startDate = isSDD ? 2019 : 2017;
 
     window.angular.forEach(moment.months(), function(key, value) {
         vm.monthsCopy.push({
@@ -39,11 +39,10 @@ function MonthModalController($location, $uibModalInstance) {
         vm.months = _.filter(vm.monthsCopy, function (month) {
             return month.id <= new Date().getMonth() + month_offset;
         });
-
-        if (startDate === 2019) {
+        if (isSDD && vm.selectedYear === 2019) {
             vm.months.shift();
         }
-    } else if (startDate === 2019 && vm.selectedYear === 2019) {
+    } else if (isSDD && vm.selectedYear === 2019) {
         vm.months = _.filter(vm.monthsCopy, function (month) {
             return month.id >= 2;
         });
@@ -69,12 +68,12 @@ function MonthModalController($location, $uibModalInstance) {
                 return month.id <= new Date().getMonth() + 1;
             });
 
-            if (startDate === 2019) {
+            if (isSDD && item.id === 2019) {
                 vm.months.shift();
             }
             
             vm.selectedMonth = vm.selectedMonth <= new Date().getMonth() + 1 ? vm.selectedMonth : new Date().getMonth() + 1;
-        } else if (startDate === 2019 && vm.selectedYear === 2019) {
+        } else if (isSDD && vm.selectedYear === 2019) {
             vm.months = _.filter(vm.monthsCopy, function (month) {
                 return month.id >= 2;
             });

--- a/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
+++ b/custom/icds_reports/static/js/directives/month-filter/month-filter.directive.js
@@ -35,9 +35,9 @@ function MonthModalController($location, $uibModalInstance) {
     }
 
     if (vm.selectedYear === new Date().getFullYear()) {
-        var month_offset = new Date().getDate() < 3 ? 0 : 1;
+        var monthOffset = new Date().getDate() < 3 ? 0 : 1;
         vm.months = _.filter(vm.monthsCopy, function (month) {
-            return month.id <= new Date().getMonth() + month_offset;
+            return month.id <= new Date().getMonth() + monthOffset;
         });
         if (isSDD && vm.selectedYear === 2019) {
             vm.months.shift();


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This started as an attempt to clear up some really confusing behavior in the dashboard. We currently allow you to select the current month during the first 2 days of a month but will show you last month's data (with a friendly disclaimer that no one reads). This will block you from doing that.

The second commit tries to clean up some confusing logic (using startDate as a proxy for the SDD) and a potential bug that would happen when the current year was no longer 2019.

This is pending signoff from the program team so please don't merge yet.