### PR TITLE
Add validation that daily feeding form modifies child_health cases

### DIFF
--- a/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
@@ -68,6 +68,31 @@
           },
           "property_value": "awc"
         }
+      },
+      {
+        "name": "child_health_changes",
+        "error_message": "Form did not change any child_health cases",
+        "expression": {
+          "type": "boolean_expression",
+          "operator": "gt",
+          "expression": {
+            "type": "filter_items",
+            "items_expression": {
+              "type": "property_path",
+              "property_path": ["form", "child_health_cases", "item"]
+            },
+            "filter_expression": {
+              "type": "boolean_expression",
+              "operator": "eq",
+              "expression": {
+                "type": "property_name",
+                "property_name": "eligible"
+              },
+              "property_value": "yes"
+            }
+          },
+          "property_value": 0
+        }
       }
     ],
     "configured_indicators": [

--- a/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
@@ -76,20 +76,24 @@
           "type": "boolean_expression",
           "operator": "gt",
           "expression": {
-            "type": "filter_items",
+            "type": "reduce_items",
             "items_expression": {
-              "type": "property_path",
-              "property_path": ["form", "child_health_cases", "item"]
+                "type": "filter_items",
+                "items_expression": {
+                  "type": "property_path",
+                  "property_path": ["form", "child_health_cases", "item"]
+                },
+                "filter_expression": {
+                  "type": "boolean_expression",
+                  "operator": "eq",
+                  "expression": {
+                    "type": "property_name",
+                    "property_name": "eligible"
+                  },
+                  "property_value": "yes"
+                }
             },
-            "filter_expression": {
-              "type": "boolean_expression",
-              "operator": "eq",
-              "expression": {
-                "type": "property_name",
-                "property_name": "eligible"
-              },
-              "property_value": "yes"
-            }
+            "aggregation_fn": "count"
           },
           "property_value": 0
         }


### PR DESCRIPTION
##### SUMMARY
Among the errors of their being no rows https://sentry.io/organizations/dimagi/issues/1221245091/?project=1545828 was that some daily feeding forms did not modify any child health cases (so the base item expression did not produce any rows). This was really confusing to me, so I'd like to add this here. 

I think that these errors could also be displayed more in an obvious way, though I'm not quite sure how to best do that. My first thought is adding some info to the "data source debugger" view, but let me know if you have better ideas

fyi @snopoke 