### PR TITLE
Disable stickler isort since it is buggy

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -7,7 +7,6 @@ linters:
     python: 3
     max-line-length: 115
     ignore: E128,E265,F403,W503,W1618  # http://pep8.readthedocs.org/en/latest/intro.html#error-codes
-    isort: true
   eslint:
     config: ./.eslintrc.js
     install_plugins: true


### PR DESCRIPTION
I'm happy to have this re-enabled once the issues are fixed.

Most recent false trigger https://github.com/dimagi/commcare-hq/pull/25524#pullrequestreview-296400254