### PR TITLE
Sk/doc store

### DIFF
--- a/corehq/apps/change_feed/tests/test_data_sources.py
+++ b/corehq/apps/change_feed/tests/test_data_sources.py
@@ -1,19 +1,19 @@
 from django.test import SimpleTestCase, override_settings
 
-from casexml.apps.phone.document_store import ReadonlySyncLogDocumentStore
+from casexml.apps.phone.document_store import SyncLogDocumentStore
 from pillowtop.dao.couch import CouchDocumentStore
 
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed.data_sources import get_document_store
 from corehq.apps.change_feed.exceptions import UnknownDocumentStore
-from corehq.apps.locations.document_store import ReadonlyLocationDocumentStore
-from corehq.apps.sms.document_stores import ReadonlySMSDocumentStore
+from corehq.apps.locations.document_store import LocationDocumentStore
+from corehq.apps.sms.document_stores import SMSDocumentStore
 from corehq.form_processor.document_stores import (
     DocStoreLoadTracker,
     LedgerV1DocumentStore,
-    ReadonlyCaseDocumentStore,
-    ReadonlyFormDocumentStore,
-    ReadonlyLedgerV2DocumentStore,
+    CaseDocumentStore,
+    FormDocumentStore,
+    LedgerV2DocumentStore,
 )
 from corehq.util.exceptions import DatabaseNotFound
 from corehq.util.test_utils import generate_cases
@@ -33,21 +33,21 @@ class DocumentStoreTests(SimpleTestCase):
     (data_sources.SOURCE_COUCH, 'test_commcarehq', CouchDocumentStore),
 
     # legacy
-    (data_sources.CASE_SQL, '', ReadonlyCaseDocumentStore, True),
-    (data_sources.FORM_SQL, '', ReadonlyFormDocumentStore, True),
+    (data_sources.CASE_SQL, '', CaseDocumentStore, True),
+    (data_sources.FORM_SQL, '', FormDocumentStore, True),
     (data_sources.LEDGER_V1, '', LedgerV1DocumentStore),
-    (data_sources.LEDGER_V2, '', ReadonlyLedgerV2DocumentStore, True),
-    (data_sources.LOCATION, '', ReadonlyLocationDocumentStore),
-    (data_sources.SYNCLOG_SQL, '', ReadonlySyncLogDocumentStore),
-    (data_sources.SMS, '', ReadonlySMSDocumentStore),
+    (data_sources.LEDGER_V2, '', LedgerV2DocumentStore, True),
+    (data_sources.LOCATION, '', LocationDocumentStore),
+    (data_sources.SYNCLOG_SQL, '', SyncLogDocumentStore),
+    (data_sources.SMS, '', SMSDocumentStore),
 
-    (data_sources.SOURCE_SQL, data_sources.CASE_SQL, ReadonlyCaseDocumentStore, True),
-    (data_sources.SOURCE_SQL, data_sources.FORM_SQL, ReadonlyFormDocumentStore, True),
+    (data_sources.SOURCE_SQL, data_sources.CASE_SQL, CaseDocumentStore, True),
+    (data_sources.SOURCE_SQL, data_sources.FORM_SQL, FormDocumentStore, True),
     (data_sources.SOURCE_SQL, data_sources.LEDGER_V1, LedgerV1DocumentStore),
-    (data_sources.SOURCE_SQL, data_sources.LEDGER_V2, ReadonlyLedgerV2DocumentStore, True),
-    (data_sources.SOURCE_SQL, data_sources.LOCATION, ReadonlyLocationDocumentStore),
-    (data_sources.SOURCE_SQL, data_sources.SYNCLOG_SQL, ReadonlySyncLogDocumentStore),
-    (data_sources.SOURCE_SQL, data_sources.SMS, ReadonlySMSDocumentStore),
+    (data_sources.SOURCE_SQL, data_sources.LEDGER_V2, LedgerV2DocumentStore, True),
+    (data_sources.SOURCE_SQL, data_sources.LOCATION, LocationDocumentStore),
+    (data_sources.SOURCE_SQL, data_sources.SYNCLOG_SQL, SyncLogDocumentStore),
+    (data_sources.SOURCE_SQL, data_sources.SMS, SMSDocumentStore),
 
 ], DocumentStoreTests)
 def test_get_document_store(self, source_type, source_name, expected, sql_domain=False):

--- a/corehq/apps/change_feed/tests/test_data_sources.py
+++ b/corehq/apps/change_feed/tests/test_data_sources.py
@@ -1,6 +1,12 @@
-from django.test import SimpleTestCase, override_settings
+import uuid
+from datetime import datetime
+
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from decorator import contextmanager
 
 from casexml.apps.phone.document_store import SyncLogDocumentStore
