### PR TITLE
Import Observations as extension cases

### DIFF
--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -8,6 +8,7 @@ from casexml.apps.case.models import (
     INDEX_RELATIONSHIP_CHILD,
     INDEX_RELATIONSHIP_EXTENSION,
 )
+from corehq.form_processor.abstract_models import DEFAULT_PARENT_IDENTIFIER
 from dimagi.ext.couchdbkit import (
     DocumentSchema,
     ListProperty,
@@ -166,6 +167,7 @@ class OpenmrsCaseConfig(DocumentSchema):
 
 
 class IndexedCaseMapping(DocumentSchema):
+    identifier = StringProperty(required=True, default=DEFAULT_PARENT_IDENTIFIER)
     case_type = StringProperty(required=True)
     relationship = StringProperty(required=True, choices=INDEX_RELATIONSHIPS,
                                   default=INDEX_RELATIONSHIP_EXTENSION)

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -2,7 +2,6 @@ import json
 from collections import defaultdict
 from itertools import chain
 
-from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
@@ -20,6 +19,7 @@ from dimagi.ext.couchdbkit import (
     StringProperty,
 )
 
+from corehq.apps.locations.dbaccessors import get_one_commcare_user_at_location
 from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
@@ -142,6 +142,10 @@ class OpenmrsRepeater(CaseRepeater):
                     # don't get overwritten by later ones:
                     obs_mappings[obs_mapping.concept].append(obs_mapping)
         return obs_mappings
+
+    @cached_property
+    def get_first_user(self):
+        return get_one_commcare_user_at_location(self.domain, self.location_id)
 
     @memoized
     def payload_doc(self, repeat_record):

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -132,7 +132,10 @@ class OpenmrsRepeater(CaseRepeater):
         obs_mappings = defaultdict(list)
         for form_config in self.openmrs_config.form_configs:
             for obs_mapping in form_config.openmrs_observations:
-                if obs_mapping.value.check_direction(DIRECTION_IMPORT) and obs_mapping.case_property:
+                if (
+                    obs_mapping.value.check_direction(DIRECTION_IMPORT)
+                    and (obs_mapping.case_property or obs_mapping.indexed_case_mapping)
+                ):
                     # It's possible that an OpenMRS concept appears more
                     # than once in form_configs. We are using a
                     # defaultdict(list) so that earlier definitions

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -138,48 +138,98 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
         )
 
     def setUpRepeater(self):
-        self.repeater = OpenmrsRepeater.wrap({
-            "_id": "123456",
-            "domain": "test_domain",
-            "username": "foo",
-            "password": "bar",
-            "white_listed_case_types": ['patient'],
-            "openmrs_config": {
-                "form_configs": [{
-                    "doc_type": "OpenmrsFormConfig",
-                    "xmlns": "http://openrosa.org/formdesigner/9481169B-0381-4B27-BA37-A46AB7B4692D",
-                    "openmrs_visit_type": "c22a5000-3f10-11e4-adec-0800271c1b75",
-                    "openmrs_encounter_type": "81852aee-3f10-11e4-adec-0800271c1b75",
-                    "openmrs_observations": [
-                        {
-                            "doc_type": "ObservationMapping",
-                            "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                            "value": {
-                                "doc_type": "FormQuestion",
-                                "form_question": "/data/height"
-                            },
-                            "case_property": "height"
-                        },
-                        {
-                            "doc_type": "ObservationMapping",
-                            "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
-                            "value": {
-                                "doc_type": "FormQuestionMap",
-                                "form_question": "/data/bahmni_hypothermia",
-                                "value_map": {
-                                    "emergency_room_user_id": "Hypothermia",  # Value must match diagnosis name
-                                },
-                                "direction": "in",
-                            },
-                            "case_property": "owner_id"
-                        }
-                    ]
-                }]
+        observations = [
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "value": {
+                    "doc_type": "FormQuestion",
+                    "form_question": "/data/height"
+                },
+                "case_property": "height"
+            },
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
+                "value": {
+                    "doc_type": "FormQuestionMap",
+                    "form_question": "/data/bahmni_hypothermia",
+                    "value_map": {
+                        "emergency_room_user_id": "Hypothermia",  # Value must match diagnosis name
+                    },
+                    "direction": "in",
+                },
+                "case_property": "owner_id"
             }
-        })
+        ]
+        self.repeater = OpenmrsRepeater.wrap(self.get_repeater_dict(observations))
 
     def setUpRepeaterForExtCase(self):
