### PR TITLE
Change inactive AWW agg to use JOIN

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
@@ -65,9 +65,8 @@ class InactiveAwwsAggregationDistributedHelper(BaseICDSAggregationDistributedHel
                 loc.state_id as state_id,
                 loc.state_name as state_name
             FROM "{awc_location_table_name}" loc
-            WHERE loc.doc_id not in (
-              SELECT aww.awc_id FROM "{table_name}" aww
-            ) and loc.doc_id != 'All'
+            LEFT OUTER JOIN "{table_name}" aww ON loc.doc_id = aww.awc_id
+            WHERE aww.awc_id IS NULL AND loc.doc_id != 'All'
         )
         """.format(
             table_name=self.aggregate_parent_table,

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/inactive-awws.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/inactive-awws.distributed.txt
@@ -16,9 +16,8 @@
                 loc.state_id as state_id,
                 loc.state_name as state_name
             FROM "awc_location_local" loc
-            WHERE loc.doc_id not in (
-              SELECT aww.awc_id FROM "icds_reports_aggregateinactiveaww" aww
-            ) and loc.doc_id != 'All'
+            LEFT OUTER JOIN "icds_reports_aggregateinactiveaww" aww ON loc.doc_id = aww.awc_id
+            WHERE aww.awc_id IS NULL AND loc.doc_id != 'All'
         )
         
 {}


### PR DESCRIPTION
##### SUMMARY
This isn't directly related to the aggregation, but holy crap this was a terrible query.

Previous plan:

```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather  (cost=1000.42..2725198901.33 rows=317267 width=269)
   Workers Planned: 4
   ->  Parallel Seq Scan on awc_location_local loc  (cost=0.42..2725166174.63 rows=79317 width=269)
         Filter: ((doc_id <> 'All'::text) AND (NOT (SubPlan 1)))
         SubPlan 1
           ->  Materialize  (cost=0.42..31342.31 rows=634784 width=33)
                 ->  Index Only Scan using icds_reports_aggregateinactiveaww_awc_id_66aca043_like on icds_reports_aggregateinactiveaww aww  (cost=0.42..23208.39 rows=634784 width=33)
(7 rows)
```

New plan:

```
                                                                                          QUERY PLAN                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                                 
 Gather  (cost=21709.08..95033.99 rows=1 width=269)                                                                                                                                                                                                                            
   Workers Planned: 4                                                                                                                                                                                                                                                          
   ->  Parallel Hash Anti Join  (cost=20709.08..94033.89 rows=1 width=269)                                                                                                                                                                                                     
         Hash Cond: (loc.doc_id = aww.awc_id)                                                                                                                                                                                                                                  
         ->  Parallel Seq Scan on awc_location_local loc  (cost=0.00..61201.93 rows=158634 width=248)
               Filter: (doc_id <> 'All'::text)
         ->  Parallel Hash  (cost=18130.11..18130.11 rows=126957 width=33)
               ->  Parallel Index Only Scan using icds_reports_aggregateinactiveaww_awc_id_66aca043_like on icds_reports_aggregateinactiveaww aww  (cost=0.42..18130.11 rows=126957 width=33)
(8 rows)
```

Estimated cost reduction from 2725198901.33 -> 95033.99. In practice there's very rarely going to be many new AWW added here, and this new query will finish ~instanteously.