### PR TITLE
Fix mpr 4b infra report

### DIFF
--- a/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
@@ -1,0 +1,150 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "sankalp_cas",
+    "zohaib-sandbox",
+    "akshita-sandbox",
+    "sunaina-sandbox",
+    "laurence-project-1",
+    "jessica-icds-cas",
+    "marissa-test",
+    "derek-icds-sandbox",
+    "priyanka-app",
+    "shrena-dev",
+    "aparatest",
+    "reach-sandbox",
+    "reach-dashboard-qa",
+    "reach-test",
+    "icds-cas",
+    "icds-cas-sandbox",
+    "cas-lab"
+  ],
+  "server_environment": [
+    "india",
+    "icds"
+  ],
+  "report_id": "static-mpr_4b_infra_forms",
+  "data_source_table": "static-infrastructure_form",
+  "config": {
+    "title": "MPR - 4b - Infra forms (Static)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "compare_as_string": false,
+        "datatype": "date",
+        "required": false,
+        "display": "Date Form Submitted",
+        "field": "submitted_on",
+        "type": "date",
+        "slug": "submitted_on"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "awc_id",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+        },
+        "display": "Filter by AWW"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "supervisor_id",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Supervisor"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "block_id",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Block"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "district_id",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by District"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "state_id",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by State"
+      }
+    ],
+    "columns": [
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        },
+        "column_id": "owner_id",
+        "field": "awc_id",
+        "calculate_total": false,
+        "type": "field",
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "aggregation": "simple"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "sum",
+        "column_id": "use_salt",
+        "field": "use_salt",
+        "transform": {},
+        "calculate_total": false,
+        "type": "field",
+        "display": "use_salt"
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}

--- a/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
@@ -144,7 +144,12 @@
         "display": "use_salt"
       }
     ],
-    "sort_expression": [],
+    "sort_expression": [
+      {
+        "field": "month",
+        "order": "DESC"
+      }
+    ],
     "configured_charts": []
   }
 }

--- a/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
@@ -26,7 +26,7 @@
   "report_id": "static-mpr_4b_infra_forms",
   "data_source_table": "static-infrastructure_form",
   "config": {
-    "title": "MPR - 4b - Infra forms (Static)",
+    "title": "MPR - 4b - Infra forms (Static) V2",
     "description": "",
     "visible": false,
     "aggregation_columns": [

--- a/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms_v2.json
@@ -135,7 +135,7 @@
         "sortable": false,
         "description": null,
         "format": "default",
-        "aggregation": "sum",
+        "aggregation": "max",
         "column_id": "use_salt",
         "field": "use_salt",
         "transform": {},


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-916

##### SUMMARY
Fix the report by using `max` instead of `sum` so that the report shows 1 i.e `True` if any of the forms, for the an AWC and a month have the value for field as 1.
The ideal/correct requirement was to pick the latest value but UCR does not support that as of now, so this is best solution we have for now which is an improvement.
Cal suggested we should update the UCR framework to support [window](https://www.postgresql.org/docs/11/functions-window.html) function to support such requirements.

