### PR TITLE
Fix line item logic when multiple subscriptions are present in account level invoices

### DIFF
--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -448,7 +448,7 @@ class InvoiceTemplate(object):
 
             description = Paragraph(item.description,
                                     ParagraphStyle('',
-                                                   fontSize=12,
+                                                   fontSize=DEFAULT_FONT_SIZE,
                                                    ))
             description.wrapOn(self.canvas, description_x - inches(0.2),
                                -header_height)

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -823,7 +823,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
             is_valid=True,
             date_sent__gte=self.invoice.date_start,
             date_sent__lt=self.invoice.date_end + datetime.timedelta(days=1),
-        ).order_by('-date_sent')
+        ).order_by('date_sent')
 
     @property
     @memoized

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -732,14 +732,25 @@ class UserLineItemFactory(FeatureLineItemFactory):
 
     @property
     def unit_description(self):
+        prorated_notice = ""
+        if self.is_prorated:
+            prorated_notice = _(" (Prorated for {date_range})").format(
+                date_range=(
+                    self.subscription_date_range
+                    if self.subscription_date_range is not None else ""
+                )
+            )
         if self.quantity > 0:
             return ungettext(
-                "Per User fee exceeding limit of %(monthly_limit)s user.",
-                "Per User fee exceeding limit of %(monthly_limit)s users.",
+                "Per-user fee exceeding limit of {monthly_limit} user "
+                "with plan above.{prorated_notice}",
+                "Per-user fee exceeding limit of {monthly_limit} users "
+                "with plan above.{prorated_notice}",
                 self.rate.monthly_limit
-            ) % {
-                'monthly_limit': self.rate.monthly_limit,
-            }
+            ).format(
+                monthly_limit=self.rate.monthly_limit,
+                prorated_notice=prorated_notice,
+            )
 
 
 class SmsLineItemFactory(FeatureLineItemFactory):

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -620,13 +620,19 @@ class ProductLineItemFactory(LineItemFactory):
     def unit_description(self):
         if self.is_prorated:
             return ungettext(
-                "%(num_days)s day of %(plan_name)s Software Plan.",
-                "%(num_days)s days of %(plan_name)s Software Plan.",
+                "{num_days} day of {plan_name} Software Plan."
+                "{subscription_date_range}",
+                "{num_days} days of {plan_name} Software Plan."
+                "{subscription_date_range}",
                 self.num_prorated_days
-            ) % {
-                'num_days': self.num_prorated_days,
-                'plan_name': self.plan_name,
-            }
+            ).format(
+                num_days=self.num_prorated_days,
+                plan_name=self.plan_name,
+                subscription_date_range=(
+                    " ({})".format(self.subscription_date_range)
+                    if self.subscription_date_range is not None else ""
+                ),
+            )
 
     @property
     def unit_cost(self):

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -531,7 +531,7 @@ class LineItemFactory(object):
     @memoized
     def _subscription_ends_before_invoice(self):
         return (
-            self.subscription.date_end is not None
+            self.subscription.date_end
             and self.subscription.date_end < self.invoice.date_end
         )
 
@@ -630,7 +630,7 @@ class ProductLineItemFactory(LineItemFactory):
                 plan_name=self.plan_name,
                 subscription_date_range=(
                     " ({})".format(self.subscription_date_range)
-                    if self.subscription_date_range is not None else ""
+                    if self.subscription_date_range else ""
                 ),
             )
 
@@ -737,7 +737,7 @@ class UserLineItemFactory(FeatureLineItemFactory):
             prorated_notice = _(" (Prorated for {date_range})").format(
                 date_range=(
                     self.subscription_date_range
-                    if self.subscription_date_range is not None else ""
+                    if self.subscription_date_range else ""
                 )
             )
         if self.quantity > 0:
@@ -794,7 +794,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
             if sms_count <= self.rate.monthly_limit:
                 # don't count fees until the free monthly limit is exceeded
                 continue
-            elif self._start_date_count_sms is not None and (
+            elif self._start_date_count_sms and (
                 billable.date_sent.date() < self._start_date_count_sms
             ):
                 # count the SMS billables sent before the start date toward
@@ -836,7 +836,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
                 monthly_limit=self.rate.monthly_limit,
                 date_range=(
                     _(" from {}").format(self.subscription_date_range)
-                    if self.subscription_date_range is not None else ""
+                    if self.subscription_date_range else ""
                 )
             )
         else:
@@ -855,7 +855,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
                 monthly_limit=self.rate.monthly_limit,
                 date_range=(
                     _(" from {}").format(self.subscription_date_range)
-                    if self.subscription_date_range is not None else ""
+                    if self.subscription_date_range else ""
                 )
             )
 
@@ -872,7 +872,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
             # subscription related to this line item. Save it for the
             # next subscription in the invoice.
             date_sent__lt=(
-                self._end_date_count_sms if self._end_date_count_sms is not None
+                self._end_date_count_sms if self._end_date_count_sms
                 else self.invoice.date_end + datetime.timedelta(days=1)
             ),
 

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -266,14 +266,18 @@ class TestProductLineItem(BaseCustomerInvoiceCase):
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
-        self.assertEqual(invoice.balance, Decimal('1200.0000'))
+        self.assertEqual(invoice.balance, Decimal('851.6200'))
         self.assertEqual(invoice.account, self.account)
 
         product_line_items = invoice.lineitem_set.get_products()
         self.assertEqual(product_line_items.count(), 1)
         self.assertEqual(
             product_line_items.first().base_description,
-            'One month of CommCare Advanced Edition Software Plan.'
+            None
+        )
+        self.assertEqual(
+            product_line_items.first().unit_description,
+            '22 days of CommCare Advanced Edition Software Plan. (Jul 1 - Jul 22)'
         )
 
         num_feature_line_items = invoice.lineitem_set.get_features().count()

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -161,7 +161,7 @@ class TestCustomerInvoice(BaseCustomerInvoiceCase):
 
         self.assertEqual(CustomerInvoice.objects.count(), 1)
         invoice = CustomerInvoice.objects.first()
-        self.assertEqual(invoice.balance, Decimal('1200.0000'))
+        self.assertEqual(invoice.balance, Decimal('851.6200'))
         self.assertEqual(invoice.account, self.account)
 
         num_product_line_items = invoice.lineitem_set.get_products().count()


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10127

##### SUMMARY
If there are two enterprise subscriptions present in an account-level invoice, don't charge for the entirety of the invoicing range if the subscriptions stopped and started within only a portion of the invoicing period.