### PR TITLE
Test XForm pillow error for ResourceConflicts

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -149,4 +149,4 @@ def mark_latest_submission(domain, user_id, app_id, build_id, version, metadata,
         )
         update_device_meta(user, device_id, app_version_info.commcare_version, app_meta, save=False)
 
-        user.save()
+        user.save(fire_signals=False)

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -3,8 +3,6 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from corehq.util.es.elasticsearch import ConnectionError
-
 from pillow_retry.models import PillowError
 from pillowtop.es_utils import initialize_index_and_mapping
 
@@ -18,6 +16,7 @@ from corehq.form_processor.tests.utils import (
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
+from corehq.util.es.elasticsearch import ConnectionError
 from corehq.util.test_utils import create_and_save_a_case, trap_extra_setup
 from testapps.test_pillowtop.utils import process_pillow_changes
 

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -1,20 +1,23 @@
 from decimal import Decimal
 
 from django.test.testcases import SimpleTestCase, TestCase
-from corehq.util.es.elasticsearch import ConnectionError
+
+from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.es import FormES
 from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import (
+    FormProcessorTestUtils,
+    run_with_all_backends,
+)
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
-from corehq.pillows.xform import (
-    transform_xform_for_elasticsearch)
+from corehq.pillows.xform import transform_xform_for_elasticsearch
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
+from corehq.util.es.elasticsearch import ConnectionError
 from corehq.util.test_utils import get_form_ready_to_save, trap_extra_setup
-from pillowtop.es_utils import initialize_index_and_mapping
 from testapps.test_pillowtop.utils import process_pillow_changes
 
 

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -2,6 +2,10 @@ from decimal import Decimal
 
 from django.test.testcases import SimpleTestCase, TestCase
 
+from couchdbkit import ResourceConflict
+from mock import patch
+
+from pillow_retry.models import PillowError
 from pillowtop.es_utils import initialize_index_and_mapping
 
 from corehq.apps.es import FormES
@@ -40,6 +44,7 @@ class XFormPillowTest(TestCase):
 
     def tearDown(self):
         ensure_index_deleted(XFORM_INDEX_INFO.index)
+        PillowError.objects.all().delete()
         super(XFormPillowTest, self).tearDown()
 
     @run_with_all_backends
@@ -71,6 +76,19 @@ class XFormPillowTest(TestCase):
         # ensure not there anymore
         results = FormES().run()
         self.assertEqual(0, results.total)
+
+    @run_with_all_backends
+    def test_form_pillow_error_in_form_metadata(self):
+        self.assertEqual(0, PillowError.objects.filter(pillow='xform-pillow').count())
+        with patch('pillowtop.processors.form.mark_latest_submission') as mark_latest_submission:
+            mark_latest_submission.side_effect = ResourceConflict('couch sucks')
+            case_id, case_name = self._create_form_and_sync_to_es()
+
+        # confirm change made it to form index
+        results = FormES().run()
+        self.assertEqual(1, results.total)
+
+        self.assertEqual(1, PillowError.objects.filter(pillow='xform-pillow').count())
 
     def _create_form_and_sync_to_es(self):
         with self.process_form_changes:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-984

##### SUMMARY
I looked at the logs around the time of inserted_at for document `61d5043c-2fb3-491b-941f-2a20aa1f0d09` and found quite a few `ResourceConflict` errors. However I added this test and ensure that the pillow error is created correctly.

I also realized that we are saving to the user ES pillow in the xform pillow. I've removed the signals from the third commit