### PR TITLE
Fixed condition for adding last_released to (media_)profile.ccpr down…

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -292,7 +292,7 @@ def download_file(request, domain, app_id, path):
         if path in ['profile.xml', 'media_profile.xml']:
             payload = convert_XML_To_J2ME(payload, path, request.app.use_j2me_endpoint)
         response.write(payload)
-        if path in ['profile.ccpr', 'media_profile.ccpr'] and request.app.is_released:
+        if path in ['profile.ccpr', 'media_profile.ccpr'] and request.app.last_released:
             response['X-CommCareHQ-AppReleasedOn'] = request.app.last_released.isoformat()
         response['Content-Length'] = len(response.content)
         return response


### PR DESCRIPTION
…loads

##### SUMMARY
Fixes https://sentry.io/organizations/dimagi/issues/1253285560/

Introduced in https://github.com/dimagi/commcare-hq/pull/25518/

App downloads are failing for apps that were released before https://github.com/dimagi/commcare-hq/pull/25382 was merged the week before last.