### PR TITLE
update character limit to 255 on OData labels

### DIFF
--- a/corehq/apps/export/views/utils.py
+++ b/corehq/apps/export/views/utils.py
@@ -387,6 +387,6 @@ def clean_odata_columns(export_instance):
         for column in table.columns:
             column.label = column.label.replace('@', '').replace(
                 '.', ' ').replace('\n', '').replace('\t', ' ').replace('#', '')
-            # truncate labels for PowerBI limits
-            if len(column.label) >= 511:
-                column.label = column.label[:511]
+            # truncate labels for PowerBI and Tableau limits
+            if len(column.label) >= 255:
+                column.label = column.label[:255]


### PR DESCRIPTION
##### SUMMARY
update character limit to 255 on odata labels. Tableau does not support more than 255 characters