### PR TITLE
Change email to soft assert

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -47,7 +47,7 @@ from .analytics.esaccessors import (
 logging = get_task_logger(__name__)
 EXPIRE_TIME = ONE_DAY
 
-_calc_props_soft_assert = soft_assert(to='{}@{}'.format('dmore', 'dimagi.com'))
+_calc_props_soft_assert = soft_assert(to='{}@{}'.format('dmore', 'dimagi.com'), exponential_backoff=False)
 
 
 @periodic_task(run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -56,7 +56,7 @@ def update_calculated_properties():
         _update_calculated_properties()
     except Exception:
         _calc_props_soft_assert(
-            True,
+            False,
             "Calculated properties report task was unsuccessful",
             msg="Sentry will have relevant exception in case of failure",
         )
@@ -65,7 +65,7 @@ def update_calculated_properties():
             message="update_calculated_properties task has errored",
         )
     else:
-        _calc_props_soft_assert(True, "Calculated properties report task was successful")
+        _calc_props_soft_assert(False, "Calculated properties report task was successful")
 
 
 def _update_calculated_properties():

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -36,6 +36,7 @@ from corehq.elastic import (
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.pillows.mappings.app_mapping import APP_INDEX
 from corehq.util.files import TransientTempfile, safe_filename_header
+from corehq.util.soft_assert import soft_assert
 from corehq.util.view_utils import absolute_reverse
 
 from .analytics.esaccessors import (
@@ -46,24 +47,25 @@ from .analytics.esaccessors import (
 logging = get_task_logger(__name__)
 EXPIRE_TIME = ONE_DAY
 
+_calc_props_soft_assert = soft_assert(to='{}@{}'.format('dmore', 'dimagi.com'))
+
 
 @periodic_task(run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')
 def update_calculated_properties():
-    success = False
     try:
         _update_calculated_properties()
-        success = True
     except Exception:
+        _calc_props_soft_assert(
+            True,
+            "Calculated properties report task was unsuccessful",
+            msg="Sentry will have relevant exception in case of failure",
+        )
         notify_exception(
             None,
             message="update_calculated_properties task has errored",
         )
-    send_mail_async.delay(
-        subject="Calculated properties report task was " + ("successful" if success else "unsuccessful"),
-        message="Sentry will have relevant exception in case of failure",
-        from_email=settings.DEFAULT_FROM_EMAIL,
-        recipient_list=["{}@{}.com".format("dmore", "dimagi")]
-    )
+    else:
+        _calc_props_soft_assert(True, "Calculated properties report task was successful")
 
 
 def _update_calculated_properties():


### PR DESCRIPTION
##### SUMMARY
Project Balance mentioned that they were seeing this email every day.

Changing this from a plain email task to a soft assert because soft asserts have a localsetting to not send that is set for enterprise deployments. 

fyi sol-tech devs @esoergel and @kaapstorm 

Heads up @djmore9 that the calculated properties email will start coming from our soft asserts email soon.