### PR TITLE
Run calls to ES 1 & 2 through a consistent interface

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -10,6 +10,7 @@ from django.views.generic import View
 from corehq.util.es.elasticsearch import ElasticsearchException, NotFoundError
 
 from casexml.apps.case.models import CommCareCase
+from corehq.util.es.interface import ElasticsearchInterface
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import ISO_DATE_FORMAT
 
@@ -84,6 +85,7 @@ class ESView(View):
         super(ESView, self).__init__()
         self.domain = domain.lower()
         self.es = get_es_new()
+        self.es_interface = ElasticsearchInterface(self.es)
 
     def head(self, *args, **kwargs):
         raise NotImplementedError("Not implemented")
@@ -148,7 +150,7 @@ class ESView(View):
             es_query['fields'] = fields
 
         try:
-            es_results = self.es.search(self.index, es_type, body=es_query)
+            es_results = self.es_interface.search(self.index, es_type, body=es_query)
             report_and_fail_on_shard_failures(es_results)
         except ElasticsearchException as e:
             if 'query_string' in es_query.get('query', {}).get('filtered', {}).get('query', {}):
@@ -333,7 +335,7 @@ class UserES(ESView):
         self.validate_query(es_query)
 
         try:
-            es_results = self.es.search(self.index, es_type, body=es_query)
+            es_results = self.es_interface.search(self.index, es_type, body=es_query)
             report_and_fail_on_shard_failures(es_results)
         except ElasticsearchException as e:
             msg = "Error in elasticsearch query [%s]: %s\nquery: %s" % (

--- a/corehq/apps/hqadmin/escheck.py
+++ b/corehq/apps/hqadmin/escheck.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from couchdbkit import ResourceNotFound
 
 from casexml.apps.case.models import CommCareCase
+from corehq.util.es.interface import ElasticsearchInterface
 from couchforms.models import XFormInstance
 from dimagi.utils.logging import notify_error
 
@@ -135,10 +136,10 @@ def _get_latest_doc_from_index(es_index, sort_field):
         "sort": {sort_field: "desc"},
         "size": 1
     }
-    es = get_es_new()
+    es_interface = ElasticsearchInterface(get_es_new())
 
     try:
-        res = es.search(es_index, body=recent_query)
+        res = es_interface.search(es_index, body=recent_query)
         if 'hits' in res:
             if 'hits' in res['hits']:
                 result = res['hits']['hits'][0]
