### PR TITLE
Added deprecation warnings to exchange

### DIFF
--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -3,6 +3,7 @@ from datetime import date
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -100,6 +101,11 @@ class BaseCommCareExchangeSectionView(BaseSectionPageView):
     def dispatch(self, request, *args, **kwargs):
         if self.include_unapproved and not self.request.user.is_superuser:
             raise Http404()
+        msg = """
+            The CommCare Exchange is being retired in early December 2019.
+            If you have questions or concerns, please contact <a href='mailto:{}'>{}</a>.
+        """.format(settings.SUPPORT_EMAIL, settings.SUPPORT_EMAIL)
+        messages.add_message(self.request, messages.ERROR, msg, extra_tags="html")
         return super(BaseCommCareExchangeSectionView, self).dispatch(request, *args, **kwargs)
 
     @property

--- a/corehq/apps/domain/views/exchange.py
+++ b/corehq/apps/domain/views/exchange.py
@@ -102,6 +102,11 @@ class ExchangeSnapshotsView(BaseAdminProjectSettingsView):
     def dispatch(self, request, *args, **kwargs):
         if is_linked_domain(request.domain):
             raise Http404()
+        msg = """
+            The CommCare Exchange is being retired in early December 2019.
+            If you have questions or concerns, please contact <a href='mailto:{}'>{}</a>.
+        """.format(settings.SUPPORT_EMAIL, settings.SUPPORT_EMAIL)
+        messages.add_message(self.request, messages.ERROR, msg, extra_tags="html")
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 
     @property
@@ -122,6 +127,11 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
     @method_decorator(domain_admin_required)
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
+        msg = """
+            The CommCare Exchange is being retired in early December 2019.
+            If you have questions or concerns, please contact <a href='mailto:{}'>{}</a>.
+        """.format(settings.SUPPORT_EMAIL, settings.SUPPORT_EMAIL)
+        messages.add_message(self.request, messages.ERROR, msg, extra_tags="html")
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 
     @property


### PR DESCRIPTION
##### SUMMARY
See https://github.com/dimagi/commcare-hq/issues/25506

##### PRODUCT DESCRIPTION
Adds warnings to the top of Project Settings > CommCare Exchange and to the exchange itself, announcing that the exchange will be retired in early December.

fyi @dimagi/product 

Comms for this are being tracked in https://dimagi-dev.atlassian.net/browse/SAASP-10138