### PR TITLE
add ability to "take the dashboard down" with a feature flag

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1013,6 +1013,16 @@ ICDS_DASHBOARD_REPORT_FEATURES = StaticToggle(
     [NAMESPACE_USER]
 )
 
+
+ICDS_DASHBOARD_TEMPORARY_DOWNTIME = StaticToggle(
+    'icds_dashboard_temporary_downtime',
+    'ICDS: Temporarily disable the ICDS dashboard by showing a downtime page. '
+    'This can be cicurmvented by adding "?bypass-downtime=True" to the end of the url.',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN]
+)
+
+
 OPENMRS_INTEGRATION = StaticToggle(
     'openmrs_integration',
     'Enable OpenMRS integration',

--- a/custom/icds_reports/templates/icds_reports/dashboard_down.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard_down.html
@@ -5,14 +5,14 @@
 {% block tabs %}{% endblock tabs %}
 {% block page_name %}{% trans "Apologies, the ICDS Dashboard is currently under maintenance." %}{% endblock %}
 {% block page_content %}
-  <section class="section section-primary section-lead">
+  <section class="section">
     <div class="container">
       <div class="row">
-        <div class="col-sm-3 flower-container">
+        <div class="col-sm-3">
           <img style="width: 100%" src="{% static 'icds/img/ICDS-CAS_banner.png' %}" alt="ICDS-CAS"/>
         </div>
-        <div class="col-sm-9 container-welcome">
-          <div class="welcome-container-inner">
+        <div class="col-sm-9">
+          <div>
             <p class="lead">
               {% blocktrans %}
               We are working hard to restore this service and it will be back online as soon as possible.

--- a/custom/icds_reports/templates/icds_reports/dashboard_down.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard_down.html
@@ -1,0 +1,27 @@
+{% extends "error_base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% block title %}{% trans "ICDS Dashboard is Under Maintenance" %}{% endblock %}
+{% block tabs %}{% endblock tabs %}
+{% block page_name %}{% trans "Apologies, the ICDS Dashboard is currently under maintenance." %}{% endblock %}
+{% block page_content %}
+  <section class="section section-primary section-lead">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-3 flower-container">
+          <img style="width: 100%" src="{% static 'icds/img/ICDS-CAS_banner.png' %}" alt="ICDS-CAS"/>
+        </div>
+        <div class="col-sm-9 container-welcome">
+          <div class="welcome-container-inner">
+            <p class="lead">
+              {% blocktrans %}
+              We are working hard to restore this service and it will be back online as soon as possible.
+              You may continue to use other parts of this site.
+              {% endblocktrans %}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -223,8 +223,8 @@ class DashboardView(TemplateView):
     @property
     def show_downtime(self):
         return (
-            ICDS_DASHBOARD_TEMPORARY_DOWNTIME.enabled(self.domain) and
-            not self.request.GET.get('bypass-downtime')
+            ICDS_DASHBOARD_TEMPORARY_DOWNTIME.enabled(self.domain)
+            and not self.request.GET.get('bypass-downtime')
         )
 
     @property

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -14,6 +14,8 @@ from django.core.exceptions import PermissionDenied
 from django.db.models.query_utils import Q
 from django.http.response import JsonResponse, HttpResponseBadRequest, HttpResponse, StreamingHttpResponse, Http404
 from django.shortcuts import get_object_or_404, redirect
+
+from corehq.toggles import ICDS_DASHBOARD_TEMPORARY_DOWNTIME
 from corehq.util.view_utils import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic.base import View, TemplateView, RedirectView
@@ -209,10 +211,21 @@ def get_tableau_access_token(tableau_user, client_ip):
 @method_decorator(DASHBOARD_CHECKS, name='dispatch')
 class DashboardView(TemplateView):
     template_name = 'icds_reports/dashboard.html'
+    downtime_template_name = 'icds_reports/dashboard_down.html'
+
+    def get_template_names(self):
+        return self.template_name if not self.show_downtime else self.downtime_template_name
 
     @property
     def domain(self):
         return self.kwargs['domain']
+
+    @property
+    def show_downtime(self):
+        return (
+            ICDS_DASHBOARD_TEMPORARY_DOWNTIME.enabled(self.domain) and
+            not self.request.GET.get('bypass-downtime')
+        )
 
     @property
     def couch_user(self):

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -214,7 +214,7 @@ class DashboardView(TemplateView):
     downtime_template_name = 'icds_reports/dashboard_down.html'
 
     def get_template_names(self):
-        return self.template_name if not self.show_downtime else self.downtime_template_name
+        return [self.template_name] if not self.show_downtime else [self.downtime_template_name]
 
     @property
     def domain(self):


### PR DESCRIPTION
Temporarily take down _just_ the ICDS dashboard via a feature flag. Also allows bypassing it with a url param (https://www.icds-cas.gov.in/a/icds-cas/icds_dashboard?bypass-downtime=true) so that you can still view/test the dashboard internally.

![image](https://user-images.githubusercontent.com/66555/68573916-73de8580-0471-11ea-9220-e703e6b8f358.png)

Note that the flower image in the upper right would be replaced with the domain logo in production.

##### FEATURE FLAG
(new) ICDS_DASHBOARD_TEMPORARY_DOWNTIME

@calellowitz heard you mention this and thought it sounded easy, so decided to take a crack at it

