### PR TITLE
Polished UI for EOF nav / case list reg warning

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -158,6 +158,9 @@ hqDefine("app_manager/js/modules/module_view", function () {
                 var self = {};
 
                 self.caseListForm = ko.observable(originalFormId);
+                self.caseListFormSettingsUrl = ko.computed(function () {
+                    return hqImport("hqwebapp/js/initial_page_data").reverse("view_form", self.caseListForm());
+                });
                 self.postFormWorkflow = ko.observable(postFormWorkflow);
                 self.endOfRegistrationOptions = [
                     {id: 'case_list', text: gettext('Go back to case list')},

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -78,6 +78,7 @@
   {% initial_page_data 'sessionid' request.COOKIES.sessionid %}
   {% initial_page_data 'default_language' app.default_language %}
   {% initial_page_data 'current_language' lang %}
+  {% registerurl "view_form" domain app.id '---' %}
   {% registerurl "edit_module_detail_screens" domain app.id module.unique_id %}
   {% registerurl "hqmedia_remove_detail_print_template" domain app.id %}
   {% registerurl "validate_module_for_build" domain app.id module.unique_id %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_workflow.html
@@ -19,10 +19,9 @@
       </div>
       <span class="help-block" data-bind="visible: hasWarning">
         {% blocktrans %}
-          This form is being used as a Case List Registration Form.
-          Specifying End of Form Navigation here will override the Case List Registration workflow.
-          To avoid overriding the Case List Registration workflow set the End of Form Navigation
-          to the default option ('Home Screen').
+          The end of form navigation specified here will override the end of registration
+          action in the menu(s) where this form is a case list registration form.
+          To avoid this, select the default option here ('Home Screen').
         {% endblocktrans %}
       </span>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_form_setting.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_form_setting.html
@@ -14,7 +14,7 @@
         ></span>
       </label>
       {% if not case_list_form_not_allowed_reasons %}
-        <div class="{% css_field_class %}" data-bind="css: {'has-error': formMissing(), 'has-warning': formHasEOFNav()}">
+        <div class="{% css_field_class %}" data-bind="css: {'has-error': formMissing()}">
           <select class="form-control" data-bind="value: caseListForm">
             {% if case_list_form_options.form.form_id and case_list_form_options.form.form_id not in case_list_form_options.options.keys %}
               <option value="{{ case_list_form_options.form.form_id }}" selected>{% trans "Unknown Form (missing)" %}</option>
@@ -27,12 +27,6 @@
           <input type="hidden" name="case_list_form_id" data-bind="value: caseListForm" />
           <div data-bind="visible: formMissing()" class="help-block">
             {% trans "Error! The selected form does not exist." %}
-          </div>
-          <div data-bind="visible: formHasEOFNav()" class="help-block">
-            {% blocktrans %}
-              The selected form uses end of form navigation, which may interfere with the case list registration
-              workflow. To avoid this, set the form's end of form navigation to the default option ('Home Screen').
-            {% endblocktrans %}
           </div>
         </div>
       {% else %}
@@ -62,13 +56,21 @@
     </div>
     <div class="form-group" id="case_list_form-label" data-bind="visible: caseListForm()">
       <label class="{% css_label_class %} control-label">
-        {% trans "End of Registration action" %}
+        {% trans "End of Registration Action" %}
       </label>
       <div class="{% css_field_class %}">
         <select-toggle data-apply-bindings="false"
+                       data-bind="visible: !formHasEOFNav()"
                        params="name: 'case_list_post_form_workflow',
                                      options: endOfRegistrationOptions,
                                      value: postFormWorkflow"></select-toggle>
+        <div data-bind="visible: formHasEOFNav()" class="alert alert-info">
+          {% blocktrans %}
+            The case list registration action will be the same as the selected form's end of form navigation.
+            To avoid this, set the form's end of form navigation to the default option ('Home Screen') in
+            <a target='_blank' data-bind="attr: {href: caseListFormSettingsUrl() + '#form-settings'}">form settings</a>.
+          {% endblocktrans %}
+        </div>
       </div>
 
     </div>


### PR DESCRIPTION
##### SUMMARY
Minor followup for https://github.com/dimagi/commcare-hq/pull/25592

##### PRODUCT DESCRIPTION
Change menu settings so that end of reg action isn't available at all when the selected form uses EOF nav, and style this like neutral info rather than a warning:
<img width="695" alt="Screen Shot 2019-10-09 at 11 35 25 AM" src="https://user-images.githubusercontent.com/1486591/66503918-20ee6880-ea96-11e9-8b96-2d0c026323a0.png">

Minor text updates to form settings text.
<img width="524" alt="Screen Shot 2019-10-09 at 11 36 14 AM" src="https://user-images.githubusercontent.com/1486591/66503841-fb615f00-ea95-11e9-8f8b-9755b63cc899.png">


