### PR TITLE
Ignore cert validation warning

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -7,6 +7,7 @@ import logging
 import re
 import time
 import uuid
+import urllib3
 from io import BytesIO
 
 from django.conf import settings
@@ -34,7 +35,7 @@ from corehq.celery_monitoring.heartbeat import (
     HeartbeatNeverRecorded,
 )
 from corehq.elastic import refresh_elasticsearch_index, send_to_elasticsearch
-from corehq.util.decorators import change_log_level
+from corehq.util.decorators import change_log_level, ignore_warning
 from corehq.util.timer import TimingContext
 
 
@@ -215,6 +216,7 @@ def check_couch():
     return ServiceStatus(True, "Successfully queried an arbitrary couch view")
 
 
+@ignore_warning(urllib3.exceptions.InsecureRequestWarning)
 def check_formplayer():
     try:
         # Setting verify=False in this request keeps this from failing for urls with self-signed certificates.

--- a/corehq/util/decorators.py
+++ b/corehq/util/decorators.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import warnings
 from contextlib import ContextDecorator, contextmanager
 from functools import wraps
 
@@ -80,6 +81,13 @@ class change_log_level(ContextDecorator):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.logger.setLevel(self.original_level)
+
+
+@contextmanager
+def ignore_warning(warning_class):
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', warning_class)
+        yield
 
 
 class require_debug_true(ContextDecorator):


### PR DESCRIPTION
https://forum.dimagi.com/t/letsencrypt-insecurerequestwarning-unverified-https-request/6975/4

##### SUMMARY
`verify` is intentionally set to False, which triggers a warning about an unvalidated certificate.