### PR TITLE
Rename AutomaticUpdateRule methods

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -112,7 +112,7 @@ def _get_active_scheduling_rules(domain, survey_only=False):
 
     result = []
     for rule in rules:
-        schedule = rule.get_messaging_rule_schedule()
+        schedule = rule.get_schedule()
         if schedule.active and (not survey_only or schedule.memoized_uses_sms_survey):
             result.append(rule)
 
@@ -167,7 +167,7 @@ def _deactivate_schedules(domain, survey_only=False):
         for more information.
         """
         with transaction.atomic():
-            schedule = rule.get_messaging_rule_schedule()
+            schedule = rule.get_schedule()
             if isinstance(schedule, AlertSchedule):
                 AlertSchedule.objects.filter(schedule_id=schedule.schedule_id).update(active=False)
             elif isinstance(schedule, TimedSchedule):

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -382,7 +382,7 @@ class DeactivateScheduleTest(TransactionTestCase):
         elif isinstance(obj, ImmediateBroadcast):
             schedule = AlertSchedule.objects.get(schedule_id=obj.schedule_id)
         elif isinstance(obj, AutomaticUpdateRule):
-            schedule = AlertSchedule.objects.get(schedule_id=obj.get_messaging_rule_schedule().schedule_id)
+            schedule = AlertSchedule.objects.get(schedule_id=obj.get_schedule().schedule_id)
         else:
             raise TypeError("Expected ScheduledBroadcast, ImmediateBroadcast, or AutomaticUpdateRule")
 

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -206,7 +206,7 @@ class AutomaticUpdateRule(models.Model):
             if not isinstance(definition, allowed_criteria_definitions):
                 return False
 
-        action_definition = self.get_messaging_rule_action_definition()
+        action_definition = self.get_action_definition()
 
         allowed_recipient_types = (
             CaseScheduleInstanceMixin.RECIPIENT_TYPE_SELF,
@@ -305,7 +305,7 @@ class AutomaticUpdateRule(models.Model):
                         "Unexpected criteria definition. Did conditional_alert_can_be_copied() get called?"
                     )
 
-            action_definition = self.get_messaging_rule_action_definition()
+            action_definition = self.get_action_definition()
             schedule = action_definition.schedule
 
             new_schedule = self.copy_schedule(schedule, to_domain,
@@ -690,7 +690,7 @@ class AutomaticUpdateRule(models.Model):
                 active_only=active_only,
             )
 
-    def get_messaging_rule_action_definition(self):
+    def get_action_definition(self):
         if self.workflow != self.WORKFLOW_SCHEDULING:
             raise ValueError("Expected scheduling workflow")
 
@@ -705,7 +705,7 @@ class AutomaticUpdateRule(models.Model):
         return action_definition
 
     def get_schedule(self):
-        return self.get_messaging_rule_action_definition().schedule
+        return self.get_action_definition().schedule
 
 
 class CaseRuleCriteria(models.Model):

--- a/corehq/apps/data_interfaces/models.py
+++ b/corehq/apps/data_interfaces/models.py
@@ -173,7 +173,7 @@ class AutomaticUpdateRule(models.Model):
         """
         result = []
         for rule in cls.by_domain(domain, cls.WORKFLOW_SCHEDULING, active_only=False):
-            schedule = rule.get_messaging_rule_schedule()
+            schedule = rule.get_schedule()
             for event in schedule.memoized_events:
                 if isinstance(event.content, SMSSurveyContent):
                     result.append(event.content.form_unique_id)
@@ -543,7 +543,7 @@ class AutomaticUpdateRule(models.Model):
             self.deleted = True
             self.save()
             if self.workflow == self.WORKFLOW_SCHEDULING:
-                schedule = self.get_messaging_rule_schedule()
+                schedule = self.get_schedule()
                 schedule.deleted = True
                 schedule.save()
                 if isinstance(schedule, AlertSchedule):
@@ -704,7 +704,7 @@ class AutomaticUpdateRule(models.Model):
 
         return action_definition
 
-    def get_messaging_rule_schedule(self):
+    def get_schedule(self):
         return self.get_messaging_rule_action_definition().schedule
 
 

--- a/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
+++ b/corehq/messaging/scheduling/tests/test_bulk_conditional_alerts.py
@@ -321,7 +321,7 @@ class TestBulkConditionalAlerts(TestCase):
 
         test_cases = (self.UNTRANSLATED_IMMEDIATE_RULE, self.UNTRANSLATED_DAILY_RULE, self.IMMEDIATE_RULE,
                       self.DAILY_RULE, self.WEEKLY_RULE, self.MONTHLY_RULE)
