### PR TITLE
don't run inactive user tasks twice

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1759,13 +1759,6 @@ MANAGE_CCZ_HOSTING = StaticToggle(
 )
 
 
-PARALLEL_AGGREGATION = StaticToggle(
-    'parallel_agg',
-    'This makes the icds dashboard aggregation run on both distributed and monolith backends',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN]
-)
-
 SKIP_ORM_FIXTURE_UPLOAD = StaticToggle(
     'skip_orm_fixture_upload',
     'Exposes an option in fixture api upload to skip saving through couchdbkit',

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -1064,13 +1064,6 @@ def collect_inactive_awws(force_citus=False):
 
 @periodic_task(run_every=crontab(day_of_week='monday', hour=0, minute=0),
                acks_late=True, queue='background_queue')
-def collect_inactive_dashboard_users_task():
-    collect_inactive_dashboard_users.delay()
-    if toggles.PARALLEL_AGGREGATION.enabled(DASHBOARD_DOMAIN):
-        collect_inactive_dashboard_users.delay(force_citus=True)
-
-
-@task(queue='background_queue')
 def collect_inactive_dashboard_users(force_citus=False):
     with force_citus_engine(force_citus):
         celery_task_logger.info("Started updating the Inactive Dashboard users")

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -1023,13 +1023,6 @@ def _get_value(data, field):
     acks_late=True,
     queue='icds_aggregation_queue'
 )
-def collect_inactive_awws_task():
-    collect_inactive_awws.delay()
-    if toggles.PARALLEL_AGGREGATION.enabled(DASHBOARD_DOMAIN):
-        collect_inactive_awws.delay(force_citus=True)
-
-
-@task(queue='icds_aggregation_queue')
 def collect_inactive_awws(force_citus=False):
     with force_citus_engine(force_citus):
         celery_task_logger.info("Started updating the Inactive AWW")


### PR DESCRIPTION
Now that we are fully on Citus both of these task calls do exactly the same thing.