### PR TITLE
Refactor: serialize() and deserialize() call check_direction()

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -197,22 +197,14 @@ def create_patient(requests, info, case_config):
         return {
             property_: value_source.get_value(info)
             for property_, value_source in case_config.person_preferred_name.items()
-            if (
-                property_ in NAME_PROPERTIES and
-                value_source.check_direction(DIRECTION_EXPORT) and
-                value_source.get_value(info)
-            )
+            if property_ in NAME_PROPERTIES and value_source.get_value(info)
         }
 
     def get_address():
         return {
             property_: value_source.get_value(info)
             for property_, value_source in case_config.person_preferred_address.items()
-            if (
-                property_ in ADDRESS_PROPERTIES and
-                value_source.check_direction(DIRECTION_EXPORT) and
-                value_source.get_value(info)
-            )
+            if property_ in ADDRESS_PROPERTIES and value_source.get_value(info)
         }
 
     def get_properties():

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -211,11 +211,7 @@ def create_patient(requests, info, case_config):
         return {
             property_: value_source.get_value(info)
             for property_, value_source in case_config.person_properties.items()
-            if (
-                property_ in PERSON_PROPERTIES and
-                value_source.check_direction(DIRECTION_EXPORT) and
-                value_source.get_value(info)
-            )
+            if property_ in PERSON_PROPERTIES and value_source.get_value(info) is not None
         }
 
     def get_identifiers():

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -618,11 +618,7 @@ class UpdatePersonPropertiesTask(WorkflowTask):
         properties = {
             property_: value_source.get_value(self.info)
             for property_, value_source in self.openmrs_config.case_config.person_properties.items()
-            if (
-                property_ in PERSON_PROPERTIES and
-                value_source.check_direction(DIRECTION_EXPORT) and
-                value_source.get_value(self.info)
-            )
+            if property_ in PERSON_PROPERTIES and value_source.get_value(self.info) is not None
         }
         if properties:
             self.requests.post(

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -165,7 +165,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
         return {
             obs.concept: [obs.value.get_value(self.info)]
             for obs in form_config.openmrs_observations
-            if obs.value.check_direction(DIRECTION_EXPORT) and not is_blank(obs.value.get_value(self.info))
+            if not is_blank(obs.value.get_value(self.info))
         }
 
     def run(self):
@@ -494,11 +494,7 @@ class UpdatePersonNameTask(WorkflowTask):
         properties = {
             property_: value_source.get_value(self.info)
             for property_, value_source in self.openmrs_config.case_config.person_preferred_name.items()
-            if (
-                property_ in NAME_PROPERTIES and
-                value_source.check_direction(DIRECTION_EXPORT) and
-                value_source.get_value(self.info)
-            )
+            if property_ in NAME_PROPERTIES and value_source.get_value(self.info)
         }
         if properties:
             self.requests.post(
@@ -546,11 +542,7 @@ class CreatePersonAddressTask(WorkflowTask):
         properties = {
             property_: value_source.get_value(self.info)
             for property_, value_source in self.openmrs_config.case_config.person_preferred_address.items()
-            if (
-                property_ in ADDRESS_PROPERTIES and
-                value_source.check_direction(DIRECTION_EXPORT) and
-                value_source.get_value(self.info)
-            )
+            if property_ in ADDRESS_PROPERTIES and value_source.get_value(self.info)
         }
         if properties:
             response = self.requests.post(
@@ -585,11 +577,7 @@ class UpdatePersonAddressTask(WorkflowTask):
         properties = {
             property_: value_source.get_value(self.info)
             for property_, value_source in self.openmrs_config.case_config.person_preferred_address.items()
-            if (
-                property_ in ADDRESS_PROPERTIES and
-                value_source.check_direction(DIRECTION_EXPORT) and
-                value_source.get_value(self.info)
-            )
+            if property_ in ADDRESS_PROPERTIES and value_source.get_value(self.info)
         }
         if properties:
             self.requests.post(

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -393,7 +393,7 @@ def test_doctests():
     assert results.failed == 0
 
 
-def get_constant_spam(update: dict=None) -> ValueSource:
+def get_constant_spam(update: dict = None) -> ValueSource:
     constant_spam = {
         "doc_type": "ConstantValue",
         "value": "spam",

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -360,6 +360,34 @@ class CheckDeserializeDirectionTests(SimpleTestCase):
         self.assertEqual(value_source.deserialize("spam"), "spam")
 
 
+class GetValueDirectionTests(SimpleTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.info = CaseTriggerInfo(
+            domain="test-domain",
+            case_id="123456",
+        )
+
+    def test_get_value_in(self):
+        value_source = get_constant_spam({"direction": "in"})
+        self.assertIsNone(value_source.get_value(self.info))
+
+    def test_get_value_out(self):
+        value_source = get_constant_spam({"direction": "out"})
+        value = value_source.get_value(self.info)
+        self.assertEqual(value, "spam")
+
+    def test_get_value_both(self):
+        value_source = get_constant_spam({"direction": None})
+        self.assertEqual(value_source.get_value(self.info), "spam")
+
+    def test_get_value_default(self):
+        value_source = get_constant_spam()
+        self.assertEqual(value_source.get_value(self.info), "spam")
+
+
 def test_doctests():
     results = doctest.testmod(corehq.motech.value_source)
     assert results.failed == 0

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -10,6 +10,9 @@ from corehq.motech.const import (
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_INTEGER,
     COMMCARE_DATA_TYPE_TEXT,
+    DIRECTION_BOTH,
+    DIRECTION_EXPORT,
+    DIRECTION_IMPORT,
 )
 from corehq.motech.value_source import (
     CaseProperty,
@@ -278,6 +281,57 @@ class JsonPathConstantValueTests(SimpleTestCase):
         self.assertEqual(external_value, "qux")
 
 
+class CheckDirectionTests(SimpleTestCase):
+
+    def test_check_direction_in_true(self):
+        value_source = get_constant_spam({"direction": "in"})
+        can_import = value_source.check_direction(DIRECTION_IMPORT)
+        self.assertTrue(can_import)
+
+    def test_check_direction_in_false(self):
+        value_source = get_constant_spam({"direction": "in"})
+        can_export = value_source.check_direction(DIRECTION_EXPORT)
+        self.assertFalse(can_export)
+
+    def test_check_direction_out_true(self):
+        value_source = get_constant_spam({"direction": "out"})
+        can_export = value_source.check_direction(DIRECTION_EXPORT)
+        self.assertTrue(can_export)
+
+    def test_check_direction_out_false(self):
+        value_source = get_constant_spam({"direction": "out"})
+        can_import = value_source.check_direction(DIRECTION_IMPORT)
+        self.assertFalse(can_import)
+
+    def test_check_direction_both(self):
+        value_source = get_constant_spam({"direction": None})
+        can_import = value_source.check_direction(DIRECTION_IMPORT)
+        can_export = value_source.check_direction(DIRECTION_EXPORT)
+        can_import_and_export = value_source.check_direction(DIRECTION_BOTH)
+        self.assertTrue(can_import)
+        self.assertTrue(can_export)
+        self.assertTrue(can_import_and_export)
+
+    def test_check_default(self):
+        value_source = get_constant_spam()
+        can_import = value_source.check_direction(DIRECTION_IMPORT)
+        can_export = value_source.check_direction(DIRECTION_EXPORT)
+        can_import_and_export = value_source.check_direction(DIRECTION_BOTH)
+        self.assertTrue(can_import)
+        self.assertTrue(can_export)
+        self.assertTrue(can_import_and_export)
+
+
 def test_doctests():
     results = doctest.testmod(corehq.motech.value_source)
     assert results.failed == 0
+
+
+def get_constant_spam(update: dict=None) -> ValueSource:
+    constant_spam = {
+        "doc_type": "ConstantValue",
+        "value": "spam",
+    }
+    if update:
+        constant_spam.update(update)
+    return ValueSource.wrap(constant_spam)

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -322,6 +322,44 @@ class CheckDirectionTests(SimpleTestCase):
         self.assertTrue(can_import_and_export)
 
 
+class CheckSerializeDirectionTests(SimpleTestCase):
+
+    def test_serialize_in(self):
+        value_source = get_constant_spam({"direction": "in"})
+        self.assertIsNone(value_source.serialize("spam"))
+
+    def test_serialize_out(self):
+        value_source = get_constant_spam({"direction": "out"})
+        self.assertEqual(value_source.serialize("spam"), "spam")
+
+    def test_serialize_both(self):
+        value_source = get_constant_spam({"direction": None})
+        self.assertEqual(value_source.serialize("spam"), "spam")
+
+    def test_serialize_default(self):
+        value_source = get_constant_spam()
+        self.assertEqual(value_source.serialize("spam"), "spam")
+
+
+class CheckDeserializeDirectionTests(SimpleTestCase):
+
+    def test_deserialize_in(self):
+        value_source = get_constant_spam({"direction": "in"})
+        self.assertEqual(value_source.deserialize("spam"), "spam")
+
+    def test_deserialize_out(self):
+        value_source = get_constant_spam({"direction": "out"})
+        self.assertIsNone(value_source.deserialize("spam"))
+
+    def test_deserialize_both(self):
+        value_source = get_constant_spam({"direction": None})
+        self.assertEqual(value_source.deserialize("spam"), "spam")
+
+    def test_deserialize_default(self):
+        value_source = get_constant_spam()
+        self.assertEqual(value_source.deserialize("spam"), "spam")
+
+
 def test_doctests():
     results = doctest.testmod(corehq.motech.value_source)
     assert results.failed == 0


### PR DESCRIPTION
##### SUMMARY
`ValueSource.serialize()` returns a value from CommCare serialized for exporting to an external system, like OpenMRS or DHIS2. `ValueSource.deserialize()` accepts a value from an external system, and converts its data type to whatever is right for importing to CommCare.

`ValueSource.check_direction(DIRECTION_IMPORT)` returns True if the ValueSource can be imported, and `ValueSource.check_direction(DIRECTION_EXPORT)` returns True if the ValueSource can be exported.

This PR is a refactor to make `serialize()` and `deserialize()` call `check_direction()` themselves, so that calling functions don't have to.

Review by commit :blowfish: 
