### PR TITLE
More flexible delete_domain command

### DIFF
--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from corehq.apps.domain.dbaccessors import iter_all_domains_and_deleted_domains_with_name
 from corehq.apps.domain.models import Domain
 
 
@@ -19,10 +20,13 @@ class Command(BaseCommand):
         )
 
     def handle(self, domain_name, **options):
-        domain_obj = Domain.get_by_name(domain_name)
-        if not domain_obj:
+        domain_objs = list(iter_all_domains_and_deleted_domains_with_name(domain_name))
+        if not domain_objs:
             print('domain with name "{}" not found'.format(domain_name))
             return
+        if len(domain_objs) > 1:
+            print("FYI: There are multiple domain objects for this domain"
+                  "and they will all be soft-deleted.")
         if not options['noinput']:
             confirm = input(
                 """
@@ -39,5 +43,6 @@ class Command(BaseCommand):
               "(i.e. switching its type to Domain-Deleted, "
               "which will prevent anyone from reusing that domain)"
               .format(domain_name))
-        domain_obj.delete(leave_tombstone=True)
+        for domain_obj in domain_objs:
+            domain_obj.delete(leave_tombstone=True)
         print("Operation completed")

--- a/corehq/apps/domain/management/commands/delete_domain.py
+++ b/corehq/apps/domain/management/commands/delete_domain.py
@@ -44,5 +44,6 @@ class Command(BaseCommand):
               "which will prevent anyone from reusing that domain)"
               .format(domain_name))
         for domain_obj in domain_objs:
+            assert domain_obj.name == domain_name  # Just to be really sure!
             domain_obj.delete(leave_tombstone=True)
         print("Operation completed")

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -960,10 +960,9 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 'Cannot delete domain without leaving a tombstone except during testing')
         self._pre_delete()
         if leave_tombstone:
-            domain = Domain.get_by_name(self.name)
-            if not domain.doc_type.endswith('-Deleted'):
-                domain.doc_type = '{}-Deleted'.format(self.doc_type)
-            domain.save()
+            if not self.doc_type.endswith('-Deleted'):
+                self.doc_type = '{}-Deleted'.format(self.doc_type)
+            self.save()
         else:
             super().delete()
 


### PR DESCRIPTION
##### SUMMARY
A follow up to https://github.com/dimagi/commcare-hq/pull/25781 to improve the `delete_domain` process to support deleting data under an already "deleted" domain/tombstone. This is useful for cleaning up lingering data that was missed in the original deletion.
