### PR TITLE
Linked Apps - Route URL to correct view

### DIFF
--- a/corehq/apps/linked_domain/urls.py
+++ b/corehq/apps/linked_domain/urls.py
@@ -15,7 +15,7 @@ app_name = 'linked_domain'
 
 
 urlpatterns = [
-    url(r'^brief_apps/$', custom_data_models, name='brief_apps'),
+    url(r'^brief_apps/$', brief_apps, name='brief_apps'),
     url(r'^case_search_config/$', case_search_config, name='case_search_config'),
     url(r'^custom_data_models/$', custom_data_models, name='custom_data_models'),
     url(r'^toggles/$', toggles_and_previews, name='toggles'),


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1252779084/
Guessing this was a copy-paste error

##### SUMMARY
This URL returned the wrong response, triggering a 500 on the receiving environment.  Affects only cross environment linked apps.

##### FEATURE FLAG
Linked domains