### PR TITLE
toggle test failure

### DIFF
--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -222,7 +222,7 @@ class TestDumpLoadToggles(SimpleTestCase):
         output_stream.seek(0)
         lines = output_stream.readlines()
         dumped = [json.loads(line.strip()) for line in lines]
-        self.assertEqual(len(dumped, 3), ','.join([d['slug'] for d in dumped]))
+        self.assertEqual(len(dumped), 3, ','.join([d['slug'] for d in dumped]))
         for dump in dumped:
             self.assertItemsEqual(self.expected_items[dump['slug']], dump['enabled_users'])
 

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -218,10 +218,11 @@ class TestDumpLoadToggles(SimpleTestCase):
         output_stream = BytesIO()
 
         with mock_out_couch(docs=[doc.to_json() for doc in self.mocked_toggles.values()]):
-            dump_counter = dumper.dump(output_stream)
-        self.assertEqual(3, dump_counter['Toggle'])
+            dumper.dump(output_stream)
         output_stream.seek(0)
-        dumped = [json.loads(line.strip()) for line in output_stream.readlines()]
+        lines = output_stream.readlines()
+        dumped = [json.loads(line.strip()) for line in lines]
+        self.assertEqual(len(dumped, 3), ','.join([d['slug'] for d in dumped]))
         for dump in dumped:
             self.assertItemsEqual(self.expected_items[dump['slug']], dump['enabled_users'])
 

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -57,13 +57,13 @@ class FeaturePreview(StaticToggle):
         return has_privilege and can_self_enable
 
 
-@quickcache([])
 def all_previews():
-    return list(all_toggles_by_name_in_scope(globals()).values())
+    return list(all_previews_by_name().values())
 
 
+@quickcache([])
 def all_previews_by_name():
-    return all_toggles_by_name_in_scope(globals())
+    return all_toggles_by_name_in_scope(globals(), toggle_class=FeaturePreview)
 
 
 @quickcache(['domain'])

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -393,11 +393,11 @@ def all_toggles_by_name():
     return all_toggles_by_name_in_scope(globals())
 
 
-def all_toggles_by_name_in_scope(scope_dict):
+def all_toggles_by_name_in_scope(scope_dict, toggle_class=StaticToggle):
     result = {}
     for toggle_name, toggle in scope_dict.items():
         if not toggle_name.startswith('__'):
-            if isinstance(toggle, StaticToggle):
+            if isinstance(toggle, toggle_class):
                 result[toggle_name] = toggle
     return result
 


### PR DESCRIPTION
##### SUMMARY
Fix this random test failure:
```
FAIL: corehq.apps.dump_reload.tests.test_couch_dump_load:TestDumpLoadToggles.test_dump_toggles
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/media/data/src/cchq/corehq/apps/dump_reload/tests/test_couch_dump_load.py", line 225, in test_dump_toggles
    self.assertEqual(3, dump_counter['Toggle'])
AssertionError: 3 != 4
```

The dump function then checks all `all_toggles() + all_previews()`. Because some toggles are imported into the `feature_previews` module the `all_previews` function was returning those toggles in the list of previews meaning that `all_toggles() + all_previews()` contained some duplicates.

This only happened sometimes because the test randomly selects toggles from `all_toggles()`.