### PR TITLE
[ICDS Dashboard] Don't get table names from UCR configs

### DIFF
--- a/custom/icds_reports/tests/agg_tests/__init__.py
+++ b/custom/icds_reports/tests/agg_tests/__init__.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 import mock
-import sqlalchemy
 import csv
 
 from django.conf import settings
@@ -14,13 +13,13 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.userreports.models import StaticDataSourceConfiguration
 from corehq.apps.userreports.util import get_indicator_adapter
-from corehq.sql_db.connections import connection_manager, ICDS_UCR_CITUS_ENGINE_ID
 
 from custom.icds_reports.tasks import (
     move_ucr_data_into_aggregation_tables,
     build_incentive_report,
 )
-from .agg_setup import setup_location_hierarchy, setup_tables_and_fixtures, aggregate_state_form_data
+from .agg_setup import setup_location_hierarchy, setup_tables_and_fixtures, aggregate_state_form_data, \
+    cleanup_misc_agg_tables
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), 'outputs')
 

--- a/custom/icds_reports/tests/agg_tests/__init__.py
+++ b/custom/icds_reports/tests/agg_tests/__init__.py
@@ -71,14 +71,8 @@ def tearDownModule():
                 continue
             adapter.drop_table()
 
-        engine = connection_manager.get_engine(ICDS_UCR_CITUS_ENGINE_ID)
-        with engine.begin() as connection:
-            metadata = sqlalchemy.MetaData(bind=engine)
-            metadata.reflect(bind=engine, extend_existing=True)
-            for name in ('ucr_table_name_mapping', 'awc_location', 'awc_location_local'):
-                table = metadata.tables[name]
-                delete = table.delete()
-                connection.execute(delete)
+        cleanup_misc_agg_tables()
+
     LocationType.objects.filter(domain='icds-cas').delete()
     SQLLocation.objects.filter(domain='icds-cas').delete()
 

--- a/custom/icds_reports/tests/agg_tests/agg_setup.py
+++ b/custom/icds_reports/tests/agg_tests/agg_setup.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 import postgres_copy
 import sqlalchemy
-from django.conf import settings
 
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.userreports.models import StaticDataSourceConfiguration
@@ -174,6 +173,7 @@ def setup_tables_and_fixtures(domain_name):
             pass
         adapter.build_table()
 
+    cleanup_misc_agg_tables()
     engine = connection_manager.get_engine(ICDS_UCR_CITUS_ENGINE_ID)
     metadata = sqlalchemy.MetaData(bind=engine)
     metadata.reflect(bind=engine, extend_existing=True)
@@ -223,3 +223,14 @@ def aggregate_state_form_data():
         _aggregate_child_health_pnc_forms(state_id, datetime(2017, 3, 31))
         _aggregate_gm_forms(state_id, datetime(2017, 3, 31))
         _aggregate_bp_forms(state_id, datetime(2017, 3, 31))
+
+
+def cleanup_misc_agg_tables():
+    engine = connection_manager.get_engine(ICDS_UCR_CITUS_ENGINE_ID)
+    with engine.begin() as connection:
+        metadata = sqlalchemy.MetaData(bind=engine)
+        metadata.reflect(bind=engine, extend_existing=True)
+        for name in ('ucr_table_name_mapping', 'awc_location', 'awc_location_local'):
+            table = metadata.tables[name]
+            delete = table.delete()
+            connection.execute(delete)

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -44,11 +44,6 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
     def tablename(self):
         return self._tablename_func(5)
 
