### PR TITLE
Revert "handle TypeError"

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3771,11 +3771,7 @@ class LazyBlobDoc(BlobMixin):
             # it has been fetched already during this request
             content = self._LAZY_ATTACHMENTS_CACHE[name]
         except KeyError:
-            try:
-                content = cache.get(self.__attachment_cache_key(name))
-            except TypeError:
-                # TODO - remove try/except sometime after Python 3 migration is complete
-                return None
+            content = cache.get(self.__attachment_cache_key(name))
             if content is not None:
                 if isinstance(content, str):
                     return None


### PR DESCRIPTION
Stumbled on this while reading `app_manager.models` over tea.

This reverts commit 78e28d8146c3e8e52601bb2f79b930a20b01f5e6 now that the python 3 migration is complete.

@dimagi/py3 