### PR TITLE
remove PRUNE_PREVIOUS_SYNCLOGS toggle

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -14,7 +14,6 @@ from casexml.apps.case.exceptions import PhoneDateValueError
 from casexml.apps.phone.models import delete_synclog
 from casexml.apps.phone.xml import get_case_element
 from casexml.apps.stock.models import StockReport
-from corehq.toggles import PRUNE_PREVIOUS_SYNCLOGS, NAMESPACE_USER
 from corehq.util.soft_assert import soft_assert
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.utils import should_use_sql_backend
@@ -112,8 +111,6 @@ def get_case_xform_ids(case_id):
 
 
 def prune_previous_log(sync_log):
-    if not PRUNE_PREVIOUS_SYNCLOGS.enabled(sync_log.user_id, NAMESPACE_USER):
-        return False
     if sync_log.previous_log_id:
         delete_synclog(sync_log.previous_log_id)
         sync_log.previous_log_id = None

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_purge.py
@@ -30,7 +30,6 @@ class TestSyncPurge(TestCase):
         cls.project.delete()
         super(TestSyncPurge, cls).tearDownClass()
 
-    @flag_enabled('PRUNE_PREVIOUS_SYNCLOGS')
     def test_previous_log_purged(self):
         device = MockDevice(self.project, self.restore_user)
         initial_sync = device.sync(items=True, version=V1)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1822,13 +1822,6 @@ PHI_CAS_INTEGRATION = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-PRUNE_PREVIOUS_SYNCLOGS = DynamicallyPredictablyRandomToggle(
-    'prune_previous_synclogs',
-    'Delete old synclogs during form submission',
-    TAG_CUSTOM,
-    [NAMESPACE_USER]
-)
-
 DAILY_INDICATORS = StaticToggle(
     'daily_indicators',
     'Enable daily indicators api',


### PR DESCRIPTION
##### SUMMARY
Now that this has been tested and rolled out fully on ICDS there
is no need for the toggle.