### PR TITLE
Consider more XForm types as shardable

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -278,7 +278,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
 
         # these doc types were blocking the queue but the approach could be applied
         # more generally with some more testing
-        SHARDABLE_DOC_TYPES = ('XFormArchived', 'XFormDuplicate')
+        SHARDABLE_DOC_TYPES = ('XFormArchived', 'XFormDuplicate', 'XFormError')
         table = self.get_table()
         doc_ids_to_delete = []
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -292,17 +292,18 @@ class IndicatorSqlAdapter(IndicatorAdapter):
                 tmp_doc = doc.copy()
                 tmp_doc['doc_type'] = 'XFormInstance'
                 rows = self.get_all_values(tmp_doc)
-                first_row = rows[0]
-                sharded_column_value = [
-                    i.value for i in first_row
-                    if i.column.database_column_name.decode('utf-8') == column
-                ]
-                if sharded_column_value:
-                    delete = table.delete().where(table.c.doc_id == doc['_id'])
-                    delete = delete.where(table.c.get(column) == sharded_column_value[0])
-                    with self.session_context() as session:
-                        session.execute(delete)
-                    continue  # skip adding doc ID into doc_ids_to_delete
+                if not rows:
+                    first_row = rows[0]
+                    sharded_column_value = [
+                        i.value for i in first_row
+                        if i.column.database_column_name.decode('utf-8') == column
+                    ]
+                    if sharded_column_value:
+                        delete = table.delete().where(table.c.doc_id == doc['_id'])
+                        delete = delete.where(table.c.get(column) == sharded_column_value[0])
+                        with self.session_context() as session:
+                            session.execute(delete)
+                        continue  # skip adding doc ID into doc_ids_to_delete
 
             doc_ids_to_delete.append(doc['_id'])
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -278,7 +278,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
 
         # these doc types were blocking the queue but the approach could be applied
         # more generally with some more testing
-        SHARDABLE_DOC_TYPES = ('XFormArchived', 'XFormDuplicate', 'XFormError')
+        SHARDABLE_DOC_TYPES = ('XFormArchived', 'XFormDeprecated', 'XFormDuplicate', 'XFormError')
         table = self.get_table()
         doc_ids_to_delete = []
 


### PR DESCRIPTION
So this was my first attempt at unblocking the xform pillow. I think this ends up being all the XForm data types (though I didn't see a particular constant for this). 

This should make the general delete process more efficient, but this did not totally solve all the lock contention, which I'm going to be following up with (at least) two more PRs.

I cherry-picked @snopoke commit because I ended up testing this on the form pillows to monitor the situation.