### PR TITLE
Check GROUP_API_USE_ES_BACKEND request.user (not just domain)

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -316,7 +316,7 @@ class GroupResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMi
         return get_object_or_not_exist(Group, kwargs['pk'], kwargs['domain'])
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        if toggles.GROUP_API_USE_ES_BACKEND.enabled(domain):
+        if toggles.GROUP_API_USE_ES_BACKEND.enabled_for_request(bundle.request):
             return GroupQuerySetAdapterES(domain)
         else:
             return GroupQuerySetAdapterCouch(domain)


### PR DESCRIPTION
##### SUMMARY
Follow up to #25532, which enabled setting the flag for a user, but then just ignored it on a user.

##### FEATURE FLAG
GROUP_API_USE_ES_BACKEND
