### PR TITLE
Updates to CCUI bulk translations parameter validation

### DIFF
--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -82,14 +82,14 @@ class BulkUiTranslation(SimpleTestCase):
         )
         self.assertEqual(len(error_properties), 2)
         self.assertEqual([e.strip() for e in error_properties], [
-            "Could not understand '${x0}' in fra value of sync.progress.",
-            "Could not understand '$ {1}' in fra value of sync.progress.",
+            "Could not understand '${x0}' in fra value of 'sync.progress'.",
+            "Could not understand '$ {1}' in fra value of 'sync.progress'.",
         ])
         self.assertEqual(len(warnings), 3)
         self.assertEqual([e.strip() for e in warnings], [
-            "Property unknown_string is not a known CommCare UI string, but we added it anyway.",
-            "Property updates.found should contain ${0}, ${1} but en value contains no parameters.",
-            "Property updates.found should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
+            "Property 'unknown_string' is not a known CommCare UI string, but we added it anyway.",
+            "Property 'updates.found' should contain ${0}, ${1} but en value contains no parameters.",
+            "Property 'updates.found' should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
         ])
 
         # test existing translations get updated correctly

--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -87,7 +87,7 @@ class BulkUiTranslation(SimpleTestCase):
         ])
         self.assertEqual(len(warnings), 3)
         self.assertEqual([e.strip() for e in warnings], [
-            "unknown_string is not a known CommCare UI string, but we added it anyway",
+            "Property unknown_string is not a known CommCare UI string, but we added it anyway.",
             "Property updates.found should contain ${0}, ${1} but en value contains no parameters.",
             "Property updates.found should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
         ])

--- a/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_ui_translation.py
@@ -80,15 +80,17 @@ class BulkUiTranslation(SimpleTestCase):
             }
 
         )
-        self.assertEqual(len(error_properties), 4)
+        self.assertEqual(len(error_properties), 2)
         self.assertEqual([e.strip() for e in error_properties], [
-            "Property updates.found should contain ${0}, ${1} but en value contains no parameters.",
-            "Property updates.found should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
             "Could not understand '${x0}' in fra value of sync.progress.",
             "Could not understand '$ {1}' in fra value of sync.progress.",
         ])
-        # There should be a warning that 'unknown_string' is not a CommCare string
-        self.assertEqual(len(warnings), 1, warnings)
+        self.assertEqual(len(warnings), 3)
+        self.assertEqual([e.strip() for e in warnings], [
+            "unknown_string is not a known CommCare UI string, but we added it anyway",
+            "Property updates.found should contain ${0}, ${1} but en value contains no parameters.",
+            "Property updates.found should contain ${0}, ${1} but fra value contains ${0}, ${1}, ${2}.",
+        ])
 
         # test existing translations get updated correctly
         data = (('home.start.demo', 'change_1', 'change_2'))

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -71,7 +71,8 @@ def process_ui_translation_upload(app, trans_file):
         if row["property"] not in commcare_ui_strings:
             # Add a warning for  unknown properties, but still add them to the translation dict
             warnings.append(row["property"] + " is not a known CommCare UI string, but we added it anyway")
-        default_params_text = _get_params_text(_get_params(default_trans.get(row["property"])))
+        default = default_trans.get(row["property"])
+        default_params_text = _get_params_text(_get_params(default)) if default else None
         for lang in app.langs:
             if row.get(lang):
                 params = _get_params(row[lang])
@@ -81,7 +82,7 @@ def process_ui_translation_upload(app, trans_file):
                         error_properties.append(_("""
                             Could not understand '{param}' in {lang} value of {prop}.
                         """).format(param=param, lang=lang, prop=row["property"]))
-                if params_text != default_params_text:
+                if default_params_text and params_text != default_params_text:
                     warnings.append(_("""
                         Property {prop} should contain {expected} but {lang} value contains {actual}.
                     """).format(prop=row["property"],

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -82,7 +82,7 @@ def process_ui_translation_upload(app, trans_file):
                             Could not understand '{param}' in {lang} value of {prop}.
                         """).format(param=param, lang=lang, prop=row["property"]))
                 if params_text != default_params_text:
-                    error_properties.append(_("""
+                    warnings.append(_("""
                         Property {prop} should contain {expected} but {lang} value contains {actual}.
                     """).format(prop=row["property"],
                                 expected=default_params_text,

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -70,7 +70,8 @@ def process_ui_translation_upload(app, trans_file):
     for row in translations:
         if row["property"] not in commcare_ui_strings:
             # Add a warning for  unknown properties, but still add them to the translation dict
-            warnings.append(row["property"] + " is not a known CommCare UI string, but we added it anyway")
+            warnings.append("Property " + row["property"] + " is not a known CommCare UI string, "
+                            "but we added it anyway.")
         default = default_trans.get(row["property"])
         default_params_text = _get_params_text(_get_params(default)) if default else None
         for lang in app.langs:

--- a/corehq/apps/app_manager/ui_translations/ui_translations.py
+++ b/corehq/apps/app_manager/ui_translations/ui_translations.py
@@ -70,7 +70,7 @@ def process_ui_translation_upload(app, trans_file):
     for row in translations:
         if row["property"] not in commcare_ui_strings:
             # Add a warning for  unknown properties, but still add them to the translation dict
-            warnings.append("Property " + row["property"] + " is not a known CommCare UI string, "
+            warnings.append("Property '" + row["property"] + "' is not a known CommCare UI string, "
                             "but we added it anyway.")
         default = default_trans.get(row["property"])
         default_params_text = _get_params_text(_get_params(default)) if default else None
@@ -81,11 +81,11 @@ def process_ui_translation_upload(app, trans_file):
                 for param in params:
                     if not re.match(r"\$\{[0-9]+}", param):
                         error_properties.append(_("""
-                            Could not understand '{param}' in {lang} value of {prop}.
+                            Could not understand '{param}' in {lang} value of '{prop}'.
                         """).format(param=param, lang=lang, prop=row["property"]))
                 if default_params_text and params_text != default_params_text:
                     warnings.append(_("""
-                        Property {prop} should contain {expected} but {lang} value contains {actual}.
+                        Property '{prop}' should contain {expected} but {lang} value contains {actual}.
                     """).format(prop=row["property"],
                                 expected=default_params_text,
                                 lang=lang,


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-961

Updates to the validation added in https://github.com/dimagi/commcare-hq/pull/25231

##### PRODUCT DESCRIPTION
- The error is downgraded to a warning.
- The error is not triggered for translations where a default value can't be found, which happens for translations that were present in older versions of CommCare but not the current version.