-        self.repeater = OpenmrsRepeater.wrap({
+        observations = [
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "value": {
+                    "doc_type": "FormQuestion",
+                    "form_question": "/data/height"
+                },
+                "indexed_case_mapping": {
+                    "identifier": "parent",
+                    "case_type": "observation",
+                    "relationship": "extension",
+                    "case_properties": [
+                        {
+                            "doc_type": "JsonPathCaseProperty",
+                            "jsonpath": "concept.name",
+                            "case_property": "case_name",
+                        },
+                        {
+                            "doc_type": "JsonPathCaseProperty",
+                            "jsonpath": "value",
+                            "case_property": "observation_value",
+                        }
+                    ]
+                }
+            },
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
+                "value": {
+                    "doc_type": "FormQuestionMap",
+                    "form_question": "/data/bahmni_hypothermia",
+                    "value_map": {
+                        "emergency_room_user_id": "Hypothermia",  # Value must match diagnosis name
+                    },
+                    "direction": "in",
+                },
+                "indexed_case_mapping": {
+                    "identifier": "parent",
+                    "case_type": "diagnosis",
+                    "relationship": "extension",
+                    "case_properties": [
+                        {
+                            "doc_type": "JsonPathCaseProperty",
+                            "jsonpath": "codedAnswer.name",
+                            "case_property": "case_name",
+                        },
+                        {
+                            "doc_type": "JsonPathCaseProperty",
+                            "jsonpath": "certainty",
+                            "case_property": "certainty",
+                        },
+                        {
+                            "doc_type": "JsonPathCaseProperty",
+                            "jsonpath": "order",
+                            "case_property": "primary_or_secondary",
+                        },
+                    ]
+                }
+            }
+        ]
+        self.repeater = OpenmrsRepeater.wrap(self.get_repeater_dict(observations))
+
+    def get_repeater_dict(self, observations):
+        return {
             "_id": "123456",
             "domain": "test_domain",
             "username": "foo",
@@ -191,70 +241,10 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                     "xmlns": "http://openrosa.org/formdesigner/9481169B-0381-4B27-BA37-A46AB7B4692D",
                     "openmrs_visit_type": "c22a5000-3f10-11e4-adec-0800271c1b75",
                     "openmrs_encounter_type": "81852aee-3f10-11e4-adec-0800271c1b75",
-                    "openmrs_observations": [
-                        {
-                            "doc_type": "ObservationMapping",
-                            "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                            "value": {
-                                "doc_type": "FormQuestion",
-                                "form_question": "/data/height"
-                            },
-                            "indexed_case_mapping": {
-                                "identifier": "parent",
-                                "case_type": "observation",
-                                "relationship": "extension",
-                                "case_properties": [
-                                    {
-                                        "doc_type": "JsonPathCaseProperty",
-                                        "jsonpath": "concept.name",
-                                        "case_property": "case_name",
-                                    },
-                                    {
-                                        "doc_type": "JsonPathCaseProperty",
-                                        "jsonpath": "value",
-                                        "case_property": "observation_value",
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "doc_type": "ObservationMapping",
-                            "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
-                            "value": {
-                                "doc_type": "FormQuestionMap",
-                                "form_question": "/data/bahmni_hypothermia",
-                                "value_map": {
-                                    "emergency_room_user_id": "Hypothermia",  # Value must match diagnosis name
-                                },
-                                "direction": "in",
-                            },
-                            "indexed_case_mapping": {
-                                "identifier": "parent",
-                                "case_type": "diagnosis",
-                                "relationship": "extension",
-                                "case_properties": [
-                                    {
-                                        "doc_type": "JsonPathCaseProperty",
-                                        "jsonpath": "codedAnswer.name",
-                                        "case_property": "case_name",
-                                    },
-                                    {
-                                        "doc_type": "JsonPathCaseProperty",
-                                        "jsonpath": "certainty",
-                                        "case_property": "certainty",
-                                    },
-                                    {
-                                        "doc_type": "JsonPathCaseProperty",
-                                        "jsonpath": "order",
-                                        "case_property": "primary_or_secondary",
-                                    },
-                                ]
-                            }
-                        }
-                    ]
+                    "openmrs_observations": observations
                 }]
             }
