### PR TITLE
remove redundant py3 section of dev setup instructions

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -73,23 +73,6 @@ Next, install the appropriate requirements (only one is necessary).
 
 Note that once you're up and running, you'll want to periodically re-run these steps, and a few others, to keep your environment up to date. Some developers have found it helpful to automate these tasks. For pulling code, instead of `git pull`, you can run [this script](https://github.com/dimagi/commcare-hq/blob/master/scripts/update-code.sh) to update all code, including submodules. [This script](https://github.com/dimagi/commcare-hq/blob/master/scripts/hammer.sh) will update all code and do a few more tasks like run migrations and update libraries, so it's good to run once a month or so, or when you pull code and then immediately hit an error.
 
-#### Setup for Python 3
-
-- Install [Python 3.6](https://www.python.org/downloads/)
-    - For OSX, you can [install using Homebrew](http://osxdaily.com/2018/06/13/how-install-update-python-3x-mac/)
-    - For Ubuntu 18.04:
-
-          $ sudo apt install python3.6 python3.6-dev
-
-    - For Ubuntu < 18.04:
-
-          $ sudo add-apt-repository ppa:deadsnakes/ppa
-          $ sudo apt-get update
-          $ sudo apt-get install python3.6
-
-- [Create and activate virtualenv](https://docs.python.org/3/library/venv.html#creating-virtual-environments)
-- `$ pip install -r requirements/dev-requirements.txt`
-
 #### Setup localsettings
 
 First create your `localsettings.py` file:


### PR DESCRIPTION
I think this section is no longer needed since Py3 is the default (and we already have links above).