### PR TITLE
add service check for pillows

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -26,6 +26,7 @@ from soil import heartbeat
 
 from corehq.apps.app_manager.models import Application
 from corehq.apps.change_feed.connection import get_kafka_client
+from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.apps.es import GroupES
 from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.apps.hqadmin.escheck import check_es_cluster_health
@@ -235,14 +236,14 @@ def check_formplayer():
 def check_pillows():
     pillows = [
         pillow for pillow in get_all_pillow_instances()
-        if pillow in getattr(settings, 'ACTIVE_PILLOW_NAMES', [pillow.pillow_id])
+        if pillow.pillow_id in getattr(settings, 'ACTIVE_PILLOW_NAMES', [pillow.pillow_id])
         and isinstance(pillow.get_change_feed(), KafkaChangeFeed)
     ]
 
     failed_pillows = []
     for pillow in pillows:
         oldest_checkpoint = min(c.last_modified for c in pillow.checkpoint._get_checkpoints())
-        time_since_oldest = datetime.utcnow() - oldest_checkpoint
+        time_since_oldest = datetime.datetime.utcnow() - oldest_checkpoint
 
         # allow 60 second buffer since save only occurs after max is exceeded
         # and to account for delay between read and comparison


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds a service check for kafka pillows based on the idea that we can tell if a pillow has hung or crashed when it does not checkpoint. This should give us more visibility into pillow failures by triggering a site down alert. It does not fix the issue of pillows that are processing very slowly, the other half of the problems we have seen recently, but definitely seems better than nothing as we look to improve our pillow reporting. 

I was a bit concerned about pillows with very low volume but ran this on both ICDS and India and it passed, so those must checkpoint regularly even without new changes.