### PR TITLE
Notify third-party admins, take 2

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -2,10 +2,13 @@ import re
 import uuid
 from datetime import datetime
 
+from django.utils.translation import ugettext as _
+
 import pytz
 from dateutil import parser as dateutil_parser
 from dateutil.tz import tzutc
 from lxml import etree
+from requests import RequestException
 from urllib3.exceptions import HTTPError
 
 from casexml.apps.case.mock import CaseBlock
@@ -26,10 +29,6 @@ from corehq.motech.openmrs.exceptions import OpenmrsFeedDoesNotExist
 from corehq.motech.openmrs.openmrs_config import get_property_map
 from corehq.motech.openmrs.repeater_helpers import get_patient_by_uuid
 from corehq.motech.openmrs.repeaters import AtomFeedStatus
-from corehq.util.soft_assert import soft_assert
-from requests import RequestException
-
-_assert = soft_assert(['@'.join(('nhooper', 'dimagi.com'))])
 
 
 def get_feed_xml(requests, feed_name, page):
@@ -45,14 +44,19 @@ def get_feed_xml(requests, feed_name, page):
         resp.status_code == 500
         and 'AtomFeedRuntimeException: feed does not exist' in resp.content
     ):
-        # This can happen if a Repeater IP address is changed to point
-        # to a different server, or if a server has been rebuilt.
-        _assert(
-            False,
-            f'Domain "{requests.domain_name}": Page does not exist in '
-            f'atom feed "{resp.url}". Resetting Atom feed status.'
+        exception = OpenmrsFeedDoesNotExist(
+            f'Domain "{requests.domain_name}": Page does not exist in atom '
+            f'feed "{resp.url}". Resetting atom feed status.'
         )
-        raise OpenmrsFeedDoesNotExist()
+        requests.notify_exception(
+            str(exception),
+            _("This can happen if the IP address of a Repeater is changed to "
+              "point to a different server, or if a server has been rebuilt. "
+              "It can signal more severe consequences, like attempts to "
+              "synchromise CommCare cases with OpenMRS patients that can no "
+              "longer be found.")
+        )
+        raise exception
     root = etree.fromstring(resp.content)
     return root
 
@@ -252,11 +256,10 @@ def update_patient(repeater, patient_uuid):
 
     """
     if len(repeater.white_listed_case_types) != 1:
-        _assert(
-            False,
-            f'Unable to update patients from OpenMRS unless a single case type '
-            f'is specified. domain: "{repeater.domain}". repeater: "{repeater}".'
-        )
+        repeater.requests.notify_error(_(
+            f"{repeater}: Error in settings: Unable to update patients from "
+            "OpenMRS unless only one case type is specified."
+        ))
         return
     case_type = repeater.white_listed_case_types[0]
     patient = get_patient_by_uuid(repeater.requests, patient_uuid)
@@ -271,12 +274,10 @@ def update_patient(repeater, patient_uuid):
         if owner:
             case_block = get_addpatient_caseblock(case_type, owner, patient, repeater)
         else:
-            _assert(
-                False,
-                f'No users found at location "{repeater.location_id}" '
-                f'to own patients added from OpenMRS atom feed. '
-                f'domain: "{repeater.domain}". repeater: "{repeater}".'
-            )
+            repeater.requests.notify_error(_(
+                f'{repeater}: No users found at location "{repeater.location_id}" '
+                "to own patients added from OpenMRS atom feed."
+            ))
             return
     elif error == LookupErrors.MultipleResults:
         # Multiple cases have been matched to the same patient.
@@ -287,12 +288,10 @@ def update_patient(repeater, patient_uuid):
         # * PatientFinder matched badly.
         # * Race condition where a patient was previously added to
         #   both CommCare and OpenMRS.
-        _assert(
-            False,
-            f'More than one case found matching unique OpenMRS UUID. domain: '
-            f'"{repeater.domain}". case external_id: "{patient_uuid}". '
-            f'repeater: "{repeater}".'
-        )
+        repeater.requests.notify_error(_(
+            f'{repeater}: More than one case found matching unique OpenMRS UUID. '
+            f'case external_id: "{patient_uuid}". '
+        ))
         return
     else:
         case_block = get_updatepatient_caseblock(case, patient, repeater)
@@ -355,13 +354,11 @@ def import_encounter(repeater, encounter_uuid):
             case_blocks.append(case_block)
             case_id = case_block.case_id
 
-        elif error == LookupErrors.MultipleResults:
-            _assert(
-                False,
-                f'More than one case found matching unique OpenMRS UUID. '
-                f'domain: "{repeater.domain}". case external_id: '
-                f'"{patient_uuid}". repeater: "{repeater}".'
-            )
+        else:  # error == LookupErrors.MultipleResults:
+            repeater.requests.notify_error(_(
+                f'{repeater}: More than one case found matching unique OpenMRS '
+                f'UUID. case external_id: "{patient_uuid}". '
+            ))
             return
 
         case_blocks.append(CaseBlock(

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -53,7 +53,7 @@ def get_feed_xml(requests, feed_name, page):
             _("This can happen if the IP address of a Repeater is changed to "
               "point to a different server, or if a server has been rebuilt. "
               "It can signal more severe consequences, like attempts to "
-              "synchromise CommCare cases with OpenMRS patients that can no "
+              "synchronize CommCare cases with OpenMRS patients that can no "
               "longer be found.")
         )
         raise exception

--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -71,9 +71,12 @@ class OpenmrsImporterForm(forms.Form):
                                  help_text=_('e.g. "http://www.example.com/openmrs"'))
     username = forms.CharField(label=_('Username'), required=True)
     password = forms.CharField(label=_('Password'), widget=forms.PasswordInput, required=False)
+    notify_addresses_str = forms.CharField(label=_('Addresses to send notifications'), required=False,
+                                           help_text=_('A comma-separated list of email addresses to send error '
+                                                       'notifications'))
     location_id = forms.CharField(label=_('Location ID'), required=False,
-                                  help_text='If a project space has multiple OpenMRS servers to import from, for '
-                                            'which CommCare location is this OpenMRS server authoritative?')
+                                  help_text=_('If a project space has multiple OpenMRS servers to import from, '
+                                              'for which CommCare location is this OpenMRS server authoritative?'))
     import_frequency = forms.ChoiceField(label=_('Import Frequency'), choices=IMPORT_FREQUENCY_CHOICES,
                                          help_text=_('How often should cases be imported?'), required=False)
     log_level = forms.TypedChoiceField(label=_('Log Level'), required=False, choices=LOG_LEVEL_CHOICES, coerce=int)

--- a/corehq/motech/openmrs/forms.py
+++ b/corehq/motech/openmrs/forms.py
@@ -1,5 +1,3 @@
-import logging
-
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
@@ -15,9 +13,6 @@ from corehq.motech.openmrs.const import (
     NAME_PROPERTIES,
     PERSON_PROPERTIES,
 )
-from corehq.motech.openmrs.dbaccessors import get_openmrs_importers_by_domain
-from corehq.motech.openmrs.models import ColumnMapping, OpenmrsImporter
-from corehq.motech.utils import b64_aes_encrypt
 
 
 class OpenmrsConfigForm(forms.Form):
@@ -101,43 +96,3 @@ class OpenmrsImporterForm(forms.Form):
                                                'name (e.g. "givenName familyName")'))
     column_map = JsonField(label=_('Map columns to properties'), required=True, expected_type=list,
                            help_text=_('e.g. [{"column": "givenName", "property": "first_name"}, ...]'))
-
-    def clean(self):
-        cleaned_data = super(OpenmrsImporterForm, self).clean()
-        if bool(cleaned_data.get('owner_id')) == bool(cleaned_data.get('location_type_name')):
-            message = _(
-                'The owner of imported patient cases is determined using either "{owner_id}" or '
-                '"{location_type_name}". Please specify either one or the other.').format(
-                owner_id=_owner_id_label, location_type_name=_location_type_name_label)
-            self.add_error('owner_id', message)
-            self.add_error('location_type_name', message)
-        return self.cleaned_data
-
-    def save(self, domain_name):
-        try:
-            importers = get_openmrs_importers_by_domain(domain_name)
-            importer = importers[0] if importers else None  # TODO: Support multiple
-            if importer is None:
-                importer = OpenmrsImporter(domain=domain_name)
-            importer.server_url = self.cleaned_data['server_url']
-            importer.username = self.cleaned_data['username']
-            if self.cleaned_data['password']:
-                # Don't save it if it hasn't been changed.
-                importer.password = b64_aes_encrypt(self.cleaned_data['password'])
-            importer.location_id = self.cleaned_data['location_id']
-            importer.import_frequency = self.cleaned_data['import_frequency']
-            importer.log_level = self.cleaned_data['log_level']
-
-            importer.report_uuid = self.cleaned_data['report_uuid']
-            importer.report_params = self.cleaned_data['report_params']
-            importer.case_type = self.cleaned_data['case_type']
-            importer.owner_id = self.cleaned_data['owner_id']
-            importer.location_type_name = self.cleaned_data['location_type_name']
-            importer.external_id_column = self.cleaned_data['external_id_column']
-            importer.name_columns = self.cleaned_data['name_columns']
-            importer.column_map = list(map(ColumnMapping.wrap, self.cleaned_data['column_map']))
-            importer.save()
-            return True
-        except Exception as err:
-            logging.error('Unable to save OpenMRS Importer: %s' % err)
-            return False

--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 
 from memoized import memoized
@@ -8,6 +9,7 @@ from dimagi.ext.couchdbkit import (
     DocumentSchema,
     IntegerProperty,
     ListProperty,
+    StringListProperty,
     StringProperty,
 )
 
@@ -44,6 +46,8 @@ class OpenmrsImporter(Document):
     server_url = StringProperty()  # e.g. "http://www.example.com/openmrs"
     username = StringProperty()
     password = StringProperty()
+
+    notify_addresses_str = StringProperty()
 
     # If a domain has multiple OpenmrsImporter instances, for which CommCare location is this one authoritative?
     location_id = StringProperty()
@@ -87,6 +91,10 @@ class OpenmrsImporter(Document):
 
     def __str__(self):
         return self.server_url
+
+    @property
+    def notify_addresses(self):
+        return [addr for addr in re.split('[, ]+', self.notify_addresses_str) if addr]
 
     @memoized
     def get_timezone(self):

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -123,7 +123,8 @@ class OpenmrsRepeater(CaseRepeater):
             self.url,
             self.username,
             self.plaintext_password,
-            verify=self.verify
+            verify=self.verify,
+            notify_addresses=self.notify_addresses,
         )
 
     @cached_property

--- a/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
+++ b/corehq/motech/openmrs/static/openmrs/js/openmrs_importers.js
@@ -23,6 +23,7 @@ hqDefine('openmrs/js/openmrs_importers', [
         // using the Django form field names.
         self.username = ko.observable(properties["username"]);
         self.password = ko.observable(properties["password"]);
+        self.notify_addresses_str = ko.observable(properties["notify_addresses_str"]);
         self.location_id = ko.observable(properties["location_id"]);
         self.import_frequency = ko.observable(properties["import_frequency"]);
         self.log_level = ko.observable(properties["log_level"]);
@@ -52,6 +53,7 @@ hqDefine('openmrs/js/openmrs_importers', [
                 "server_url": self.server_url(),
                 "username": self.username(),
                 "password": self.password(),
+                "notify_addresses_str": self.notify_addresses_str(),
                 "location_id": self.location_id(),
                 "import_frequency": self.import_frequency(),
                 "log_level": self.log_level(),

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -584,20 +584,18 @@ class SaveMatchIdsTests(SimpleTestCase):
             update={}
         )
 
-    @mock.patch('corehq.motech.openmrs.repeater_helpers._assert')
     @mock.patch('corehq.motech.openmrs.repeater_helpers.submit_case_blocks')
     @mock.patch('corehq.motech.openmrs.repeater_helpers.importer_util')
-    def test_save_duplicate_external_id(self, importer_util_mock, _, __):
+    def test_save_duplicate_external_id(self, importer_util_mock, _):
         another_case = mock.Mock()
         importer_util_mock.lookup_case.return_value = (another_case, None)
         self.case_config['patient_identifiers']['uuid']['case_property'] = 'external_id'
         with self.assertRaises(DuplicateCaseMatch):
             save_match_ids(self.case, self.case_config, self.patient)
 
-    @mock.patch('corehq.motech.openmrs.repeater_helpers._assert')
     @mock.patch('corehq.motech.openmrs.repeater_helpers.submit_case_blocks')
     @mock.patch('corehq.motech.openmrs.repeater_helpers.importer_util')
-    def test_save_multiple_external_id(self, importer_util_mock, _, __):
+    def test_save_multiple_external_id(self, importer_util_mock, _):
         importer_util_mock.lookup_case.return_value = (None, LookupErrors.MultipleResults)
         self.case_config['patient_identifiers']['uuid']['case_property'] = 'external_id'
         with self.assertRaises(DuplicateCaseMatch):

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -24,8 +24,8 @@ class GenericRepeaterForm(forms.Form):
 
     url = forms.URLField(
         required=True,
-        label='URL to forward to',
-        help_text='Please enter the full url, like http://www.example.com/forwarding/',
+        label=_('URL to forward to'),
+        help_text=_('Please enter the full URL, like "http://www.example.com/forwarding/"'),
         widget=forms.TextInput(attrs={"class": "url"})
     )
     auth_type = forms.ChoiceField(
@@ -39,11 +39,11 @@ class GenericRepeaterForm(forms.Form):
     )
     username = forms.CharField(
         required=False,
-        label='Username',
+        label=_('Username'),
     )
     password = forms.CharField(
         required=False,
-        label='Password',
+        label=_('Password'),
         widget=forms.PasswordInput(render_value=True)
     )
     skip_cert_verify = forms.BooleanField(

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from datetime import datetime, timedelta
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -111,6 +112,8 @@ class Repeater(QuickCachedDocumentMixin, Document):
     username = StringProperty()
     password = StringProperty()
     skip_cert_verify = BooleanProperty(default=False)
+    notify_addresses_str = StringProperty()
+
     friendly_name = _("Data")
     paused = BooleanProperty(default=False)
 
@@ -297,6 +300,10 @@ class Repeater(QuickCachedDocumentMixin, Document):
     @property
     def verify(self):
         return not self.skip_cert_verify
+
+    @property
+    def notify_addresses(self):
+        return [addr for addr in re.split('[, ]+', self.notify_addresses_str) if addr]
 
     def send_request(self, repeat_record, payload):
         headers = self.get_headers(repeat_record)

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -143,6 +143,7 @@ class BaseRepeaterView(BaseAdminProjectSettingsView):
                 ciphertext=b64_aes_encrypt(cleaned_data['password'])
             )
         repeater.format = cleaned_data['format']
+        repeater.notify_addresses_str = cleaned_data['notify_addresses_str']
         repeater.skip_cert_verify = cleaned_data['skip_cert_verify']
         return repeater
 

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -148,7 +148,7 @@ class Requests(object):
         send_mail_async.delay(
             'MOTECH Error',
             message_body,
-            from_email=settings.DEFAULT_FROM_ADDRESS,
+            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=self.notify_addresses,
         )
 

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -1,6 +1,11 @@
 import logging
+import re
 
 import requests
+
+from dimagi.utils.logging import notify_exception
+
+from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.motech.const import REQUEST_TIMEOUT
 from corehq.motech.models import RequestLog
 from corehq.motech.utils import pformat_json
@@ -48,12 +53,26 @@ class Requests(object):
     To maintain a session of authenticated non-API requests, use
     Requests as a context manager.
     """
-    def __init__(self, domain_name, base_url, username, password, verify=True):
+
+    def __init__(self, domain_name, base_url, username, password,
+                 verify=True, notify_addresses=None):
+        """
+        Initialise instance
+
+        :param domain_name: Domain to store logs under
+        :param base_url: Remote API base URL
+        :param username: Remote API username
+        :param password: Remote API plaintext password
+        :param verify: Verify SSL certificate?
+        :param notify_addresses: A list of email addresses to notify of
+            errors.
+        """
         self.domain_name = domain_name
         self.base_url = base_url
         self.username = username
         self.password = password
         self.verify = verify
+        self.notify_addresses = [] if notify_addresses is None else notify_addresses
         self._session = None
 
     def __enter__(self):
@@ -109,6 +128,28 @@ class Requests(object):
         return self.send_request('POST', self.get_url(uri), *args,
                                  data=data, json=json,
                                  auth=(self.username, self.password), **kwargs)
+
+    def notify_exception(self, message=None, details=None):
+        self.notify_error(message, details)
+        notify_exception(None, message, details)
+
+    def notify_error(self, message, details=None):
+        if not self.notify_addresses:
+            return
+        message_body = '\r\n'.join((
+            message,
+            f'Project space: {self.domain_name}',
+            f'Remote API base URL: {self.base_url}',
+            f'Remote API username: {self.username}',
+        ))
+        if details:
+            message_body += f'\r\n\r\n{details}'
+        send_mail_async.delay(
+            'MOTECH Error',
+            message_body,
+            from_email='no-reply@commcarehq.org',
+            recipient_list=self.notify_addresses,
+        )
 
 
 def parse_request_exception(err):

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.conf import settings
+
 import requests
 
 from dimagi.utils.logging import notify_exception
@@ -146,7 +148,7 @@ class Requests(object):
         send_mail_async.delay(
             'MOTECH Error',
             message_body,
-            from_email='no-reply@commcarehq.org',
+            from_email=settings.DEFAULT_FROM_ADDRESS,
             recipient_list=self.notify_addresses,
         )
 

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -1,5 +1,4 @@
 import logging
-import re
 
 import requests
 

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -143,6 +143,6 @@ class RequestsTests(SimpleTestCase):
                     'Remote API base URL: http://localhost:9080/api/\r\n'
                     'Remote API username: admin'
                 ),
