### PR TITLE
add index on blobmeta table for efficient attachment deletion (take 2)

### DIFF
--- a/corehq/blobs/migrations/0010_auto_20191023_0938.py
+++ b/corehq/blobs/migrations/0010_auto_20191023_0938.py
@@ -1,7 +1,7 @@
 from django.db import migrations
 import partial_index
 
-
+from corehq.sql_db.migrations import partitioned
 
 CREATE_INDEX_SQL = """
     CREATE INDEX CONCURRENTLY IF NOT EXISTS "blobs_blobm_type_co_23e226_partial"
@@ -11,6 +11,7 @@ CREATE_INDEX_SQL = """
 DROP_INDEX_SQL = "DROP INDEX CONCURRENTLY IF EXISTS blobs_blobm_type_co_23e226_partial"
 
 
+@partitioned
 class Migration(migrations.Migration):
     atomic = False
 

--- a/corehq/blobs/migrations/0010_auto_20191023_0938.py
+++ b/corehq/blobs/migrations/0010_auto_20191023_0938.py
@@ -19,4 +19,8 @@ class Migration(migrations.Migration):
                 index=partial_index.PartialIndex(fields=['expires_on'], name='blobs_blobm_expires_ed7e3d_partial', unique=False, where=partial_index.PQ(expires_on__isnull=False)),
             )
         ]),
+        migrations.AddIndex(
+            model_name='blobmeta',
+            index=partial_index.PartialIndex(fields=['type_code', 'created_on'], name='blobs_blobm_type_co_23e226_partial', unique=False, where=partial_index.PQ(domain='icds-cas')),
+        ),
     ]

--- a/corehq/blobs/migrations/0010_auto_20191023_0938.py
+++ b/corehq/blobs/migrations/0010_auto_20191023_0938.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+import partial_index
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blobs', '0009_delete_blobexpiration'),
+    ]
+
+    operations = [
+        migrations.RunSQL(migrations.RunSQL.noop, migrations.RunSQL.noop, state_operations=[
+            migrations.RemoveIndex(
+                model_name='blobmeta',
+                name='blobs_blobm_expires_64b92d_partial',
+            ),
+            migrations.AddIndex(
+                model_name='blobmeta',
+                index=partial_index.PartialIndex(fields=['expires_on'], name='blobs_blobm_expires_ed7e3d_partial', unique=False, where=partial_index.PQ(expires_on__isnull=False)),
+            )
+        ]),
+    ]

--- a/corehq/blobs/migrations/0010_auto_20191023_0938.py
+++ b/corehq/blobs/migrations/0010_auto_20191023_0938.py
@@ -2,7 +2,17 @@ from django.db import migrations
 import partial_index
 
 
+
+CREATE_INDEX_SQL = """
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS "blobs_blobm_type_co_23e226_partial"
+    ON "blobs_blobmeta" ("type_code", "created_on")
+    WHERE "blobs_blobmeta"."domain" = 'icds-cas'
+"""
+DROP_INDEX_SQL = "DROP INDEX CONCURRENTLY IF EXISTS blobs_blobm_type_co_23e226_partial"
+
+
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         ('blobs', '0009_delete_blobexpiration'),
@@ -19,8 +29,16 @@ class Migration(migrations.Migration):
                 index=partial_index.PartialIndex(fields=['expires_on'], name='blobs_blobm_expires_ed7e3d_partial', unique=False, where=partial_index.PQ(expires_on__isnull=False)),
             )
         ]),
-        migrations.AddIndex(
-            model_name='blobmeta',
-            index=partial_index.PartialIndex(fields=['type_code', 'created_on'], name='blobs_blobm_type_co_23e226_partial', unique=False, where=partial_index.PQ(domain='icds-cas')),
+        migrations.RunSQL(
+            sql=CREATE_INDEX_SQL,
+            reverse_sql=DROP_INDEX_SQL,
+            state_operations=[
+                migrations.AddIndex(
+                    model_name='blobmeta',
+                    index=partial_index.PartialIndex(fields=['type_code', 'created_on'],
+                                                     name='blobs_blobm_type_co_23e226_partial', unique=False,
+                                                     where=partial_index.PQ(domain='icds-cas')),
+                ),
+            ]
         ),
     ]

--- a/corehq/blobs/migrations/0010_auto_20191023_0938.py
+++ b/corehq/blobs/migrations/0010_auto_20191023_0938.py
@@ -2,7 +2,6 @@ from django.db import migrations
 import partial_index
 
 from corehq.sql_db.migrations import partitioned
-
 CREATE_INDEX_SQL = """
     CREATE INDEX CONCURRENTLY IF NOT EXISTS "blobs_blobm_type_co_23e226_partial"
     ON "blobs_blobmeta" ("type_code", "created_on")

--- a/corehq/blobs/models.py
+++ b/corehq/blobs/models.py
@@ -76,7 +76,12 @@ class BlobMeta(PartitionedModel, Model):
                 fields=['expires_on'],
                 unique=False,
                 where=PQ(expires_on__isnull=False),
-            )
+            ),
+            PartialIndex(
+                fields=['type_code', 'created_on'],
+                unique=False,
+                where=PQ(domain='icds-cas'),
+            ),
         ]
 
     def __repr__(self):

--- a/corehq/blobs/models.py
+++ b/corehq/blobs/models.py
@@ -10,7 +10,7 @@ from django.db.models import (
     PositiveSmallIntegerField,
 )
 from memoized import memoized
-from partial_index import PartialIndex
+from partial_index import PartialIndex, PQ
 
 from corehq.sql_db.models import PartitionedModel, RestrictedManager
 
@@ -75,8 +75,8 @@ class BlobMeta(PartitionedModel, Model):
             PartialIndex(
                 fields=['expires_on'],
                 unique=False,
-                where='expires_on IS NOT NULL',
-            ),
+                where=PQ(expires_on__isnull=False),
+            )
         ]
 
     def __repr__(self):


### PR DESCRIPTION
rework of https://github.com/dimagi/commcare-hq/pull/25629

##### SUMMARY
This should speed up the [delete_old_images](https://github.com/dimagi/commcare-hq/blob/cc93bc6ab718bde08e8d16e374d5cc25eff94958/custom/icds/tasks/__init__.py#L15) tasks dramatically. The current query does a sequence scan on the table.

Only adding this for ICDS since the task is ICDS specific.

I think the main value of the partial query is to communicate that this index was specifically added for ICDS.