### PR TITLE
kafka producer audit logging

### DIFF
--- a/corehq/apps/change_feed/management/commands/reconcile_producer_logs.py
+++ b/corehq/apps/change_feed/management/commands/reconcile_producer_logs.py
@@ -1,0 +1,178 @@
+import csv
+import logging
+import os
+from datetime import datetime
+from logging.handlers import TimedRotatingFileHandler
+
+from django.core.management import BaseCommand, CommandError
+
+import settings
+from corehq.apps.change_feed.producer import (
+    CHANGE_ERROR,
+    CHANGE_PRE_SEND,
+    CHANGE_SENT,
+    KAFKA_AUDIT_LOGGER,
+)
+
+logger = logging.getLogger(KAFKA_AUDIT_LOGGER)
+
+
+class DocTypeReconciliation(object):
+    """Reconcile Kafka producer transactions. Each attempt to send has a unique
+    transaction ID which is used by the reconciliation.
+
+    Transactions are processed until point A at which stage the reconcilliation is 'frozen'.
+    Transactions seen after the 'freeze' will only be used to reconcile transactions seen before the freeze
+    and will not be added to the list of transactions to reconcile.
+    """
+    def __init__(self, doc_type):
+        self.doc_type = doc_type
+        self.pre_send = {}
+        self.sent = {}
+        self.errors = {}
+        self.by_type = {
+            CHANGE_PRE_SEND: self.pre_send,
+            CHANGE_SENT: self.sent,
+            CHANGE_ERROR: self.errors
+        }
+        self.count_sent = 0
+
+        self.frozen = False
+
+    def freeze(self):
+        self.frozen = True
+
+    def add_row(self, row):
+        date, trans_type, doc_type, doc_id, transaction_id = row
+        if doc_type != self.doc_type:
+            return
+
+        if self.frozen:
+            if trans_type == CHANGE_PRE_SEND:
+                return
+            if trans_type == CHANGE_SENT or (trans_type == CHANGE_ERROR and transaction_id in self.pre_send):
+                self.by_type[trans_type][transaction_id] = doc_id
+        else:
+            self.by_type[trans_type][transaction_id] = doc_id
+
+    def reconcile(self):
+        if not self.frozen:
+            self.count_sent += len(self.sent)
+
+        for transaction_id in set(self.sent) | set(self.errors):
+            try:
+                del self.pre_send[transaction_id]
+            except KeyError:
+                pass
+
+        errors_by_doc_id = dict(reversed(t) for t in self.errors.items())
+        for doc_id in self.sent.values():
+            try:
+                del errors_by_doc_id[doc_id]
+            except KeyError:
+                pass
+
+        self.errors = dict(reversed(t) for t in errors_by_doc_id.items())
+        self.by_type[CHANGE_ERROR] = self.errors
+        self.sent.clear()
+
+    def get_results(self):
+        return {
+            'sent_count': self.count_sent,
+            'persistent_error_count': len(self.errors),
+            'unaccounted_for': len(self.pre_send),
+            'unaccounted_for_ids': set(self.pre_send.values()),
+        }
+
+    def has_results(self):
+        return self.errors or self.pre_send
+
+
+class Reconciliation(object):
+    def __init__(self):
+        self.by_doc_type = {}
+
+    def freeze(self):
+        for doc_type_recon in self.by_doc_type.values():
+            doc_type_recon.freeze()
+
+    def add_row(self, row):
+        doc_type = row[2]
+        if doc_type not in self.by_doc_type:
+            self.by_doc_type[doc_type] = DocTypeReconciliation(doc_type)
+        self.by_doc_type[doc_type].add_row(row)
+
+    def reconcile(self):
+        for doc_type_recon in self.by_doc_type.values():
+            doc_type_recon.reconcile()
+
+    def get_results(self):
+        return {
+            doc_type: recon.get_results()
+            for doc_type, recon in self.by_doc_type.items()
+            if recon.has_results()
+        }
+
+
+class Command(BaseCommand):
+
+    def handle(self, **options):
+        date_suffix_format = None
+        for handler in logger.handlers:
+            if isinstance(handler, TimedRotatingFileHandler):
+                date_suffix_format = handler.suffix
+
+        if not date_suffix_format:
+            raise CommandError('Could not find date format from log handler')
+
+        num_logs_to_process = 2
+        include_current_log = False
+
+        log_files_with_dates = get_log_files_with_dates(settings.KAFKA_PRODUCER_AUDIT_FILE, date_suffix_format)
+        if len(log_files_with_dates) < num_logs_to_process:
+            raise CommandError(f'Not enough files to process. Only {len(log_files_with_dates)} found.')
+
+        sorted_logs = list(sorted(log_files_with_dates, key=lambda x: x[0]))
+        logs_to_process = [log[1] for log in sorted_logs[-num_logs_to_process:]]
+
+        if include_current_log:
+            logs_to_process.append(settings.KAFKA_PRODUCER_AUDIT_FILE)
+
+        recon = Reconciliation()
+
+        def _process_log_file(log_file):
+            with open(log_file, 'r') as f:
+                reader = csv.reader(f)
+                for i, row in enumerate(reader):
+                    recon.add_row(row)
+                    if i % 10000 == 0:
+                        recon.reconcile()
+
+        # Process all but the last log file before freezing the recon
+        for log in logs_to_process[:-1]:
+            _process_log_file(log)
+
+        recon.freeze()
+        _process_log_file(logs_to_process[-1])
+        recon.reconcile()
+
+
+def get_log_files_with_dates(current_log_path, date_suffix_format):
+    log_files = []
+    current_log_file = os.path.basename(current_log_path)
+    log_root, log_filename = os.path.split(current_log_path)
+    for path in os.listdir(log_root):
+        if os.path.isfile(path) and path.startswith(log_filename) and path != current_log_file:
+            log_files.append(os.path.join(log_root, path))
+
+    log_files_with_dates = []
+    for path in log_files:
+        date_part = path.split('.')[-1]
+        try:
+            date = datetime.strptime(date_part, date_suffix_format)
+        except ValueError:
+            pass  # log file format changed
+        else:
+            log_files_with_dates.append((date, path))
+
+    return log_files_with_dates

