### PR TITLE
set publish_timesamp when republishing change

### DIFF
--- a/corehq/ex-submodules/pillow_retry/api.py
+++ b/corehq/ex-submodules/pillow_retry/api.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime
 
 from memoized import memoized
 
@@ -66,6 +67,7 @@ def _process_couch_change(pillow, error):
 
 def _process_kafka_change(producer, error):
     change_metadata = error.change_object.metadata
+    change_metadata.publish_timestamp = datetime.utcnow()
     producer.send_change(
         get_topic_for_doc_type(
             change_metadata.document_type,


### PR DESCRIPTION
This will prevent the change lag metrics from incorrectly reporting lag when errors are re-published.

![image](https://user-images.githubusercontent.com/249606/66381203-25911f00-e9b9-11e9-8299-cc924e33d6e7.png)
