### PR TITLE
Ensure submenu names don't override the parent menu name

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -157,24 +157,12 @@ class MenuContributor(SuiteContributorByModule):
                         })
                         menu = LocalizedMenu(**menu_kwargs)
                     else:
-                        if (module.put_in_root
-                                and module.root_module
-                                and not module.root_module.put_in_root):
-                            # Mobile will combine this module with its parent
-                            # Reference the parent's name to avoid ambiguity
-                            locale_kwargs = {
-                                'locale_id': get_module_locale_id(module.root_module),
-                                'enum_text': get_module_enum_text(module.root_module),
-                            }
-                        else:
-                            locale_kwargs = {
-                                'locale_id': get_module_locale_id(module),
-                                'enum_text': get_module_enum_text(module),
-                            }
                         menu_kwargs.update({
                             'media_image': module.default_media_image,
                             'media_audio': module.default_media_audio,
-                        }, **locale_kwargs)
+                            'locale_id': get_module_locale_id(module),
+                            'enum_text': get_module_enum_text(module),
+                        })
                         menu = Menu(**menu_kwargs)
 
                     excluded_form_ids = []

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -9,18 +9,18 @@ from corehq.apps.app_manager.suite_xml.xml_models import Suite, Text, XpathEnum
 
 
 def get_select_chain(app, module, include_self=True):
-        select_chain = [module] if include_self else []
-        current_module = module
-        while hasattr(current_module, 'parent_select') and current_module.parent_select.active:
-            current_module = app.get_module_by_unique_id(
-                current_module.parent_select.module_id,
-                error=_("Case list used by parent child selection in '{}' not found").format(
-                      current_module.default_name()),
-            )
-            if current_module in select_chain:
-                raise SuiteValidationError("Circular reference in case hierarchy")
-            select_chain.append(current_module)
-        return select_chain
+    select_chain = [module] if include_self else []
+    current_module = module
+    while hasattr(current_module, 'parent_select') and current_module.parent_select.active:
+        current_module = app.get_module_by_unique_id(
+            current_module.parent_select.module_id,
+            error=_("Case list used by parent child selection in '{}' not found").format(
+                  current_module.default_name()),
+        )
+        if current_module in select_chain:
+            raise SuiteValidationError("Circular reference in case hierarchy")
+        select_chain.append(current_module)
+    return select_chain
 
 
 def get_select_chain_meta(app, module):

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -79,7 +79,15 @@ def _form_uses_name_enum(form):
     return bool(form.name_enum)
 
 
+def _should_use_root_display(module):
+    # child modules set to display only forms should use their parent module's
+    # name so as not to confuse mobile when the two are combined
+    return module.put_in_root and module.root_module and not module.root_module.put_in_root
+
+
 def get_module_locale_id(module):
+    if _should_use_root_display(module):
+        module = module.root_module
     if not _module_uses_name_enum(module):
         return id_strings.module_locale(module)
 
@@ -90,6 +98,8 @@ def get_form_locale_id(form):
 
 
 def get_module_enum_text(module):
+    if _should_use_root_display(module):
+        module = module.root_module
     if not _module_uses_name_enum(module):
         return None
 

--- a/corehq/apps/app_manager/suite_xml/utils.py
+++ b/corehq/apps/app_manager/suite_xml/utils.py
@@ -15,7 +15,7 @@ def get_select_chain(app, module, include_self=True):
         current_module = app.get_module_by_unique_id(
             current_module.parent_select.module_id,
             error=_("Case list used by parent child selection in '{}' not found").format(
-                  current_module.default_name()),
+                current_module.default_name()),
         )
         if current_module in select_chain:
             raise SuiteValidationError("Circular reference in case hierarchy")


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-152

##### SUMMARY
This is a followup on the same basic issue from https://github.com/dimagi/commcare-hq/pull/23072

That logic was inside a conditional branch, so it only applied to one part of that branch.  Here I move it into the utility function so it's applied consistently (and also makes a bit more sense).

##### PRODUCT DESCRIPTION
This resolves a bug where a submenu set to "display only forms" would sometimes override the name of the parent menu.