### PR TITLE
Remove emord from couch -> SQL migration owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@
 /corehq/apps/commtrack/ @esoergel
 /corehq/apps/commtrack/static/ @esoergel @orangejenny
 /corehq/apps/commtrack/templates/ @esoergel @orangejenny
-/corehq/apps/couch_sql_migration/ @snopoke @emord @millerdev
+/corehq/apps/couch_sql_migration/ @snopoke @millerdev
 /corehq/apps/es/ @esoergel @proteusvacuum
 /corehq/apps/hqwebapp/ @orangejenny
 /corehq/apps/locations/ @esoergel


### PR DESCRIPTION
Originally added myself when i thought I was going to work on the model migraiton, and will add myself back when that happens