### PR TITLE
Use consistent ordering in both toggles UIs

### DIFF
--- a/corehq/apps/domain/static/domain/js/toggles.js
+++ b/corehq/apps/domain/static/domain/js/toggles.js
@@ -18,9 +18,9 @@ hqDefine('domain/js/toggles', [
 
     var Toggle = function (data) {
         assertProperties.assert(data, [
-            'slug', 'label', 'description', 'help_link', 'tag', 'tag_css_class',
-            'tag_description', 'domain_enabled', 'user_enabled',
-            'has_domain_namespace',
+            'slug', 'label', 'description', 'help_link', 'tag', 'tag_index',
+            'tag_css_class', 'tag_description', 'domain_enabled',
+            'user_enabled', 'has_domain_namespace',
         ]);
 
         var self = {};

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -223,7 +223,7 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
 
         def _sort_key(toggle):
             return (not (toggle['domain_enabled'] or toggle['user_enabled']),
-                    [t.name for t in toggles.ALL_TAGS].index(toggle['tag']),
+                    toggle['tag_index'],
                     toggle['label'])
 
         unsorted_toggles = [{
@@ -232,6 +232,7 @@ class FlagsAndPrivilegesView(BaseAdminProjectSettingsView):
             'description': toggle.description,
             'help_link': toggle.help_link,
             'tag': toggle.tag.name,
+            'tag_index': toggle.tag.index,
             'tag_description': toggle.tag.description,
             'tag_css_class': toggle.tag.css_class,
             'has_domain_namespace': toggles.NAMESPACE_DOMAIN in toggle.namespaces,

--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -58,7 +58,11 @@
       <tbody>
       {% for toggle in toggles %}
         <tr>
-          <td><span class="label label-{{ toggle.tag.css_class }}">{{ toggle.tag.name }}</span></td>
+            <td>
+                {# Put the index here (hidden) so it sorts properly #}
+                <span class="hide">{{ toggle.tag.index }}</span>
+                <span class="label label-{{ toggle.tag.css_class }}">{{ toggle.tag.name }}</span>
+            </td>
           <td>
             {% if toggle.randomness %}
               <i class="fa fa-random" title="Also applied randomly under certain conditions"></i>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1,21 +1,34 @@
-import inspect
-from collections import namedtuple
-from functools import wraps
 import hashlib
+import inspect
 import math
+from functools import wraps
 
-from django.contrib import messages
 from django.conf import settings
+from django.contrib import messages
 from django.http import Http404
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
+from attr import attrib, attrs
 from couchdbkit import ResourceNotFound
-from corehq.util.quickcache import quickcache
-from toggle.models import Toggle
-from toggle.shortcuts import toggle_enabled, set_toggle
 
-Tag = namedtuple('Tag', 'name css_class description')
+from toggle.models import Toggle
+from toggle.shortcuts import set_toggle, toggle_enabled
+
+from corehq.util.quickcache import quickcache
+
+
+@attrs(frozen=True)
+class Tag:
+    name = attrib(type=str)
+    css_class = attrib(type=str)
+    description = attrib(type=str)
+
+    @property
+    def index(self):
+        return ALL_TAGS.index(self)
+
+
 TAG_CUSTOM = Tag(
     name='One-Off / Custom',
     css_class='warning',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-93
##### SUMMARY
Moves the concept of a toggle tag ordering to the tag class itself, then uses that in both places the toggle list is displayed

##### FEATURE FLAG
*ALL OF THEM!!*

##### PRODUCT DESCRIPTION
Makes the main feature flags page display toggles ordered the same way they are on the domain-specific feature flags page. 
