### PR TITLE
Fix downstream view of cross-environment linked apps

### DIFF
--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -3,7 +3,6 @@ from corehq.apps.app_manager.dbaccessors import (
     get_latest_released_app,
     get_latest_released_app_versions_by_app_id,
 )
-from corehq.apps.linked_domain.exceptions import ActionNotPermitted
 from corehq.apps.linked_domain.models import DomainLink
 from corehq.apps.linked_domain.remote_accessors import (
     get_brief_apps,
@@ -14,7 +13,7 @@ from corehq.apps.linked_domain.remote_accessors import (
 
 def get_master_app_briefs(domain_link, family_id):
     if domain_link.is_remote:
-        apps = get_brief_apps(domain_link.master_domain, domain_link.remote_details)
+        apps = get_brief_apps(domain_link)
     else:
         apps = get_brief_apps_in_domain(domain_link.master_domain, include_remote=False)
 


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1252563866/?environment=pna&project=136860&query=is%3Aunresolved

##### SUMMARY
This function only accepts one argument.  This code error broke the "releases" page in downstream linked apps pulling from another environment.

##### FEATURE FLAG
Linked apps