### PR TITLE
Demote new build error back to a warning

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -18,7 +18,6 @@ from corehq.apps.app_manager.const import (
     AUTO_SELECT_FIXTURE,
     AUTO_SELECT_RAW,
     AUTO_SELECT_USER,
-    WORKFLOW_DEFAULT,
     WORKFLOW_FORM,
     WORKFLOW_MODULE,
     WORKFLOW_PARENT_MODULE,
@@ -347,12 +346,6 @@ class ModuleBaseValidator(object):
                 if not form.is_registration_form(self.module.case_type):
                     errors.append({
                         'type': 'case list form not registration',
-                        'module': self.get_module_info(),
-                        'form': form,
-                    })
-                if form.post_form_workflow != WORKFLOW_DEFAULT:
-                    errors.append({
-                        'type': 'case list form eof nav',
                         'module': self.get_module_info(),
                         'form': form,
                     })

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_workflow.js
@@ -1,5 +1,3 @@
-/* global ko, _, $ */
-
 hqDefine('app_manager/js/forms/form_workflow', function () {
     'use strict';
 
@@ -16,6 +14,11 @@ hqDefine('app_manager/js/forms/form_workflow', function () {
 
         self.workflowfallback = ko.observable(options.workflow_fallback);
         self.hasError = ko.observable(self.workflow() === FormWorkflow.Values.ERROR);
+        self.hasWarning = ko.computed(function () {
+            return !self.hasError()
+                && hqImport("hqwebapp/js/initial_page_data").get("is_case_list_form")
+                && self.workflow() !== FormWorkflow.Values.DEFAULT;
+        });
 
         self.workflow.subscribe(function (value) {
             self.showFormLinkUI(value === FormWorkflow.Values.FORM);

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -168,6 +168,17 @@ hqDefine("app_manager/js/modules/module_view", function () {
                     return self.caseListForm() && !formOptions[self.caseListForm()];
                 });
 
+                self.formHasEOFNav = ko.computed(function () {
+                    if (!self.caseListForm()) {
+                        return false;
+                    }
+                    var formData = formOptions[self.caseListForm()];
+                    if (formData) {
+                        return formData.post_form_workflow !== 'default';
+                    }
+                    return false;
+                });
+
                 var showMedia = function (formId) {
                     if (formId) {
                         $("#case_list_media").show();

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -138,6 +138,7 @@
   {% initial_page_data 'form_name' form.name|trans:app.langs %}
   {% initial_page_data 'form_requires' form.requires %}
   {% initial_page_data 'has_form_source' form.source|yesno:"1," %}
+  {% initial_page_data 'is_case_list_form' is_case_list_form %}
   {% initial_page_data 'is_usercase_in_use' is_usercase_in_use %}
   {% initial_page_data 'langs' app.langs %}
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -160,13 +160,6 @@
                 This form is not a registration form. You need to select a form which opens a case and
                 does not update an existing case. Please select a different form.
               {% endblocktrans %}
-            {% case "case list form eof nav" %}
-              {% blocktrans with module_name=error.module.name|trans:langs form_name=error.form.name|trans:langs %}
-                You have selected the <a href="{{ form_url }}">{{ form_name }}</a> form
-                as the case registration form for <a href="{{ module_url }}">{{ module_name }}</a>, but it uses
-                end of form navigation, which will override the case list registration workflow.
-                Please select a different form, or set the end of form navigation to the default option ('Home Screen').
-              {% endblocktrans %}
             {% case "case list form missing" %}
               {% blocktrans with module_name=error.module.name|trans:langs %}
                 The form you have selected as the case registration form for

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -41,11 +41,11 @@
                 }
                 ">
       </div>
-      <div class="panel panel-default">
-        <div class="panel-heading clearfix">
+      <div class="form-group">
+        <strong>
           {% trans "Navigation Fallback" %}
-        </div>
-        <div class="panel-body">
+        </strong>
+        <div>
           <select name="post_form_workflow_fallback" class="form-control" data-bind="
                         optstr: workflowFallbackOptions(),
                         value: workflowfallback,
@@ -53,8 +53,8 @@
                     "></select>
         </div>
       </div>
-      <div class="row">
-        <button class="btn btn-primary" data-bind="click: onAddFormLink">
+      <div class="form-group">
+        <button class="btn btn-default" data-bind="click: onAddFormLink">
           <i class="fa fa-plus"></i>
           {% trans "Add link" %}
         </button>
@@ -66,84 +66,57 @@
 
 <script type="text/html" id="form-link-template">
   <div class="well">
-    <div class="form-group">
-      <div class="row">
-        <div class="col-sm-11">
-                <textarea name="form_links_xpath_expressions"
-                          placeholder="{% trans "XPath Expression" %}"
-                          rows="1"
-                          class="form-control vertical-resize"
-                          data-bind="text: formLink.xpath, value: formLink.xpath"
-                          spellcheck="false"
-                ></textarea>
-        </div>
-        <div class="col-sm-1">
-          <a class="pull-right"
-             role="button"
-             href="#"
-             data-bind="click: $parent.onDestroyFormLink.bind($parent)">
-            <i class="fa fa-remove"></i>
-          </a>
-        </div>
+    <div>
+      <div class="form-group">
+        <textarea name="form_links_xpath_expressions"
+                  placeholder="{% trans "XPath Expression" %}"
+                  rows="1"
+                  class="form-control vertical-resize"
+                  data-bind="text: formLink.xpath, value: formLink.xpath"
+                  spellcheck="false"
+        ></textarea>
       </div>
-      <div class="row">
-        <div class="col-sm-11 text-center">
-          <i class="fa fa-arrow-down"></i>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-11">
-          <select class="form-control" name="form_links_form_ids" data-bind="
-                    options: $parent.forms,
-                    optionsText: 'name',
-                    optionsValue: 'uniqueId',
-                    optionsCaption: $parent.displayUnknownForm.call($parent, formLink),
-                    value: formLink.formId
-                    "></select>
-        </div>
+      <div class="form-group">
+        <select class="form-control" name="form_links_form_ids" data-bind="
+                  options: $parent.forms,
+                  optionsText: 'name',
+                  optionsValue: 'uniqueId',
+                  optionsCaption: $parent.displayUnknownForm.call($parent, formLink),
+                  value: formLink.formId
+                  "></select>
         <input type="hidden" name="datums_json" data-bind="value: formLink.serializedDatums"/>
-      </div>
-      <div class="row">
-        <div class="col-sm-11" data-bind="visible: !formLink.autoLink()">
-          <p>{% trans "This form requires manual linking." %}</p>
+        <div class="help-block" data-bind="visible: !formLink.autoLink()">
+          {% trans "This form requires manual linking." %}
         </div>
-        <div class="col-sm-11" data-bind="visible: formLink.autoLink()">
-          <p>{% trans "This form doesn't require manual linking." %}</p>
+        <div class="help-block" data-bind="visible: formLink.autoLink()">
+          {% trans "This form doesn't require manual linking." %}
         </div>
-        <div class="col-sm-11" data-bind="visible: formLink.autoLink() && !formLink.manualDatums()">
-                <span data-bind="click: enableManualDatums" class="btn btn-default btn-sm">
-                    {% trans "Enable manual linking" %}
-                </span>
+        <div class="help-block" data-bind="visible: formLink.autoLink() && !formLink.manualDatums()">
+          <span data-bind="click: enableManualDatums" class="btn btn-default btn-xs">
+            {% trans "Enable manual linking" %}
+          </span>
         </div>
-        <div class="col-sm-11" data-bind="visible: formLink.manualDatums">
-                <span data-bind="click: disableManualDatums" class="btn btn-danger btn-sm">
-                    {% trans "Disable manual linking" %}
-                </span>
+        <div class="help-block" data-bind="visible: formLink.manualDatums">
+          <span data-bind="click: disableManualDatums" class="btn btn-danger btn-xs">
+            {% trans "Disable manual linking" %}
+          </span>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-11"  data-bind="visible: formLink.showLinkDatums()">
-          <p>
-            <button class="btn btn-default btn-sm" data-bind="click: formLink.fetchDatums">
-              <!-- ko if: formLink.datumsFetched() -->
+        <div class="help-block" data-bind="visible: formLink.showLinkDatums()">
+          <button class="btn btn-default btn-xs" data-bind="click: formLink.fetchDatums">
+            <!-- ko if: formLink.datumsFetched() -->
               {% trans "Refresh" %}
-              <!-- /ko -->
-              <!-- ko if: !formLink.datumsFetched() -->
+            <!-- /ko -->
+            <!-- ko if: !formLink.datumsFetched() -->
               {% trans "Continue" %}
-              <!-- /ko -->
-            </button>
-          </p>
+            <!-- /ko -->
+          </button>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-11" data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0 && !formLink.autoLink()">
-          <p>
-            {% trans "No additional linking required." %}
-          </p>
+        <div class="help-block" data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0 && !formLink.autoLink()">
+          {% trans "No additional linking required." %}
         </div>
       </div>
       <div data-bind="foreach: formLink.datums, visible: formLink.datumsFetched() && formLink.datums().length">
-        <div class="form-group col-sm-11">
+        <div class="form-group">
           <div class="panel panel-appmanager">
             <div class="panel-heading">
               <h4 class="panel-title panel-title-nolink">
@@ -153,13 +126,13 @@
             </div>
             <div class="panel-body">
               <div class="controls">
-                                <textarea name="_xpath"
-                                          placeholder="XPath Expression"
-                                          rows="1"
-                                          data-bind="text: xpath, value: xpath"
-                                          class="form-control"
-                                          spellcheck="false">
-                                </textarea>
+                <textarea name="_xpath"
+                          placeholder="XPath Expression"
+                          rows="1"
+                          data-bind="text: xpath, value: xpath"
+                          class="form-control"
+                          spellcheck="false">
+                </textarea>
               </div>
             </div>
           </div>
@@ -167,15 +140,17 @@
       </div>
     </div>
 
-    <div class="alert alert-danger" data-bind="
-            visible: formLink.errors().length
-            ">
-      <ul data-bind="
-                    foreach: formLink.errors(),
-            ">
+    <div class="alert alert-danger" data-bind="visible: formLink.errors().length">
+      <ul data-bind="foreach: formLink.errors()">
         <li data-bind="text: $data"></li>
       </ul>
     </div>
+
+    <button class="btn btn-danger btn-xs"
+            data-bind="click: $parent.onDestroyFormLink.bind($parent)">
+      <i class="fa fa-remove"></i>
+      {% trans "Remove this link" %}
+    </button>
   </div>
   </div>
 </script>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -9,7 +9,7 @@
     ></span>
   </label>
   <div id="form-workflow" class="col-sm-4 commcare-feature" data-since-version="2.10">
-    <div class="form-group" data-bind="css: {'has-error': hasError}">
+    <div class="form-group" data-bind="css: {'has-error': hasError, 'has-warning': hasWarning}">
       <select name="post_form_workflow" class="form-control" data-bind="
                 optstr: workflowOptions(),
                 value: workflow
@@ -17,6 +17,14 @@
       <div data-bind="visible: hasError" class="help-block">
         {% trans "This is an unknown value, possibly a deleted form. Please change this value." %}
       </div>
+      <span class="help-block" data-bind="visible: hasWarning">
+        {% blocktrans %}
+          This form is being used as a Case List Registration Form.
+          Specifying End of Form Navigation here will override the Case List Registration workflow.
+          To avoid overriding the Case List Registration workflow set the End of Form Navigation
+          to the default option ('Home Screen').
+        {% endblocktrans %}
+      </span>
     </div>
 
     <div class="form-links-container" data-bind="

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_form_setting.html
@@ -14,19 +14,25 @@
         ></span>
       </label>
       {% if not case_list_form_not_allowed_reasons %}
-        <div class="{% css_field_class %}" data-bind="css: {'has-error': formMissing()}">
+        <div class="{% css_field_class %}" data-bind="css: {'has-error': formMissing(), 'has-warning': formHasEOFNav()}">
           <select class="form-control" data-bind="value: caseListForm">
             {% if case_list_form_options.form.form_id and case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
               <option value="{{ case_list_form_options.form.form_id }}" selected>{% trans "Unknown Form (missing)" %}</option>
             {% endif %}
             <option value="">{% trans "Don't Show" %}</option>
-            {% for id, name in case_list_form_options.options.items %}
-              <option value="{{ id }}">{{ name }}</option>
+            {% for id, data in case_list_form_options.options.items %}
+              <option value="{{ id }}">{{ data.name }}</option>
             {% endfor %}
           </select>
           <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
           <div data-bind="visible: formMissing()" class="help-block">
             {% trans "Error! The selected form does not exist." %}
+          </div>
+          <div data-bind="visible: formHasEOFNav()" class="help-block">
+            {% blocktrans %}
+              The selected form uses end of form navigation, which may interfere with the case list registration
+              workflow. To avoid this, set the form's end of form navigation to the default option ('Home Screen').
+            {% endblocktrans %}
           </div>
         </div>
       {% else %}

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -363,7 +363,10 @@ def _case_list_form_options(app, module, case_type_, lang=None):
         for form in mod.get_forms() if form.is_registration_form(case_type_)
     ]
     langs = None if lang is None else [lang]
-    options.update({f.unique_id: trans(f.name, langs) for f in forms})
+    options.update({f.unique_id: {
+        'name': trans(f.name, langs),
+        'post_form_workflow': f.post_form_workflow,
+    } for f in forms})
 
     return {
         'options': options,


### PR DESCRIPTION
##### SUMMARY
Adjustment to https://github.com/dimagi/commcare-hq/pull/25561/

Addresses https://dimagi-dev.atlassian.net/browse/SAASP-10088

Case list reg and EOF nav aren't wholly incompatible. One of the effects of case list reg is to add an EOF action to the selected form (to proceed with the newly-registered case or to go back to the case list).  If the case list reg form also uses EOF nav, that EOF nav will be used instead of the action specified in case list reg. So using these two features together is a valid workflow, but they can interact in a confusing way.

##### PRODUCT DESCRIPTION
This removes the new build error that prevented apps from building if they used a form for case list registration that also used end of form navigation. It restores the old warning to the form settings page (where you select EOF nav), and it adds a similar warning to the menu settings page (where you select case list reg).

New warning:
<img width="674" alt="Screen Shot 2019-10-08 at 5 39 26 PM" src="https://user-images.githubusercontent.com/1486591/66435623-44140c00-e9f3-11e9-8bb4-9eec820409a4.png">

Also cleans up the form link UI a bit. Old:
<img width="531" alt="Screen Shot 2019-10-08 at 5 17 43 PM" src="https://user-images.githubusercontent.com/1486591/66435670-60b04400-e9f3-11e9-8759-7a719acf01fd.png">

New:
<img width="558" alt="Screen Shot 2019-10-08 at 5 17 01 PM" src="https://user-images.githubusercontent.com/1486591/66435680-660d8e80-e9f3-11e9-8927-a8857ed6bd7a.png">

