### PR TITLE
Turn EOF nav / case list reg clash into a build error

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -18,6 +18,7 @@ from corehq.apps.app_manager.const import (
     AUTO_SELECT_FIXTURE,
     AUTO_SELECT_RAW,
     AUTO_SELECT_USER,
+    WORKFLOW_DEFAULT,
     WORKFLOW_FORM,
     WORKFLOW_MODULE,
     WORKFLOW_PARENT_MODULE,
@@ -346,6 +347,12 @@ class ModuleBaseValidator(object):
                 if not form.is_registration_form(self.module.case_type):
                     errors.append({
                         'type': 'case list form not registration',
+                        'module': self.get_module_info(),
+                        'form': form,
+                    })
+                if form.post_form_workflow != WORKFLOW_DEFAULT:
+                    errors.append({
+                        'type': 'case list form eof nav',
                         'module': self.get_module_info(),
                         'form': form,
                     })

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -107,7 +107,15 @@
                 some menus.
               {% endblocktrans %}
             {% case "missing module" %}
-              {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
+              {% if not_actual_build %}
+                {% blocktrans %}
+                  This menu references a missing menu.
+                {% endblocktrans %}
+              {% else %}
+                {% blocktrans with module_name=error.module.name|trans:langs %}
+                  <a href="{{ module_url }}">{{ module_name }}</a> references a missing menu.
+                {% endblocktrans %}
+              {% endif %}
               {% if error.message %}
                 {% trans "Details:" %}
               {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -3,7 +3,6 @@
 {% load xforms_extras %}{% if build_errors %}
 
 <div class="alert alert-warning alert-block alert-build">
-  {# todo make sure this makes sense for cloudcare outside of v2 (advanced build errors) #}
   <h4 class="alert-heading">
     <i class="fa fa-exclamation-circle"></i>
     {% trans "Cannot make new version" %}</h4>

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -10,440 +10,435 @@
     {% for error in build_errors %}
     <li>
       <span>
-          {% case error.type "blank form" %}
-        {% if not error.message %}
-          <strong>Add a Question</strong> to the
-        {% endif %}
-        {% include "app_manager/partials/form_error_message.html" %}
-          {% case "invalid xml" %}
-        {% if not error.message %}
+        {% case error.type "blank form" %}
+          {% if not error.message %}
+            <strong>Add a Question</strong> to the
+          {% endif %}
+          {% include "app_manager/partials/form_error_message.html" %}
+        {% case "invalid xml" %}
+          {% if not error.message %}
+            {% blocktrans %}
+              If you don't know why this happened, please report an issue.
+            {% endblocktrans %}
+          {% endif %}
+          {% include "app_manager/partials/form_error_message.html" %}
+        {% case "validation error" %}
+                {{ error.validation_message|linebreaksbr }} in form
+                {% include "app_manager/partials/form_error_message.html" %}
+        {% case "no form links" %}
           {% blocktrans %}
-            If you don't know why this happened, please report an issue.
+            Link to other form is selected, but no form links have been provided.
           {% endblocktrans %}
-        {% endif %}
-        {% include "app_manager/partials/form_error_message.html" %}
-          {% case "validation error" %}
-              {{ error.validation_message|linebreaksbr }} in form
-              {% include "app_manager/partials/form_error_message.html" %}
-          {% case "no form links" %}
-        {% blocktrans %}
-          Link to other form is selected, but no form links have been provided.
-        {% endblocktrans %}
-        {% include "app_manager/partials/form_error_message.html" %}
-          {% case "bad form link" %}
-        {% blocktrans %}
-          Link to other form is selected, but we don't recognize the form you provided.
-        {% endblocktrans %}
-        {% include "app_manager/partials/form_error_message.html" %}
-          {% case "form link to missing root" %}
-        {% blocktrans %}
-          Please check that end of form navigation is correct. It appears to be pointing
-          to a parent menu form, but the menu doesn't have a parent.
-         {% endblocktrans %}
-        {% include "app_manager/partials/form_error_message.html" %}
-          {% case "form link to display only forms" %}
-        {% blocktrans %}
-          Please check that end of form navigation is correct. It appears to be pointing
-          to a menu using "Display only forms," which makes that menu an invalid choice.
-        {% endblocktrans %}
-        {% include "app_manager/partials/form_error_message.html" %}
-          {% case "no ref detail" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          uses referrals but doesn't have detail screens configured for referrals.
-        {% endblocktrans %}
+          {% include "app_manager/partials/form_error_message.html" %}
+        {% case "bad form link" %}
+          {% blocktrans %}
+            Link to other form is selected, but we don't recognize the form you provided.
+          {% endblocktrans %}
+          {% include "app_manager/partials/form_error_message.html" %}
+        {% case "form link to missing root" %}
+          {% blocktrans %}
+            Please check that end of form navigation is correct. It appears to be pointing
+            to a parent menu form, but the menu doesn't have a parent.
+          {% endblocktrans %}
+          {% include "app_manager/partials/form_error_message.html" %}
+        {% case "form link to display only forms" %}
+          {% blocktrans %}
+            Please check that end of form navigation is correct. It appears to be pointing
+            to a menu using "Display only forms," which makes that menu an invalid choice.
+          {% endblocktrans %}
+          {% include "app_manager/partials/form_error_message.html" %}
+        {% case "no ref detail" %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            uses referrals but doesn't have detail screens configured for referrals.
+          {% endblocktrans %}
         {% case "no case detail" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          uses cases but doesn't have detail screens configured for cases.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            uses cases but doesn't have detail screens configured for cases.
+          {% endblocktrans %}
         {% case "no product detail" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          uses CommCare Supply products but doesn't have detail screens configured for products.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            uses CommCare Supply products but doesn't have detail screens configured for products.
+          {% endblocktrans %}
         {% case "invalid id key" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          has an incorrectly formatted ID key ({{ error_key }}).
-          Make sure your key has only letters, numbers, space characters, underscores, and dashes.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            has an incorrectly formatted ID key ({{ error_key }}).
+            Make sure your key has only letters, numbers, space characters, underscores, and dashes.
+          {% endblocktrans %}
         {% case "no modules" %}
-        {% blocktrans %}
-          No menus are available. <br />
-          <i class="fa fa-arrow-left"></i>
-          Please click
-          <i class="fa fa-plus"></i> <strong>Add...</strong> to create
-          some menus.
-        {% endblocktrans %}
+          {% blocktrans %}
+            No menus are available. <br />
+            <i class="fa fa-arrow-left"></i>
+            Please click
+            <i class="fa fa-plus"></i> <strong>Add...</strong> to create
+            some menus.
+          {% endblocktrans %}
         {% case "missing module" %}
-              {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
-        {% if error.message %}
-          {% trans "Details:" %}
-        {% endif %}
+          {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
+          {% if error.message %}
+            {% trans "Details:" %}
+          {% endif %}
         {% case "no forms" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          has no forms.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            has no forms.
+          {% endblocktrans %}
         {% case "no forms or case list" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          has no forms or case list.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            has no forms or case list.
+          {% endblocktrans %}
         {% case "training module parent" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          cannot have a training module as a parent module.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            cannot have a training module as a parent module.
+          {% endblocktrans %}
         {% case "training module child" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          is a training module and therefore cannot have a parent module.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            is a training module and therefore cannot have a parent module.
+          {% endblocktrans %}
         {% case "no reports" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          has no reports.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            has no reports.
+          {% endblocktrans %}
         {% case "circular case hierarchy" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
+          {% endblocktrans %}
         {% case "no case type" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          uses cases but doesn't have a case type defined.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            uses cases but doesn't have a case type defined.
+          {% endblocktrans %}
         {% case "case list form not registration" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-          as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
-          This form is not a registration form. You need to select a form which opens a case and
-          does not update an existing case. Please select a different form.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
+            as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
+            This form is not a registration form. You need to select a form which opens a case and
+            does not update an existing case. Please select a different form.
+          {% endblocktrans %}
         {% case "case list form eof nav" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-          as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
-          end of form navigation, which will override the case list registration workflow.
-          Please select a different form, or set the end of form navigation to the default option ('Home Screen').
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
+            as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
+            end of form navigation, which will override the case list registration workflow.
+            Please select a different form, or set the end of form navigation to the default option ('Home Screen').
+          {% endblocktrans %}
         {% case "case list form missing" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          The form you have selected as the case registration form for
-          <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
-          Please select another form.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            The form you have selected as the case registration form for
+            <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
+            Please select another form.
+          {% endblocktrans %}
         {% case "report config ref invalid" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          There are references to reports that are deleted in
-          <a href="{{ module_url }}">{{ module_name }}</a>.
-          You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            There are references to reports that are deleted in
+            <a href="{{ module_url }}">{{ module_name }}</a>.
+            You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
+          {% endblocktrans %}
         {% case "report config id duplicated" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          There are multiple reports with the same report code in
-          <a href="{{ module_url }}">{{ module_name }}</a>.
-          These codes must be unique.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            There are multiple reports with the same report code in
+            <a href="{{ module_url }}">{{ module_name }}</a>.
+            These codes must be unique.
+          {% endblocktrans %}
         {% case "module filter has xpath error" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
+          {% endblocktrans %}
         {% case "form filter has xpath error" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          Display Condition has syntax errors
-          in the <a href="{{ form_url }}">{{ form_name }}</a> form
-          in <a href="{{ module_url }}">{{ module_name }}</a>.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            Display Condition has syntax errors
+            in the <a href="{{ form_url }}">{{ form_name }}</a> form
+            in <a href="{{ module_url }}">{{ module_name }}</a>.
+          {% endblocktrans %}
         {% case "all forms in case list module must load the same cases" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-          loads different case types from the other forms. All forms in a case list that has a case registration form
-          selected must load the same case types.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+            loads different case types from the other forms. All forms in a case list that has a case registration form
+            selected must load the same case types.
+          {% endblocktrans %}
         {% case "case list module form must require case" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-          must update a case. All forms in a case list that has a case registration form selected must update a case.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+            must update a case. All forms in a case list that has a case registration form selected must update a case.
+          {% endblocktrans %}
         {% case "case list module form can only load parent cases" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-          can only load or update a single case and its parents. All forms in a case list that
-          has a case registration form selected can only update a single case and its parents.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+            can only load or update a single case and its parents. All forms in a case list that
+            has a case registration form selected can only update a single case and its parents.
+          {% endblocktrans %}
         {% case "case list module form must match module case type" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
-          <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
-          selected must load a case of the same type as the case list.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
+            <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
+            selected must load a case of the same type as the case list.
+          {% endblocktrans %}
         {% case "all forms in case list module must have same case management" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
-          The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-          loads a case with a different case tag to the other forms in the case list.
-          All forms in a case list that has a case registration form selected must use the same case tag.
-          Expected case tag: <strong>{{ expected_tag }}</strong>
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
+            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+            loads a case with a different case tag to the other forms in the case list.
+            All forms in a case list that has a case registration form selected must use the same case tag.
+            Expected case tag: <strong>{{ expected_tag }}</strong>
+          {% endblocktrans %}
         {% case "forms in case list module must use modules details" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-              {% url "view_form" domain app.id error.form.unique_id as form_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-          The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-          uses a details screen from another case list. All forms in a case list that has a case
-          registration form selected must use the details screen from that case list.
-        {% endblocktrans %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+            uses a details screen from another case list. All forms in a case list that has a case
+            registration form selected must use the details screen from that case list.
+          {% endblocktrans %}
         {% case "invalid filter xpath" %}
-        {% if error.filter %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
-            Case List has invalid filter xpath <code>{{ error_filter }}</code> in
-            <a href="{{ module_url }}">{{ module_name }}</a>
-          {% endblocktrans %}
-        {% else %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            Case List has blank filter in
-            <a href="{{ module_url }}">{{ module_name }}</a>
-          {% endblocktrans %}
-        {% endif %}
-        {% case "invalid sort field" %}
-        {% if error.field %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
-            Case List has invalid sort field <code>{{ error_field }}</code> in
-            <a href="{{ module_url }}">{{ module_name }}</a>
-          {% endblocktrans %}
-        {% else %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            Case List has blank sort field in
-            <a href="{{ module_url }}">{{ module_name }}</a>
-          {% endblocktrans %}
-        {% endif %}
-        {% case "invalid tile configuration" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
-          The case list in
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          has an invalid case tile configuration. Reason: {{ error_reason }}
-        {% endblocktrans %}
-        {% case "no source module id" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          Shadow module
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          doesn't have a source module specified.
-        {% endblocktrans %}
-        {% case "no parent select id" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs %}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-          uses parent case selection but doesn't have a parent case list specified.
-        {% endblocktrans %}
-        {% case "parent cycle" %}
-        {% blocktrans %}
-          The app's parent child case selection graph contains a cycle.
-        {% endblocktrans %}
-        {% case "root cycle" %}
-        {% blocktrans %}
-          The app's parent child graph contains a cycle.
-        {% endblocktrans %}
-        {% case "unknown root" %}
-        {% blocktrans %}
-          A menu points to an unknown Parent Menu.
-        {% endblocktrans %}
-        {% case "invalid location xpath" %}
-              {% url "view_module" domain app.id error.module.unique_id as module_url %}
-        {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
-          Case List has invalid location reference <code>{{ property }}</code>.
-          Details: {{ details }}
-          <a href="{{ module_url }}">{{ module_name }}</a>
-        {% endblocktrans %}
-        {% case "subcase has no case type" %}
-              Child case specifies no case list
-              in form {% include "app_manager/partials/form_error_message.html" %}
-          {% case "form error" %}
-        {% blocktrans %}
-          One or more forms are invalid: check all your forms for error messages.
-        {% endblocktrans %}
-        {% case "missing languages" %}
-              {% include "app_manager/partials/form_error_message.html" %} missing languages:
-        {% for lang in error.missing_languages %}
-          {{ lang }}
-        {% endfor %}
-        {% case "duplicate xmlns" %}
-        {% if error.xmlns %}
-          {% blocktrans with xmlns=error.xmlns %}
-            You have two forms with the xmlns "{{ xmlns }}"
-          {% endblocktrans %}
-        {% endif %}
-        {% case "update_case uses reserved word" %}
-              Case Update uses reserved word "{{ error.word }}"
-        {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "update_case word illegal" %}
-              Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
-        {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "case_name required" %}
-              <strong>Every case must have a name.</strong> Please specify a value for the name property under
-              "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "path error" %}
-        {% if error.path %}
-          The case management
-          {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
-          in form {% include "app_manager/partials/form_error_message.html" %}
-          references a question that no longer exists: "{{ error.path }}". It is likely that
-          this question has been renamed or deleted. Please update or delete this question
-          reference before you make a new version.
-        {% else %}
-          The case management
-          {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
-          in the form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
-          is missing a question.
-          Please choose a question from the dropdown next to the case property.
-        {% endif %}
-        {% case "multimedia case property not supported" %}
-        {% blocktrans with path=error.path %}
-          Multimedia case property "{{ path }}" is not supported on apps on or before v2.5.
-        {% endblocktrans %}
-        {% case "remote error" %}
-        {% blocktrans %}
-          Remote Error:
-        {% endblocktrans %}
-        {% case "empty lang" %}
-              {% url "app_settings" domain app.id as app_url %}
-        {% blocktrans %}
-          One of your languages is empty. Check your <a href="{{ app_url }}">app settings</a>.
-        {% endblocktrans %}
-        {% case "missing parent tag" %}
-              A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "missing relationship question" %}
-              A subcase's index relationship with parent case tag "{{ error.case_tag }}" is determined by a question,
-              but no question is specified.
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "subcase repeat context" %}
-              The subcase "{{ error.case_tag }}" is in a different repeat context to its parent "{{ error.parent_tag }}"
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "auto select key" %}
-              The auto-select case action is missing the "{{ error.key_name }}" value
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "auto select source" %}
-              The auto-select case action is missing the "{{ error.source_name }}" value
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "auto select case ref" %}
-              The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "no case type in action" %}
-              The form action "{{ error.case_tag }}" does not have a case type selected
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "filtering without case" %}
-              The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
-        {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
-          {% case "invalid case xpath reference" %}
-        {% if error.form %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
-          {% blocktrans with form_name=error.form.name|trans:langs %}
-            Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
-            but cases are not available for this form. Please either remove the case reference or (1) make sure
-            that the case list is set to display the case list first and then form, and (2) make sure that all forms in
-            this case list update or close a case (which means registration forms must go in a different case list).
-          {% endblocktrans %}
-        {% else %}
-          {% blocktrans %}
-            You have a display condition which refers to a case, but cases are not available. Please either remove
-            the case reference or (1) make sure that the case list is set to display the case list first and then form,
-            and (2) make sure that all forms in this case list update or close a case (which means registration forms
-            must go in a different case list).
-          {% endblocktrans %}
-        {% endif %}
-        {% case "practice user config error" %}
-        {% if error.build_profile_id %}
-          {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
-            Error with Practice Mobile Worker in Application Profile {{ profile.name }}.
-          {% endblocktrans %}
-        {% else %}
-          {% blocktrans%}
-            Error with Practice Mobile Worker in Application Settings.
-          {% endblocktrans %}
-        {% endif %}
-        {% case "invalid user property xpath reference" %}
-        {% if error.form %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
-          {% blocktrans with form_name=error.form.name|trans:langs %}
-            Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
-            but your project does not use user properties. Please remove the user property reference.
-          {% endblocktrans %}
-        {% else %}
-          {% blocktrans %}
-            You have a display condition which refers to a user property, but your project does not use user properties.
-            Please remove the user property reference.
-          {% endblocktrans %}
-        {% endif %}
-        {% case "error" %}
-              Details: {{ error.message }}
-          {% case "subscription" %}
-              {% url 'domain_select_plan' domain as domain_url %}
-        {% blocktrans %}
-          Your application uses a feature that is not available in your current subscription. You
-          can <a href="{{ domain_url }}">change your subscription</a>, or
-          remove the feature as follows.
-        {% endblocktrans %}
-        {% case "missing shadow parent" %}
-              A shadow parent must be specified
-        {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        Select a shadow parent in the "Advanced" section of the shadow form's settings tab.
-          {% case "shadow parent does not exist" %}
-              A shadow parent specified
-        {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
-          {% case "missing shadow parent tag" %}
-              Shadow parent form action tags do not appear in the action configuration for the shadow form.
-              The missing tags are: {{ error.case_tags|join:", " }}
-        {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "password_format" %}
-              {# Do nothing; the full message is contained in error.message #}
+          {% if error.filter %}
+            {% url "view_module" domain app.id error.module.unique_id as module_url %}
+            {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
+              Case List has invalid filter xpath <code>{{ error_filter }}</code> in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+            {% endblocktrans %}
           {% else %}
-              Unknown error: {{ error.type }}
-              Details: {{ error }}
-          {% endcase %}
-          {# And then show the optional `message` regardless #}
+            {% url "view_module" domain app.id error.module.unique_id as module_url %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              Case List has blank filter in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+            {% endblocktrans %}
+          {% endif %}
+        {% case "invalid sort field" %}
+          {% if error.field %}
+            {% url "view_module" domain app.id error.module.unique_id as module_url %}
+            {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
+              Case List has invalid sort field <code>{{ error_field }}</code> in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+            {% endblocktrans %}
+          {% else %}
+            {% url "view_module" domain app.id error.module.unique_id as module_url %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              Case List has blank sort field in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+            {% endblocktrans %}
+          {% endif %}
+        {% case "invalid tile configuration" %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
+            The case list in
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            has an invalid case tile configuration. Reason: {{ error_reason }}
+          {% endblocktrans %}
+        {% case "no source module id" %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            Shadow module
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            doesn't have a source module specified.
+          {% endblocktrans %}
+        {% case "no parent select id" %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs %}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+            uses parent case selection but doesn't have a parent case list specified.
+          {% endblocktrans %}
+        {% case "parent cycle" %}
+          {% blocktrans %}
+            The app's parent child case selection graph contains a cycle.
+          {% endblocktrans %}
+        {% case "root cycle" %}
+          {% blocktrans %}
+            The app's parent child graph contains a cycle.
+          {% endblocktrans %}
+        {% case "unknown root" %}
+          {% blocktrans %}
+            A menu points to an unknown Parent Menu.
+          {% endblocktrans %}
+        {% case "invalid location xpath" %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+          {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
+            Case List has invalid location reference <code>{{ property }}</code>.
+            Details: {{ details }}
+            <a href="{{ module_url }}">{{ module_name }}</a>
+          {% endblocktrans %}
+        {% case "subcase has no case type" %}
+          Child case specifies no case list in form {% include "app_manager/partials/form_error_message.html" %}
+        {% case "form error" %}
+          {% blocktrans %}
+            One or more forms are invalid: check all your forms for error messages.
+          {% endblocktrans %}
+        {% case "missing languages" %}
+          {% include "app_manager/partials/form_error_message.html" %} missing languages:
+          {% for lang in error.missing_languages %}
+            {{ lang }}
+          {% endfor %}
+        {% case "duplicate xmlns" %}
+          {% if error.xmlns %}
+            {% blocktrans with xmlns=error.xmlns %}
+              You have two forms with the xmlns "{{ xmlns }}"
+            {% endblocktrans %}
+          {% endif %}
+        {% case "update_case uses reserved word" %}
+          Case Update uses reserved word "{{ error.word }}"
+          {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "update_case word illegal" %}
+          Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
+          {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "case_name required" %}
+          <strong>Every case must have a name.</strong> Please specify a value for the name property under
+          "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "path error" %}
+          {% if error.path %}
+            The case management
+            {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
+            in form {% include "app_manager/partials/form_error_message.html" %}
+            references a question that no longer exists: "{{ error.path }}". It is likely that
+            this question has been renamed or deleted. Please update or delete this question
+            reference before you make a new version.
+          {% else %}
+            The case management
+            {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
+            in the form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
+            is missing a question.
+            Please choose a question from the dropdown next to the case property.
+          {% endif %}
+        {% case "multimedia case property not supported" %}
+          {% blocktrans with path=error.path %}
+            Multimedia case property "{{ path }}" is not supported on apps on or before v2.5.
+          {% endblocktrans %}
+        {% case "empty lang" %}
+          {% url "app_settings" domain app.id as app_url %}
+          {% blocktrans %}
+            One of your languages is empty. Check your <a href="{{ app_url }}">app settings</a>.
+          {% endblocktrans %}
+        {% case "missing parent tag" %}
+          A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "missing relationship question" %}
+          A subcase's index relationship with parent case tag "{{ error.case_tag }}" is determined by a question,
+          but no question is specified.
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "subcase repeat context" %}
+          The subcase "{{ error.case_tag }}" is in a different repeat context to its parent "{{ error.parent_tag }}"
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "auto select key" %}
+          The auto-select case action is missing the "{{ error.key_name }}" value
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "auto select source" %}
+          The auto-select case action is missing the "{{ error.source_name }}" value
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "auto select case ref" %}
+          The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "no case type in action" %}
+          The form action "{{ error.case_tag }}" does not have a case type selected
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "filtering without case" %}
+          The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
+          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
+        {% case "invalid case xpath reference" %}
+          {% if error.form %}
+            {% url "view_form" domain app.id error.form.unique_id as form_url %}
+            {% blocktrans with form_name=error.form.name|trans:langs %}
+              Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
+              but cases are not available for this form. Please either remove the case reference or (1) make sure
+              that the case list is set to display the case list first and then form, and (2) make sure that all forms in
+              this case list update or close a case (which means registration forms must go in a different case list).
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans %}
+              You have a display condition which refers to a case, but cases are not available. Please either remove
+              the case reference or (1) make sure that the case list is set to display the case list first and then form,
+              and (2) make sure that all forms in this case list update or close a case (which means registration forms
+              must go in a different case list).
+            {% endblocktrans %}
+          {% endif %}
+        {% case "practice user config error" %}
+          {% if error.build_profile_id %}
+            {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
+              Error with Practice Mobile Worker in Application Profile {{ profile.name }}.
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans%}
+              Error with Practice Mobile Worker in Application Settings.
+            {% endblocktrans %}
+          {% endif %}
+        {% case "invalid user property xpath reference" %}
+          {% if error.form %}
+            {% url "view_form" domain app.id error.form.unique_id as form_url %}
+            {% blocktrans with form_name=error.form.name|trans:langs %}
+              Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
+              but your project does not use user properties. Please remove the user property reference.
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans %}
+              You have a display condition which refers to a user property, but your project does not use user properties.
+              Please remove the user property reference.
+            {% endblocktrans %}
+          {% endif %}
+        {% case "subscription" %}
+          {% url 'domain_select_plan' domain as domain_url %}
+          {% blocktrans %}
+            Your application uses a feature that is not available in your current subscription. You
+            can <a href="{{ domain_url }}">change your subscription</a>, or
+            remove the feature as follows.
+          {% endblocktrans %}
+        {% case "missing shadow parent" %}
+          A shadow parent must be specified
+          {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          Select a shadow parent in the "Advanced" section of the shadow form's settings tab.
+        {% case "shadow parent does not exist" %}
+          A shadow parent specified
+          {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
+        {% case "missing shadow parent tag" %}
+                Shadow parent form action tags do not appear in the action configuration for the shadow form.
+                The missing tags are: {{ error.case_tags|join:", " }}
+          {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+        {% case "password_format" %}
+          {# Do nothing; the full message is contained in error.message #}
+        {% case "error" %}
+          Details: {{ error.message }}
+        {% else %}
+          Unknown error: {{ error.type }}
+          Details: {{ error }}
+        {% endcase %}
+        {# And then show the optional `message` regardless #}
         {% if error.type != 'error' %}
           {# Don't show the error message if we already did above #}
           <span>{{ error.message }}</span>

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -2,6 +2,32 @@
 {% load hq_shared_tags %}
 {% load xforms_extras %}
 
+{% comment %}
+  This file displays errors found during app validation, which is handled by the validators in corehq.apps.app_manager.helpers.validators.
+  Each error is a dict containing:
+  - type (required)
+  - message (optional)
+  - module (optional): a dict containing the module's id, name dict, and unique_id
+  - form (optional): possibly a form, possibly just a dict containing id and name dict
+  - ...and occasionally other data
+
+  This file is primarily a giant case statement that switches on the error type.
+  It's inconsistent. Best practices for new errors:
+  - This file is included in several contexts, some general to the whole app and some
+    specific to a single form or module. The flag not_actual_build is set when we're
+    only looking at part of an app. This is used to make messages less redundant: you
+    might say "Form X in menu Y is broken" in an app context, but in a form context
+    that can just become "This form is broken."
+  - For menu or form-specific errors, always link to the menu or form.
+  - For form specific errors, display the menu name ("Form X in menu Y") but only link to
+    the place where the user would go to fix the error (probably the form).
+  - For form errors, consider whether the message should link to form_source or to
+    form_settings (probably form settings).
+  - Aim to translate error messages, even though it can get complex to handle the
+    not_actual_build flag and links to menus/forms. For this reason, avoid including
+    templates like form_error_message.html.
+{% endcomment %}
+
 {% if build_errors %}
   <div class="alert alert-warning alert-block alert-build">
     <h4 class="alert-heading">

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -18,10 +18,7 @@
         <li>
           <span>
             {% case error.type "blank form" %}
-              {% if not error.message %}
-                <strong>Add a Question</strong> to the
-              {% endif %}
-              {% include "app_manager/partials/form_error_message.html" %}
+              <strong>Add a question</strong> to the {% include "app_manager/partials/form_error_message.html" %}
             {% case "invalid xml" %}
               {% if not error.message %}
                 {% blocktrans %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -29,7 +29,7 @@
 {% endcomment %}
 
 {% if build_errors %}
-  <div class="alert alert-warning alert-block alert-build">
+  <div class="alert alert-warning alert-build">
     <h4 class="alert-heading">
       <i class="fa fa-exclamation-circle"></i>
       {% trans "Cannot make new version" %}</h4>

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -135,6 +135,15 @@
           This form is not a registration form. You need to select a form which opens a case and
           does not update an existing case. Please select a different form.
         {% endblocktrans %}
+        {% case "case list form eof nav" %}
+              {% url "view_module" domain app.id error.module.unique_id as module_url %}
+              {% url "view_form" domain app.id error.form.unique_id as form_url %}
+        {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+          You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
+          as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
+          end of form navigation, which will override the case list registration workflow.
+          Please select a different form, or set the end of form navigation to the default option ('Home Screen').
+        {% endblocktrans %}
         {% case "case list form missing" %}
               {% url "view_module" domain app.id error.module.unique_id as module_url %}
         {% blocktrans with module_name=error.module.name|trans:langs %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -15,400 +15,400 @@
       {% if error.form %}
         {% url "view_form" domain app.id error.form.unique_id as form_url %}
       {% endif %}
-    <li>
-      <span>
-        {% case error.type "blank form" %}
-          {% if not error.message %}
-            <strong>Add a Question</strong> to the
-          {% endif %}
-          {% include "app_manager/partials/form_error_message.html" %}
-        {% case "invalid xml" %}
-          {% if not error.message %}
+      <li>
+        <span>
+          {% case error.type "blank form" %}
+            {% if not error.message %}
+              <strong>Add a Question</strong> to the
+            {% endif %}
+            {% include "app_manager/partials/form_error_message.html" %}
+          {% case "invalid xml" %}
+            {% if not error.message %}
+              {% blocktrans %}
+                If you don't know why this happened, please report an issue.
+              {% endblocktrans %}
+            {% endif %}
+            {% include "app_manager/partials/form_error_message.html" %}
+          {% case "validation error" %}
+                  {{ error.validation_message|linebreaksbr }} in form
+                  {% include "app_manager/partials/form_error_message.html" %}
+          {% case "no form links" %}
             {% blocktrans %}
-              If you don't know why this happened, please report an issue.
+              Link to other form is selected, but no form links have been provided.
             {% endblocktrans %}
-          {% endif %}
-          {% include "app_manager/partials/form_error_message.html" %}
-        {% case "validation error" %}
-                {{ error.validation_message|linebreaksbr }} in form
-                {% include "app_manager/partials/form_error_message.html" %}
-        {% case "no form links" %}
-          {% blocktrans %}
-            Link to other form is selected, but no form links have been provided.
-          {% endblocktrans %}
-          {% include "app_manager/partials/form_error_message.html" %}
-        {% case "bad form link" %}
-          {% blocktrans %}
-            Link to other form is selected, but we don't recognize the form you provided.
-          {% endblocktrans %}
-          {% include "app_manager/partials/form_error_message.html" %}
-        {% case "form link to missing root" %}
-          {% blocktrans %}
-            Please check that end of form navigation is correct. It appears to be pointing
-            to a parent menu form, but the menu doesn't have a parent.
-          {% endblocktrans %}
-          {% include "app_manager/partials/form_error_message.html" %}
-        {% case "form link to display only forms" %}
-          {% blocktrans %}
-            Please check that end of form navigation is correct. It appears to be pointing
-            to a menu using "Display only forms," which makes that menu an invalid choice.
-          {% endblocktrans %}
-          {% include "app_manager/partials/form_error_message.html" %}
-        {% case "no ref detail" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            uses referrals but doesn't have detail screens configured for referrals.
-          {% endblocktrans %}
-        {% case "no case detail" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            uses cases but doesn't have detail screens configured for cases.
-          {% endblocktrans %}
-        {% case "no product detail" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            uses CommCare Supply products but doesn't have detail screens configured for products.
-          {% endblocktrans %}
-        {% case "invalid id key" %}
-          {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            has an incorrectly formatted ID key ({{ error_key }}).
-            Make sure your key has only letters, numbers, space characters, underscores, and dashes.
-          {% endblocktrans %}
-        {% case "no modules" %}
-          {% blocktrans %}
-            No menus are available. <br />
-            <i class="fa fa-arrow-left"></i>
-            Please click
-            <i class="fa fa-plus"></i> <strong>Add...</strong> to create
-            some menus.
-          {% endblocktrans %}
-        {% case "missing module" %}
-          {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
-          {% if error.message %}
-            {% trans "Details:" %}
-          {% endif %}
-        {% case "no forms" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            has no forms.
-          {% endblocktrans %}
-        {% case "no forms or case list" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            has no forms or case list.
-          {% endblocktrans %}
-        {% case "training module parent" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            cannot have a training module as a parent module.
-          {% endblocktrans %}
-        {% case "training module child" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            is a training module and therefore cannot have a parent module.
-          {% endblocktrans %}
-        {% case "no reports" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            has no reports.
-          {% endblocktrans %}
-        {% case "circular case hierarchy" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
-          {% endblocktrans %}
-        {% case "no case type" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            uses cases but doesn't have a case type defined.
-          {% endblocktrans %}
-        {% case "case list form not registration" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-            as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
-            This form is not a registration form. You need to select a form which opens a case and
-            does not update an existing case. Please select a different form.
-          {% endblocktrans %}
-        {% case "case list form eof nav" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-            as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
-            end of form navigation, which will override the case list registration workflow.
-            Please select a different form, or set the end of form navigation to the default option ('Home Screen').
-          {% endblocktrans %}
-        {% case "case list form missing" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            The form you have selected as the case registration form for
-            <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
-            Please select another form.
-          {% endblocktrans %}
-        {% case "report config ref invalid" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            There are references to reports that are deleted in
-            <a href="{{ module_url }}">{{ module_name }}</a>.
-            You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
-          {% endblocktrans %}
-        {% case "report config id duplicated" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            There are multiple reports with the same report code in
-            <a href="{{ module_url }}">{{ module_name }}</a>.
-            These codes must be unique.
-          {% endblocktrans %}
-        {% case "module filter has xpath error" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
-          {% endblocktrans %}
-        {% case "form filter has xpath error" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            Display Condition has syntax errors
-            in the <a href="{{ form_url }}">{{ form_name }}</a> form
-            in <a href="{{ module_url }}">{{ module_name }}</a>.
-          {% endblocktrans %}
-        {% case "all forms in case list module must load the same cases" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-            loads different case types from the other forms. All forms in a case list that has a case registration form
-            selected must load the same case types.
-          {% endblocktrans %}
-        {% case "case list module form must require case" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-            must update a case. All forms in a case list that has a case registration form selected must update a case.
-          {% endblocktrans %}
-        {% case "case list module form can only load parent cases" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-            can only load or update a single case and its parents. All forms in a case list that
-            has a case registration form selected can only update a single case and its parents.
-          {% endblocktrans %}
-        {% case "case list module form must match module case type" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
-            <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
-            selected must load a case of the same type as the case list.
-          {% endblocktrans %}
-        {% case "all forms in case list module must have same case management" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
-            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-            loads a case with a different case tag to the other forms in the case list.
-            All forms in a case list that has a case registration form selected must use the same case tag.
-            Expected case tag: <strong>{{ expected_tag }}</strong>
-          {% endblocktrans %}
-        {% case "forms in case list module must use modules details" %}
-          {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-            The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-            uses a details screen from another case list. All forms in a case list that has a case
-            registration form selected must use the details screen from that case list.
-          {% endblocktrans %}
-        {% case "invalid filter xpath" %}
-          {% if error.filter %}
-            {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
-              Case List has invalid filter xpath <code>{{ error_filter }}</code> in
-              <a href="{{ module_url }}">{{ module_name }}</a>
+            {% include "app_manager/partials/form_error_message.html" %}
+          {% case "bad form link" %}
+            {% blocktrans %}
+              Link to other form is selected, but we don't recognize the form you provided.
             {% endblocktrans %}
-          {% else %}
+            {% include "app_manager/partials/form_error_message.html" %}
+          {% case "form link to missing root" %}
+            {% blocktrans %}
+              Please check that end of form navigation is correct. It appears to be pointing
+              to a parent menu form, but the menu doesn't have a parent.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
+          {% case "form link to display only forms" %}
+            {% blocktrans %}
+              Please check that end of form navigation is correct. It appears to be pointing
+              to a menu using "Display only forms," which makes that menu an invalid choice.
+            {% endblocktrans %}
+            {% include "app_manager/partials/form_error_message.html" %}
+          {% case "no ref detail" %}
             {% blocktrans with module_name=error.module.name|trans:langs %}
-              Case List has blank filter in
               <a href="{{ module_url }}">{{ module_name }}</a>
+              uses referrals but doesn't have detail screens configured for referrals.
             {% endblocktrans %}
-          {% endif %}
-        {% case "invalid sort field" %}
-          {% if error.field %}
-            {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
-              Case List has invalid sort field <code>{{ error_field }}</code> in
-              <a href="{{ module_url }}">{{ module_name }}</a>
-            {% endblocktrans %}
-          {% else %}
+          {% case "no case detail" %}
             {% blocktrans with module_name=error.module.name|trans:langs %}
-              Case List has blank sort field in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses cases but doesn't have detail screens configured for cases.
+            {% endblocktrans %}
+          {% case "no product detail" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses CommCare Supply products but doesn't have detail screens configured for products.
+            {% endblocktrans %}
+          {% case "invalid id key" %}
+            {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has an incorrectly formatted ID key ({{ error_key }}).
+              Make sure your key has only letters, numbers, space characters, underscores, and dashes.
+            {% endblocktrans %}
+          {% case "no modules" %}
+            {% blocktrans %}
+              No menus are available. <br />
+              <i class="fa fa-arrow-left"></i>
+              Please click
+              <i class="fa fa-plus"></i> <strong>Add...</strong> to create
+              some menus.
+            {% endblocktrans %}
+          {% case "missing module" %}
+            {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
+            {% if error.message %}
+              {% trans "Details:" %}
+            {% endif %}
+          {% case "no forms" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has no forms.
+            {% endblocktrans %}
+          {% case "no forms or case list" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has no forms or case list.
+            {% endblocktrans %}
+          {% case "training module parent" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              cannot have a training module as a parent module.
+            {% endblocktrans %}
+          {% case "training module child" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              is a training module and therefore cannot have a parent module.
+            {% endblocktrans %}
+          {% case "no reports" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has no reports.
+            {% endblocktrans %}
+          {% case "circular case hierarchy" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
+            {% endblocktrans %}
+          {% case "no case type" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses cases but doesn't have a case type defined.
+            {% endblocktrans %}
+          {% case "case list form not registration" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
+              as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
+              This form is not a registration form. You need to select a form which opens a case and
+              does not update an existing case. Please select a different form.
+            {% endblocktrans %}
+          {% case "case list form eof nav" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
+              as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
+              end of form navigation, which will override the case list registration workflow.
+              Please select a different form, or set the end of form navigation to the default option ('Home Screen').
+            {% endblocktrans %}
+          {% case "case list form missing" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The form you have selected as the case registration form for
+              <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
+              Please select another form.
+            {% endblocktrans %}
+          {% case "report config ref invalid" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              There are references to reports that are deleted in
+              <a href="{{ module_url }}">{{ module_name }}</a>.
+              You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
+            {% endblocktrans %}
+          {% case "report config id duplicated" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              There are multiple reports with the same report code in
+              <a href="{{ module_url }}">{{ module_name }}</a>.
+              These codes must be unique.
+            {% endblocktrans %}
+          {% case "module filter has xpath error" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
+            {% endblocktrans %}
+          {% case "form filter has xpath error" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              Display Condition has syntax errors
+              in the <a href="{{ form_url }}">{{ form_name }}</a> form
+              in <a href="{{ module_url }}">{{ module_name }}</a>.
+            {% endblocktrans %}
+          {% case "all forms in case list module must load the same cases" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+              loads different case types from the other forms. All forms in a case list that has a case registration form
+              selected must load the same case types.
+            {% endblocktrans %}
+          {% case "case list module form must require case" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+              must update a case. All forms in a case list that has a case registration form selected must update a case.
+            {% endblocktrans %}
+          {% case "case list module form can only load parent cases" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+              can only load or update a single case and its parents. All forms in a case list that
+              has a case registration form selected can only update a single case and its parents.
+            {% endblocktrans %}
+          {% case "case list module form must match module case type" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
+              <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
+              selected must load a case of the same type as the case list.
+            {% endblocktrans %}
+          {% case "all forms in case list module must have same case management" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+              loads a case with a different case tag to the other forms in the case list.
+              All forms in a case list that has a case registration form selected must use the same case tag.
+              Expected case tag: <strong>{{ expected_tag }}</strong>
+            {% endblocktrans %}
+          {% case "forms in case list module must use modules details" %}
+            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+              uses a details screen from another case list. All forms in a case list that has a case
+              registration form selected must use the details screen from that case list.
+            {% endblocktrans %}
+          {% case "invalid filter xpath" %}
+            {% if error.filter %}
+              {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
+                Case List has invalid filter xpath <code>{{ error_filter }}</code> in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                Case List has blank filter in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% endif %}
+          {% case "invalid sort field" %}
+            {% if error.field %}
+              {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
+                Case List has invalid sort field <code>{{ error_field }}</code> in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                Case List has blank sort field in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% endblocktrans %}
+            {% endif %}
+          {% case "invalid tile configuration" %}
+            {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
+              The case list in
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              has an invalid case tile configuration. Reason: {{ error_reason }}
+            {% endblocktrans %}
+          {% case "no source module id" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              Shadow module
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              doesn't have a source module specified.
+            {% endblocktrans %}
+          {% case "no parent select id" %}
+            {% blocktrans with module_name=error.module.name|trans:langs %}
+              <a href="{{ module_url }}">{{ module_name }}</a>
+              uses parent case selection but doesn't have a parent case list specified.
+            {% endblocktrans %}
+          {% case "parent cycle" %}
+            {% blocktrans %}
+              The app's parent child case selection graph contains a cycle.
+            {% endblocktrans %}
+          {% case "root cycle" %}
+            {% blocktrans %}
+              The app's parent child graph contains a cycle.
+            {% endblocktrans %}
+          {% case "unknown root" %}
+            {% blocktrans %}
+              A menu points to an unknown Parent Menu.
+            {% endblocktrans %}
+          {% case "invalid location xpath" %}
+            {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
+              Case List has invalid location reference <code>{{ property }}</code>.
+              Details: {{ details }}
               <a href="{{ module_url }}">{{ module_name }}</a>
             {% endblocktrans %}
-          {% endif %}
-        {% case "invalid tile configuration" %}
-          {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
-            The case list in
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            has an invalid case tile configuration. Reason: {{ error_reason }}
-          {% endblocktrans %}
-        {% case "no source module id" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            Shadow module
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            doesn't have a source module specified.
-          {% endblocktrans %}
-        {% case "no parent select id" %}
-          {% blocktrans with module_name=error.module.name|trans:langs %}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-            uses parent case selection but doesn't have a parent case list specified.
-          {% endblocktrans %}
-        {% case "parent cycle" %}
-          {% blocktrans %}
-            The app's parent child case selection graph contains a cycle.
-          {% endblocktrans %}
-        {% case "root cycle" %}
-          {% blocktrans %}
-            The app's parent child graph contains a cycle.
-          {% endblocktrans %}
-        {% case "unknown root" %}
-          {% blocktrans %}
-            A menu points to an unknown Parent Menu.
-          {% endblocktrans %}
-        {% case "invalid location xpath" %}
-          {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
-            Case List has invalid location reference <code>{{ property }}</code>.
-            Details: {{ details }}
-            <a href="{{ module_url }}">{{ module_name }}</a>
-          {% endblocktrans %}
-        {% case "subcase has no case type" %}
-          Child case specifies no case list in form {% include "app_manager/partials/form_error_message.html" %}
-        {% case "form error" %}
-          {% blocktrans %}
-            One or more forms are invalid: check all your forms for error messages.
-          {% endblocktrans %}
-        {% case "missing languages" %}
-          {% include "app_manager/partials/form_error_message.html" %} missing languages:
-          {% for lang in error.missing_languages %}
-            {{ lang }}
-          {% endfor %}
-        {% case "duplicate xmlns" %}
-          {% if error.xmlns %}
-            {% blocktrans with xmlns=error.xmlns %}
-              You have two forms with the xmlns "{{ xmlns }}"
-            {% endblocktrans %}
-          {% endif %}
-        {% case "update_case uses reserved word" %}
-          Case Update uses reserved word "{{ error.word }}"
-          {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "update_case word illegal" %}
-          Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
-          {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "case_name required" %}
-          <strong>Every case must have a name.</strong> Please specify a value for the name property under
-          "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "path error" %}
-          {% if error.path %}
-            The case management
-            {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
-            in form {% include "app_manager/partials/form_error_message.html" %}
-            references a question that no longer exists: "{{ error.path }}". It is likely that
-            this question has been renamed or deleted. Please update or delete this question
-            reference before you make a new version.
-          {% else %}
-            The case management
-            {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
-            in the form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
-            is missing a question.
-            Please choose a question from the dropdown next to the case property.
-          {% endif %}
-        {% case "multimedia case property not supported" %}
-          {% blocktrans with path=error.path %}
-            Multimedia case property "{{ path }}" is not supported on apps on or before v2.5.
-          {% endblocktrans %}
-        {% case "empty lang" %}
-          {% url "app_settings" domain app.id as app_url %}
-          {% blocktrans %}
-            One of your languages is empty. Check your <a href="{{ app_url }}">app settings</a>.
-          {% endblocktrans %}
-        {% case "missing parent tag" %}
-          A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "missing relationship question" %}
-          A subcase's index relationship with parent case tag "{{ error.case_tag }}" is determined by a question,
-          but no question is specified.
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "subcase repeat context" %}
-          The subcase "{{ error.case_tag }}" is in a different repeat context to its parent "{{ error.parent_tag }}"
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "auto select key" %}
-          The auto-select case action is missing the "{{ error.key_name }}" value
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "auto select source" %}
-          The auto-select case action is missing the "{{ error.source_name }}" value
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "auto select case ref" %}
-          The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "no case type in action" %}
-          The form action "{{ error.case_tag }}" does not have a case type selected
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "filtering without case" %}
-          The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
-          {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
-        {% case "invalid case xpath reference" %}
-          {% if error.form %}
-            {% blocktrans with form_name=error.form.name|trans:langs %}
-              Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
-              but cases are not available for this form. Please either remove the case reference or (1) make sure
-              that the case list is set to display the case list first and then form, and (2) make sure that all forms in
-              this case list update or close a case (which means registration forms must go in a different case list).
-            {% endblocktrans %}
-          {% else %}
+          {% case "subcase has no case type" %}
+            Child case specifies no case list in form {% include "app_manager/partials/form_error_message.html" %}
+          {% case "form error" %}
             {% blocktrans %}
-              You have a display condition which refers to a case, but cases are not available. Please either remove
-              the case reference or (1) make sure that the case list is set to display the case list first and then form,
-              and (2) make sure that all forms in this case list update or close a case (which means registration forms
-              must go in a different case list).
+              One or more forms are invalid: check all your forms for error messages.
             {% endblocktrans %}
-          {% endif %}
-        {% case "practice user config error" %}
-          {% if error.build_profile_id %}
-            {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
-              Error with Practice Mobile Worker in Application Profile {{ profile.name }}.
+          {% case "missing languages" %}
+            {% include "app_manager/partials/form_error_message.html" %} missing languages:
+            {% for lang in error.missing_languages %}
+              {{ lang }}
+            {% endfor %}
+          {% case "duplicate xmlns" %}
+            {% if error.xmlns %}
+              {% blocktrans with xmlns=error.xmlns %}
+                You have two forms with the xmlns "{{ xmlns }}"
+              {% endblocktrans %}
+            {% endif %}
+          {% case "update_case uses reserved word" %}
+            Case Update uses reserved word "{{ error.word }}"
+            {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "update_case word illegal" %}
+            Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
+            {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "case_name required" %}
+            <strong>Every case must have a name.</strong> Please specify a value for the name property under
+            "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "path error" %}
+            {% if error.path %}
+              The case management
+              {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
+              in form {% include "app_manager/partials/form_error_message.html" %}
+              references a question that no longer exists: "{{ error.path }}". It is likely that
+              this question has been renamed or deleted. Please update or delete this question
+              reference before you make a new version.
+            {% else %}
+              The case management
+              {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
+              in the form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
+              is missing a question.
+              Please choose a question from the dropdown next to the case property.
+            {% endif %}
+          {% case "multimedia case property not supported" %}
+            {% blocktrans with path=error.path %}
+              Multimedia case property "{{ path }}" is not supported on apps on or before v2.5.
             {% endblocktrans %}
-          {% else %}
-            {% blocktrans%}
-              Error with Practice Mobile Worker in Application Settings.
-            {% endblocktrans %}
-          {% endif %}
-        {% case "invalid user property xpath reference" %}
-          {% if error.form %}
-            {% blocktrans with form_name=error.form.name|trans:langs %}
-              Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
-              but your project does not use user properties. Please remove the user property reference.
-            {% endblocktrans %}
-          {% else %}
+          {% case "empty lang" %}
+            {% url "app_settings" domain app.id as app_url %}
             {% blocktrans %}
-              You have a display condition which refers to a user property, but your project does not use user properties.
-              Please remove the user property reference.
+              One of your languages is empty. Check your <a href="{{ app_url }}">app settings</a>.
             {% endblocktrans %}
+          {% case "missing parent tag" %}
+            A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "missing relationship question" %}
+            A subcase's index relationship with parent case tag "{{ error.case_tag }}" is determined by a question,
+            but no question is specified.
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "subcase repeat context" %}
+            The subcase "{{ error.case_tag }}" is in a different repeat context to its parent "{{ error.parent_tag }}"
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "auto select key" %}
+            The auto-select case action is missing the "{{ error.key_name }}" value
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "auto select source" %}
+            The auto-select case action is missing the "{{ error.source_name }}" value
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "auto select case ref" %}
+            The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "no case type in action" %}
+            The form action "{{ error.case_tag }}" does not have a case type selected
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "filtering without case" %}
+            The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
+            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
+          {% case "invalid case xpath reference" %}
+            {% if error.form %}
+              {% blocktrans with form_name=error.form.name|trans:langs %}
+                Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
+                but cases are not available for this form. Please either remove the case reference or (1) make sure
+                that the case list is set to display the case list first and then form, and (2) make sure that all forms in
+                this case list update or close a case (which means registration forms must go in a different case list).
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans %}
+                You have a display condition which refers to a case, but cases are not available. Please either remove
+                the case reference or (1) make sure that the case list is set to display the case list first and then form,
+                and (2) make sure that all forms in this case list update or close a case (which means registration forms
+                must go in a different case list).
+              {% endblocktrans %}
+            {% endif %}
+          {% case "practice user config error" %}
+            {% if error.build_profile_id %}
+              {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
+                Error with Practice Mobile Worker in Application Profile {{ profile.name }}.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans%}
+                Error with Practice Mobile Worker in Application Settings.
+              {% endblocktrans %}
+            {% endif %}
+          {% case "invalid user property xpath reference" %}
+            {% if error.form %}
+              {% blocktrans with form_name=error.form.name|trans:langs %}
+                Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
+                but your project does not use user properties. Please remove the user property reference.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans %}
+                You have a display condition which refers to a user property, but your project does not use user properties.
+                Please remove the user property reference.
+              {% endblocktrans %}
+            {% endif %}
+          {% case "subscription" %}
+            {% url 'domain_select_plan' domain as domain_url %}
+            {% blocktrans %}
+              Your application uses a feature that is not available in your current subscription. You
+              can <a href="{{ domain_url }}">change your subscription</a>, or
+              remove the feature as follows.
+            {% endblocktrans %}
+          {% case "missing shadow parent" %}
+            A shadow parent must be specified
+            {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            Select a shadow parent in the "Advanced" section of the shadow form's settings tab.
+          {% case "shadow parent does not exist" %}
+            A shadow parent specified
+            {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
+          {% case "missing shadow parent tag" %}
+                  Shadow parent form action tags do not appear in the action configuration for the shadow form.
+                  The missing tags are: {{ error.case_tags|join:", " }}
+            {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+          {% case "password_format" %}
+            {# Do nothing; the full message is contained in error.message #}
+          {% case "error" %}
+            Details: {{ error.message }}
+          {% else %}
+            Unknown error: {{ error.type }}
+            Details: {{ error }}
+          {% endcase %}
+          {# And then show the optional `message` regardless #}
+          {% if error.type != 'error' %}
+            {# Don't show the error message if we already did above #}
+            <span>{{ error.message }}</span>
           {% endif %}
-        {% case "subscription" %}
-          {% url 'domain_select_plan' domain as domain_url %}
-          {% blocktrans %}
-            Your application uses a feature that is not available in your current subscription. You
-            can <a href="{{ domain_url }}">change your subscription</a>, or
-            remove the feature as follows.
-          {% endblocktrans %}
-        {% case "missing shadow parent" %}
-          A shadow parent must be specified
-          {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          Select a shadow parent in the "Advanced" section of the shadow form's settings tab.
-        {% case "shadow parent does not exist" %}
-          A shadow parent specified
-          {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
-        {% case "missing shadow parent tag" %}
-                Shadow parent form action tags do not appear in the action configuration for the shadow form.
-                The missing tags are: {{ error.case_tags|join:", " }}
-          {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-        {% case "password_format" %}
-          {# Do nothing; the full message is contained in error.message #}
-        {% case "error" %}
-          Details: {{ error.message }}
-        {% else %}
-          Unknown error: {{ error.type }}
-          Details: {{ error }}
-        {% endcase %}
-        {# And then show the optional `message` regardless #}
-        {% if error.type != 'error' %}
-          {# Don't show the error message if we already did above #}
-          <span>{{ error.message }}</span>
-        {% endif %}
-      </span>
-    </li>
+        </span>
+      </li>
     {% endfor %}
   </ul>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -30,8 +30,8 @@
             {% endif %}
             {% include "app_manager/partials/form_error_message.html" %}
           {% case "validation error" %}
-                  {{ error.validation_message|linebreaksbr }} in form
-                  {% include "app_manager/partials/form_error_message.html" %}
+            {{ error.validation_message|linebreaksbr }} in form
+            {% include "app_manager/partials/form_error_message.html" %}
           {% case "no form links" %}
             {% blocktrans %}
               Link to other form is selected, but no form links have been provided.
@@ -391,8 +391,8 @@
             {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
             does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
           {% case "missing shadow parent tag" %}
-                  Shadow parent form action tags do not appear in the action configuration for the shadow form.
-                  The missing tags are: {{ error.case_tags|join:", " }}
+            Shadow parent form action tags do not appear in the action configuration for the shadow form.
+            The missing tags are: {{ error.case_tags|join:", " }}
             {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
           {% case "password_format" %}
             {# Do nothing; the full message is contained in error.message #}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -5,7 +5,7 @@
   {# todo make sure this makes sense for cloudcare outside of v2 (advanced build errors) #}
   <h4 class="alert-heading">
     <i class="fa fa-exclamation-circle"></i>
-    {% trans "Cannot Create Menus" %}</h4>
+    {% trans "Cannot make new version" %}</h4>
   <ul class="list-unstyled" id="build-errors">
     {% for error in build_errors %}
     <li>

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -1,414 +1,415 @@
 {% load i18n %}
 {% load hq_shared_tags %}
-{% load xforms_extras %}{% if build_errors %}
+{% load xforms_extras %}
 
-<div class="alert alert-warning alert-block alert-build">
-  <h4 class="alert-heading">
-    <i class="fa fa-exclamation-circle"></i>
-    {% trans "Cannot make new version" %}</h4>
-  <ul class="list-unstyled" id="build-errors">
-    {% for error in build_errors %}
-      {% if error.module %}
-        {% url "view_module" domain app.id error.module.unique_id as module_url %}
-      {% endif %}
-      {% if error.form %}
-        {% url "view_form" domain app.id error.form.unique_id as form_url %}
-      {% endif %}
-      <li>
-        <span>
-          {% case error.type "blank form" %}
-            {% if not error.message %}
-              <strong>Add a Question</strong> to the
-            {% endif %}
-            {% include "app_manager/partials/form_error_message.html" %}
-          {% case "invalid xml" %}
-            {% if not error.message %}
+{% if build_errors %}
+  <div class="alert alert-warning alert-block alert-build">
+    <h4 class="alert-heading">
+      <i class="fa fa-exclamation-circle"></i>
+      {% trans "Cannot make new version" %}</h4>
+    <ul class="list-unstyled" id="build-errors">
+      {% for error in build_errors %}
+        {% if error.module %}
+          {% url "view_module" domain app.id error.module.unique_id as module_url %}
+        {% endif %}
+        {% if error.form %}
+          {% url "view_form" domain app.id error.form.unique_id as form_url %}
+        {% endif %}
+        <li>
+          <span>
+            {% case error.type "blank form" %}
+              {% if not error.message %}
+                <strong>Add a Question</strong> to the
+              {% endif %}
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% case "invalid xml" %}
+              {% if not error.message %}
+                {% blocktrans %}
+                  If you don't know why this happened, please report an issue.
+                {% endblocktrans %}
+              {% endif %}
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% case "validation error" %}
+              {{ error.validation_message|linebreaksbr }} in form
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% case "no form links" %}
               {% blocktrans %}
-                If you don't know why this happened, please report an issue.
+                Link to other form is selected, but no form links have been provided.
               {% endblocktrans %}
-            {% endif %}
-            {% include "app_manager/partials/form_error_message.html" %}
-          {% case "validation error" %}
-            {{ error.validation_message|linebreaksbr }} in form
-            {% include "app_manager/partials/form_error_message.html" %}
-          {% case "no form links" %}
-            {% blocktrans %}
-              Link to other form is selected, but no form links have been provided.
-            {% endblocktrans %}
-            {% include "app_manager/partials/form_error_message.html" %}
-          {% case "bad form link" %}
-            {% blocktrans %}
-              Link to other form is selected, but we don't recognize the form you provided.
-            {% endblocktrans %}
-            {% include "app_manager/partials/form_error_message.html" %}
-          {% case "form link to missing root" %}
-            {% blocktrans %}
-              Please check that end of form navigation is correct. It appears to be pointing
-              to a parent menu form, but the menu doesn't have a parent.
-            {% endblocktrans %}
-            {% include "app_manager/partials/form_error_message.html" %}
-          {% case "form link to display only forms" %}
-            {% blocktrans %}
-              Please check that end of form navigation is correct. It appears to be pointing
-              to a menu using "Display only forms," which makes that menu an invalid choice.
-            {% endblocktrans %}
-            {% include "app_manager/partials/form_error_message.html" %}
-          {% case "no ref detail" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              uses referrals but doesn't have detail screens configured for referrals.
-            {% endblocktrans %}
-          {% case "no case detail" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              uses cases but doesn't have detail screens configured for cases.
-            {% endblocktrans %}
-          {% case "no product detail" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              uses CommCare Supply products but doesn't have detail screens configured for products.
-            {% endblocktrans %}
-          {% case "invalid id key" %}
-            {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              has an incorrectly formatted ID key ({{ error_key }}).
-              Make sure your key has only letters, numbers, space characters, underscores, and dashes.
-            {% endblocktrans %}
-          {% case "no modules" %}
-            {% blocktrans %}
-              No menus are available. <br />
-              <i class="fa fa-arrow-left"></i>
-              Please click
-              <i class="fa fa-plus"></i> <strong>Add...</strong> to create
-              some menus.
-            {% endblocktrans %}
-          {% case "missing module" %}
-            {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
-            {% if error.message %}
-              {% trans "Details:" %}
-            {% endif %}
-          {% case "no forms" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              has no forms.
-            {% endblocktrans %}
-          {% case "no forms or case list" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              has no forms or case list.
-            {% endblocktrans %}
-          {% case "training module parent" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              cannot have a training module as a parent module.
-            {% endblocktrans %}
-          {% case "training module child" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              is a training module and therefore cannot have a parent module.
-            {% endblocktrans %}
-          {% case "no reports" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              has no reports.
-            {% endblocktrans %}
-          {% case "circular case hierarchy" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
-            {% endblocktrans %}
-          {% case "no case type" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              uses cases but doesn't have a case type defined.
-            {% endblocktrans %}
-          {% case "case list form not registration" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-              as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
-              This form is not a registration form. You need to select a form which opens a case and
-              does not update an existing case. Please select a different form.
-            {% endblocktrans %}
-          {% case "case list form eof nav" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-              as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
-              end of form navigation, which will override the case list registration workflow.
-              Please select a different form, or set the end of form navigation to the default option ('Home Screen').
-            {% endblocktrans %}
-          {% case "case list form missing" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              The form you have selected as the case registration form for
-              <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
-              Please select another form.
-            {% endblocktrans %}
-          {% case "report config ref invalid" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              There are references to reports that are deleted in
-              <a href="{{ module_url }}">{{ module_name }}</a>.
-              You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
-            {% endblocktrans %}
-          {% case "report config id duplicated" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              There are multiple reports with the same report code in
-              <a href="{{ module_url }}">{{ module_name }}</a>.
-              These codes must be unique.
-            {% endblocktrans %}
-          {% case "module filter has xpath error" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
-            {% endblocktrans %}
-          {% case "form filter has xpath error" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              Display Condition has syntax errors
-              in the <a href="{{ form_url }}">{{ form_name }}</a> form
-              in <a href="{{ module_url }}">{{ module_name }}</a>.
-            {% endblocktrans %}
-          {% case "all forms in case list module must load the same cases" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-              loads different case types from the other forms. All forms in a case list that has a case registration form
-              selected must load the same case types.
-            {% endblocktrans %}
-          {% case "case list module form must require case" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-              must update a case. All forms in a case list that has a case registration form selected must update a case.
-            {% endblocktrans %}
-          {% case "case list module form can only load parent cases" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-              can only load or update a single case and its parents. All forms in a case list that
-              has a case registration form selected can only update a single case and its parents.
-            {% endblocktrans %}
-          {% case "case list module form must match module case type" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
-              <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
-              selected must load a case of the same type as the case list.
-            {% endblocktrans %}
-          {% case "all forms in case list module must have same case management" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
-              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-              loads a case with a different case tag to the other forms in the case list.
-              All forms in a case list that has a case registration form selected must use the same case tag.
-              Expected case tag: <strong>{{ expected_tag }}</strong>
-            {% endblocktrans %}
-          {% case "forms in case list module must use modules details" %}
-            {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-              The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
-              uses a details screen from another case list. All forms in a case list that has a case
-              registration form selected must use the details screen from that case list.
-            {% endblocktrans %}
-          {% case "invalid filter xpath" %}
-            {% if error.filter %}
-              {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
-                Case List has invalid filter xpath <code>{{ error_filter }}</code> in
-                <a href="{{ module_url }}">{{ module_name }}</a>
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% case "bad form link" %}
+              {% blocktrans %}
+                Link to other form is selected, but we don't recognize the form you provided.
               {% endblocktrans %}
-            {% else %}
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% case "form link to missing root" %}
+              {% blocktrans %}
+                Please check that end of form navigation is correct. It appears to be pointing
+                to a parent menu form, but the menu doesn't have a parent.
+              {% endblocktrans %}
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% case "form link to display only forms" %}
+              {% blocktrans %}
+                Please check that end of form navigation is correct. It appears to be pointing
+                to a menu using "Display only forms," which makes that menu an invalid choice.
+              {% endblocktrans %}
+              {% include "app_manager/partials/form_error_message.html" %}
+            {% case "no ref detail" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
-                Case List has blank filter in
                 <a href="{{ module_url }}">{{ module_name }}</a>
+                uses referrals but doesn't have detail screens configured for referrals.
               {% endblocktrans %}
-            {% endif %}
-          {% case "invalid sort field" %}
-            {% if error.field %}
-              {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
-                Case List has invalid sort field <code>{{ error_field }}</code> in
-                <a href="{{ module_url }}">{{ module_name }}</a>
-              {% endblocktrans %}
-            {% else %}
+            {% case "no case detail" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
-                Case List has blank sort field in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses cases but doesn't have detail screens configured for cases.
+              {% endblocktrans %}
+            {% case "no product detail" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses CommCare Supply products but doesn't have detail screens configured for products.
+              {% endblocktrans %}
+            {% case "invalid id key" %}
+              {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has an incorrectly formatted ID key ({{ error_key }}).
+                Make sure your key has only letters, numbers, space characters, underscores, and dashes.
+              {% endblocktrans %}
+            {% case "no modules" %}
+              {% blocktrans %}
+                No menus are available. <br />
+                <i class="fa fa-arrow-left"></i>
+                Please click
+                <i class="fa fa-plus"></i> <strong>Add...</strong> to create
+                some menus.
+              {% endblocktrans %}
+            {% case "missing module" %}
+              {% include "app_manager/partials/module_error_message.html" %} references a missing menu.
+              {% if error.message %}
+                {% trans "Details:" %}
+              {% endif %}
+            {% case "no forms" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has no forms.
+              {% endblocktrans %}
+            {% case "no forms or case list" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has no forms or case list.
+              {% endblocktrans %}
+            {% case "training module parent" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                cannot have a training module as a parent module.
+              {% endblocktrans %}
+            {% case "training module child" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                is a training module and therefore cannot have a parent module.
+              {% endblocktrans %}
+            {% case "no reports" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has no reports.
+              {% endblocktrans %}
+            {% case "circular case hierarchy" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
+              {% endblocktrans %}
+            {% case "no case type" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses cases but doesn't have a case type defined.
+              {% endblocktrans %}
+            {% case "case list form not registration" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
+                as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
+                This form is not a registration form. You need to select a form which opens a case and
+                does not update an existing case. Please select a different form.
+              {% endblocktrans %}
+            {% case "case list form eof nav" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
+                as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
+                end of form navigation, which will override the case list registration workflow.
+                Please select a different form, or set the end of form navigation to the default option ('Home Screen').
+              {% endblocktrans %}
+            {% case "case list form missing" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                The form you have selected as the case registration form for
+                <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
+                Please select another form.
+              {% endblocktrans %}
+            {% case "report config ref invalid" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                There are references to reports that are deleted in
+                <a href="{{ module_url }}">{{ module_name }}</a>.
+                You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
+              {% endblocktrans %}
+            {% case "report config id duplicated" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                There are multiple reports with the same report code in
+                <a href="{{ module_url }}">{{ module_name }}</a>.
+                These codes must be unique.
+              {% endblocktrans %}
+            {% case "module filter has xpath error" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
+              {% endblocktrans %}
+            {% case "form filter has xpath error" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                Display Condition has syntax errors
+                in the <a href="{{ form_url }}">{{ form_name }}</a> form
+                in <a href="{{ module_url }}">{{ module_name }}</a>.
+              {% endblocktrans %}
+            {% case "all forms in case list module must load the same cases" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+                loads different case types from the other forms. All forms in a case list that has a case registration form
+                selected must load the same case types.
+              {% endblocktrans %}
+            {% case "case list module form must require case" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+                must update a case. All forms in a case list that has a case registration form selected must update a case.
+              {% endblocktrans %}
+            {% case "case list module form can only load parent cases" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+                can only load or update a single case and its parents. All forms in a case list that
+                has a case registration form selected can only update a single case and its parents.
+              {% endblocktrans %}
+            {% case "case list module form must match module case type" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
+                <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
+                selected must load a case of the same type as the case list.
+              {% endblocktrans %}
+            {% case "all forms in case list module must have same case management" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
+                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+                loads a case with a different case tag to the other forms in the case list.
+                All forms in a case list that has a case registration form selected must use the same case tag.
+                Expected case tag: <strong>{{ expected_tag }}</strong>
+              {% endblocktrans %}
+            {% case "forms in case list module must use modules details" %}
+              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
+                The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
+                uses a details screen from another case list. All forms in a case list that has a case
+                registration form selected must use the details screen from that case list.
+              {% endblocktrans %}
+            {% case "invalid filter xpath" %}
+              {% if error.filter %}
+                {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
+                  Case List has invalid filter xpath <code>{{ error_filter }}</code> in
+                  <a href="{{ module_url }}">{{ module_name }}</a>
+                {% endblocktrans %}
+              {% else %}
+                {% blocktrans with module_name=error.module.name|trans:langs %}
+                  Case List has blank filter in
+                  <a href="{{ module_url }}">{{ module_name }}</a>
+                {% endblocktrans %}
+              {% endif %}
+            {% case "invalid sort field" %}
+              {% if error.field %}
+                {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
+                  Case List has invalid sort field <code>{{ error_field }}</code> in
+                  <a href="{{ module_url }}">{{ module_name }}</a>
+                {% endblocktrans %}
+              {% else %}
+                {% blocktrans with module_name=error.module.name|trans:langs %}
+                  Case List has blank sort field in
+                  <a href="{{ module_url }}">{{ module_name }}</a>
+                {% endblocktrans %}
+              {% endif %}
+            {% case "invalid tile configuration" %}
+              {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
+                The case list in
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                has an invalid case tile configuration. Reason: {{ error_reason }}
+              {% endblocktrans %}
+            {% case "no source module id" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                Shadow module
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                doesn't have a source module specified.
+              {% endblocktrans %}
+            {% case "no parent select id" %}
+              {% blocktrans with module_name=error.module.name|trans:langs %}
+                <a href="{{ module_url }}">{{ module_name }}</a>
+                uses parent case selection but doesn't have a parent case list specified.
+              {% endblocktrans %}
+            {% case "parent cycle" %}
+              {% blocktrans %}
+                The app's parent child case selection graph contains a cycle.
+              {% endblocktrans %}
+            {% case "root cycle" %}
+              {% blocktrans %}
+                The app's parent child graph contains a cycle.
+              {% endblocktrans %}
+            {% case "unknown root" %}
+              {% blocktrans %}
+                A menu points to an unknown Parent Menu.
+              {% endblocktrans %}
+            {% case "invalid location xpath" %}
+              {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
+                Case List has invalid location reference <code>{{ property }}</code>.
+                Details: {{ details }}
                 <a href="{{ module_url }}">{{ module_name }}</a>
               {% endblocktrans %}
-            {% endif %}
-          {% case "invalid tile configuration" %}
-            {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
-              The case list in
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              has an invalid case tile configuration. Reason: {{ error_reason }}
-            {% endblocktrans %}
-          {% case "no source module id" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              Shadow module
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              doesn't have a source module specified.
-            {% endblocktrans %}
-          {% case "no parent select id" %}
-            {% blocktrans with module_name=error.module.name|trans:langs %}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-              uses parent case selection but doesn't have a parent case list specified.
-            {% endblocktrans %}
-          {% case "parent cycle" %}
-            {% blocktrans %}
-              The app's parent child case selection graph contains a cycle.
-            {% endblocktrans %}
-          {% case "root cycle" %}
-            {% blocktrans %}
-              The app's parent child graph contains a cycle.
-            {% endblocktrans %}
-          {% case "unknown root" %}
-            {% blocktrans %}
-              A menu points to an unknown Parent Menu.
-            {% endblocktrans %}
-          {% case "invalid location xpath" %}
-            {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
-              Case List has invalid location reference <code>{{ property }}</code>.
-              Details: {{ details }}
-              <a href="{{ module_url }}">{{ module_name }}</a>
-            {% endblocktrans %}
-          {% case "subcase has no case type" %}
-            Child case specifies no case list in form {% include "app_manager/partials/form_error_message.html" %}
-          {% case "form error" %}
-            {% blocktrans %}
-              One or more forms are invalid: check all your forms for error messages.
-            {% endblocktrans %}
-          {% case "missing languages" %}
-            {% include "app_manager/partials/form_error_message.html" %} missing languages:
-            {% for lang in error.missing_languages %}
-              {{ lang }}
-            {% endfor %}
-          {% case "duplicate xmlns" %}
-            {% if error.xmlns %}
-              {% blocktrans with xmlns=error.xmlns %}
-                You have two forms with the xmlns "{{ xmlns }}"
-              {% endblocktrans %}
-            {% endif %}
-          {% case "update_case uses reserved word" %}
-            Case Update uses reserved word "{{ error.word }}"
-            {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "update_case word illegal" %}
-            Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
-            {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "case_name required" %}
-            <strong>Every case must have a name.</strong> Please specify a value for the name property under
-            "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "path error" %}
-            {% if error.path %}
-              The case management
-              {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
-              in form {% include "app_manager/partials/form_error_message.html" %}
-              references a question that no longer exists: "{{ error.path }}". It is likely that
-              this question has been renamed or deleted. Please update or delete this question
-              reference before you make a new version.
-            {% else %}
-              The case management
-              {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
-              in the form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
-              is missing a question.
-              Please choose a question from the dropdown next to the case property.
-            {% endif %}
-          {% case "multimedia case property not supported" %}
-            {% blocktrans with path=error.path %}
-              Multimedia case property "{{ path }}" is not supported on apps on or before v2.5.
-            {% endblocktrans %}
-          {% case "empty lang" %}
-            {% url "app_settings" domain app.id as app_url %}
-            {% blocktrans %}
-              One of your languages is empty. Check your <a href="{{ app_url }}">app settings</a>.
-            {% endblocktrans %}
-          {% case "missing parent tag" %}
-            A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "missing relationship question" %}
-            A subcase's index relationship with parent case tag "{{ error.case_tag }}" is determined by a question,
-            but no question is specified.
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "subcase repeat context" %}
-            The subcase "{{ error.case_tag }}" is in a different repeat context to its parent "{{ error.parent_tag }}"
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "auto select key" %}
-            The auto-select case action is missing the "{{ error.key_name }}" value
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "auto select source" %}
-            The auto-select case action is missing the "{{ error.source_name }}" value
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "auto select case ref" %}
-            The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "no case type in action" %}
-            The form action "{{ error.case_tag }}" does not have a case type selected
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "filtering without case" %}
-            The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
-            {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
-          {% case "invalid case xpath reference" %}
-            {% if error.form %}
-              {% blocktrans with form_name=error.form.name|trans:langs %}
-                Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
-                but cases are not available for this form. Please either remove the case reference or (1) make sure
-                that the case list is set to display the case list first and then form, and (2) make sure that all forms in
-                this case list update or close a case (which means registration forms must go in a different case list).
-              {% endblocktrans %}
-            {% else %}
+            {% case "subcase has no case type" %}
+              Child case specifies no case list in form {% include "app_manager/partials/form_error_message.html" %}
+            {% case "form error" %}
               {% blocktrans %}
-                You have a display condition which refers to a case, but cases are not available. Please either remove
-                the case reference or (1) make sure that the case list is set to display the case list first and then form,
-                and (2) make sure that all forms in this case list update or close a case (which means registration forms
-                must go in a different case list).
+                One or more forms are invalid: check all your forms for error messages.
               {% endblocktrans %}
-            {% endif %}
-          {% case "practice user config error" %}
-            {% if error.build_profile_id %}
-              {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
-                Error with Practice Mobile Worker in Application Profile {{ profile.name }}.
+            {% case "missing languages" %}
+              {% include "app_manager/partials/form_error_message.html" %} missing languages:
+              {% for lang in error.missing_languages %}
+                {{ lang }}
+              {% endfor %}
+            {% case "duplicate xmlns" %}
+              {% if error.xmlns %}
+                {% blocktrans with xmlns=error.xmlns %}
+                  You have two forms with the xmlns "{{ xmlns }}"
+                {% endblocktrans %}
+              {% endif %}
+            {% case "update_case uses reserved word" %}
+              Case Update uses reserved word "{{ error.word }}"
+              {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "update_case word illegal" %}
+              Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
+              {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "case_name required" %}
+              <strong>Every case must have a name.</strong> Please specify a value for the name property under
+              "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "path error" %}
+              {% if error.path %}
+                The case management
+                {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
+                in form {% include "app_manager/partials/form_error_message.html" %}
+                references a question that no longer exists: "{{ error.path }}". It is likely that
+                this question has been renamed or deleted. Please update or delete this question
+                reference before you make a new version.
+              {% else %}
+                The case management
+                {% if visit_scheduler_enabled %} or visit scheduler {% endif %}
+                in the form{% include "app_manager/partials/form_error_message.html" with no_form="." %}
+                is missing a question.
+                Please choose a question from the dropdown next to the case property.
+              {% endif %}
+            {% case "multimedia case property not supported" %}
+              {% blocktrans with path=error.path %}
+                Multimedia case property "{{ path }}" is not supported on apps on or before v2.5.
               {% endblocktrans %}
-            {% else %}
-              {% blocktrans%}
-                Error with Practice Mobile Worker in Application Settings.
-              {% endblocktrans %}
-            {% endif %}
-          {% case "invalid user property xpath reference" %}
-            {% if error.form %}
-              {% blocktrans with form_name=error.form.name|trans:langs %}
-                Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
-                but your project does not use user properties. Please remove the user property reference.
-              {% endblocktrans %}
-            {% else %}
+            {% case "empty lang" %}
+              {% url "app_settings" domain app.id as app_url %}
               {% blocktrans %}
-                You have a display condition which refers to a user property, but your project does not use user properties.
-                Please remove the user property reference.
+                One of your languages is empty. Check your <a href="{{ app_url }}">app settings</a>.
               {% endblocktrans %}
+            {% case "missing parent tag" %}
+              A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "missing relationship question" %}
+              A subcase's index relationship with parent case tag "{{ error.case_tag }}" is determined by a question,
+              but no question is specified.
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "subcase repeat context" %}
+              The subcase "{{ error.case_tag }}" is in a different repeat context to its parent "{{ error.parent_tag }}"
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "auto select key" %}
+              The auto-select case action is missing the "{{ error.key_name }}" value
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "auto select source" %}
+              The auto-select case action is missing the "{{ error.source_name }}" value
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "auto select case ref" %}
+              The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "no case type in action" %}
+              The form action "{{ error.case_tag }}" does not have a case type selected
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "filtering without case" %}
+              The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
+              {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
+            {% case "invalid case xpath reference" %}
+              {% if error.form %}
+                {% blocktrans with form_name=error.form.name|trans:langs %}
+                  Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
+                  but cases are not available for this form. Please either remove the case reference or (1) make sure
+                  that the case list is set to display the case list first and then form, and (2) make sure that all forms in
+                  this case list update or close a case (which means registration forms must go in a different case list).
+                {% endblocktrans %}
+              {% else %}
+                {% blocktrans %}
+                  You have a display condition which refers to a case, but cases are not available. Please either remove
+                  the case reference or (1) make sure that the case list is set to display the case list first and then form,
+                  and (2) make sure that all forms in this case list update or close a case (which means registration forms
+                  must go in a different case list).
+                {% endblocktrans %}
+              {% endif %}
+            {% case "practice user config error" %}
+              {% if error.build_profile_id %}
+                {% blocktrans with profile=app.build_profiles|getattr:error.build_profile_id %}
+                  Error with Practice Mobile Worker in Application Profile {{ profile.name }}.
+                {% endblocktrans %}
+              {% else %}
+                {% blocktrans%}
+                  Error with Practice Mobile Worker in Application Settings.
+                {% endblocktrans %}
+              {% endif %}
+            {% case "invalid user property xpath reference" %}
+              {% if error.form %}
+                {% blocktrans with form_name=error.form.name|trans:langs %}
+                  Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
+                  but your project does not use user properties. Please remove the user property reference.
+                {% endblocktrans %}
+              {% else %}
+                {% blocktrans %}
+                  You have a display condition which refers to a user property, but your project does not use user properties.
+                  Please remove the user property reference.
+                {% endblocktrans %}
+              {% endif %}
+            {% case "subscription" %}
+              {% url 'domain_select_plan' domain as domain_url %}
+              {% blocktrans %}
+                Your application uses a feature that is not available in your current subscription. You
+                can <a href="{{ domain_url }}">change your subscription</a>, or
+                remove the feature as follows.
+              {% endblocktrans %}
+            {% case "missing shadow parent" %}
+              A shadow parent must be specified
+              {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+              Select a shadow parent in the "Advanced" section of the shadow form's settings tab.
+            {% case "shadow parent does not exist" %}
+              A shadow parent specified
+              {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+              does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
+            {% case "missing shadow parent tag" %}
+              Shadow parent form action tags do not appear in the action configuration for the shadow form.
+              The missing tags are: {{ error.case_tags|join:", " }}
+              {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
+            {% case "password_format" %}
+              {# Do nothing; the full message is contained in error.message #}
+            {% case "error" %}
+              Details: {{ error.message }}
+            {% else %}
+              Unknown error: {{ error.type }}
+              Details: {{ error }}
+            {% endcase %}
+            {# And then show the optional `message` regardless #}
+            {% if error.type != 'error' %}
+              {# Don't show the error message if we already did above #}
+              <span>{{ error.message }}</span>
             {% endif %}
-          {% case "subscription" %}
-            {% url 'domain_select_plan' domain as domain_url %}
-            {% blocktrans %}
-              Your application uses a feature that is not available in your current subscription. You
-              can <a href="{{ domain_url }}">change your subscription</a>, or
-              remove the feature as follows.
-            {% endblocktrans %}
-          {% case "missing shadow parent" %}
-            A shadow parent must be specified
-            {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-            Select a shadow parent in the "Advanced" section of the shadow form's settings tab.
-          {% case "shadow parent does not exist" %}
-            A shadow parent specified
-            {% if not not_actual_build %}for form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-            does not exist. Select a new shadow parent in the "Advanced" section of the shadow form's settings tab.
-          {% case "missing shadow parent tag" %}
-            Shadow parent form action tags do not appear in the action configuration for the shadow form.
-            The missing tags are: {{ error.case_tags|join:", " }}
-            {% if not not_actual_build %}The shadow form is {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-          {% case "password_format" %}
-            {# Do nothing; the full message is contained in error.message #}
-          {% case "error" %}
-            Details: {{ error.message }}
-          {% else %}
-            Unknown error: {{ error.type }}
-            Details: {{ error }}
-          {% endcase %}
-          {# And then show the optional `message` regardless #}
-          {% if error.type != 'error' %}
-            {# Don't show the error message if we already did above #}
-            <span>{{ error.message }}</span>
-          {% endif %}
-        </span>
-      </li>
-    {% endfor %}
-  </ul>
-</div>
+          </span>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load xforms_extras %}{% if build_errors %}
+
 <div class="alert alert-warning alert-block alert-build">
   {# todo make sure this makes sense for cloudcare outside of v2 (advanced build errors) #}
   <h4 class="alert-heading">
@@ -8,6 +9,12 @@
     {% trans "Cannot make new version" %}</h4>
   <ul class="list-unstyled" id="build-errors">
     {% for error in build_errors %}
+      {% if error.module %}
+        {% url "view_module" domain app.id error.module.unique_id as module_url %}
+      {% endif %}
+      {% if error.form %}
+        {% url "view_form" domain app.id error.form.unique_id as form_url %}
+      {% endif %}
     <li>
       <span>
         {% case error.type "blank form" %}
@@ -48,25 +55,21 @@
           {% endblocktrans %}
           {% include "app_manager/partials/form_error_message.html" %}
         {% case "no ref detail" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             uses referrals but doesn't have detail screens configured for referrals.
           {% endblocktrans %}
         {% case "no case detail" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             uses cases but doesn't have detail screens configured for cases.
           {% endblocktrans %}
         {% case "no product detail" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             uses CommCare Supply products but doesn't have detail screens configured for products.
           {% endblocktrans %}
         {% case "invalid id key" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs key=error.key %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             has an incorrectly formatted ID key ({{ error_key }}).
@@ -86,49 +89,40 @@
             {% trans "Details:" %}
           {% endif %}
         {% case "no forms" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             has no forms.
           {% endblocktrans %}
         {% case "no forms or case list" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             has no forms or case list.
           {% endblocktrans %}
         {% case "training module parent" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             cannot have a training module as a parent module.
           {% endblocktrans %}
         {% case "training module child" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             is a training module and therefore cannot have a parent module.
           {% endblocktrans %}
         {% case "no reports" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             has no reports.
           {% endblocktrans %}
         {% case "circular case hierarchy" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             The case hierarchy for <a href="{{ module_url }}">{{ module_name }}</a> contains a circular reference.
           {% endblocktrans %}
         {% case "no case type" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             uses cases but doesn't have a case type defined.
           {% endblocktrans %}
         {% case "case list form not registration" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
             as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>.
@@ -136,8 +130,6 @@
             does not update an existing case. Please select a different form.
           {% endblocktrans %}
         {% case "case list form eof nav" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
             as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
@@ -145,73 +137,57 @@
             Please select a different form, or set the end of form navigation to the default option ('Home Screen').
           {% endblocktrans %}
         {% case "case list form missing" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             The form you have selected as the case registration form for
             <a href="{{ module_url }}">{{ module_name }}</a> does not exist.
             Please select another form.
           {% endblocktrans %}
         {% case "report config ref invalid" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             There are references to reports that are deleted in
             <a href="{{ module_url }}">{{ module_name }}</a>.
             You may re-save <a href="{{ module_url }}">{{ module_name }}</a> to delete them.
           {% endblocktrans %}
         {% case "report config id duplicated" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             There are multiple reports with the same report code in
             <a href="{{ module_url }}">{{ module_name }}</a>.
             These codes must be unique.
           {% endblocktrans %}
         {% case "module filter has xpath error" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             The filter for <a href="{{ module_url }}">{{ module_name }}</a> has errors.
           {% endblocktrans %}
         {% case "form filter has xpath error" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             Display Condition has syntax errors
             in the <a href="{{ form_url }}">{{ form_name }}</a> form
             in <a href="{{ module_url }}">{{ module_name }}</a>.
           {% endblocktrans %}
         {% case "all forms in case list module must load the same cases" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
             loads different case types from the other forms. All forms in a case list that has a case registration form
             selected must load the same case types.
           {% endblocktrans %}
         {% case "case list module form must require case" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
             must update a case. All forms in a case list that has a case registration form selected must update a case.
           {% endblocktrans %}
         {% case "case list module form can only load parent cases" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
             can only load or update a single case and its parents. All forms in a case list that
             has a case registration form selected can only update a single case and its parents.
           {% endblocktrans %}
         {% case "case list module form must match module case type" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             The <a href="{{ form_url }}">{{ form_name }}</a> form loads a different case type than
             <a href="{{ module_url }}">{{ module_name }}</a>. All forms in a case list that has a case registration form
             selected must load a case of the same type as the case list.
           {% endblocktrans %}
         {% case "all forms in case list module must have same case management" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs expected_tag=error.expected_tag %}
             The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
             loads a case with a different case tag to the other forms in the case list.
@@ -219,8 +195,6 @@
             Expected case tag: <strong>{{ expected_tag }}</strong>
           {% endblocktrans %}
         {% case "forms in case list module must use modules details" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
-          {% url "view_form" domain app.id error.form.unique_id as form_url %}
           {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
             The <a href="{{ form_url }}">{{ form_name }}</a> form in <a href="{{ module_url }}">{{ module_name }}</a>
             uses a details screen from another case list. All forms in a case list that has a case
@@ -228,13 +202,11 @@
           {% endblocktrans %}
         {% case "invalid filter xpath" %}
           {% if error.filter %}
-            {% url "view_module" domain app.id error.module.unique_id as module_url %}
             {% blocktrans with module_name=error.module.name|trans:langs error_filter=error.filter %}
               Case List has invalid filter xpath <code>{{ error_filter }}</code> in
               <a href="{{ module_url }}">{{ module_name }}</a>
             {% endblocktrans %}
           {% else %}
-            {% url "view_module" domain app.id error.module.unique_id as module_url %}
             {% blocktrans with module_name=error.module.name|trans:langs %}
               Case List has blank filter in
               <a href="{{ module_url }}">{{ module_name }}</a>
@@ -242,34 +214,29 @@
           {% endif %}
         {% case "invalid sort field" %}
           {% if error.field %}
-            {% url "view_module" domain app.id error.module.unique_id as module_url %}
             {% blocktrans with module_name=error.module.name|trans:langs error_field=error.field %}
               Case List has invalid sort field <code>{{ error_field }}</code> in
               <a href="{{ module_url }}">{{ module_name }}</a>
             {% endblocktrans %}
           {% else %}
-            {% url "view_module" domain app.id error.module.unique_id as module_url %}
             {% blocktrans with module_name=error.module.name|trans:langs %}
               Case List has blank sort field in
               <a href="{{ module_url }}">{{ module_name }}</a>
             {% endblocktrans %}
           {% endif %}
         {% case "invalid tile configuration" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs error_reason=error.reason %}
             The case list in
             <a href="{{ module_url }}">{{ module_name }}</a>
             has an invalid case tile configuration. Reason: {{ error_reason }}
           {% endblocktrans %}
         {% case "no source module id" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             Shadow module
             <a href="{{ module_url }}">{{ module_name }}</a>
             doesn't have a source module specified.
           {% endblocktrans %}
         {% case "no parent select id" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs %}
             <a href="{{ module_url }}">{{ module_name }}</a>
             uses parent case selection but doesn't have a parent case list specified.
@@ -287,7 +254,6 @@
             A menu points to an unknown Parent Menu.
           {% endblocktrans %}
         {% case "invalid location xpath" %}
-          {% url "view_module" domain app.id error.module.unique_id as module_url %}
           {% blocktrans with module_name=error.module.name|trans:langs property=error.column.field_property details=error.details %}
             Case List has invalid location reference <code>{{ property }}</code>.
             Details: {{ details }}
@@ -373,7 +339,6 @@
           {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
         {% case "invalid case xpath reference" %}
           {% if error.form %}
-            {% url "view_form" domain app.id error.form.unique_id as form_url %}
             {% blocktrans with form_name=error.form.name|trans:langs %}
               Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a case,
               but cases are not available for this form. Please either remove the case reference or (1) make sure
@@ -400,7 +365,6 @@
           {% endif %}
         {% case "invalid user property xpath reference" %}
           {% if error.form %}
-            {% url "view_form" domain app.id error.form.unique_id as form_url %}
             {% blocktrans with form_name=error.form.name|trans:langs %}
               Your form display condition for form <a href="{{ form_url }}">{{ form_name }}</a> refers to a user property,
               but your project does not use user properties. Please remove the user property reference.

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_error_message.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_error_message.html
@@ -1,6 +1,5 @@
 {# Poor spacing in this file because this template is used in the middle of sentences #}{% load xforms_extras %}{% load i18n %}{% if not not_actual_build %}
   "<a href="{% url "form_source" domain app.id error.form.unique_id %}">{{ error.form.name|trans:langs }}</a>"
   Form
-  in the "{{ error.module.name|trans:langs }}" Menu.<br />
-  <a class="btn btn-primary btn-xs" href="{% url "form_source" domain app.id error.form.unique_id %}">{% trans 'Go to' %} {{ error.form.name|trans:langs }} {% trans 'Form' %}</a>
+  in the "{{ error.module.name|trans:langs }}" Menu
 {% else %}{{ no_form }}{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -173,7 +173,7 @@
       </tr>
       </tbody>
     </table>
-    <div class="alert alert-block alert-info"
+    <div class="alert alert-info"
          data-bind="visible: !case_preload().length">
       {% trans "No properties will be loaded" %}
     </div>
@@ -272,7 +272,7 @@
       </tr>
       </tbody>
     </table>
-    <div class="alert alert-block alert-info"
+    <div class="alert alert-info"
          data-bind="visible: !case_properties().length">
       {% trans "No properties will be saved" %}
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -17,16 +17,6 @@
       <div data-bind="visible: hasError" class="help-block">
         {% trans "This is an unknown value, possibly a deleted form. Please change this value." %}
       </div>
-      {% if is_case_list_form %}
-        <!-- ko if: workflow() !== 'default' -->
-        <p class="alert alert-warning">{% blocktrans %}
-          This form is being used as a Case List Registration Form.
-          Specifying End of Form Navigation here will override the Case List Registration workflow.
-          To avoid overriding the Case List Registration workflow set the End of Form Navigation
-          to the default option ('Home Screen').
-        {% endblocktrans %}</p>
-        <!-- /ko -->
-      {% endif %}
     </div>
 
     <div class="form-links-container" data-bind="

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_error_message.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_error_message.html
@@ -1,3 +1,0 @@
-{# Poor spacing in this file because this template is used in the middle of sentences #}{% load xforms_extras %}{% load i18n %}{% if not not_actual_build %}
-Menu "<a href="{% url "view_module" domain app.id error.module.unique_id %}">{{ error.module.name|trans:langs }}</a>"
-{% else %}This menu{% endif %}

--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -115,7 +115,6 @@ def get_direct_ccz(domain, app, lang, langs, version=None, include_multimedia=Fa
             'build_errors': errors,
             'domain': domain,
             'langs': langs,
-            'lang': lang,
             'visit_scheduler_enabled': visit_scheduler_enabled,
         })
         return json_response(

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -451,14 +451,11 @@ def validate_form_for_build(request, domain, app_id, form_unique_id, ajax=True):
         response_html = ""
     else:
         response_html = render_to_string("app_manager/partials/build_errors.html", {
-            'request': request,
             'app': app,
-            'form': form,
             'build_errors': errors,
             'not_actual_build': True,
             'domain': domain,
             'langs': langs,
-            'lang': lang
         })
 
     if ajax:

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -447,12 +447,9 @@ def validate_form_for_build(request, domain, app_id, form_unique_id, ajax=True):
     errors = form.validate_for_build()
     lang, langs = get_langs(request, app)
 
-    if ajax and "blank form" in [error.get('type') for error in errors] and not form.form_type == "shadow_form":
+    if ajax and "blank form" in [error.get('type') for error in errors]:
         response_html = ""
     else:
-        if form.form_type == "shadow_form":
-            # Don't display the blank form error if its a shadow form
-            errors = [e for e in errors if e['type'] != "blank form"]
         response_html = render_to_string("app_manager/partials/build_errors.html", {
             'request': request,
             'app': app,

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -976,13 +976,11 @@ def validate_module_for_build(request, domain, app_id, module_unique_id, ajax=Tr
     lang, langs = get_langs(request, app)
 
     response_html = render_to_string("app_manager/partials/build_errors.html", {
-        'request': request,
         'app': app,
         'build_errors': errors,
         'not_actual_build': True,
         'domain': domain,
         'langs': langs,
-        'lang': lang,
     })
     if ajax:
         return json_response({'error_html': response_html})

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -325,12 +325,10 @@ def save_copy(request, domain, app_id):
     return json_response({
         "saved_app": copy,
         "error_html": render_to_string("app_manager/partials/build_errors.html", {
-            'request': request,
             'app': get_app(domain, app_id),
             'build_errors': errors,
             'domain': domain,
             'langs': langs,
-            'lang': lang
         }),
     })
 

--- a/corehq/apps/data_interfaces/templates/data_interfaces/case_rule.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/case_rule.html
@@ -14,7 +14,7 @@
 
   <div id="rule-definition">
     {% if read_only_mode %}
-      <p class="alert alert-block alert-warning">
+      <p class="alert alert-warning">
         {% trans "NOTE: A system administrator is required to edit this rule." %}
       </p>
     {% endif %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
@@ -5,7 +5,7 @@
 
 {% block reportcontent %}
   <div id="data-interfaces-archive-forms">
-    <p class="alert fade in hide page-level-alert alert-danger" id="errorMessage">
+    <p class="alert fade in hide alert-danger" id="errorMessage">
       {% blocktrans %}
         Something went wrong! There was an error. If you see this error repeatedly please report it as issue.
       {% endblocktrans %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_actions.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_actions.html
@@ -6,7 +6,7 @@
 
 <script type="text/html" id="case-actions">
   {% if form.errors %}
-    <div class="alert alert-block alert-danger">
+    <div class="alert alert-danger">
       <span class="help-block"><strong>{% trans "Error:" %}</strong></span>
       {% for field, errors in form.errors.items %}
         {% for error in errors %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/partials/case_rule_criteria.html
@@ -9,7 +9,7 @@
 
 <script type="text/html" id="case-filters">
   {% if form.errors %}
-    <div class="alert alert-block alert-danger">
+    <div class="alert alert-danger">
       <span class="help-block"><strong>{% trans "Error:" %}</strong></span>
       {% for field, errors in form.errors.items %}
         {% for error in errors %}

--- a/corehq/apps/domain/static/domain/js/info_basic.js
+++ b/corehq/apps/domain/static/domain/js/info_basic.js
@@ -8,19 +8,6 @@ hqDefine("domain/js/info_basic", [
     _
 ) {
     $(function () {
-        // Update project dropdown in page header with potentially new project name
-        var name = $('#id_hr_name').val(),
-            $projectsMenu = $('#nav-projects-menu'),
-            currentHref = $projectsMenu.find(".btn-project-active").attr("href");
-        if ($(".page-level-alert.alert-success").length) {
-            _.each($projectsMenu.find("a"), function (link) {
-                var $link = $(link);
-                if (currentHref.startsWith($link.attr("href"))) {
-                    $link.text(name);
-                }
-            });
-        }
-
         $('#id_default_timezone').select2({
             placeholder: gettext('Select a Timezone...'),
         });

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -23,7 +23,7 @@
       <a href='https://confluence.dimagi.com/pages/viewpage.action?pageId=12222793' target='_blank'>Help Site</a>.
     {% endblocktrans %}
   </p>
-  <p class="alert fade in hide page-level-alert alert-danger" id="editFailure">
+  <p class="alert fade in hide alert-danger" id="editFailure">
     <a class="close" href="#">×</a>
     <span id="FailText">
     {% blocktrans %}

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
@@ -70,7 +70,7 @@
           <div class="row">
             <div class="col-sm-12">
                 {% for message in errors %}
-                  <div class="alert alert-margin-top fade in page-level-alert alert-danger">
+                  <div class="alert alert-margin-top fade in alert-danger">
                     {{ message }}
                   </div>
                 {% endfor %}

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
@@ -70,7 +70,7 @@
           <div class="row">
             <div class="col-sm-12">
                 {% for message in errors %}
-                  <div class="alert alert-margin-top fade in alert-block alert-full page-level-alert alert-danger">
+                  <div class="alert alert-margin-top fade in alert-block page-level-alert alert-danger">
                     {{ message }}
                   </div>
                 {% endfor %}

--- a/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/raw_doc.html
@@ -70,7 +70,7 @@
           <div class="row">
             <div class="col-sm-12">
                 {% for message in errors %}
-                  <div class="alert alert-margin-top fade in alert-block page-level-alert alert-danger">
+                  <div class="alert alert-margin-top fade in page-level-alert alert-danger">
                     {{ message }}
                   </div>
                 {% endfor %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
@@ -25,7 +25,7 @@ function (
         var alert_obj = {
             "message": ko.observable(message),
             "alert_class": ko.observable(
-                "alert fade in page-level-alert message-alert"
+                "alert fade in message-alert"
             ),
         };
         if (tags) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
@@ -25,7 +25,7 @@ function (
         var alert_obj = {
             "message": ko.observable(message),
             "alert_class": ko.observable(
-                "alert fade in alert-block page-level-alert message-alert"
+                "alert fade in page-level-alert message-alert"
             ),
         };
         if (tags) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/alert_user.js
@@ -25,7 +25,7 @@ function (
         var alert_obj = {
             "message": ko.observable(message),
             "alert_class": ko.observable(
-                "alert fade in alert-block alert-full page-level-alert message-alert"
+                "alert fade in alert-block page-level-alert message-alert"
             ),
         };
         if (tags) {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -94,17 +94,6 @@ hqDefine("hqwebapp/js/hq.helpers", [
         });
     };
 
-    $.showMessage = function (message, level) {
-        var $notice = $('<div />').addClass("alert fade in")
-            .addClass("alert-" + level);
-        var $closeIcon = $('<a />').addClass("close").attr("data-dismiss", "alert");
-        $closeIcon.attr("href", "#").html("&times;");
-        $notice.append($closeIcon);
-        $notice.append(message);
-        $(".hq-page-header-container").prepend($notice);
-    };
-
-
     $.fn.addSpinnerToButton = function () {
         $(this).prepend('<i class="fa fa-refresh fa-spin icon-refresh icon-spin"></i> ');
     };

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -108,7 +108,7 @@ hqDefine("hqwebapp/js/hq.helpers", [
     };
 
     $.showMessage = function (message, level) {
-        var $notice = $('<div />').addClass("alert fade in alert-block alert-full page-level-alert")
+        var $notice = $('<div />').addClass("alert fade in alert-block page-level-alert")
             .addClass("alert-" + level);
         var $closeIcon = $('<a />').addClass("close").attr("data-dismiss", "alert");
         $closeIcon.attr("href", "#").html("&times;");

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -108,7 +108,7 @@ hqDefine("hqwebapp/js/hq.helpers", [
     };
 
     $.showMessage = function (message, level) {
-        var $notice = $('<div />').addClass("alert fade in alert-block page-level-alert")
+        var $notice = $('<div />').addClass("alert fade in page-level-alert")
             .addClass("alert-" + level);
         var $closeIcon = $('<a />').addClass("close").attr("data-dismiss", "alert");
         $closeIcon.attr("href", "#").html("&times;");

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -9,19 +9,6 @@ hqDefine("hqwebapp/js/hq.helpers", [
     _,
     googleAnalytics
 ) {
-    var clearAnnouncement = function (announcementID) {
-        $.ajax({
-            url: '/announcements/clear/' + announcementID,
-        });
-    };
-
-    $('.page-level-alert').on('closed', function () {
-        var announcement_id = $('.page-level-alert').find('.announcement-control').data('announcementid');
-        if (announcement_id) {
-            clearAnnouncement(announcement_id);
-        }
-    });
-
     // disable-on-submit is a class for form submit buttons so they're automatically disabled when the form is submitted
     $(document).on('submit', 'form', function (ev) {
         var form = $(ev.target);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -95,7 +95,7 @@ hqDefine("hqwebapp/js/hq.helpers", [
     };
 
     $.showMessage = function (message, level) {
-        var $notice = $('<div />').addClass("alert fade in page-level-alert")
+        var $notice = $('<div />').addClass("alert fade in")
             .addClass("alert-" + level);
         var $closeIcon = $('<a />').addClass("close").attr("data-dismiss", "alert");
         $closeIcon.attr("href", "#").html("&times;");

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -261,7 +261,7 @@
 
       <!--[if IE]>
         <div id="unsupported-browser"
-             class="alert alert-danger alert-block alert-full">
+             class="alert alert-danger alert-block">
           <p>
             <i class="fa fa-warning-sign"></i>
             <strong>
@@ -284,7 +284,7 @@
             <div class="col-sm-12">
               {% if messages %}
                 {% for message in messages %}
-                  <div class="alert alert-margin-top fade in alert-block alert-full page-level-alert{% if message.tags %} {{ message.tags }}{% endif %}">
+                  <div class="alert alert-margin-top fade in alert-block page-level-alert{% if message.tags %} {{ message.tags }}{% endif %}">
                     <a class="close" data-dismiss="alert" href="#">&times;</a>
                     {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
                   </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -284,7 +284,7 @@
             <div class="col-sm-12">
               {% if messages %}
                 {% for message in messages %}
-                  <div class="alert alert-margin-top fade in page-level-alert{% if message.tags %} {{ message.tags }}{% endif %}">
+                  <div class="alert alert-margin-top fade in{% if message.tags %} {{ message.tags }}{% endif %}">
                     <a class="close" data-dismiss="alert" href="#">&times;</a>
                     {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
                   </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -261,7 +261,7 @@
 
       <!--[if IE]>
         <div id="unsupported-browser"
-             class="alert alert-danger alert-block">
+             class="alert alert-danger">
           <p>
             <i class="fa fa-warning-sign"></i>
             <strong>
@@ -284,7 +284,7 @@
             <div class="col-sm-12">
               {% if messages %}
                 {% for message in messages %}
-                  <div class="alert alert-margin-top fade in alert-block page-level-alert{% if message.tags %} {{ message.tags }}{% endif %}">
+                  <div class="alert alert-margin-top fade in page-level-alert{% if message.tags %} {{ message.tags }}{% endif %}">
                     <a class="close" data-dismiss="alert" href="#">&times;</a>
                     {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
                   </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/form_list_form.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/form_list_form.html
@@ -9,7 +9,7 @@
   {% csrf_token %}
   <fieldset>
     {% if errors %}
-      <div class="alert alert-block alert-danger">
+      <div class="alert alert-danger">
         {% trans "Form has errors" %}
       </div>
     {% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/time_notice.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/time_notice.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="alert alert-info alert-full hq-report-time-notice{% if hide %} hide{% endif %}">
+<div class="alert alert-info hq-report-time-notice{% if hide %} hide{% endif %}">
   <strong>
     {% trans "The current date and time is" %}
     {% if timezone %}{{ timezone_now }} {{ timezone }}{% else %}{{ now }} GMT{% endif %}.

--- a/corehq/apps/reports/static/reports/js/hq_report.js
+++ b/corehq/apps/reports/static/reports/js/hq_report.js
@@ -231,12 +231,12 @@ hqDefine("reports/js/hq_report", [
                     .done(function () {
                         $(hqReport.emailReportModal).modal('hide');
                         self.resetModal();
-                        $.showMessage(hqReport.emailSuccessMessage, "success");
+                        alertUser.alert_user(hqReport.emailSuccessMessage, "success");
                     })
                     .fail(function () {
                         $(hqReport.emailReportModal).modal('hide');
                         self.resetModal();
-                        $.showMessage(hqReport.emailErrorMessage, "error");
+                        alertUser.alert_user(hqReport.emailErrorMessage, "error");
                     });
             };
 

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -53,7 +53,7 @@
 </style>
 
 {% if is_archived %}
-  <div class="alert alert-info alert-block">
+  <div class="alert alert-info">
     {% blocktrans %}
       This form is archived and will not be included in reports.
     {% endblocktrans %}
@@ -67,7 +67,7 @@
 {% endif %}
 
 {% if edit_info.was_edited %}
-  <div class="alert alert-info alert-block">
+  <div class="alert alert-info">
     {% url "render_form_data" domain edit_info.latest_version as latest_version_url %}
     {% blocktrans %}
       This form has been edited. The latest version can be viewed <a href="{{ latest_version_url }}">here</a>.
@@ -76,7 +76,7 @@
 {% endif %}
 
 {% if edit_info.is_edit %}
-  <div class="alert alert-warning alert-block">
+  <div class="alert alert-warning">
     {% url "render_form_data" domain edit_info.previous_version as previous_version_url %}
     {% blocktrans with when=edit_info.edited_on|naturaltime %}
       This submission was edited from a previous version {{ when }}. You can view the previous version <a href="{{ previous_version_url }}">here</a>.

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -53,7 +53,7 @@
 </style>
 
 {% if is_archived %}
-  <div class="alert alert-info alert-full alert-block">
+  <div class="alert alert-info alert-block">
     {% blocktrans %}
       This form is archived and will not be included in reports.
     {% endblocktrans %}
@@ -67,7 +67,7 @@
 {% endif %}
 
 {% if edit_info.was_edited %}
-  <div class="alert alert-info alert-full alert-block">
+  <div class="alert alert-info alert-block">
     {% url "render_form_data" domain edit_info.latest_version as latest_version_url %}
     {% blocktrans %}
       This form has been edited. The latest version can be viewed <a href="{{ latest_version_url }}">here</a>.
@@ -76,7 +76,7 @@
 {% endif %}
 
 {% if edit_info.is_edit %}
-  <div class="alert alert-warning alert-full alert-block">
+  <div class="alert alert-warning alert-block">
     {% url "render_form_data" domain edit_info.previous_version as previous_version_url %}
     {% blocktrans with when=edit_info.edited_on|naturaltime %}
       This submission was edited from a previous version {{ when }}. You can view the previous version <a href="{{ previous_version_url }}">here</a>.

--- a/corehq/messaging/scheduling/templates/scheduling/conditional_alert.html
+++ b/corehq/messaging/scheduling/templates/scheduling/conditional_alert.html
@@ -56,7 +56,7 @@
     <div class="col-sm-12">
       {% if read_only_mode %}
         {% if criteria_form.requires_system_admin_to_edit or schedule_form.requires_system_admin_to_edit %}
-          <p class="alert alert-block alert-warning">
+          <p class="alert alert-warning">
             {% trans "NOTE: A system administrator is required to edit this alert." %}
           </p>
         {% endif %}

--- a/corehq/messaging/scheduling/templates/scheduling/partials/schedule_form.html
+++ b/corehq/messaging/scheduling/templates/scheduling/partials/schedule_form.html
@@ -1,6 +1,5 @@
 {% load crispy_forms_tags %}
 
-
 <div id="create-schedule-form" class="col-sm-12">
   {% crispy schedule_form schedule_form.before_content %}
   {% crispy schedule_form.standalone_content_form %}
@@ -11,7 +10,7 @@
         <label class="control-label col-sm-2 col-md-2 col-lg-2"></label>
         <div class="controls col-sm-10 col-md-7 col-lg-5 controls-multiple">
           {% for error in schedule_form.custom_event_formset.non_form_errors %}
-            <div class="alert alert-block alert-danger">
+            <div class="alert alert-danger">
               <strong>{{ error }}</strong>
             </div>
           {% endfor %}


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-914

End of form nav can't be used on forms that are being used as a case list registration form. We warn about this on the form settings page under the EOF setting, but not on menu settings near the case list reg setting. This PR removes the warning and instead adds a validation error so you can't make a build.

First commit addresses this issue. Remaining commits are all minor cleanup.

fyi @dimagi/product this means that there may be apps that previously "worked" and will now start failing. The error does have instructions on how to fix it.

<img width="1018" alt="Screen Shot 2019-10-04 at 5 34 09 PM" src="https://user-images.githubusercontent.com/1486591/66241502-3bf35e00-e6cd-11e9-866b-3520be45c88f.png">
