### PR TITLE
Fix remote apps request

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -254,18 +254,22 @@ def get_apps_in_domain(domain, include_remote=True):
     return apps
 
 
-def get_brief_apps_in_domain(domain, include_remote=True):
+def get_brief_app_docs_in_domain(domain, include_remote=True):
     from .models import Application
-    from corehq.apps.app_manager.util import get_correct_app_class
+    from .util import is_remote_app
     docs = [row['value'] for row in Application.get_db().view(
         'app_manager/applications_brief',
         startkey=[domain],
         endkey=[domain, {}]
     )]
-    apps = [get_correct_app_class(doc).wrap(doc) for doc in docs]
     if not include_remote:
-        apps = [app for app in apps if not app.is_remote_app()]
-    return sorted(apps, key=lambda app: app.name)
+        docs = [doc for doc in docs if not is_remote_app(doc)]
+    return sorted(docs, key=lambda doc: doc['name'])
+
+
+def get_brief_apps_in_domain(domain, include_remote=True):
+    docs = get_brief_app_docs_in_domain(domain, include_remote)
+    return [wrap_app(doc) for doc in docs]
 
 
 def get_brief_app(domain, app_id):

--- a/corehq/apps/linked_domain/remote_accessors.py
+++ b/corehq/apps/linked_domain/remote_accessors.py
@@ -33,7 +33,8 @@ def get_user_roles(domain_link):
 
 
 def get_brief_apps(domain_link):
-    return _do_simple_request('linked_domain:brief_apps', domain_link)['brief_apps']
+    apps = _do_simple_request('linked_domain:brief_apps', domain_link)['brief_apps']
+    return [wrap_app(app) for app in apps]
 
 
 def get_case_search_config(domain_link):

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -14,6 +14,7 @@ from memoized import memoized
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
+    get_brief_app_docs_in_domain,
     get_brief_apps_in_domain,
     get_latest_released_app,
     get_latest_released_app_versions_by_app_id,
@@ -86,7 +87,7 @@ def user_roles(request, domain):
 @login_or_api_key
 @require_linked_domain
 def brief_apps(request, domain):
-    return JsonResponse({'brief_apps': get_brief_apps_in_domain(domain, include_remote=False)})
+    return JsonResponse({'brief_apps': get_brief_app_docs_in_domain(domain, include_remote=False)})
 
 
 @login_or_api_key


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1252973987/?environment=production&project=136860

##### SUMMARY
JSON needs to be used for the transfer.  This change leaves the data unwrapped when it's passed to the view and wraps it on the other side.

##### FEATURE FLAG
Linked domains

##### PRODUCT DESCRIPTION
Fixes a 500 error on cross-environment linked apps
