### PR TITLE
change response code for submission errors that are not recoverable

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -143,7 +143,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
                 res = self.client.post(self.url, {
                     "xml_submission_file": f
                 })
-            self.assertEqual(500, res.status_code)
+            self.assertEqual(422, res.status_code)
             self.assertIn('Invalid XML', res.content.decode('utf-8'))
 
         # make sure we logged it
@@ -167,7 +167,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
 
     def test_missing_xmlns(self):
         file, res = self._submit('missing_xmlns.xml')
-        self.assertEqual(500, res.status_code)
+        self.assertEqual(422, res.status_code)
         message = "Form is missing a required field: XMLNS"
         self.assertIn(message, res.content.decode('utf-8'))
 

--- a/corehq/ex-submodules/couchforms/openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/openrosa_response.py
@@ -17,10 +17,6 @@ class ResponseNature(object):
     PROCESSING_FAILURE = 'processing_failure'
     POST_PROCESSING_FAILURE = 'post_processing_failure'
 
-    # users app
-    SUBMIT_USER_REGISTERED = 'submit_user_registered'
-    SUBMIT_USER_UPDATED = 'submit_user_updated'
-
     OTA_RESTORE_SUCCESS = 'ota_restore_success'
     OTA_RESTORE_PENDING = 'ota_restore_pending'
     OTA_RESTORE_ERROR = 'ota_restore_error'

--- a/corehq/ex-submodules/couchforms/openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/openrosa_response.py
@@ -10,8 +10,7 @@ class ResponseNature(object):
     """
     A const holding class for different response natures
     """
-    # not super decoupled having stuff related to submissions and user reg
-    # here, but nice for this all to be in one place
+    # See https://confluence.dimagi.com/display/commcarepublic/Submission+API
     SUBMIT_SUCCESS = 'submit_success'
     SUBMIT_ERROR = 'submit_error'
     PROCESSING_FAILURE = 'processing_failure'

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -479,7 +479,6 @@ class SubmissionPost(object):
         """Returns a 422(Unprocessable Entity) response
         - if nature == 'processing_failure' the mobile device will quarantine this form and not retry it
         - any other value of `nature` will result in the form being marked as a failure and retrying
-        https://confluence.dimagi.com/display/commcarepublic/Submission+API
         """
         return OpenRosaResponse(
             message=message, nature=nature, status=422,

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -495,10 +495,13 @@ class SubmissionPost(object):
                 'error_message': error_instance.problem
             }
         )
+        # This are generally badly formed XML resulting from file corruption, encryption errors
+        # or other errors on the device which can not be recovered from.
+        # To prevent retries of these errors we submit a 422 response with `processing_failure` nature.
         return OpenRosaResponse(
             message="There was an error processing the form: %s" % error_instance.problem,
-            nature=ResponseNature.SUBMIT_ERROR,
-            status=500,
+            nature=ResponseNature.PROCESSING_FAILURE,
+            status=422,
         ).response()
 
     @tracer.wrap(name='submission.handle_system_action')

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -454,7 +454,7 @@ class SubmissionPost(object):
                 response = openrosa_response.get_openarosa_success_response(message=success_message)
             else:
                 error_message = error_message or instance.problem
-                response = self.get_retry_response(error_message, error_nature)
+                response = self.get_v3_error_response(error_message, error_nature)
         else:
             if instance.is_normal:
                 response = openrosa_response.get_openarosa_success_response()
@@ -475,8 +475,11 @@ class SubmissionPost(object):
         ).response()
 
     @staticmethod
-    def get_retry_response(message, nature):
-        """Returns a 422(Unprocessable Entity) response, mobile will retry this submission
+    def get_v3_error_response(message, nature):
+        """Returns a 422(Unprocessable Entity) response
+        - if nature == 'processing_failure' the mobile device will quarantine this form and not retry it
+        - any other value of `nature` will result in the form being marked as a failure and retrying
+        https://confluence.dimagi.com/display/commcarepublic/Submission+API
         """
         return OpenRosaResponse(
             message=message, nature=nature, status=422,


### PR DESCRIPTION
##### SUMMARY
Prevent mobile devices from retrying unprocessable form XML submissions.

##### PRODUCT DESCRIPTION
This changes the response code we use for form submissions that we are unable to parse. Previously we would return a 500 (Server Error) response code but now we are returning a 422 (Unprocessable Entity) code.

The main goal is to prevent mobile devices from retrying these forms.

Probably not worth announcing this change but putting details here anyway.

Docs for this already exists here: https://confluence.dimagi.com/display/commcarepublic/Submission+API

@ctsims FYI