### PR TITLE
Fix cp_n_saved_scheduled_reports new scheduled report message

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -593,7 +593,8 @@ class ScheduledReportsView(BaseProjectReportSectionView):
 
     @property
     def is_new(self):
-        return self.report_notification.new_document
+        """True if before this request the ReportNotification object did not exist"""
+        return bool(not self.scheduled_report_id)
 
     @property
     def page_name(self):


### PR DESCRIPTION
##### SUMMARY
I think this must have been broken for ~4 years possibly starting with
https://github.com/dimagi/commcare-hq/commit/47e0b1567b7d862b2346d71da31e33ecb9b84c3c.

Basically for most of ScheduledReportsView its self.is_new correctly distinguishes
the "new scheduled report" mode and the "edit scheduled report" mode,
but once a new scheduled report is saved, self.is_new incorrectly returned False
for the remainder of the request, circumventing a couple lines of intended workflow.

I'm going to put this PR in because it's a strict improvement and now that I've done it I might as well, but if cp_n_saved_scheduled_reports has been broken for ~4 years then clearly no one has been missing it, right? @djmore9 Can you confirm you've never looked at cp_n_saved_scheduled_reports / or been sad that that data's not there? It counts the number of times a new report has been added since we started tracking (so starting tomorrow, or before ~4 years ago).

##### PRODUCT DESCRIPTION
Fix message after creating a new scheduled report. Currently it says updated where it should say added:
<img width="248" alt="Screen Shot 2019-10-07 at 5 31 04 PM" src="https://user-images.githubusercontent.com/137212/66354917-f97b8c80-e92b-11e9-9d03-a846731a0099.png">

