### PR TITLE
Added tooltips to app manager menu with menu/form index

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/form_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/form_link.html
@@ -38,10 +38,11 @@
         {% else %}
             class="fa fa-file-o appnav-primary-icon"
         {% endif %}
-            title="{{ form.get_icon_help_text }}"
+            title="{% if request|toggle_enabled:"SUPPORT" %}{% blocktrans with form.id as index %}This is form {{ index }}<br>{% endblocktrans %} {% endif %}{{ form.get_icon_help_text }}"
             data-toggle="tooltip"
             data-placement="right"
             data-container="body"
+            data-html="true"
             >
         </i>
         <span {% if form == selected_form %}class="variable-form_name"{% endif %}>

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/module_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/module_link.html
@@ -14,18 +14,22 @@
        class="appnav-title{% if module.doc_type != 'ReportModule' and module.doc_type != 'ShadowModule' %} appnav-title-secondary{% endif %} appnav-responsive">
         <i class="drag_handle appnav-drag-icon js-appnav-drag-module"></i>
         {% if module.module_type == 'advanced' %}
-          <i class="fa fa-flask appmanager-icon-type appnav-primary-icon"></i>
+          <i class="fa fa-flask appmanager-icon-type appnav-primary-icon"
         {% elif module.module_type == 'report' %}
-          <i class="fa fa-bar-chart appmanager-icon-type appnav-primary-icon"></i>
+          <i class="fa fa-bar-chart appmanager-icon-type appnav-primary-icon"
         {% elif module.module_type == 'shadow' %}
-          <i class="fa fa-folder-open-o appmanager-icon-type appnav-primary-icon"></i>
+          <i class="fa fa-folder-open-o appmanager-icon-type appnav-primary-icon"
         {% elif module.is_training_module %}
-          <i class="fa fa-book appnav-primary-icon"></i>
+          <i class="fa fa-book appnav-primary-icon"
         {% elif not module.is_surveys %}
-          <i class="fa fa-bars appnav-primary-icon"></i>
+          <i class="fa fa-bars appnav-primary-icon"
         {% else %}
-          <i class="fa fa-folder-open appnav-primary-icon"></i>
+          <i class="fa fa-folder-open appnav-primary-icon"
         {% endif %}
+            title="{% if request|toggle_enabled:"SUPPORT" %}{% blocktrans with module.id as index %}This is menu {{ index }}{% endblocktrans %}{% endif %}"
+            data-toggle="tooltip"
+            data-placement="right"
+            data-container="body"></i>
         <span {% if module.unique_id == selected_module.unique_id %}class="variable-module_name"{% endif %}>
             {{ module.name|html_trans_prefix:langs }}
         </span>


### PR DESCRIPTION
##### SUMMARY
A year and a half later, I have come around to seeing the value of https://github.com/dimagi/commcare-hq/pull/20000 especially when View Source Files is several clicks (and page loads) away. Putting it behind the support flag because I do still think this is too prominent a location for most users.

##### FEATURE FLAG
Support

##### PRODUCT DESCRIPTION
menu
<img width="271" alt="Screen Shot 2019-10-04 at 12 37 41 PM" src="https://user-images.githubusercontent.com/1486591/66224440-dd65ba00-e6a3-11e9-80b7-77210b887ecc.png">

form
<img width="270" alt="Screen Shot 2019-10-04 at 12 37 49 PM" src="https://user-images.githubusercontent.com/1486591/66224456-e35b9b00-e6a3-11e9-9446-29dcd11bf62b.png">
