### PR TITLE
Use a different elasticsearch lib depending on the ES major version

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse
 from django.utils.decorators import classonlymethod, method_decorator
 from django.views.generic import View
 
-from elasticsearch.exceptions import ElasticsearchException, NotFoundError
+from corehq.util.es.elasticsearch import ElasticsearchException, NotFoundError
 
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.logging import notify_exception

--- a/corehq/apps/api/odata/tests/utils.py
+++ b/corehq/apps/api/odata/tests/utils.py
@@ -3,7 +3,7 @@ import base64
 from django.test import Client
 from django.urls import reverse
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 from tastypie.models import ApiKey
 
 from pillowtop.es_utils import initialize_index_and_mapping

--- a/corehq/apps/callcenter/tests/test_owner_options_view.py
+++ b/corehq/apps/callcenter/tests/test_owner_options_view.py
@@ -3,7 +3,7 @@ import math
 
 from django.test import TestCase
 
-from elasticsearch import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from pillowtop.es_utils import initialize_index_and_mapping
 

--- a/corehq/apps/case_search/tests/test_filter_dsl.py
+++ b/corehq/apps/case_search/tests/test_filter_dsl.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase, TestCase
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 from eulxml.xpath import parse as parse_xpath
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure

--- a/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
@@ -4,7 +4,7 @@ import uuid
 from django.core.management import call_command
 from django.test import TestCase
 
-from elasticsearch import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 from mock import MagicMock, patch
 from testil import tempdir
 

--- a/corehq/apps/es/management/commands/restore_es_snapshot.py
+++ b/corehq/apps/es/management/commands/restore_es_snapshot.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from elasticsearch.client import IndicesClient, SnapshotClient
+from corehq.util.es.elasticsearch import IndicesClient, SnapshotClient
 
 from pillowtop.models import str_to_kafka_seq
 from pillowtop.utils import get_all_pillow_instances

--- a/corehq/apps/export/esaccessors.py
+++ b/corehq/apps/export/esaccessors.py
@@ -1,4 +1,4 @@
-from elasticsearch import ElasticsearchException
+from corehq.util.es.elasticsearch import ElasticsearchException
 
 from corehq.apps.es import CaseES, FormES, GroupES
 from corehq.apps.es.sms import SMSES

--- a/corehq/apps/export/tests/test_export_filters.py
+++ b/corehq/apps/export/tests/test_export_filters.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from pillowtop.es_utils import initialize_index_and_mapping
 

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -4,7 +4,7 @@ import re
 from django.core.cache import cache
 from django.test import SimpleTestCase
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 from mock import patch
 from openpyxl import load_workbook
 

--- a/corehq/apps/hqadmin/management/commands/prune_elastic_indices.py
+++ b/corehq/apps/hqadmin/management/commands/prune_elastic_indices.py
@@ -1,9 +1,8 @@
 from django.core.management import BaseCommand
 
-import elasticsearch
-
 from corehq.elastic import get_es_new
 from corehq.pillows.utils import get_all_expected_es_indices
+from corehq.util.es import AuthorizationException
 
 
 class Command(BaseCommand):
@@ -69,7 +68,7 @@ def _delete_indices(es, to_delete):
         for index in to_delete:
             try:
                 es.indices.flush(index)
-            except elasticsearch.exceptions.AuthorizationException:
+            except AuthorizationException:
                 # already closed
                 pass
             es.indices.delete(index)
@@ -89,7 +88,7 @@ def _close_indices(es, to_close, noinput):
         for index in to_close:
             try:
                 es.indices.flush(index)
-            except elasticsearch.exceptions.AuthorizationException:
+            except AuthorizationException:
                 # already closed
                 pass
             es.indices.close(index)

