### PR TITLE
Remove unused daily feeding form index

### DIFF
--- a/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
@@ -130,8 +130,7 @@
           },
           "location_type": "state",
           "location_property": "_id"
-        },
-        "create_index": true
+        }
       },
       {
         "display_name": "Supervisor ID",
@@ -308,9 +307,6 @@
       "primary_key": ["supervisor_id","doc_id","repeat_iteration"]
     },
     "sql_column_indexes": [
-      {
-        "column_ids": ["state_id", "timeend"]
-      },
       {
         "column_ids": ["doc_id"]
       }


### PR DESCRIPTION
##### SUMMARY
Unused since before https://github.com/dimagi/commcare-hq/pull/25510 (note even in the before query it was not used)

I should experiment with an extra `timeend` index here, but I don't have much confidence that will help as the state_id was unused before