### PR TITLE
don't store SMS billables when ENTRPRISE_MODE=True

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -693,7 +693,7 @@ def create_billable_for_sms(msg, delay=True):
     if not isinstance(msg, SMS):
         raise Exception("Expected msg to be an SMS")
 
-    if not msg.domain:
+    if not settings.ENTERPRISE_MODE or not msg.domain:
         return
 
     try:

--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -693,7 +693,7 @@ def create_billable_for_sms(msg, delay=True):
     if not isinstance(msg, SMS):
         raise Exception("Expected msg to be an SMS")
 
-    if not settings.ENTERPRISE_MODE or not msg.domain:
+    if settings.ENTERPRISE_MODE or not msg.domain:
         return
 
     try:


### PR DESCRIPTION
##### SUMMARY
SMS Billables are only used for creating invoices which is not something that happens in enterprise deployments so there is no need to store them in the first place.
