### PR TITLE
Truncate daily feeding forms intermediate table

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
@@ -21,10 +21,7 @@ class DailyFeedingFormsChildHealthAggregationDistributedHelper(BaseICDSAggregati
     def aggregate(self, cursor):
         agg_query, agg_params = self.aggregation_query()
 
-        cursor.execute(
-            f'DELETE FROM "{self.tablename}" WHERE month=%(month)s',
-            {'month': month_formatter(self.month)}
-        )
+        cursor.execute(f'TRUNCATE "{self.tablename}"')
         cursor.execute(agg_query, agg_params)
 
     def drop_table_query(self):

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
@@ -1,5 +1,5 @@
-DELETE FROM "icds_dashboard_daily_feeding_forms" WHERE month=%(month)s
-{"month": "2019-01-01"}
+TRUNCATE "icds_dashboard_daily_feeding_forms"
+{}
 
         INSERT INTO "icds_dashboard_daily_feeding_forms" (
           state_id, supervisor_id, month, case_id, latest_time_end_processed,


### PR DESCRIPTION
##### SUMMARY
This changes the daily_feeding_forms intermediate table to truncate instead of delete.

This is fine because the aggregation does not depend on other month's data. (so it wouldn't be ok for growth monitoring forms).

This should reduce disk access when the agg starts up, and should be applied where safe.

I/O wait% on citus as "stage 1" starts up. The peak is slightly over 90%
![image](https://user-images.githubusercontent.com/1471773/66522426-683b2000-eabb-11e9-99d8-b4ac2f34c16c.png) source: https://app.datadoghq.com/dashboard/unt-6cf-nbs/postgres---overview?from_ts=1570570515085&fullscreen_widget=188861322&live=true&tile_size=l&to_ts=1570656915085&tpl_var_env=icds&tpl_var_pg_group=citusdb&fullscreen_section=overview
