### PR TITLE
restructure plproxy config

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -172,8 +172,8 @@ def get_model_iterator_builders_to_dump(domain, excludes):
 
 def get_all_model_iterators_builders_for_domain(model_class, domain, limit_to_db=None):
     using = router.db_for_read(model_class)
-    if settings.USE_PARTITIONED_DATABASE and using == partition_config.get_proxy_db():
-        using = partition_config.get_form_processing_dbs()
+    if settings.USE_PARTITIONED_DATABASE and using == partition_config.proxy_db:
+        using = partition_config.form_processing_dbs
     else:
         using = [using]
 

--- a/corehq/apps/dump_reload/sql/load.py
+++ b/corehq/apps/dump_reload/sql/load.py
@@ -168,7 +168,7 @@ def _group_objects_by_db(objects):
         app_label = obj['model']
         model = apps.get_model(app_label)
         db_alias = router.db_for_write(model)
-        if settings.USE_PARTITIONED_DATABASE and db_alias == partition_config.get_proxy_db():
+        if settings.USE_PARTITIONED_DATABASE and db_alias == partition_config.proxy_db:
             doc_id = _get_doc_id(app_label, obj)
             db_alias = ShardAccessor.get_database_for_doc(doc_id)
 

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -120,10 +120,7 @@ PARTITION_DATABASE_CONFIG = {
         'p4': [615, 819],
         'p5': [820, 1023]
     },
-    'groups': {
-        'proxy': ['proxy'],
-        'form_processing': ['p1', 'p2', 'p3', 'p4', 'p5'],
-    }
+    'proxy': 'proxy',
 }
 
 

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -24,7 +24,7 @@ class ShardingTests(TestCase):
             # https://github.com/nose-devs/nose/issues/946
             raise SkipTest('Only applicable if sharding is setup')
         super(ShardingTests, cls).setUpClass()
-        assert len(partition_config.get_form_processing_dbs()) > 1
+        assert len(partition_config.form_processing_dbs) > 1
 
     def tearDown(self):
         FormProcessorTestUtils.delete_all_sql_forms(DOMAIN)
@@ -37,7 +37,7 @@ class ShardingTests(TestCase):
 
         dbs_with_form = []
         dbs_with_case = []
-        for db in partition_config.get_form_processing_dbs():
+        for db in partition_config.form_processing_dbs:
             form_in_db = XFormInstanceSQL.objects.using(db).filter(form_id=form.form_id).exists()
             if form_in_db:
                 dbs_with_form.append(db)
@@ -59,7 +59,7 @@ class ShardingTests(TestCase):
 
         forms_per_db = {}
         cases_per_db = {}
-        for db in partition_config.get_form_processing_dbs():
+        for db in partition_config.form_processing_dbs:
             forms_per_db[db] = XFormInstanceSQL.objects.using(db).filter(domain=DOMAIN).count()
             cases_per_db[db] = CommCareCaseSQL.objects.using(db).filter(domain=DOMAIN).count()
 
@@ -163,7 +163,7 @@ class ShardAccessorTests(TestCase):
         for db_alias in doc_db_map.values():
             doc_count_per_db[db_alias] += 1
 
