### PR TITLE
Only skip if whole row is blank

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -66,12 +66,11 @@ class _Importer(object):
         return self.results.to_json()
 
     def import_row(self, row_num, raw_row):
-        search_id = _parse_search_id(self.config, raw_row)
-        fields_to_update = _populate_updated_fields(self.config, raw_row)
-        if not any(fields_to_update.values()):
-            # if the row was blank, just skip it, no errors
+        if row_is_blank(raw_row):
             return
 
+        search_id = _parse_search_id(self.config, raw_row)
+        fields_to_update = _populate_updated_fields(self.config, raw_row)
         row = _CaseImportRow(
             search_id=search_id,
             fields_to_update=fields_to_update,
@@ -152,6 +151,25 @@ class _Importer(object):
                     'error adding inferred export properties in domain '
                     '({}): {}'.format(self.domain, ", ".join(properties))
                 )
+
+
+def row_is_blank(row_dict):
+    return all(is_blank(v) for v in row_dict.values())
+
+
+def is_blank(value):
+    """
+    Returns True if ``value`` is ``None`` or an empty string.
+
+    >>> is_blank("")
+    True
+    >>> is_blank(0)
+    False
+    >>> is_blank([])
+    False
+
+    """
+    return value is None or value == ""
 
 
 class _CaseImportRow(object):

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -1,3 +1,4 @@
+import doctest
 from contextlib import contextmanager
 
 from django.test import TestCase
@@ -493,6 +494,13 @@ class ImporterTest(TestCase):
             ['', 'Jeff', '', 'blue', bad_group.name],
         ])
         self.assertIn(exceptions.InvalidOwner.title, res['errors'])
+
+
+def test_doctests():
+    import corehq.apps.case_importer.do_import
+
+    results = doctest.testmod(corehq.apps.case_importer.do_import)
+    assert results.failed == 0
 
 
 def make_worksheet_wrapper(*rows):


### PR DESCRIPTION
##### SUMMARY
Currently, case importer checks whether `fields_to_update.values()` are all falsy, and if so, it skips the row.

There are a couple of problems with this:
* `fields_to_update` doesn't include the case/external ID. If an ID is given, then blank values should be valid.
* 0 is falsy but a valid value.

This change resolves that by only skipping rows that are completely empty.

(Opening as a draft PR pending testing and a Jira ticket.)

##### PRODUCT DESCRIPTION
Allows the case importer to set all given case properties to blank or zero values.
