### PR TITLE
use ID as row number for odata feeds

### DIFF
--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -69,10 +69,8 @@ class ODataBaseSerializer(Serializer):
         if next_page:
             return '{}{}{}'.format(get_url_base(), api_path, next_page)
 
-    def get_full_row_number(self, row_number):
-        return row_number + self.offset
-
-    def serialize_documents_using_config(self, documents, config, table_id):
+    @staticmethod
+    def serialize_documents_using_config(documents, config, table_id):
         if table_id + 1 > len(config.tables):
             return []
 
@@ -84,7 +82,7 @@ class ODataBaseSerializer(Serializer):
         for row_number, document in enumerate(documents):
             rows = table.get_rows(
                 document,
-                self.get_full_row_number(row_number),
+                document.get('_id'),  # needed because of pagination
                 split_columns=config.split_multiselects,
                 transform_dates=config.transform_dates,
                 as_json=True,

--- a/corehq/apps/api/odata/tests/test_serializers.py
+++ b/corehq/apps/api/odata/tests/test_serializers.py
@@ -18,7 +18,7 @@ class TestODataCaseSerializer(SimpleTestCase):
 
     def test_selected_column_included(self):
         self.assertEqual(
-            ODataCaseSerializer().serialize_documents_using_config(
+            ODataCaseSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',
@@ -50,7 +50,7 @@ class TestODataCaseSerializer(SimpleTestCase):
 
     def test_unselected_column_excluded(self):
         self.assertEqual(
-            ODataCaseSerializer().serialize_documents_using_config(
+            ODataCaseSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',
@@ -82,7 +82,7 @@ class TestODataCaseSerializer(SimpleTestCase):
 
     def test_missing_value_is_null(self):
         self.assertEqual(
-            ODataCaseSerializer().serialize_documents_using_config(
+            ODataCaseSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',
@@ -112,7 +112,7 @@ class TestODataCaseSerializer(SimpleTestCase):
 
     def test_non_standard_case_property(self):
         self.assertEqual(
-            ODataCaseSerializer().serialize_documents_using_config(
+            ODataCaseSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',
@@ -143,7 +143,7 @@ class TestODataCaseSerializer(SimpleTestCase):
 
     def test_case_id(self):
         self.assertEqual(
-            ODataCaseSerializer().serialize_documents_using_config(
+            ODataCaseSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': 'case-id-value',
@@ -173,7 +173,7 @@ class TestODataCaseSerializer(SimpleTestCase):
 
     def test_case_name(self):
         self.assertEqual(
-            ODataCaseSerializer().serialize_documents_using_config(
+            ODataCaseSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',
@@ -223,7 +223,7 @@ class TestODataFormSerializer(SimpleTestCase):
 
     def test_selected_column_included(self):
         self.assertEqual(
-            ODataFormSerializer().serialize_documents_using_config(
+            ODataFormSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',
@@ -254,7 +254,7 @@ class TestODataFormSerializer(SimpleTestCase):
 
     def test_unselected_column_excluded(self):
         self.assertEqual(
-            ODataFormSerializer().serialize_documents_using_config(
+            ODataFormSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',
@@ -285,7 +285,7 @@ class TestODataFormSerializer(SimpleTestCase):
 
     def test_missing_value_is_null(self):
         self.assertEqual(
-            ODataFormSerializer().serialize_documents_using_config(
+            ODataFormSerializer.serialize_documents_using_config(
                 [{
                     'domain': 'test_domain',
                     '_id': '54352-25234',


### PR DESCRIPTION
##### SUMMARY
We ended up having to use the document ID as the row number for odata feeds due to how Power BI and Tableau handle pagination.

Note that we didn't want to make this a global change yet, due to the documentation changes that are required. This will be specific to OData feeds only.