### PR TITLE
Fix sms calculated properties on domain

### DIFF
--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -31,7 +31,7 @@ from corehq.apps.hqcase.analytics import get_number_of_cases_in_domain
 from corehq.apps.hqmedia.models import ApplicationMediaMixin
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.locations.models import LocationType
-from corehq.apps.sms.models import SQLMobileBackend
+from corehq.apps.sms.models import SQLMobileBackend, INCOMING, OUTGOING
 from corehq.apps.userreports.util import (
     number_of_report_builder_reports,
     number_of_ucr_reports,
@@ -164,10 +164,13 @@ def j2me_forms_in_last_bool(domain, days):
 
 
 def _sms_helper(domain, direction=None, days=None):
+    assert direction in (INCOMING, OUTGOING, None)
     query = SMSES().domain(domain).size(0)
 
-    if direction:
-        query = query.direction(direction)
+    if direction is INCOMING:
+        query = query.incoming_messages()
+    elif direction is OUTGOING:
+        query = query.outgoing_messages()
 
     if days:
         query = query.received(date.today() - relativedelta(days=30))
@@ -188,11 +191,11 @@ def sms_in_last_bool(domain, days=None):
 
 
 def sms_in_in_last(domain, days=None):
-    return _sms_helper(domain, direction="I", days=days)
+    return _sms_helper(domain, direction=INCOMING, days=days)
 
 
 def sms_out_in_last(domain, days=None):
-    return _sms_helper(domain, direction="O", days=days)
+    return _sms_helper(domain, direction=OUTGOING, days=days)
 
 
 def active(domain, *args):
@@ -384,8 +387,8 @@ def calced_props(domain_obj, id, all_stats):
         "cp_is_active": CALC_FNS["active"](dom),
         "cp_has_app": CALC_FNS["has_app"](dom),
         "cp_last_updated": json_format_datetime(datetime.utcnow()),
-        "cp_n_in_sms": int(CALC_FNS["sms"](dom, "I")),
-        "cp_n_out_sms": int(CALC_FNS["sms"](dom, "O")),
+        "cp_n_in_sms": int(CALC_FNS["sms"](dom, INCOMING)),
+        "cp_n_out_sms": int(CALC_FNS["sms"](dom, OUTGOING)),
         "cp_n_sms_ever": int(CALC_FNS["sms_in_last"](dom)),
         "cp_n_sms_30_d": int(CALC_FNS["sms_in_last"](dom, 30)),
         "cp_n_sms_60_d": int(CALC_FNS["sms_in_last"](dom, 60)),

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -167,9 +167,9 @@ def _sms_helper(domain, direction=None, days=None):
     assert direction in (INCOMING, OUTGOING, None), repr(direction)
     query = SMSES().domain(domain).size(0)
 
-    if direction is INCOMING:
+    if direction == INCOMING:
         query = query.incoming_messages()
-    elif direction is OUTGOING:
+    elif direction == OUTGOING:
         query = query.outgoing_messages()
 
     if days:

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -164,7 +164,7 @@ def j2me_forms_in_last_bool(domain, days):
 
 
 def _sms_helper(domain, direction=None, days=None):
-    assert direction in (INCOMING, OUTGOING, None)
+    assert direction in (INCOMING, OUTGOING, None), repr(direction)
     query = SMSES().domain(domain).size(0)
 
     if direction is INCOMING:

--- a/corehq/apps/domain/tests/test_domain_calculated_properties.py
+++ b/corehq/apps/domain/tests/test_domain_calculated_properties.py
@@ -1,16 +1,21 @@
+import datetime
 import json
 
 from django.test import TestCase
 
+from corehq.apps.es.sms import SMSES
+from corehq.apps.sms.models import INCOMING, OUTGOING
+from dimagi.utils.parsing import json_format_datetime
 from pillowtop.es_utils import initialize_index_and_mapping
 
-from corehq.apps.domain.calculations import all_domain_stats, calced_props
+from corehq.apps.domain.calculations import all_domain_stats, calced_props, sms
 from corehq.apps.domain.models import Domain
-from corehq.elastic import get_es_new
+from corehq.elastic import get_es_new, refresh_elasticsearch_index
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
+from pillowtop.processors.elastic import send_to_elasticsearch
 
 
 class DomainCalculatedPropertiesTest(TestCase):
@@ -29,6 +34,26 @@ class DomainCalculatedPropertiesTest(TestCase):
         for es in self.es:
             ensure_index_deleted(es['info'].index)
             initialize_index_and_mapping(es['instance'], es['info'])
+        self._set_up_sms_es()
+
+    def _set_up_sms_es(self):
+        sms_doc = {
+            '_id': 'some_sms_id',
+            'domain': self.domain.name,
+            'direction': INCOMING,
+            'date': json_format_datetime(datetime.datetime.utcnow()),
+            'doc_type': SMS_INDEX_INFO.type,
+        }
+        send_to_elasticsearch(
+            index=SMS_INDEX_INFO.index,
+            doc_type=SMS_INDEX_INFO.type,
+            doc_id=sms_doc['_id'],
+            es_getter=get_es_new,
+            name='ElasticProcessor',
+            data=sms_doc,
+            update=False,
+        )
+        refresh_elasticsearch_index('sms')
 
     def tearDown(self):
         self.domain.delete()
@@ -39,3 +64,8 @@ class DomainCalculatedPropertiesTest(TestCase):
         self.assertFalse(props['cp_has_app'])
         # ensure serializable
         json.dumps(props)
+
+    def test_sms(self):
+        self.assertEqual(SMSES().count(), 1)
+        self.assertEqual(sms(self.domain.name, INCOMING), 1)
+        self.assertEqual(sms(self.domain.name, OUTGOING), 0)


### PR DESCRIPTION
##### SUMMARY
Was passing "I" and "O" to elasticsearch for the `direction` field,
but in elasticsearch the field has values "i" and "o", so the queries
were all returning 0. This changes to using the INCOMING and OUTGOING
constants (which are just "I" and "O") for passing values around and
the built in SMSES filters for incoming_messages and outgoing_messages
to fix the issue while also improving readability and reducing confusion.

Should fix at least a big part of the issue in https://dimagi-dev.atlassian.net/browse/SAASP-173. As far as I can tell, the sms properties must have been broken for a very long time. Not sure if it was an ES version upgrade that caused it, a change in the smslog index, or a change in this code. If it was a change in code that would take us back to at least 2015!

##### PRODUCT DESCRIPTION
This fixes calculations in a Dimagi-internal salesforce integration, and has no user facing consequences.