### PR TITLE
Support importing Bahmni diagnoses

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -324,6 +324,19 @@ def import_encounter(repeater, encounter_uuid):
                 fields.update(fields_from_observations(obs['groupMembers'], mappings))
         return fields
 
+    def fields_from_bahmni_diagnoses(diagnoses, mappings):
+        """
+        Iterate a list of Bahmni diagnoses, and return the ones mapped
+        to case properties.
+        """
+        fields = {}
+        for diag in diagnoses:
+            if diag['codedAnswer']['uuid'] in mappings:
+                for mapping in mappings[diag['codedAnswer']['uuid']]:
+                    fields[mapping.case_property] = mapping.value.deserialize(diag['codedAnswer']['name'])
+        return fields
+
+
     response = repeater.requests.get(
         '/ws/rest/v1/bahmnicore/bahmniencounter/' + encounter_uuid,
         {'includeAll': 'true'},
@@ -332,6 +345,11 @@ def import_encounter(repeater, encounter_uuid):
     encounter = response.json()
 
     case_property_updates = fields_from_observations(encounter['observations'], repeater.observation_mappings)
+    if 'bahmniDiagnoses' in encounter:
+        case_property_updates.update(fields_from_bahmni_diagnoses(
+            encounter['bahmniDiagnoses'],
+            repeater.observation_mappings
+        ))
 
     if case_property_updates:
         case_blocks = []

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -165,6 +165,14 @@ class ObservationMapping(DocumentSchema):
     # requires len(OpenmrsRepeater.white_listed_case_types) == 1.)
     case_property = StringProperty(required=False)
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and other.concept == self.concept
+            and other.value == self.value
+            and other.case_property == self.case_property
+        )
+
 
 class OpenmrsFormConfig(DocumentSchema):
     xmlns = StringProperty()

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -133,6 +133,10 @@ class OpenmrsRepeater(CaseRepeater):
         for form_config in self.openmrs_config.form_configs:
             for obs_mapping in form_config.openmrs_observations:
                 if obs_mapping.value.check_direction(DIRECTION_IMPORT) and obs_mapping.case_property:
+                    # It's possible that an OpenMRS concept appears more
+                    # than once in form_configs. We are using a
+                    # defaultdict(list) so that earlier definitions
+                    # don't get overwritten by later ones:
                     obs_mappings[obs_mapping.concept].append(obs_mapping)
         return obs_mappings
 

--- a/corehq/motech/openmrs/tests/data/encounter_with_diagnoses.json
+++ b/corehq/motech/openmrs/tests/data/encounter_with_diagnoses.json
@@ -1,0 +1,115 @@
+{
+  "accessionNotes": [],
+  "associatedToPatientProgram": false,
+  "bahmniDiagnoses": [
+    {
+      "certainty": "CONFIRMED",
+      "codedAnswer": {
+        "conceptClass": "Diagnosis",
+        "dataType": "N/A",
+        "hiNormal": null,
+        "lowNormal": null,
+        "mappings": [
+          {
+            "code": "T68",
+            "name": "Hypothermia",
+            "source": "ICD 10 - WHO"
+          }
+        ],
+        "name": "Hypothermia",
+        "set": false,
+        "shortName": "Hypothermia",
+        "uuid": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0"
+      },
+      "comments": "",
+      "creatorName": "Eric Idle",
+      "diagnosisDateTime": "2019-10-18T16:04:04.000+0530",
+      "diagnosisStatusConcept": null,
+      "encounterUuid": "9759abd0-11b8-40d2-89ed-bb784e823423",
+      "existingObs": "30fe21d6-088c-42ce-af48-0df3d05d1ce2",
+      "firstDiagnosis": {
+        "certainty": "CONFIRMED",
+        "codedAnswer": {
+          "conceptClass": "Diagnosis",
+          "dataType": "N/A",
+          "hiNormal": null,
+          "lowNormal": null,
+          "mappings": [
+            {
+              "code": "T68",
+              "name": "Hypothermia",
+              "source": "ICD 10 - WHO"
+            }
+          ],
+          "name": "Hypothermia",
+          "set": false,
+          "shortName": "Hypothermia",
+          "uuid": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0"
+        },
+        "comments": "",
+        "creatorName": "Eric Idle",
+        "diagnosisDateTime": "2019-10-18T16:04:04.000+0530",
+        "diagnosisStatusConcept": null,
+        "encounterUuid": "9759abd0-11b8-40d2-89ed-bb784e823423",
+        "existingObs": "30fe21d6-088c-42ce-af48-0df3d05d1ce2",
+        "firstDiagnosis": null,
+        "freeTextAnswer": null,
+        "latestDiagnosis": null,
+        "order": "PRIMARY",
+        "previousObs": null,
+        "providers": [
+          {
+            "encounterRoleUuid": "a0b03050-c99b-11e0-9572-0800200c9a66",
+            "name": "Eric Idle",
+            "uuid": "9c4d72f8-a8ab-4921-9f44-2a026c3fb841"
+          }
+        ],
+        "revised": false,
+        "voidReason": null,
+        "voided": false
+      },
+      "freeTextAnswer": null,
+      "latestDiagnosis": null,
+      "order": "PRIMARY",
+      "previousObs": null,
+      "providers": [
+        {
+          "encounterRoleUuid": "a0b03050-c99b-11e0-9572-0800200c9a66",
+          "name": "Eric Idle",
+          "uuid": "9c4d72f8-a8ab-4921-9f44-2a026c3fb841"
+        }
+      ],
+      "revised": false,
+      "voidReason": null,
+      "voided": false
+    }
+  ],
+  "context": {},
+  "disposition": null,
+  "drugOrders": [],
+  "encounterDateTime": "2019-10-18T15:28:05.000+0530",
+  "encounterType": "Consultation",
+  "encounterTypeUuid": "81852aee-3f10-11e4-adec-0800271c1b75",
+  "encounterUuid": "9759abd0-11b8-40d2-89ed-bb784e823423",
+  "extensions": {
+    "mdrtbSpecimen": []
+  },
+  "locationName": "Hospital Registration Desk",
+  "locationUuid": "c5854fd7-3f12-11e4-adec-0800271c1b75",
+  "observations": [],
+  "orders": [],
+  "patientId": "NEHR123456",
+  "patientProgramUuid": null,
+  "patientUuid": "8b4a90d7-726e-4d3f-9457-11327af15cfd",
+  "providers": [
+    {
+      "encounterRoleUuid": "a0b03050-c99b-11e0-9572-0800200c9a66",
+      "name": "Eric Idle",
+      "uuid": "9c4d72f8-a8ab-4921-9f44-2a026c3fb841"
+    }
+  ],
+  "reason": null,
+  "visitType": null,
+  "visitTypeUuid": "c23d6c9d-3f10-11e4-adec-0800271c1b75",
+  "visitUuid": "6fb1f0d3-187b-45c6-a819-10d32af78d8b"
+}

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -7,6 +7,7 @@ import uuid
 from django.test import SimpleTestCase, TestCase
 
 import mock