-                from_email=settings.DEFAULT_FROM_ADDRESS,
+                from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=['foo@example.com', 'bar@example.com']
             )

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -124,3 +124,25 @@ class RequestsTests(SimpleTestCase):
                 self.requests.get('me')
             self.requests.get('me')
             self.assertEqual(close_mock.call_count, 2)
+
+    def test_notify_error_no_address(self):
+        with patch('corehq.motech.requests.send_mail_async') as send_mail_mock:
+            self.requests.notify_error('foo')
+            send_mail_mock.delay.assert_not_called()
+
+    def test_notify_error_address_list(self):
+        requests = Requests(TEST_DOMAIN, TEST_API_URL, TEST_API_USERNAME, TEST_API_PASSWORD,
+                            notify_addresses=['foo@example.com', 'bar@example.com'])
+        with patch('corehq.motech.requests.send_mail_async') as send_mail_mock:
+            requests.notify_error('foo')
+            send_mail_mock.delay.assert_called_with(
+                'MOTECH Error',
+                (
+                    'foo\r\n'
+                    'Project space: test-domain\r\n'
+                    'Remote API base URL: http://localhost:9080/api/\r\n'
+                    'Remote API username: admin'
+                ),
+                from_email='no-reply@commcarehq.org',
+                recipient_list=['foo@example.com', 'bar@example.com']
+            )

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -1,10 +1,10 @@
 import json
 
