### PR TITLE
Include attachments during bulk form pillow

### DIFF
--- a/corehq/form_processor/document_stores.py
+++ b/corehq/form_processor/document_stores.py
@@ -23,12 +23,16 @@ class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
     def get_document(self, doc_id):
         try:
             form = self.form_accessors.get_form(doc_id)
-            if isinstance(form, XFormInstanceSQL):
-                return form.to_json(include_attachments=True)
-            else:
-                return form.to_json()
+            return self._to_json(form)
         except (XFormNotFound, BlobError) as e:
             raise DocumentNotFoundError(e)
+
+    @staticmethod
+    def _to_json(form):
+        if isinstance(form, XFormInstanceSQL):
+            return form.to_json(include_attachments=True)
+        else:
+            return form.to_json()
 
     def iter_document_ids(self, last_id=None):
         # todo: support last_id
@@ -36,7 +40,7 @@ class ReadonlyFormDocumentStore(ReadOnlyDocumentStore):
 
     def iter_documents(self, ids):
         for wrapped_form in self.form_accessors.iter_forms(ids):
-            yield wrapped_form.to_json()
+            yield self._to_json(wrapped_form)
 
 
 class ReadonlyCaseDocumentStore(ReadOnlyDocumentStore):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10112

##### SUMMARY
The switch to bulk processing in https://github.com/dimagi/commcare-hq/pull/25676
stopped sending external_blobs to elasticsearch for SQL forms.

##### PRODUCT DESCRIPTION
Fixes form multimedia export which recently broke for forms submitted in the last couple days.