### PR TITLE
Updated path for india_now mock in test_thr_report

### DIFF
--- a/custom/icds_reports/tests/agg_tests/test_export_data.py
+++ b/custom/icds_reports/tests/agg_tests/test_export_data.py
@@ -22,15 +22,22 @@ class TestExportData(TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestExportData, cls).setUpClass()
+        now = '16:21:11 15 November 2017'
         cls.india_now_mock = mock.patch(
             'custom.icds_reports.utils.india_now',
-            new=mock.Mock(return_value='16:21:11 15 November 2017')
+            new=mock.Mock(return_value=now)
         )
         cls.india_now_mock.start()
+        cls.other_india_now_mock = mock.patch(
+            'custom.icds_reports.utils.mixins.india_now',
+            new=mock.Mock(return_value=now)
+        )
+        cls.other_india_now_mock.start()
 
     @classmethod
     def tearDownClass(cls):
         cls.india_now_mock.stop()
+        cls.other_india_now_mock.stop()
         super(TestExportData, cls).tearDownClass()
 
     def test_children_export(self):

--- a/custom/icds_reports/tests/agg_tests/test_export_data.py
+++ b/custom/icds_reports/tests/agg_tests/test_export_data.py
@@ -23,7 +23,7 @@ class TestExportData(TestCase):
     def setUpClass(cls):
         super(TestExportData, cls).setUpClass()
         cls.india_now_mock = mock.patch(
-            'custom.icds_reports.utils.mixins.india_now',
+            'custom.icds_reports.utils.india_now',
             new=mock.Mock(return_value='16:21:11 15 November 2017')
         )
         cls.india_now_mock.start()


### PR DESCRIPTION
##### SUMMARY
https://travis-ci.org/dimagi/commcare-hq/jobs/601507950 failed because the mock of `india_now` isn't working.

```
======================================================================
FAIL: custom.icds_reports.tests.agg_tests.test_export_data:TestExportData.test_thr_report
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/commcare-hq-ro/custom/icds_reports/tests/agg_tests/test_export_data.py", line 2315, in test_thr_report
    ['Year', 2017]]
AssertionError: Lists differ: [['Ta[1912 chars]:37:12 23 October 2019'], ['State', 'st1'], ['[65 chars]7]]]] != [['Ta[1912 chars]:37:13 23 October 2019'], ['State', 'st1'], ['[65 chars]7]]]]
First differing element 1:
...
   ['Export Info',
-   [['Generated at', '03:37:12 23 October 2019'],
?                             ^
+   [['Generated at', '03:37:13 23 October 2019'],
?                             ^
     ['State', 'st1'],
     ['District', 'd1'],
     ['Block', 'b1'],
     ['Month', 'May'],
     ['Year', 2017]]]]
```

Guessing this broke in https://github.com/dimagi/commcare-hq/commit/4a86929c43c031f794eef2acb7019afad5a355a3

Should this test run locally? I get `sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) relation "pg_dist_partition" does not exist`