### PR TITLE
Fix incorrect conditional in Citus delete

### DIFF
--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -292,7 +292,7 @@ class IndicatorSqlAdapter(IndicatorAdapter):
                 tmp_doc = doc.copy()
                 tmp_doc['doc_type'] = 'XFormInstance'
                 rows = self.get_all_values(tmp_doc)
-                if not rows:
+                if rows:
                     first_row = rows[0]
                     sharded_column_value = [
                         i.value for i in first_row


### PR DESCRIPTION
@snopoke I think this was the original intent of https://github.com/dimagi/commcare-hq/pull/25535/. I realize this when I saw we're still getting lots of locks on the icds DB https://app.datadoghq.com/dashboard/unt-6cf-nbs/postgres---overview?from_ts=1571224989791&fullscreen_widget=6649602022880068&live=true&tile_size=l&to_ts=1571239389791&tpl_var_env=icds&fullscreen_section=overview

**Question on testing**
I'd also be curious to hear about any ideas on better testing this since we've had a few issues with it. Its intended to recover "gracefully" in that it the deletes will still work, they're just slow. I can't think of a good way to test this without exposing some internal state in this class. Something like:

Change this function to look something like:
```python
def get_parameters_for_delete(self, doc):
    rows = self.get_all_values(tmp_doc)
    ...
    return {shard_column: shard_value, doc_id: doc_id, ...}
    
def run_delete(self, params):
    delete = table.delete().where(*delete)
```

and create a test that looks like:
```
# setup location hierarchy
# Create citus data source that distributes based on "location_type_A" 
# Create XFormError doc
# Mock a the run_delete command to inspect values passed to it
# Run XFormError doc through UCR pillow
# verify the correct parameters are passed to it
```

Hopefully the above makes sense. I'm not sure that that sort of change is worth the effort, but would be curious on how you guys feel about testing these sorts of performance changes, and the trade off on how much code should be changed/introduced to do so.