### PR TITLE
Drop OpenmrsImporter.location_type_name

### DIFF
--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -68,7 +68,6 @@ class OpenmrsConfigForm(forms.Form):
 
 
 _owner_id_label = _('Owner ID')
-_location_type_name_label = _('Organization Level')
 
 
 class OpenmrsImporterForm(forms.Form):
@@ -89,11 +88,8 @@ class OpenmrsImporterForm(forms.Form):
                                   help_text=_('The OpenMRS UUID of the report of patients to be imported'))
     report_params = JsonField(label=_('Report Parameters'), required=False, expected_type=dict)
     case_type = forms.CharField(label=_('Case Type'), required=True)
-    owner_id = forms.CharField(label=_owner_id_label, required=False,
+    owner_id = forms.CharField(label=_owner_id_label, required=True,
                                help_text=_('The ID of the mobile worker or location who will own new cases'))
-    location_type_name = forms.CharField(label=_location_type_name_label, required=False,
-                                         help_text=_('The Organization Level whose mobile worker will own new '
-                                                     'cases'))
     external_id_column = forms.CharField(label=_('External ID Column'), required=True,
                                          help_text=_("The column that contains the OpenMRS UUID of the patient"))
     name_columns = forms.CharField(label=_('Name Columns'), required=True,
@@ -101,17 +97,6 @@ class OpenmrsImporterForm(forms.Form):
                                                'name (e.g. "givenName familyName")'))
     column_map = JsonField(label=_('Map columns to properties'), required=True, expected_type=list,
                            help_text=_('e.g. [{"column": "givenName", "property": "first_name"}, ...]'))
-
-    def clean(self):
-        cleaned_data = super(OpenmrsImporterForm, self).clean()
-        if bool(cleaned_data.get('owner_id')) == bool(cleaned_data.get('location_type_name')):
-            message = _(
-                'The owner of imported patient cases is determined using either "{owner_id}" or '
-                '"{location_type_name}". Please specify either one or the other.').format(
-                owner_id=_owner_id_label, location_type_name=_location_type_name_label)
-            self.add_error('owner_id', message)
-            self.add_error('location_type_name', message)
-        return self.cleaned_data
 
     def save(self, domain_name):
         try:
@@ -132,7 +117,6 @@ class OpenmrsImporterForm(forms.Form):
             importer.report_params = self.cleaned_data['report_params']
             importer.case_type = self.cleaned_data['case_type']
             importer.owner_id = self.cleaned_data['owner_id']
-            importer.location_type_name = self.cleaned_data['location_type_name']
             importer.external_id_column = self.cleaned_data['external_id_column']
             importer.name_columns = self.cleaned_data['name_columns']
             importer.column_map = list(map(ColumnMapping.wrap, self.cleaned_data['column_map']))

--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -70,8 +70,6 @@ class OpenmrsImporter(Document):
     # cases to different owners, see `location_type` below.
     owner_id = StringProperty()
 
-    location_type_name = StringProperty()  # UNUSED
-
     # external_id should always be the OpenMRS UUID of the patient (and not, for example, a national ID number)
     # because it is immutable. external_id_column is the column that contains the UUID
     external_id_column = StringProperty()

--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -70,11 +70,7 @@ class OpenmrsImporter(Document):
     # cases to different owners, see `location_type` below.
     owner_id = StringProperty()
 
-    # If report_params includes "{{ location }}" then location_type_name is used to determine which locations to
-    # pull the report for. Those locations will need an "openmrs_uuid" param set. Imported cases will be owned by
-    # the first mobile worker assigned to that location. If this OpenmrsImporter.location_id is set, only
-    # sub-locations will be returned
-    location_type_name = StringProperty()
+    location_type_name = StringProperty()  # UNUSED
 
     # external_id should always be the OpenMRS UUID of the patient (and not, for example, a national ID number)
     # because it is immutable. external_id_column is the column that contains the UUID

