### PR TITLE
Prevent Duplicate Column Labels in OData Configs

### DIFF
--- a/corehq/apps/export/exceptions.py
+++ b/corehq/apps/export/exceptions.py
@@ -16,3 +16,7 @@ class ExportFormValidationException(Exception):
 
 class ExportAsyncException(Exception):
     pass
+
+
+class ExportODataDuplicateLabelException(Exception):
+    pass

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -108,10 +108,32 @@ hqDefine('export/js/models', [
 
         // True if the form has no errors
         self.isValid = ko.pureComputed(function () {
+            if (self.is_odata_config() && self.hasDuplicateColumnLabels()) {
+                return false;
+            }
             if (!self.hasDailySavedAccess && self.is_daily_saved_export()) {
                 return false;
             }
             return true;
+        });
+
+        self.duplicateLabel = ko.observable();
+
+        self.hasDuplicateColumnLabels = ko.pureComputed(function () {
+            self.duplicateLabel('');
+            var hasDuplicates = false;
+            _.each(self.tables(), function (table) {
+                var labels = [];
+                _.each(table.columns(), function (column) {
+                    if (column.selected() && labels.indexOf(column.label()) === -1) {
+                        labels.push(column.label());
+                    } else if (column.selected()) {
+                        hasDuplicates = true;
+                        self.duplicateLabel(column.label());
+                    }
+                });
+            });
+            return hasDuplicates;
         });
 
         // The url to save the export to.

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -255,7 +255,7 @@
             <button type="submit"
                     class="btn btn-lg btn-primary"
                     data-bind="click: save,
-                               disable: saveStateSaving() || saveStateSuccess || !isValid()">
+                               disable: saveStateSaving() || saveStateSuccess() || !isValid()">
               <span data-bind="visible: saveStateReady(),
                                text: getSaveText()"></span>
               <span data-bind="visible: saveStateSaving()">

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -284,8 +284,21 @@
               {% trans "Copy this Export" %}
             </a>
           {% endif %}
+
+          {% if export_instance.is_odata_config %}
+            <div style="display: inline-block"
+                 data-bind="if: hasDuplicateColumnLabels">
+              <div class="alert alert-danger">
+                {% blocktrans %}
+                  Column labels must be unique. '<span data-bind="text: duplicateLabel"></span>'
+                  has been used more than once.
+                {% endblocktrans %}
+              </div>
+            </div>
+          {% endif %}
+
           <div class="text-danger"
-               data-bind="if: !isValid()">
+               data-bind="if: !isValid(){% if export_instance.is_odata_config %} && !hasDuplicateColumnLabels(){% endif %}">
             {% trans "There are errors with your configuration. Please fix them before creating the export." %}
           </div>
         </div>

--- a/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partials/new_customize_export_templates.html
@@ -328,7 +328,7 @@
             <td>
               <input class="form-control"
                      type="text"
-                     data-bind="value: column.label,
+                     data-bind="textInput: column.label,
                                 disable: $root.isReservedOdataColumn(column, $parentContext.$index())" />
             </td>
           {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -27,6 +27,7 @@ from corehq.apps.export.dbaccessors import get_properly_wrapped_export_instance
 from corehq.apps.export.exceptions import (
     BadExportConfiguration,
     ExportAppException,
+    ExportODataDuplicateLabelException,
 )
 from corehq.apps.export.models import (
     CaseExportDataSchema,
@@ -147,6 +148,7 @@ class BaseExportView(BaseProjectDataView):
 
         if export.is_odata_config:
             for table_id, table in enumerate(export.tables):
+                labels = []
                 for column in table.columns:
                     is_reserved_number = (
                         column.label == 'number' and table_id > 0 and table.selected
@@ -155,6 +157,14 @@ class BaseExportView(BaseProjectDataView):
                             or column.label == 'caseid'
                             or is_reserved_number):
                         column.selected = True
+
+                    if column.label not in labels and column.selected:
+                        labels.append(column.label)
+                    elif column.selected:
+                        raise ExportODataDuplicateLabelException(
+                            _("Column labels must be unique. "
+                              "'{}' appears more than once.").format(column.label)
+                        )
             num_nodes = sum([1 for table in export.tables[1:] if table.selected])
             if hasattr(self, 'is_copy') and self.is_copy:
                 event_title = "[BI Integration] Clicked Save button for feed copy"


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-803

##### SUMMARY
Make sure that for odata feeds we catch duplicate column labels so that a user is not allowed to create a configuration with duplicate column labels. If duplicate labels are present, then Tableau and PowerBI both throw unexpected and unclear errors.