### PR TITLE
use temp child table for agg_awc

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/__init__.py
+++ b/custom/icds_reports/utils/aggregation_helpers/__init__.py
@@ -12,6 +12,13 @@ def date_to_string(date):
     return date.strftime('%Y-%m-%d')
 
 
+def get_child_health_temp_tablename(month):
+    from custom.icds_reports.utils.aggregation_helpers.distributed import ChildHealthMonthlyAggregationDistributedHelper
+    base_tablename = ChildHealthMonthlyAggregationDistributedHelper.base_tablename 
+    month_string = month.strftime("%Y-%m-%d")
+    return f"tmp_{base_tablename}_{month_string}"
+
+
 class AggregationHelper(object):
     """Base class used to tag aggregation helpers
 

--- a/custom/icds_reports/utils/aggregation_helpers/__init__.py
+++ b/custom/icds_reports/utils/aggregation_helpers/__init__.py
@@ -14,7 +14,7 @@ def date_to_string(date):
 
 def get_child_health_temp_tablename(month):
     from custom.icds_reports.utils.aggregation_helpers.distributed import ChildHealthMonthlyAggregationDistributedHelper
-    base_tablename = ChildHealthMonthlyAggregationDistributedHelper.base_tablename 
+    base_tablename = ChildHealthMonthlyAggregationDistributedHelper.base_tablename
     month_string = month.strftime("%Y-%m-%d")
     return f"tmp_{base_tablename}_{month_string}"
 

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -3,7 +3,7 @@ from dateutil.relativedelta import relativedelta
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
 
-from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
+from custom.icds_reports.utils.aggregation_helpers import get_child_health_temp_tablename, transform_day_to_month
 from custom.icds_reports.const import AGG_CCS_RECORD_CF_TABLE, AGG_THR_V2_TABLE
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
 
@@ -24,8 +24,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
 
     @property
     def child_temp_tablename(self):
-        from custom.icds_reports.utils.aggregation_helpers.distributed import ChildHealthMonthlyAggregationDistributedHelper
-        return ChildHealthMonthlyAggregationDistributedHelper([], self.month_start).temporary_tablename
+        return get_child_health_temp_tablename(self.month)
 
     def aggregate(self, cursor):
         agg_query, agg_params = self.aggregation_query()

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -24,7 +24,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
 
     @property
     def child_temp_tablename(self):
-        return get_child_health_temp_tablename(self.month)
+        return get_child_health_temp_tablename(self.month_start)
 
     def aggregate(self, cursor):
         agg_query, agg_params = self.aggregation_query()

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -22,6 +22,11 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         self.month_end_15yr = self.month_end - relativedelta(years=15)
         self.month_start_18yr = self.month_start - relativedelta(years=18)
 
+    @property
+    def child_temp_tablename(self):
+        from custom.icds_reports.utils.aggregation_helpers.distributed import ChildHealthMonthlyAggregationDistributedHelper
+        return ChildHealthMonthlyAggregationDistributedHelper([], self.month_start).temporary_tablename
+
     def aggregate(self, cursor):
         agg_query, agg_params = self.aggregation_query()
         update_queries = self.updates()
@@ -346,7 +351,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         DROP TABLE "tmp_child";
         """.format(
             tablename=self.tablename,
-            child_health_monthly="child_health_monthly",
+            child_health_monthly=self.child_temp_tablename,
         ), {
             "month": self.month_start
         }

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
@@ -1,3 +1,4 @@
+from custom.icds_reports.utils.aggregation_helpers import get_child_health_temp_tablename
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import (
     AggregationPartitionedHelper,
 )
@@ -23,8 +24,7 @@ class AggChildHealthAggregationDistributedHelper(AggregationPartitionedHelper):
 
     @property
     def child_temp_tablename(self):
-        from custom.icds_reports.utils.aggregation_helpers.distributed import ChildHealthMonthlyAggregationDistributedHelper
-        return ChildHealthMonthlyAggregationDistributedHelper([], self.month).temporary_tablename
+        return get_child_health_temp_tablename(self.month)
 
     def staging_queries(self):
         columns = (

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -8,7 +8,11 @@ from custom.icds_reports.const import (
     AGG_DAILY_FEEDING_TABLE,
     AGG_GROWTH_MONITORING_TABLE,
 )
-from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month, month_formatter
+from custom.icds_reports.utils.aggregation_helpers import (
+    get_child_health_temp_tablename,
+    transform_day_to_month,
+    month_formatter,
+)
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
 
 
@@ -57,7 +61,7 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
 
     @property
     def temporary_tablename(self):
-        return "tmp_{}_{}".format(self.base_tablename, self.month.strftime("%Y-%m-%d"))
+        return get_child_health_temp_tablename(self.month)
 
     def drop_table_query(self):
         return 'DELETE FROM "{}" WHERE month=%(month)s'.format(self.tablename), {'month': self.month}

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
@@ -224,7 +224,7 @@
             awc_id,
             sum(has_aadhar_id) as child_has_aadhar,
             sum(immunization_in_month) AS num_children_immunized
-        FROM "child_health_monthly"
+        FROM "tmp_child_health_monthly_2019-01-01"
         WHERE month = %(month)s and valid_in_month = 1
         GROUP BY awc_id;
         UPDATE "agg_awc_2019-01-01_5" agg_awc SET


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This lets agg awc use the temp child health table so it is no longer dependent on the final insert into the child health monthly. Should provide a moderate speed up, since it can start earlier in the aggregation.