### PR TITLE
Reduce gevent workers for ICDS Dashboard agg query

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
         state_ids = agg_record.state_ids
         query = self.function_map[query_name]
         if query.by_state == SINGLE_STATE:
-            pool = Pool(10)
+            pool = Pool(5)
             for state in state_ids:
                 pool.spawn(query.func, state, agg_date)
             pool.join(raise_error=True)


### PR DESCRIPTION
We've been getting a lot of connection timeouts during the "stage 1" tasks. I believe this is because we are overloading the the disk i/o and the workers can't respond quickly enough because all their CPU is on IO wait. I'm working on other solutions to disk io, but wanted to float this as an idea to make those tasks more stable.