### PR TITLE
[VectorLink] Exclude deactivated users from 'Late PMT' report

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -32,16 +32,34 @@
     "engine_id": "default",
     "base_item_expression": {},
     "configured_filter": {
-      "expression": {
-          "type": "property_path",
-          "property_path": [
-            "user_data",
-            "usertype"
-          ]
-      },
-      "operator": "eq",
-      "property_value": "pmt",
-      "type": "boolean_expression"
+      "type": "and",
+      "filters": [
+        {
+          "expression": {
+            "type": "property_path",
+            "property_path": [
+              "user_data",
+              "usertype"
+            ],
+            "datatype": null
+          },
+          "operator": "eq",
+          "property_value": "pmt",
+          "type": "boolean_expression",
+          "comment": null
+        },
+        {
+          "expression": {
+            "type": "property_name",
+            "property_name": "is_active",
+            "datatype": null
+          },
+          "operator": "eq",
+          "property_value": true,
+          "type": "boolean_expression",
+          "comment": null
+        }
+      ]
     },
     "configured_indicators": [
       {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/projects/SL/issues/SL-324

##### SUMMARY
The deactivated users were seen in the Late PMT report. Now they are filtered out.
