### PR TITLE
Remove architect from uninstall requirements

### DIFF
--- a/requirements-python3/uninstall-requirements.txt
+++ b/requirements-python3/uninstall-requirements.txt
@@ -1,6 +1,4 @@
 # This file is for requirements that should be removed _before_ pip install
-# https://github.com/maxtepkeev/architect/pull/52
-architect
 # https://github.com/django-nose/django-nose/pull/228
 django-nose
 feedparser

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -1,6 +1,4 @@
 # This file is for requirements that should be removed _before_ pip install
-# https://github.com/maxtepkeev/architect/pull/52
-architect
 # https://github.com/django-nose/django-nose/pull/228
 django-nose
 feedparser


### PR DESCRIPTION
We moved back to mainline architect in https://github.com/dimagi/commcare-hq/pull/21994

Our remaining usage of architect is compatible with either the git
version or the mainline

