### PR TITLE
remove the leaflet / map related js from the compress block for user reports

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -20,6 +20,7 @@
   {% endcompress %}
 
   {# don't compress this block related to maps. it causes strange issues with the default image path #}
+  {# see https://dimagi-dev.atlassian.net/browse/SAASP-179 #}
   <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
   <script src="{% static 'reports/js/maps_utils.js' %}"></script><!-- depends on leaflet -->
   <script src="{% static 'reports_core/js/maps.js' %}"></script>

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -16,11 +16,15 @@
     <script src="{% static 'reports/js/config.dataTables.bootstrap.js' %}"></script>
     <script src="{% static 'reports_core/js/choice_list_utils.js' %}"></script>
     <script src="{% static 'reports_core/js/charts.js' %}"></script>
-    <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
-    <script src="{% static 'reports/js/maps_utils.js' %}"></script><!-- depends on leaflet -->
-    <script src="{% static 'reports_core/js/maps.js' %}"></script>
     <script src="{% static 'userreports/js/report_analytix.js' %}"></script>
   {% endcompress %}
+
+  {# don't compress this block related to maps. it causes strange issues with the default image path #}
+  <script src="{% static 'leaflet/dist/leaflet.js' %}"></script>
+  <script src="{% static 'reports/js/maps_utils.js' %}"></script><!-- depends on leaflet -->
+  <script src="{% static 'reports_core/js/maps.js' %}"></script>
+
+
   {% include 'reports/partials/filters_js.html' %}
   {% include 'reports/partials/graphs/charts_js.html' %}
   <script src="{% static 'reports_core/js/base_template_new.js' %}"></script>


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-179

##### SUMMARY
compressing leaflet and maps related js in user reports causes issues with finding the default image path.