### PR TITLE
Updated last_released header format

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -1,4 +1,5 @@
 import json
+import pytz
 import re
 from collections import OrderedDict, defaultdict
 
@@ -35,6 +36,7 @@ from corehq.apps.app_manager.views.utils import back_to_main, get_langs
 from corehq.apps.builds.jadjar import convert_XML_To_J2ME
 from corehq.apps.hqmedia.views import DownloadMultimediaZip
 from corehq.util.soft_assert import soft_assert
+from corehq.util.timezones.conversions import ServerTime
 from corehq.util.view_utils import set_file_download
 
 BAD_BUILD_MESSAGE = _("Sorry: this build is invalid. Try deleting it and rebuilding. "
@@ -293,7 +295,8 @@ def download_file(request, domain, app_id, path):
             payload = convert_XML_To_J2ME(payload, path, request.app.use_j2me_endpoint)
         response.write(payload)
         if path in ['profile.ccpr', 'media_profile.ccpr'] and request.app.last_released:
-            response['X-CommCareHQ-AppReleasedOn'] = request.app.last_released.isoformat()
+            last_released = ServerTime(request.app.last_released).user_time(pytz.UTC).done().isoformat()
+            response['X-CommCareHQ-AppReleasedOn'] = last_released
         response['Content-Length'] = len(response.content)
         return response
     except (ResourceNotFound, AssertionError):

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -1,4 +1,5 @@
 import json
+import pytz
 import re
 from collections import OrderedDict, defaultdict
 
@@ -36,7 +37,6 @@ from corehq.apps.builds.jadjar import convert_XML_To_J2ME
 from corehq.apps.hqmedia.views import DownloadMultimediaZip
 from corehq.util.soft_assert import soft_assert
 from corehq.util.timezones.conversions import ServerTime
-from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import set_file_download
 
 BAD_BUILD_MESSAGE = _("Sorry: this build is invalid. Try deleting it and rebuilding. "
@@ -295,9 +295,7 @@ def download_file(request, domain, app_id, path):
             payload = convert_XML_To_J2ME(payload, path, request.app.use_j2me_endpoint)
         response.write(payload)
         if path in ['profile.ccpr', 'media_profile.ccpr'] and request.app.last_released:
-            timezone = get_timezone_for_user(request.couch_user.get_id, domain)
-            last_released = request.app.last_released.replace(microsecond=0)    # mobile doesn't want microseconds
-            last_released = ServerTime(last_released).user_time(timezone).done().isoformat()
+            last_released = ServerTime(request.app.last_released).user_time(pytz.UTC).done().isoformat()
             response['X-CommCareHQ-AppReleasedOn'] = last_released
         response['Content-Length'] = len(response.content)
         return response

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -295,7 +295,8 @@ def download_file(request, domain, app_id, path):
             payload = convert_XML_To_J2ME(payload, path, request.app.use_j2me_endpoint)
         response.write(payload)
         if path in ['profile.ccpr', 'media_profile.ccpr'] and request.app.last_released:
-            last_released = ServerTime(request.app.last_released).user_time(pytz.UTC).done().isoformat()
+            last_released = request.app.last_released.replace(microsecond=0)    # mobile doesn't want microseconds
+            last_released = ServerTime(last_released).user_time(pytz.UTC).done().isoformat()
             response['X-CommCareHQ-AppReleasedOn'] = last_released
         response['Content-Length'] = len(response.content)
         return response


### PR DESCRIPTION
##### SUMMARY
Update format as discussed in https://docs.google.com/document/d/1RYRPgmsvP0vUEkMJSJMHGtO0EprQK2P8kvwO0FKCSEA/edit?ts=5db261e3

@shubham1g5 it looks like this now:
<img width="1079" alt="Screen Shot 2019-10-28 at 9 15 04 AM" src="https://user-images.githubusercontent.com/1486591/67681553-ed4f8180-f963-11e9-8dc7-812de4efe93d.png">

@dannyroberts Pinged in case you have suggestions on the time zone code. Seems weird to use `user_time` for a date that's only ever read/written by the server, but that's the only way I've found to make the exact format as other dates sent to mobile (the sticking point is getting the `+00:00` to show up). Used [mobile UCR last_sync](https://github.com/dimagi/commcare-hq/blob/39d71fa0cdc8feec03c3727b5be8cfab854f7312/corehq/apps/app_manager/fixtures/mobile_ucr.py#L443) as the model.