### PR TITLE
Improve error propagation during gevent pooled aggregation commands

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -103,10 +103,13 @@ class Command(BaseCommand):
         state_ids = agg_record.state_ids
         query = self.function_map[query_name]
         if query.by_state == SINGLE_STATE:
+            greenlets = []
             pool = Pool(10)
             for state in state_ids:
-                pool.spawn(query.func, state, agg_date)
+                greenlets.append(pool.spawn(query.func, state, agg_date))
             pool.join(raise_error=True)
+            for g in greenlets:
+                g.get()
         elif query.by_state == NO_STATES:
             query.func(agg_date)
         else:


### PR DESCRIPTION
Fix for: https://dimagi-dev.atlassian.net/browse/ICDS-1018

##### SUMMARY
gevent joins only propagate errors for greenlets that are still in the group used by the pool, so errors that occur in all but the last 10 states are swallowed.

This just keeps track of the greenlets as they are produced from spawn and after the pool is joined checks the results one by one, which will rethrow the first exception it runs across (if any). 

The alternative implementations are to catch the exceptions from wrapper or callback, but those approaches have much more complex thread/execution considerations which seem error prone.

##### Read
I don't have a great way to test this, so someone with more context on dashboard tests would be extremely important to review first.