### PR TITLE
Expand errors caught when fetching a form's multimedia

### DIFF
--- a/corehq/apps/app_manager/tests/test_views.py
+++ b/corehq/apps/app_manager/tests/test_views.py
@@ -204,6 +204,12 @@ class TestViews(TestCase):
         self.app.save()
         self._test_status_codes(['view_form', 'form_source'], kwargs)
 
+        bad_form = self.app.new_form(module.id, "Form1", "en",
+                                     attachment="this is not xml")
+        kwargs['form_unique_id'] = bad_form.unique_id
+        self.app.save()
+        self._test_status_codes(['view_form', 'form_source'], kwargs)
+
     def test_advanced_module(self, mock):
         module = self.app.add_module(AdvancedModule.new_module("Module0", "en"))
         self.app.save()

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -713,24 +713,27 @@ class FormMediaMixin(MediaMixin):
         media = copy(self.menu_media(self, lang=lang))
 
         # Form questions
-        parsed = self.wrapped_xform()
-        if parsed.exists():
-            try:
+        try:
+            parsed = self.wrapped_xform()
+            if parsed.exists():
                 self.validate_form()
-            except (XFormValidationError, XFormException):
+            else:
                 return media
-            for image in parsed.image_references(lang=lang):
-                if image:
-                    media.append(ApplicationMediaReference(image, media_class=CommCareImage, **kwargs))
-            for audio in parsed.audio_references(lang=lang):
-                if audio:
-                    media.append(ApplicationMediaReference(audio, media_class=CommCareAudio, **kwargs))
-            for video in parsed.video_references(lang=lang):
-                if video:
-                    media.append(ApplicationMediaReference(video, media_class=CommCareVideo, **kwargs))
-            for text in parsed.text_references(lang=lang):
-                if text:
-                    media.append(ApplicationMediaReference(text, media_class=CommCareMultimedia, **kwargs))
+        except (XFormValidationError, XFormException):
+            return media
+
+        for image in parsed.image_references(lang=lang):
+            if image:
+                media.append(ApplicationMediaReference(image, media_class=CommCareImage, **kwargs))
+        for audio in parsed.audio_references(lang=lang):
+            if audio:
+                media.append(ApplicationMediaReference(audio, media_class=CommCareAudio, **kwargs))
+        for video in parsed.video_references(lang=lang):
+            if video:
+                media.append(ApplicationMediaReference(video, media_class=CommCareVideo, **kwargs))
+        for text in parsed.text_references(lang=lang):
+            if text:
+                media.append(ApplicationMediaReference(text, media_class=CommCareMultimedia, **kwargs))
 
         return media
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://dimagi-dev.atlassian.net/browse/SAASP-203

Followup for https://github.com/dimagi/commcare-hq/pull/25496 - `wrapped_xform` can throw an exception if a form is so badly broken it can't be parsed so forms with that kind of error were still 500ing.