### PR TITLE
Fix Elasticsearch library regression for index prune command

### DIFF
--- a/corehq/apps/hqadmin/management/commands/prune_elastic_indices.py
+++ b/corehq/apps/hqadmin/management/commands/prune_elastic_indices.py
@@ -2,7 +2,7 @@ from django.core.management import BaseCommand
 
 from corehq.elastic import get_es_new
 from corehq.pillows.utils import get_all_expected_es_indices
-from corehq.util.es import AuthorizationException
+from corehq.util.es.elasticsearch import AuthorizationException
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Fixes regression introduced in https://github.com/dimagi/commcare-hq/pull/25728 to the `prune_elasticsearch_indices` management command