### PR TITLE
Update to django>=1.11.23,<2 (==1.11.25)

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -64,7 +64,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -56,7 +56,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -54,7 +54,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -59,7 +59,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -64,7 +64,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -56,7 +56,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -8,7 +8,7 @@ jsonobject-couchdbkit~=0.9
 git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 # required by django-digest
 decorator==4.0.11
-django>=1.11.22  # security update
+django>=1.11.23,<2  # security update
 django-braces==1.13.0
 django-celery-results~=1.0
 django-crispy-forms==1.7.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -54,7 +54,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -59,7 +59,7 @@ django-transfer==0.4
 django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
-django==1.11.22
+django==1.11.25
 djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore


### PR DESCRIPTION
##### SUMMARY
Comes from https://github.com/dimagi/commcare-hq/network/alert/requirements/prod-requirements.txt/django/open:

https://nvd.nist.gov/vuln/detail/CVE-2019-14234
https://nvd.nist.gov/vuln/detail/CVE-2019-14232
https://nvd.nist.gov/vuln/detail/CVE-2019-14235
https://nvd.nist.gov/vuln/detail/CVE-2019-14233

##### PRODUCT DESCRIPTION
This is a security fix, no user facing change.
