### PR TITLE
Restrict updates to app submission metadata to the latest form

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -74,7 +74,17 @@ def _last_submission_needs_update(last_submission, received_on_datetime, build_v
     # If debounce is false it updates if the submission is newer at all
     if not (last_submission and last_submission.submission_date):
         return True
+
     time_difference = received_on_datetime - last_submission.submission_date
+    if time_difference < timedelta(seconds=0):
+        return False
+
+    # Ignore debounce if the user has updated since the last submission
+    if build_version != last_submission.build_version:
+        return True
+    if cc_version != last_submission.commcare_version:
+        return True
+
     debounce_delay = settings.USER_REPORTING_METADATA_UPDATE_FREQUENCY
     update_frequency = timedelta(minutes=debounce_delay) if debounce else timedelta(seconds=0)
     return time_difference > update_frequency

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -77,13 +77,7 @@ def _last_submission_needs_update(last_submission, received_on_datetime, build_v
     time_difference = received_on_datetime - last_submission.submission_date
     debounce_delay = settings.USER_REPORTING_METADATA_UPDATE_FREQUENCY
     update_frequency = timedelta(minutes=debounce_delay) if debounce else timedelta(seconds=0)
-    if time_difference > update_frequency:
-        return True
-    if build_version != last_submission.build_version:
-        return True
-    if cc_version != last_submission.commcare_version:
-        return True
-    return False
+    return time_difference > update_frequency
 
 
 def mark_latest_submission(domain, user_id, app_id, build_id, version, metadata, received_on):


### PR DESCRIPTION
Beginning with https://github.com/dimagi/commcare-hq/pull/16219/ we
began to update the reporting data when the build or version was
changed, but this causes the last submission time to go backwards if we
reprocess forms at a later time.

In this case (https://dimagi-dev.atlassian.net/browse/ICDS-882) a user
upgraded her version of the app. Due to an infrastructure issue we
needed to reprocess a large amount of forms from a couple of weeks in
the past. When our pillow reprocessed it, it caused her last
submission to go from the past day to two weeks ago because the version
of the app was not the same.

@czue @calellowitz you guys tired of hearing about https://dimagi-dev.atlassian.net/browse/ICDS-918 yet?