--- a/corehq/apps/change_feed/management/commands/reconcile_producer_logs.py
+++ b/corehq/apps/change_feed/management/commands/reconcile_producer_logs.py
@@ -1,10 +1,13 @@
 import csv
+import inspect
 import logging
 import os
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
 
+from django.core.mail import mail_admins
 from django.core.management import BaseCommand, CommandError
+from django.template import engines
 
 import settings
 from corehq.apps.change_feed.producer import (
@@ -28,14 +31,8 @@ class DocTypeReconciliation(object):
     def __init__(self, doc_type):
         self.doc_type = doc_type
         self.pre_send = {}
-        self.sent = {}
-        self.errors = {}
-        self.by_type = {
-            CHANGE_PRE_SEND: self.pre_send,
-            CHANGE_SENT: self.sent,
-            CHANGE_ERROR: self.errors
-        }
-        self.count_sent = 0
+        self.error_doc_ids = set()
+        self.count = 0
 
         self.frozen = False
 
@@ -47,45 +44,35 @@ class DocTypeReconciliation(object):
         if doc_type != self.doc_type:
             return
 
-        if self.frozen:
-            if trans_type == CHANGE_PRE_SEND:
-                return
-            if trans_type == CHANGE_SENT or (trans_type == CHANGE_ERROR and transaction_id in self.pre_send):
-                self.by_type[trans_type][transaction_id] = doc_id
-        else:
-            self.by_type[trans_type][transaction_id] = doc_id
-
-    def reconcile(self):
-        if not self.frozen:
-            self.count_sent += len(self.sent)
-
-        for transaction_id in set(self.sent) | set(self.errors):
+        if trans_type == CHANGE_PRE_SEND and not self.frozen:
+            self.count += 1
+            self.pre_send[transaction_id] = doc_id
+        elif trans_type == CHANGE_SENT:
             try:
                 del self.pre_send[transaction_id]
             except KeyError:
                 pass
-
-        errors_by_doc_id = dict(reversed(t) for t in self.errors.items())
-        for doc_id in self.sent.values():
             try:
-                del errors_by_doc_id[doc_id]
+                self.error_doc_ids.remove(doc_id)
             except KeyError:
                 pass
-
-        self.errors = dict(reversed(t) for t in errors_by_doc_id.items())
-        self.by_type[CHANGE_ERROR] = self.errors
-        self.sent.clear()
+        if trans_type == CHANGE_ERROR and (not self.frozen or transaction_id in self.pre_send):
+            try:
+                del self.pre_send[transaction_id]
+            except KeyError:
+                pass
+            self.error_doc_ids.add(doc_id)
 
     def get_results(self):
         return {
-            'sent_count': self.count_sent,
-            'persistent_error_count': len(self.errors),
+            'transaction_count': self.count,
+            'persistent_error_count': len(self.error_doc_ids),
             'unaccounted_for': len(self.pre_send),
             'unaccounted_for_ids': set(self.pre_send.values()),
         }
 
     def has_results(self):
-        return self.errors or self.pre_send
+        return self.error_doc_ids or self.pre_send
 
 
 class Reconciliation(object):
@@ -115,8 +102,37 @@ class Reconciliation(object):
 
 
 class Command(BaseCommand):
+    help = """"Kafka Producer log file reconciliation command.
 
-    def handle(self, **options):
+    This command will process kafka producer audit logs to look for transactions that were initiated
+    but not completed.
+
+    The recon process will read new transactions from '-n' log files. After that it will continue to look
+    for completion logs in '-f' log files.
+
+    e.g. -n 2 -f 1
+        logA: process all logs
+        logB: process all logs
+        logC: only process completion logs (don't add new transactions to the recon)
+
+    Any transactions that have not been completed by the end of the processing
+    will be considered unaccounted for.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-n', dest='pre_logs', type=int, default=1,
+            help='Number of historical log files to process for new transactions')
+        parser.add_argument(
+            '-f', dest='post_logs', type=int, default=1,
+            help='Number of additional log files to process for completion logs')
+        parser.add_argument(
+            '--include-current', action='store_true',
+            help='Include the current log file in the list of files to check for completion logs')
+        parser.add_argument(
+            '--notify', action='store_true', help='Send notification with recon summary')
+
+    def handle(self, pre_logs, post_logs, include_current, notify, **options):
         date_suffix_format = None
         for handler in logger.handlers:
             if isinstance(handler, TimedRotatingFileHandler):
@@ -125,17 +141,17 @@ class Command(BaseCommand):
         if not date_suffix_format:
             raise CommandError('Could not find date format from log handler')
 
-        num_logs_to_process = 2
-        include_current_log = False
+        num_logs_to_process = pre_logs + post_logs
+        if include_current:
+            num_logs_to_process -= 1
 
-        log_files_with_dates = get_log_files_with_dates(settings.KAFKA_PRODUCER_AUDIT_FILE, date_suffix_format)
-        if len(log_files_with_dates) < num_logs_to_process:
-            raise CommandError(f'Not enough files to process. Only {len(log_files_with_dates)} found.')
+        log_files = get_log_files(settings.KAFKA_PRODUCER_AUDIT_FILE, date_suffix_format)
+        if len(log_files) < num_logs_to_process:
+            raise CommandError(f'Not enough files to process. Only {len(log_files)} found.')
 
-        sorted_logs = list(sorted(log_files_with_dates, key=lambda x: x[0]))
-        logs_to_process = [log[1] for log in sorted_logs[-num_logs_to_process:]]
+        logs_to_process = log_files[-num_logs_to_process:]
 
-        if include_current_log:
+        if include_current:
             logs_to_process.append(settings.KAFKA_PRODUCER_AUDIT_FILE)
 
         recon = Reconciliation()
@@ -144,20 +160,62 @@ class Command(BaseCommand):
             with open(log_file, 'r') as f:
                 reader = csv.reader(f)
                 for i, row in enumerate(reader):
-                    recon.add_row(row)
-                    if i % 10000 == 0:
-                        recon.reconcile()
+                    date, trans_type, doc_id, transaction_id = row
+                    recon.add_row((date, trans_type, 'case', doc_id, transaction_id))
 
         # Process all but the last log file before freezing the recon
-        for log in logs_to_process[:-1]:
+        for log in logs_to_process[:pre_logs]:
             _process_log_file(log)
 
         recon.freeze()
-        _process_log_file(logs_to_process[-1])
-        recon.reconcile()
+
+        for log in logs_to_process[pre_logs:pre_logs + post_logs]:
+            _process_log_file(log)
+
+        django_engine = engines['django']
+        template = django_engine.from_string(inspect.cleandoc("""
+            Files processed:
+            {% for log in logs_to_process %}
+              - {{ log }}
+            {% endfor %}
+
+            {% for res in doc_type_results %}
+            {{ res }}
+            {% endfor %}
+        """))
+        sub_template = django_engine.from_string(inspect.cleandoc("""
+            Results for {{ doc_type }}:
+                Transactions processed: {{ transaction_count }}
+                Persistent errors: {{ persistent_error_count }}
+                Unaccounted for transaction count: {{ unaccounted_for }}
+                {% if unaccounted_for_ids %}
+                Doc IDs unaccounted for:
+                {% for doc_id in unaccounted_for_ids %}
+                  - {{ doc_id }}
+                {% endfor %}
+                {% endif %}
+        """))
+        doc_type_results = []
+        for doc_type, results in recon.get_results().items():
+            results['doc_type'] = doc_type
+            doc_type_results.append(sub_template.render(results))
+
+        context = {
+            'logs_to_process': logs_to_process,
+            'doc_type_results': doc_type_results
+        }
+        message = template.render(context)
+
+        if notify:
+            mail_admins(
+                "Kakfa producer reconciliation results",
+                message
+            )
+        else:
+            print(message)
 
 
-def get_log_files_with_dates(current_log_path, date_suffix_format):
+def get_log_files(current_log_path, date_suffix_format):
     log_files = []
     current_log_file = os.path.basename(current_log_path)
     log_root, log_filename = os.path.split(current_log_path)
@@ -175,4 +233,4 @@ def get_log_files_with_dates(current_log_path, date_suffix_format):
         else:
             log_files_with_dates.append((date, path))
 
-    return log_files_with_dates
+    return [log[1] for log in sorted(log_files_with_dates, key=lambda x: x[0])]

--- a/corehq/apps/change_feed/management/commands/reconcile_producer_logs.py
+++ b/corehq/apps/change_feed/management/commands/reconcile_producer_logs.py
@@ -160,8 +160,7 @@ class Command(BaseCommand):
             with open(log_file, 'r') as f:
                 reader = csv.reader(f)
                 for i, row in enumerate(reader):
-                    date, trans_type, doc_id, transaction_id = row
-                    recon.add_row((date, trans_type, 'case', doc_id, transaction_id))
+                    recon.add_row((row))
 
         # Process all but the last log file before freezing the recon
         for log in logs_to_process[:pre_logs]:

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -70,7 +70,7 @@ def _on_error(change_meta, exc_info):
 
 
 def _audit_log(stage, change_meta):
-    logger.debug('%s change to kafka: %s,%s', stage, change_meta.document_type, change_meta.document_id)
+    logger.debug('%s,%s,%s', stage, change_meta.document_type, change_meta.document_id)
 
 
 producer = ChangeProducer()

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -1,10 +1,19 @@
 import json
+import logging
+from functools import partial
 
 from django.conf import settings
 
 from kafka import KafkaProducer
 
-from corehq.util.soft_assert import soft_assert
+from dimagi.utils.logging import notify_exception
+
+CHANGE_PRE_SEND = 'PRE-SEND'
+CHANGE_ERROR = 'ERROR'
+CHANGE_SENT = 'SENT'
+KAFKA_AUDIT_LOGGER = 'kafka_producer_audit'
+
+logger = logging.getLogger(KAFKA_AUDIT_LOGGER)
 
 
 class ChangeProducer(object):
@@ -32,15 +41,36 @@ class ChangeProducer(object):
         message = change_meta.to_json()
         message_json_dump = json.dumps(message).encode('utf-8')
         try:
-            self.producer.send(topic, message_json_dump, key=change_meta.document_id)
+            _audit_log(CHANGE_PRE_SEND, change_meta)
+            future = self.producer.send(topic, message_json_dump, key=change_meta.document_id)
             if self.auto_flush:
-                self.producer.flush()
+                future.get()
+                _audit_log(CHANGE_SENT, change_meta)
         except Exception:
+            _audit_log('ERROR', change_meta)
             notify_exception(None, 'Problem sending change to Kafka', details=message)
             raise
 
+        if not self.auto_flush:
+            on_success = partial(_on_success, change_meta)
+            on_error = partial(_on_error, change_meta)
+            future.add_callback(on_success).add_errback(on_error)
+
     def flush(self, timeout=None):
         self.producer.flush(timeout=timeout)
+
+
+def _on_success(change_meta, record_metadata):
+    _audit_log(CHANGE_SENT, change_meta)
+
+
+def _on_error(change_meta, exc_info):
+    _audit_log(CHANGE_ERROR, change_meta)
+    notify_exception(None, 'Problem sending change to Kafka', details=change_meta.to_json(), exec_info=exc_info)
+
+
+def _audit_log(stage, change_meta):
+    logger.debug('%s change to kafka: %s,%s', stage, change_meta.document_type, change_meta.document_id)
 
 
 producer = ChangeProducer()

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -35,11 +35,8 @@ class ChangeProducer(object):
             self.producer.send(topic, message_json_dump, key=change_meta.document_id)
             if self.auto_flush:
                 self.producer.flush()
-        except Exception as e:
-            _assert = soft_assert(notify_admins=True)
-            _assert(False, 'Problem sending change to kafka {}: {} ({})'.format(
-                message, e, type(e)
-            ))
+        except Exception:
+            notify_exception(None, 'Problem sending change to Kafka', details=message)
             raise
 
     def flush(self, timeout=None):

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -68,7 +68,10 @@ def _on_success(change_meta, record_metadata):
 
 def _on_error(change_meta, exc_info):
     _audit_log(CHANGE_ERROR, change_meta)
-    notify_exception(None, 'Problem sending change to Kafka', details=change_meta.to_json(), exec_info=exc_info)
+    notify_exception(
+        None, 'Problem sending change to Kafka (async)',
+        details=change_meta.to_json(), exec_info=exc_info
+    )
 
 
 def _audit_log(stage, change_meta):

--- a/corehq/apps/change_feed/tests/test_kafka_change_feed.py
+++ b/corehq/apps/change_feed/tests/test_kafka_change_feed.py
@@ -3,6 +3,9 @@ from copy import deepcopy
 
 from django.test import SimpleTestCase, TestCase
 
+from kafka.future import Future
+from mock import Mock
+
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.feed.interface import ChangeMeta
 from pillowtop.pillow.interface import ConstructedPillow
@@ -14,10 +17,18 @@ from corehq.apps.change_feed.consumer.feed import (
     KafkaCheckpointEventHandler,
 )
 from corehq.apps.change_feed.exceptions import UnavailableKafkaOffset
-from corehq.apps.change_feed.producer import producer
+from corehq.apps.change_feed.producer import (
+    CHANGE_ERROR,
+    CHANGE_PRE_SEND,
+    CHANGE_SENT,
+    KAFKA_AUDIT_LOGGER,
+    ChangeProducer,
+    producer,
+)
 from corehq.apps.change_feed.topics import (
     get_multi_topic_first_available_offsets,
 )
+from corehq.util.test_utils import capture_log_output
 
 
 class KafkaChangeFeedTest(SimpleTestCase):
@@ -118,7 +129,61 @@ class KafkaCheckpointTest(TestCase):
         self.assertEqual(feed.get_current_checkpoint_offsets(), current_kafka_offsets)
 
 
-def publish_stub_change(topic):
+def publish_stub_change(topic, kafka_producer=None):
     meta = ChangeMeta(document_id=uuid.uuid4().hex, data_source_type='dummy-type', data_source_name='dummy-name')
-    producer.send_change(topic, meta)
+    (kafka_producer or producer).send_change(topic, meta)
     return meta
+
+
+class TestKafkaAuditLogging(SimpleTestCase):
+    def test_success_synchronous(self):
+        self._test_success(auto_flush=True)
+
+    def test_success_asynchronous(self):
+        self._test_success(auto_flush=False)
+
+    def test_error_synchronous(self):
+        kafka_producer = ChangeProducer()
+        future = Future()
+        future.get = Mock(side_effect=Exception())
+        kafka_producer.producer.send = Mock(return_value=future)
+
+        meta = ChangeMeta(
+            document_id=uuid.uuid4().hex, data_source_type='dummy-type', data_source_name='dummy-name'
+        )
+
+        with capture_log_output(KAFKA_AUDIT_LOGGER) as logs:
+            with self.assertRaises(Exception):
+                kafka_producer.send_change(topics.CASE, meta)
+
+        self._check_logs(logs, meta.document_id, [CHANGE_PRE_SEND, CHANGE_ERROR])
+
+    def test_error_asynchronous(self):
+        kafka_producer = ChangeProducer(auto_flush=False)
+        future = Future()
+        kafka_producer.producer.send = Mock(return_value=future)
+
+        meta = ChangeMeta(
+            document_id=uuid.uuid4().hex, data_source_type='dummy-type', data_source_name='dummy-name'
+        )
+
+        with capture_log_output(KAFKA_AUDIT_LOGGER) as logs:
+            kafka_producer.send_change(topics.CASE, meta)
+            future.failure(Exception())
+
+        self._check_logs(logs, meta.document_id, [CHANGE_PRE_SEND, CHANGE_ERROR])
+
+    def _test_success(self, auto_flush):
+        kafka_producer = ChangeProducer(auto_flush=auto_flush)
+        with capture_log_output(KAFKA_AUDIT_LOGGER) as logs:
+            meta = publish_stub_change(topics.CASE, kafka_producer)
+            if not auto_flush:
+                kafka_producer.flush()
+        self._check_logs(logs, meta.document_id, [CHANGE_PRE_SEND, CHANGE_SENT])
+
+    def _check_logs(self, captured_logs, doc_id, events):
+        lines = captured_logs.get_output().splitlines()
+        self.assertEqual(len(events), len(lines))
+        for event, line in zip(events, lines):
+            self.assertIn(doc_id, line)
+            self.assertIn(event, line)

--- a/corehq/apps/change_feed/tests/test_producer_reconciliation.py
+++ b/corehq/apps/change_feed/tests/test_producer_reconciliation.py
@@ -1,0 +1,65 @@
+from nose.tools import assert_equal, assert_true
+
+from corehq.apps.change_feed.management.commands.reconcile_producer_logs import (
+    Reconciliation,
+)
+from corehq.apps.change_feed.producer import (
+    CHANGE_ERROR,
+    CHANGE_PRE_SEND,
+    CHANGE_SENT,
+)
+
+
+def test_recon():
+    recon = Reconciliation()
+    rows = [
+        # date, type, doc_type, doc_id, transaction_id
+        ('', CHANGE_PRE_SEND, 'case', '1', 'a'),
+        ('', CHANGE_SENT, 'case', '1', 'a'),
+        ('', CHANGE_PRE_SEND, 'case', '2', 'b'),
+        ('', CHANGE_ERROR, 'case', '2', 'b'),
+        ('', CHANGE_PRE_SEND, 'case', '3', 'c'),
+        ('', CHANGE_PRE_SEND, 'case', '4', 'd'),
+        ('', CHANGE_SENT, 'case', '3', 'c'),
+        ('', CHANGE_SENT, 'case', '4', 'd'),
+        ('', CHANGE_PRE_SEND, 'case', '1', 'e'),
+        ('', CHANGE_PRE_SEND, 'case', '5', 'f'),
+    ]
+
+    for row in rows:
+        recon.add_row(row)
+    recon.reconcile()
+    case_recon = recon.by_doc_type['case']
+    assert_true(case_recon.has_results())
+    assert_equal(case_recon.get_results(), {
+        'sent_count': 3,
+        'persistent_error_count': 1,
+        'unaccounted_for': 2,
+        'unaccounted_for_ids': {'1', '5'},
+    })
+    assert_equal(case_recon.errors, {'b': '2'})
+    return recon
+
+
+def test_recon_with_freeze():
+    recon = test_recon()
+    recon.freeze()
+    rows = [
+        ('', CHANGE_PRE_SEND, 'case', '6', 'g'),
+        ('', CHANGE_PRE_SEND, 'case', '2', 'h'),
+        ('', CHANGE_SENT, 'case', '1', 'e'),  # reconciles transaction from pre-freeze
+        ('', CHANGE_SENT, 'case', '2', 'h'),  # reconciles persistent error from pre-freeze
+        ('', CHANGE_ERROR, 'case', '5', 'f'),  # reconciles transaction from pre-freeze
+    ]
+    for row in rows:
+        recon.add_row(row)
+    recon.reconcile()
+    case_recon = recon.by_doc_type['case']
+    assert_true(case_recon.has_results())
+    assert_equal(case_recon.get_results(), {
+        'sent_count': 3,
+        'persistent_error_count': 1,
+        'unaccounted_for': 0,
+        'unaccounted_for_ids': set(),
+    })
+    assert_equal(case_recon.errors, {'f': '5'})

--- a/settings.py
+++ b/settings.py
@@ -113,7 +113,7 @@ SOFT_ASSERTS_LOG_FILE = "%s/%s" % (FILEPATH, "soft_asserts.log")
 MAIN_COUCH_SQL_DATAMIGRATION = "%s/%s" % (FILEPATH, "main_couch_sql_datamigration.log")
 SESSION_ACCESS_LOG_FILE = "%s/%s" % (FILEPATH, "session_access_log.log")
 KAFKA_PRODUCER_AUDIT_FILE = "%s/%s" % (FILEPATH, "commcarehq.kafka_audit.log")
-KAFKA_PRODUCER_AUDIT_LOG_ENABLED = True
+KAFKA_PRODUCER_AUDIT_LOG_ENABLED = False
 
 LOCAL_LOGGING_HANDLERS = {}
 LOCAL_LOGGING_LOGGERS = {}

--- a/settings.py
+++ b/settings.py
@@ -112,6 +112,8 @@ FORMPLAYER_DIFF_FILE = "%s/%s" % (FILEPATH, "formplayer.diff.log")
 SOFT_ASSERTS_LOG_FILE = "%s/%s" % (FILEPATH, "soft_asserts.log")
 MAIN_COUCH_SQL_DATAMIGRATION = "%s/%s" % (FILEPATH, "main_couch_sql_datamigration.log")
 SESSION_ACCESS_LOG_FILE = "%s/%s" % (FILEPATH, "session_access_log.log")
+KAFKA_PRODUCER_AUDIT_FILE = "%s/%s" % (FILEPATH, "kafka_audit.log")
+KAFKA_PRODUCER_AUDIT_LOG_ENABLED = False
 
 LOCAL_LOGGING_HANDLERS = {}
 LOCAL_LOGGING_LOGGERS = {}
@@ -1046,6 +1048,9 @@ LOGGING = {
         'ucr_exception': {
             'format': '%(asctime)s\t%(domain)s\t%(report_config_id)s\t%(filter_values)s\t%(candidate)s'
         },
+        'kafka_audit': {
+            'format': '%(asctime)s,%(message)s'
+        },
     },
     'filters': {
         'hqcontext': {
@@ -1133,6 +1138,14 @@ LOGGING = {
             'filename': SOFT_ASSERTS_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 200  # Backup 2000 MB of logs
+        },
+        'kafka_audit': {
+            "level": "DEBUG" if KAFKA_PRODUCER_AUDIT_LOG_ENABLED else 'ERROR',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'formatter': 'kafka_audit',
+            'filename': KAFKA_PRODUCER_AUDIT_FILE,
+            'when': 'H',
+            'backupCount': 5
         },
         'main_couch_sql_datamigration': {
             'level': 'INFO',
@@ -1239,6 +1252,11 @@ LOGGING = {
         'kafka': {
             'handlers': ['file'],
             'level': 'ERROR',
+            'propagate': False,
+        },
+        'kafka_producer_audit': {
+            'handlers': ['kafka_audit'],
+            'level': 'INFO',
             'propagate': False,
         },
         'warehouse': {

--- a/settings.py
+++ b/settings.py
@@ -112,8 +112,8 @@ FORMPLAYER_DIFF_FILE = "%s/%s" % (FILEPATH, "formplayer.diff.log")
 SOFT_ASSERTS_LOG_FILE = "%s/%s" % (FILEPATH, "soft_asserts.log")
 MAIN_COUCH_SQL_DATAMIGRATION = "%s/%s" % (FILEPATH, "main_couch_sql_datamigration.log")
 SESSION_ACCESS_LOG_FILE = "%s/%s" % (FILEPATH, "session_access_log.log")
-KAFKA_PRODUCER_AUDIT_FILE = "%s/%s" % (FILEPATH, "kafka_audit.log")
-KAFKA_PRODUCER_AUDIT_LOG_ENABLED = False
+KAFKA_PRODUCER_AUDIT_FILE = "%s/%s" % (FILEPATH, "commcarehq.kafka_audit.log")
+KAFKA_PRODUCER_AUDIT_LOG_ENABLED = True
 
 LOCAL_LOGGING_HANDLERS = {}
 LOCAL_LOGGING_LOGGERS = {}

--- a/settings.py
+++ b/settings.py
@@ -112,8 +112,6 @@ FORMPLAYER_DIFF_FILE = "%s/%s" % (FILEPATH, "formplayer.diff.log")
 SOFT_ASSERTS_LOG_FILE = "%s/%s" % (FILEPATH, "soft_asserts.log")
 MAIN_COUCH_SQL_DATAMIGRATION = "%s/%s" % (FILEPATH, "main_couch_sql_datamigration.log")
 SESSION_ACCESS_LOG_FILE = "%s/%s" % (FILEPATH, "session_access_log.log")
-KAFKA_PRODUCER_AUDIT_FILE = "%s/%s" % (FILEPATH, "commcarehq.kafka_audit.log")
-KAFKA_PRODUCER_AUDIT_LOG_ENABLED = False
 
 LOCAL_LOGGING_HANDLERS = {}
 LOCAL_LOGGING_LOGGERS = {}
@@ -1139,14 +1137,6 @@ LOGGING = {
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 200  # Backup 2000 MB of logs
         },
-        'kafka_audit': {
-            "level": "DEBUG" if KAFKA_PRODUCER_AUDIT_LOG_ENABLED else 'ERROR',
-            'class': 'logging.handlers.TimedRotatingFileHandler',
-            'formatter': 'kafka_audit',
-            'filename': KAFKA_PRODUCER_AUDIT_FILE,
-            'when': 'H',
-            'backupCount': 5
-        },
         'main_couch_sql_datamigration': {
             'level': 'INFO',
             'class': 'logging.handlers.RotatingFileHandler',
@@ -1252,11 +1242,6 @@ LOGGING = {
         'kafka': {
             'handlers': ['file'],
             'level': 'ERROR',
-            'propagate': False,
-        },
-        'kafka_producer_audit': {
-            'handlers': ['kafka_audit'],
-            'level': 'INFO',
             'propagate': False,
         },
         'warehouse': {


### PR DESCRIPTION
##### SUMMARY
The main change in this PR is to add audit logging to the Kafka producer. This logging allows us to verify whether data is being sent to Kafka successfully (assuming there are no bugs in the kafka client).

This change also includes a management command to process the log data. This command can be run via a cron job on each VM that's sending data to kafka.

There is also one other change to how the producer works. Instead of calling `producer.flush()` for synchronous sending we use the Future returned from `producer.send`:

```python
future = producer.send(...)
future.get()
```
This is the recommended style for synchronous sending according to the python client documentation: https://kafka-python.readthedocs.io/en/master/usage.html

I'm not very confident that this will find any errors from the synchronous publishing but it's clear that we are not handling asynchronous errors at all. We do async calls from the pillow error queue. I specifically chose not to address that in this PR and will do a followup PR. 

A quick note on performance. I've got the log rollover set to every hour so at current rate we could expect a max of 4M logs per file. If we process 2 log files on each run it shouldn't take more than 30s (based on local testing).