### PR TITLE
Revert "Remove signal firing from form submission metadata tracker pillow"

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -169,4 +169,4 @@ def mark_latest_submission(domain, user_id, app_id, build_id, version, metadata,
         )
         update_device_meta(user, device_id, app_version_info.commcare_version, app_meta, save=False)
 
-        user.save(fire_signals=False)
+        user.save()


### PR DESCRIPTION
##### SUMMARY
This reverts commit aac7946cc237372d6eb39dd8864948b9a3f28a78, which could possibly be the cause of the sudden rise of `ResourceConflict` errors on the `UpdateUserSyncHistory` pillow, e.g. https://app.datadoghq.com/dashboard/ewu-jyr-udt/change-feeds-pillows?from_ts=1572827476544&live=false&tile_size=m&to_ts=1573058785000&tpl_var_env=production&tpl_var_pillow=updateusersynchistorypillow
