### PR TITLE
Include form question translations in app diff

### DIFF
--- a/corehq/apps/app_manager/app_schemas/form_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/form_metadata.py
@@ -23,8 +23,8 @@ CHANGED = 'changed'
 DIFF_STATES = (REMOVED, ADDED, CHANGED)
 
 QUESTION_ATTRIBUTES = (
-    'label', 'type', 'value', 'options', 'calculate', 'relevant',
-    'required', 'comment', 'setvalue', 'constraint',
+    'label', 'translations', 'type', 'value', 'options', 'calculate',
+    'relevant', 'required', 'comment', 'setvalue', 'constraint',
     'load_properties', 'save_properties'
 )
 
@@ -51,6 +51,7 @@ class _TranslationChange(_Change):
 class _QuestionDiff(JsonObject):
     question = ObjectProperty(_Change)
     label = ObjectProperty(_Change)
+    translations = ObjectProperty(_Change)
     type = ObjectProperty(_Change)
     value = ObjectProperty(_Change)
     calculate = ObjectProperty(_Change)
@@ -305,8 +306,10 @@ class _AppDiffGenerator(object):
                 self._mark_item_added(second_module, 'module')
 
     def _mark_attribute(self, first_item, second_item, attribute):
-        translation_changed = (self._is_translatable_property(first_item[attribute], second_item[attribute])
-                               and set(second_item[attribute].items()) - set(first_item[attribute].items()))
+        translation_changed = (self._is_translatable_property(first_item[attribute],
+                                                              second_item[attribute])
+                               and (set(second_item[attribute].items())
+                                    - set(first_item[attribute].items())))
         attribute_changed = first_item[attribute] != second_item[attribute]
         attribute_added = second_item[attribute] and not first_item[attribute]
         attribute_removed = first_item[attribute] and not second_item[attribute]

--- a/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
@@ -127,6 +127,15 @@ class TestAppDiffs(_BaseTestAppDiffs, SimpleTestCase):
         self.assertEqual(first[0]['forms'][0]['questions'][0]['changes']['label']['type'], CHANGED)
         self.assertEqual(second[0]['forms'][0]['questions'][0]['changes']['label']['type'], CHANGED)
 
+    def test_add_question_translation(self):
+        self.app1.langs = ['en', 'it']
+        self.app2.langs = ['en', 'it']
+        self._add_question(self.app1.modules[0].forms[0], {'label': {'en': 'food'}})
+        self._add_question(self.app2.modules[0].forms[0], {'label': {'en': 'food', 'it': 'cibo'}})
+        first, second = get_app_diff(self.app1, self.app2)
+        self.assertEqual(first[0]['forms'][0]['questions'][0]['changes']['translations']['type'], CHANGED)
+        self.assertEqual(second[0]['forms'][0]['questions'][0]['changes']['translations']['type'], CHANGED)
+
     def test_add_question_constraint(self):
         self._add_question(self.app1.modules[0].forms[0], {'constraint': ''})
         self._add_question(self.app2.modules[0].forms[0], {'constraint': 'foo = bar'})

--- a/corehq/apps/app_manager/static/app_manager/js/summary/models.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/models.js
@@ -113,7 +113,6 @@ hqDefine('app_manager/js/summary/models',[
                     'form': gettext("Form"),
                     'question': gettext("Question"),
                     'name': gettext("Name"),
-                    'label': gettext("Label"),
                     'translations': gettext("Label"),
                     'type': gettext("Question Type"),
                     'value': gettext("Question Value"),

--- a/corehq/apps/app_manager/static/app_manager/js/summary/models.js
+++ b/corehq/apps/app_manager/static/app_manager/js/summary/models.js
@@ -114,6 +114,7 @@ hqDefine('app_manager/js/summary/models',[
                     'question': gettext("Question"),
                     'name': gettext("Name"),
                     'label': gettext("Label"),
+                    'translations': gettext("Label"),
                     'type': gettext("Question Type"),
                     'value': gettext("Question Value"),
                     'options': gettext("Option"),

--- a/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_summary_base.html
@@ -98,10 +98,10 @@
     <span data-bind="css: getDiffClass('type'), popover: getDiffPopover(changes['type'], 'type')">
       <i data-bind="attr: { 'class': $root.questionIcon($data) }"></i>
       <!-- ko ifnot: $root.readOnly -->
-      <a data-bind="attr: { 'href': $parents[$parents.length - 3].url + hashtagValue }, css: getDiffClass('label'), text: $root.showIds() ? value :  $root.translateQuestion($data), popover: getDiffPopover(changes['label'], 'label')" target="_blank"></a>
+      <a data-bind="attr: { 'href': $parents[$parents.length - 3].url + hashtagValue }, css: getDiffClass('translations'), text: $root.showIds() ? value :  $root.translateQuestion($data), popover: getDiffPopover(changes['translations'], 'translations')" target="_blank"></a>
       <!-- /ko  -->
       <!-- ko if: $root.readOnly -->
-      <span data-bind="text: $root.showIds() ? value :  $root.translateQuestion($data), css: getDiffClass('label'), popover: getDiffPopover(changes['label'], 'label')"></span>
+      <span data-bind="text: $root.showIds() ? value :  $root.translateQuestion($data), css: getDiffClass('translations'), popover: getDiffPopover(changes['translations'], 'translations')"></span>
       <!-- /ko -->
       <!-- ko if: required -->
       <sup class="text-muted" data-bind="css: getDiffClass('required'), popover: getDiffPopover(changes['required'], 'required')">{% trans "required" %}</sup>

--- a/corehq/apps/app_manager/tests/data/xform_builder/unicode_translation.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/unicode_translation.xml
@@ -11,6 +11,11 @@
       <itext>
         <translation lang="en" default="">
           <text id="name-label">
+            <value>What is your name?</value>
+          </text>
+        </translation>
+        <translation lang="bur">
+          <text id="name-label">
             <value>သင့်နာမည်ဘယ်လိုခေါ်လဲ?</value>
           </text>
         </translation>

--- a/corehq/apps/app_manager/tests/test_xform_builder.py
+++ b/corehq/apps/app_manager/tests/test_xform_builder.py
@@ -62,10 +62,11 @@ class XFormBuilderTests(SimpleTestCase, TestXmlMixin):
             self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
         )
 
-    def test_unicode(self):
-        self.xform.new_question('name', 'သင့်နာမည်ဘယ်လိုခေါ်လဲ?')  # ("What is your name?" in Myanmar/Burmese)
+    def test_unicode_translation(self):
+        self.xform.new_question('name', {'en': 'What is your name?',
+                                         'bur': 'သင့်နာမည်ဘယ်လိုခေါ်လဲ?'})  # (Myanmar/Burmese)
         self.assertXmlEqual(
-            self.replace_xmlns(self.get_xml('unicode'), self.xform.xmlns),
+            self.replace_xmlns(self.get_xml('unicode_translation'), self.xform.xmlns),
             self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
         )
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-89
##### SUMMARY
App question translations were being ignored.  This PR makes them appear highlighted and have additional information in the app diff view.  It also adds the capability to translate questions in `XFormBuilder` so this sort of thing can be tested.

##### FEATURE FLAG
"Improved app changes view"

##### PRODUCT DESCRIPTION
This will highlight differences in question label translations in the app diff.  Previously, changes to secondary languages were ignored.

![image](https://user-images.githubusercontent.com/2367539/66955769-09ccef00-f031-11e9-8e52-5b459bfe495b.png)