### PR TITLE
Mark moved forms as deleted and re-added in app diff

### DIFF
--- a/corehq/apps/app_manager/app_schemas/form_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/form_metadata.py
@@ -89,6 +89,7 @@ class _FormMetadataQuestion(FormQuestionResponse):
 
 class _FormMetadata(JsonObject):
     unique_id = StringProperty()
+    module_uid = StringProperty()
     name = DictProperty()
     short_comment = StringProperty()
     action_type = StringProperty()
@@ -146,6 +147,7 @@ class _AppSummaryFormDataGenerator(object):
     def _compile_form(self, form):
         form_meta = _FormMetadata(**{
             'unique_id': form.unique_id,
+            'module_uid': form.get_module().unique_id,
             'name': form.name,
             'short_comment': form.short_comment,
             'action_type': form.get_action_type(),

--- a/corehq/apps/app_manager/app_schemas/form_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/form_metadata.py
@@ -440,25 +440,14 @@ class _AppDiffGenerator(object):
         This is used for the "View Changed Items" filter in the UI
         """
         try:
-            for form in self._get_form_ancestors(item):
-                form.changes.contains_changes = True
             item.changes.contains_changes = True
+            if isinstance(item, _FormMetadataQuestion):
+                for form in [self._first_forms_by_id.get(item['form_id']),
+                             self._second_forms_by_id.get(item['form_id'])]:
+                    if form:
+                        form.changes.contains_changes = True
         except AttributeError:
             pass
-
-    def _get_form_ancestors(self, question):
-        """Returns forms from both apps with the same form_id.
-        If something other than a question is passed in, it will be ignored
-
-        """
-        ancestors = []
-        for tree in [self._first_forms_by_id, self._second_forms_by_id]:
-            try:
-                form_id = question['form_id']
-                ancestors.append(tree[form_id])
-            except KeyError:
-                continue
-        return ancestors
 
 
 def get_app_diff(app1, app2):

--- a/corehq/apps/app_manager/app_schemas/form_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/form_metadata.py
@@ -238,9 +238,11 @@ class _AppDiffGenerator(object):
         self.first = get_app_summary_formdata(app1.domain, app1)[0]
         self.second = get_app_summary_formdata(app2.domain, app2)[0]
 
-        self._first_by_id = {}
+        self._first_modules_by_id = {}
+        self._first_forms_by_id = {}
         self._first_questions_by_form_id = defaultdict(dict)
-        self._second_by_id = {}
+        self._second_modules_by_id = {}
+        self._second_forms_by_id = {}
         self._second_questions_by_form_id = defaultdict(dict)
         self._populate_id_caches()
 
@@ -254,17 +256,17 @@ class _AppDiffGenerator(object):
             id_cache[form_id][question_path] = question
 
         for module in self.first:
-            self._first_by_id[module['unique_id']] = module
+            self._first_modules_by_id[module['unique_id']] = module
             for form in module['forms']:
-                self._first_by_id[form['unique_id']] = form
+                self._first_forms_by_id[form['unique_id']] = form
                 for question in form['questions']:
                     add_question_to_id_cache(self._first_questions_by_form_id,
                                              form['unique_id'], question['value'], question)
 
         for module in self.second:
-            self._second_by_id[module['unique_id']] = module
+            self._second_modules_by_id[module['unique_id']] = module
             for form in module['forms']:
-                self._second_by_id[form['unique_id']] = form
+                self._second_forms_by_id[form['unique_id']] = form
                 for question in form['questions']:
                     add_question_to_id_cache(self._second_questions_by_form_id,
                                              form['unique_id'], question['value'], question)
@@ -273,12 +275,12 @@ class _AppDiffGenerator(object):
         """Finds all removed modules, forms, and questions from the second app
         """
         for module in self.first:
-            if module['unique_id'] not in self._second_by_id:
+            if module['unique_id'] not in self._second_modules_by_id:
                 self._mark_item_removed(module, 'module')
                 continue
 
             for form in module['forms']:
-                if form['unique_id'] not in self._second_by_id:
+                if form['unique_id'] not in self._second_forms_by_id:
                     self._mark_item_removed(form, 'form')
                     continue
 
@@ -297,7 +299,7 @@ class _AppDiffGenerator(object):
         """
         for second_module in self.second:
             try:
-                first_module = self._first_by_id[second_module['unique_id']]
+                first_module = self._first_modules_by_id[second_module['unique_id']]
                 for attribute in MODULE_ATTRIBUTES:
                     self._mark_attribute(first_module, second_module, attribute)
                 self._mark_forms(second_module['forms'])
@@ -324,7 +326,7 @@ class _AppDiffGenerator(object):
     def _mark_forms(self, second_forms):
         for second_form in second_forms:
             try:
-                first_form = self._first_by_id[second_form['unique_id']]
+                first_form = self._first_forms_by_id[second_form['unique_id']]
                 for attribute in FORM_ATTRIBUTES:
                     self._mark_attribute(first_form, second_form, attribute)
                 self._mark_questions(second_form['unique_id'], second_form['questions'])
@@ -450,7 +452,7 @@ class _AppDiffGenerator(object):
 
         """
         ancestors = []
-        for tree in [self._first_by_id, self._second_by_id]:
+        for tree in [self._first_forms_by_id, self._second_forms_by_id]:
             try:
                 form_id = question['form_id']
                 ancestors.append(tree[form_id])

--- a/corehq/apps/app_manager/app_schemas/form_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/form_metadata.py
@@ -282,7 +282,9 @@ class _AppDiffGenerator(object):
                 continue
 
             for form in module['forms']:
-                if form['unique_id'] not in self._second_forms_by_id:
+                second_form = self._second_forms_by_id.get(form['unique_id'])
+                if not second_form or form.module_uid != second_form.module_uid:
+                    # Also show moved form as deleted and re-added.
                     self._mark_item_removed(form, 'form')
                     continue
 
@@ -327,13 +329,15 @@ class _AppDiffGenerator(object):
 
     def _mark_forms(self, second_forms):
         for second_form in second_forms:
-            try:
+            first_form = self._first_forms_by_id.get(second_form['unique_id'])
+            if not first_form or first_form.module_uid != second_form.module_uid:
+                # Also show moved form as deleted and re-added.
+                self._mark_item_added(second_form, 'form')
+            else:
                 first_form = self._first_forms_by_id[second_form['unique_id']]
                 for attribute in FORM_ATTRIBUTES:
                     self._mark_attribute(first_form, second_form, attribute)
                 self._mark_questions(second_form['unique_id'], second_form['questions'])
-            except KeyError:
-                self._mark_item_added(second_form, 'form')
 
     def _mark_questions(self, form_id, second_questions):
         for second_question in second_questions:

--- a/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
+++ b/corehq/apps/app_manager/app_schemas/tests/test_app_diffs.py
@@ -103,6 +103,24 @@ class TestAppDiffs(_BaseTestAppDiffs, SimpleTestCase):
         first, second = get_app_diff(self.app1, self.app2)
         self.assertEqual(first[0]['forms'][1]['changes']['form']['type'], REMOVED)
 
+    def test_move_form(self):
+        # A moved form should show up as deleted and re-added
+        self.factory1.new_form(self.app1.modules[0])
+        self.factory1.new_basic_module('module_2', 'case')
+        self.factory2.new_form(self.app2.modules[0])
+        self.factory2.new_basic_module('module_2', 'case')
+
+        self.app2.rearrange_forms(
+            from_module_uid=self.app2.modules[0].unique_id,
+            to_module_uid=self.app2.modules[1].unique_id,
+            from_index=1,
+            to_index=1,
+        )
+
+        first, second = get_app_diff(self.app1, self.app2)
+        self.assertEqual(first[0]['forms'][1]['changes']['form']['type'], REMOVED)
+        self.assertEqual(second[1]['forms'][1]['changes']['form']['type'], ADDED)
+
     def test_add_question(self):
         self._add_question(self.app2.modules[0].forms[0])
         first, second = get_app_diff(self.app1, self.app2)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-90

##### SUMMARY
In the same vein as https://github.com/dimagi/commcare-hq/pull/25653

##### FEATURE FLAG
"Improved app changes view"

##### PRODUCT DESCRIPTION
This changes the way the app diff view displays forms that were moved from one module to another.  Previously, this didn't result in any highlighting, now it marks the old form as deleted, and the new form as added.
![image](https://user-images.githubusercontent.com/2367539/67239248-d3221a80-f41c-11e9-8bc4-ca79c0aa47b7.png)