+from testil import eq
 
 from casexml.apps.case.models import CommCareCase
 
@@ -25,6 +26,7 @@ from corehq.motech.openmrs.const import (
 )
 from corehq.motech.openmrs.exceptions import DuplicateCaseMatch
 from corehq.motech.openmrs.openmrs_config import (
+    ObservationMapping,
     OpenmrsCaseConfig,
     OpenmrsConfig,
 )
@@ -39,7 +41,12 @@ from corehq.motech.openmrs.repeater_helpers import (
     save_match_ids,
 )
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
-from corehq.motech.value_source import CaseTriggerInfo, get_case_location
+from corehq.motech.value_source import (
+    CaseTriggerInfo,
+    ConstantString,
+    FormQuestionMap,
+    get_case_location,
+)
 from corehq.util.test_utils import TestFileMixin, _create_case
 
 DOMAIN = 'openmrs-repeater-tests'
@@ -602,7 +609,67 @@ class SaveMatchIdsTests(SimpleTestCase):
             save_match_ids(self.case, self.case_config, self.patient)
 
 
-class DocTests(SimpleTestCase):
+def test_observation_mappings():
+    repeater = OpenmrsRepeater.wrap({
+        "openmrs_config": {
+            "openmrs_provider": "",
+            "case_config": {},
+            "form_configs": [{
+                "xmlns": "http://openrosa.org/formdesigner/9ECA0608-307A-4357-954D-5A79E45C3879",
+                "openmrs_encounter_type": "81852aee-3f10-11e4-adec-0800271c1b75",
+                "openmrs_visit_type": "c23d6c9d-3f10-11e4-adec-0800271c1b75",
+                "openmrs_observations": [
+                    {
+                        "concept": "397b9631-2911-435a-bf8a-ae4468b9c1d4",
+                        "case_property": "abnormal_temperature",
+                        "value": {
+                            "doc_type": "FormQuestionMap",
+                            "form_question": "/data/abnormal_temperature",
+                            "value_map": {
+                                "yes": "05ced69b-0790-4aad-852f-ba31fe82fbd9",
+                                "no": "eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0"
+                            },
+                        },
+                    },
+                    {
+                        "concept": "397b9631-2911-435a-bf8a-ae4468b9c1d4",
+                        "case_property": "bahmni_abnormal_temperature",
+                        "value": {
+                            "doc_type": "ConstantString",
+                            "value": "",
+                            "direction": "in",
+                        },
+                    },
+                ]
+            }]
+        }
+    })
+    observation_mappings = repeater.observation_mappings
+    eq(observation_mappings, {
+        '397b9631-2911-435a-bf8a-ae4468b9c1d4': [
+            ObservationMapping(
+                concept='397b9631-2911-435a-bf8a-ae4468b9c1d4',
+                case_property='abnormal_temperature',
+                value=FormQuestionMap(
+                    form_question='/data/abnormal_temperature',
+                    value_map={
+                        'yes': '05ced69b-0790-4aad-852f-ba31fe82fbd9',
+                        'no': 'eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0'
+                    }
+                )
+            ),
+            ObservationMapping(
+                concept='397b9631-2911-435a-bf8a-ae4468b9c1d4',
+                case_property='bahmni_abnormal_temperature',
+                value=ConstantString(
+                    direction='in',
+                    doc_type='ConstantString',
+                    value=''
+                )
+            )
+        ]
+    })
+
 
     def test_doctests(self):
         results = doctest.testmod(corehq.motech.openmrs.repeater_helpers)

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -671,6 +671,6 @@ def test_observation_mappings():
     })
 
 
