### PR TITLE
Optimize sum aggregation query so invoices do not time out

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
-from django.db.models import F, Q
+from django.db.models import F, Q, Sum
 from django.db.models.manager import Manager
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
@@ -2039,7 +2039,7 @@ class Invoice(InvoiceBase):
         """
         if self.lineitem_set.count() == 0:
             return Decimal('0.0000')
-        return sum([line_item.total for line_item in self.lineitem_set.all()])
+        return self.lineitem_set.all().aggregate(Sum('total'))['total__sum']
 
     @property
     def applied_tax(self):
@@ -2148,7 +2148,7 @@ class CustomerInvoice(InvoiceBase):
         """
         if self.lineitem_set.count() == 0:
             return Decimal('0.0000')
-        return sum([line_item.total for line_item in self.lineitem_set.all()])
+        return self.lineitem_set.all().aggregate(Sum('total'))['total__sum']
 
     @property
     def applied_tax(self):


### PR DESCRIPTION
##### SUMMARY
I haven't actually tested this locally, but in principle it seems better. This is a stab at fixing the timeout on https://www.commcarehq.org/hq/accounting/invoices/?payment_status=&report_filter_statement_period_month=10&report_filter_statement_period_year=2019&report_filter_due_date_month=11&report_filter_due_date_year=2019&is_hidden=; looks like it fails on this line, so thought it could have something to do with the inefficient in-memory aggregation, but could be a red herring