+from dimagi.utils.couch.database import get_db
 from pillowtop.dao.couch import CouchDocumentStore
 
 from corehq.apps.change_feed import data_sources
@@ -8,13 +14,22 @@ from corehq.apps.change_feed.data_sources import get_document_store
 from corehq.apps.change_feed.exceptions import UnknownDocumentStore
 from corehq.apps.locations.document_store import LocationDocumentStore
 from corehq.apps.sms.document_stores import SMSDocumentStore
+from corehq.form_processor.backends.sql.dbaccessors import (
+    CaseAccessorSQL,
+    FormAccessorSQL,
+    LedgerAccessorSQL)
 from corehq.form_processor.document_stores import (
-    DocStoreLoadTracker,
-    LedgerV1DocumentStore,
     CaseDocumentStore,
+    DocStoreLoadTracker,
     FormDocumentStore,
+    LedgerV1DocumentStore,
     LedgerV2DocumentStore,
 )
+from corehq.form_processor.tests.utils import (
+    FormProcessorTestUtils,
+    use_sql_backend,
+)
+from corehq.form_processor.utils import should_use_sql_backend
 from corehq.util.exceptions import DatabaseNotFound
 from corehq.util.test_utils import generate_cases
 
@@ -56,3 +71,227 @@ def test_get_document_store(self, source_type, source_name, expected, sql_domain
     if isinstance(store, DocStoreLoadTracker):
         store = store.store
     self.assertEqual(store.__class__, expected)
+
+
+@contextmanager
+def couch_data():
+    db = get_db()
+    docs = [
+        {'doc_type': 'doc_type', 'domain': 'domain'}
+        for i in range(3)
+    ]
+    for doc in docs:
+        db.save_doc(doc)
+
+    try:
+        yield [doc['_id'] for doc in docs]
+    finally:
+        db.delete_docs(docs)
+
+
+@contextmanager
+def case_form_data():
+    from casexml.apps.case.mock import CaseFactory
+    factory = CaseFactory('domain')
+    cases = []
+    forms = []
+    for i in range(3):
+        case_id = uuid.uuid4().hex
+        case_block = factory.get_case_block(case_id, case_type='case_type')
+        form, [case] = factory.post_case_blocks([case_block])
+        cases.append(case)
+        forms.append(form)
+
+    case_ids = [case.case_id for case in cases]
+    form_ids = [form.form_id for form in forms]
+
+    try:
+        yield form_ids, case_ids
+    finally:
+        if should_use_sql_backend('domain'):
+            FormAccessorSQL.hard_delete_forms('domain', form_ids)
+            CaseAccessorSQL.hard_delete_cases('domain', case_ids)
+        else:
+            for case in cases:
+                case.delete()
+            for form in forms:
+                form.delete()
+
+
+@contextmanager
+def test_domain():
+    from corehq.apps.domain.shortcuts import create_domain
+    domain = create_domain('domain')
+    try:
+        yield domain
+    finally:
+        domain.delete()
+
+
+@contextmanager
+def case_data():
+    with case_form_data() as (form_ids, case_ids):
+        yield case_ids
+
+
+@contextmanager
+def form_data():
+    with case_form_data() as (form_ids, case_ids):
+        yield form_ids
+
+
+@contextmanager
+def location_data():
+    from corehq.apps.locations.tests.util import LocationTypeStructure
+    from corehq.apps.locations.tests.util import LocationStructure
+    from corehq.apps.locations.tests.util import setup_location_types_with_structure
+    from corehq.apps.locations.tests.util import setup_locations_with_structure
+    location_type_structure = [LocationTypeStructure('t1', [])]
+
+    location_structure = [
+        LocationStructure('L1', 't1', []),
+        LocationStructure('L2', 't1', []),
+        LocationStructure('L3', 't1', []),
+    ]
+
+    with test_domain():
+        setup_location_types_with_structure('domain', location_type_structure)
+        locs = setup_locations_with_structure('domain', location_structure)
+
+        yield [loc.location_id for name, loc in locs.items()]
+
+
+@contextmanager
+def stock_data():
+    from corehq.apps.commtrack.models import StockState
+    from corehq.apps.commtrack.tests.util import make_product
+    from corehq.apps.products.models import SQLProduct
+    from casexml.apps.case.mock import CaseFactory
+
+    product = make_product('domain', 'Sample Product 1', 'pp', None)
+    case = CaseFactory('domain').create_case()
+    stock_state = [
+        StockState(
+            section_id=str(i),
+            case_id=case.case_id,
+            product_id=product._id,
+            last_modified_date=datetime.utcnow(),
+            sql_product=SQLProduct.objects.get(product_id=product._id),
+        )
+        for i in range(3)
+    ]
+    for stock in stock_state:
+        stock.save()
+
+    try:
+        yield [stock.pk for stock in stock_state]
+    finally:
+        for stock in stock_state:
+            stock.delete()
+        case.delete()
+
+
+@contextmanager
+def ledger_data():
+    from casexml.apps.stock.mock import Balance
+    from casexml.apps.case.mock import CaseFactory
+    from casexml.apps.stock.mock import Entry
+
+    factory = CaseFactory('domain')
+    with case_data() as case_ids:
+        balance_blocks = [
+            Balance(
+                entity_id=case_id,
+                date=datetime.utcnow(),
+                section_id='test',
+                entry=Entry(id='chocolate', quantity=4),
+            ).as_xml()
+            for case_id in case_ids
+        ]
+        form, _ = factory.post_case_blocks(balance_blocks)
+
+        ledgers = LedgerAccessorSQL.get_ledger_values_for_cases(case_ids)
+
+        try:
+            yield [ledger.ledger_id for ledger in ledgers]
+        finally:
+            form.delete()
+            for ledger in ledgers:
+                ledger.delete()
+
+
+@contextmanager
+def synclog_data():
+    from casexml.apps.phone.models import SimplifiedSyncLog
+    synclogs = [
+        SimplifiedSyncLog(domain='domain', user_id=uuid.uuid4().hex, date=datetime.utcnow())
+        for i in range(3)
+    ]
+    for synclog in synclogs:
+        synclog.save()
+
+    try:
+        yield [synclog.get_id for synclog in synclogs]
+    finally:
+        for synclog in synclogs:
+            synclog.delete()
+
+
+@contextmanager
+def sms_data():
+    from corehq.apps.sms.models import SMS
+    sms_objects = [
+        SMS.objects.create(domain='domain')
+        for i in range(3)
+    ]
+
+    try:
+        yield [sms.couch_id for sms in sms_objects]
+    finally:
+        for sms in sms_objects:
+            sms.delete()
+
+
+class DocumentStoreDbTests(TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers()
+        super().tearDownClass()
+
+
+@use_sql_backend
+class DocumentStoreDbTestsSQL(TestCase):
+    pass
+
+
+def _test_document_store(self, doc_store_cls, doc_store_args, data_context, id_field):
+    doc_store = doc_store_cls(*doc_store_args)
+    with data_context() as doc_ids:
+        self.assertIsNotNone(doc_store.get_document(doc_ids[0]))
+
+        self.assertEqual(set(doc_ids), set(doc_store.iter_document_ids()))
+
+        docs = doc_store.iter_documents(doc_ids[1:])
+        self.assertEqual(set(doc_ids[1:]), {doc[id_field] for doc in docs})
+
+
+@generate_cases([
+    (CouchDocumentStore, (get_db(), 'domain', 'doc_type'), couch_data, '_id'),
+    (CaseDocumentStore, ('domain',), case_data, '_id'),
+    (FormDocumentStore, ('domain',), form_data, '_id'),
+    (LocationDocumentStore, ('domain',), location_data, 'location_id'),
+    (LedgerV1DocumentStore, ('domain',), stock_data, '_id'),
+    (SyncLogDocumentStore, (), synclog_data, '_id'),
+    (SMSDocumentStore, (), sms_data, '_id'),
+], DocumentStoreDbTests)
+def test_documet_store(*args):
+    _test_document_store(*args)
+
+
+@generate_cases([
+    (CaseDocumentStore, ('domain',), case_data, '_id'),
+    (FormDocumentStore, ('domain',), form_data, '_id'),
+    (LedgerV2DocumentStore, ('domain',), ledger_data, '_id'),
+], DocumentStoreDbTestsSQL)
+def test_documet_store_sql(*args):
+    _test_document_store(*args)

--- a/corehq/apps/locations/document_store.py
+++ b/corehq/apps/locations/document_store.py
@@ -16,7 +16,8 @@ class LocationDocumentStore(DjangoDocumentStore):
 
     def __init__(self, domain):
         self.domain = domain
-        queryset = SQLLocation.active_objects.filter(domain=domain).select_related('parent', 'location_type')
+        queryset = SQLLocation.active_objects\
+            .filter(domain=domain).select_related('parent', 'location_type')
         super().__init__(SQLLocation, model_manager=queryset, id_field='location_id')
 
 

--- a/corehq/apps/locations/document_store.py
+++ b/corehq/apps/locations/document_store.py
@@ -12,7 +12,7 @@ from .models import SQLLocation
 LOCATION_DOC_TYPE = "Location"
 
 
-class ReadonlyLocationDocumentStore(DjangoDocumentStore):
+class LocationDocumentStore(DjangoDocumentStore):
 
     def __init__(self, domain):
         self.domain = domain

--- a/corehq/apps/sms/document_stores.py
+++ b/corehq/apps/sms/document_stores.py
@@ -1,15 +1,7 @@
-from pillowtop.dao.exceptions import DocumentNotFoundError
-from pillowtop.dao.interface import ReadOnlyDocumentStore
-
 from corehq.apps.sms.models import SMS
+from pillowtop.dao.django import DjangoDocumentStore
 
 
-class ReadonlySMSDocumentStore(ReadOnlyDocumentStore):
-
-    def get_document(self, doc_id):
-        try:
-            sms = SMS.objects.get(couch_id=doc_id)
-        except SMS.DoesNotExist as e:
-            raise DocumentNotFoundError(e)
-
-        return sms.to_json()
+class ReadonlySMSDocumentStore(DjangoDocumentStore):
+    def __init__(self):
+        super().__init__(SMS, id_field='couch_id')

--- a/corehq/apps/sms/document_stores.py
+++ b/corehq/apps/sms/document_stores.py
@@ -2,6 +2,6 @@ from corehq.apps.sms.models import SMS
 from pillowtop.dao.django import DjangoDocumentStore
 
 
-class ReadonlySMSDocumentStore(DjangoDocumentStore):
+class SMSDocumentStore(DjangoDocumentStore):
     def __init__(self):
         super().__init__(SMS, id_field='couch_id')

--- a/corehq/apps/userreports/tests/test_async_indicators.py
+++ b/corehq/apps/userreports/tests/test_async_indicators.py
@@ -212,7 +212,7 @@ class BulkAsyncIndicatorProcessingTest(TestCase):
         self.datadog_patch = _patch.start()
         # patch docstore to avoid overhead of saving/querying docs
         docstore_patch = mock.patch(
-            'corehq.form_processor.document_stores.ReadonlyCaseDocumentStore.iter_documents',
+            'corehq.form_processor.document_stores.CaseDocumentStore.iter_documents',
             new=fake_iter_documents
         )
         docstore_patch.start()

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -162,7 +162,7 @@ class ChunkedUCRProcessorTest(TestCase):
         process_change_patch.assert_has_calls([mock.call(mock.ANY)] * 10)
 
     @mock.patch('corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor.process_change')
-    @mock.patch('corehq.form_processor.document_stores.ReadonlyCaseDocumentStore.iter_documents')
+    @mock.patch('corehq.form_processor.document_stores.CaseDocumentStore.iter_documents')
     def test_partial_fallback_calls(self, iter_docs_patch, process_change_patch):
         # this is equivalent to failing on last 4 docs, since they are missing in docstore
         docs = [
@@ -175,7 +175,7 @@ class ChunkedUCRProcessorTest(TestCase):
         # since chunked processing failed, normal processing should get called
         process_change_patch.assert_has_calls([mock.call(mock.ANY)] * 4)
 
-    @mock.patch('corehq.form_processor.document_stores.ReadonlyCaseDocumentStore.iter_documents')
+    @mock.patch('corehq.form_processor.document_stores.CaseDocumentStore.iter_documents')
     def test_partial_fallback_data(self, iter_docs_patch):
         docs = [
             get_sample_doc_and_indicators(self.fake_time_now)[0]

--- a/corehq/ex-submodules/casexml/apps/phone/document_store.py
+++ b/corehq/ex-submodules/casexml/apps/phone/document_store.py
@@ -1,14 +1,11 @@
 from casexml.apps.phone.models import SyncLogSQL
-from pillowtop.dao.exceptions import DocumentNotFoundError
-from pillowtop.dao.interface import ReadOnlyDocumentStore
+from pillowtop.dao.django import DjangoDocumentStore
 
 
-class ReadonlySyncLogDocumentStore(ReadOnlyDocumentStore):
+class ReadonlySyncLogDocumentStore(DjangoDocumentStore):
+    def __init__(self):
 
-    def get_document(self, doc_id):
-        try:
-            sycnlog = SyncLogSQL.objects.get(synclog_id=doc_id)
-        except SyncLogSQL.DoesNotExist as e:
-            raise DocumentNotFoundError(e)
+        def _to_doc(model):
+            return model.doc
 
-        return sycnlog.doc
+        super().__init__(SyncLogSQL, doc_generator_fn=_to_doc)

--- a/corehq/ex-submodules/casexml/apps/phone/document_store.py
+++ b/corehq/ex-submodules/casexml/apps/phone/document_store.py
@@ -9,3 +9,7 @@ class SyncLogDocumentStore(DjangoDocumentStore):
             return model.doc
 
         super().__init__(SyncLogSQL, doc_generator_fn=_to_doc)
+
+    def iter_document_ids(self):
+        for doc_id in super().iter_document_ids():
+            yield doc_id.hex

--- a/corehq/ex-submodules/casexml/apps/phone/document_store.py
+++ b/corehq/ex-submodules/casexml/apps/phone/document_store.py
@@ -2,7 +2,7 @@ from casexml.apps.phone.models import SyncLogSQL
 from pillowtop.dao.django import DjangoDocumentStore
 
 
-class ReadonlySyncLogDocumentStore(DjangoDocumentStore):
+class SyncLogDocumentStore(DjangoDocumentStore):
     def __init__(self):
 
         def _to_doc(model):

--- a/corehq/ex-submodules/pillowtop/dao/couch.py
+++ b/corehq/ex-submodules/pillowtop/dao/couch.py
@@ -24,25 +24,17 @@ class CouchDocumentStore(DocumentStore):
             else:
                 raise DocumentDeletedError()
 
-    def iter_document_ids(self, last_id=None):
+    def iter_document_ids(self):
         from corehq.apps.domain.dbaccessors import iterate_doc_ids_in_domain_by_type
 
         if not (self.domain and self.doc_type):
             raise ValueError('This function requires a domain and doc_type set!')
-        start_key = None
-        if last_id:
-            last_doc = self.get_document(last_id)
-            start_key = [self.domain, self.doc_type]
-            if self.doc_type in list(_DATE_MAP):
-                start_key.append(last_doc[_DATE_MAP[self.doc_type]])
 
         return iterate_doc_ids_in_domain_by_type(
             self.domain,
             self.doc_type,
             chunk_size=ID_CHUNK_SIZE,
             database=self._couch_db,
-            startkey=start_key,
-            startkey_docid=last_id
         )
 
     def iter_documents(self, ids):

--- a/corehq/ex-submodules/pillowtop/dao/couch.py
+++ b/corehq/ex-submodules/pillowtop/dao/couch.py
@@ -24,16 +24,6 @@ class CouchDocumentStore(DocumentStore):
             else:
                 raise DocumentDeletedError()
 
-    def save_document(self, doc_id, document):
-        document['_id'] = doc_id
-        self._couch_db.save_doc(document)
-
-    def delete_document(self, doc_id):
-        try:
-            return self._couch_db.delete_doc(doc_id)
-        except ResourceNotFound:
-            raise DocumentNotFoundError()
-
     def iter_document_ids(self, last_id=None):
         from corehq.apps.domain.dbaccessors import iterate_doc_ids_in_domain_by_type
 

--- a/corehq/ex-submodules/pillowtop/dao/django.py
+++ b/corehq/ex-submodules/pillowtop/dao/django.py
@@ -26,8 +26,7 @@ class DjangoDocumentStore(DocumentStore):
         except ObjectDoesNotExist:
             raise DocumentNotFoundError()
 
-    def iter_document_ids(self, last_id=None):
-        # todo: support last_id
+    def iter_document_ids(self):
         return self._model_manager.all().values_list(self._id_field, flat=True)
 
     def iter_documents(self, ids):

--- a/corehq/ex-submodules/pillowtop/dao/django.py
+++ b/corehq/ex-submodules/pillowtop/dao/django.py
@@ -7,26 +7,35 @@ class DjangoDocumentStore(DocumentStore):
     """
     An implementation of the DocumentStore that uses the Django ORM.
     """
-
-    def __init__(self, model_class, doc_generator_fn, model_manager=None):
+    def __init__(self, model_class, doc_generator_fn=None, model_manager=None, id_field='pk'):
         self._model_manager = model_manager or model_class.objects
         self._model_class = model_class
         self._doc_generator_fn = doc_generator_fn
+        if not doc_generator_fn:
+            try:
+                self._doc_generator_fn = model_class.to_json
+            except AttributeError:
+                raise ValueError('DjangoDocumentStore must be supplied with a doc_generator_fn argument')
+        self._id_field = id_field
+        self._in_query_filter = f'{id_field}__in'
 
     def get_document(self, doc_id):
         try:
-            model = self._model_manager.get(pk=doc_id)
+            model = self._model_manager.get(**{self._id_field: doc_id})
             return self._doc_generator_fn(model)
         except ObjectDoesNotExist:
             raise DocumentNotFoundError()
 
     def iter_document_ids(self, last_id=None):
         # todo: support last_id
-        return self._model_manager.all().values_list('id', flat=True)
+        return self._model_manager.all().values_list(self._id_field, flat=True)
 
     def iter_documents(self, ids):
         from dimagi.utils.chunked import chunked
         for chunk in chunked(ids, 500):
             chunk = list([_f for _f in chunk if _f])
-            for model in self._model_manager.filter(pk__in=chunk):
+            filters = {
+                self._in_query_filter: chunk
+            }
+            for model in self._model_manager.filter(**filters):
                 yield self._doc_generator_fn(model)

--- a/corehq/ex-submodules/pillowtop/dao/django.py
+++ b/corehq/ex-submodules/pillowtop/dao/django.py
@@ -8,14 +8,10 @@ class DjangoDocumentStore(DocumentStore):
     An implementation of the DocumentStore that uses the Django ORM.
     """
 
-    def __init__(self, model_class, doc_generator_fn, model_generator_fn=None, model_manager=None):
+    def __init__(self, model_class, doc_generator_fn, model_manager=None):
         self._model_manager = model_manager or model_class.objects
         self._model_class = model_class
         self._doc_generator_fn = doc_generator_fn
-        if model_generator_fn is None:
-            # the default generator just assumes the dict is flat set of model fields
-            model_generator_fn = lambda document_dict: self._model_class(**document_dict)
-        self._model_generator_fn = model_generator_fn
 
     def get_document(self, doc_id):
         try:
@@ -23,14 +19,6 @@ class DjangoDocumentStore(DocumentStore):
             return self._doc_generator_fn(model)
         except ObjectDoesNotExist:
             raise DocumentNotFoundError()
-
-    def save_document(self, doc_id, document):
-        document['pk'] = doc_id
-        instance = self._model_generator_fn(document)
-        instance.save()
-
-    def delete_document(self, doc_id):
-        self._model_manager.filter(pk=doc_id).delete()
 
     def iter_document_ids(self, last_id=None):
         # todo: support last_id

--- a/corehq/ex-submodules/pillowtop/dao/django.py
+++ b/corehq/ex-submodules/pillowtop/dao/django.py
@@ -8,7 +8,9 @@ class DjangoDocumentStore(DocumentStore):
     An implementation of the DocumentStore that uses the Django ORM.
     """
     def __init__(self, model_class, doc_generator_fn=None, model_manager=None, id_field='pk'):
-        self._model_manager = model_manager or model_class.objects
+        self._model_manager = model_manager
+        if model_manager is None:
+            self._model_manager = model_class.objects
         self._model_class = model_class
         self._doc_generator_fn = doc_generator_fn
         if not doc_generator_fn:

--- a/corehq/ex-submodules/pillowtop/dao/interface.py
+++ b/corehq/ex-submodules/pillowtop/dao/interface.py
@@ -10,14 +10,6 @@ class DocumentStore(metaclass=ABCMeta):
     def get_document(self, doc_id):
         pass
 
-    @abstractmethod
-    def save_document(self, doc_id, document):
-        pass
-
-    @abstractmethod
-    def delete_document(self, doc_id):
-        pass
-
     def iter_document_ids(self, last_id=None):
         # todo: can convert to @abstractmethod once subclasses handle it
         raise NotImplementedError('this function not yet implemented')
@@ -28,9 +20,4 @@ class DocumentStore(metaclass=ABCMeta):
 
 
 class ReadOnlyDocumentStore(DocumentStore):
-
-    def save_document(self, doc_id, document):
-        raise NotImplementedError('This document store is read only!')
-
-    def delete_document(self, doc_id):
-        raise NotImplementedError('This document store is read only!')
+    pass

--- a/corehq/ex-submodules/pillowtop/dao/interface.py
+++ b/corehq/ex-submodules/pillowtop/dao/interface.py
@@ -14,8 +14,8 @@ class DocumentStore(metaclass=ABCMeta):
         # todo: can convert to @abstractmethod once subclasses handle it
         raise NotImplementedError('this function not yet implemented')
 
+    @abstractmethod
     def iter_documents(self, ids):
-        # todo: can convert to @abstractmethod once subclasses handle it
         raise NotImplementedError('this function not yet implemented')
 
 

--- a/corehq/ex-submodules/pillowtop/dao/interface.py
+++ b/corehq/ex-submodules/pillowtop/dao/interface.py
@@ -17,7 +17,3 @@ class DocumentStore(metaclass=ABCMeta):
     @abstractmethod
     def iter_documents(self, ids):
         raise NotImplementedError('this function not yet implemented')
-
-
-class ReadOnlyDocumentStore(DocumentStore):
-    pass

--- a/corehq/ex-submodules/pillowtop/dao/interface.py
+++ b/corehq/ex-submodules/pillowtop/dao/interface.py
@@ -11,7 +11,7 @@ class DocumentStore(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def iter_document_ids(self, last_id=None):
+    def iter_document_ids(self):
         raise NotImplementedError('this function not yet implemented')
 
     @abstractmethod

--- a/corehq/ex-submodules/pillowtop/dao/interface.py
+++ b/corehq/ex-submodules/pillowtop/dao/interface.py
@@ -10,8 +10,8 @@ class DocumentStore(metaclass=ABCMeta):
     def get_document(self, doc_id):
         pass
 
+    @abstractmethod
     def iter_document_ids(self, last_id=None):
-        # todo: can convert to @abstractmethod once subclasses handle it
         raise NotImplementedError('this function not yet implemented')
 
     @abstractmethod

--- a/corehq/ex-submodules/pillowtop/dao/mock.py
+++ b/corehq/ex-submodules/pillowtop/dao/mock.py
@@ -12,3 +12,7 @@ class MockDocumentStore(DocumentStore):
             return self._data_store[doc_id]
         except KeyError:
             raise DocumentNotFoundError()
+
+    def iter_documents(self, ids):
+        for doc_id in ids:
+            yield self.get_document(doc_id)

--- a/corehq/ex-submodules/pillowtop/dao/mock.py
+++ b/corehq/ex-submodules/pillowtop/dao/mock.py
@@ -17,5 +17,5 @@ class MockDocumentStore(DocumentStore):
         for doc_id in ids:
             yield self.get_document(doc_id)
 
-    def iter_document_ids(self, last_id=None):
+    def iter_document_ids(self):
         return iter(self._data_store)

--- a/corehq/ex-submodules/pillowtop/dao/mock.py
+++ b/corehq/ex-submodules/pillowtop/dao/mock.py
@@ -4,20 +4,11 @@ from pillowtop.dao.interface import DocumentStore
 
 class MockDocumentStore(DocumentStore):
 
-    def __init__(self):
-        self._data_store = {}
+    def __init__(self, data=None):
+        self._data_store = data or {}
 
     def get_document(self, doc_id):
         try:
             return self._data_store[doc_id]
-        except KeyError:
-            raise DocumentNotFoundError()
-
-    def save_document(self, doc_id, document):
-        self._data_store[doc_id] = document
-
-    def delete_document(self, doc_id):
-        try:
-            del self._data_store[doc_id]
         except KeyError:
             raise DocumentNotFoundError()

--- a/corehq/ex-submodules/pillowtop/dao/mock.py
+++ b/corehq/ex-submodules/pillowtop/dao/mock.py
@@ -16,3 +16,6 @@ class MockDocumentStore(DocumentStore):
     def iter_documents(self, ids):
         for doc_id in ids:
             yield self.get_document(doc_id)
+
+    def iter_document_ids(self, last_id=None):
+        return iter(self._data_store)

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -14,7 +14,7 @@ from pillowtop.tests.utils import TEST_INDEX_INFO
 from pillowtop.utils import bulk_fetch_changes_docs, get_errors_with_ids
 
 from corehq.elastic import get_es_new
-from corehq.form_processor.document_stores import ReadonlyCaseDocumentStore
+from corehq.form_processor.document_stores import CaseDocumentStore
 from corehq.form_processor.signals import sql_case_post_save
 from corehq.form_processor.tests.utils import (
     FormProcessorTestUtils,
@@ -82,7 +82,7 @@ class TestBulkDocOperations(TestCase):
             Change(
                 id=case_id,
                 sequence_id=None,
-                document_store=ReadonlyCaseDocumentStore('domain'),
+                document_store=CaseDocumentStore('domain'),
                 metadata=ChangeMeta(
                     document_id=case_id, domain='domain', data_source_type='sql', data_source_name='case-sql'
                 )

--- a/corehq/ex-submodules/pillowtop/tests/test_changes.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_changes.py
@@ -62,10 +62,11 @@ class TestChangeDocument(SimpleTestCase):
 
     def setUp(self):
         # bootstrap a dao with a doc in it
-        self.dao = MockDocumentStore()
         self.doc_id = uuid.uuid4().hex
         self.doc = {'id': self.doc_id, 'random_property': uuid.uuid4().hex}
-        self.dao.save_document(self.doc_id, self.doc)
+        self.dao = MockDocumentStore({
+            self.doc_id: self.doc
+        })
 
     def test_get_set_document(self):
         change = Change(id='id', sequence_id='')

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -119,12 +119,7 @@ class LedgerV1DocumentStore(DjangoDocumentStore):
         from corehq.apps.commtrack.models import StockState
         assert not should_use_sql_backend(domain), "Only non-SQL backend supported"
         self.domain = domain
-
-        def _doc_gen_fn(obj):
-            return obj.to_json()
-
-        super(LedgerV1DocumentStore, self).__init__(
-            StockState, _doc_gen_fn, model_manager=StockState.include_archived)
+        super(LedgerV1DocumentStore, self).__init__(StockState, model_manager=StockState.include_archived)
 
 
 class DocStoreLoadTracker(object):

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -30,8 +30,7 @@ class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
         except (XFormNotFound, BlobError) as e:
             raise DocumentNotFoundError(e)
 
-    def iter_document_ids(self, last_id=None):
-        # todo: support last_id
+    def iter_document_ids(self):
         return iter(self.form_accessors.iter_form_ids_by_xmlns(self.xmlns))
 
     def iter_documents(self, ids):
@@ -52,7 +51,7 @@ class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):
         except CaseNotFound as e:
             raise DocumentNotFoundError(e)
 
-    def iter_document_ids(self, last_id=None):
+    def iter_document_ids(self):
         if should_use_sql_backend(self.domain):
             accessor = CaseReindexAccessor(self.domain, case_type=self.case_type)
             return iter_all_ids(accessor)
@@ -85,7 +84,7 @@ class ReadonlyLedgerV2DocumentStore(ReadOnlyDocumentStore):
         from corehq.apps.products.models import SQLProduct
         return list(SQLProduct.objects.filter(domain=self.domain).product_ids())
 
-    def iter_document_ids(self, last_id=None):
+    def iter_document_ids(self):
         if should_use_sql_backend(self.domain):
             accessor = LedgerReindexAccessor(self.domain)
             return iter_all_ids(accessor)

--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -1,19 +1,30 @@
 from collections import defaultdict
 
 from corehq.blobs import Error as BlobError
-from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL, \
-    iter_all_ids, CaseReindexAccessor, LedgerReindexAccessor
-from corehq.form_processor.exceptions import CaseNotFound, XFormNotFound, LedgerValueNotFound
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors
+from corehq.form_processor.backends.sql.dbaccessors import (
+    CaseReindexAccessor,
+    LedgerAccessorSQL,
+    LedgerReindexAccessor,
+    iter_all_ids,
+)
+from corehq.form_processor.exceptions import (
+    CaseNotFound,
+    LedgerValueNotFound,
+    XFormNotFound,
+)
+from corehq.form_processor.interfaces.dbaccessors import (
+    CaseAccessors,
+    FormAccessors,
+)
 from corehq.form_processor.models import XFormInstanceSQL
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.util.quickcache import quickcache
 from pillowtop.dao.django import DjangoDocumentStore
 from pillowtop.dao.exceptions import DocumentNotFoundError
-from pillowtop.dao.interface import ReadOnlyDocumentStore
+from pillowtop.dao.interface import DocumentStore
 
 
-class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
+class FormDocumentStore(DocumentStore):
 
     def __init__(self, domain, xmlns=None):
         self.domain = domain
@@ -38,7 +49,7 @@ class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
             yield wrapped_form.to_json()
 
 
-class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):
+class CaseDocumentStore(DocumentStore):
 
     def __init__(self, domain, case_type=None):
         self.domain = domain
@@ -63,7 +74,7 @@ class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):
             yield wrapped_case.to_json()
 
 
-class ReadonlyLedgerV2DocumentStore(ReadOnlyDocumentStore):
+class LedgerV2DocumentStore(DocumentStore):
 
     def __init__(self, domain):
         assert should_use_sql_backend(domain), "Only SQL backend supported: {}".format(domain)

--- a/corehq/form_processor/serializers.py
+++ b/corehq/form_processor/serializers.py
@@ -233,7 +233,7 @@ class LedgerValueSerializer(serializers.ModelSerializer):
 
 
 class StockStateSerializer(serializers.ModelSerializer):
-    _id = serializers.CharField(source='id')
+    _id = serializers.IntegerField(source='id')
     entry_id = serializers.CharField(source='product_id')
     location_id = serializers.CharField(source='sql_location.location_id')
     balance = serializers.IntegerField(source='stock_on_hand')


### PR DESCRIPTION
##### SUMMARY
Initially started looking to address this https://sentry.io/organizations/dimagi/issues/1292940649/ but ended up doing a cleanup of the `DocumentStore` classes.

* Make all doc stores implement the same set of methods
* Remove the ability to use doc stores to save and delete docs (never used)
* Remove the ability to use `iter_document_ids` with a `last_id` param (never used)
* Make more use of `DjangoDocumentStore` class

Easiest review by commit.