### PR TITLE
New Admin User List Report

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -1331,3 +1331,30 @@ class UserAuditReport(AdminReport, DatespanMixin):
                     event.event_date, event.user, event.domain or '', event.ip_address, event.request_path
                 ])
         return rows
+
+
+class UserListReport(AdminReport):
+    base_template = 'reports/base_template.html'
+
+    slug = 'user_list_report'
+    name = ugettext_lazy("User List")
+
+    fields = []
+    emailable = False
+    exportable = False
+    default_rows = 10
+
+    @property
+    def headers(self):
+        return DataTablesHeader(
+            DataTablesColumn(_("Username")),
+            DataTablesColumn(_("Project Spaces")),
+            DataTablesColumn(_("Date Joined")),
+            DataTablesColumn(_("Last Login")),
+            DataTablesColumn(_("Type")),
+            DataTablesColumn(_("SuperUser?")),
+        )
+
+    @property
+    def rows(self):
+        return []

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -12,6 +12,7 @@ from memoized import memoized
 
 from auditcare.models import NavigationEventAudit
 from auditcare.utils.export import navigation_event_ids_by_user
+from dateutil.parser import parse
 from dimagi.utils.couch.database import iter_docs
 from phonelog.models import DeviceReportEntry
 from phonelog.reports import BaseDeviceLogReport
@@ -50,6 +51,7 @@ from corehq.apps.reports.standard.sms import PhoneNumberReport
 from corehq.apps.sms.filters import RequiredPhoneNumberFilter
 from corehq.apps.sms.mixin import apply_leniency
 from corehq.apps.sms.models import PhoneNumber
+from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.elastic import (
     es_query,
     fill_mapping_with_facets,
@@ -1366,8 +1368,8 @@ class UserListReport(GetParamsMixin, AdminReport):
             yield [
                 self._user_link(user['username']),
                 self._get_domains(user),
-                user['date_joined'],
-                user['last_login'],
+                self._format_date(user['date_joined']),
+                self._format_date(user['last_login']),
                 user['doc_type'],
                 user['is_superuser'],
             ]
@@ -1404,3 +1406,9 @@ class UserListReport(GetParamsMixin, AdminReport):
         if user['doc_type'] == "WebUser":
             return ", ".join(dm['domain'] for dm in user['domain_memberships'])
         return user['domain_membership']['domain']
+
+    @staticmethod
+    def _format_date(date):
+        if date:
+            return parse(date).strftime(SERVER_DATETIME_FORMAT)
+        return "---"

--- a/corehq/apps/reports/filters/simple.py
+++ b/corehq/apps/reports/filters/simple.py
@@ -17,3 +17,8 @@ class SimpleDomain(BaseSimpleFilter):
     slug = 'domain_name'
     label = ugettext_lazy('Domain')
     help_inline = ugettext_lazy('Optional')
+
+
+class SimpleSearch(BaseSimpleFilter):
+    slug = 'search_string'
+    label = ugettext_lazy('Search')

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -7,7 +7,9 @@ from corehq.apps.hqadmin.reports import (
     AdminPhoneNumberReport,
     AdminUserReport,
     DeviceLogSoftAssertReport,
-    UserAuditReport)
+    UserAuditReport,
+    UserListReport,
+)
 from corehq.apps.hqpillow_retry.views import PillowErrorsReport
 from corehq.apps.linked_domain.views import DomainLinkHistoryReport
 from corehq.apps.reports.standard import (
@@ -338,6 +340,7 @@ BASIC_REPORTS = (
 
 ADMIN_REPORTS = (
     (_('Domain Stats'), (
+        UserListReport,
         AdminUserReport,
         PillowErrorsReport,
         DeviceLogSoftAssertReport,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -35,6 +35,7 @@ from corehq.apps.domain.views.releases import (
 from corehq.apps.hqadmin.reports import (
     DeviceLogSoftAssertReport,
     UserAuditReport,
+    UserListReport,
 )
 from corehq.apps.hqwebapp.models import GaTracker
 from corehq.apps.hqwebapp.view_permissions import user_can_view_reports
@@ -2099,7 +2100,7 @@ class AdminTab(UITab):
                     url=reverse('admin_report_dispatcher', args=(report.slug,)),
                     params="?{}".format(urlencode(report.default_params)) if report.default_params else ""
                 )
-            } for report in [DeviceLogSoftAssertReport, UserAuditReport]
+            } for report in [DeviceLogSoftAssertReport, UserAuditReport, UserListReport]
         ]))
         return sections
 


### PR DESCRIPTION
##### SUMMARY
Hoping to unblock the deletion of admin reports in https://github.com/dimagi/commcare-hq/pull/25105, I made a new user list report.

The search box is I think the main feature people will care about.  Right now it just uses the `search_string_query` logic, but I think that's a bit muddled - would be open to changing that.  My rollout plan is:

- [x] Roll this out close to as-is
- [ ] Confirm that the functionality meets minimum requirements to drop the other user-list report
- [ ] Drop the other user list report and all faceted admin reports (merge https://github.com/dimagi/commcare-hq/pull/25105)
- [ ] Make tweaks to the functionality as desired

##### FEATURE FLAG
Admin users only

##### PRODUCT DESCRIPTION
This introduces a new admin-focused user-list report.  It's pretty similar to the old one, but instead of the facets option on the lower left, this has a single search box.
![image](https://user-images.githubusercontent.com/2367539/66839353-44049680-ef34-11e9-8178-d71050bcecfe.png)

