### PR TITLE
Drop openmrs.logger

### DIFF
--- a/corehq/motech/openmrs/finders.py
+++ b/corehq/motech/openmrs/finders.py
@@ -5,7 +5,7 @@ OpenmrsCaseConfig.match_on_ids have successfully matched a patient.
 
 See `README.md`__ for more context.
 """
-
+import logging
 from collections import namedtuple
 from functools import partial
 from operator import eq
@@ -40,6 +40,8 @@ MATCH_FUNCTIONS = {
 }
 MATCH_TYPES = tuple(MATCH_FUNCTIONS)
 MATCH_TYPE_DEFAULT = MATCH_TYPE_EXACT
+
+logger = logging.getLogger(__name__)
 
 
 constant_false = ConstantString(
@@ -188,7 +190,6 @@ class WeightedPropertyPatientFinder(PatientFinder):
         Matches cases to patients. Returns a list of patients, each
         with a confidence score >= self.threshold
         """
-        from corehq.motech.openmrs.logger import logger
         from corehq.motech.openmrs.openmrs_config import get_property_map
         from corehq.motech.openmrs.repeater_helpers import search_patients
 

--- a/corehq/motech/openmrs/logger.py
+++ b/corehq/motech/openmrs/logger.py
@@ -1,3 +1,0 @@
-import logging
-
-logger = logging.getLogger('openmrs')

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -26,7 +26,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
 )
 from corehq.motech.const import DIRECTION_IMPORT
 from corehq.motech.openmrs.const import ATOM_FEED_NAME_PATIENT, XMLNS_OPENMRS
-from corehq.motech.openmrs.logger import logger
 from corehq.motech.openmrs.openmrs_config import OpenmrsConfig
 from corehq.motech.openmrs.repeater_helpers import (
     get_case_location_ancestor_repeaters,
@@ -279,7 +278,7 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
         )
 
     if errors:
-        logger.error('Errors encountered sending OpenMRS data: %s', errors)
+        requests.notify_error(f'Errors encountered sending OpenMRS data: {errors}')
         # If the form included multiple patients, some workflows may
         # have succeeded, but don't say everything was OK if any
         # workflows failed. (Of course most forms will only involve one
@@ -287,7 +286,6 @@ def send_openmrs_data(requests, domain, form_json, openmrs_config, case_trigger_
         return OpenmrsResponse(400, 'Bad Request', "Errors: " + pformat_json([str(e) for e in errors]))
 
     if warnings:
-        logger.warning("Warnings encountered sending OpenMRS data: %s", warnings)
         return OpenmrsResponse(201, "Accepted", "Warnings: " + pformat_json([str(e) for e in warnings]))
 
     return OpenmrsResponse(200, "OK")


### PR DESCRIPTION
##### SUMMARY
A small change to drop the unnecessary openmrs.logger module. It uses normal name-based logging instead. It also notifies admins on errors sending data to OpenMRS.

##### FEATURE FLAG
"OpenMRS integration"
