### PR TITLE
Add X-FORMPLAYER-SESSION header for sticky sms form sessions

### DIFF
--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -353,16 +353,6 @@ def get_response(data, auth=None):
         raise e
 
 
-def sync_db(username, domain, auth):
-    data = {
-        "action":"sync-db",
-        "username": username,
-        "domain": domain
-    }
-
-    return post_data(json.dumps(data), auth)
-
-
 def get_raw_instance(session_id, domain=None, auth=None):
     """
     Gets the raw xml instance of the current session regardless of the state that we're in (used for logging partially complete

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -295,10 +295,12 @@ class XformsResponse(object):
 
 def formplayer_post_data_helper(d, content_type, url):
     data = json.dumps(d).encode('utf-8')
+    session_id = data['session-id']
     headers = {}
     headers["Content-Type"] = content_type
     headers["content-length"] = str(len(data))
     headers["X-MAC-DIGEST"] = get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, data)
+    headers["X-FORMPLAYER-SESSION"] = session_id
     response = requests.post(
         url,
         data=data,


### PR DESCRIPTION
##### SUMMARY
Goes with

Should help with at least part of what's going on in https://dimagi-dev.atlassian.net/browse/SAASP-115.

##### PRODUCT DESCRIPTION
This gives more consistent behavior for SMS Surveys, where previously certain aspects of form state could change unpredictably during each incoming / outgoing SMS cycle for the same form.