### PR TITLE
Catch TypeError when converting to int

### DIFF
--- a/corehq/motech/openmrs/tests/test_serializers.py
+++ b/corehq/motech/openmrs/tests/test_serializers.py
@@ -4,7 +4,10 @@ import doctest
 from django.test import SimpleTestCase
 
 import corehq.motech.openmrs.serializers
-from corehq.motech.openmrs.serializers import to_omrs_datetime
+from corehq.motech.openmrs.serializers import (
+    omrs_timestamp_to_datetime,
+    to_omrs_datetime,
+)
 
 
 class SerializerTests(SimpleTestCase):
@@ -47,6 +50,10 @@ class SerializerTests(SimpleTestCase):
         day_int = 1
         openmrs_timestamp = to_omrs_datetime(day_int)
         self.assertIsNone(openmrs_timestamp)
+
+    def test_omrs_timestamp_to_date_none(self):
+        value = omrs_timestamp_to_datetime(None)
+        self.assertIsNone(value)
 
 
 def test_doctests():

--- a/corehq/motech/serializers.py
+++ b/corehq/motech/serializers.py
@@ -35,7 +35,7 @@ def to_decimal(value):
 def to_integer(value):
     try:
         return int(value)
-    except ValueError:
+    except (TypeError, ValueError):
         return None
 
 

--- a/corehq/motech/tests/test_serializers.py
+++ b/corehq/motech/tests/test_serializers.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 
 from django.test import SimpleTestCase
 
-from corehq.motech.serializers import to_date_str
+from corehq.motech.serializers import to_date_str, to_integer
 
 
 class SerializerTests(SimpleTestCase):
@@ -26,3 +26,19 @@ class SerializerTests(SimpleTestCase):
         day_int = 1
         date_str = to_date_str(day_int)
         self.assertIsNone(date_str)
+
+    def test_to_integer_none(self):
+        value = to_integer(None)
+        self.assertIsNone(value)
+
+    def test_to_integer_valid_str(self):
+        value = to_integer("123")
+        self.assertEqual(value, 123)
+
+    def test_to_integer_invalid_str(self):
+        value = to_integer("one hundred and twenty three")
+        self.assertIsNone(value)
+
+    def test_to_integer_float(self):
+        value = to_integer(1.23)
+        self.assertEqual(value, 1)


### PR DESCRIPTION
Context: [Sentry](https://sentry.io/organizations/dimagi/issues/1306579163/events/40a1d10b94b34d6d8432ddd3d040ac65/?project=136860)

##### SUMMARY
This change catches TypeError when converting values to integers; `int(None)` raises a TypeError.

##### FEATURE FLAG
"OpenMRS integration"

##### PRODUCT DESCRIPTION
Fixes a bug when trying to convert null values to integers when importing patients from OpenMRS.

cc @avazirna
