### PR TITLE
Replaced ConditionalAggregationColumn with ConditionalAggregationRangesColumn

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1412,7 +1412,7 @@ value falls within those ranges.
 
 There are two types: ``conditional_aggregation`` for most values, and
 ``conditional_aggregation_age_in_months``, where the given field must be a date
-and the buckets are based on the number of moonths since that date.
+and the buckets are based on the number of months since that date.
 
 Here's an example that groups children based on their age at the time of
 registration:

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1406,13 +1406,13 @@ Keep in mind that the only variables available for formatting are
 ConditionalAggregationRangesColumn
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**NOTE** This feature is only available to static UCR reports maintained
-by Dimagi developers.
+Conditional aggregation columns allow you to define a series of ranges
+with corresponding names, then group together rows where a specific field's
+value falls within those ranges.
 
-Conditional aggregation columns allow you to define a series of
-conditional expressions with corresponding names, then group together
-rows which which meet the same conditions. They have a type of
-``"conditional_aggregation"``.
+There are two types: ``conditional_aggregation`` for most values, and
+``conditional_aggregation_age_in_months``, where the given field must be a date
+and the buckets are based on the number of moonths since that date.
 
 Here's an example that groups children based on their age at the time of
 registration:
@@ -1423,33 +1423,33 @@ registration:
        "display": "age_range",
        "column_id": "age_range",
        "type": "conditional_aggregation",
-       "whens": {
-           "0 <= age_at_registration AND age_at_registration < 12": "infant",
-           "12 <= age_at_registration AND age_at_registration < 36": "toddler",
-           "36 <= age_at_registration AND age_at_registration < 60": "preschooler"
+       "field": "age_at_registration",
+       "ranges": {
+            "infant": [0, 12],
+            "toddler": [12, 36],
+            "preschooler": [36, 60]
        },
        "else_": "older"
    }
 
-The ``"whens"`` attribute maps conditional expressions to labels. If
-none of the conditions are met, the row will receive the ``"else_"``
-value, if provided.
+The ``"ranges"`` attribute maps conditional expressions to labels. If the field's value
+does not fall into any of these ranges, the row will receive the ``"else_"`` value, if provided.
 
-Here's a more complex example which uses SQL functions to dynamically
-calculate ranges based on a date property:
+Here's an example using ``conditional_aggregation_age_in_months``:
 
 .. code:: json
 
    {
        "display": "Age Group",
        "column_id": "age_group",
-       "type": "conditional_aggregation",
+       "type": "conditional_aggregation_age_in_months",
+       "field": "dob",
        "whens": {
-           "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 0 and 5": "0_to_5",
-           "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 6 and 11": "6_to_11",
-           "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 12 and 35": "12_to_35",
-           "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 36 and 59": "36_to_59",
-           "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 60 and 71": "60_to_71"
+            "0_to_5": [0, 5],
+            "6_to_11": [6, 11],
+            "12_to_35": [12, 35],
+            "36_to_59": [36, 59],
+            "60_to_71": [60, 71],
        }
    }
 

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1403,8 +1403,8 @@ Keep in mind that the only variables available for formatting are
 | "%b (%y)" | "Sep (08)"        |
 +-----------+-------------------+
 
-ConditionalAggregationColumn
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ConditionalAggregationRangesColumn
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **NOTE** This feature is only available to static UCR reports maintained
 by Dimagi developers.

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1427,8 +1427,8 @@ registration:
        "type": "integer_buckets",
        "field": "age_at_registration",
        "ranges": {
-            "infant": [0, 12],
-            "toddler": [12, 36],
+            "infant": [0, 11],
+            "toddler": [12, 35],
             "preschooler": [36, 60]
        },
        "else_": "older"
@@ -1446,7 +1446,7 @@ Here's an example using ``age_in_months_buckets``:
        "column_id": "age_group",
        "type": "age_in_months_buckets",
        "field": "dob",
