### PR TITLE
Fixed family_id assignment when copying an older version of an app

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5662,7 +5662,7 @@ def import_app(app_id_or_source, domain, source_properties=None, request=None):
     app.date_created = datetime.datetime.utcnow()
     app.cloudcare_enabled = domain_has_privilege(domain, privileges.CLOUDCARE)
     if source_domain == domain:
-        app.family_id = source_app.get_id
+        app.family_id = source_app.master_id
 
     report_map = get_static_report_mapping(source_domain, domain)
     if report_map:


### PR DESCRIPTION
##### SUMMARY
Described in https://dimagi-dev.atlassian.net/browse/ICDS-919

##### FEATURE FLAG
Multi master linked apps

##### PRODUCT DESCRIPTION
Fixes a bug where apps copied from an older version of some app (app A) would not properly show up in the master app dropdown for linked apps linked to app A.