### PR TITLE
Added .ko-template on linked domain settings page

### DIFF
--- a/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
+++ b/corehq/apps/linked_domain/templates/linked_domain/domain_links.html
@@ -10,7 +10,7 @@
   {% registerurl 'domain_links' '---' %}
   {% registerurl 'app_settings' domain '---' %}
 
-  <div id="domain_links">
+  <div id="domain_links" class="ko-template">
     <div data-bind="visible: !master_link && !linked_domains().length">
       <p>
         {% trans "This project has no links to other projects." %}


### PR DESCRIPTION
##### FEATURE FLAG
Linked domains

##### PRODUCT DESCRIPTION
Very minor. Prevents the "Project Settings > Linked Projects" page from showing odd-looking content while the page is loading.
