### PR TITLE
Fix Case UCR Export by fixing DateSpan pickle

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -123,37 +123,6 @@ class DateSpan(object):
         self.timezone = timezone
         self.max_days = max_days
 
-    def __getstate__(self):
-        """
-            For pickling the DateSpan object.
-        """
-        return dict(
-            startdate=self.startdate,
-            enddate=self.enddate,
-            format=self.format,
-            inclusive=self.inclusive,
-            is_default=self.is_default,
-            timezone=self.timezone.zone,
-            max_days=self.max_days,
-        )
-
-    def __setstate__(self, state):
-        """
-            For un-pickling the DateSpan object.
-        """
-        logging = get_task_logger(__name__)  # logging is likely to happen within celery
-        self.startdate = state.get('startdate')
-        self.enddate = state.get('enddate')
-        self.format = state.get('format', ISO_DATE_FORMAT)
-        self.inclusive = state.get('inclusive', True)
-        self.timezone = pytz.utc
-        self.is_default = state.get('is_default', False)
-        self.max_days = state.get('max_days')
-        try:
-            self.timezone = pytz.timezone(state.get('timezone'))
-        except Exception as e:
-            logging.error("Could not unpack timezone for DateSpan. Error: %s" % e)
-
     def __eq__(self, other):
         return (
             self.startdate == other.startdate

--- a/corehq/ex-submodules/dimagi/utils/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/dates.py
@@ -128,8 +128,8 @@ class DateSpan(object):
             For pickling the DateSpan object.
         """
         return dict(
-            startdate=self.startdate.isoformat() if self.startdate else None,
-            enddate=self.enddate.isoformat() if self.enddate else None,
+            startdate=self.startdate,
+            enddate=self.enddate,
             format=self.format,
             inclusive=self.inclusive,
             is_default=self.is_default,
@@ -141,12 +141,9 @@ class DateSpan(object):
         """
             For un-pickling the DateSpan object.
         """
-        logging = get_task_logger(__name__) # logging is likely to happen within celery
-        try:
-            self.startdate = dateutil.parser.parse(state.get('startdate')) if state.get('startdate') else None
-            self.enddate = dateutil.parser.parse(state.get('enddate')) if state.get('enddate') else None
-        except Exception as e:
-            logging.error("Could not unpack start and end dates for DateSpan. Error: %s" % e)
+        logging = get_task_logger(__name__)  # logging is likely to happen within celery
+        self.startdate = state.get('startdate')
+        self.enddate = state.get('enddate')
         self.format = state.get('format', ISO_DATE_FORMAT)
         self.inclusive = state.get('inclusive', True)
         self.timezone = pytz.utc
@@ -156,6 +153,16 @@ class DateSpan(object):
             self.timezone = pytz.timezone(state.get('timezone'))
         except Exception as e:
             logging.error("Could not unpack timezone for DateSpan. Error: %s" % e)
+
+    def __eq__(self, other):
+        return (
+            self.startdate == other.startdate
+            and self.enddate == other.enddate
+            and self.format == other.format
+            and self.inclusive == other.inclusive
+            and self.timezone == other.timezone
+            and self.max_days == other.max_days
+        )
 
     @property
     def max_days(self):

--- a/corehq/ex-submodules/dimagi/utils/tests/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/dates.py
@@ -1,3 +1,4 @@
+import pickle
 from datetime import datetime, timedelta, date
 from six.moves.urllib.parse import urlencode
 import pytz
@@ -148,3 +149,17 @@ class DateSpanValidationTests(SimpleTestCase):
     def test_negative_max_days(self):
         with self.assertRaisesRegex(ValueError, 'max_days cannot be less than 0'):
             DateSpan(datetime(2015, 1, 1), datetime(2015, 4, 1), max_days=-1)
+
+
+class DateSpanPickleTest(SimpleTestCase):
+    def _assert_datespan_equal_pre_post_pickle(self, datespan):
+        datespan_post_pickle = pickle.loads(pickle.dumps(datespan))
+        self.assertEqual(datespan.startdate, datespan_post_pickle.startdate)
+        self.assertEqual(datespan.enddate, datespan_post_pickle.enddate)
+        self.assertEqual(datespan, datespan_post_pickle)
+
+    def test_case_1(self):
+        self._assert_datespan_equal_pre_post_pickle(DateSpan(date(2019, 10, 9), date(2019, 10, 9)))
+
+    def test_case_2(self):
+        self._assert_datespan_equal_pre_post_pickle(DateSpan(None, date(2019, 10, 9)))

--- a/corehq/ex-submodules/dimagi/utils/tests/dates.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/dates.py
@@ -6,6 +6,7 @@ from dimagi.utils.dates import DateSpan, add_months_to_date
 from django.test import SimpleTestCase
 from django.http import HttpRequest, QueryDict
 from dimagi.utils.decorators.datespan import datespan_in_request
+from dimagi.utils.parsing import ISO_DATETIME_FORMAT
 
 
 class DateSpanSinceTest(SimpleTestCase):
@@ -158,8 +159,23 @@ class DateSpanPickleTest(SimpleTestCase):
         self.assertEqual(datespan.enddate, datespan_post_pickle.enddate)
         self.assertEqual(datespan, datespan_post_pickle)
 
-    def test_case_1(self):
+    def test_date(self):
         self._assert_datespan_equal_pre_post_pickle(DateSpan(date(2019, 10, 9), date(2019, 10, 9)))
 
-    def test_case_2(self):
+    def test_datetime(self):
+        self._assert_datespan_equal_pre_post_pickle(DateSpan(datetime(2019, 10, 9), datetime(2019, 10, 9)))
+
+    def test_none(self):
         self._assert_datespan_equal_pre_post_pickle(DateSpan(None, date(2019, 10, 9)))
+        self._assert_datespan_equal_pre_post_pickle(DateSpan(date(2019, 10, 9), None))
+        self._assert_datespan_equal_pre_post_pickle(DateSpan(None, None))
+
+    def test_other_args(self):
+        self._assert_datespan_equal_pre_post_pickle(
+            DateSpan(
+                date(2019, 10, 7), date(2019, 10, 9),
+                format=ISO_DATETIME_FORMAT, inclusive=False, timezone=pytz.timezone('EST'),
+                max_days=6
+            ),
+
+        )


### PR DESCRIPTION
##### SUMMARY
I finally reproduced this locally https://dimagi-dev.atlassian.net/browse/SAASP-178, and it came down to DateSpan instances not being equal before and after the round trip.

I haven't investigated this guess thoroughly, but I believe the reason this only affects **Case** UCRs, it's that in form UCRs the dates are perhaps compared not as strings but as actual date/datetime objects. Since the pickle roundtrip was appending " 00:00:00.000000" to the date string being used to compare, it made it no longer less than or equal to the original date string. This might not be the case if using actual date objects in forms.

##### PRODUCT DESCRIPTION
Fixes an issue where Report Builder reports based on cases with date filters have different values for the web report versus the exported version of the report.