### PR TITLE
Add doc_id indexes to ICDS data source s

### DIFF
--- a/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
@@ -1004,6 +1004,11 @@
           "district_id",
           "submitted_on"
         ]
+      },
+      {
+        "column_ids": [
+          "doc_id"
+        ]
       }
     ],
     "disable_destructive_rebuild": true,

--- a/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
@@ -281,6 +281,9 @@
     "sql_column_indexes": [
       {
         "column_ids": ["state_id", "timeend"]
+      },
+      {
+        "column_ids": ["doc_id"]
       }
     ],
     "disable_destructive_rebuild": true

--- a/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
@@ -396,6 +396,9 @@
       },
       {
         "column_ids": ["state_id", "timeend"]
+      },
+      {
+        "column_ids": ["doc_id"]
       }
     ],
     "disable_destructive_rebuild": true

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -176,6 +176,11 @@
       },
       "primary_key": ["supervisor_id","doc_id"]
     },
+    "sql_column_indexes": [
+      {
+        "column_ids": ["doc_id"]
+      }
+    ],
     "disable_destructive_rebuild": true
   }
 }

--- a/custom/icds_reports/ucr/data_sources/usage_forms.json
+++ b/custom/icds_reports/ucr/data_sources/usage_forms.json
@@ -1003,6 +1003,11 @@
       },
       "primary_key": ["supervisor_id","doc_id"]
     },
+    "sql_column_indexes": [
+      {
+        "column_ids": ["doc_id"]
+      }
+    ],
     "disable_destructive_rebuild": true
   }
 }


### PR DESCRIPTION
This is following up on the same issue as https://github.com/dimagi/commcare-hq/pull/25540/

In my previous work, I found that Citus has a cluster wide table lock when a DELETE is issued that does not include the distribution column. This is still true and its still beneficial to include the distribution column in all queries as it ensures that only 1 shard is handling the query and any locks are contained to that shard. 

With that said, it won't always be possible to include distribution column in the queries. `doc_id` is our universal unique key and previously (in the monolith setup) it was the leading column of our primary key. During the move to citus the distribution column (supervisor_id) is now the leading column for our primary key making doc_id lookups very expensive. They are still relatively expensive even with these added indexes as they require an index scan on all 64 shards. That's a lot more efficient than 64 sequential scans.

The three that have been added here are the ones I definitely saw when monitoring. I am currently creating them concurrently in a tmux session on pillow26. I plan to add this index to more, but adding this now as documentation for what has been added