### PR TITLE
memoize filter_out_stale_standbys cache storage

### DIFF
--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -297,7 +297,10 @@ def get_standby_delays_by_db():
     return ret
 
 
-@quickcache(['dbs'], timeout=STALE_CHECK_FREQUENCY, skip_arg=lambda *args: settings.UNIT_TESTING)
+@quickcache(
+    ['dbs'], timeout=STALE_CHECK_FREQUENCY, skip_arg=lambda *args: settings.UNIT_TESTING,
+    memoize_timeout=STALE_CHECK_FREQUENCY, session_function=None
+)
 def filter_out_stale_standbys(dbs):
     # from given list of databases filters out those with more than
     #   acceptable standby delay, if that database is a standby


### PR DESCRIPTION
This value is never cleared and relies on the expiration to be
re-calculated hence there is no reason not to maintain the value
in local memory cache

Checking cache usage this key was accessed 2 orders ~20 times any other key:

```
redis-cli monitor > log.txt
cat log.txt | cut -d' ' -f 5 | sort | uniq -c | sort -nr | head
  19598 ":1:quickcache.filter_out_stale_standbys.e99dfd36/L5b7fe7d59a1d0a6d8009af9dd9b24425"
   1108 ":1:quickcache.cached_get.6e9fc146/ua8875bbe4272c0bdd786cfaaedf77921,u46d4378e436a23c834910f676704ca45"
    784 "c3f8721cbb97f72bc19e972846bd7aaf91901658"
    780 ":1:quickcache.any_migrations_in_progress.e7334dc2/u7c2a3b6bada25888e23c8c4ad89f3c97"
    779 ":1:quickcache.get_migration_status.73eff139/u7c2a3b6bada25888e23c8c4ad89f3c97,u61b4f9531ba0798e5c810e29309c18ea"
    750 "5688a2541c9edd77746bcd2385e65ff3639a664f"
    561 ":1:quickcache.get_version_and_app_from_build_id.8b750c9c/u7c2a3b6bada25888e23c8c4ad89f3c97,u1f36df546e0889abd6a84a4806742323"
    509 ":1:#gen#reports#"
    163 ":1:quickcache.get_fixture_data_types_in_domain.47787914/u7c2a3b6bada25888e23c8c4ad89f3c97"
     38 ":1:owner_id_to_display_cache_776467d333a249208aa9617463f0d2f5"
```