-        old_schedules = {test_case: self._get_rule(test_case).get_messaging_rule_schedule()
+        old_schedules = {test_case: self._get_rule(test_case).get_schedule()
                          for test_case in test_cases}
 
         msgs = self._upload(data)
@@ -336,7 +336,7 @@ class TestBulkConditionalAlerts(TestCase):
         untranslated_immediate_rule = self._get_rule(self.UNTRANSLATED_IMMEDIATE_RULE)
         self.assertEqual(untranslated_immediate_rule.name, 'test untranslated')
         self.assertEqual(untranslated_immediate_rule.case_type, 'person')
-        untranslated_schedule = untranslated_immediate_rule.get_messaging_rule_schedule()
+        untranslated_schedule = untranslated_immediate_rule.get_schedule()
         self._assertAlertScheduleEventsEqual(untranslated_schedule,
                                              old_schedules[self.UNTRANSLATED_IMMEDIATE_RULE])
         untranslated_content = untranslated_schedule.memoized_events[0].content
@@ -347,7 +347,7 @@ class TestBulkConditionalAlerts(TestCase):
         untranslated_daily_rule = self._get_rule(self.UNTRANSLATED_DAILY_RULE)
         self.assertEqual(untranslated_daily_rule.name, 'test change sheet')
         self.assertEqual(untranslated_daily_rule.case_type, 'person')
-        untranslated_schedule = untranslated_daily_rule.get_messaging_rule_schedule()
+        untranslated_schedule = untranslated_daily_rule.get_schedule()
         self._assertTimedScheduleEventsEqual(untranslated_schedule, old_schedules[self.UNTRANSLATED_DAILY_RULE])
         untranslated_content = untranslated_schedule.memoized_events[0].content
         self.assertEqual(untranslated_content.message, {
@@ -357,7 +357,7 @@ class TestBulkConditionalAlerts(TestCase):
 
         immediate_rule = self._get_rule(self.IMMEDIATE_RULE)
         self.assertEqual(immediate_rule.name, 'test immediate')
-        immediate_schedule = immediate_rule.get_messaging_rule_schedule()
+        immediate_schedule = immediate_rule.get_schedule()
         self._assertAlertScheduleEventsEqual(immediate_schedule, old_schedules[self.IMMEDIATE_RULE])
         immediate_content = immediate_schedule.memoized_events[0].content
         self.assertEqual(immediate_content.message, {
@@ -366,7 +366,7 @@ class TestBulkConditionalAlerts(TestCase):
 
         daily_rule = self._get_rule(self.DAILY_RULE)
         self.assertEqual(daily_rule.name, 'test daily')
-        daily_schedule = daily_rule.get_messaging_rule_schedule()
+        daily_schedule = daily_rule.get_schedule()
         self._assertTimedScheduleEventsEqual(daily_schedule, old_schedules[self.DAILY_RULE])
         self._assertContent(daily_schedule, {
             'en': 'Rustier',
@@ -374,7 +374,7 @@ class TestBulkConditionalAlerts(TestCase):
         })
 
         weekly_rule = self._get_rule(self.WEEKLY_RULE)
-        weekly_schedule = weekly_rule.get_messaging_rule_schedule()
+        weekly_schedule = weekly_rule.get_schedule()
         self._assertTimedScheduleEventsEqual(weekly_schedule, old_schedules[self.WEEKLY_RULE])
         self._assertContent(weekly_schedule, {
             'en': 'It\'s On Time',
@@ -382,7 +382,7 @@ class TestBulkConditionalAlerts(TestCase):
         })
 
         monthly_rule = self._get_rule(self.MONTHLY_RULE)
-        monthly_schedule = monthly_rule.get_messaging_rule_schedule()
+        monthly_schedule = monthly_rule.get_schedule()
         self._assertTimedScheduleEventsEqual(monthly_schedule, old_schedules[self.MONTHLY_RULE])
         self._assertContent(monthly_schedule, {
             '*': 'The Other Side Now',
@@ -403,7 +403,7 @@ class TestBulkConditionalAlerts(TestCase):
         )
 
         test_cases = (self.CUSTOM_IMMEDIATE_RULE, self.CUSTOM_DAILY_RULE)
-        old_schedules = {test_case: self._get_rule(test_case).get_messaging_rule_schedule()
+        old_schedules = {test_case: self._get_rule(test_case).get_schedule()
                          for test_case in test_cases}
 
         msgs = self._upload(data)
@@ -413,7 +413,7 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertIn("Updated 1 rule(s) in 'not translated' sheet", msgs)
 
         custom_daily_rule = self._get_rule(self.CUSTOM_DAILY_RULE)
-        custom_daily_schedule = custom_daily_rule.get_messaging_rule_schedule()
+        custom_daily_schedule = custom_daily_rule.get_schedule()
         self._assertTimedScheduleEventsEqual(custom_daily_schedule, old_schedules[self.CUSTOM_DAILY_RULE])
         self._assertCustomContent(custom_daily_schedule, [
             {'*': 'Not Like This Train'},
@@ -421,7 +421,7 @@ class TestBulkConditionalAlerts(TestCase):
         ])
 
         custom_immediate_rule = self._get_rule(self.CUSTOM_IMMEDIATE_RULE)
-        custom_immediate_schedule = custom_immediate_rule.get_messaging_rule_schedule()
+        custom_immediate_schedule = custom_immediate_rule.get_schedule()
         self._assertAlertScheduleEventsEqual(custom_immediate_schedule, old_schedules[self.CUSTOM_IMMEDIATE_RULE])
         self._assertCustomContent(custom_immediate_schedule, [{
             'en': 'Plastic Bag',
@@ -450,7 +450,7 @@ class TestBulkConditionalAlerts(TestCase):
             )),
         )
 
-        old_schedule = self._get_rule(self.CUSTOM_RULE_BOTH_SHEETS).get_messaging_rule_schedule()
+        old_schedule = self._get_rule(self.CUSTOM_RULE_BOTH_SHEETS).get_schedule()
 
         msgs = self._upload(data)
 
@@ -461,7 +461,7 @@ class TestBulkConditionalAlerts(TestCase):
         self._assertPatternIn(r"Row 3 in 'not translated' sheet.* rule id \d+, .*currently processing", msgs)
 
         rule = self._get_rule(self.CUSTOM_RULE_BOTH_SHEETS)
-        schedule = rule.get_messaging_rule_schedule()
+        schedule = rule.get_schedule()
         self._assertAlertScheduleEventsEqual(schedule, old_schedule)
         self._assertCustomContent(schedule, [{
             'en': "You're Lucky",
@@ -512,7 +512,7 @@ class TestBulkConditionalAlerts(TestCase):
             ("not translated", ()),
         )
 
-        old_schedule = self._get_rule(self.CUSTOM_RULE_BOTH_SHEETS).get_messaging_rule_schedule()
+        old_schedule = self._get_rule(self.CUSTOM_RULE_BOTH_SHEETS).get_schedule()
         msgs = self._upload(data)
 
         self.assertEqual(len(msgs), 2)
@@ -520,7 +520,7 @@ class TestBulkConditionalAlerts(TestCase):
         self.assertIn("Updated 0 rule(s) in 'not translated' sheet", msgs)
 
         rule = self._get_rule(self.CUSTOM_RULE_BOTH_SHEETS)
-        schedule = rule.get_messaging_rule_schedule()
+        schedule = rule.get_schedule()
         self._assertAlertScheduleEventsEqual(schedule, old_schedule)
         self._assertCustomContent(schedule, [{
             'en': "You're Lucky",
@@ -634,7 +634,7 @@ class TestBulkConditionalAlerts(TestCase):
         untranslated_rule = self._get_rule(self.UNTRANSLATED_DAILY_RULE)
         self.assertEqual(untranslated_rule.name, 'test untranslated')
         self.assertEqual(untranslated_rule.case_type, 'person')
-        untranslated_content = untranslated_rule.get_messaging_rule_schedule().memoized_events[0].content
+        untranslated_content = untranslated_rule.get_schedule().memoized_events[0].content
         self.assertEqual(untranslated_content.message, {
             '*': 'Joan',
         })
@@ -642,7 +642,7 @@ class TestBulkConditionalAlerts(TestCase):
         daily_rule = self._get_rule(self.DAILY_RULE)
         self.assertEqual(daily_rule.name, 'test daily')
         self.assertEqual(daily_rule.case_type, 'person')
-        daily_content = daily_rule.get_messaging_rule_schedule().memoized_events[0].content
+        daily_content = daily_rule.get_schedule().memoized_events[0].content
         self.assertEqual(daily_content.message, {
             'en': 'Diamonds and Rust',
             'es': 'Más Oxidado',
@@ -672,7 +672,7 @@ class TestBulkConditionalAlerts(TestCase):
 
         untranslated_rule = self._get_rule(self.UNTRANSLATED_DAILY_RULE)
         self.assertEqual(untranslated_rule.name, 'test untranslated')
-        untranslated_content = untranslated_rule.get_messaging_rule_schedule().memoized_events[0].content
+        untranslated_content = untranslated_rule.get_schedule().memoized_events[0].content
         self.assertEqual(untranslated_content.message, {
             '*': 'Joanie',
         })

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -625,7 +625,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
         )
 
     def _format_rule_for_json(self, rule):
-        schedule = rule.get_messaging_rule_schedule()
+        schedule = rule.get_schedule()
         return {
             'name': rule.name,
             'case_type': rule.case_type,
@@ -680,7 +680,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
         we don't send a large quantity of stale messages.
         """
         with transaction.atomic():
-            schedule = rule.get_messaging_rule_schedule()
+            schedule = rule.get_schedule()
             if active_flag and not self.can_use_inbound_sms and schedule.memoized_uses_sms_survey:
                 return HttpResponseBadRequest(
                     "Cannot create or edit survey reminders because subscription "
@@ -933,7 +933,7 @@ class EditConditionalAlertView(CreateConditionalAlertView):
 
     @cached_property
     def schedule(self):
-        return self.rule.get_messaging_rule_schedule()
+        return self.rule.get_schedule()
 
     def dispatch(self, request, *args, **kwargs):
         with get_conditional_alert_edit_critical_section(self.rule_id):


### PR DESCRIPTION
I often forget what these are called, and they're redundant, since they're being called on a messaging rule.