-    def _ucr_tablename(self, ucr_id):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, ucr_id)
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
-
     def aggregation_query(self):
         return """
         INSERT INTO "{tablename}"
@@ -97,8 +92,9 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         )
         """.format(
             tablename=self.tablename,
-            cbe_table=self._ucr_tablename('static-cbe_form'),
-            vhnd_table=self._ucr_tablename('static-vhnd_form'),
+            cbe_table=get_table_name(self.domain, 'static-cbe_form'),
+            vhnd_table=get_table_name(self.domain, 'static-vhnd_form'),
+
             thr_v2_table=AGG_THR_V2_TABLE
         ), {
             'start_date': self.month_start
@@ -238,7 +234,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         DROP TABLE "tmp_home_visit";
         """.format(
             tablename=self.tablename,
-            ccs_record_case_ucr=self._ucr_tablename('static-ccs_record_cases'),
+            ccs_record_case_ucr=get_table_name(self.domain, 'static-ccs_record_cases'),
             agg_cf_table=AGG_CCS_RECORD_CF_TABLE,
         ), {
             'start_date': self.month_start
@@ -266,7 +262,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         DROP TABLE "tmp_household";
         """.format(
             tablename=self.tablename,
-            household_cases=self._ucr_tablename('static-household_cases'),
+            household_cases=get_table_name(self.domain, 'static-household_cases'),
         ), {'end_date': self.month_end}
 
         yield """
@@ -312,7 +308,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         DROP TABLE "tmp_person";
         """.format(
             tablename=self.tablename,
-            ucr_tablename=self._ucr_tablename('static-person_cases_v3'),
+            ucr_tablename=get_table_name(self.domain, 'static-person_cases_v3'),
             seeking_services=(
                 "CASE WHEN "
                 "registered_status IS DISTINCT FROM 0 AND migration_status IS DISTINCT FROM 1 "
@@ -421,7 +417,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         DROP TABLE "tmp_usage";
         """.format(
             tablename=self.tablename,
-            usage_table=self._ucr_tablename('static-usage_forms'),
+            usage_table=get_table_name(self.domain, 'static-usage_forms'),
         ), {
             'start_date': self.month_start
         }

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_ls_data.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_ls_data.py
@@ -1,6 +1,5 @@
 from dateutil.relativedelta import relativedelta
 
-from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
 from custom.icds_reports.const import AGG_LS_VHND_TABLE, AGG_LS_AWC_VISIT_TABLE, AGG_LS_BENEFICIARY_TABLE
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month, month_formatter
@@ -63,9 +62,7 @@ class AggLsHelper(BaseICDSAggregationDistributedHelper):
         return self._tablename_func(4)
 
     def _ucr_tablename(self, ucr_id):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, ucr_id)
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, ucr_id)
 
     def aggregate_query(self):
         """

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_ls_data.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_ls_data.py
@@ -1,6 +1,5 @@
 from dateutil.relativedelta import relativedelta
 
-from corehq.apps.userreports.util import get_table_name
 from custom.icds_reports.const import AGG_LS_VHND_TABLE, AGG_LS_AWC_VISIT_TABLE, AGG_LS_BENEFICIARY_TABLE
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month, month_formatter
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
@@ -60,9 +59,6 @@ class AggLsHelper(BaseICDSAggregationDistributedHelper):
     @property
     def tablename(self):
         return self._tablename_func(4)
-
-    def _ucr_tablename(self, ucr_id):
-        return get_table_name(self.domain, ucr_id)
 
     def aggregate_query(self):
         """

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/aww_incentive.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/aww_incentive.py
@@ -1,7 +1,3 @@
-from corehq.apps.userreports.models import (
-    StaticDataSourceConfiguration,
-    get_datasource_config,
-)
 from corehq.apps.userreports.util import get_table_name
 from custom.icds_reports.const import (
     AGG_CCS_RECORD_CF_TABLE,
@@ -20,9 +16,7 @@ class AwwIncentiveAggregationDistributedHelper(StateBasedAggregationPartitionedH
 
     @property
     def ccs_record_case_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-ccs_record_cases')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-ccs_record_cases')
 
     def aggregate_query(self):
         month = self.month.replace(day=1)

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/base.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/base.py
@@ -3,10 +3,6 @@ import logging
 
 from django.db import transaction
 
-from corehq.apps.userreports.models import (
-    StaticDataSourceConfiguration,
-    get_datasource_config,
-)
 from corehq.apps.userreports.util import get_table_name
 from corehq.sql_db.routers import db_for_read_write
 from custom.icds_reports.const import DASHBOARD_DOMAIN
@@ -43,9 +39,7 @@ class BaseICDSAggregationDistributedHelper(AggregationHelper):
 
     @property
     def ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, self.ucr_data_source_id)
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, self.ucr_data_source_id)
 
     def aggregate(self, cursor):
         raise NotImplementedError

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/ccs_record_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/ccs_record_monthly.py
@@ -32,21 +32,15 @@ class CcsRecordMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribute
 
     @property
     def ccs_record_case_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-ccs_record_cases')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-ccs_record_cases')
 
     @property
     def pregnant_tasks_cases_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-pregnant-tasks_cases')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-pregnant-tasks_cases')
 
     @property
     def person_case_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-person_cases_v3')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-person_cases_v3')
 
     def drop_table_query(self):
         return (

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -1,6 +1,5 @@
 from dateutil.relativedelta import relativedelta
 
-from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
 from custom.icds_reports.const import (
     AGG_COMP_FEEDING_TABLE,
@@ -42,21 +41,15 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
 
     @property
     def child_health_case_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-child_health_cases')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-child_health_cases')
 
     @property
     def child_tasks_case_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-child_tasks_cases')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-child_tasks_cases')
 
     @property
     def person_case_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-person_cases_v3')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-person_cases_v3')
 
     @property
     def tablename(self):

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/daily_attendance.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/daily_attendance.py
@@ -1,4 +1,3 @@
-from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
 from custom.icds_reports.const import DAILY_FEEDING_TABLE_ID
 from custom.icds_reports.utils.aggregation_helpers import date_to_string, transform_day_to_month
@@ -27,9 +26,7 @@ class DailyAttendanceAggregationDistributedHelper(BaseICDSAggregationDistributed
 
     @property
     def ucr_daily_attendance_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, self.ucr_daily_attendance_table)
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, self.ucr_daily_attendance_table)
 
     def aggregate_query(self):
         return """

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/mbt.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/mbt.py
@@ -158,9 +158,7 @@ class ChildHealthMbtDistributedHelper(MBTDistributedHelper):
 
     @property
     def person_case_ucr_tablename(self):
-        doc_id = StaticDataSourceConfiguration.get_doc_id(self.domain, 'static-person_cases_v3')
-        config, _ = get_datasource_config(doc_id, self.domain)
-        return get_table_name(self.domain, config.table_id)
+        return get_table_name(self.domain, 'static-person_cases_v3')
 
     @property
     def columns(self):


### PR DESCRIPTION
https://app.asana.com/0/1112385193248823/1145790857847618

##### SUMMARY

Remove the ES dependency of getting Static UCR tablenames when running the agg.

Funnily / ironically, the `table_id` that we get from the data source config [*is* the data souce id](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/models.py#L871). So this whole business of getting the config to get the `table_id` is completely unnecessary (except as a check that there is a datasource with that ID that belongs to the domain, which I think is not necessary to keep around given this is all in custom code).

This also bundles in an unrelated change to cleanup locations during test setup (can review by commit)