-    def test_doctests(self):
-        results = doctest.testmod(corehq.motech.openmrs.repeater_helpers)
-        self.assertEqual(results.failed, 0)
+def test_doctests():
+    results = doctest.testmod(corehq.motech.openmrs.repeater_helpers)
+    assert results.failed == 0

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -112,7 +112,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
     username = StringProperty()
     password = StringProperty()
     skip_cert_verify = BooleanProperty(default=False)
-    notify_addresses_str = StringProperty()
+    notify_addresses_str = StringProperty(default="")
 
     friendly_name = _("Data")
     paused = BooleanProperty(default=False)

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -9,6 +9,8 @@ import corehq.motech.value_source
 from corehq.motech.value_source import (
     CaseProperty,
     CaseTriggerInfo,
+    FormQuestionMap,
+    ValueSource,
     get_form_question_values,
 )
 
@@ -114,3 +116,53 @@ class CasePropertyValidationTests(SimpleTestCase):
         case_property = CaseProperty.wrap({"case_property": None})
         with self.assertRaisesRegexp(BadValueError, "Property case_property is required."):
             case_property.validate()
+
+
+class WrapTests(SimpleTestCase):
+
+    def test_wrap_subclass(self):
+        doc = {
+            "doc_type": "FormQuestionMap",
+            "form_question": "/data/abnormal_temperature",
+            "value_map": {
+                "yes": "05ced69b-0790-4aad-852f-ba31fe82fbd9",
+                "no": "eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0"
+            },
+        }
+        form_question_map = ValueSource.wrap(doc)
+        self.assertIsInstance(form_question_map, ValueSource)
+        self.assertIsInstance(form_question_map, FormQuestionMap)
+
+    def test_subclass_wrap(self):
+        doc = {
+            "doc_type": "FormQuestionMap",
+            "form_question": "/data/abnormal_temperature",
+            "value_map": {
+                "yes": "05ced69b-0790-4aad-852f-ba31fe82fbd9",
+                "no": "eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0"
+            },
+        }
+        form_question_map = FormQuestionMap.wrap(doc)
+        self.assertIsInstance(form_question_map, ValueSource)
+        self.assertIsInstance(form_question_map, FormQuestionMap)
+
+    def test_wrap_class(self):
+        """
+        Wrapping a ValueSource instance should return None.
+
+        ValueSource must be subclassed because ValueSource.get_value
+        raises NotImplementedError.
+        """
+        doc = {
+            "doc_type": "ValueSource"
+        }
+        value_source = ValueSource.wrap(doc)
+        self.assertIsNone(value_source)
+
+    def test_wrap_something_else(self):
+        doc = {
+            "doc_type": "Foo",
+            "foo": "bar"
+        }
+        foo = ValueSource.wrap(doc)
+        self.assertIsNone(foo)

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -72,7 +72,7 @@ class ValueSource(DocumentSchema):
 
     def __eq__(self, other):
         return (
-            isinstance(other, ValueSource)
+            isinstance(other, self.__class__)
             and self.doc_type == other.doc_type
             and self.external_data_type == other.external_data_type
             and self.commcare_data_type == other.commcare_data_type


### PR DESCRIPTION
##### SUMMARY
Bahmni is a hospital management system built on top of OpenMRS. In OpenMRS an Encounter object has zero or more Observations. Bahmni allows an OpenMRS Encounter also to include zero or more Diagnosis instances. An example of a diagnosis might be "hypothermia" or "contact dermatitis". 

This change allows us to import the Diagnoses of an Encounter. A Diagnosis doesn't have a "value" attribute the way an Observation does, so we use its "name" attribute instead.

##### FEATURE FLAG
"OpenMRS integration"

##### PRODUCT DESCRIPTION
Support for importing diagnoses from Bahmni.
