### PR TITLE
Upgrade pip-tools

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -128,7 +128,7 @@ pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
 pillow==6.2.1
-pip-tools==4.0.0
+pip-tools==4.2.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prompt-toolkit==1.0.16    # via ipython

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -110,7 +110,7 @@ pbr==5.2.0                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.10
 pillow==6.2.1
-pip-tools==4.0.0
+pip-tools==4.2.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -128,7 +128,7 @@ pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.10
 pickleshare==0.7.5        # via ipython
 pillow==6.2.1
-pip-tools==4.0.0
+pip-tools==4.2.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prompt-toolkit==1.0.16    # via ipython

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -6,7 +6,7 @@ git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 fakecouch==0.0.15
 nose==1.3.7
 nose-exclude==0.5.0
-pip-tools>=4.0.0
+pip-tools>4.0.0
 testil
 unittest2
 requests-mock

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -110,7 +110,7 @@ pbr==5.2.0                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.10
 pillow==6.2.1
-pip-tools==4.0.0
+pip-tools==4.2.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1

--- a/scripts/test-make-requirements.sh
+++ b/scripts/test-make-requirements.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# 19.3.1 causes locally reproduceable test failure
-# todo: remove this line once that's no longer a problem
-pip install 'pip<19.3.0'
-
 make requirements
 git --no-pager diff
 git update-index -q --refresh


### PR DESCRIPTION
##### SUMMARY
I made https://github.com/dimagi/commcare-hq/pull/25739 to deal with the acute build failure issue, but after digging today I realized fairly quickly that upgrading `pip-tools` gets rid of the error, and so doing that is clearly the better fix.
