### PR TITLE
bulk ES pillow processor

### DIFF
--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -192,22 +192,6 @@ class ChunkedUCRProcessorTest(TestCase):
             set([row.doc_id for row in query.all()])
         )
 
-    def test_get_docs(self):
-        docs = [
-            get_sample_doc_and_indicators(self.fake_time_now)[0]
-            for i in range(10)
-        ]
-        feed = self.pillow.get_change_feed()
-        since = feed.get_latest_offsets()
-        cases = self._create_cases(docs=docs)
-        changes = list(feed.iter_changes(since, forever=False))
-        bad_changes, result_docs = ConfigurableReportPillowProcessor.get_docs_for_changes(
-            changes, docs[1]['domain'])
-        self.assertEqual(
-            set([c.id for c in changes]),
-            set([doc['_id'] for doc in result_docs])
-        )
-
     @mock.patch('corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor.process_change')
     def test_invalid_data_bulk_processor(self, process_change):
         self.config.validations = [

--- a/corehq/ex-submodules/pillowtop/exceptions.py
+++ b/corehq/ex-submodules/pillowtop/exceptions.py
@@ -14,3 +14,7 @@ class PillowtopIndexingError(Exception):
 
 class PillowConfigError(Exception):
     pass
+
+
+class BulkDocExeption(Exception):
+    pass

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -1,18 +1,24 @@
 from abc import ABCMeta, abstractmethod
-from datetime import datetime
-import time
 
 from elasticsearch import TransportError
+from elasticsearch.helpers import bulk
+
+from pillowtop.es_utils import (
+    initialize_mapping_if_necessary,
+    set_index_normal_settings,
+    set_index_reindex_settings,
+)
+from pillowtop.feed.interface import Change
+from pillowtop.logger import pillow_logging
+from pillowtop.pillow.interface import ConstructedPillow
+from pillowtop.utils import ErrorCollector, build_bulk_payload
 
 from corehq.apps.change_feed.document_types import is_deletion
 from corehq.util.argparse_types import date_type
-from corehq.util.doc_processor.interface import BaseDocProcessor, BulkDocProcessor
-from pillowtop.es_utils import set_index_reindex_settings, \
-    set_index_normal_settings, initialize_mapping_if_necessary
-from pillowtop.feed.interface import Change
-from pillowtop.pillow.interface import ConstructedPillow
-from pillowtop.logger import pillow_logging
-from pillowtop.utils import prepare_bulk_payloads, build_bulk_payload, ErrorCollector
+from corehq.util.doc_processor.interface import (
+    BaseDocProcessor,
+    BulkDocProcessor,
+)
 
 MAX_TRIES = 3
 RETRY_TIME_DELAY_FACTOR = 15
@@ -206,42 +212,13 @@ class BulkPillowReindexProcessor(BaseDocProcessor):
         for change, exception in error_collector.errors:
             pillow_logging.error("Error procesing doc %s: %s (%s)", change.id, type(exception), exception)
 
-        payloads = prepare_bulk_payloads(bulk_changes, MAX_PAYLOAD_SIZE)
-        if len(payloads) > 1:
-            pillow_logging.info("Payload split into %s parts" % len(payloads))
-
-        for payload in payloads:
-            success = self._send_payload_with_retries(payload)
-            if not success:
-                # stop the reindexer if we're unable to send a payload to ES
-                return False
+        try:
+            bulk(self.es, bulk_changes)
+        except Exception:
+            pillow_logging.exception("\tException sending payload to ES")
+            return False
 
         return True
-
-    def _send_payload_with_retries(self, payload):
-        pillow_logging.info("Sending payload to ES")
-
-        retries = 0
-        bulk_start = datetime.utcnow()
-        success = False
-        while retries < MAX_TRIES:
-            if retries:
-                retry_time = (datetime.utcnow() - bulk_start).seconds + retries * RETRY_TIME_DELAY_FACTOR
-                pillow_logging.warning("\tRetrying in %s seconds" % retry_time)
-                time.sleep(retry_time)
-                pillow_logging.warning("\tRetrying now ...")
-                # reset timestamp when looping again
-                bulk_start = datetime.utcnow()
-
-            try:
-                self.es.bulk(payload.decode('utf-8'))
-                success = True
-                break
-            except Exception:
-                retries += 1
-                pillow_logging.exception("\tException sending payload to ES")
-
-        return success
 
     @staticmethod
     def _doc_to_change(doc):

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -1,4 +1,3 @@
-import json
 import uuid
 
 from django.test import SimpleTestCase, TestCase
@@ -8,7 +7,7 @@ from six.moves import range
 from casexml.apps.case.signals import case_post_save
 from pillowtop.feed.interface import Change, ChangeMeta
 from pillowtop.pillow.interface import PillowBase
-from pillowtop.utils import bulk_fetch_changes_docs, prepare_bulk_payloads
+from pillowtop.utils import bulk_fetch_changes_docs
 
 from corehq.form_processor.document_stores import ReadonlyCaseDocumentStore
 from corehq.form_processor.signals import sql_case_post_save
@@ -18,21 +17,9 @@ from corehq.form_processor.tests.utils import (
     use_sql_backend,
 )
 from corehq.util.context_managers import drop_connected_signals
-from corehq.util.test_utils import generate_cases
 
 
 class BulkTest(SimpleTestCase):
-
-    def test_prepare_bulk_payloads_unicode(self):
-        unicode_domain = 'हिंदी'
-        bulk_changes = [
-            {'id': 'doc1'},
-            {'id': 'doc2', 'domain': unicode_domain},
-        ]
-        payloads = prepare_bulk_payloads(bulk_changes, max_size=10, chunk_size=1)
-        self.assertEqual(2, len(payloads))
-        self.assertEqual(unicode_domain, json.loads(payloads[1])['domain'])
-
     def test_deduplicate_changes(self):
         changes = [
             Change(1, 'a'),
@@ -47,24 +34,6 @@ class BulkTest(SimpleTestCase):
             [(change.id, change.sequence_id) for change in deduped],
             [(3, 'a'), (2, 'b'), (4, 'a'), (1, 'b')]
         )
-
-
-@generate_cases([
-    (100, 1, 3),
-    (100, 10, 1),
-    (1, 1, 10),
-    (1, 2, 5),
-], BulkTest)
-def test_prepare_bulk_payloads2(self, max_size, chunk_size, expected_payloads):
-    bulk_changes = [{'id': 'doc%s' % i} for i in range(10)]
-    payloads = prepare_bulk_payloads(bulk_changes, max_size=max_size, chunk_size=chunk_size)
-    self.assertEqual(expected_payloads, len(payloads))
-    self.assertTrue(all(payloads))
-
-    # check that we can reform the original list of changes
-    json_docs = b''.join(payloads).strip().split(b'\n')
-    reformed_changes = [json.loads(doc) for doc in json_docs]
-    self.assertEqual(bulk_changes, reformed_changes)
 
 
 @use_sql_backend

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -2,13 +2,18 @@ import uuid
 
 from django.test import SimpleTestCase, TestCase
 
+from mock import Mock, patch
 from six.moves import range
 
 from casexml.apps.case.signals import case_post_save
+from pillowtop.es_utils import initialize_index_and_mapping
 from pillowtop.feed.interface import Change, ChangeMeta
 from pillowtop.pillow.interface import PillowBase
-from pillowtop.utils import bulk_fetch_changes_docs
+from pillowtop.processors.elastic import BulkElasticProcessor
+from pillowtop.tests.utils import TEST_INDEX_INFO
+from pillowtop.utils import bulk_fetch_changes_docs, get_errors_with_ids
 
+from corehq.elastic import get_es_new
 from corehq.form_processor.document_stores import ReadonlyCaseDocumentStore
 from corehq.form_processor.signals import sql_case_post_save
 from corehq.form_processor.tests.utils import (
@@ -17,9 +22,12 @@ from corehq.form_processor.tests.utils import (
     use_sql_backend,
 )
 from corehq.util.context_managers import drop_connected_signals
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import trap_extra_setup
 
 
 class BulkTest(SimpleTestCase):
+
     def test_deduplicate_changes(self):
         changes = [
             Change(1, 'a'),
@@ -35,6 +43,13 @@ class BulkTest(SimpleTestCase):
             [(3, 'a'), (2, 'b'), (4, 'a'), (1, 'b')]
         )
 
+    def test_get_errors_with_ids(self):
+        errors = get_errors_with_ids([
+            {'index': {'_id': 1, 'status': 500, 'error': 'e1'}},
+            {'index': {'_id': 2, 'status': 500, 'error': 'e2'}}
+        ])
+        self.assertEqual([(1, 'e1'), (2, 'e2')], errors)
+
 
 @use_sql_backend
 class TestBulkDocOperations(TestCase):
@@ -49,9 +64,17 @@ class TestBulkDocOperations(TestCase):
             for case_id in cls.case_ids:
                 create_form_for_test(cls.domain, case_id)
 
+        cls.es = get_es_new()
+        cls.index = TEST_INDEX_INFO.index
+
+        with trap_extra_setup(ConnectionError):
+            ensure_index_deleted(cls.index)
+            initialize_index_and_mapping(cls.es, TEST_INDEX_INFO)
+
     @classmethod
     def tearDownClass(cls):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers(cls.domain)
+        ensure_index_deleted(cls.index)
         super().tearDownClass()
 
     def _changes_from_ids(self, case_ids):
@@ -78,4 +101,39 @@ class TestBulkDocOperations(TestCase):
         self.assertEqual(
             set(missing_case_ids),
             set([change.id for change in bad_changes])
+        )
+
+    def test_process_changes_chunk(self):
+        processor = BulkElasticProcessor(self.es, TEST_INDEX_INFO)
+
+        changes = self._changes_from_ids(self.case_ids)
+
+        retry, errors = processor.process_changes_chunk(changes)
+        self.assertEqual([], retry)
+        self.assertEqual([], errors)
+
+        es_docs = self.es.mget(
+            index=self.index, doc_type=TEST_INDEX_INFO.type, body={'ids': self.case_ids}, _source=True
+        )['docs']
+        ids_in_es = {
+            doc['_source']['_id'] for doc in es_docs
+        }
+        self.assertEqual(set(self.case_ids), ids_in_es)
+
+    def test_process_changes_chunk_with_errors(self):
+        mock_response = (5, [{'index': {'_id': self.case_ids[0], 'error': 'DateParseError'}}])
+        processor = BulkElasticProcessor(Mock(), TEST_INDEX_INFO)
+
+        missing_case_ids = [uuid.uuid4().hex, uuid.uuid4().hex]
+        changes = self._changes_from_ids(self.case_ids + missing_case_ids)
+
+        with patch('pillowtop.processors.elastic.bulk', return_value=mock_response):
+            retry, errors = processor.process_changes_chunk(changes)
+        self.assertEqual(
+            set(missing_case_ids),
+            set([change.id for change in retry])
+        )
+        self.assertEqual(
+            [self.case_ids[0]],
+            [error[0].id for error in errors]
         )

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -328,7 +328,7 @@ def bulk_fetch_changes_docs(changes, domain=None):
     # break up by doctype
     changes_by_doctype = defaultdict(list)
     for change in changes:
-        if domain and change.metadata.domain == domain:
+        if domain and change.metadata.domain != domain:
             raise ValueError("Domain does not match change")
         changes_by_doctype[change.metadata.data_source_name].append(change)
 

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -321,11 +321,12 @@ def ensure_document_exists(change):
         raise change.error_raised
 
 
-def bulk_fetch_changes_docs(changes, domain):
+def bulk_fetch_changes_docs(changes, domain=None):
     # break up by doctype
     changes_by_doctype = defaultdict(list)
     for change in changes:
-        assert change.metadata.domain == domain
+        if domain and change.metadata.domain == domain:
+            raise ValueError("Domain does not match change")
         changes_by_doctype[change.metadata.data_source_name].append(change)
 
     # query

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -21,7 +21,7 @@ from corehq.util.doc_processor.sql import SqlDocumentProvider
 from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow, KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
 from pillowtop.pillow.interface import ConstructedPillow
-from pillowtop.processors.elastic import ElasticProcessor
+from pillowtop.processors.elastic import BulkElasticProcessor, ElasticProcessor
 from pillowtop.reindexer.reindexer import ResumableBulkElasticPillowReindexer, ReindexerFactory
 
 pillow_logging = logging.getLogger("pillowtop")
@@ -98,7 +98,7 @@ def get_case_pillow(
     )
     if ucr_configs:
         ucr_processor.bootstrap(ucr_configs)
-    case_to_es_processor = ElasticProcessor(
+    case_to_es_processor = BulkElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
         doc_prep_fn=transform_case_for_elasticsearch

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -4,17 +4,19 @@ from corehq.apps.sms.change_publishers import change_meta_from_sms
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
 from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
+from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
 from pillowtop.feed.interface import Change
 from pillowtop.pillow.interface import ConstructedPillow
-from pillowtop.processors.elastic import ElasticProcessor
+from pillowtop.processors.elastic import BulkElasticProcessor
 from pillowtop.reindexer.change_providers.django_model import DjangoModelChangeProvider
 from pillowtop.reindexer.reindexer import ElasticPillowReindexer, ReindexerFactory
 
 
-def get_sql_sms_pillow(pillow_id='SqlSMSPillow', num_processes=1, process_num=0, **kwargs):
+def get_sql_sms_pillow(pillow_id='SqlSMSPillow', num_processes=1, process_num=0,
+                       processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
     assert pillow_id == 'SqlSMSPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, SMS_INDEX_INFO, [topics.SMS])
-    processor = ElasticProcessor(
+    processor = BulkElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=SMS_INDEX_INFO,
         doc_prep_fn=lambda x: x
@@ -31,6 +33,7 @@ def get_sql_sms_pillow(pillow_id='SqlSMSPillow', num_processes=1, process_num=0,
         change_processed_event_handler=KafkaCheckpointEventHandler(
             checkpoint=checkpoint, checkpoint_frequency=100, change_feed=change_feed
         ),
+        processor_chunk_size=processor_chunk_size
     )
 
 

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -13,8 +13,10 @@ from corehq.elastic import (
 from corehq.pillows.mappings.user_mapping import USER_INDEX, USER_INDEX_INFO
 from corehq.util.quickcache import quickcache
 from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
+from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor, PillowProcessor
+from pillowtop.processors.elastic import BulkElasticProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
 from pillowtop.reindexer.reindexer import ElasticPillowReindexer, ReindexerFactory
 
@@ -99,7 +101,7 @@ def add_demo_user_to_user_index():
 
 
 def get_user_es_processor():
-    return ElasticProcessor(
+    return BulkElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=USER_INDEX_INFO,
         doc_prep_fn=transform_user_for_elasticsearch,
@@ -130,7 +132,7 @@ def get_user_pillow_old(pillow_id='UserPillow', num_processes=1, process_num=0, 
 
 
 def get_user_pillow(pillow_id='user-pillow', num_processes=1, process_num=0,
-        skip_ucr=False, **kwargs):
+        skip_ucr=False, processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
     # Pillow that sends users to ES and UCR
     assert pillow_id == 'user-pillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO, topics.USER_TOPICS)
@@ -150,6 +152,7 @@ def get_user_pillow(pillow_id='user-pillow', num_processes=1, process_num=0,
         change_processed_event_handler=KafkaCheckpointEventHandler(
             checkpoint=checkpoint, checkpoint_frequency=100, change_feed=change_feed
         ),
+        processor_chunk_size=processor_chunk_size
     )
 
 

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -30,7 +30,7 @@ from pillowtop.checkpoints.manager import KafkaPillowCheckpoint, get_checkpoint_
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.form import FormSubmissionMetadataTrackerProcessor
-from pillowtop.processors.elastic import ElasticProcessor
+from pillowtop.processors.elastic import BulkElasticProcessor, ElasticProcessor
 from pillowtop.reindexer.reindexer import ResumableBulkElasticPillowReindexer, ReindexerFactory
 
 
@@ -183,7 +183,7 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         exclude_ucrs=exclude_ucrs,
         run_migrations=(process_num == 0),  # only first process runs migrations
     )
-    xform_to_es_processor = ElasticProcessor(
+    xform_to_es_processor = BulkElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=XFORM_INDEX_INFO,
         doc_prep_fn=transform_xform_for_elasticsearch,
@@ -206,7 +206,7 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
     if settings.RUN_FORM_META_PILLOW:
         processors.append(form_meta_processor)
     if not settings.ENTERPRISE_MODE:
-        xform_to_report_es_processor = ElasticProcessor(
+        xform_to_report_es_processor = BulkElasticProcessor(
             elasticsearch=get_es_new(),
             index_info=REPORT_XFORM_INDEX_INFO,
             doc_prep_fn=transform_xform_for_report_forms_index,

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -63,9 +63,11 @@ class CasePillowTest(TestCase):
     @run_with_all_backends
     def test_case_pillow_error_in_case_es(self):
         self.assertEqual(0, PillowError.objects.filter(pillow='case-pillow').count())
-        with patch('corehq.pillows.case_search.domain_needs_search_index', return_value=True):
-            with patch('corehq.pillows.case.transform_case_for_elasticsearch') as transform_patch:
-                transform_patch.side_effect = Exception()
+        with patch('corehq.pillows.case_search.domain_needs_search_index', return_value=True), \
+            patch('corehq.pillows.case.transform_case_for_elasticsearch') as case_transform, \
+            patch('corehq.pillows.case_search.transform_case_for_elasticsearch') as case_search_transform:
+                case_transform.side_effect = Exception('case_transform error')
+                case_search_transform.side_effect = Exception('case_search_transform error')
                 case_id, case_name = self._create_case_and_sync_to_es()
 
         # confirm change did not make it to case search index


### PR DESCRIPTION
##### SUMMARY
ES pillow processor that uses the [bulk ES API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html). I think this is a good idea for 2 reasons:

1. It should reduce the connection load on ES and possibly other load depending on how ES handles these.
2. Having mixed batch and serial processors in a pillow makes it harder to reason about what's happening in the pillow.

Pillows using bulk:
* case-pillow
* form-pillow
* SqlSMSPillow
* user-pillow