### PR TITLE
Make delete_domain a little smoother

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -960,9 +960,10 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 'Cannot delete domain without leaving a tombstone except during testing')
         self._pre_delete()
         if leave_tombstone:
-            if not self.doc_type.endswith('-Deleted'):
-                self.doc_type = '{}-Deleted'.format(self.doc_type)
-            self.save()
+            domain = self.get(self._id)
+            if not domain.doc_type.endswith('-Deleted'):
+                domain.doc_type = '{}-Deleted'.format(domain.doc_type)
+                domain.save()
         else:
             super().delete()
 


### PR DESCRIPTION

##### SUMMARY
I just ran this for https://dimagi-dev.atlassian.net/browse/SAASP-74 and had to run it twice because it failed with a ResourceConflict the first time; then after all that, the domain was still in caches, so the project urls didn't immediately 404 like they should.

This PR fixes those two fairly minor issues.