-        num_dbs = len(partition_config.get_form_processing_dbs())
+        num_dbs = len(partition_config.form_processing_dbs)
         even_split = int(N // num_dbs)
         tolerance = N * 0.05  # 5% tollerance
         diffs = [abs(even_split - count) for count in doc_count_per_db.values()]

--- a/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_partitioned.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/tests/test_dbaccessors_partitioned.py
@@ -74,7 +74,7 @@ class TestSchedulingPartitionedDBAccessorsGetAndSave(BaseSchedulingPartitionedDB
         cls.p2_uuid = uuid.UUID('8440dbd6-61b1-4b2f-a310-7e1768902d04')
 
     def tearDown(self):
-        for db in partition_config.get_form_processing_dbs():
+        for db in partition_config.form_processing_dbs:
             AlertScheduleInstance.objects.using(db).filter(domain=self.domain).delete()
             TimedScheduleInstance.objects.using(db).filter(domain=self.domain).delete()
 
@@ -83,26 +83,26 @@ class TestSchedulingPartitionedDBAccessorsGetAndSave(BaseSchedulingPartitionedDB
         self.assertEqual(ShardAccessor.get_database_for_doc(self.p2_uuid), self.db2)
 
     def test_save_alert_schedule_instance(self):
-        self.assertEqual(AlertScheduleInstance.objects.using(partition_config.get_proxy_db()).count(), 0)
+        self.assertEqual(AlertScheduleInstance.objects.using(partition_config.proxy_db).count(), 0)
         self.assertEqual(AlertScheduleInstance.objects.using(self.db1).count(), 0)
         self.assertEqual(AlertScheduleInstance.objects.using(self.db2).count(), 0)
 
         instance = self.make_alert_schedule_instance(self.p1_uuid)
         save_alert_schedule_instance(instance)
 
-        self.assertEqual(AlertScheduleInstance.objects.using(partition_config.get_proxy_db()).count(), 0)
+        self.assertEqual(AlertScheduleInstance.objects.using(partition_config.proxy_db).count(), 0)
         self.assertEqual(AlertScheduleInstance.objects.using(self.db1).count(), 1)
         self.assertEqual(AlertScheduleInstance.objects.using(self.db2).count(), 0)
 
     def test_save_timed_schedule_instance(self):
-        self.assertEqual(TimedScheduleInstance.objects.using(partition_config.get_proxy_db()).count(), 0)
+        self.assertEqual(TimedScheduleInstance.objects.using(partition_config.proxy_db).count(), 0)
         self.assertEqual(TimedScheduleInstance.objects.using(self.db1).count(), 0)
         self.assertEqual(TimedScheduleInstance.objects.using(self.db2).count(), 0)
 
         instance = self.make_timed_schedule_instance(self.p2_uuid)
         save_timed_schedule_instance(instance)
 
-        self.assertEqual(TimedScheduleInstance.objects.using(partition_config.get_proxy_db()).count(), 0)
+        self.assertEqual(TimedScheduleInstance.objects.using(partition_config.proxy_db).count(), 0)
         self.assertEqual(TimedScheduleInstance.objects.using(self.db1).count(), 0)
         self.assertEqual(TimedScheduleInstance.objects.using(self.db2).count(), 1)
 
@@ -161,7 +161,7 @@ class TestSchedulingPartitionedDBAccessorsDeleteAndFilter(BaseSchedulingPartitio
         save_timed_schedule_instance(self.timed_instance3_p2)
 
     def tearDown(self):
-        for db in partition_config.get_form_processing_dbs():
+        for db in partition_config.form_processing_dbs:
             AlertScheduleInstance.objects.using(db).filter(domain=self.domain).delete()
             TimedScheduleInstance.objects.using(db).filter(domain=self.domain).delete()
 

--- a/corehq/sql_db/config.py
+++ b/corehq/sql_db/config.py
@@ -146,28 +146,6 @@ def _is_power_of_2(num):
     return num and not (num & (num - 1))
 
 
-def parse_existing_shard(shard_option):
-    shard_name, options = shard_option.split('=', 1)
-    assert shard_name[0] == 'p'
-    shard_id = int(shard_name[1:])
-    options = options.split(' ')
-    option_kwargs = dict(tuple(option.split('=')) for option in options)
-    if 'port' in option_kwargs:
-        option_kwargs['port'] = int(option_kwargs['port'])
-    return ShardMeta(id=shard_id, **option_kwargs)
-
-
-def get_shards_to_update(existing_shards, new_shards):
-    assert len(existing_shards) == len(new_shards)
-    shards_to_update = []
-    for existing, new in zip(existing_shards, new_shards):
-        assert existing.id == new.id, '{} != {}'.format(existing.id, new.id)
-        if existing != new:
-            shards_to_update.append(new)
-
-    return shards_to_update
-
-
 def _get_config():
     if settings.USE_PARTITIONED_DATABASE:
         return PartitionConfig()

--- a/corehq/sql_db/management/commands/configure_pl_proxy_cluster.py
+++ b/corehq/sql_db/management/commands/configure_pl_proxy_cluster.py
@@ -110,7 +110,7 @@ def _update_pl_proxy_cluster(existing_config, verbose):
             if verbose:
                 print(alter_sql)
 
-            with connections[partition_config.get_proxy_db()].cursor() as cursor:
+            with connections[partition_config.proxy_db].cursor() as cursor:
                 cursor.execute(alter_sql)
         else:
             print('Abort')
@@ -129,7 +129,7 @@ def _get_alter_server_sql(shards_to_update):
 
 
 def create_pl_proxy_cluster(verbose=False, drop_existing=False):
-    proxy_db = partition_config.get_proxy_db()
+    proxy_db = partition_config.proxy_db
 
     if drop_existing:
         with connections[proxy_db].cursor() as cursor:
@@ -153,7 +153,7 @@ def get_drop_server_sql():
 
 
 def _get_existing_cluster_config(cluster_name):
-    proxy_db = partition_config.get_proxy_db()
+    proxy_db = partition_config.proxy_db
     with connections[proxy_db].cursor() as cursor:
         cursor.execute('SELECT * from pg_foreign_server where srvname = %s', [cluster_name])
         results = list(fetchall_as_namedtuple(cursor))
@@ -173,7 +173,7 @@ def get_pl_proxy_server_config_sql(shards):
 
 
 def get_user_mapping_sql():
-    proxy_db = partition_config.get_proxy_db()
+    proxy_db = partition_config.proxy_db
     proxy_db_config = settings.DATABASES[proxy_db].copy()
     proxy_db_config['server_name'] = settings.PL_PROXY_CLUSTER_NAME
     return USER_MAPPING_TEMPLATE.format(**proxy_db_config)

--- a/corehq/sql_db/migrations.py
+++ b/corehq/sql_db/migrations.py
@@ -51,8 +51,8 @@ def partitioned(cls_or_op=None, apply_to_proxy=True):
 
 def is_partition_alias(db, apply_to_proxy):
     return not settings.USE_PARTITIONED_DATABASE or (
-        (db == partition_config.get_proxy_db() and apply_to_proxy) or
-        db in partition_config.get_form_processing_dbs()
+        (db == partition_config.proxy_db and apply_to_proxy) or
+        db in partition_config.form_processing_dbs
     )
 
 

--- a/corehq/sql_db/routers.py
+++ b/corehq/sql_db/routers.py
@@ -74,18 +74,18 @@ def allow_migrate(db, app_label, model_name=None):
         return app_label != PROXY_APP and db in (DEFAULT_DB_ALIAS, None)
 
     if app_label == PROXY_APP:
-        return db == partition_config.get_proxy_db()
+        return db == partition_config.proxy_db
     elif app_label == BLOB_DB_APP and db == DEFAULT_DB_ALIAS:
         return True
     elif app_label == BLOB_DB_APP and model_name == 'blobexpiration':
         return False
     elif app_label in (FORM_PROCESSOR_APP, SCHEDULING_PARTITIONED_APP, BLOB_DB_APP):
         return (
-            db == partition_config.get_proxy_db() or
-            db in partition_config.get_form_processing_dbs()
+            db == partition_config.proxy_db or
+            db in partition_config.form_processing_dbs
         )
     elif app_label == SQL_ACCESSORS_APP:
-        return db in partition_config.get_form_processing_dbs()
+        return db in partition_config.form_processing_dbs
     else:
         return db == DEFAULT_DB_ALIAS
 
@@ -115,10 +115,10 @@ def db_for_read_write(model, write=True):
 
     if app_label == BLOB_DB_APP:
         if hasattr(model, 'partition_attr'):
-            return partition_config.get_proxy_db()
+            return partition_config.proxy_db
         return DEFAULT_DB_ALIAS
     if app_label == FORM_PROCESSOR_APP:
-        return partition_config.get_proxy_db()
+        return partition_config.proxy_db
     else:
         default_db = DEFAULT_DB_ALIAS
         if not write:

--- a/corehq/sql_db/shard_data_management.py
+++ b/corehq/sql_db/shard_data_management.py
@@ -128,13 +128,13 @@ def _get_counts_by_shard_query_for_testing(model):
             "hash_string(decode(replace({id_field}::text, '-', ''), 'hex'), 'siphash24')"
             " & {total_shard_count}"
         ).format(
-            total_shard_count=partition_config.num_shards - 1,
+            total_shard_count=partition_config.shard_count - 1,
             id_field=model.partition_attr,
         )
     elif _is_a_string_field(field_type):
         # todo: are there any other types we need to worry about?
         shard_id_function = "hash_string({id_field}, 'siphash24') & {total_shard_count}".format(
-            total_shard_count=partition_config.num_shards - 1,
+            total_shard_count=partition_config.shard_count - 1,
             id_field=model.partition_attr,
         )
     else:

--- a/corehq/sql_db/tests/test_model_partitioning.py
+++ b/corehq/sql_db/tests/test_model_partitioning.py
@@ -49,8 +49,8 @@ class TestPartitionedModelsWithMultipleDBs(PartitionedModelsTestMixin, TestCase)
     ('form_processor', True),
 ], TestPartitionedModelsWithMultipleDBs)
 def test_models_are_located_in_correct_dbs(self, app_label, is_partitioned):
-    proxy_db = partition_config.get_proxy_db()
-    partitioned_dbs = partition_config.get_form_processing_dbs()
+    proxy_db = partition_config.proxy_db
+    partitioned_dbs = partition_config.form_processing_dbs
 
     for model_class in self.get_models(app_label):
         if is_partitioned:

--- a/corehq/sql_db/tests/test_partition_config.py
+++ b/corehq/sql_db/tests/test_partition_config.py
@@ -2,9 +2,19 @@ from django.db import DEFAULT_DB_ALIAS
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-from corehq.sql_db.config import parse_existing_shard, ShardMeta, get_shards_to_update
+from corehq.sql_db.config import ShardMeta
+from corehq.sql_db.management.commands.configure_pl_proxy_cluster import (
+    get_shards_to_update,
+    parse_existing_shard,
+)
+
 from ..config import PartitionConfig
-from ..exceptions import NotPowerOf2Error, NotZeroStartError, NonContinuousShardsError, NoSuchShardDatabaseError
+from ..exceptions import (
+    NonContinuousShardsError,
+    NoSuchShardDatabaseError,
+    NotPowerOf2Error,
+    NotZeroStartError,
+)
 
 
 def _get_partition_config(shard_config):

--- a/corehq/sql_db/tests/test_partition_config.py
+++ b/corehq/sql_db/tests/test_partition_config.py
@@ -10,11 +10,20 @@ from ..exceptions import NotPowerOf2Error, NotZeroStartError, NonContinuousShard
 def _get_partition_config(shard_config):
     return {
         'shards': shard_config,
-        'groups': {
-            'proxy': ['proxy'],
-            'form_processing': ['db1', 'db2'],
-        }
+        'proxy': 'proxy'
     }
+
+
+TEST_LEGACY_FORMAT = {
+    'shards': {
+        'db1': [0, 1],
+        'db2': [2, 3],
+    },
+    'groups': {
+        'proxy': ['proxy'],
+        'form_processing': ['db1', 'db2'],
+    }
+}
 
 TEST_PARTITION_CONFIG = _get_partition_config({
     'db1': [0, 1],
@@ -111,6 +120,12 @@ class TestPartitionConfig(SimpleTestCase):
     def test_invalid_shard_range_power_2(self):
         with self.assertRaises(NotPowerOf2Error):
             PartitionConfig()
+
+    @override_settings(PARTITION_DATABASE_CONFIG=TEST_LEGACY_FORMAT)
+    def test_legacy_format(self):
+        config = PartitionConfig()
+        self.assertEqual('proxy', config.get_proxy_db())
+        self.assertEqual({'db1', 'db2'}, set(config.get_form_processing_dbs()))
 
 
 @override_settings(DATABASES=TEST_DATABASES)

--- a/corehq/sql_db/tests/test_shard_management.py
+++ b/corehq/sql_db/tests/test_shard_management.py
@@ -32,7 +32,7 @@ class ShardManagementTest(DefaultShardingTestConfigMixIn, TestCase):
         cls.p2_uuid = uuid.UUID('8440dbd6-61b1-4b2f-a310-7e1768902d04')
 
     def tearDown(self):
-        for db in partition_config.get_form_processing_dbs():
+        for db in partition_config.form_processing_dbs:
             AlertScheduleInstance.objects.using(db).filter(domain=self.domain).delete()
             XFormInstanceSQL.objects.using(db).filter(domain=self.domain).delete()
 

--- a/corehq/sql_db/tests/utils.py
+++ b/corehq/sql_db/tests/utils.py
@@ -1,7 +1,6 @@
-from django.conf import settings
 from sqlalchemy.exc import ProgrammingError
-from corehq.sql_db.config import partition_config
 
+from corehq.sql_db.config import partition_config
 from corehq.sql_db.connections import connection_manager, DEFAULT_ENGINE_ID
 from corehq.util.decorators import ContextDecorator
 
@@ -47,10 +46,9 @@ class DefaultShardingTestConfigMixIn(object):
         partitioning is working properly, so this test makes sure those assumptions
         are valid.
         """
-
-        self.assertEqual(len(settings.PARTITION_DATABASE_CONFIG['shards']), 2)
-        self.assertIn(self.db1, settings.PARTITION_DATABASE_CONFIG['shards'])
-        self.assertIn(self.db2, settings.PARTITION_DATABASE_CONFIG['shards'])
-        self.assertEqual(settings.PARTITION_DATABASE_CONFIG['shards'][self.db1], [0, 1])
-        self.assertEqual(settings.PARTITION_DATABASE_CONFIG['shards'][self.db2], [2, 3])
+        self.assertEqual(len(partition_config.shard_map), 2)
+        self.assertIn(self.db1, partition_config.shard_map)
+        self.assertIn(self.db2, partition_config.shard_map)
+        self.assertEqual(partition_config.shard_map[self.db1], [0, 1])
+        self.assertEqual(partition_config.shard_map[self.db2], [2, 3])
         self.assertEqual(set(partition_config.form_processing_dbs), set([self.db1, self.db2]))

--- a/corehq/sql_db/tests/utils.py
+++ b/corehq/sql_db/tests/utils.py
@@ -53,4 +53,4 @@ class DefaultShardingTestConfigMixIn(object):
         self.assertIn(self.db2, settings.PARTITION_DATABASE_CONFIG['shards'])
         self.assertEqual(settings.PARTITION_DATABASE_CONFIG['shards'][self.db1], [0, 1])
         self.assertEqual(settings.PARTITION_DATABASE_CONFIG['shards'][self.db2], [2, 3])
-        self.assertEqual(set(partition_config.get_form_processing_dbs()), set([self.db1, self.db2]))
+        self.assertEqual(set(partition_config.form_processing_dbs), set([self.db1, self.db2]))

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -162,7 +162,7 @@ def get_db_alias_for_partitioned_doc(partition_value):
 
 def get_db_aliases_for_partitioned_query():
     if settings.USE_PARTITIONED_DATABASE:
-        db_names = partition_config.get_form_processing_dbs()
+        db_names = partition_config.form_processing_dbs
     else:
         db_names = [DEFAULT_DB_ALIAS]
     return db_names

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -30,6 +30,10 @@ if USE_PARTITIONED_DATABASE:
             'TEST': {
                 'SERIALIZE': False,
             },
+            'PLPROXY': {
+                'PROXY': True,
+                'PLPROXY_HOST': 'localhost'
+            }
         },
         'p1': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -41,6 +45,9 @@ if USE_PARTITIONED_DATABASE:
             'TEST': {
                 'SERIALIZE': False,
             },
+            'PLPROXY': {
+                'SHARDS': [0, 1],
+            }
         },
         'p2': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -52,6 +59,9 @@ if USE_PARTITIONED_DATABASE:
             'TEST': {
                 'SERIALIZE': False,
             },
+            'PLPROXY': {
+                'SHARDS': [1, 2],
+            }
         },
         'warehouse': {
              'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -65,20 +75,6 @@ if USE_PARTITIONED_DATABASE:
              },
          },
     })
-
-    PARTITION_DATABASE_CONFIG = {
-        'shards': {
-            'p1': [0, 1],
-            'p2': [2, 3]
-        },
-        'groups': {
-            'proxy': ['proxy'],
-            'form_processing': ['p1', 'p2'],
-        },
-        'host_map': {
-            'postgres': 'localhost'
-        }
-    }
 
     WAREHOUSE_DATABASE_ALIAS = 'warehouse'
 

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -60,7 +60,7 @@ if USE_PARTITIONED_DATABASE:
                 'SERIALIZE': False,
             },
             'PLPROXY': {
-                'SHARDS': [1, 2],
+                'SHARDS': [2, 3],
             }
         },
         'warehouse': {

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -24,18 +24,6 @@ USE_PARTITIONED_DATABASE = False
 
 if USE_PARTITIONED_DATABASE:
 
-    PARTITION_DATABASE_CONFIG = {
-        'shards': {
-            'p1': [0, 1],
-            'p2': [2, 3]
-        },
-        'groups': {
-            'proxy': ['proxy'],
-            'form_processing': ['p1', 'p2'],
-        },
-        'host_map': {}  # allows mapping HOST in DATABASE settings to a different value for plproxy
-    }
-
     DATABASES.update({
         'proxy': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -47,6 +35,9 @@ if USE_PARTITIONED_DATABASE:
             'TEST': {
                 'SERIALIZE': False,
             },
+            'PLPROXY': {
+                'PROXY': True
+            }
         },
         'p1': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -58,6 +49,9 @@ if USE_PARTITIONED_DATABASE:
             'TEST': {
                 'SERIALIZE': False,
             },
+            'PLPROXY': {
+                'SHARDS': [0, 1],
+            }
         },
         'p2': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -69,6 +63,9 @@ if USE_PARTITIONED_DATABASE:
             'TEST': {
                 'SERIALIZE': False,
             },
+            'PLPROXY': {
+                'SHARDS': [2, 3],
+            }
         },
     })
 


### PR DESCRIPTION
##### SUMMARY
Move plproxy config into django `DATABASES` setting.

Retake of https://github.com/dimagi/commcare-hq/pull/25802 (without the standby config)

**old**
```python
DATABASES = {}  # normal Django DATABASES setting
config = {
    'shards': {
        'db1': [0, 1],
        'db2': [2, 3],
    },
    'proxy': 'proxy'
}
```
**new**
```python
DATABASES = {
    'proxy': {
        ...
        'PLPROXY': {
            'PROXY': True
        }
    },
    'db1': {
        ...
        'PLPROXY': {
            'SHARDS': [0, 1]  # Shard range for this DB
        }
    },
    'db2': {
        ...
        'PLPROXY': {
            'SHARDS': [1, 2]
        }
    }
}
```