### PR TITLE
fix DD gauge metrics with tags

### DIFF
--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -15,5 +15,7 @@ def record_pillow_error_queue_size():
     data = PillowError.objects.values('pillow').annotate(num_errors=Count('id'))
     for row in data:
         datadog_gauge('commcare.pillowtop.error_queue', row['num_errors'], tags=[
-            'pillow_name:%s' % row['pillow']
+            'pillow_name:%s' % row['pillow'],
+            'host:celery',
+            'group:celery'
         ])

--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -23,9 +23,14 @@ def pillow_datadog_metrics():
         pillow_meta = [pillow for pillow in pillow_meta if pillow['name'] in active_pillows]
 
     for pillow in pillow_meta:
+        # The host and group tags are added here to ensure they remain constant
+        # regardless of which celery worker the task get's executed on.
+        # Without this the sum of the metrics get's inflated.
         tags = [
             'pillow_name:{}'.format(pillow['name']),
-            'feed_type:{}'.format('couch' if _is_couch(pillow) else 'kafka')
+            'feed_type:{}'.format('couch' if _is_couch(pillow) else 'kafka'),
+            'host:celery',
+            'group:celery'
         ]
 
         datadog_gauge(


### PR DESCRIPTION
##### SUMMARY
Fix for inflated DD metrics on ICDS. Since we have multiple hosts processing the celery periodic queue the metrics get tagged with different host names which means that when we sum by pillow name in DD it will treat the metrics from different hosts as separate and add then together.

This is only an issue when summing gauge metrics across a subset of tags.