+from django.conf import settings
 from django.test import SimpleTestCase
 
-from mock import Mock, patch
-
 import requests
+from mock import Mock, patch
 
 from corehq.motech.const import REQUEST_TIMEOUT
 from corehq.motech.requests import Requests
@@ -143,6 +143,6 @@ class RequestsTests(SimpleTestCase):
                     'Remote API base URL: http://localhost:9080/api/\r\n'
                     'Remote API username: admin'
                 ),
-                from_email='no-reply@commcarehq.org',
+                from_email=settings.DEFAULT_FROM_ADDRESS,
                 recipient_list=['foo@example.com', 'bar@example.com']
             )


### PR DESCRIPTION
##### SUMMARY
This PR responds to feedback on #25452 and adds a few more commits to use the new `notify_error()` method. I've opened a new PR because I rebased off master to try to keep commits clean and readable. :tropical_fish: 

There is some feedback about the standard for names for observables that I haven't responded to ...

> I think that the new standard is to use hungarian notation https://github.com/dimagi/commcare-hq/pull/25394/files

... I will try to implement that in a follow-up PR. The reason I've used Python convention / snake case for observables is because [the template that renders the form](https://github.com/dimagi/commcare-hq/blob/acea6efeaf2484bb92012e79a1917b809bdb5566/corehq/motech/openmrs/templates/openmrs/partials/openmrs_importer_template.html#L39) uses [a Django form](https://github.com/dimagi/commcare-hq/blob/63b71f5b0cfb5f53297f13089dbdeb9a535a49e1/corehq/motech/openmrs/forms.py#L69)'s field's `html_name` property as the name for the observable. That makes the template and the viewmodel tightly coupled to a Django form in a non-obvious way. (It evolved from when a domain could only import from one OpenMRS server. When we allowed for importing from multiple servers, we kept the form, and wrote a template to render the viewmodel as if it was the form. ... It seemed like a good idea at the time :see_no_evil: )

I would like to drop the Django form and rewrite the template. But that feels out of scope of this PR.  (And I would also like to get this deployed before then; there are a couple of projects that would like to use it soon.)

Also worth noting is that the model stores addresses in a `StringProperty`, not a `StringListProperty`. I chose this to keep the view simple. (I tried using `StringListProperty` in the model with [`MultiEmailField`](https://github.com/dimagi/commcare-hq/blob/1b4a2a6c08ca3b50a4e6e86e2c57220a64f32b5c/corehq/apps/hqwebapp/fields.py#L52) in the form, and adding a repeater behaved as expected, but when editing the repeater, the form did not render initial values; the field was always blank).

cc @emord @orangejenny 

##### FEATURE FLAG
Currently "OpenMRS integration", potentially also "DHIS2 integration"

##### PRODUCT DESCRIPTION
Adds the ability to notify third-party administrators of integration errors.
