### PR TITLE
make sure tabs and newlines cannot be used in odata labels

### DIFF
--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -385,4 +385,5 @@ def can_view_case_exports(couch_user, domain):
 def clean_odata_columns(export_instance):
     for table in export_instance.tables:
         for column in table.columns:
-            column.label = column.label.replace('@', '').replace('.', ' ')
+            column.label = column.label.replace('@', '').replace(
+                '.', ' ').replace('\n', '').replace('\t', ' ')

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -387,3 +387,6 @@ def clean_odata_columns(export_instance):
         for column in table.columns:
             column.label = column.label.replace('@', '').replace(
                 '.', ' ').replace('\n', '').replace('\t', ' ').replace('#', '')
+            # truncate labels for PowerBI limits
+            if len(column.label) >= 511:
+                column.label = column.label[:511]

--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -386,4 +386,4 @@ def clean_odata_columns(export_instance):
     for table in export_instance.tables:
         for column in table.columns:
             column.label = column.label.replace('@', '').replace(
-                '.', ' ').replace('\n', '').replace('\t', ' ')
+                '.', ' ').replace('\n', '').replace('\t', ' ').replace('#', '')


### PR DESCRIPTION
##### SUMMARY
Somehow someone was able to insert newline `\n` characters into their label when creating an odata export. I assume this was from copy/paste but i wasn't able to replicate it (on save the newlines and tabs I put into the labels appeared to be properly escaped.

Anyway, to make sure that the tools ingesting odata don't freak out, I am making sure under no circumstance newlines and tab `\t` characters can be used in the label