### PR TITLE
Fix app status pillows when record already exists

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2775,6 +2775,9 @@ class AnonymousCouchUser(object):
         return False
 
 
+reporting_update_freq = timedelta(minutes=settings.USER_REPORTING_METADATA_UPDATE_FREQUENCY)
+
+
 class UserReportingMetadataStaging(models.Model):
     domain = models.TextField()
     user_id = models.TextField()
@@ -2810,7 +2813,7 @@ class UserReportingMetadataStaging(models.Model):
 
         save = False
 
-        if (received_on - obj.received_on) > timedelta(minutes=settings.USER_REPORTING_METADATA_UPDATE_FREQUENCY):
+        if not obj.received_on or (received_on - obj.received_on) > reporting_update_freq:
             obj.received_on = received_on
             save = True
         if build_id != obj.build_id:
@@ -2836,7 +2839,7 @@ class UserReportingMetadataStaging(models.Model):
         if created:
             return
 
-        if sync_date > obj.sync_date:
+        if not obj.sync_date or sync_date > obj.sync_date:
             obj.sync_date = sync_date
             obj.build_id = build_id
             obj.device_id = device_id

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_synclog_pillow.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_synclog_pillow.py
@@ -5,7 +5,7 @@ from django.test import TestCase, override_settings
 from casexml.apps.case.tests.util import delete_all_sync_logs
 from casexml.apps.phone.models import SimplifiedSyncLog, SyncLogSQL, properly_wrap_sync_log
 from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CommCareUser, UserReportingMetadataStaging
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
 from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer
@@ -101,6 +101,48 @@ class SyncLogPillowTest(TestCase):
         synclog = self._get_latest_synclog()
         self.assertEqual(change_meta.document_id, synclog._id)
         self.assertEqual(change_meta.domain, self.domain.name)
+
+        # make sure processor updates the user correctly
+        pillow = get_user_sync_history_pillow()
+        pillow.process_changes(since=kafka_seq, forever=False)
+        process_reporting_metadata_staging()
+        ccuser = CommCareUser.get(self.ccuser._id)
+        self.assertEqual(len(ccuser.reporting_metadata.last_syncs), 1)
+        self.assertEqual(ccuser.reporting_metadata.last_syncs[0].sync_date, synclog.date)
+        self.assertEqual(ccuser.reporting_metadata.last_sync_for_user.sync_date, synclog.date)
+
+    @override_settings(USER_REPORTING_METADATA_BATCH_ENABLED=True)
+    def test_pillow_form_processed(self):
+        from corehq.apps.change_feed.topics import get_topic_offset
+        from corehq.pillows.synclog import get_user_sync_history_pillow
+
+        self.assertEqual(UserReportingMetadataStaging.objects.count(), 0)
+        UserReportingMetadataStaging.add_submission(
+            self.domain.name, self.ccuser._id, '123', None, None, {}, datetime.datetime.utcnow()
+        )
+        self.assertEqual(UserReportingMetadataStaging.objects.count(), 1)
+
+        consumer = get_test_kafka_consumer(topics.SYNCLOG_SQL)
+        # get the seq id before the change is published
+        kafka_seq = get_topic_offset(topics.SYNCLOG_SQL)
+
+        # make sure user has empty reporting-metadata before a sync
+        ccuser = CommCareUser.get(self.ccuser._id)
+        self.assertEqual(ccuser.reporting_metadata.last_syncs, [])
+
+        # do a sync
+        synclog = SimplifiedSyncLog(domain=self.domain.name, user_id=self.ccuser._id,
+                          date=datetime.datetime(2015, 7, 1, 0, 0), app_id='123')
+        synclog.save()
+
+        # make sure kafka change updates the user with latest sync info
+        message = next(consumer)
+        change_meta = change_meta_from_kafka_message(message.value)
+        synclog = self._get_latest_synclog()
+        self.assertEqual(change_meta.document_id, synclog._id)
+        self.assertEqual(change_meta.domain, self.domain.name)
+
+        self.assertEqual(UserReportingMetadataStaging.objects.count(), 1)
 
         # make sure processor updates the user correctly
         pillow = get_user_sync_history_pillow()

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from decimal import Decimal
 
 from django.test import override_settings
@@ -127,6 +128,30 @@ class XFormPillowTest(TestCase):
         self.assertEqual(UserReportingMetadataStaging.objects.count(), 1)
         self.assertEqual(UserReportingMetadataStaging.objects.first().user_id, self.user._id)
         self.assertEqual(0, PillowError.objects.filter(pillow=self.pillow_id).count())
+
+        process_reporting_metadata_staging()
+        self.assertEqual(UserReportingMetadataStaging.objects.count(), 0)
+        user = CommCareUser.get_by_user_id(self.user._id, self.domain)
+        self.assertEqual(len(user.reporting_metadata.last_submissions), 1)
+        last_submission = user.reporting_metadata.last_submissions[0]
+
+        self.assertEqual(
+            last_submission.submission_date,
+            string_to_utc_datetime(self.metadata.received_on),
+        )
+        self.assertEqual(last_submission.app_id, self.metadata.app_id)
+
+    @run_with_all_backends
+    @override_settings(USER_REPORTING_METADATA_BATCH_ENABLED=True)
+    def test_app_metadata_tracker_synclog_processed(self):
+        UserReportingMetadataStaging.add_sync(
+            self.domain, self.user._id, self.metadata.app_id,
+            '123', datetime.utcnow(), self.metadata.device_id
+        )
+
+        form, metadata = self._create_form_and_sync_to_es()
+        self.assertEqual(UserReportingMetadataStaging.objects.count(), 1)
+        self.assertEqual(UserReportingMetadataStaging.objects.first().user_id, self.user._id)
 
         process_reporting_metadata_staging()
         self.assertEqual(UserReportingMetadataStaging.objects.count(), 0)


### PR DESCRIPTION
Saw a few `TypeError` on india after the first day of turning on batch records. This appears to only affect records where the other type of pillow had processed a record before the erroring type processed. In other words:

1. Synclog from User A is processed by synclog pillow
   a. A record is added to the staging table successfully
2. Form form User A is processed by xform pillow
   a. This errors and adds a record to `PillowError` to be retried later
3. New synclog from user A is processed by synclog pillow (this is processed correctly, same as # 1)
4. The periodic task processes the record added staging table in 1a
4. When form from 2a is retried, it is processed successfully

Concurrent processing is hard. (note this only affects envs where batch processing is enabled (india))