### PR TITLE
default empty case relationship to 'child'

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -165,6 +165,25 @@ class IndexTest(TestCase):
         post_case_blocks([create_index], domain=self.project.name)
         deprecated_check_user_has_case(self, self.user, create_index)
 
+    def test_default_relationship(self):
+        parent_case_id = uuid.uuid4().hex
+        post_case_blocks(
+            [CaseBlock(create=True, case_id=parent_case_id, user_id=self.user.user_id).as_xml()],
+            domain=self.project.name
+        )
+        create_index = CaseBlock(
+            create=True,
+            case_id=self.CASE_ID,
+            user_id=self.user.user_id,
+            owner_id=self.user.user_id,
+        )
+        # set outside constructor to skip validation
+        create_index.index = {
+            'parent': IndexAttrs(case_type='parent', case_id=parent_case_id, relationship='')
+        }
+        form, cases = post_case_blocks([create_index.as_xml()], domain=self.project.name)
+        self.assertEqual(cases[0].indices[0].relationship, 'child')
+
 
 @use_sql_backend
 class IndexTestSQL(IndexTest):

--- a/corehq/ex-submodules/casexml/apps/case/xml/parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/parser.py
@@ -225,12 +225,12 @@ class CaseIndex(object):
     A class that holds an index to a case.
     """
 
-    def __init__(self, identifier, referenced_type, referenced_id, relationship='child'):
+    def __init__(self, identifier, referenced_type, referenced_id, relationship):
         self.identifier = identifier
         self.referenced_type = referenced_type
         self.referenced_id = referenced_id
-        self.relationship = relationship
-    
+        self.relationship = relationship or "child"
+
 
 class CaseIndexAction(CaseActionBase):
     """


### PR DESCRIPTION
##### SUMMARY
Use the default relationship if an empty relationship type if given.

An empty string for the index relationship is caused by an app error using 'save to case'. This has the potential to set the wrong case relationship type but that seems preferable to failing the form except that the app error may never be detected.

https://sentry.io/organizations/dimagi/issues/1241425577