### PR TITLE
Speed Up Group API (under flag)

### DIFF
--- a/corehq/apps/api/query_adapters.py
+++ b/corehq/apps/api/query_adapters.py
@@ -64,7 +64,7 @@ class GroupQuerySetAdapterES(object):
     def __getitem__(self, item):
         if isinstance(item, slice):
             limit = item.stop - item.start
-            result = GroupES().domain(self.domain).sort('name').size(limit).start(item.start).run()
+            result = GroupES().domain(self.domain).sort('name.exact').size(limit).start(item.start).run()
             groups = [Group.wrap(group) for group in result.hits]
 
             user_ids = {user_id for group in groups for user_id in group.users}

--- a/corehq/apps/api/query_adapters.py
+++ b/corehq/apps/api/query_adapters.py
@@ -49,7 +49,7 @@ class GroupQuerySetAdapterCouch(object):
                 'Invalid type of argument. Item should be an instance of slice class.')
 
         for group in groups:
-            group._precomputed_active_users = group.get_user_ids()
+            group.__dict__['get_user_ids'] = group.get_user_ids()
 
         return groups
 
@@ -76,7 +76,7 @@ class GroupQuerySetAdapterES(object):
             )
 
             for group in groups:
-                group._precomputed_active_users = [
+                group.__dict__['get_user_ids'] = lambda: [
                     user_id for user_id in group.users
                     if user_id in active_user_ids
                 ]

--- a/corehq/apps/api/query_adapters.py
+++ b/corehq/apps/api/query_adapters.py
@@ -1,6 +1,6 @@
 from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class, \
     get_docs_in_domain_by_class
-from corehq.apps.es import GroupES
+from corehq.apps.es import GroupES, UserES
 from corehq.apps.groups.models import Group
 from corehq.apps.users.analytics import (
     get_active_commcare_users_in_domain,
@@ -43,9 +43,15 @@ class GroupQuerySetAdapterCouch(object):
     def __getitem__(self, item):
         if isinstance(item, slice):
             limit = item.stop - item.start
-            return get_docs_in_domain_by_class(self.domain, Group, limit=limit, skip=item.start)
-        raise ValueError(
-            'Invalid type of argument. Item should be an instance of slice class.')
+            groups = get_docs_in_domain_by_class(self.domain, Group, limit=limit, skip=item.start)
+        else:
+            raise ValueError(
+                'Invalid type of argument. Item should be an instance of slice class.')
+
+        for group in groups:
+            group._precomputed_active_users = group.get_user_ids()
+
+        return groups
 
 
 class GroupQuerySetAdapterES(object):
@@ -59,6 +65,21 @@ class GroupQuerySetAdapterES(object):
         if isinstance(item, slice):
             limit = item.stop - item.start
             result = GroupES().domain(self.domain).sort('name').size(limit).start(item.start).run()
-            return map(Group.wrap, result.hits)
+            groups = [Group.wrap(group) for group in result.hits]
+
+            user_ids = {user_id for group in groups for user_id in group.users}
+            active_user_ids = (
+                UserES().domain(self.domain)
+                .user_ids(user_ids)
+                .is_active(True)
+                .values_list('_id', flat=True)
+            )
+
+            for group in groups:
+                group._precomputed_active_users = [
+                    user_id for user_id in group.users
+                    if user_id in active_user_ids
+                ]
+            return groups
         raise ValueError(
             'Invalid type of argument. Item should be an instance of slice class.')

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -304,7 +304,7 @@ class GroupResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMi
     domain = fields.CharField(attribute='domain')
     name = fields.CharField(attribute='name')
 
-    users = fields.ListField(attribute='_precomputed_active_users')
+    users = fields.ListField(attribute='get_user_ids')
     path = fields.ListField(attribute='path')
 
     case_sharing = fields.BooleanField(attribute='case_sharing', default=False)

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -304,7 +304,7 @@ class GroupResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMi
     domain = fields.CharField(attribute='domain')
     name = fields.CharField(attribute='name')
 
-    users = fields.ListField(attribute='get_user_ids')
+    users = fields.ListField(attribute='_precomputed_active_users')
     path = fields.ListField(attribute='path')
 
     case_sharing = fields.BooleanField(attribute='case_sharing', default=False)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1802,5 +1802,5 @@ GROUP_API_USE_ES_BACKEND = StaticToggle(
     'group_api_use_es_backend',
     'Use ES backend for Group API',
     TAG_PRODUCT,
-    [NAMESPACE_DOMAIN],
+    [NAMESPACE_DOMAIN, NAMESPACE_USER],
 )


### PR DESCRIPTION
##### SUMMARY
I'm working on speeding up the group API (https://dimagi-dev.atlassian.net/browse/SAASP-119). The main breakthrough in this PR is that I found through local profiling that for each group returned, a request was being made to couch in the rehydrate step to figure out which of the groups user_ids represented active users. For a limit of 1000 groups, this would make (I think / at least) 1000 requests to couch just for the purpose of filtering to only active users.

I move this work into the query adapter where it's much more visible and rewrote the ES version to get the same info in a single query to ES. From preliminary tests, this seems to cut query time significant. (In profiling, this piece was often 10s out of 12s, so the vast majority of the time spent.)

I also made the toggle allow being activated per user so that I could turn it on for just myself on production and then test against real projects, comparing the timing of the two backends, as well as the results for correctness.

##### FEATURE FLAG
GROUP_API_USE_ES_BACKEND

##### PRODUCT DESCRIPTION
Speeds up the Group API ES implementation (which is behind a flag for testing)
