### PR TITLE
Don't match more than one case to the same patient

### DIFF
--- a/corehq/motech/openmrs/exceptions.py
+++ b/corehq/motech/openmrs/exceptions.py
@@ -1,3 +1,4 @@
+from corehq.motech.exceptions import ConfigurationError
 
 
 class OpenmrsException(Exception):
@@ -21,5 +22,16 @@ class OpenmrsFeedDoesNotExist(OpenmrsException):
 class OpenmrsHtmlUiChanged(OpenmrsException):
     """
     OpenMRS HTML UI is no longer what we expect.
+    """
+    pass
+
+
+class DuplicateCaseMatch(ConfigurationError):
+    """
+    Multiple CommCare cases match the same OpenMRS patient.
+
+    Either there are two CommCare cases for the same person, or OpenMRS
+    repeater configuration needs to be modified to match cases with
+    patients more accurately.
     """
     pass


### PR DESCRIPTION
##### SUMMARY
When matching a CommCare case with an OpenMRS patient, this change flags if a different case has already been matched to the same patient.

This could have two causes: 
* The same person has more than one CommCare case.
* Poor configuration has resulted in cases and patients being matched incorrectly.

A soft assert is raised because both these causes need to be corrected by a human.

##### FEATURE FLAG
OpenMRS integration

##### PRODUCT DESCRIPTION
Flag poor configuration or duplicate CommCare cases when exporting cases to OpenMRS.