@@ -157,7 +158,7 @@ def _check_es_rev(index, doc_id, couch_revs):
     doc_id: id to query in ES
     couch_rev: target couch_rev that you want to match
     """
-    es = get_es_new()
+    es_interface = ElasticsearchInterface(get_es_new())
     doc_id_query = {
         "filter": {
             "ids": {"values": [doc_id]}
@@ -166,7 +167,7 @@ def _check_es_rev(index, doc_id, couch_revs):
     }
 
     try:
-        res = es.search(index, body=doc_id_query)
+        res = es_interface.search(index, body=doc_id_query)
         status = False
         message = "Not in sync"
 

--- a/corehq/apps/hqadmin/management/commands/forms_not_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/forms_not_in_es.py
@@ -2,9 +2,10 @@ import inspect
 
 from django.core.management.base import BaseCommand
 
+from corehq.util.es.interface import ElasticsearchInterface
 from dimagi.utils.chunked import chunked
 
-from corehq.elastic import ES_DEFAULT_INSTANCE, ES_META, get_es_instance
+from corehq.elastic import ES_META, get_es_new
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 
 DOC_TYPES = ('XFormInstance', )
@@ -52,10 +53,10 @@ def form_ids_in_domain(domain):
 
 def form_ids_in_es(form_ids):
     query = {"filter": {"ids": {"values": list(form_ids)}}}
-    es_instance = get_es_instance(ES_DEFAULT_INSTANCE)
+    es_interface = ElasticsearchInterface(get_es_new())
     es_meta = ES_META['forms']
-    results = es_instance.search(es_meta.index, es_meta.type, query,
-                                 params={'size': CHUNK_SIZE})
+    results = es_interface.search(es_meta.index, es_meta.type, query,
+                                  params={'size': CHUNK_SIZE})
     if 'hits' in results:
         for hit in results['hits']['hits']:
             es_doc = hit['_source']

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -144,7 +144,7 @@ def send_to_elasticsearch(index_name, doc, delete=False, es_merge_update=False):
         name="{}.{} <{}>:".format(send_to_elasticsearch.__module__,
                                   send_to_elasticsearch.__name__, index_name),
         data=doc,
-        except_on_failure=True,
+        propagate_failure=True,
         update=doc_exists,
         delete=delete,
         es_merge_update=es_merge_update,

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -321,7 +321,7 @@ def scan(client, query=None, scroll='5m', **kwargs):
         while True:
 
             start = int(time.time() * 1000)
-            resp = client.scroll(scroll_id, scroll=scroll)
+            resp = es_interface.scroll(scroll_id, scroll=scroll)
             for hit in resp['hits']['hits']:
                 yield hit
 

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -215,7 +215,7 @@ def run_query(index_name, q, debug_host=None, es_instance_alias=ES_DEFAULT_INSTA
         raise ESError(e)
 
 
-def mget_query(index_name, ids, source):
+def mget_query(index_name, ids):
     if not ids:
         return []
 
@@ -223,7 +223,7 @@ def mget_query(index_name, ids, source):
     es_meta = ES_META[index_name]
     try:
         return es_instance.mget(
-            index=es_meta.index, doc_type=es_meta.type, body={'ids': ids}, _source=source
+            index=es_meta.index, doc_type=es_meta.type, body={'ids': ids}, _source=True
         )['docs']
     except ElasticsearchException as e:
         raise ESError(e)
@@ -232,7 +232,7 @@ def mget_query(index_name, ids, source):
 def iter_es_docs(index_name, ids):
     """Returns a generator which pulls documents from elasticsearch in chunks"""
     for ids_chunk in chunked(ids, 100):
-        for result in mget_query(index_name, ids_chunk, source=True):
+        for result in mget_query(index_name, ids_chunk):
             if result['found']:
                 yield result['_source']
 

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -1,9 +1,9 @@
+from corehq.util.es.interface import ElasticsearchInterface
 from dimagi.ext import jsonobject
 from django.conf import settings
 from copy import copy, deepcopy
 from datetime import datetime
 from corehq.util.es.elasticsearch import TransportError
-from pillowtop import get_all_pillow_classes
 from pillowtop.logger import pillow_logging
 
 INDEX_REINDEX_SETTINGS = {
@@ -129,22 +129,18 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
         return json
 
 
-def update_settings(es, index, settings_dict):
-    return es.indices.put_settings(settings_dict, index=index)
-
-
 def set_index_reindex_settings(es, index):
     """
     Set a more optimized setting setup for fast reindexing
     """
-    return update_settings(es, index, INDEX_REINDEX_SETTINGS)
+    return ElasticsearchInterface(es).update_index_settings(index, INDEX_REINDEX_SETTINGS)
 
 
 def set_index_normal_settings(es, index):
     """
     Normal indexing configuration
     """
-    return update_settings(es, index, INDEX_STANDARD_SETTINGS)
+    return ElasticsearchInterface(es).update_index_settings(index, INDEX_STANDARD_SETTINGS)
 
 
 def create_index_and_set_settings_normal(es, index, metadata=None):

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -9,15 +9,16 @@ from pillowtop.logger import pillow_logging
 INDEX_REINDEX_SETTINGS = {
     "index": {
         "refresh_interval": "1800s",
+        # todo: remove these deprecated properties we are off ES 1
         "merge.policy.merge_factor": 20,
         "store.throttle.max_bytes_per_sec": "1mb",
         "store.throttle.type": "merge",
     }
 }
-
 INDEX_STANDARD_SETTINGS = {
     "index": {
         "refresh_interval": "5s",
+        # todo: remove these deprecated properties we are off ES 1
         "merge.policy.merge_factor": 10,
         "store.throttle.max_bytes_per_sec": "5mb",
         "store.throttle.type": "node",

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -6,25 +6,6 @@ from datetime import datetime
 from corehq.util.es.elasticsearch import TransportError
 from pillowtop.logger import pillow_logging
 
-INDEX_REINDEX_SETTINGS = {
-    "index": {
-        "refresh_interval": "1800s",
-        # todo: remove these deprecated properties we are off ES 1
-        "merge.policy.merge_factor": 20,
-        "store.throttle.max_bytes_per_sec": "1mb",
-        "store.throttle.type": "merge",
-    }
-}
-INDEX_STANDARD_SETTINGS = {
-    "index": {
-        "refresh_interval": "5s",
-        # todo: remove these deprecated properties we are off ES 1
-        "merge.policy.merge_factor": 10,
-        "store.throttle.max_bytes_per_sec": "5mb",
-        "store.throttle.type": "node",
-    }
-}
-
 
 def _get_analysis(*names):
     return {
@@ -134,6 +115,7 @@ def set_index_reindex_settings(es, index):
     """
     Set a more optimized setting setup for fast reindexing
     """
+    from pillowtop.index_settings import INDEX_REINDEX_SETTINGS
     return ElasticsearchInterface(es).update_index_settings(index, INDEX_REINDEX_SETTINGS)
 
 
@@ -141,6 +123,7 @@ def set_index_normal_settings(es, index):
     """
     Normal indexing configuration
     """
+    from pillowtop.index_settings import INDEX_STANDARD_SETTINGS
     return ElasticsearchInterface(es).update_index_settings(index, INDEX_STANDARD_SETTINGS)
 
 

--- a/corehq/ex-submodules/pillowtop/index_settings.py
+++ b/corehq/ex-submodules/pillowtop/index_settings.py
@@ -3,6 +3,7 @@ from corehq.elastic import SIZE_LIMIT
 INDEX_REINDEX_SETTINGS = {
     "index": {
         "refresh_interval": "1800s",
+        # this property will be filtered out on ES 1
         "max_result_window": SIZE_LIMIT,
         # todo: remove these deprecated properties we are off ES 1
         "merge.policy.merge_factor": 20,
@@ -13,6 +14,7 @@ INDEX_REINDEX_SETTINGS = {
 INDEX_STANDARD_SETTINGS = {
     "index": {
         "refresh_interval": "5s",
+        # this property will be filtered out on ES 1
         "max_result_window": SIZE_LIMIT,
         # todo: remove these deprecated properties we are off ES 1
         "merge.policy.merge_factor": 10,

--- a/corehq/ex-submodules/pillowtop/index_settings.py
+++ b/corehq/ex-submodules/pillowtop/index_settings.py
@@ -1,0 +1,23 @@
+from corehq.elastic import SIZE_LIMIT
+
+INDEX_REINDEX_SETTINGS = {
+    "index": {
+        "refresh_interval": "1800s",
+        "max_result_window": SIZE_LIMIT,
+        # todo: remove these deprecated properties we are off ES 1
+        "merge.policy.merge_factor": 20,
+        "store.throttle.max_bytes_per_sec": "1mb",
+        "store.throttle.type": "merge",
+    }
+}
+INDEX_STANDARD_SETTINGS = {
+    "index": {
+        "refresh_interval": "5s",
+        "max_result_window": SIZE_LIMIT,
+        # todo: remove these deprecated properties we are off ES 1
+        "merge.policy.merge_factor": 10,
+        "store.throttle.max_bytes_per_sec": "5mb",
+        "store.throttle.type": "node",
+
+    }
+}

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -128,7 +128,7 @@ class TestBulkDocOperations(TestCase):
         missing_case_ids = [uuid.uuid4().hex, uuid.uuid4().hex]
         changes = self._changes_from_ids(self.case_ids + missing_case_ids)
 
-        with patch('pillowtop.processors.elastic.bulk', return_value=mock_response):
+        with patch.object(ElasticsearchInterface, 'bulk_ops', return_value=mock_response):
             retry, errors = processor.process_changes_chunk(changes)
         self.assertEqual(
             set(missing_case_ids),

--- a/corehq/ex-submodules/pillowtop/tests/test_bulk.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_bulk.py
@@ -6,6 +6,7 @@ from mock import Mock, patch
 from six.moves import range
 
 from casexml.apps.case.signals import case_post_save
+from corehq.util.es.interface import ElasticsearchInterface
 from pillowtop.es_utils import initialize_index_and_mapping
 from pillowtop.feed.interface import Change, ChangeMeta
 from pillowtop.pillow.interface import PillowBase
@@ -65,6 +66,7 @@ class TestBulkDocOperations(TestCase):
                 create_form_for_test(cls.domain, case_id)
 
         cls.es = get_es_new()
+        cls.es_interface = ElasticsearchInterface(cls.es)
         cls.index = TEST_INDEX_INFO.index
 
         with trap_extra_setup(ConnectionError):
@@ -112,11 +114,10 @@ class TestBulkDocOperations(TestCase):
         self.assertEqual([], retry)
         self.assertEqual([], errors)
 
-        es_docs = self.es.mget(
-            index=self.index, doc_type=TEST_INDEX_INFO.type, body={'ids': self.case_ids}, _source=True
-        )['docs']
+        es_docs = self.es_interface.get_bulk_docs(
+            index=self.index, doc_type=TEST_INDEX_INFO.type, doc_ids=self.case_ids)
         ids_in_es = {
-            doc['_source']['_id'] for doc in es_docs
+            doc['_id'] for doc in es_docs
         }
         self.assertEqual(set(self.case_ids), ids_in_es)
 

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -63,7 +63,7 @@ class ElasticPillowTest(SimpleTestCase):
         doc_id = uuid.uuid4().hex
         doc = {'_id': doc_id, 'doc_type': 'CommCareCase', 'type': 'mother'}
         self.assertEqual(0, get_doc_count(self.es, self.index))
-        self.es.create(self.index, 'case', doc, id=doc_id)
+        self.es_interface.create_doc(self.index, 'case', doc_id, doc)
         self.assertEqual(0, get_doc_count(self.es, self.index, refresh_first=False))
         self.es.indices.refresh(self.index)
         self.assertEqual(1, get_doc_count(self.es, self.index, refresh_first=False))

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -81,7 +81,7 @@ class ElasticPillowTest(SimpleTestCase):
         send_to_elasticsearch(self.index, TEST_INDEX_INFO.type, doc_id, get_es_new, 'test', doc)
         self.assertEqual(1, get_doc_count(self.es, self.index))
         assume_alias(self.es, self.index, TEST_INDEX_INFO.alias)
-        es_doc = self.es.get_source(TEST_INDEX_INFO.alias, TEST_INDEX_INFO.type, doc_id)
+        es_doc = self.es_interface.get_doc(TEST_INDEX_INFO.alias, TEST_INDEX_INFO.type, doc_id)
         for prop in doc:
             self.assertEqual(doc[prop], es_doc[prop])
 
@@ -139,6 +139,7 @@ class TestSendToElasticsearch(SimpleTestCase):
 
     def setUp(self):
         self.es = get_es_new()
+        self.es_interface = ElasticsearchInterface(self.es)
         self.index = TEST_INDEX_INFO.index
 
         with trap_extra_setup(ConnectionError):
@@ -155,7 +156,7 @@ class TestSendToElasticsearch(SimpleTestCase):
     def _send_to_es_and_check(self, doc, update=False, es_merge_update=False,
                               delete=False, esgetter=None):
         if update and es_merge_update:
-            old_doc = self.es.get_source(self.index, TEST_INDEX_INFO.type, doc['_id'])
+            old_doc = self.es_interface.get_doc(self.index, TEST_INDEX_INFO.type, doc['_id'])
 
         send_to_elasticsearch(
             index=self.index,
@@ -172,7 +173,7 @@ class TestSendToElasticsearch(SimpleTestCase):
 
         if not delete:
             self.assertEqual(1, get_doc_count(self.es, self.index))
-            es_doc = self.es.get_source(self.index, TEST_INDEX_INFO.type, doc['_id'])
+            es_doc = self.es_interface.get_doc(self.index, TEST_INDEX_INFO.type, doc['_id'])
             if es_merge_update:
                 old_doc.update(es_doc)
                 for prop in doc:

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -8,9 +8,15 @@ from corehq.util.es.elasticsearch import ConnectionError
 from corehq.elastic import get_es_new
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup
-from pillowtop.es_utils import INDEX_REINDEX_SETTINGS, INDEX_STANDARD_SETTINGS, \
-    set_index_reindex_settings, set_index_normal_settings, mapping_exists, initialize_index, \
-    initialize_index_and_mapping, assume_alias
+from pillowtop.es_utils import (
+    assume_alias,
+    initialize_index,
+    initialize_index_and_mapping,
+    mapping_exists,
+    set_index_normal_settings,
+    set_index_reindex_settings,
+)
+from pillowtop.index_settings import INDEX_REINDEX_SETTINGS, INDEX_STANDARD_SETTINGS
 from corehq.util.es.interface import ElasticsearchInterface
 from pillowtop.exceptions import PillowtopIndexingError
 from pillowtop.processors.elastic import send_to_elasticsearch

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -114,31 +114,40 @@ class ElasticPillowTest(SimpleTestCase):
         initialize_index_and_mapping(self.es, TEST_INDEX_INFO)
         self.es_interface.update_index_settings(self.index, INDEX_REINDEX_SETTINGS)
         index_settings_back = self.es.indices.get_settings(self.index)[self.index]['settings']
-        self._compare_es_dicts(INDEX_REINDEX_SETTINGS, index_settings_back, 'index')
+        self._compare_es_dicts(INDEX_REINDEX_SETTINGS, index_settings_back)
         self.es_interface.update_index_settings(self.index, INDEX_STANDARD_SETTINGS)
         index_settings_back = self.es.indices.get_settings(self.index)[self.index]['settings']
-        self._compare_es_dicts(INDEX_STANDARD_SETTINGS, index_settings_back, 'index')
+        self._compare_es_dicts(INDEX_STANDARD_SETTINGS, index_settings_back)
 
     def test_set_index_reindex(self):
         initialize_index_and_mapping(self.es, TEST_INDEX_INFO)
         set_index_reindex_settings(self.es, self.index)
         index_settings_back = self.es.indices.get_settings(self.index)[self.index]['settings']
-        self._compare_es_dicts(INDEX_REINDEX_SETTINGS, index_settings_back, 'index')
+        self._compare_es_dicts(INDEX_REINDEX_SETTINGS, index_settings_back)
 
     def test_set_index_normal(self):
         initialize_index_and_mapping(self.es, TEST_INDEX_INFO)
         set_index_normal_settings(self.es, self.index)
         index_settings_back = self.es.indices.get_settings(self.index)[self.index]['settings']
-        self._compare_es_dicts(INDEX_STANDARD_SETTINGS, index_settings_back, 'index')
+        self._compare_es_dicts(INDEX_STANDARD_SETTINGS, index_settings_back)
 
-    def _compare_es_dicts(self, expected, returned, prefix):
-        sub_returned = returned[prefix]
-        for key, value in expected[prefix].items():
+    def _compare_es_dicts(self, expected, returned):
+        sub_returned = returned['index']
+        should_not_exist = ElasticsearchInterface._disallowed_index_settings
+        for key, value in expected['index'].items():
+            if key in should_not_exist:
+                continue
             split_key = key.split('.')
             returned_value = sub_returned[split_key[0]]
             for sub_key in split_key[1:]:
                 returned_value = returned_value[sub_key]
             self.assertEqual(str(value), returned_value)
+
+        for disallowed_setting in should_not_exist:
+            self.assertNotIn(
+                disallowed_setting, sub_returned,
+                '{} is disallowed and should not be in the index settings'
+                .format(disallowed_setting))
 
 
 class TestSendToElasticsearch(SimpleTestCase):

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -167,7 +167,6 @@ class TestSendToElasticsearch(SimpleTestCase):
             update=update,
             es_merge_update=es_merge_update,
             delete=delete,
-            except_on_failure=True,
             retries=1
         )
 

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -8,9 +8,10 @@ from corehq.util.es.elasticsearch import ConnectionError
 from corehq.elastic import get_es_new
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup
-from pillowtop.es_utils import INDEX_REINDEX_SETTINGS, INDEX_STANDARD_SETTINGS, update_settings, \
+from pillowtop.es_utils import INDEX_REINDEX_SETTINGS, INDEX_STANDARD_SETTINGS, \
     set_index_reindex_settings, set_index_normal_settings, mapping_exists, initialize_index, \
     initialize_index_and_mapping, assume_alias
+from corehq.util.es.interface import ElasticsearchInterface
 from pillowtop.exceptions import PillowtopIndexingError
 from pillowtop.processors.elastic import send_to_elasticsearch
 from .utils import get_doc_count, get_index_mapping, TEST_INDEX_INFO
@@ -21,6 +22,7 @@ class ElasticPillowTest(SimpleTestCase):
     def setUp(self):
         self.index = TEST_INDEX_INFO.index
         self.es = get_es_new()
+        self.es_interface = ElasticsearchInterface(self.es)
         with trap_extra_setup(ConnectionError):
             ensure_index_deleted(self.index)
 
@@ -104,10 +106,10 @@ class ElasticPillowTest(SimpleTestCase):
 
     def test_update_settings(self):
         initialize_index_and_mapping(self.es, TEST_INDEX_INFO)
-        update_settings(self.es, self.index, INDEX_REINDEX_SETTINGS)
+        self.es_interface.update_index_settings(self.index, INDEX_REINDEX_SETTINGS)
         index_settings_back = self.es.indices.get_settings(self.index)[self.index]['settings']
         self._compare_es_dicts(INDEX_REINDEX_SETTINGS, index_settings_back, 'index')
-        update_settings(self.es, self.index, INDEX_STANDARD_SETTINGS)
+        self.es_interface.update_index_settings(self.index, INDEX_STANDARD_SETTINGS)
         index_settings_back = self.es.indices.get_settings(self.index)[self.index]['settings']
         self._compare_es_dicts(INDEX_STANDARD_SETTINGS, index_settings_back, 'index')
 

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -8,6 +8,13 @@ class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
         self.es = es
 
     def update_index_settings(self, index, settings_dict):
+        assert set(settings_dict.keys()) == {'index'}, settings_dict.keys()
+        settings_dict = {
+            "index": {
+                key: value for key, value in settings_dict['index'].items()
+                if key not in self._disallowed_index_settings
+            }
+        }
         return self.es.indices.put_settings(settings_dict, index=index)
 
     def get_doc(self, index, doc_type, doc_id):
@@ -64,25 +71,17 @@ class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
 
 
 class ElasticsearchInterface1(AbstractElasticsearchInterface):
-    pass
+    _disallowed_index_settings = (
+        'max_result_window',
+    )
 
 
 class ElasticsearchInterface2(AbstractElasticsearchInterface):
-    _deprecated_index_settings = (
+    _disallowed_index_settings = (
         'merge.policy.merge_factor',
         'store.throttle.max_bytes_per_sec',
         'store.throttle.type',
     )
-
-    def update_index_settings(self, index, settings_dict):
-        assert set(settings_dict.keys()) == {'index'}, settings_dict.keys()
-        settings_dict = {
-            "index": {
-                key: value for key, value in settings_dict['index'].items()
-                if key not in self._deprecated_index_settings
-            }
-        }
-        super(ElasticsearchInterface2, self).update_index_settings(index, settings_dict)
 
 
 ElasticsearchInterface = {

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -1,0 +1,6 @@
+class ElasticsearchInterface(object):
+    def __init__(self, es):
+        self.es = es
+
+    def update_index_settings(self, index, settings_dict):
+        return self.es.indices.put_settings(settings_dict, index=index)

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -58,7 +58,7 @@ class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
         return results
 
     def scroll(self, scroll_id=None, body=None, params=None, **kwargs):
-        results = self.es.scroll(scroll_id, body, params or {}, **kwargs)
+        results = self.es.scroll(scroll_id, body, params=params or {}, **kwargs)
         self._fix_hits_in_results(results)
         return results
 

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -72,7 +72,8 @@ class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
 
     @staticmethod
     def _fix_hit(hit):
-        hit['_source']['_id'] = hit['_id']
+        if '_source' in hit:
+            hit['_source']['_id'] = hit['_id']
 
     def _fix_hits_in_results(self, results):
         try:

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -10,6 +10,26 @@ class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
     def update_index_settings(self, index, settings_dict):
         return self.es.indices.put_settings(settings_dict, index=index)
 
+    def create_doc(self, index, doc_type, doc_id, doc):
+        # Field [_id] is a metadata field and cannot be added inside a document.
+        # Use the index API request parameters.
+        doc = {key: value for key, value in doc.items() if key != '_id'}
+        self.es.create(index, doc_type, body=doc, id=doc_id)
+
+    def get_doc(self, index, doc_type, doc_id):
+        doc = self.es.get_source(index, doc_type, doc_id)
+        doc['_id'] = doc_id
+        return doc
+
+    def update_doc(self, index, doc_type, doc_id, doc, params=None):
+        self.es.index(index, doc_type, body=doc, id=doc_id, params=params)
+
+    def update_doc_fields(self, index, doc_type, doc_id, fields, params=None):
+        self.es.update(index, doc_type, doc_id, body={"doc": fields}, params=params)
+
+    def delete_doc(self, index, doc_type, doc_id):
+        self.es.delete(index, doc_type, doc_id)
+
 
 class ElasticsearchInterface1(AbstractElasticsearchInterface):
     pass

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -38,6 +38,8 @@ class ElasticsearchInterface1(AbstractElasticsearchInterface):
 class ElasticsearchInterface2(AbstractElasticsearchInterface):
     _deprecated_index_settings = (
         'merge.policy.merge_factor',
+        'store.throttle.max_bytes_per_sec',
+        'store.throttle.type',
     )
 
     def update_index_settings(self, index, settings_dict):

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -1,6 +1,37 @@
-class ElasticsearchInterface(object):
+import abc
+
+from django.conf import settings
+
+
+class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
     def __init__(self, es):
         self.es = es
 
     def update_index_settings(self, index, settings_dict):
         return self.es.indices.put_settings(settings_dict, index=index)
+
+
+class ElasticsearchInterface1(AbstractElasticsearchInterface):
+    pass
+
+
+class ElasticsearchInterface2(AbstractElasticsearchInterface):
+    _deprecated_index_settings = (
+        'merge.policy.merge_factor',
+    )
+
+    def update_index_settings(self, index, settings_dict):
+        assert set(settings_dict.keys()) == {'index'}, settings_dict.keys()
+        settings_dict = {
+            "index": {
+                key: value for key, value in settings_dict['index'].items()
+                if key not in self._deprecated_index_settings
+            }
+        }
+        super(ElasticsearchInterface2, self).update_index_settings(index, settings_dict)
+
+
+ElasticsearchInterface = {
+    1: ElasticsearchInterface1,
+    2: ElasticsearchInterface2,
+}[settings.ELASTICSEARCH_MAJOR_VERSION]

--- a/corehq/util/es/interface.py
+++ b/corehq/util/es/interface.py
@@ -20,11 +20,9 @@ class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
         results = self.es.mget(
             index=index, doc_type=doc_type, body={'ids': doc_ids}, _source=True)
         for doc_result in results['docs']:
-            doc_id = doc_result['_id']
             if doc_result['found']:
-                doc = doc_result['_source']
-                doc['_id'] = doc_id
-                docs.append(doc)
+                self._fix_hit(doc_result)
+                docs.append(doc_result['_source'])
         return docs
 
     def create_doc(self, index, doc_type, doc_id, doc):
@@ -34,13 +32,35 @@ class AbstractElasticsearchInterface(metaclass=abc.ABCMeta):
         self.es.create(index, doc_type, body=doc, id=doc_id)
 
     def update_doc(self, index, doc_type, doc_id, doc, params=None):
-        self.es.index(index, doc_type, body=doc, id=doc_id, params=params)
+        self.es.index(index, doc_type, body=doc, id=doc_id, params=params or {})
 
     def update_doc_fields(self, index, doc_type, doc_id, fields, params=None):
-        self.es.update(index, doc_type, doc_id, body={"doc": fields}, params=params)
+        self.es.update(index, doc_type, doc_id, body={"doc": fields}, params=params or {})
 
     def delete_doc(self, index, doc_type, doc_id):
         self.es.delete(index, doc_type, doc_id)
+
+    def search(self, index=None, doc_type=None, body=None, params=None, **kwargs):
+        results = self.es.search(index, doc_type, body=body, params=params or {}, **kwargs)
+        self._fix_hits_in_results(results)
+        return results
+
+    def scroll(self, scroll_id=None, body=None, params=None, **kwargs):
+        results = self.es.scroll(scroll_id, body, params or {}, **kwargs)
+        self._fix_hits_in_results(results)
+        return results
+
+    @staticmethod
+    def _fix_hit(hit):
+        hit['_source']['_id'] = hit['_id']
+
+    def _fix_hits_in_results(self, results):
+        try:
+            hits = results['hits']['hits']
+        except KeyError:
+            return results
+        for hit in hits:
+            self._fix_hit(hit)
 
 
 class ElasticsearchInterface1(AbstractElasticsearchInterface):

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -231,7 +231,7 @@ class FormsInDateExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
     @staticmethod
     def _bulk_get_form_json_from_es(forms):
         form_ids = [form.form_id for form in forms]
-        es_forms = FormsInDateExpressionSpec._bulk_get_forms_from_elasticsearch(form_ids, source=True)
+        es_forms = FormsInDateExpressionSpec._bulk_get_forms_from_elasticsearch(form_ids)
         return {
             f['_id']: f for f in es_forms
         }
@@ -249,8 +249,8 @@ class FormsInDateExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
         return (XFORM_CACHE_KEY_PREFIX, form.form_id)
 
     @staticmethod
-    def _bulk_get_forms_from_elasticsearch(form_ids, source):
-        forms = mget_query('forms', form_ids, source)
+    def _bulk_get_forms_from_elasticsearch(form_ids):
+        forms = mget_query('forms', form_ids)
         return list(filter(None, [
             FormsInDateExpressionSpec._transform_time_end_and_filter_bad_data(f) for f in forms
         ]))

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -257,7 +257,6 @@ class FormsInDateExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
 
     @staticmethod
     def _transform_time_end_and_filter_bad_data(xform):
-        xform = xform.get('_source', {})
         if not xform.get('xmlns', None):
             return None
         try:

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -198,7 +198,7 @@ class FormsInDateExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
             return context.get_cache_value(cache_key)
 
         source = True if es_toggle_enabled else ['form.meta.timeEnd', 'xmlns', '_id']
-        forms = FormsInDateExpressionSpec._bulk_get_forms_from_elasticsearch(xform_ids, source)
+        forms = FormsInDateExpressionSpec._bulk_get_forms_from_elasticsearch(xform_ids)
         context.set_cache_value(cache_key, forms)
         return forms
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-143

##### SUMMARY
This incorporates some of the same fixes as https://github.com/dimagi/commcare-hq/pull/25085 but supersedes that PR. This PR builds off the approach I started in https://github.com/dimagi/commcare-hq/pull/25728, but adds another layer of normalization to make it irrelevant in most of the code base whether we're working with ES 1 or ES 2.

Unlike that PR, this PR does _not_ change our ES version, so the tests passing means that things continue to work on ES 1.7, and after review this is safe to merge and continue to build off of from there.

While making this PR, I've been testing it against ES 2.4.6 locally. Once this is merged, we can run all tests against ES 2 by just opening a PR with just https://github.com/dimagi/commcare-hq/commit/a28aab1acf151ed285f9a7cb46ea612bcc5b8df2 cherry-picked onto master (like this one: https://github.com/dimagi/commcare-hq/pull/25744).