### PR TITLE
Move pip fix to top of test-make-requirements.sh

### DIFF
--- a/scripts/test-make-requirements.sh
+++ b/scripts/test-make-requirements.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-make requirements
-git --no-pager diff
-git update-index -q --refresh
 # 19.3.1 causes locally reproduceable test failure
 # todo: remove this line once that's no longer a problem
 pip install 'pip<19.3.0'
+
+make requirements
+git --no-pager diff
+git update-index -q --refresh
 if git diff-index --quiet HEAD --; then
     # No changes
     echo "requirements ok"


### PR DESCRIPTION
Previously I had put it below `make requirements`
which defeats the purpose.

This is a followup to this commit I (by mistake) pushed directly to master: https://github.com/dimagi/commcare-hq/commit/13e6c09144abe6a246329cddbf3aa9850aa0986f

##### SUMMARY
This should fix the persistent error on the 4th travis build like this one

like this one https://travis-ci.org/dimagi/commcare-hq/jobs/602871465?utm_medium=notification&utm_source=github_status

> AttributeError: module 'pip._internal.download' has no attribute 'is_file_url'
