### PR TITLE
Remove removed location check

### DIFF
--- a/custom/icds_reports/tests/agg_tests/test_aggregation_script.py
+++ b/custom/icds_reports/tests/agg_tests/test_aggregation_script.py
@@ -14,7 +14,6 @@ from corehq.sql_db.connections import (
     ICDS_UCR_CITUS_ENGINE_ID,
     connection_manager,
 )
-from custom.icds_reports.exceptions import LocationRemovedException
 from custom.icds_reports.models.aggregate import (
     AggregateInactiveAWW,
     AwcLocation,
@@ -512,11 +511,6 @@ class LocationAggregationTest(TestCase):
         self.maxDiff = None
 
         with maybe_atomic(AwcLocation):
-            # if we ran the aggregation now, we'd have 55 fewer locations
-            with self.assertRaisesRegex(LocationRemovedException, '55'):
-                with get_cursor(AwcLocation) as cursor:
-                    self.helper.aggregate(cursor)
-
             try:
                 with maybe_atomic(AwcLocation):
                     # run agg again without any locations in awc_location


### PR DESCRIPTION
##### SUMMARY
This removes a check to ensure that no locations are going to be removed in the aggregation place. This check was originally implemented when thinking about our previous aggregation strategy in response to a P1. In the previous location aggregation we were pulling from a location UCR which is very flaky and occasionally removed locations without properly replacing them.

Our current process pulls directly from `SQLLocation`. This means the previous failure mode is no longer an issue. We also must be able to support the removal of locations as there's a somewhat often workflow where users and locations get removed due to requests from CPMU (AFAIK currently documented [here](https://docs.google.com/document/d/13MDvAOEkeWAndDUZYnm2hYHNygK8_DNfaZ-5oUhFcnI/edit?ts=5d958d12).

The impetus for this removal is that this error was triggered today and I was confused for a solid 20 minutes. I was comparing the temporary table with the real table (as is done in the query) and they were the same. They are the same because the [task creates a transaction](https://github.com/dimagi/commcare-hq/blob/75a930b78cb9d120f67e19bb6a9994393ec8262c/custom/icds_reports/tasks.py) even though on the [model its marked as non-atomic](https://github.com/dimagi/commcare-hq/blob/75a930b78cb9d120f67e19bb6a9994393ec8262c/custom/icds_reports/models/aggregate.py#L226) which meant the changes to the temporary table were rolled back during the transaction. After this I realized I needed to check `SQLLocation` and compare with `AwcLocation`.

If we want to re-implement this I think it should include (but I don't think its necessary since we pull directly from `SQLLocation` now):

- [ ] Better transaction management. Likely moving the transaction to the `aggregate` method on the class
- [ ] Include a flag that can be set through the UI to ignore the error (likely after its been investigated to verify that the exception is not an issue). This flag should have some expiration date so that it does not affect the next day's agg
- [ ] Report on the AWC ids (instead of just number) that are cause in the discrepancy.