### PR TITLE
Use CELERY_BROKER_URL

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -67,7 +67,7 @@ def check_all_rabbitmq():
     unwell_rabbits = []
     ip_regex = re.compile(r'[0-9]+.[0-9]+.[0-9]+.[0-9]+')
 
-    for broker_url in settings.BROKER_URL.split(';'):
+    for broker_url in settings.CELERY_BROKER_URL.split(';'):
         check_status, failure = check_rabbitmq(broker_url)
         if not check_status:
             failed_rabbit_ip = ip_regex.search(broker_url).group()
@@ -95,7 +95,7 @@ def check_rabbitmq(broker_url):
             return False, 'RabbitMQ Offline'
         except Exception as e:
             return False, "RabbitMQ Error: %s" % e
-    elif settings.BROKER_URL.startswith('redis'):
+    elif settings.CELERY_BROKER_URL.startswith('redis'):
         return True, "RabbitMQ Not configured, but not needed"
     else:
         return False, "RabbitMQ Not configured"

--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -73,7 +73,7 @@ class SystemInfoView(BaseAdminSectionView):
         context['user_is_support'] = hasattr(self.request, 'user') and SUPPORT.enabled(self.request.user.username)
 
         context['redis'] = service_checks.check_redis()
-        context['rabbitmq'] = service_checks.check_rabbitmq(settings.BROKER_URL)
+        context['rabbitmq'] = service_checks.check_rabbitmq(settings.CELERY_BROKER_URL)
         context['celery_stats'] = get_celery_stats()
         context['heartbeat'] = service_checks.check_heartbeat()
 
@@ -213,8 +213,8 @@ def pillow_operation_api(request):
 
 
 def get_rabbitmq_management_url():
-    if settings.BROKER_URL.startswith('amqp'):
-        amqp_parts = settings.BROKER_URL.replace('amqp://', '').split('/')
+    if settings.CELERY_BROKER_URL.startswith('amqp'):
+        amqp_parts = settings.CELERY_BROKER_URL.replace('amqp://', '').split('/')
         mq_management_url = amqp_parts[0].replace('5672', '15672')
         return "http://%s" % mq_management_url.split('@')[-1]
     else:

--- a/settings.py
+++ b/settings.py
@@ -507,7 +507,6 @@ TRANSFER_FILE_DIR_NAME = None
 
 GET_URL_BASE = 'dimagi.utils.web.get_url_base'
 
-# celery
 CELERY_BROKER_URL = 'redis://localhost:6379/0'
 
 # https://github.com/celery/celery/issues/4226

--- a/settings.py
+++ b/settings.py
@@ -508,7 +508,7 @@ TRANSFER_FILE_DIR_NAME = None
 GET_URL_BASE = 'dimagi.utils.web.get_url_base'
 
 # celery
-BROKER_URL = CELERY_BROKER_URL = 'redis://localhost:6379/0'
+CELERY_BROKER_URL = 'redis://localhost:6379/0'
 
 # https://github.com/celery/celery/issues/4226
 CELERY_BROKER_POOL_LIMIT = None


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/25790#discussion_r342421473

According to https://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#using-celery-with-django and the fact we use https://github.com/dimagi/commcare-hq/blob/2b7a0b72093368dac79ee84c6237469842b3218a/corehq/celery.py#L17 means we should use `CELERY_*` for  localsettings