### PR TITLE
Reduce timewindow

### DIFF
--- a/custom/icds_reports/tests/agg_tests/test_aggregation_script.py
+++ b/custom/icds_reports/tests/agg_tests/test_aggregation_script.py
@@ -432,16 +432,10 @@ class InactiveAWWsTest(TestCase):
         with get_cursor(AggregateInactiveAWW) as cursor:
             cursor.execute(missing_location_query)
             cursor.execute(aggregation_query, agg_params)
+
         records = AggregateInactiveAWW.objects.filter(first_submission__isnull=False)
         self.assertEqual(records.count(), 46)
 
-    def test_submission_dates(self):
-        with freeze_time(self.agg_time):
-            missing_location_query = self.helper.missing_location_query()
-            aggregation_query, agg_params = self.helper.aggregate_query()
-        with get_cursor(AggregateInactiveAWW) as cursor:
-            cursor.execute(missing_location_query)
-            cursor.execute(aggregation_query, agg_params)
         record = AggregateInactiveAWW.objects.filter(awc_id='a10').first()
         self.assertEqual(date(2017, 4, 5), record.first_submission)
         self.assertEqual(date(2017, 5, 5), record.last_submission)

--- a/custom/icds_reports/tests/agg_tests/test_aggregation_script.py
+++ b/custom/icds_reports/tests/agg_tests/test_aggregation_script.py
@@ -417,7 +417,7 @@ class InactiveAWWsTest(TestCase):
         AggregateInactiveAWW.objects.all().delete()
 
     def test_missing_locations_query(self):
-        with freeze_time(datetime(2017, 4, 31, 18)):
+        with freeze_time(datetime(2017, 4, 10)):
             missing_location_query = self.helper.missing_location_query()
         with get_cursor(AggregateInactiveAWW) as cursor:
             cursor.execute(missing_location_query)
@@ -434,9 +434,9 @@ class InactiveAWWsTest(TestCase):
                 cursor.execute(aggregation_query, agg_params)
 
         # the agg considers only one month data, run it for 3 months of test data
-        run_agg(datetime(2017, 4, 31, 18))
-        run_agg(datetime(2017, 5, 31, 18))
-        run_agg(datetime(2017, 6, 31, 18))
+        run_agg(datetime(2017, 4, 10))
+        run_agg(datetime(2017, 5, 10))
+        run_agg(datetime(2017, 6, 10))
         records = AggregateInactiveAWW.objects.filter(first_submission__isnull=False)
         self.assertEqual(records.count(), 46)
 

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/inactive_awws.py
@@ -45,7 +45,7 @@ class InactiveAwwsAggregationDistributedHelper(BaseICDSAggregationDistributedHel
                 FIRST_VALUE(form_date) OVER forms as first_submission,
                 LAST_VALUE(form_date) OVER forms as last_submission
             FROM "{ucr_tablename}"
-            WHERE inserted_at >= %(last_sync)s AND month > %(six_months_ago)s AND form_date <= %(now)s
+            WHERE inserted_at >= %(last_sync)s AND month > %(one_month_ago)s AND form_date <= %(now)s
             WINDOW forms AS (
               PARTITION BY supervisor_id, awc_id
               ORDER BY form_date ASC RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
@@ -55,7 +55,7 @@ class InactiveAwwsAggregationDistributedHelper(BaseICDSAggregationDistributedHel
         ), {
             "last_sync": self.last_sync,
             "now": datetime.datetime.utcnow(),
-            "six_months_ago": datetime.datetime.utcnow() - relativedelta(months=6),
+            "one_month_ago": datetime.datetime.utcnow() - relativedelta(months=1),
         }
 
     def missing_location_query(self):

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/inactive-awws.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/inactive-awws.distributed.txt
@@ -36,7 +36,7 @@
                 FIRST_VALUE(form_date) OVER forms as first_submission,
                 LAST_VALUE(form_date) OVER forms as last_submission
             FROM "ucr_icds-cas_static-usage_forms_92fbe2aa"
-            WHERE inserted_at >= %(last_sync)s AND month > %(six_months_ago)s AND form_date <= %(now)s
+            WHERE inserted_at >= %(last_sync)s AND month > %(one_month_ago)s AND form_date <= %(now)s
             WINDOW forms AS (
               PARTITION BY supervisor_id, awc_id
               ORDER BY form_date ASC RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
@@ -57,4 +57,4 @@
             WHERE agg_table.awc_id = ut.awc_id;
             DROP TABLE "tmp_usage";
         
-{"last_sync": "2019-01-05T00:00:00", "now": "2019-01-11T00:00:00", "six_months_ago": "2018-07-11T00:00:00"}
+{"last_sync": "2019-01-05T00:00:00", "now": "2019-01-11T00:00:00", "one_month_ago": "2018-12-11T00:00:00"}


### PR DESCRIPTION
Currently, this agg is run daily and it takes about 7 hours and considers 6 months of data. If it runs every day, it doesn't really need to look at 6 months old data. Reducing this time window should reduce the amount of time it takes for this agg to run.