-        })
+        }
 
     def test_import_encounter(self):
         """

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -187,7 +187,8 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
         self.repeater.requests.get.return_value = response
 
         with patch('corehq.motech.openmrs.atom_feed.submit_case_blocks') as submit_case_blocks_patch, \
-                patch('corehq.motech.openmrs.atom_feed.importer_util') as importer_util_patch:
+                patch('corehq.motech.openmrs.atom_feed.importer_util') as importer_util_patch, \
+                patch('corehq.motech.openmrs.repeaters.get_one_commcare_user_at_location'):
             importer_util_patch.lookup_case.return_value = (self.case, None)
 
             import_encounter(self.repeater, 'c719b87f-d221-493b-bec7-c212aa813f5d')
@@ -210,20 +211,24 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
     def test_get_case_block_kwargs_from_observations(self):
         encounter = self.get_json('encounter')
         observations = encounter['observations']
-        case_block_kwargs = get_case_block_kwargs_from_observations(
+        case_block_kwargs, case_blocks = get_case_block_kwargs_from_observations(
             observations,
-            self.repeater.observation_mappings
+            self.repeater.observation_mappings,
+            None, None, None
         )
         self.assertEqual(case_block_kwargs, {'update': {'height': 105}})
+        self.assertEqual(case_blocks, [])
 
     def test_get_case_block_kwargs_from_bahmni_diagnoses(self):
         encounter = self.get_json('encounter_with_diagnoses')
         bahmni_diagnoses = encounter['bahmniDiagnoses']
-        case_block_kwargs = get_case_block_kwargs_from_bahmni_diagnoses(
+        case_block_kwargs, case_blocks = get_case_block_kwargs_from_bahmni_diagnoses(
             bahmni_diagnoses,
-            self.repeater.observation_mappings
+            self.repeater.observation_mappings,
+            None, None, None
         )
         self.assertEqual(case_block_kwargs, {'owner_id': 'emergency_room_user_id', 'update': {}})
+        self.assertEqual(case_blocks, [])
 
 
 def test_doctests():

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -6,11 +6,16 @@ from django.test import SimpleTestCase
 from couchdbkit import BadValueError
 
 import corehq.motech.value_source
-from corehq.motech.const import COMMCARE_DATA_TYPE_DECIMAL
+from corehq.motech.const import (
+    COMMCARE_DATA_TYPE_DECIMAL,
+    COMMCARE_DATA_TYPE_INTEGER,
+    COMMCARE_DATA_TYPE_TEXT,
+)
 from corehq.motech.value_source import (
     CaseProperty,
     CaseTriggerInfo,
     ConstantString,
+    ConstantValue,
     FormQuestionMap,
     ValueSource,
     get_form_question_values,
@@ -141,6 +146,35 @@ class ConstantStringTests(SimpleTestCase):
         external_value = "bar"
         value = constant.deserialize(external_value)
         self.assertIsNone(value)
+
+
+class ConstantValueTests(SimpleTestCase):
+
+    def test_serialize(self):
+        """
+        serialize() should convert from CommCare data type to external
+        data type
+        """
+        one = ConstantValue.wrap({
+            "value": 1.0,
+            "value_data_type": COMMCARE_DATA_TYPE_DECIMAL,
+            "commcare_data_type": COMMCARE_DATA_TYPE_INTEGER,
+            "external_data_type": COMMCARE_DATA_TYPE_TEXT,
+        })
+        self.assertEqual(one.serialize("foo"), '1')
+
+    def test_deserialize(self):
+        """
+        deserialize() should convert from external data type to CommCare
+        data type
+        """
+        one = ConstantValue.wrap({
+            "value": 1.0,
+            "value_data_type": COMMCARE_DATA_TYPE_DECIMAL,
+            "commcare_data_type": COMMCARE_DATA_TYPE_TEXT,
+            "external_data_type": COMMCARE_DATA_TYPE_INTEGER,
+        })
+        self.assertEqual(one.deserialize("foo"), '1')
 
 
 class WrapTests(SimpleTestCase):

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -278,13 +278,7 @@ class ConstantValue(ConstantString):
         )
 
     def deserialize(self, external_value):
-        """
-        Ignores ``external_value`` and returns ``self.value`` cast from
-        ``self.value_data_type`` to ``self.commcare_data_type``.
-        """
-        serializer = (serializers.get((self.value_data_type, self.commcare_data_type))
-                      or serializers.get((None, self.commcare_data_type)))
-        return serializer(self.value) if serializer else self.value
+        return self._get_commcare_value(self.value)
 
     def _get_commcare_value(self, case_trigger_info):
         """
