### PR TITLE
Notify admins on OpenmrsImporter errors

### DIFF
--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -75,7 +75,7 @@ class OpenmrsImporter(Document):
     username = StringProperty()
     password = StringProperty()
 
-    notify_addresses_str = StringProperty()
+    notify_addresses_str = StringProperty(default="")
 
     # If a domain has multiple OpenmrsImporter instances, for which CommCare location is this one authoritative?
     location_id = StringProperty()

--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -118,7 +118,8 @@ class OpenmrsImporter(Document):
     column_map = ListProperty(ColumnMapping)
 
     def __str__(self):
-        return self.server_url
+        url = "@".join((self.username, self.server_url)) if self.username else self.server_url
+        return f"<{self.__class__.__name__} {self._id} {url}>"
 
     @property
     def notify_addresses(self):

--- a/corehq/motech/openmrs/tasks.py
+++ b/corehq/motech/openmrs/tasks.py
@@ -234,7 +234,10 @@ def import_patients_with_importer(importer_json):
             # PARAMETERS. If not, OpenMRS will return THE SAME PATIENTS
             # multiple times and they will be assigned to a different
             # user each time.
-            import_patients_of_owner(requests, importer, importer.domain, owner.user_id, location)
+            try:
+                import_patients_of_owner(requests, importer, importer.domain, owner.user_id, location)
+            except ConfigurationError as err:
+                requests.notify_error(str(err))
     elif importer.owner_id:
         if not is_valid_owner(importer.owner_id):
             requests.notify_error(
@@ -243,7 +246,10 @@ def import_patients_with_importer(importer_json):
                 'is invalid.'
             )
             return
-        import_patients_of_owner(requests, importer, importer.domain, importer.owner_id)
+        try:
+            import_patients_of_owner(requests, importer, importer.domain, importer.owner_id)
+        except ConfigurationError as err:
+            requests.notify_error(str(err))
     else:
         requests.notify_error(
             f'Error importing patients for project space "{importer.domain}" from '

--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -188,13 +188,13 @@ def test_bad_data_type():
     with get_importer(bad_column_mapping) as importer:
         with assert_raises_regexp(
             ConfigurationError,
-            'Error importing from <OpenmrsImporter None admin@http://www.example.com/openmrs>: '
+            'Errors importing from <OpenmrsImporter None admin@http://www.example.com/openmrs>:\n'
             'Unable to deserialize value 1551564000000 '
             'in column "data_proxima_consulta" '
             'for case property "data_proxima_consulta". '
             'OpenMRS data type is given as "omrs_datetime". '
             'CommCare data type is given as "cc_date": '
-            'argument of type \'int\' is not iterable'
+            "argument of type 'int' is not iterable"
         ):
             get_case_properties(patient, importer)
 


### PR DESCRIPTION
##### SUMMARY
Use `requests.notify_error()` to notify admins when an error occurs importing patients from OpenMRS. This change applies the behaviour we already use for data forwarding to importing data from OpenMRS.

cc @avazirna

Review by commit :blowfish: 

##### FEATURE FLAG
"OpenMRS integration"

##### PRODUCT DESCRIPTION
Notify admins when an error occurs importing patients from OpenMRS.
