### PR TITLE
Revert to daily feeding state based aggregation

### DIFF
--- a/custom/icds_reports/README.md
+++ b/custom/icds_reports/README.md
@@ -196,6 +196,13 @@ Otherwise reference the slow query section in troubleshooting.
 Currently any errors are emailed to the dashboard aggregation email group.
 The emails contain information such as the aggregation step that failed and a link to the log output of the task.
 
+Useful notes about Citus
+------------------------
+
+## Insert performance
+
+It's generally better to use many inserts to insert data as noted in the
+[Citus docs](https://docs.citusdata.com/en/v8.3/performance/performance_tuning.html#general)
 
 Troubleshooting
 ---------------

--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -30,6 +30,7 @@ STATE_TASKS = {
     'agg_ls_awc_mgt_form': _agg_ls_awc_mgt_form,
     'agg_ls_vhnd_form': _agg_ls_vhnd_form,
     'agg_beneficiary_form': _agg_beneficiary_form,
+    'aggregate_df_forms': _aggregate_df_forms,
 }
 
 ALL_STATES_TASKS = {
@@ -47,7 +48,6 @@ NORMAL_TASKS = {
     'agg_ccs_record': _agg_ccs_record_table,
     'agg_awc_table': _agg_awc_table,
     'aggregate_awc_daily': aggregate_awc_daily,
-    'aggregate_df_forms': _aggregate_df_forms,
 }
 
 

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -205,9 +205,11 @@ def move_ucr_data_into_aggregation_tables(date=None, intervals=2, force_citus=Fa
                     for state_id in state_ids
                 ]
                 stage_1_tasks.extend([
-                    icds_aggregation_task.si(
-                        date=calculation_date, func_name='_aggregate_df_forms', force_citus=force_citus
+                    icds_state_aggregation_task.si(
+                        state_id=state_id, date=monthly_date, func_name='_aggregate_df_forms',
+                        force_citus=force_citus
                     )
+                    for state_id in state_ids
                 ])
                 stage_1_tasks.extend([
                     icds_state_aggregation_task.si(state_id=state_id, date=monthly_date, func_name='_aggregate_cf_forms', force_citus=force_citus)
@@ -373,7 +375,6 @@ def icds_aggregation_task(self, date, func_name, force_citus=False):
             '_agg_ls_table': _agg_ls_table,
             '_update_months_table': _update_months_table,
             '_daily_attendance_table': _daily_attendance_table,
-            '_aggregate_df_forms': _aggregate_df_forms,
             '_agg_child_health_table': _agg_child_health_table,
             '_ccs_record_monthly_table': _ccs_record_monthly_table,
             '_agg_ccs_record_table': _agg_ccs_record_table,
@@ -416,13 +417,14 @@ def icds_state_aggregation_task(self, state_id, date, func_name, force_citus=Fal
             '_aggregate_child_health_pnc_forms': _aggregate_child_health_pnc_forms,
             '_aggregate_ccs_record_pnc_forms': _aggregate_ccs_record_pnc_forms,
             '_aggregate_delivery_forms': _aggregate_delivery_forms,
+            '_aggregate_df_forms': _aggregate_df_forms,
             '_aggregate_bp_forms': _aggregate_bp_forms,
             '_aggregate_awc_infra_forms': _aggregate_awc_infra_forms,
             '_child_health_monthly_table': _child_health_monthly_table,
             '_agg_ls_awc_mgt_form': _agg_ls_awc_mgt_form,
             '_agg_ls_vhnd_form': _agg_ls_vhnd_form,
             '_agg_beneficiary_form': _agg_beneficiary_form,
-            '_agg_thr_table': _agg_thr_table
+            '_agg_thr_table': _agg_thr_table,
         }[func_name]
 
         db_alias = get_icds_ucr_citus_db_alias()
@@ -466,8 +468,8 @@ def _aggregate_gm_forms(state_id, day):
 
 
 @track_time
-def _aggregate_df_forms(day):
-    AggregateChildHealthDailyFeedingForms.aggregate(force_to_date(day))
+def _aggregate_df_forms(state_id, day):
+    AggregateChildHealthDailyFeedingForms.aggregate(state_id, day)
 
 
 @track_time

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
@@ -1,5 +1,5 @@
-TRUNCATE "icds_dashboard_daily_feeding_forms"
-{}
+DELETE FROM "icds_dashboard_daily_feeding_forms" WHERE month=%(month)s AND state_id = %(state)s
+{"month": "2019-01-01", "state": "st1"}
 
         INSERT INTO "icds_dashboard_daily_feeding_forms" (
           state_id, supervisor_id, month, case_id, latest_time_end_processed,
@@ -18,9 +18,10 @@ TRUNCATE "icds_dashboard_daily_feeding_forms"
             ucr.supervisor_id = daily_attendance.supervisor_id AND
             daily_attendance.month=%(current_month_start)s
           )
-          WHERE ucr.timeend >= %(current_month_start)s AND ucr.timeend < %(next_month_start)s AND
-                ucr.child_health_case_id IS NOT NULL
+          WHERE ucr.timeend >= %(current_month_start)s AND ucr.timeend < %(next_month_start)s
+              AND ucr.child_health_case_id IS NOT NULL
+              AND ucr.state_id = %(state_id)s
           WINDOW w AS (PARTITION BY ucr.supervisor_id, ucr.child_health_case_id)
         )
         
-{"current_month_start": "2019-01-01", "month": "2019-01-01", "next_month_start": "2019-02-01"}
+{"current_month_start": "2019-01-01", "month": "2019-01-01", "next_month_start": "2019-02-01", "state_id": "st1"}


### PR DESCRIPTION
Basically reverts my work done in https://github.com/dimagi/commcare-hq/pull/25510

From what i can tell, this should better use resources when other inserts are occurring in parallel (as happens with the aggregation), 

I think there's still quite a bit to understand how to properly optimize each query for citus, but we'll probably get there