### PR TITLE
Use ES backend for Group API by default

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -316,10 +316,10 @@ class GroupResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMi
         return get_object_or_not_exist(Group, kwargs['pk'], kwargs['domain'])
 
     def obj_get_list(self, bundle, domain, **kwargs):
-        if toggles.GROUP_API_USE_ES_BACKEND.enabled_for_request(bundle.request):
-            return GroupQuerySetAdapterES(domain)
-        else:
+        if toggles.GROUP_API_USE_COUCH_BACKEND.enabled_for_request(bundle.request):
             return GroupQuerySetAdapterCouch(domain)
+        else:
+            return GroupQuerySetAdapterES(domain)
 
     class Meta(CustomResourceMeta):
         authentication = RequirePermissionAuthentication(Permissions.edit_commcare_users)

--- a/corehq/apps/api/tests/group_resources.py
+++ b/corehq/apps/api/tests/group_resources.py
@@ -2,6 +2,9 @@ import json
 
 from corehq.apps.api.resources import v0_5
 from corehq.apps.groups.models import Group
+from corehq.elastic import send_to_elasticsearch, get_es_new
+from corehq.pillows.mappings.group_mapping import GROUP_INDEX_INFO
+from pillowtop.es_utils import initialize_index_and_mapping
 
 from .utils import APIResourceTest
 
@@ -11,11 +14,21 @@ class TestGroupResource(APIResourceTest):
     resource = v0_5.GroupResource
     api_name = 'v0.5'
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestGroupResource, cls).setUpClass()
+        cls.es = get_es_new()
+        cls.es.indices.delete(GROUP_INDEX_INFO.index)
+        initialize_index_and_mapping(cls.es, GROUP_INDEX_INFO)
+
     def test_get_list(self):
 
         group = Group({"name": "test", "domain": self.domain.name})
         group.save()
+        send_to_elasticsearch('groups', group.to_json())
+        self.es.indices.refresh(GROUP_INDEX_INFO.index)
         self.addCleanup(group.delete)
+        self.addCleanup(lambda: send_to_elasticsearch('groups', group.to_json(), delete=True))
         backend_id = group.get_id
 
         response = self._assert_auth_get_resource(self.list_endpoint)

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -104,6 +104,8 @@ class ToggleEditView(BasePageView):
 
     @property
     def page_title(self):
+        if not self.static_toggle:
+            raise Http404()
         return self.static_toggle.label
 
     @property

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1804,9 +1804,12 @@ DISABLE_CASE_UPDATE_RULE_SCHEDULED_TASK = StaticToggle(
 )
 
 
-GROUP_API_USE_ES_BACKEND = StaticToggle(
-    'group_api_use_es_backend',
-    'Use ES backend for Group API',
+# todo: remove after Nov 15, 2019 if no one is using
+GROUP_API_USE_COUCH_BACKEND = StaticToggle(
+    'group_api_use_couch_backend',
+    'Use Old Couch backend for Group API. '
+    'This is an escape hatch for support '
+    'to immediately revert a domain to old behavior.',
     TAG_PRODUCT,
     [NAMESPACE_DOMAIN, NAMESPACE_USER],
 )


### PR DESCRIPTION
##### SUMMARY
Use https://www.commcarehq.org/hq/flags/edit/group_api_use_couch_backend/
to revert a domain to old Couch backend while we fix if there is an issue.

##### FEATURE FLAG
No feature flag is needed to receive this change.

This is rolling out what was previously under the `GROUP_API_USE_ES_BACKEND` and removing that flag.
It also introduces a new flag to _undo_ the change for a given domain, `GROUP_API_USE_COUCH_BACKEND`, changing the feature from "opt-in" to "opt-out". This flag will be removed after a month of no issues or when otherwise determined no longer necessary.

##### PRODUCT DESCRIPTION
The Group API will now be up to 80% faster.