@@ -292,7 +286,9 @@ class ConstantValue(ConstantString):
 
         Used by ``self.get_value()``.
         """
-        return self.deserialize(self.value)
+        serializer = (serializers.get((self.value_data_type, self.commcare_data_type))
+                      or serializers.get((None, self.commcare_data_type)))
+        return serializer(self.value) if serializer else self.value
 
 
 class CasePropertyMap(CaseProperty):

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -246,20 +246,20 @@ class ConstantValue(ConstantString):
     export.
 
     >>> one = ConstantValue.wrap({
-    ...     "value": 1.0,
-    ...     "value_data_type": COMMCARE_DATA_TYPE_DECIMAL,
-    ...     "commcare_data_type": COMMCARE_DATA_TYPE_INTEGER,
+    ...     "value": 1,
+    ...     "value_data_type": COMMCARE_DATA_TYPE_INTEGER,
+    ...     "commcare_data_type": COMMCARE_DATA_TYPE_DECIMAL,
     ...     "external_data_type": COMMCARE_DATA_TYPE_TEXT,
     ... })
     >>> info = CaseTriggerInfo("test-domain", None)
     >>> one.deserialize("foo")
-    1
-    >>> one.get_value(info)  # Returns '1', not '1.0'. See note below.
-    '1'
+    1.0
+    >>> one.get_value(info)  # Returns '1.0', not '1'. See note below.
+    '1.0'
 
     .. NOTE::
-       ``one.get_value(info)`` returns  ``'1'``, not ``'1.0'``, because
-       ``ConstantValue._get_commcare_value`` casts ``value`` as
+       ``one.get_value(info)`` returns  ``'1.0'``, not ``'1'``, because
+       ``ConstantValue.serialize`` casts ``value`` as
        ``commcare_data_type`` first. ``ValueSource.serialize()`` casts
        it from ``commcare_data_type`` to ``external_data_type``.
 
@@ -277,18 +277,30 @@ class ConstantValue(ConstantString):
             and self.value_data_type == other.value_data_type
         )
 
-    def deserialize(self, external_value):
-        return self._get_commcare_value(self.value)
-
-    def _get_commcare_value(self, case_trigger_info):
+    def serialize(self, value):
         """
-        Returns ``self.value`` cast as ``self.commcare_data_type``.
-
-        Used by ``self.get_value()``.
+        Convert self.value from CommCare data type to external data type
         """
         serializer = (serializers.get((self.value_data_type, self.commcare_data_type))
                       or serializers.get((None, self.commcare_data_type)))
-        return serializer(self.value) if serializer else self.value
+        commcare_value = serializer(self.value) if serializer else self.value
+        return ValueSource.serialize(self, commcare_value)
+
+    def deserialize(self, external_value):
+        """
+        Convert self.value from external data type to CommCare data type
+        """
+        serializer = (serializers.get((self.value_data_type, self.external_data_type))
+                      or serializers.get((None, self.external_data_type)))
+        external_value = serializer(self.value) if serializer else self.value
+        return ValueSource.deserialize(self, external_value)
+
+    def _get_commcare_value(self, case_trigger_info):
+        # get_value() calls this and serialize(), so this shouldn't call
+        # serialize(), and serialize() shouldn't call this. Just do
+        # nothing, and let `serialize()` cast `self.value` as
+        # `self.commcare_data_type`.
+        pass
 
 
 class CasePropertyMap(CaseProperty):


### PR DESCRIPTION
##### SUMMARY
This change allows OpenMRS Observations and Bahmni Encounters to be imported as extension or child cases.

This supports advanced workflows for referrals. It also allows us to track the progress and history of diagnoses.

Review by commit :fish: :tropical_fish: :blowfish: 

(Note that this builds on PR #25861)

##### FEATURE FLAG
OpenMRS integration

##### PRODUCT DESCRIPTION
OpenMRS Observations and Bahmni Encounters can be imported as extension cases. This supports advanced workflows for referrals. It also allows us to track the progress and history of diagnoses.
