### PR TITLE
Fix 500 error on get_month_display(None)

### DIFF
--- a/corehq/apps/userreports/transforms/custom/date.py
+++ b/corehq/apps/userreports/transforms/custom/date.py
@@ -9,7 +9,7 @@ from dimagi.utils.dates import force_to_datetime
 def get_month_display(month_index):
     try:
         return calendar.month_name[int(month_index)]
-    except (KeyError, ValueError):
+    except (KeyError, ValueError, TypeError):
         return ""
 
 


### PR DESCRIPTION
##### SUMMARY
This is causing UCR errors during rebuild and on case-pillow

