### PR TITLE
Don't export import-only Observations

### DIFF
--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -1,0 +1,95 @@
+from testil import eq
+
+from corehq.motech.openmrs.openmrs_config import OpenmrsConfig, OpenmrsFormConfig
+from corehq.motech.openmrs.workflow_tasks import CreateVisitsEncountersObsTask
+from corehq.motech.value_source import CaseTriggerInfo
+
+
+def test_concept_directions():
+    form_json = {
+        "form": {
+            "@xmlns": "http://openrosa.org/formdesigner/9ECA0608-307A-4357-954D-5A79E45C3879",
+            "pneumonia": "no",
+            "malnutrition": "no",
+        }
+    }
+    form_config_dict = get_form_config_dict()
+    openmrs_config = OpenmrsConfig.wrap({
+        "case_config": {},
+        "form_configs": [form_config_dict]
+    })
+
+    info = CaseTriggerInfo(
+        domain="test-domain",
+        case_id="c0ffee",
+        form_question_values={
+            "/data/pneumonia": "no",
+            "/data/malnutrition": "no",
+        }
+    )
+
+    task = CreateVisitsEncountersObsTask(
+        requests=None,
+        domain="test-domain",
+        info=info,
+        form_json=form_json,
+        openmrs_config=openmrs_config,
+        person_uuid="test-person_uuid",
+    )
+    values_for_concept=task._get_values_for_concept(OpenmrsFormConfig.wrap(form_config_dict))
+    eq(values_for_concept, {
+        # "direction": "out"
+        'e7fdcd25-6d11-4d85-a80a-8979785f0f4b': ['eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0'],
+        # "direction": null, or not specified
+        '4000cf24-8fab-437d-9950-ea8d9bb05a09': ['eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0'],
+        # "direction": "in" should be missing
+    })
+
+
+def get_form_config_dict():
+    return {
+        "xmlns": "http://openrosa.org/formdesigner/9ECA0608-307A-4357-954D-5A79E45C3879",
+        "openmrs_visit_type": "c23d6c9d-3f10-11e4-adec-0800271c1b75",
+        "openmrs_encounter_type": "81852aee-3f10-11e4-adec-0800271c1b75",
+        "openmrs_observations": [
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "e7fdcd25-6d11-4d85-a80a-8979785f0f4b",
+                "value": {
+                    "form_question": "/data/pneumonia",
+                    "doc_type": "FormQuestionMap",
+                    "value_map": {
+                        "yes": "05ced69b-0790-4aad-852f-ba31fe82fbd9",
+                        "no": "eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0",
+                    },
+                    "direction": "out",
+                },
+                "case_property": None,
+            },
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "4000cf24-8fab-437d-9950-ea8d9bb05a09",
+                "value": {
+                    "form_question": "/data/malnutrition",
+                    "doc_type": "FormQuestionMap",
+                    "value_map": {
+                        "yes": "05ced69b-0790-4aad-852f-ba31fe82fbd9",
+                        "no": "eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0",
+                    },
+                    # direction defaults to null, for both import and export
+                },
+                "case_property": "malnutrition",
+            },
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "724a5cb9-3826-4fe0-bc0d-0a8e9d9c4c42",
+                "value": {
+                    "doc_type": "ConstantValue",
+                    "direction": "in",
+                    "value": "Fever, unspecified",
+                    "value_data_type": "cc_text",
+                },
+                "case_property": "ehr_fever_unspecified",
+            },
+        ],
+    }

--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -18,7 +18,6 @@ def test_concept_directions():
         "case_config": {},
         "form_configs": [form_config_dict]
     })
-
     info = CaseTriggerInfo(
         domain="test-domain",
         case_id="c0ffee",
@@ -27,7 +26,6 @@ def test_concept_directions():
             "/data/malnutrition": "no",
         }
     )
-
     task = CreateVisitsEncountersObsTask(
         requests=None,
         domain="test-domain",
@@ -36,7 +34,9 @@ def test_concept_directions():
         openmrs_config=openmrs_config,
         person_uuid="test-person_uuid",
     )
-    values_for_concept=task._get_values_for_concept(OpenmrsFormConfig.wrap(form_config_dict))
+    values_for_concept = task._get_values_for_concept(
+        OpenmrsFormConfig.wrap(form_config_dict)
+    )
     eq(values_for_concept, {
         # "direction": "out"
         'e7fdcd25-6d11-4d85-a80a-8979785f0f4b': ['eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0'],

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -165,7 +165,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
         return {
             obs.concept: [obs.value.get_value(self.info)]
             for obs in form_config.openmrs_observations
-            if obs.value.get_value(self.info)
+            if obs.value.check_direction(DIRECTION_EXPORT) and not is_blank(obs.value.get_value(self.info))
         }
 
     def run(self):
@@ -660,3 +660,17 @@ class UpdatePersonPropertiesTask(WorkflowTask):
                 json=properties,
                 raise_for_status=True,
             )
+
+
+# TODO: Refactor once https://github.com/dimagi/commcare-hq/pull/25732 is merged
+def is_blank(value):
+    """
+    Returns True if ``value`` is ``None`` or an empty string.
+    >>> is_blank("")
+    True
+    >>> is_blank(0)
+    False
+    >>> is_blank([])
+    False
+    """
+    return value is None or value == ""

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -161,6 +161,13 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
             stop_datetime = to_omrs_datetime(cc_stop_datetime)
         return start_datetime, stop_datetime
 
+    def _get_values_for_concept(self, form_config):
+        return {
+            obs.concept: [obs.value.get_value(self.info)]
+            for obs in form_config.openmrs_observations
+            if obs.value.get_value(self.info)
+        }
+
     def run(self):
         """
         Returns WorkflowTasks for creating visits, encounters and observations
@@ -184,9 +191,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
                         provider_uuid=provider_uuid,
                         start_datetime=start_datetime,
                         stop_datetime=stop_datetime,
-                        values_for_concept={obs.concept: [obs.value.get_value(self.info)]
-                                            for obs in form_config.openmrs_observations
-                                            if obs.value.get_value(self.info)},
+                        values_for_concept=self._get_values_for_concept(form_config),
                         encounter_type=form_config.openmrs_encounter_type,
                         openmrs_form=form_config.openmrs_form,
                         visit_type=form_config.openmrs_visit_type,


### PR DESCRIPTION
##### SUMMARY
Fixes a bug where import-only OpenMRS Observations are exported

##### FEATURE FLAG
"OpenMRS integration"

##### PRODUCT DESCRIPTION
Fixes a bug where import-only OpenMRS Observations are exported