-       "whens": {
+       "ranges": {
             "0_to_5": [0, 5],
             "6_to_11": [6, 11],
             "12_to_35": [12, 35],

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1408,7 +1408,8 @@ ConditionalAggregationRangesColumn
 
 Conditional aggregation columns allow you to define a series of ranges
 with corresponding names, then group together rows where a specific field's
-value falls within those ranges.
+value falls within those ranges. These ranges are inclusive, since they are implemented
+using the ``between`` operator.
 
 There are two types: ``conditional_aggregation`` for most values, and
 ``conditional_aggregation_age_in_months``, where the given field must be a date

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1403,16 +1403,17 @@ Keep in mind that the only variables available for formatting are
 | "%b (%y)" | "Sep (08)"        |
 +-----------+-------------------+
 
-ConditionalAggregationRangesColumn
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+IntegerBucketsColumn and AgeInMonthsBucketsColumn
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Conditional aggregation columns allow you to define a series of ranges
-with corresponding names, then group together rows where a specific field's
-value falls within those ranges. These ranges are inclusive, since they are implemented
-using the ``between`` operator.
+Bucket columns allow you to define a series of ranges with corresponding names,
+then group together rows where a specific field's value falls within those ranges.
+These ranges are inclusive, since they are implemented using the ``between`` operator.
+It is the user's responsibility to make sure the ranges do not overlap; if a value
+falls into multiple ranges, it is undefined behavior which bucket it will be assigned to.
 
-There are two types: ``conditional_aggregation`` for most values, and
-``conditional_aggregation_age_in_months``, where the given field must be a date
+There are two types: ``integer_buckets`` for integer values, and
+``age_in_months_buckets``, where the given field must be a date
 and the buckets are based on the number of months since that date.
 
 Here's an example that groups children based on their age at the time of
@@ -1423,7 +1424,7 @@ registration:
    {
        "display": "age_range",
        "column_id": "age_range",
-       "type": "conditional_aggregation",
+       "type": "integer_buckets",
        "field": "age_at_registration",
        "ranges": {
             "infant": [0, 12],
@@ -1436,14 +1437,14 @@ registration:
 The ``"ranges"`` attribute maps conditional expressions to labels. If the field's value
 does not fall into any of these ranges, the row will receive the ``"else_"`` value, if provided.
 
-Here's an example using ``conditional_aggregation_age_in_months``:
+Here's an example using ``age_in_months_buckets``:
 
 .. code:: json
 
    {
        "display": "Age Group",
        "column_id": "age_group",
-       "type": "conditional_aggregation_age_in_months",
+       "type": "age_in_months_buckets",
        "field": "dob",
        "whens": {
             "0_to_5": [0, 5],

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -8,7 +8,7 @@ from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.reports.specs import (
     AggregateDateColumn,
-    ConditionalAggregationColumn,
+    ConditionalAggregationRangesColumn,
     ConditionalAggregationAgeInMonthsRangesColumn,
     ExpandedColumn,
     ExpressionColumn,
@@ -26,7 +26,7 @@ from corehq.apps.userreports.reports.specs import (
 class ReportColumnFactory(object):
     class_map = {
         'aggregate_date': AggregateDateColumn,
-        'conditional_aggregation': ConditionalAggregationColumn,
+        'conditional_aggregation': ConditionalAggregationRangesColumn,
         'conditional_aggregation_age_in_months': ConditionalAggregationAgeInMonthsRangesColumn,
         'sum_when': SumWhenColumn,
         'expanded': ExpandedColumn,

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -7,12 +7,12 @@ from jsonobject.exceptions import BadValueError
 
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.reports.specs import (
+    AgeInMonthsBucketsColumn,
     AggregateDateColumn,
-    ConditionalAggregationRangesColumn,
-    ConditionalAggregationAgeInMonthsRangesColumn,
     ExpandedColumn,
     ExpressionColumn,
     FieldColumn,
+    IntegerBucketsColumn,
     LocationColumn,
     MultibarAggregateChartSpec,
     MultibarChartSpec,
@@ -25,15 +25,15 @@ from corehq.apps.userreports.reports.specs import (
 
 class ReportColumnFactory(object):
     class_map = {
+        'age_in_months_buckets': AgeInMonthsBucketsColumn,
         'aggregate_date': AggregateDateColumn,
-        'conditional_aggregation': ConditionalAggregationRangesColumn,
-        'conditional_aggregation_age_in_months': ConditionalAggregationAgeInMonthsRangesColumn,
-        'sum_when': SumWhenColumn,
         'expanded': ExpandedColumn,
-        'field': FieldColumn,
-        'percent': PercentageColumn,
-        'location': LocationColumn,
         'expression': ExpressionColumn,
+        'field': FieldColumn,
+        'integer_buckets': IntegerBucketsColumn,
+        'location': LocationColumn,
+        'percent': PercentageColumn,
+        'sum_when': SumWhenColumn,
     }
 
     @classmethod

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -9,6 +9,7 @@ from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.reports.specs import (
     AggregateDateColumn,
     ConditionalAggregationColumn,
+    ConditionalAggregationAgeInMonthsRangesColumn,
     ExpandedColumn,
     ExpressionColumn,
     FieldColumn,
@@ -26,6 +27,7 @@ class ReportColumnFactory(object):
     class_map = {
         'aggregate_date': AggregateDateColumn,
         'conditional_aggregation': ConditionalAggregationColumn,
+        'conditional_aggregation_age_in_months': ConditionalAggregationAgeInMonthsRangesColumn,
         'sum_when': SumWhenColumn,
         'expanded': ExpandedColumn,
         'field': FieldColumn,

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -333,7 +333,7 @@ class _CaseExpressionColumn(ReportColumn):
         return [self.column_id]
 
 
-class ConditionalAggregationColumn(_CaseExpressionColumn):
+class ConditionalAggregationRangesColumn(_CaseExpressionColumn):
     """Used for grouping by SQL conditionals"""
     type = TypeProperty('conditional_aggregation')
     _agg_column_type = ConditionalAggregation
@@ -356,7 +356,7 @@ class ConditionalAggregationColumn(_CaseExpressionColumn):
         return "{} between {} and {}".format(self.field, bounds[0], bounds[1])
 
 
-class ConditionalAggregationAgeInMonthsRangesColumn(ConditionalAggregationColumn):
+class ConditionalAggregationAgeInMonthsRangesColumn(ConditionalAggregationRangesColumn):
     type = TypeProperty('conditional_aggregation_age_in_months')
 
     def _base_expression(self, bounds):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -333,9 +333,9 @@ class _CaseExpressionColumn(ReportColumn):
         return [self.column_id]
 
 
-class ConditionalAggregationRangesColumn(_CaseExpressionColumn):
+class IntegerBucketsColumn(_CaseExpressionColumn):
     """Used for grouping by SQL conditionals"""
-    type = TypeProperty('conditional_aggregation')
+    type = TypeProperty('integer_buckets')
     _agg_column_type = ConditionalAggregation
     field = StringProperty(required=True)
     ranges = DictProperty()
@@ -356,8 +356,8 @@ class ConditionalAggregationRangesColumn(_CaseExpressionColumn):
         return "{} between {} and {}".format(self.field, bounds[0], bounds[1])
 
 
-class ConditionalAggregationAgeInMonthsRangesColumn(ConditionalAggregationRangesColumn):
-    type = TypeProperty('conditional_aggregation_age_in_months')
+class AgeInMonthsBucketsColumn(IntegerBucketsColumn):
+    type = TypeProperty('age_in_months_buckets')
 
     def _base_expression(self, bounds):
         return "extract(year from age({}))*12 + extract(month from age({})) BETWEEN {} and {}".format(

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -346,7 +346,7 @@ class ConditionalAggregationRangesColumn(_CaseExpressionColumn):
             if len(bounds) != 2:
                 raise BadSpecError('Range must contain 2 items, contains {}'.format(len(bounds)))
             try:
-                bounds = [float(b) for b in bounds]
+                bounds = [int(b) for b in bounds]
             except ValueError:
                 raise BadSpecError('Invalid range: [{}, {}]'.format(bounds[0], bounds[1]))
             whens.update({self._base_expression(bounds): bindparam(None, value)})

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -364,7 +364,7 @@ class SumWhenColumn(_CaseExpressionColumn):
         # so this column type is only available for static reports.  To release this,
         # we should require that conditions be expressed using a PreFilterValue type
         # syntax, as attempted in commit 02833e28b7aaf5e0a71741244841ad9910ffb1e5
-        return False
+        return True
 
 
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -349,8 +349,19 @@ class ConditionalAggregationColumn(_CaseExpressionColumn):
                 bounds = [float(b) for b in bounds]
             except ValueError:
                 raise BadSpecError('Invalid range: [{}, {}]'.format(bounds[0], bounds[1]))
-            whens.update({"{} between {} and {}".format(self.field, bounds[0], bounds[1]): bindparam(None, value)})
+            whens.update({self._base_expression(bounds): bindparam(None, value)})
         return whens
+
+    def _base_expression(self, bounds):
+        return "{} between {} and {}".format(self.field, bounds[0], bounds[1])
+
+
+class ConditionalAggregationAgeInMonthsRangesColumn(ConditionalAggregationColumn):
+    type = TypeProperty('conditional_aggregation_age_in_months')
+
+    def _base_expression(self, bounds):
+        return "extract(year from age({}))*12 + extract(month from age({})) BETWEEN {} and {}".format(
+            self.field, self.field, bounds[0], bounds[1])
 
 
 class SumWhenColumn(_CaseExpressionColumn):

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1,5 +1,6 @@
 from django.http import HttpRequest
 from django.test import TestCase
+from datetime import datetime
 
 from corehq.apps.userreports.exceptions import UserReportsError
 from corehq.apps.userreports.models import (
@@ -561,12 +562,45 @@ class TestReportAggregationSQL(ConfigurableReportTestMixin, TestCase):
 
 class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
     @classmethod
+    def _relative_date(cls, month, day, year_offset=0):
+        year = datetime.utcnow().year + year_offset
+        return f"{year}-{month:02}-{day:02}"
+
+    @classmethod
+    def _relative_month(cls, month, year_offset=0):
+        year = datetime.utcnow().year + year_offset
+        return f"{year}-{month:02}"
+
+    @classmethod
     def _create_data(cls):
         for row in [
-            {"state": "MA", "city": "Boston", "number": 4, "age_at_registration": 1, "date": "2018-01-03"},
-            {"state": "MA", "city": "Boston", "number": 3, "age_at_registration": 5, "date": "2018-02-18"},
-            {"state": "MA", "city": "Cambridge", "number": 2, "age_at_registration": 8, "date": "2018-01-22"},
-            {"state": "TN", "city": "Nashville", "number": 1, "age_at_registration": 14, "date": "2017-01-03"},
+            {
+                "state": "MA",
+                "city": "Boston",
+                "number": 4,
+                "age_at_registration": 1,
+                "date": cls._relative_date(1, 3, year_offset=-1),
+            },
+            {
+                "state": "MA",
+                "city": "Boston", "number": 3,
+                "age_at_registration": 5,
+                "date": cls._relative_date(2, 18, year_offset=-1),
+            },
+            {
+                "state": "MA",
+                "city": "Cambridge",
+                "number": 2,
+                "age_at_registration": 8,
+                "date": cls._relative_date(1, 22, year_offset=-1),
+            },
+            {
+                "state": "TN",
+                "city": "Nashville",
+                "number": 1,
+                "age_at_registration": 14,
+                "date": cls._relative_date(1, 3, year_offset=-2),
+            },
         ]:
             cls._new_case(row).save()
 
@@ -841,9 +875,9 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
             view.export_table,
             [['foo',
               [['report_column_display_state', 'month', 'report_column_display_number'],
-               ['MA', '2018-01', 6],
-               ['MA', '2018-02', 3],
-               ['TN', '2017-01', 1]]]]
+               ['MA', self._relative_month(1, year_offset=-1), 6],
+               ['MA', self._relative_month(2, year_offset=-1), 3],
+               ['TN', self._relative_month(1, year_offset=-2), 1]]]]
         )
 
     def test_conditional_aggregation(self):
@@ -889,6 +923,51 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
             ['MA', '0-6', 7],
             ['MA', '7-12', 2],
             ['TN', '13+', 1],
+        ]:
+            self.assertIn(table_row, table)
+
+    def test_conditional_aggregation_age_in_months(self):
+        report_config = self._create_report(
+            aggregation_columns=[
+                'indicator_col_id_state',
+                'months_ago',
+            ],
+            columns=[
+                {
+                    'type': 'field',
+                    'display': 'state',
+                    'field': 'indicator_col_id_state',
+                    'column_id': 'state',
+                    'aggregation': 'simple'
+                },
+                {
+                    'type': 'conditional_aggregation_age_in_months',
+                    'display': 'months_ago',
+                    'column_id': 'months_ago',
+                    'field': 'date',
+                    'ranges': {
+                        '0-12': [0, 12],
+                        '12-24': [12, 24],
+                    },
+                    'else_': '24+'
+                },
+                {
+                    'type': 'field',
+                    'display': 'report_column_display_number',
+                    'field': 'indicator_col_id_number',
+                    'column_id': 'report_column_col_id_number',
+                    'aggregation': 'sum'
+                }
+            ],
+            filters=None,
+        )
+        view = self._create_view(report_config)
+        table = view.export_table[0][1]
+        self.assertEqual(len(table), 3)
+        for table_row in [
+            ['state', 'months_ago', 'report_column_display_number'],
+            ['MA', '12-24', 9],
+            ['TN', '24+', 1],
         ]:
             self.assertIn(table_row, table)
 

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -880,7 +880,7 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                ['TN', self._relative_month(1, year_offset=-2), 1]]]]
         )
 
-    def test_conditional_aggregation(self):
+    def test_integer_buckets(self):
         report_config = self._create_report(
             aggregation_columns=[
                 'indicator_col_id_state',
@@ -895,7 +895,7 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'aggregation': 'simple'
                 },
                 {
-                    'type': 'conditional_aggregation',
+                    'type': 'integer_buckets',
                     'display': 'age_range',
                     'column_id': 'age_range',
                     'field': 'age_at_registration',
@@ -926,7 +926,7 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
         ]:
             self.assertIn(table_row, table)
 
-    def test_bad_conditional_aggregation_specs(self):
+    def test_bad_integer_buckets_specs(self):
         report_config = self._create_report(
             aggregation_columns=[
                 'indicator_col_id_state',
@@ -941,7 +941,7 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'aggregation': 'simple'
                 },
                 {
-                    'type': 'conditional_aggregation',
+                    'type': 'integer_buckets',
                     'display': 'age_range',
                     'column_id': 'age_range',
                     'field': 'age_at_registration',
@@ -972,7 +972,7 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'aggregation': 'simple'
                 },
                 {
-                    'type': 'conditional_aggregation',
+                    'type': 'integer_buckets',
                     'display': 'age_range',
                     'column_id': 'age_range',
                     'field': 'age_at_registration',
@@ -989,7 +989,7 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
         with self.assertRaises(BadSpecError):
             view.export_table
 
-    def test_conditional_aggregation_age_in_months(self):
+    def test_age_in_months_buckets(self):
         report_config = self._create_report(
             aggregation_columns=[
                 'indicator_col_id_state',
@@ -1004,7 +1004,7 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'aggregation': 'simple'
                 },
                 {
-                    'type': 'conditional_aggregation_age_in_months',
+                    'type': 'age_in_months_buckets',
                     'display': 'months_ago',
                     'column_id': 'months_ago',
                     'field': 'date',

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -864,9 +864,10 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'type': 'conditional_aggregation',
                     'display': 'age_range',
                     'column_id': 'age_range',
-                    'whens': {
-                        "age_at_registration between 0 and 6": "0-6",
-                        "age_at_registration between 7 and 12": "7-12",
+                    'field': 'age_at_registration',
+                    'ranges': {
+                        '0-6': [0, 6],
+                        '7-12': [7, 12],
                     },
                     'else_': '13+'
                 },

--- a/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
@@ -109,13 +109,14 @@
       {
         "display": "Age Group",
         "column_id": "age_group",
-        "type": "conditional_aggregation",
-        "whens": {
-          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 0 and 5": "0_to_5",
-          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 6 and 11": "6_to_11",
-          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 12 and 35": "12_to_35",
-          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 36 and 59": "36_to_59",
-          "extract(year from age(dob))*12 + extract(month from age(dob)) BETWEEN 60 and 71": "60_to_71"
+        "type": "conditional_aggregation_age_in_months",
+        "field": "dob",
+        "ranges": {
+          "0_to_5": [0, 5],
+          "6_to_11": [6, 11],
+          "12_to_35": [12, 35],
+          "36_to_59": [36, 59],
+          "60_to_71": [60, 71]
         }
       },
       {

--- a/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
@@ -109,7 +109,7 @@
       {
         "display": "Age Group",
         "column_id": "age_group",
-        "type": "conditional_aggregation_age_in_months",
+        "type": "age_in_months_buckets",
         "field": "dob",
         "ranges": {
           "0_to_5": [0, 5],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3_children_registered.json
@@ -126,9 +126,10 @@
         "display": "Age Group",
         "column_id": "age_group",
         "type": "conditional_aggregation",
-        "whens": {
-            "age_at_reg BETWEEN 0 AND 2": "0_to_2",
-            "age_at_reg BETWEEN 3 AND 6": "3_to_6"
+        "field": "age_at_reg",
+        "ranges": {
+            "0_to_2": [0, 2],
+            "3_to_6": [3, 6]
         }
       },
       {

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3_children_registered.json
@@ -125,7 +125,7 @@
       {
         "display": "Age Group",
         "column_id": "age_group",
-        "type": "conditional_aggregation",
+        "type": "integer_buckets",
         "field": "age_at_reg",
         "ranges": {
             "0_to_2": [0, 2],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_5_child_nutrition.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_5_child_nutrition.json
@@ -125,7 +125,7 @@
       {
         "display": "Age Group",
         "column_id": "age_group",
-        "type": "conditional_aggregation",
+        "type": "integer_buckets",
         "field": "age_in_months",
         "ranges": {
             "6_to_35": [6, 35],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_5_child_nutrition.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_5_child_nutrition.json
@@ -126,9 +126,10 @@
         "display": "Age Group",
         "column_id": "age_group",
         "type": "conditional_aggregation",
-        "whens": {
-            "age_in_months BETWEEN 6 AND 35": "6_to_35",
-            "age_in_months BETWEEN 36 AND 72": "36_to_72"
+        "field": "age_in_months",
+        "ranges": {
+            "6_to_35": [6, 35],
+            "36_to_72": [36, 72]
         }
       },
       {

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_6b_pse_attendance_per_year.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_6b_pse_attendance_per_year.json
@@ -126,10 +126,11 @@
         "display": "Age Group",
         "column_id": "age_group",
         "type": "conditional_aggregation",
-        "whens": {
-            "age_in_months BETWEEN 36 AND 47": "36_to_47",
-            "age_in_months BETWEEN 48 AND 59": "48_to_59",
-            "age_in_months BETWEEN 60 AND 72": "60_to_72"
+        "field": "age_in_months",
+        "ranges": {
+            "36_to_47": [36, 47],
+            "48_to_59": [48, 59],
+            "60_to_72": [60, 72]
         }
       },
       {

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_6b_pse_attendance_per_year.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_6b_pse_attendance_per_year.json
@@ -125,7 +125,7 @@
       {
         "display": "Age Group",
         "column_id": "age_group",
-        "type": "conditional_aggregation",
+        "type": "integer_buckets",
         "field": "age_in_months",
         "ranges": {
             "36_to_47": [36, 47],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_7_growth_monitored.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_7_growth_monitored.json
@@ -125,7 +125,7 @@
       {
         "display": "Age Group",
         "column_id": "age_group",
-        "type": "conditional_aggregation",
+        "type": "integer_buckets",
         "field": "age_in_months",
         "ranges": {
             "0_to_11": [0, 11],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_7_growth_monitored.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_7_growth_monitored.json
@@ -126,10 +126,11 @@
         "display": "Age Group",
         "column_id": "age_group",
         "type": "conditional_aggregation",
-        "whens": {
-            "age_in_months BETWEEN 0 AND 11": "0_to_11",
-            "age_in_months BETWEEN 12 AND 35": "12_to_35",
-            "age_in_months BETWEEN 36 AND 60": "36_to_60"
+        "field": "age_in_months",
+        "ranges": {
+            "0_to_11": [0, 11],
+            "12_to_35": [12, 35],
+            "36_to_60": [36, 60]
         }
       },
       {


### PR DESCRIPTION
##### SUMMARY
Part of https://dimagi-dev.atlassian.net/browse/ICDS-871 as discussed [here](https://docs.google.com/document/d/1UxS--Zb4ISyVSEore2rjiDWbA2C7PhQNwacfluzdUJE/edit#) ("Option 1").

##### FEATURE FLAG
UCR

##### PRODUCT DESCRIPTION
This changes conditional aggregation columns so that instead of supporting an arbitrary expression, they now may now be used only to mark which of several labeled "buckets" a row falls into, based on a value of a single column. It also makes these columns available in dynamic reports - they're currently limited to static reports and only used by ICDS.