--- a/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
+++ b/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
@@ -31,7 +31,6 @@ hqDefine('openmrs/js/openmrs_importers', [
         self.report_params = ko.observable(properties["report_params"]);
         self.case_type = ko.observable(properties["case_type"]);
         self.owner_id = ko.observable(properties["owner_id"]);
-        self.location_type_name = ko.observable(properties["location_type_name"]);
         self.external_id_column = ko.observable(properties["external_id_column"]);
         self.name_columns = ko.observable(properties["name_columns"]);
         self.column_map = ko.observable(properties["column_map"]);
@@ -60,7 +59,6 @@ hqDefine('openmrs/js/openmrs_importers', [
                 "report_params": self.report_params(),
                 "case_type": self.case_type(),
                 "owner_id": self.owner_id(),
-                "location_type_name": self.location_type_name(),
                 "external_id_column": self.external_id_column(),
                 "name_columns": self.name_columns(),
                 "column_map": self.column_map(),

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -22,8 +22,6 @@ from corehq.apps.case_importer import util as importer_util
 from corehq.apps.case_importer.const import LookupErrors
 from corehq.apps.case_importer.util import EXTERNAL_ID
 from corehq.apps.hqcase.utils import submit_case_blocks
-from corehq.apps.locations.dbaccessors import get_one_commcare_user_at_location
-from corehq.apps.locations.models import LocationType, SQLLocation
 from corehq.motech.openmrs.atom_feed import (
     get_feed_updates,
     import_encounter,
@@ -47,32 +45,28 @@ from corehq.motech.utils import b64_aes_decrypt
 RowAndCase = namedtuple('RowAndCase', ['row', 'case'])
 # REQUEST_TIMEOUT is 5 minutes, but reports can take up to an hour
 REPORT_REQUEST_TIMEOUT = 60 * 60
-# The location metadata key that maps to its corresponding OpenMRS location UUID
-LOCATION_OPENMRS = 'openmrs_uuid'
 
 
-def parse_params(params, location=None):
+def parse_params(params):
     """
-    Inserts date and OpenMRS location UUID into report params
+    Inserts date into report params
     """
     today = datetime.today().strftime('%Y-%m-%d')
-    location_uuid = location.metadata[LOCATION_OPENMRS] if location else None
-
     parsed = {}
     for key, value in params.items():
         if isinstance(value, str) and '{{' in value:
             template = Template(value)
-            value = template.render(today=today, location=location_uuid)
+            value = template.render(today=today)
         parsed[key] = value
     return parsed
 
 
-def get_openmrs_patients(requests, importer, location=None):
+def get_openmrs_patients(requests, importer):
     """
     Send request to OpenMRS Reporting API and return results
     """
     endpoint = f'/ws/rest/v1/reportingrest/reportdata/{importer.report_uuid}'
-    params = parse_params(importer.report_params, location)
+    params = parse_params(importer.report_params)
     response = requests.get(endpoint, params=params, raise_for_status=True,
                             timeout=REPORT_REQUEST_TIMEOUT)
     data = response.json()
@@ -128,8 +122,8 @@ def get_updatepatient_caseblock(case, patient, importer):
     )
 
 
-def import_patients_of_owner(requests, importer, domain_name, owner_id, location=None):
-    openmrs_patients = get_openmrs_patients(requests, importer, location)
+def import_patients_of_owner(requests, importer, domain_name, owner_id):
+    openmrs_patients = get_openmrs_patients(requests, importer)
     case_blocks = []
     for i, patient in enumerate(openmrs_patients):
         case, error = importer_util.lookup_case(
@@ -157,32 +151,6 @@ def import_patients_to_domain(domain_name, force=False):
     """
     Iterates OpenmrsImporters of a domain, and imports patients
 
-    Who owns the imported cases?
-
-    If `importer.owner_id` is set, then the server will be queried
-    once. All patients, regardless of their location, will be assigned
-    to the mobile worker whose ID is `importer.owner_id`.
-
-    If `importer.location_type_name` is set, then check whether the
-    OpenmrsImporter's location is set with `importer.location_id`.
-
-    If `importer.location_id` is given, then the server will be queried
-    for each location among its descendants whose type is
-    `importer.location_type_name`. The request's query parameters will
-    include that descendant location's OpenMRS UUID. Imported cases
-    will be owned by the first mobile worker in that location.
-
-    If `importer.location_id` is given, then the server will be queried
-    for each location in the project space whose type is
-    `importer.location_type_name`. As when `importer.location_id` is
-    specified, the request's query parameters will include that
-    location's OpenMRS UUID, and imported cases will be owned by the
-    first mobile worker in that location.
-
-    ..NOTE:: As you can see from the description above, if
-             `importer.owner_id` is set then `importer.location_id` is
-             not used.
-
     :param domain_name: The name of the domain
     :param force: Import regardless of the configured import frequency / today's date
     """
@@ -196,51 +164,14 @@ def import_patients_with_importer(importer_json):
     importer = OpenmrsImporter.wrap(importer_json)
     password = b64_aes_decrypt(importer.password)
     requests = Requests(importer.domain, importer.server_url, importer.username, password)
-    if importer.location_type_name:
-        try:
-            location_type = LocationType.objects.get(domain=importer.domain, name=importer.location_type_name)
-        except LocationType.DoesNotExist:
-            logger.error(
-                f'No organization level named "{importer.location_type_name}" '
-                f'found in project space "{importer.domain}".'
-            )
-            return
-        if importer.location_id:
-            location = SQLLocation.objects.filter(domain=importer.domain).get(importer.location_id)
-            locations = location.get_descendants.filter(location_type=location_type)
-        else:
-            locations = SQLLocation.objects.filter(domain=importer.domain, location_type=location_type)
-        for location in locations:
-            # Assign cases to the first user in the location, not to the location itself
-            owner = get_one_commcare_user_at_location(importer.domain, location.location_id)
-            if not owner:
-                logger.error(
-                    f'Project space "{importer.domain}" at location '
-                    f'"{location.name}" has no user to own cases imported '
-                    f'from OpenMRS Importer "{importer}"'
-                )
-                continue
-            # The same report is fetched for each location. WE DO THIS
-            # ASSUMING THAT THE LOCATION IS USED IN THE REPORT
-            # PARAMETERS. If not, OpenMRS will return THE SAME PATIENTS
-            # multiple times and they will be assigned to a different
-            # user each time.
-            import_patients_of_owner(requests, importer, importer.domain, owner.user_id, location)
-    elif importer.owner_id:
-        if not is_valid_owner(importer.owner_id):
-            logger.error(
-                f'Error importing patients for project space "{importer.domain}" '
-                f'from OpenMRS Importer "{importer}": owner_id "{importer.owner_id}" '
-                'is invalid.'
-            )
-            return
-        import_patients_of_owner(requests, importer, importer.domain, importer.owner_id)
-    else:
+    if not is_valid_owner(importer.owner_id):
         logger.error(
-            f'Error importing patients for project space "{importer.domain}" from '
-            f'OpenMRS Importer "{importer}": Unable to determine the owner of '
-            'imported cases without either owner_id or location_type_name'
+            f'Error importing patients for project space "{importer.domain}" '
+            f'from OpenMRS Importer "{importer}": owner_id "{importer.owner_id}" '
+            'is invalid.'
         )
+        return
+    import_patients_of_owner(requests, importer, importer.domain, importer.owner_id)
 
 
 def is_valid_owner(owner_id):

--- a/corehq/motech/openmrs/tests/test_importer.py
+++ b/corehq/motech/openmrs/tests/test_importer.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from mock import patch
 
@@ -58,3 +58,16 @@ class ImporterTests(SimpleTestCase):
                 import_frequency=IMPORT_FREQUENCY_MONTHLY,
             )
             self.assertFalse(importer.should_import_today())
+
+
+class LocationTypeNameTest(TestCase):
+
+    def test_wrapping_old_definition(self):
+        imp = OpenmrsImporter.wrap({
+            'domain': domain_name,
+            'location_type_name': ''
+        })
+        try:
+            imp.save()
+        finally:
+            imp.delete()

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -34,7 +34,6 @@ def get_importer():
         'report_params': {},
         'case_type': 'patient',
         'owner_id': '123456',
-        'location_type_name': '',
         'external_id_column': 'NID',
         'name_columns': 'nome_inicial apelido',
         'column_map': [


### PR DESCRIPTION
##### SUMMARY
OpenMRS Importers have two ways to set ownership of imported patients:
* A simple way, where the owner is set by specifying the owner ID. **All** OpenMRS Importers in production use this way.
* A convoluted way, determined by specifying the location type name of the location of the mobile worker to which the patients must be assigned. **Zero** OpenMRS Importers in production use this way.

The same functionality offered by the convoluted way can be achieved using the simple way, by specifying multiple OpenmrsImporter instances that refer to the same server.

This change drops the convoluted way. 

The change builds on #25584 to avoid awkward merge conflicts. Review commits :tropical_fish: from be1f441 "Drop OpenmrsImporter.location_type_name".

Opening as a draft PR to test from Staging.

##### FEATURE FLAG
OpenMRS integration

##### PRODUCT DESCRIPTION
Simplifies the way that patients imported from OpenMRS are assigned to owners.
