### PR TITLE
dont rely on naming that can change

### DIFF
--- a/corehq/apps/hqadmin/views/data.py
+++ b/corehq/apps/hqadmin/views/data.py
@@ -110,7 +110,6 @@ def get_databases():
     ]
 
     all_dbs = OrderedDict()
-    all_dbs['commcarehq'] = None  # make this DB first in list
     couchdbs_by_name = couch_config.all_dbs_by_db_name
     for dbname in sorted(couchdbs_by_name):
         all_dbs[dbname] = _CouchDb(couchdbs_by_name[dbname])


### PR DESCRIPTION
Introduced in https://github.com/dimagi/commcare-hq/pull/25456

##### SUMMARY
On staging the default db is called "staging_commcarehq" and not "commcarehq". I checked on prod and ICDS where the name is "commcarehq", which is true for local as well. But since the name is configurable, it can fail. Plus "commcarehq" db is the first db in the list of staging, production and ICDS already. So this PR removes the logic to get "commcarehq" db first.
