### PR TITLE
Delete extra stale record from inactive report

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
@@ -25,8 +25,7 @@ class InactiveAwwsAggregationDistributedHelper(BaseICDSAggregationDistributedHel
         cursor.execute(aggregation_query, agg_params)
 
     def delete_extra_record_query(self):
-        return
-            """
+        return """
             DELETE FROM icds_reports_aggregateinactiveaww
                 WHERE awc_id IN (
                     SELECT awc_id from icds_reports_aggregateinactiveaww inactive

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
@@ -16,11 +16,24 @@ class InactiveAwwsAggregationDistributedHelper(BaseICDSAggregationDistributedHel
         self.last_sync = last_sync
 
     def aggregate(self, cursor):
+        delete_extra_record_query = self.drop_table_query()
         missing_location_query = self.missing_location_query()
         aggregation_query, agg_params = self.aggregate_query()
 
+        cursor.execute(delete_extra_record_query)
         cursor.execute(missing_location_query)
         cursor.execute(aggregation_query, agg_params)
+
+    def delete_extra_record_query(self):
+        return
+            """
+            DELETE FROM icds_reports_aggregateinactiveaww
+                WHERE awc_id IN (
+                    SELECT awc_id from icds_reports_aggregateinactiveaww inactive
+                                        left join awc_location_local awc on inactive.awc_id=awc.doc_id
+                                        where awc.doc_id is null
+                                );
+            """
 
     @cached_property
     def aggregate_parent_table(self):

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
@@ -16,7 +16,7 @@ class InactiveAwwsAggregationDistributedHelper(BaseICDSAggregationDistributedHel
         self.last_sync = last_sync
 
     def aggregate(self, cursor):
-        delete_extra_record_query = self.drop_table_query()
+        delete_extra_record_query = self.delete_extra_record_query()
         missing_location_query = self.missing_location_query()
         aggregation_query, agg_params = self.aggregate_query()
 

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/inactive-awws.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/inactive-awws.distributed.txt
@@ -1,4 +1,13 @@
 
+            DELETE FROM icds_reports_aggregateinactiveaww
+                WHERE awc_id IN (
+                    SELECT awc_id from icds_reports_aggregateinactiveaww inactive
+                                        left join awc_location_local awc on inactive.awc_id=awc.doc_id
+                                        where awc.doc_id is null
+                                );
+            
+{}
+
         INSERT INTO "icds_reports_aggregateinactiveaww" (
             awc_id, awc_name, awc_site_code, supervisor_id, supervisor_name,
             block_id, block_name, district_id, district_name, state_id, state_name


### PR DESCRIPTION
When the locations are updated. I found the locations uuids getting changes because the old is getting deleted and new one is created. Which is causing problem in this report because this report is not cleaning up every time its generated like aggregation.
So adding the piece of code to clean up stale locations before the report generation:
