### PR TITLE
exit early if list is empty

### DIFF
--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -323,6 +323,9 @@ def select_db_for_read(weighted_dbs):
             ]
 
     """
+    if not weighted_dbs:
+        return
+
     # convert to a db to weight dictionary
     weights_by_db = {_db: weight for _db, weight in weighted_dbs}
 


### PR DESCRIPTION
##### SUMMARY
Our highest traffic cache key (by call count and bandwidth) is from calling `filter_out_stale_standbys`
with an empty list.

I believe this is what's causing the high bandwidth usage on redis4 on ICDS.

I found this using https://github.com/hirose31/redis-traffic-stats