--- a/corehq/apps/hqcase/tests/test_dbaccessors.py
+++ b/corehq/apps/hqcase/tests/test_dbaccessors.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import TestCase
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 from mock import patch
 
 from casexml.apps.case.dbaccessors import get_open_case_ids_in_domain

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -4,7 +4,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
-from elasticsearch import TransportError
+from corehq.util.es.elasticsearch import TransportError
 from memoized import memoized
 
 from corehq.apps.es import cases as case_es

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
 import pytz
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 from mock import patch
 
 from casexml.apps.case.const import CASE_ACTION_CREATE

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -15,7 +15,7 @@ from botocore.vendored.requests.packages.urllib3.exceptions import (
 from celery.schedules import crontab
 from celery.task import periodic_task, task
 from couchdbkit import ResourceConflict, ResourceNotFound
-from elasticsearch.exceptions import ConnectionTimeout
+from corehq.util.es.elasticsearch import ConnectionTimeout
 
 from couchexport.models import Format
 from dimagi.utils.chunked import chunked

--- a/corehq/apps/users/tests/test_get_domain_language.py
+++ b/corehq/apps/users/tests/test_get_domain_language.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from pillowtop.es_utils import initialize_index_and_mapping
 

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 from mock import MagicMock, patch
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -1,20 +1,18 @@
-import json
-from collections import namedtuple
 import copy
+import json
 import logging
 import time
-
+from collections import namedtuple
 from urllib.parse import unquote
 
-from corehq.util.json import CommCareJSONEncoder
-from dimagi.utils.chunked import chunked
 from django.conf import settings
-from elasticsearch import Elasticsearch, SerializationError
-from elasticsearch.exceptions import ElasticsearchException
+
+from memoized import memoized
+
+from dimagi.utils.chunked import chunked
+from pillowtop.processors.elastic import send_to_elasticsearch as send_to_es
 
 from corehq.apps.es.utils import flatten_field_dict
-from corehq.util.datadog.gauges import datadog_counter
-from corehq.util.files import TransientTempfile
 from corehq.pillows.mappings.app_mapping import APP_INDEX
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
@@ -26,8 +24,14 @@ from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
-from memoized import memoized
-from pillowtop.processors.elastic import send_to_elasticsearch as send_to_es
+from corehq.util.datadog.gauges import datadog_counter
+from corehq.util.es.elasticsearch import (
+    Elasticsearch,
+    ElasticsearchException,
+    SerializationError,
+)
+from corehq.util.files import TransientTempfile
+from corehq.util.json import CommCareJSONEncoder
 
 
 class ESJSONSerializer(object):

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -2,7 +2,7 @@ from dimagi.ext import jsonobject
 from django.conf import settings
 from copy import copy, deepcopy
 from datetime import datetime
-from elasticsearch import TransportError
+from corehq.util.es.elasticsearch import TransportError
 from pillowtop import get_all_pillow_classes
 from pillowtop.logger import pillow_logging
 

--- a/corehq/ex-submodules/pillowtop/management/commands/ptop_es_manage.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/ptop_es_manage.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 import simplejson
-from elasticsearch.exceptions import NotFoundError
+from corehq.util.es.elasticsearch import NotFoundError
 
 from corehq.elastic import get_es_new
 from corehq.pillows.utils import get_all_expected_es_indices

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -1,13 +1,13 @@
 import math
 import time
 
-from elasticsearch.exceptions import (
+from corehq.util.es.elasticsearch import (
     ConflictError,
     ConnectionError,
     NotFoundError,
     RequestError,
+    bulk,
 )
-from elasticsearch.helpers import bulk
 
 from pillowtop.exceptions import BulkDocExeption, PillowtopIndexingError
 from pillowtop.logger import pillow_logging

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
-from elasticsearch import TransportError
-from elasticsearch.helpers import bulk
+from corehq.util.es.elasticsearch import TransportError
+from corehq.util.es.elasticsearch import bulk
 
 from pillowtop.es_utils import (
     initialize_mapping_if_necessary,

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.conf import settings
 from django.test import SimpleTestCase
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.elastic import get_es_new
 from corehq.util.elastic import ensure_index_deleted
@@ -215,7 +215,7 @@ class TestSendToElasticsearch(SimpleTestCase):
 
     def test_connection_failure(self):
         def _bad_es_getter():
-            from elasticsearch import Elasticsearch
+            from corehq.util.es.elasticsearch import Elasticsearch
             return Elasticsearch(
                 [{
                     'host': settings.ELASTICSEARCH_HOST,

--- a/corehq/ex-submodules/pillowtop/tests/utils.py
+++ b/corehq/ex-submodules/pillowtop/tests/utils.py
@@ -1,5 +1,4 @@
-from django.conf import settings
-from elasticsearch import TransportError
+from corehq.util.es.elasticsearch import TransportError
 
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.es_utils import ElasticsearchIndexInfo

--- a/corehq/util/elastic.py
+++ b/corehq/util/elastic.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch import NotFoundError
+from corehq.util.es.elasticsearch import NotFoundError
 
 from corehq.util.test_utils import unit_testing_only
 

--- a/corehq/util/es/elasticsearch.py
+++ b/corehq/util/es/elasticsearch.py
@@ -40,3 +40,21 @@ elif settings.ELASTICSEARCH_MAJOR_VERSION == 2:
     from elasticsearch2.helpers import bulk
 else:
     raise ValueError("ELASTICSEARCH_MAJOR_VERSION must currently be 1 or 2")
+
+
+__all__ = [
+    'AuthorizationException',
+    'ConflictError',
+    'ConnectionError',
+    'ConnectionTimeout',
+    'Elasticsearch',
+    'ElasticsearchException',
+    'IndicesClient',
+    'NotFoundError',
+    'RequestError',
+    'SerializationError',
+    'SnapshotClient',
+    'TransportError',
+    'bulk',
+    'elasticsearch',
+]

--- a/corehq/util/es/elasticsearch.py
+++ b/corehq/util/es/elasticsearch.py
@@ -1,0 +1,42 @@
+from django.conf import settings
+
+if settings.ELASTICSEARCH_MAJOR_VERSION == 1:
+    import elasticsearch
+    from elasticsearch.exceptions import AuthorizationException
+    from elasticsearch import (
+        ConnectionError,
+        ConnectionTimeout,
+        Elasticsearch,
+        ElasticsearchException,
+        NotFoundError,
+        SerializationError,
+        ConflictError,
+        TransportError,
+        RequestError,
+    )
+    from elasticsearch.client import (
+        IndicesClient,
+        SnapshotClient,
+    )
+    from elasticsearch.helpers import bulk
+elif settings.ELASTICSEARCH_MAJOR_VERSION == 2:
+    import elasticsearch2 as elasticsearch
+    from elasticsearch2.exceptions import AuthorizationException
+    from elasticsearch2 import (
+        ConnectionError,
+        ConflictError,
+        ConnectionTimeout,
+        Elasticsearch,
+        ElasticsearchException,
+        NotFoundError,
+        SerializationError,
+        TransportError,
+        RequestError,
+    )
+    from elasticsearch2.client import (
+        IndicesClient,
+        SnapshotClient,
+    )
+    from elasticsearch2.helpers import bulk
+else:
+    raise ValueError("ELASTICSEARCH_MAJOR_VERSION must currently be 1 or 2")

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -69,6 +69,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 et-xmlfile==1.0.1         # via openpyxl
@@ -200,7 +201,7 @@ twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 unittest2==1.1.0
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk, transifex-client
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -61,6 +61,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 errand-boy==0.3.8
@@ -165,7 +166,7 @@ tropo-webapi-python==0.1.3
 twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 uwsgi==2.0.18
 vine==1.3.0               # via amqp

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -59,6 +59,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 et-xmlfile==1.0.1         # via openpyxl
@@ -148,7 +149,7 @@ tropo-webapi-python==0.1.3
 twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 weasyprint==0.42.3

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -64,6 +64,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 et-xmlfile==1.0.1         # via openpyxl
@@ -166,7 +167,7 @@ twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 unittest2==1.1.0
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 weasyprint==0.42.3

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -69,6 +69,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 et-xmlfile==1.0.1         # via openpyxl
@@ -200,7 +201,7 @@ twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 unittest2==1.1.0
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk, transifex-client
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -61,6 +61,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 errand-boy==0.3.8
@@ -165,7 +166,7 @@ tropo-webapi-python==0.1.3
 twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 uwsgi==2.0.18
 vine==1.3.0               # via amqp

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -20,6 +20,7 @@ dimagi-memoized==1.1.1
 django-tastypie==0.14.2
 djangorestframework==3.5.4
 elasticsearch==1.9.0
+elasticsearch2>=2.0.0,<3.0.0
 eulxml==1.1.3
 ghdiff==0.4
 gunicorn

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -59,6 +59,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 et-xmlfile==1.0.1         # via openpyxl
@@ -148,7 +149,7 @@ tropo-webapi-python==0.1.3
 twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 weasyprint==0.42.3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -64,6 +64,7 @@ djangorestframework==3.5.4
 dnspython==1.15.0
 docutils==0.14            # via botocore
 dropbox==9.3.0
+elasticsearch2==2.5.1
 elasticsearch==1.9.0
 email_validator==1.0.3
 et-xmlfile==1.0.1         # via openpyxl
@@ -166,7 +167,7 @@ twilio==6.5.1
 ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 unittest2==1.1.0
-urllib3==1.24.3           # via botocore, elasticsearch, py-kissmetrics, requests, sentry-sdk
+urllib3==1.24.3           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 weasyprint==0.42.3

--- a/settings.py
+++ b/settings.py
@@ -730,6 +730,7 @@ SUMOLOGIC_URL = None
 # on both a single instance or distributed setup this should assume localhost
 ELASTICSEARCH_HOST = 'localhost'
 ELASTICSEARCH_PORT = 9200
+ELASTICSEARCH_MAJOR_VERSION = 1
 
 BITLY_LOGIN = ''
 BITLY_APIKEY = ''

--- a/testapps/test_elasticsearch/tests/test_require_elastic.py
+++ b/testapps/test_elasticsearch/tests/test_require_elastic.py
@@ -1,6 +1,6 @@
 from unittest import expectedFailure
 from django.test import SimpleTestCase
-from elasticsearch import Elasticsearch
+from corehq.util.es.elasticsearch import Elasticsearch
 from .utils import require_elasticsearch
 
 

--- a/testapps/test_elasticsearch/tests/test_xform_es.py
+++ b/testapps/test_elasticsearch/tests/test_xform_es.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 import uuid
 import datetime
 from django.test import SimpleTestCase
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.apps.es import FormES
 from corehq.elastic import get_es_new, send_to_elasticsearch, doc_exists_in_es

--- a/testapps/test_elasticsearch/tests/utils.py
+++ b/testapps/test_elasticsearch/tests/utils.py
@@ -1,5 +1,5 @@
 import functools
-from elasticsearch import exceptions as elasticsearch_exceptions
+from corehq.util.es import elasticsearch as elasticsearch_exceptions
 from requests import exceptions as requests_exceptions
 
 

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -2,7 +2,7 @@ import uuid
 from mock import patch, MagicMock
 
 from django.test import TestCase
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tasks import autogenerate_build, prune_auto_generated_builds

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from pillow_retry.models import PillowError
 from pillowtop.es_utils import initialize_index_and_mapping

--- a/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
+++ b/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
@@ -1,7 +1,7 @@
 import uuid
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.apps.change_feed import data_sources, topics
 from corehq.apps.change_feed.document_types import change_meta_from_doc

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.test import TestCase
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 import mock
 
 from corehq.apps.callcenter.tests.test_utils import CallCenterDomainMockTest

--- a/testapps/test_pillowtop/tests/test_report_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_case_pillow.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.test import TestCase, override_settings
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.apps.es import CaseES
 from corehq.apps.hqcase.management.commands.ptop_reindexer_v2 import reindex_and_clean

--- a/testapps/test_pillowtop/tests/test_report_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_xform_pillow.py
@@ -1,5 +1,5 @@
 from django.test import override_settings, TestCase
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.apps.es import FormES
 from corehq.elastic import get_es_new

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.test.testcases import SimpleTestCase, TestCase
-from elasticsearch.exceptions import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.apps.es import FormES
 from corehq.elastic import get_es_new


### PR DESCRIPTION
##### SUMMARY
This doesn't actually fix anything for elasticsearch 2.x yet, but to do so we will need to tightly control calls to elasticsearch, starting with using the python elasticsearch library version corresponding to the ES major version we're on.

My intention is to use this to then make sure we present a perfectly compatible interface so the rest of the code doesn't have to care if we're on 1 or 2, even though there are differences in the underlying ES API between 1 and 2.
