### PR TITLE
Add 'ndoh' to tracked domains

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2063,6 +2063,7 @@ DATADOG_DOMAINS = {
     ("production", "rec"),
     ("production", "isth-production"),
     ("production", "sauti-1"),
+    ("production", "ndoh-wbot"),
 }
 
 #### Django Compressor Stuff after localsettings overrides ####


### PR DESCRIPTION
##### SUMMARY
Adds 'ndoh-wbot' (the primary production domain for ndoh) to the list of domains whose metadata  are tracked in DataDog to facilitate monitoring and rollout
