### PR TITLE
add index on blobmeta table for efficient attachment deletion

### DIFF
--- a/custom/icds/migrations/0007_blobmeta_index.py
+++ b/custom/icds/migrations/0007_blobmeta_index.py
@@ -10,6 +10,7 @@ DROP_INDEX_SQL = "DROP INDEX CONCURRENTLY IF EXISTS {}".format(INDEX_NAME)
 
 
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         ('icds', '0006_hostedccz_status'),

--- a/custom/icds/migrations/0007_blobmeta_index.py
+++ b/custom/icds/migrations/0007_blobmeta_index.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+TABLE_NAME = 'blobs_blobmeta'
+INDEX_NAME = 'blobs_blobmeta_type_created_on_idx'
+COLUMNS = ['type', 'created_on']
+
+CREATE_INDEX_SQL = "CREATE INDEX CONCURRENTLY IF NOT EXISTS {} ON {} ({})".format(
+    INDEX_NAME, TABLE_NAME, ','.join(COLUMNS))
+DROP_INDEX_SQL = "DROP INDEX CONCURRENTLY IF EXISTS {}".format(INDEX_NAME)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icds', '0006_hostedccz_status'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=CREATE_INDEX_SQL,
+            reverse_sql=DROP_INDEX_SQL,
+        )
+    ]

--- a/custom/icds/migrations/0007_blobmeta_index.py
+++ b/custom/icds/migrations/0007_blobmeta_index.py
@@ -2,7 +2,7 @@ from django.db import migrations
 
 TABLE_NAME = 'blobs_blobmeta'
 INDEX_NAME = 'blobs_blobmeta_type_created_on_idx'
-COLUMNS = ['type', 'created_on']
+COLUMNS = ['type_code', 'created_on']
 
 CREATE_INDEX_SQL = "CREATE INDEX CONCURRENTLY IF NOT EXISTS {} ON {} ({})".format(
     INDEX_NAME, TABLE_NAME, ','.join(COLUMNS))


### PR DESCRIPTION
##### SUMMARY
This should speed up the [delete_old_images](https://github.com/dimagi/commcare-hq/blob/cc93bc6ab718bde08e8d16e374d5cc25eff94958/custom/icds/tasks/__init__.py#L15) tasks dramatically. The current query does a sequence scan on the table.

Only adding this for ICDS since the task is ICDS specific.
