### PR TITLE
in odata, treat offset as not a page offset but object offset

### DIFF
--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -19,16 +19,14 @@ class ODataBaseSerializer(Serializer):
     metadata_url = None
     table_metadata_url = None
     offset = 0
-    limit = 2000
 
     def get_config(self, config_id):
         raise NotImplementedError("implement get_config")
 
     def to_json(self, data, options=None):
 
-        # get current pagination offset and limit for use in row number
+        # get current object offset for use in row number
         self.offset = data.get('meta', {}).get('offset', 0)
-        self.limit = data.get('meta', {}).get('limit', 2000)
 
         # Convert bundled objects to JSON
         data['objects'] = [
@@ -72,7 +70,7 @@ class ODataBaseSerializer(Serializer):
             return '{}{}{}'.format(get_url_base(), api_path, next_page)
 
     def get_full_row_number(self, row_number):
-        return row_number + (self.offset * self.limit)
+        return row_number + self.offset
 
     def serialize_documents_using_config(self, documents, config, table_id):
         if table_id + 1 > len(config.tables):


### PR DESCRIPTION
##### SUMMARY
Initially the odata offset was being treated as a page offset when calculating the row number, but it is actually an object offset. This updates the code that calculates the current row number based on that information.