### PR TITLE
cache value in locmem between tasks

### DIFF
--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -1161,7 +1161,7 @@ class VisitSchedulerIntegrationHelper(object):
         self.scheduler_module_info = scheduler_module_info
 
     @classmethod
-    @quickcache(['domain', 'app_id', 'form_unique_id'], timeout=60 * 60)
+    @quickcache(['domain', 'app_id', 'form_unique_id'], timeout=60 * 60, memoize_timeout=60, session_function=None)
     def get_visit_scheduler_module_and_form(cls, domain, app_id, form_unique_id):
         app = get_latest_released_app(domain, app_id)
         if app is None:


### PR DESCRIPTION
##### SUMMARY
This cache key is one of the main contributors to network traffic on one of ICDS redis nodes. The effect of this change to keep the value in process memory for 60s. Previously the local cache was not being hit since the cache key was varied based on the celery task.

This is a pattern I'd like to start applying to other places as well where varying local memory cache between requests / tasks isn't necessary.

I had considered creating a separate quickcache decorator for this use case but decided against it for now.

Notifying a wider audience for this change to get feedback on the general idea of allowing local cache persistence beyond the scope of a request / task.