### PR TITLE
Atom feed can update case.owner_id and case.name

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -392,3 +392,29 @@ def get_updates_from_bahmni_diagnoses(diagnoses, mappings):
             for mapping in mappings[codedanswer_uuid]:
                 fields[mapping.case_property] = mapping.value.deserialize(diag['codedAnswer'].get('name'))
     return fields
+
+
+def deep_update(dict_by_ref: dict, other: dict):
+    """
+    Recursively update ``dict_by_ref`` with values from ``other``.
+
+    >>> nested = {"inner": {"ham": "spam"}}
+    >>> deep_update(nested, {"inner": {"eggs": "spam"}})
+    >>> nested == {"inner": {"ham": "spam", "eggs": "spam"}}
+    True
+
+    >>> nested = {"inner": {"ham": "spam"}}
+    >>> deep_update(nested, {"inner": "SPAM"})
+    >>> nested
+    {'inner': 'SPAM'}
+
+    """
+    for key, value in other.items():
+        if (
+            key in dict_by_ref
+            and isinstance(dict_by_ref[key], dict)
+            and isinstance(value, dict)
+        ):
+            deep_update(dict_by_ref[key], value)
+        else:
+            dict_by_ref[key] = value

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -394,6 +394,21 @@ def get_updates_from_bahmni_diagnoses(diagnoses, mappings):
     return fields
 
 
+def has_case_updates(case_block_kwargs):
+    """
+    Returns True if case_block_kwargs contains case changes.
+
+    >>> has_case_updates({"owner_id": "123456", "update": {}})
+    True
+    >>> has_case_updates({"update": {}})
+    False
+
+    """
+    if case_block_kwargs.get("update"):
+        return True
+    return any(k for k in case_block_kwargs if k != "update")
+
+
 def deep_update(dict_by_ref: dict, other: dict):
     """
     Recursively update ``dict_by_ref`` with values from ``other``.

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -203,7 +203,6 @@ def get_addpatient_caseblock(case_type, owner, patient, repeater):
             create=True,
             case_id=case_id,
             owner_id=owner.user_id,
-            user_id=owner.user_id,
             case_type=case_type,
             case_name=case_name,
             external_id=patient['uuid'],

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -12,11 +12,11 @@ from mock import Mock, patch
 
 import corehq.motech.openmrs.atom_feed
 from corehq.motech.openmrs.atom_feed import (
+    get_case_block_kwargs_from_bahmni_diagnoses,
+    get_case_block_kwargs_from_observations,
     get_encounter_uuid,
     get_patient_uuid,
     get_timestamp,
-    get_updates_from_bahmni_diagnoses,
-    get_updates_from_observations,
     import_encounter,
 )
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
@@ -204,23 +204,23 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
             self.assertEqual(kwargs['device_id'], 'openmrs-atomfeed-123456')
             self.assertEqual(kwargs['xmlns'], 'http://commcarehq.org/openmrs-integration')
 
-    def test_get_updates_from_observations(self):
+    def test_get_case_block_kwargs_from_observations(self):
         encounter = self.get_json('encounter')
         observations = encounter['observations']
-        case_updates = get_updates_from_observations(
+        case_block_kwargs = get_case_block_kwargs_from_observations(
             observations,
             self.repeater.observation_mappings
         )
-        self.assertEqual(case_updates, {'height': 105})
+        self.assertEqual(case_block_kwargs, {'update': {'height': 105}})
 
-    def test_get_updates_from_bahmni_diagnoses(self):
+    def test_get_case_block_kwargs_from_bahmni_diagnoses(self):
         encounter = self.get_json('encounter_with_diagnoses')
         bahmni_diagnoses = encounter['bahmniDiagnoses']
-        case_updates = get_updates_from_bahmni_diagnoses(
+        case_block_kwargs = get_case_block_kwargs_from_bahmni_diagnoses(
             bahmni_diagnoses,
             self.repeater.observation_mappings
         )
-        self.assertEqual(case_updates, {'bahmni_hypothermia': 'Hypothermia'})
+        self.assertEqual(case_block_kwargs, {'update': {'bahmni_hypothermia': 'Hypothermia'}})
 
 
 def test_doctests():

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -162,11 +162,14 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                             "doc_type": "ObservationMapping",
                             "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
                             "value": {
-                                "doc_type": "FormQuestion",
+                                "doc_type": "FormQuestionMap",
                                 "form_question": "/data/bahmni_hypothermia",
+                                "value_map": {
+                                    "emergency_room_user_id": "Hypothermia",  # Value must match diagnosis name
+                                },
                                 "direction": "in",
                             },
-                            "case_property": "bahmni_hypothermia"
+                            "case_property": "owner_id"
                         }
                     ]
                 }]
@@ -220,7 +223,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
             bahmni_diagnoses,
             self.repeater.observation_mappings
         )
-        self.assertEqual(case_block_kwargs, {'update': {'bahmni_hypothermia': 'Hypothermia'}})
+        self.assertEqual(case_block_kwargs, {'owner_id': 'emergency_room_user_id', 'update': {}})
 
 
 def test_doctests():


### PR DESCRIPTION
##### SUMMARY
Allows importing patient data and observations from OpenMRS to update case.owner_id and case.name. This enables support for importing referrals from OpenMRS using observations or triggered by Bahmni diagnoses.

This branch builds on [nh/omrs/diagnoses](https://github.com/dimagi/commcare-hq/pull/25699):  Review :blowfish:  from [Refactor: Pull out get_fields_to_update()](https://github.com/dimagi/commcare-hq/commit/cae1cb89d46deb412dbe6d5b3c58047c7a4033f0)

##### FEATURE FLAG
"OpenMRS integration"

##### PRODUCT DESCRIPTION
Enables support for importing referrals from OpenMRS
