### PR TITLE
improvements to close extension chain workflow

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -654,11 +654,12 @@ def _get_case_and_ledger_updates(domain, sql_form):
         load_src="couchsqlmigration",
     ) as case_db:
         touched_cases = interface.get_cases_from_forms(case_db, xforms)
-        extensions_to_close = get_all_extensions_to_close(domain, list(touched_cases.values()))
+        cases = [case_meta.case for case_meta in touched_cases.values()]
+        extensions_to_close = get_all_extensions_to_close(domain, cases)
         case_result = CaseProcessingResult(
             domain,
             [update.case for update in touched_cases.values()],
-            [],  # ignore dirtiness_flags,
+            [],  # ignore dirtiness_flags
             extensions_to_close
         )
         for case in case_result.cases:

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -654,13 +654,10 @@ def _get_case_and_ledger_updates(domain, sql_form):
         load_src="couchsqlmigration",
     ) as case_db:
         touched_cases = interface.get_cases_from_forms(case_db, xforms)
-        cases = [case_meta.case for case_meta in touched_cases.values()]
-        extensions_to_close = get_all_extensions_to_close(domain, cases)
         case_result = CaseProcessingResult(
             domain,
             [update.case for update in touched_cases.values()],
-            [],  # ignore dirtiness_flags
-            extensions_to_close
+            []  # ignore dirtiness_flags
         )
         for case in case_result.cases:
             case_db.post_process_case(case, sql_form)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -231,13 +231,17 @@ class AutoCloseExtensionsTest(TestCase):
             attrs={'close': True}
         ))
         cases = {
-            case.case_id: case.closed
+            case.case_id: case
             for case in CaseAccessors(self.domain).get_cases([self.parent_id, self.host_id] + self.extension_ids)
         }
-        self.assertFalse(cases[self.parent_id])
-        self.assertTrue(cases[self.host_id])
-        self.assertTrue(cases[self.extension_ids[0]])
-        self.assertTrue(cases[self.extension_ids[1]])
+        self.assertFalse(cases[self.parent_id].closed)
+        self.assertTrue(cases[self.host_id].closed)
+        self.assertTrue(cases[self.extension_ids[0]].closed)
+        self.assertTrue(cases[self.extension_ids[1]].closed)
+
+        self.assertEqual(1, len(cases[self.host_id].get_closing_transactions()))
+        self.assertEqual(1, len(cases[self.extension_ids[0]].get_closing_transactions()))
+        self.assertEqual(1, len(cases[self.extension_ids[1]].get_closing_transactions()))
 
 
 @use_sql_backend

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -47,19 +47,6 @@ class CaseProcessingResult(object):
     def get_flags_to_save(self):
         return {f.owner_id: f.case_id for f in self.dirtiness_flags}
 
-    def close_extensions(self, case_db, device_id):
-        from casexml.apps.case.cleanup import close_cases
-        extensions_to_close = get_all_extensions_to_close(case_db.domain, self.cases)
-        extensions_to_close = case_db.filter_closed_extensions(list(extensions_to_close))
-        if extensions_to_close:
-            return close_cases(
-                extensions_to_close,
-                self.domain,
-                SYSTEM_USER_ID,
-                device_id,
-                case_db,
-            )
-
     def commit_dirtiness_flags(self):
         """
         Updates any dirtiness flags in the database.
@@ -264,6 +251,20 @@ def _is_change_of_ownership(previous_owner_id, next_owner_id):
         and previous_owner_id != UNOWNED_EXTENSION_OWNER_ID
         and previous_owner_id != next_owner_id
     )
+
+
+def close_extension_cases(case_db, cases, device_id):
+    from casexml.apps.case.cleanup import close_cases
+    extensions_to_close = get_all_extensions_to_close(case_db.domain, cases)
+    extensions_to_close = case_db.filter_closed_extensions(list(extensions_to_close))
+    if extensions_to_close:
+        return close_cases(
+            extensions_to_close,
+            case_db.domain,
+            SYSTEM_USER_ID,
+            device_id,
+            case_db,
+        )
 
 
 def get_all_extensions_to_close(domain, cases):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -13,6 +13,8 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 import sys
+
+from casexml.apps.case.xform import close_extension_cases
 from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 import couchforms
 from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, UsesReferrals, InvalidCaseIndex, \
@@ -393,8 +395,9 @@ class SubmissionPost(object):
 
             SubmissionPost._fire_post_save_signals(instance, case_stock_result.case_models)
 
-            case_stock_result.case_result.close_extensions(
+            close_extension_cases(
                 case_db,
+                case_stock_result.case_models,
                 "SubmissionPost-%s-close_extensions" % instance.form_id
             )
         except PostSaveError:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -389,6 +389,7 @@ class SubmissionPost(object):
     @tracer.wrap(name='submission.post_save_actions')
     def do_post_save_actions(case_db, xforms, case_stock_result):
         instance = xforms[0]
+        case_db.clear_changed()
         try:
             case_stock_result.case_result.commit_dirtiness_flags()
             case_stock_result.stock_result.finalize()


### PR DESCRIPTION
##### SUMMARY
A few changes to make the process of closing extension cases more efficient and less error prone. Mainly:

1. Fetch extensions to close after saving the cases from the current form
2. Clear the CaseDBCache object's 'changed cases' to avoid re-saving cases multiple times

Best review by commit

When looking at some error forms on ICDS I noticed some weirdness that led me to this.