### PR TITLE
fix syntax error 'AttributeError: 'Settings' object has no attribute …

### DIFF
--- a/corehq/sql_db/config.py
+++ b/corehq/sql_db/config.py
@@ -106,7 +106,7 @@ class PlProxyConfig(object):
         assert settings.USE_PARTITIONED_DATABASE
         return (
             PlProxyConfig.from_dict(settings.DATABASES) or
-            PlProxyConfig.from_legacy_dict(settings.PARTITION_DATABASE_CONFIG)
+            PlProxyConfig.from_legacy_dict(getattr(settings, 'PARTITION_DATABASE_CONFIG'))
         )
 
     @classmethod

--- a/corehq/sql_db/config.py
+++ b/corehq/sql_db/config.py
@@ -106,7 +106,7 @@ class PlProxyConfig(object):
         assert settings.USE_PARTITIONED_DATABASE
         return (
             PlProxyConfig.from_dict(settings.DATABASES) or
-            PlProxyConfig.from_legacy_dict(settings.get('PARTITION_DATABASE_CONFIG'))
+            PlProxyConfig.from_legacy_dict(settings.PARTITION_DATABASE_CONFIG)
         )
 
     @classmethod


### PR DESCRIPTION
Fix syntax error: fix syntax error 'AttributeError: 'Settings' object has no attribute 'get''
It looks being created here: https://github.com/dimagi/commcare-hq/commit/3f9349bf2ebbd45c97d9bf6c4059ba860a534a0c#diff-c6cc5fe98443e3fc2f6e5cf7d2f76001R109

hindering the deploy.