### PR TITLE
Templated sum when

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1455,6 +1455,53 @@ Here's an example using ``age_in_months_buckets``:
        }
    }
 
+SumWhenColumn and SumWhenTemplateColumn
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Note: ``SumWhenColumn`` usage is limited to static reports, and ``SumWhenTemplateColumn``
+usage is behind a feature flag.
+
+Sum When columns allow you to aggregate data based on arbitrary conditions.
+
+The ``SumWhenColumn`` allows any expression.
+
+The ``SumWhenTemplateColumn`` is used in conjunction with a subclass of ``SumWhenTemplateSpec``.
+The template defines an expression and typically accepts binds. An example:
+
+Example using ``sum_when``:
+
+.. code:: json
+
+   {
+       "display": "under_six_month_olds",
+       "column_id": "under_six_month_olds",
+       "type": "sum_when",
+       "field": "age_at_registration",
+       "whens": {
+            ["age_at_registration < 6", 1],
+       },
+       "else_": 0
+   }
+
+Equivalent example using ``sum_when_template``:
+
+.. code:: json
+
+   {
+       "display": "under_x_month_olds",
+       "column_id": "under_x_month_olds",
+       "type": "sum_when_template",
+       "field": "age_at_registration",
+       "whens": {
+            {
+                "type": "under_x_months",
+                "binds": [6],
+                "then": 1
+            }
+       },
+       "else_": 0
+   }
+
 Expanded Columns
 ~~~~~~~~~~~~~~~~
 

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1477,9 +1477,9 @@ Example using ``sum_when``:
        "column_id": "under_six_month_olds",
        "type": "sum_when",
        "field": "age_at_registration",
-       "whens": {
+       "whens": [
             ["age_at_registration < 6", 1],
-       },
+       ],
        "else_": 0
    }
 
@@ -1492,13 +1492,13 @@ Equivalent example using ``sum_when_template``:
        "column_id": "under_x_month_olds",
        "type": "sum_when_template",
        "field": "age_at_registration",
-       "whens": {
+       "whens": [
             {
                 "type": "under_x_months",
                 "binds": [6],
                 "then": 1
             }
-       },
+       ],
        "else_": 0
    }
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -669,7 +669,7 @@ class ReportConfiguration(QuickCachedDocumentMixin, Document):
     @property
     @memoized
     def report_columns(self):
-        return [ReportColumnFactory.from_spec(c, self.is_static) for c in self.columns]
+        return [ReportColumnFactory.from_spec(c, self.is_static, self.domain) for c in self.columns]
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -20,6 +20,7 @@ from corehq.apps.userreports.reports.specs import (
     PercentageColumn,
     PieChartSpec,
     SumWhenColumn,
+    SumWhenTemplateColumn,
 )
 
 
@@ -34,6 +35,7 @@ class ReportColumnFactory(object):
         'location': LocationColumn,
         'percent': PercentageColumn,
         'sum_when': SumWhenColumn,
+        'sum_when_template': SumWhenTemplateColumn,
     }
 
     @classmethod

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -41,7 +41,7 @@ class ReportColumnFactory(object):
     }
 
     @classmethod
-    def from_spec(cls, spec, is_static, domain):
+    def from_spec(cls, spec, is_static, domain=None):
         column_type = spec.get('type') or 'field'
         if column_type not in cls.class_map:
             raise BadSpecError(

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -39,7 +39,7 @@ class ReportColumnFactory(object):
     }
 
     @classmethod
-    def from_spec(cls, spec, is_static):
+    def from_spec(cls, spec, is_static, domain):
         column_type = spec.get('type') or 'field'
         if column_type not in cls.class_map:
             raise BadSpecError(
@@ -49,7 +49,7 @@ class ReportColumnFactory(object):
                 )
             )
         column_class = cls.class_map[column_type]
-        if column_class.restricted_to_static() and not (is_static or settings.UNIT_TESTING):
+        if column_class.restricted_to_static(domain) and not (is_static or settings.UNIT_TESTING):
             raise BadSpecError("{} columns are only available to static report configs"
                                .format(column_type))
         try:

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -1,4 +1,6 @@
 import json
+import re
+import uuid
 from collections import namedtuple
 from datetime import date
 
@@ -21,6 +23,7 @@ from sqlagg.columns import (
     NonzeroSumColumn,
     SimpleColumn,
     SumWhen,
+    SumWhenWithBinds,
     YearColumn,
 )
 from sqlalchemy import bindparam
@@ -30,6 +33,7 @@ from dimagi.ext.jsonobject import (
     BooleanProperty,
     DictProperty,
     IntegerProperty,
+    JsonArray,
     JsonObject,
     ListProperty,
     ObjectProperty,
@@ -314,11 +318,7 @@ class _CaseExpressionColumn(ReportColumn):
         return ColumnConfig(columns=[
             DatabaseColumn(
                 header=self.get_header(lang),
-                agg_column=self._agg_column_type(
-                    whens=self.get_whens(),
-                    else_=self.else_,
-                    alias=self.column_id,
-                ),
+                agg_column=self._agg_column_type(**self._get_agg_column_params()),
                 sortable=self.sortable,
                 data_slug=self.column_id,
                 format_fn=self.get_format_fn(),
@@ -327,8 +327,15 @@ class _CaseExpressionColumn(ReportColumn):
             )],
         )
 
+    def _get_agg_column_params(self):
+        return {
+            "whens": self.get_whens(),
+            "else_": self.else_,
+            "alias": self.column_id,
+        }
+
     def get_whens(self):
-        raise NotImplementedError('subclasses must override this')
+        return self.whens
 
     def get_query_column_ids(self):
         return [self.column_id]
@@ -378,41 +385,71 @@ class SumWhenColumn(_CaseExpressionColumn):
         # syntax, as attempted in commit 02833e28b7aaf5e0a71741244841ad9910ffb1e5
         return True
 
-    def get_whens(self):
-        return self.whens
-
 
 class SumWhenTemplateColumn(SumWhenColumn):
     type = TypeProperty("sum_when_template")
+    whens = ListProperty(DictProperty)      # List of dicts with keys: when, then, params
+    _agg_column_type = SumWhenWithBinds
+    binds = DictProperty()
 
     @classmethod
     def restricted_to_static(cls):
         return False
 
+    def _get_agg_column_params(self):
+        whens, binds = self.get_whens_and_binds()
+        return {
+            "whens": whens,
+            "binds": binds,
+            "else_": self.else_,
+            "alias": self.column_id,
+        }
+
     def get_whens(self):
+        raise NotImplementedError('Use get_whens_and_binds instead')
+
+    def get_whens_and_binds(self):
         whens = []
+        binds = {}
         for item in self.whens:
-            when, then = item
+            when = item['when']
+            then = item['then']
+            params = item.get('params', [])
+
             try:
                 expression_class = to_function(when)
             except ValueError:
                 raise BadSpecError('Badly formatted expression class: {}'.format(when))
             if not expression_class:
                 raise BadSpecError('Could not find expression class: {}'.format(when))
-            whens.append([expression_class.expression, then])
-        return whens
+            if len(params) != expression_class.param_count():
+                raise BadSpecError('Expected {} parameters, found {}'.format(len(params),
+                                                                             expression_class.param_count()))
+
+            expression = ''
+            params = list(reversed(params))
+            for letter in expression_class.expression:
+                if letter != '?':
+                    expression += letter
+                else:
+                    param_name = 'p' + uuid.uuid4().hex
+                    expression += ':' + param_name
+                    binds[param_name] = params.pop()
+
+            whens.append((expression, then))
+        return whens, binds
 
 
 class SumWhenTemplate(object):
     expression = None
 
-    @property
-    def param_count(self):
-        return len(re.findall(r'{}', self.expression))
+    @classmethod
+    def param_count(cls):
+        return len(re.sub(r'[^?]', '', cls.expression))
 
 
 class YearRangeTemplate(SumWhenTemplate):
-    expression = "year >= 2010 and year < 2020"
+    expression = "year >= ? and year < ?"
 
 
 class PercentageColumn(ReportColumn):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -301,7 +301,7 @@ class _CaseExpressionColumn(ReportColumn):
     http://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.case
     """
     type = None
-    whens = DictProperty()
+    whens = ListProperty(ListProperty)      # List of (expression, value) tuples
     else_ = StringProperty()
     sortable = BooleanProperty(default=False)
 
@@ -341,7 +341,7 @@ class IntegerBucketsColumn(_CaseExpressionColumn):
     ranges = DictProperty()
 
     def get_whens(self):
-        whens = {}
+        whens = []
         for value, bounds in self.ranges.items():
             if len(bounds) != 2:
                 raise BadSpecError('Range must contain 2 items, contains {}'.format(len(bounds)))
@@ -349,7 +349,7 @@ class IntegerBucketsColumn(_CaseExpressionColumn):
                 bounds = [int(b) for b in bounds]
             except ValueError:
                 raise BadSpecError('Invalid range: [{}, {}]'.format(bounds[0], bounds[1]))
-            whens.update({self._base_expression(bounds): bindparam(None, value)})
+            whens.append([self._base_expression(bounds), bindparam(None, value)])
         return whens
 
     def _base_expression(self, bounds):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -378,7 +378,7 @@ class SumWhenColumn(_CaseExpressionColumn):
         # so this column type is only available for static reports.  To release this,
         # we should require that conditions be expressed using a PreFilterValue type
         # syntax, as attempted in commit 02833e28b7aaf5e0a71741244841ad9910ffb1e5
-        return False     # TODO True
+        return True
 
 
 class SumWhenTemplateColumn(SumWhenColumn):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -414,7 +414,7 @@ class YearRangeTemplateSpec(SumWhenTemplateSpec):
 
 
 class UnderXMonthsTemplateSpec(SumWhenTemplateSpec):
-    type = "under_x_months"
+    type = TypeProperty("under_x_months")
     expression = "age_at_registration < ?"
 
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -378,7 +378,7 @@ class SumWhenColumn(_CaseExpressionColumn):
         # so this column type is only available for static reports.  To release this,
         # we should require that conditions be expressed using a PreFilterValue type
         # syntax, as attempted in commit 02833e28b7aaf5e0a71741244841ad9910ffb1e5
-        return False    # TODO True
+        return True
 
 
 class SumWhenTemplateColumn(SumWhenColumn):

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -25,10 +25,10 @@ def expand_column(report_column, distinct_values, lang):
         alias = "{}-{}".format(report_column.column_id, index)
         if val is None:
             sql_agg_col = SumWhen(
-                whens={'"{}" is NULL'.format(report_column.field): 1}, else_=0, alias=alias
+                whens=[['"{}" is NULL'.format(report_column.field), 1]], else_=0, alias=alias
             )
         else:
-            sql_agg_col = SumWhen(report_column.field, whens={val: 1}, else_=0, alias=alias)
+            sql_agg_col = SumWhen(report_column.field, whens=[[val, 1]], else_=0, alias=alias)
 
         columns.append(UCRExpandDatabaseSubcolumn(
             "{}-{}".format(report_column.get_header(lang), val),

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -312,7 +312,7 @@ class TestExpandedColumn(TestCase):
 
         self.assertEqual(len(cols), 2)
         self.assertEqual(type(cols[0].view), SumWhen)
-        self.assertEqual(cols[1].view.whens, {'negative': 1})
+        self.assertEqual(cols[1].view.whens, [['negative', 1]])
 
     def test_none_in_values(self):
         """

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1052,9 +1052,9 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'display': 'under_six_month_olds',
                     'field': 'age_at_registration',
                     'column_id': 'under_six_month_olds',
-                    'whens': {
-                        "age_at_registration < 6": 1,
-                    },
+                    'whens': [
+                        ["age_at_registration < 6", 1],
+                    ],
                     'else_': 0
                 },
                 {

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1099,7 +1099,6 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
         ]:
             self.assertIn(table_row, table)
 
-
         report_config = self._create_report(
             aggregation_columns=[
                 'indicator_col_id_state',

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -7,7 +7,6 @@ from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     ReportConfiguration,
 )
-from corehq.apps.userreports.reports.specs import SumWhenTemplateSpec
 from corehq.apps.userreports.reports.view import ConfigurableReportView
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.userreports.tests.test_view import ConfigurableReportTestMixin

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -7,15 +7,11 @@ from corehq.apps.userreports.models import (
     DataSourceConfiguration,
     ReportConfiguration,
 )
-from corehq.apps.userreports.reports.specs import SumWhenTemplate
+from corehq.apps.userreports.reports.specs import SumWhenTemplateSpec
 from corehq.apps.userreports.reports.view import ConfigurableReportView
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.userreports.tests.test_view import ConfigurableReportTestMixin
 from corehq.apps.userreports.util import get_indicator_adapter
-
-
-class UnderXMonthsTemplate(SumWhenTemplate):
-    expression = "age_at_registration < ?"
 
 
 class TestReportAggregationSQL(ConfigurableReportTestMixin, TestCase):
@@ -1068,7 +1064,11 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'field': 'age_at_registration',
                     'column_id': 'under_x_month_olds_template',
                     'whens': [
-                        ["corehq.apps.userreports.tests.test_report_aggregation.UnderXMonthsTemplate", 6, 1],
+                        {
+                            'type': 'under_x_months',
+                            'binds': [6],
+                            'then': 1,
+                        },
                     ],
                     'else_': 0
                 },
@@ -1115,8 +1115,11 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'field': 'age_at_registration',
                     'column_id': 'under_six_month_olds',
                     'whens': [
-                        # Too many binds
-                        ['corehq.apps.userreports.tests.test_report_aggregation.UnderXMonthsTemplate', 6, 7, 1],
+                        {
+                            'type': 'under_x_months',
+                            'binds': [6, 7],            # Too many binds
+                            'then': 1,
+                        },
                     ],
                     'else_': 0
                 },

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1067,11 +1067,9 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'display': 'under_x_month_olds_template',
                     'field': 'age_at_registration',
                     'column_id': 'under_x_month_olds_template',
-                    'whens': [{
-                        "when": "corehq.apps.userreports.tests.test_report_aggregation.UnderXMonthsTemplate",
-                        "then": 1,
-                        "params": [6],
-                    }],
+                    'whens': [
+                        ["corehq.apps.userreports.tests.test_report_aggregation.UnderXMonthsTemplate", 6, 1],
+                    ],
                     'else_': 0
                 },
                 {
@@ -1116,11 +1114,10 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
                     'display': 'under_six_month_olds',
                     'field': 'age_at_registration',
                     'column_id': 'under_six_month_olds',
-                    'whens': [{
-                        'when': 'corehq.apps.userreports.tests.test_report_aggregation.UnderXMonthsTemplate',
-                        'then': 1,
-                        'params': [6, 7],   # Too many params
-                    }],
+                    'whens': [
+                        # Too many binds
+                        ['corehq.apps.userreports.tests.test_report_aggregation.UnderXMonthsTemplate', 6, 7, 1],
+                    ],
                     'else_': 0
                 },
                 {

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -584,7 +584,6 @@ VISIT_SCHEDULER = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
-
 USER_CONFIGURABLE_REPORTS = StaticToggle(
     'user_reports',
     'User configurable reports UI',
@@ -609,6 +608,18 @@ REPORT_BUILDER = StaticToggle(
     'Activate Report Builder for a project without setting up a subscription.',
     TAG_DEPRECATED,
     [NAMESPACE_DOMAIN],
+)
+
+UCR_SUM_WHEN_TEMPLATES = StaticToggle(
+    'ucr_sum_when_templates',
+    'Allow sum when template columns in dynamic UCRs',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+    description=(
+        "Enables use of SumWhenTemplateColumn with custom expressions in dynamic UCRS."
+    ),
+    always_enabled={'icds-cas'},
+    help_link='TODO write some docs',
 )
 
 ASYNC_RESTORE = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -619,7 +619,7 @@ UCR_SUM_WHEN_TEMPLATES = StaticToggle(
         "Enables use of SumWhenTemplateColumn with custom expressions in dynamic UCRS."
     ),
     always_enabled={'icds-cas'},
-    help_link='TODO write some docs',
+    help_link='https://commcare-hq.readthedocs.io/ucr.html#sumwhencolumn-and-sumwhentemplatecolumn',
 )
 
 ASYNC_RESTORE = StaticToggle(

--- a/custom/icds_reports/sqldata/agg_ccs_record_monthly.py
+++ b/custom/icds_reports/sqldata/agg_ccs_record_monthly.py
@@ -54,11 +54,11 @@ class AggCCSRecordMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 [
 
                     SumWhen(
-                        whens={"ccs_status = 'pregnant'": 'anemic_moderate'},
+                        whens=[["ccs_status = 'pregnant'", 'anemic_moderate']],
                         alias='anemic_moderate'
                     ),
                     SumWhen(
-                        whens={"ccs_status = 'pregnant'": 'anemic_severe'},
+                        whens=[["ccs_status = 'pregnant'", 'anemic_severe']],
                         alias='anemic_severe'
                     ),
                     SumColumn('pregnant', alias='pregnant')

--- a/custom/icds_reports/sqldata/agg_child_health_monthly.py
+++ b/custom/icds_reports/sqldata/agg_child_health_monthly.py
@@ -65,11 +65,11 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_weighed'},
+                        whens=[["age_tranche != :age_72", 'nutrition_status_weighed']],
                         alias='nutrition_status_weighed'
                     ),
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'wer_eligible'},
+                        whens=[["age_tranche != :age_72", 'wer_eligible']],
                         alias='wer_eligible'
                     )
                 ],
@@ -80,11 +80,11 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'height_measured_in_month'},
+                        whens=[["age_tranche != :age_72", 'height_measured_in_month']],
                         alias='height_measured_in_month_less_5'
                     ),
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'height_eligible'},
+                        whens=[["age_tranche != :age_72", 'height_eligible']],
                         alias='height_eligible'
                     )
                 ],
@@ -93,7 +93,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
             DatabaseColumn(
                 'Total number Unweighed',
                 SumWhen(
-                    whens={"age_tranche != :age_72": 'nutrition_status_unweighed'},
+                    whens=[["age_tranche != :age_72", 'nutrition_status_unweighed']],
                     alias='nutrition_status_unweighed'
                 )
             ),
@@ -102,7 +102,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_severely_underweight'},
+                        whens=[["age_tranche != :age_72", 'nutrition_status_severely_underweight']],
                         alias='nutrition_status_severely_underweight'
                     ),
                     AliasColumn('nutrition_status_weighed')
@@ -114,7 +114,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_moderately_underweight'},
+                        whens=[["age_tranche != :age_72", 'nutrition_status_moderately_underweight']],
                         alias='nutrition_status_moderately_underweight'
                     ),
                     AliasColumn('nutrition_status_weighed')
@@ -126,7 +126,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_normal'},
+                        whens=[["age_tranche != :age_72", 'nutrition_status_normal']],
                         alias='nutrition_status_normal'
                     ),
                     AliasColumn('nutrition_status_weighed')
@@ -138,11 +138,11 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): wasting_severe_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wasting_severe_column(self.beta)]],
                         alias='wasting_severe'
                     ),
                     SumWhen(
-                        whens={get_age_condition(self.beta): wfh_recorded_in_month_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wfh_recorded_in_month_column(self.beta)]],
                         alias='weighed_and_height_measured_in_month'
                     )
                 ],
@@ -153,7 +153,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): wasting_moderate_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wasting_moderate_column(self.beta)]],
                         alias='wasting_moderate'
                     ),
                     AliasColumn('weighed_and_height_measured_in_month')
@@ -165,7 +165,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): wasting_normal_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wasting_normal_column(self.beta)]],
                         alias='wasting_normal'
                     ),
                     AliasColumn('weighed_and_height_measured_in_month')
@@ -177,11 +177,11 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): stunting_severe_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), stunting_severe_column(self.beta)]],
                         alias='zscore_grading_hfa_severe'
                     ),
                     SumWhen(
-                        whens={get_age_condition(self.beta): hfa_recorded_in_month_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), hfa_recorded_in_month_column(self.beta)]],
                         alias='height_measured_in_month'
                     )
                 ],
@@ -192,7 +192,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): stunting_moderate_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), stunting_moderate_column(self.beta)]],
                         alias='zscore_grading_hfa_moderate'
                     ),
                     AliasColumn('height_measured_in_month')
@@ -204,7 +204,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
                 percent_num,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): stunting_normal_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), stunting_normal_column(self.beta)]],
                         alias='zscore_grading_hfa_normal'
                     ),
                     AliasColumn('height_measured_in_month')
@@ -287,7 +287,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
             DatabaseColumn(
                 'Children (0 - 28 Days) Seeking Services',
                 SumWhen(
-                    whens={'age_tranche = :age_0': 'valid_in_month'},
+                    whens=[['age_tranche = :age_0', 'valid_in_month']],
                     alias='zero'
                 ),
                 slug='zero'
@@ -295,7 +295,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
             DatabaseColumn(
                 'Children (28 Days - 6 mo) Seeking Services',
                 SumWhen(
-                    whens={'age_tranche = :age_6': 'valid_in_month'},
+                    whens=[['age_tranche = :age_6', 'valid_in_month']],
                     alias='one'
                 ),
                 slug='one'
@@ -303,7 +303,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
             DatabaseColumn(
                 'Children (6 mo - 1 year) Seeking Services',
                 SumWhen(
-                    whens={'age_tranche = :age_12': 'valid_in_month'},
+                    whens=[['age_tranche = :age_12', 'valid_in_month']],
                     alias='two'
                 ),
                 slug='two'
@@ -311,7 +311,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
             DatabaseColumn(
                 'Children (1 year - 3 years) Seeking Services',
                 SumWhen(
-                    whens={'age_tranche = :age_24 OR age_tranche = :age_36': 'valid_in_month'},
+                    whens=[['age_tranche = :age_24 OR age_tranche = :age_36', 'valid_in_month']],
                     alias='three'
                 ),
                 slug='three'
@@ -319,10 +319,10 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
             DatabaseColumn(
                 'Children (3 years - 6 years) Seeking Services',
                 SumWhen(
-                    whens={
-                        'age_tranche = :age_48 OR age_tranche = :age_60 OR age_tranche = :age_72':
-                            'valid_in_month'
-                    },
+                    whens=[[
+                        'age_tranche = :age_48 OR age_tranche = :age_60 OR age_tranche = :age_72',
+                        'valid_in_month'
+                    ]],
                     alias='four'
                 ),
                 slug='four'

--- a/custom/icds_reports/sqldata/exports/children.py
+++ b/custom/icds_reports/sqldata/exports/children.py
@@ -56,11 +56,11 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_weighed'}, else_=0,
+                        whens=[["age_tranche != :age_72", 'nutrition_status_weighed']], else_=0,
                         alias='nutrition_status_weighed'
                     ),
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'wer_eligible'}, else_=0,
+                        whens=[["age_tranche != :age_72", 'wer_eligible']], else_=0,
                         alias='wer_eligible'
                     )
                 ],
@@ -71,11 +71,11 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'height_measured_in_month'}, else_=0,
+                        whens=[["age_tranche != :age_72", 'height_measured_in_month']], else_=0,
                         alias='height_measured_in_month_efficiency'
                     ),
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'height_eligible'}, else_=0,
+                        whens=[["age_tranche != :age_72", 'height_eligible']], else_=0,
                         alias='height_eligible',
                     )
                 ],
@@ -84,7 +84,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
             DatabaseColumn(
                 'Total number of unweighed children (0-5 Years)',
                 SumWhen(
-                    whens={"age_tranche != :age_72": 'nutrition_status_unweighed'}, else_=0,
+                    whens=[["age_tranche != :age_72", 'nutrition_status_unweighed']], else_=0,
                     alias='nutrition_status_unweighed'
                 ),
                 slug='total_number_unweighed'
@@ -94,7 +94,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_severely_underweight'}, else_=0,
+                        whens=[["age_tranche != :age_72", 'nutrition_status_severely_underweight']], else_=0,
                         alias='nutrition_status_severely_underweight'
                     ),
                     AliasColumn('nutrition_status_weighed'),
@@ -106,7 +106,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_moderately_underweight'}, else_=0,
+                        whens=[["age_tranche != :age_72", 'nutrition_status_moderately_underweight']], else_=0,
                         alias='nutrition_status_moderately_underweight'
                     ),
                     AliasColumn('nutrition_status_weighed'),
@@ -118,7 +118,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={"age_tranche != :age_72": 'nutrition_status_normal'}, else_=0,
+                        whens=[["age_tranche != :age_72", 'nutrition_status_normal']], else_=0,
                         alias='nutrition_status_normal'
                     ),
                     AliasColumn('nutrition_status_weighed'),
@@ -130,11 +130,11 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): wasting_severe_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wasting_severe_column(self.beta)]],
                         alias='wasting_severe'
                     ),
                     SumWhen(
-                        whens={get_age_condition(self.beta): wfh_recorded_in_month_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wfh_recorded_in_month_column(self.beta)]],
                         alias='weighed_and_height_measured_in_month'
                     ),
                 ],
@@ -145,7 +145,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): wasting_moderate_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wasting_moderate_column(self.beta)]],
                         alias='wasting_moderate'
                     ),
                     AliasColumn('weighed_and_height_measured_in_month')
@@ -158,7 +158,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): wasting_normal_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), wasting_normal_column(self.beta)]],
                         alias='wasting_normal'
                     ),
                     AliasColumn('weighed_and_height_measured_in_month')
@@ -170,11 +170,11 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): stunting_severe_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), stunting_severe_column(self.beta)]],
                         alias='stunting_severe'
                     ),
                     SumWhen(
-                        whens={get_age_condition(self.beta): hfa_recorded_in_month_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), hfa_recorded_in_month_column(self.beta)]],
                         alias='height_measured_in_month'
                     ),
                 ],
@@ -185,7 +185,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): stunting_moderate_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), stunting_moderate_column(self.beta)]],
                         alias='stunting_moderate'
                     ),
                     AliasColumn('height_measured_in_month')
@@ -197,7 +197,7 @@ class ChildrenExport(ExportableMixin, IcdsSqlData):
                 percent,
                 [
                     SumWhen(
-                        whens={get_age_condition(self.beta): stunting_normal_column(self.beta)},
+                        whens=[[get_age_condition(self.beta), stunting_normal_column(self.beta)]],
                         alias='stunting_normal'
                     ),
                     AliasColumn('height_measured_in_month')

--- a/custom/icds_reports/sqldata/exports/demographics.py
+++ b/custom/icds_reports/sqldata/exports/demographics.py
@@ -57,7 +57,7 @@ class DemographicsChildHealth(ExportableMixin, IcdsSqlData):
             DatabaseColumn(
                 'num_children_0_6mo_enrolled_for_services',
                 SumWhen(
-                    whens={"age_tranche = '0' OR age_tranche = '6'": 'valid_in_month'},
+                    whens=[["age_tranche = '0' OR age_tranche = '6'", 'valid_in_month']],
                     alias='num_children_0_6mo_enrolled_for_services'
                 ),
                 slug='num_children_0_6mo_enrolled_for_services'
@@ -65,7 +65,7 @@ class DemographicsChildHealth(ExportableMixin, IcdsSqlData):
             DatabaseColumn(
                 'num_children_6mo3yr_enrolled_for_services',
                 SumWhen(
-                    whens={"age_tranche = '12' OR age_tranche = '24' OR age_tranche = '36'": 'valid_in_month'},
+                    whens=[["age_tranche = '12' OR age_tranche = '24' OR age_tranche = '36'", 'valid_in_month']],
                     alias='num_children_6mo3yr_enrolled_for_services'
                 ),
                 slug='num_children_6mo3yr_enrolled_for_services'
@@ -73,7 +73,7 @@ class DemographicsChildHealth(ExportableMixin, IcdsSqlData):
             DatabaseColumn(
                 'num_children_3yr6yr_enrolled_for_services',
                 SumWhen(
-                    whens={"age_tranche = '48' OR age_tranche = '60' OR age_tranche = '72'": 'valid_in_month'},
+                    whens=[["age_tranche = '48' OR age_tranche = '60' OR age_tranche = '72'", 'valid_in_month']],
                     alias='num_children_3yr6yr_enrolled_for_services'
                 ),
                 slug='num_children_3yr6yr_enrolled_for_services'

--- a/custom/icds_reports/sqldata/exports/pregnant_women.py
+++ b/custom/icds_reports/sqldata/exports/pregnant_women.py
@@ -45,11 +45,11 @@ class PregnantWomenExport(ExportableMixin, IcdsSqlData):
                 lambda x, y, z: '%.2f%%' % (((x or 0) + (y or 0)) * 100 / float(z or 1)),
                 [
                     SumWhen(
-                        whens={"ccs_status = 'pregnant'": 'anemic_moderate'},
+                        whens=[["ccs_status = 'pregnant'", 'anemic_moderate']],
                         alias='anemic_moderate'
                     ),
                     SumWhen(
-                        whens={"ccs_status = 'pregnant'": 'anemic_severe'},
+                        whens=[["ccs_status = 'pregnant'", 'anemic_severe']],
                         alias='anemic_severe'
                     ),
                     AliasColumn('pregnant')

--- a/custom/icds_reports/ucr/reports/asr/asr_2_3_person_cases.json
+++ b/custom/icds_reports/ucr/reports/asr/asr_2_3_person_cases.json
@@ -113,9 +113,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL": 1
-        }
+        "whens": [
+          ["closed_on IS NULL", 1]
+        ]
       },
       {
         "display": "F_st_count",
@@ -123,9 +123,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste = 'st'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste = 'st'", 1]
+        ]
       },
       {
         "display": "F_sc_count",
@@ -133,9 +133,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'", 1]
+        ]
       },
       {
         "display": "F_other_count",
@@ -143,9 +143,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('st', 'sc')": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('st', 'sc')", 1]
+        ]
       },
       {
         "display": "F_minority_count",
@@ -153,9 +153,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_minority = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_minority = 1", 1]
+        ]
       },
       {
         "display": "F_disabled_count",
@@ -163,9 +163,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and disabled = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and disabled = 1", 1]
+        ]
       },
       {
         "display": "M_st_count",
@@ -173,9 +173,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'", 1]
+        ]
       },
       {
         "display": "M_sc_count",
@@ -183,9 +183,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'", 1]
+        ]
       },
       {
         "display": "M_other_count",
@@ -193,9 +193,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('st', 'sc')": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('st', 'sc')", 1]
+        ]
       },
       {
         "display": "M_minority_count",
@@ -203,9 +203,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1", 1]
+        ]
       },
       {
         "display": "M_disabled_count",
@@ -213,9 +213,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', '0') and disabled = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', '0') and disabled = 1", 1]
+        ]
       },
       {
         "display": "disabled_movement_count",
@@ -223,9 +223,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y1\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y1\\y'", 1]
+        ]
       },
       {
         "display": "disabled_mental_count",
@@ -233,9 +233,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y2\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y2\\y'", 1]
+        ]
       },
       {
         "display": "disabled_seeing_count",
@@ -243,9 +243,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y3\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y3\\y'", 1]
+        ]
       },
       {
         "display": "disabled_hearing_count",
@@ -253,9 +253,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y4\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y4\\y'", 1]
+        ]
       },
       {
         "display": "disabled_speaking_count",
@@ -263,9 +263,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y5\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y5\\y'", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
@@ -125,9 +125,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL": 1
-        }
+        "whens": [
+          ["closed_on IS NULL", 1]
+        ]
       },
       {
         "display": "F_st_count",
@@ -135,9 +135,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste = 'st'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste = 'st'", 1]
+        ]
       },
       {
         "display": "F_sc_count",
@@ -145,9 +145,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'", 1]
+        ]
       },
       {
         "display": "F_other_count",
@@ -155,9 +155,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('sc', 'st')": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('sc', 'st')", 1]
+        ]
       },
       {
         "display": "F_minority_count",
@@ -165,9 +165,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_minority = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_minority = 1", 1]
+        ]
       },
       {
         "display": "F_disabled_count",
@@ -175,9 +175,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and disabled = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and disabled = 1", 1]
+        ]
       },
       {
         "display": "M_st_count",
@@ -185,9 +185,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'", 1]
+        ]
       },
       {
         "display": "M_sc_count",
@@ -195,9 +195,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'", 1]
+        ]
       },
       {
         "display": "M_other_count",
@@ -205,9 +205,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('sc', 'st')": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('sc', 'st')", 1]
+        ]
       },
       {
         "display": "M_minority_count",
@@ -215,9 +215,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1", 1]
+        ]
       },
       {
         "display": "M_disabled_count",
@@ -225,9 +225,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', '0') and disabled = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', '0') and disabled = 1", 1]
+        ]
       },
       {
         "display": "disabled_movement_count",
@@ -235,9 +235,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y1\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y1\\y'", 1]
+        ]
       },
       {
         "display": "disabled_mental_count",
@@ -245,9 +245,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y2\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y2\\y'", 1]
+        ]
       },
       {
         "display": "disabled_seeing_count",
@@ -255,9 +255,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y3\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y3\\y'", 1]
+        ]
       },
       {
         "display": "disabled_hearing_count",
@@ -265,9 +265,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y4\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y4\\y'", 1]
+        ]
       },
       {
         "display": "disabled_speaking_count",
@@ -275,9 +275,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y5\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y5\\y'", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/dashboard/asr_2_3_person_cases.json
+++ b/custom/icds_reports/ucr/reports/dashboard/asr_2_3_person_cases.json
@@ -113,9 +113,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL": 1
-        }
+        "whens": [
+          ["closed_on IS NULL", 1]
+        ]
       },
       {
         "display": "F_st_count",
@@ -123,9 +123,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste = 'st'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste = 'st'", 1]
+        ]
       },
       {
         "display": "F_sc_count",
@@ -133,9 +133,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste = 'sc'", 1]
+        ]
       },
       {
         "display": "F_other_count",
@@ -143,9 +143,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('st', 'sc')": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_caste NOT IN ('st', 'sc')", 1]
+        ]
       },
       {
         "display": "F_minority_count",
@@ -153,9 +153,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and hh_minority = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and hh_minority = 1", 1]
+        ]
       },
       {
         "display": "F_disabled_count",
@@ -163,9 +163,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' and disabled = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' and disabled = 1", 1]
+        ]
       },
       {
         "display": "M_st_count",
@@ -173,9 +173,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'st'", 1]
+        ]
       },
       {
         "display": "M_sc_count",
@@ -183,9 +183,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste = 'sc'", 1]
+        ]
       },
       {
         "display": "M_other_count",
@@ -193,9 +193,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('st', 'sc')": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') and hh_caste NOT IN ('st', 'sc')", 1]
+        ]
       },
       {
         "display": "M_minority_count",
@@ -203,9 +203,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', '0') and hh_minority = 1", 1]
+        ]
       },
       {
         "display": "M_disabled_count",
@@ -213,9 +213,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', '0') and disabled = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', '0') and disabled = 1", 1]
+        ]
       },
       {
         "display": "disabled_movement_count",
@@ -223,9 +223,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y1\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y1\\y'", 1]
+        ]
       },
       {
         "display": "disabled_mental_count",
@@ -233,9 +233,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y2\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y2\\y'", 1]
+        ]
       },
       {
         "display": "disabled_seeing_count",
@@ -243,9 +243,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y3\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y3\\y'", 1]
+        ]
       },
       {
         "display": "disabled_hearing_count",
@@ -253,9 +253,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y4\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y4\\y'", 1]
+        ]
       },
       {
         "display": "disabled_speaking_count",
@@ -263,9 +263,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND disability_type ~ '\\y5\\y'": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND disability_type ~ '\\y5\\y'", 1]
+        ]
       },
       {
         "sortable": false,

--- a/custom/icds_reports/ucr/reports/mpr/dashboard/mpr_10ab_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/dashboard/mpr_10ab_person_cases.json
@@ -109,9 +109,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ypremature\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ypremature\\y'", 1]
+        ]
       },
       {
         "display": "referred_sepsis",
@@ -119,9 +119,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ysepsis\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ysepsis\\y'", 1]
+        ]
       },
       {
         "display": "referred_diarrhoea",
@@ -129,9 +129,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ydiarrhoea\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ydiarrhoea\\y'", 1]
+        ]
       },
       {
         "display": "referred_pneumonia",
@@ -139,9 +139,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ypneumonia\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ypneumonia\\y'", 1]
+        ]
       },
       {
         "display": "referred_fever_child",
@@ -149,9 +149,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yfever_child\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yfever_child\\y'", 1]
+        ]
       },
       {
         "display": "referred_severely_underweight",
@@ -159,9 +159,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yseverely_underweight\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yseverely_underweight\\y'", 1]
+        ]
       },
       {
         "display": "referred_other_child",
@@ -169,9 +169,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yother_child\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yother_child\\y'", 1]
+        ]
       },
       {
         "display": "premature_reached_count",
@@ -179,9 +179,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ypremature\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ypremature\\y'", 1]
+        ]
       },
       {
         "display": "sepsis_reached_count",
@@ -189,9 +189,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ysepsis\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ysepsis\\y'", 1]
+        ]
       },
       {
         "display": "diarrhoea_reached_count",
@@ -199,9 +199,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ydiarrhoea\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ydiarrhoea\\y'", 1]
+        ]
       },
       {
         "display": "pneumonia_reached_count",
@@ -209,9 +209,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ypneumonia\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ypneumonia\\y'", 1]
+        ]
       },
       {
         "display": "fever_child_reached_count",
@@ -219,9 +219,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yfever_child\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yfever_child\\y'", 1]
+        ]
       },
       {
         "display": "sev_underweight_reached_count",
@@ -229,9 +229,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yseverely_underweight\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yseverely_underweight\\y'", 1]
+        ]
       },
       {
         "display": "other_child_reached_count",
@@ -239,9 +239,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yother_child\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yother_child\\y'", 1]
+        ]
       },
       {
         "display": "referred_bleeding",
@@ -249,9 +249,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ybleeding\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ybleeding\\y'", 1]
+        ]
       },
       {
         "display": "referred_convulsions",
@@ -259,9 +259,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yconvulsions\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yconvulsions\\y'", 1]
+        ]
       },
       {
         "display": "referred_prolonged_labor",
@@ -269,9 +269,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yprolonged_labor\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yprolonged_labor\\y'", 1]
+        ]
       },
       {
         "display": "referred_abortion_complications",
@@ -279,9 +279,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yabortion_complications\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yabortion_complications\\y'", 1]
+        ]
       },
       {
         "display": "referred_fever_discharge",
@@ -289,9 +289,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'", 1]
+        ]
       },
       {
         "display": "referred_other",
@@ -299,9 +299,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'", 1]
+        ]
       },
       {
         "display": "bleeding_reached_count",
@@ -309,9 +309,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ybleeding\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ybleeding\\y'", 1]
+        ]
       },
       {
         "display": "convulsions_reached_count",
@@ -319,9 +319,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yconvulsions\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yconvulsions\\y'", 1]
+        ]
       },
       {
         "display": "prolonged_labor_reached_count",
@@ -329,9 +329,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yprolonged_labor\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yprolonged_labor\\y'", 1]
+        ]
       },
       {
         "display": "abort_comp_reached_count",
@@ -339,9 +339,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yabortion_complications\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yabortion_complications\\y'", 1]
+        ]
       },
       {
         "display": "fever_discharge_reached_count",
@@ -349,9 +349,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')", 1]
+        ]
       },
       {
         "display": "other_reached_count",
@@ -359,9 +359,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_10a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_10a_person_cases.json
@@ -113,9 +113,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ypremature\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ypremature\\y'", 1]
+        ]
       },
       {
         "display": "referred_sepsis",
@@ -123,9 +123,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ysepsis\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ysepsis\\y'", 1]
+        ]
       },
       {
         "display": "referred_diarrhoea",
@@ -133,9 +133,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ydiarrhoea\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ydiarrhoea\\y'", 1]
+        ]
       },
       {
         "display": "referred_pneumonia",
@@ -143,9 +143,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ypneumonia\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ypneumonia\\y'", 1]
+        ]
       },
       {
         "display": "referred_fever_child",
@@ -153,9 +153,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yfever_child\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yfever_child\\y'", 1]
+        ]
       },
       {
         "display": "referred_severely_underweight",
@@ -163,9 +163,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yseverely_underweight\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yseverely_underweight\\y'", 1]
+        ]
       },
       {
         "display": "referred_other_child",
@@ -173,9 +173,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yother_child\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yother_child\\y'", 1]
+        ]
       },
       {
         "display": "premature_reached_count",
@@ -183,9 +183,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ypremature\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ypremature\\y'", 1]
+        ]
       },
       {
         "display": "sepsis_reached_count",
@@ -193,9 +193,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ysepsis\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ysepsis\\y'", 1]
+        ]
       },
       {
         "display": "diarrhoea_reached_count",
@@ -203,9 +203,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ydiarrhoea\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ydiarrhoea\\y'", 1]
+        ]
       },
       {
         "display": "pneumonia_reached_count",
@@ -213,9 +213,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ypneumonia\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ypneumonia\\y'", 1]
+        ]
       },
       {
         "display": "fever_child_reached_count",
@@ -223,9 +223,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yfever_child\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yfever_child\\y'", 1]
+        ]
       },
       {
         "display": "sev_underweight_reached_count",
@@ -233,9 +233,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yseverely_underweight\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yseverely_underweight\\y'", 1]
+        ]
       },
       {
         "display": "other_child_reached_count",
@@ -243,9 +243,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yother_child\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yother_child\\y'", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_10b_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_10b_person_cases.json
@@ -113,9 +113,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ybleeding\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ybleeding\\y'", 1]
+        ]
       },
       {
         "display": "referred_convulsions",
@@ -123,9 +123,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yconvulsions\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yconvulsions\\y'", 1]
+        ]
       },
       {
         "display": "referred_prolonged_labor",
@@ -133,9 +133,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yprolonged_labor\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yprolonged_labor\\y'", 1]
+        ]
       },
       {
         "display": "referred_abortion_complications",
@@ -143,9 +143,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yabortion_complications\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yabortion_complications\\y'", 1]
+        ]
       },
       {
         "display": "referred_fever_discharge",
@@ -153,9 +153,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'", 1]
+        ]
       },
       {
         "display": "referred_other",
@@ -163,9 +163,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'", 1]
+        ]
       },
       {
         "display": "bleeding_reached_count",
@@ -173,9 +173,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\ybleeding\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\ybleeding\\y'", 1]
+        ]
       },
       {
         "display": "convulsions_reached_count",
@@ -183,9 +183,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yconvulsions\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yconvulsions\\y'", 1]
+        ]
       },
       {
         "display": "prolonged_labor_reached_count",
@@ -193,9 +193,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yprolonged_labor\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yprolonged_labor\\y'", 1]
+        ]
       },
       {
         "display": "abort_comp_reached_count",
@@ -203,9 +203,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND referral_health_problem ~ '\\yabortion_complications\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND referral_health_problem ~ '\\yabortion_complications\\y'", 1]
+        ]
       },
       {
         "display": "fever_discharge_reached_count",
@@ -213,9 +213,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')", 1]
+        ]
       },
       {
         "display": "other_reached_count",
@@ -223,9 +223,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 1 AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 1 AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_1_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_1_person_cases.json
@@ -106,9 +106,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL": 1
-        }
+        "whens": [
+          ["closed_on IS NULL", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2a_person_cases.json
@@ -113,9 +113,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -124,9 +124,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident = 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident = 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -135,9 +135,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -146,9 +146,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -157,9 +157,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -168,9 +168,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -179,9 +179,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -190,9 +190,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -201,9 +201,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -212,9 +212,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -223,9 +223,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -234,9 +234,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -245,9 +245,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND age_at_death_yrs >= 11": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND age_at_death_yrs >= 11", 1]
+        ],
         "else_": 0
       },
       {
@@ -256,9 +256,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND age_at_death_yrs >= 11": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND age_at_death_yrs >= 11", 1]
+        ],
         "else_": 0
       },
       {
@@ -267,9 +267,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pregnant' AND resident = 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pregnant' AND resident = 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -278,9 +278,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM  1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pregnant' AND resident IS DISTINCT FROM  1", 1]
+        ],
         "else_": 0
       },
       {
@@ -289,9 +289,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'delivery' AND resident = 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'delivery' AND resident = 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -300,9 +300,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'delivery' AND resident IS DISTINCT FROM 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -311,9 +311,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pnc' AND resident = 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pnc' AND resident = 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -322,9 +322,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pnc' AND resident IS DISTINCT FROM 1", 1]
+        ],
         "else_": 0
       }
     ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
@@ -110,9 +110,9 @@
         "column_id": "dead_preg_count",
         "type": "sum_when",
         "aggregation": "sum",
-        "whens": {
-          "female_death_type IS NOT NULL AND age_at_death_yrs >= 11": 1
-        },
+        "whens": [
+          ["female_death_type IS NOT NULL AND age_at_death_yrs >= 11", 1]
+        ],
         "else_": 0,
         "visible": false
       },

--- a/custom/icds_reports/ucr/reports/mpr/mpr_3i_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_3i_person_cases.json
@@ -113,9 +113,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident = 1", 1]
+        ]
       },
       {
         "display": "pregnant_migrant_count",
@@ -123,9 +123,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident != 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident != 1", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_3ii_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_3ii_person_cases.json
@@ -127,9 +127,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' AND resident = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' AND resident = 1", 1]
+        ]
       },
       {
         "display": "M_resident_count",
@@ -137,9 +137,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') AND resident = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') AND resident = 1", 1]
+        ]
       },
       {
         "display": "F_migrant_count",
@@ -147,9 +147,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' AND resident != 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' AND resident != 1", 1]
+        ]
       },
       {
         "display": "M_migrant_count",
@@ -157,9 +157,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') AND resident != 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') AND resident != 1", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_10a_children_referred.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_10a_children_referred.json
@@ -119,9 +119,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ypremature\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ypremature\\y'", 1]
+        ]
       },
       {
         "display": "referred_sepsis",
@@ -129,9 +129,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ysepsis\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ysepsis\\y'", 1]
+        ]
       },
       {
         "display": "referred_diarrhoea",
@@ -139,9 +139,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ydiarrhoea\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ydiarrhoea\\y'", 1]
+        ]
       },
       {
         "display": "referred_pneumonia",
@@ -149,9 +149,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ypneumonia\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ypneumonia\\y'", 1]
+        ]
       },
       {
         "display": "referred_fever_child",
@@ -159,9 +159,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yfever_child\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yfever_child\\y'", 1]
+        ]
       },
       {
         "display": "referred_severely_underweight",
@@ -169,9 +169,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yseverely_underweight\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yseverely_underweight\\y'", 1]
+        ]
       },
       {
         "display": "referred_other_child",
@@ -179,9 +179,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yother_child\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yother_child\\y'", 1]
+        ]
       },
       {
         "display": "premature_reached_count",
@@ -189,9 +189,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypremature\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypremature\\y'", 1]
+        ]
       },
       {
         "display": "sepsis_reached_count",
@@ -199,9 +199,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ysepsis\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ysepsis\\y'", 1]
+        ]
       },
       {
         "display": "diarrhoea_reached_count",
@@ -209,9 +209,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ydiarrhoea\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ydiarrhoea\\y'", 1]
+        ]
       },
       {
         "display": "pneumonia_reached_count",
@@ -219,9 +219,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypneumonia\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ypneumonia\\y'", 1]
+        ]
       },
       {
         "display": "fever_child_reached_count",
@@ -229,9 +229,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yfever_child\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yfever_child\\y'", 1]
+        ]
       },
       {
         "display": "sev_underweight_reached_count",
@@ -239,9 +239,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yseverely_underweight\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yseverely_underweight\\y'", 1]
+        ]
       },
       {
         "display": "other_child_reached_count",
@@ -249,9 +249,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yother_child\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yother_child\\y'", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_10b_pregnancies_referred.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_10b_pregnancies_referred.json
@@ -119,9 +119,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\ybleeding\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\ybleeding\\y'", 1]
+        ]
       },
       {
         "display": "referred_convulsions",
@@ -129,9 +129,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yconvulsions\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yconvulsions\\y'", 1]
+        ]
       },
       {
         "display": "referred_prolonged_labor",
@@ -139,9 +139,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yprolonged_labor\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yprolonged_labor\\y'", 1]
+        ]
       },
       {
         "display": "referred_abortion_complications",
@@ -149,9 +149,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yabortion_complications\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yabortion_complications\\y'", 1]
+        ]
       },
       {
         "display": "referred_fever_discharge",
@@ -159,9 +159,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y'", 1]
+        ]
       },
       {
         "display": "referred_other",
@@ -169,9 +169,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'": 1
-        }
+        "whens": [
+          ["referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y' OR referral_health_problem ~ '\\yother\\y'", 1]
+        ]
       },
       {
         "display": "bleeding_reached_count",
@@ -179,9 +179,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ybleeding\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\ybleeding\\y'", 1]
+        ]
       },
       {
         "display": "convulsions_reached_count",
@@ -189,9 +189,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yconvulsions\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yconvulsions\\y'", 1]
+        ]
       },
       {
         "display": "prolonged_labor_reached_count",
@@ -199,9 +199,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yprolonged_labor\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yprolonged_labor\\y'", 1]
+        ]
       },
       {
         "display": "abort_comp_reached_count",
@@ -209,9 +209,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yabortion_complications\\y'": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND referral_health_problem ~ '\\yabortion_complications\\y'", 1]
+        ]
       },
       {
         "display": "fever_discharge_reached_count",
@@ -219,9 +219,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yfever\\y' OR referral_health_problem ~ '\\yoffensive_discharge\\y')", 1]
+        ]
       },
       {
         "display": "other_reached_count",
@@ -229,9 +229,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')": 1
-        }
+        "whens": [
+          ["referral_reached_facility = 'yes' AND (referral_health_problem ~ '\\yother\\y' OR referral_health_problem ~ '\\yswelling\\y' OR referral_health_problem ~ '\\yblurred_vision\\y')", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_2a_deaths.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_2a_deaths.json
@@ -140,9 +140,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -151,9 +151,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident = 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident = 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -162,9 +162,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -173,9 +173,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob <= 28", 1]
+        ],
         "else_": 0
       },
       {
@@ -184,9 +184,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -195,9 +195,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -206,9 +206,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -217,9 +217,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 29 AND 364", 1]
+        ],
         "else_": 0
       },
       {
@@ -228,9 +228,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -239,9 +239,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident = 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -250,9 +250,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -261,9 +261,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826": 1
-        },
+        "whens": [
+          ["sex = 'M' AND resident IS DISTINCT FROM 1 AND date_death - dob BETWEEN 365 AND 1826", 1]
+        ],
         "else_": 0
       },
       {
@@ -272,9 +272,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident IS DISTINCT FROM 1 AND age_at_death_yrs >= 11": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident IS DISTINCT FROM 1 AND age_at_death_yrs >= 11", 1]
+        ],
         "else_": 0
       },
       {
@@ -283,9 +283,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "sex = 'F' AND resident = 1 AND age_at_death_yrs >= 11": 1
-        },
+        "whens": [
+          ["sex = 'F' AND resident = 1 AND age_at_death_yrs >= 11", 1]
+        ],
         "else_": 0
       },
       {
@@ -294,9 +294,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pregnant' AND resident = 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pregnant' AND resident = 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -305,9 +305,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pregnant' AND resident IS DISTINCT FROM 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pregnant' AND resident IS DISTINCT FROM 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -316,9 +316,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'delivery' AND resident = 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'delivery' AND resident = 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -327,9 +327,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'delivery' AND resident IS DISTINCT FROM 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'delivery' AND resident IS DISTINCT FROM 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -338,9 +338,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pnc' AND resident = 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pnc' AND resident = 1", 1]
+        ],
         "else_": 0
       },
       {
@@ -349,9 +349,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "female_death_type = 'pnc' AND resident IS DISTINCT FROM 1": 1
-        },
+        "whens": [
+          ["female_death_type = 'pnc' AND resident IS DISTINCT FROM 1", 1]
+        ],
         "else_": 0
       }
     ],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3_children_registered.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3_children_registered.json
@@ -138,9 +138,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' AND resident = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' AND resident = 1", 1]
+        ]
       },
       {
         "display": "M_resident_count",
@@ -148,9 +148,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') AND resident = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') AND resident = 1", 1]
+        ]
       },
       {
         "display": "F_migrant_count",
@@ -158,9 +158,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex = 'F' AND resident IS DISTINCT FROM 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex = 'F' AND resident IS DISTINCT FROM 1", 1]
+        ]
       },
       {
         "display": "M_migrant_count",
@@ -168,9 +168,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND sex IN ('M', 'O') AND resident IS DISTINCT FROM 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND sex IN ('M', 'O') AND resident IS DISTINCT FROM 1", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3i_pregnancies.json
+++ b/custom/icds_reports/ucr/reports/mpr/ucr_v2/mpr_3i_pregnancies.json
@@ -119,9 +119,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident = 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident = 1", 1]
+        ]
       },
       {
         "display": "pregnant_migrant_count",
@@ -129,9 +129,9 @@
         "type": "sum_when",
         "aggregation": "sum",
         "calculate_total": true,
-        "whens": {
-          "closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident != 1": 1
-        }
+        "whens": [
+          ["closed_on IS NULL AND is_pregnant = 1 and sex = 'F' AND resident != 1", 1]
+        ]
       }
     ],
     "sort_expression": [],

--- a/custom/up_nrhm/sql_data.py
+++ b/custom/up_nrhm/sql_data.py
@@ -157,45 +157,45 @@ class ASHAFacilitatorsData(SqlData):
             ),
             DatabaseColumn(
                 _("Newborn visits within first day of birth in case of home deliveries"),
-                FunctionalityChecklistColumn('hv_fx_home_birth_visits', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_home_birth_visits', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Set of home visits for newborn care as specified in the HBNC guidelines<br/>"
                   "(six visits in case of Institutional delivery and seven in case of a home delivery)"),
-                FunctionalityChecklistColumn('hv_fx_newborns_visited', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_newborns_visited', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Attending VHNDs/Promoting immunization"),
-                FunctionalityChecklistColumn('hv_fx_vhnd', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_vhnd', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Supporting institutional delivery"),
-                FunctionalityChecklistColumn('hv_fx_support_inst_delivery', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_support_inst_delivery', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Management of childhood illness - especially diarrhea and pneumonia"),
-                FunctionalityChecklistColumn('hv_fx_child_illness_mgmt', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_child_illness_mgmt', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Household visits with nutrition counseling"),
-                FunctionalityChecklistColumn('hv_fx_nut_counseling', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_nut_counseling', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Fever cases seen/malaria slides made in malaria endemic area"),
-                FunctionalityChecklistColumn('hv_fx_malaria', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_malaria', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Acting as DOTS provider"),
-                FunctionalityChecklistColumn('hv_fx_dots', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_dots', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Holding or attending village/VHSNC meeting"),
-                FunctionalityChecklistColumn('hv_fx_vhsnc', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_vhsnc', whens=[[1, 1]]),
             ),
             DatabaseColumn(
                 _("Successful referral of the IUD, "
                   "female sterilization or male sterilization cases and/or providing OCPs/Condoms"),
-                FunctionalityChecklistColumn('hv_fx_fp', whens={1: 1}),
+                FunctionalityChecklistColumn('hv_fx_fp', whens=[[1, 1]]),
             ),
             AggregateColumn(
                 _("<b>Total number of ASHAs who are functional on at least %s of the tasks</b>") % "60%",
@@ -205,7 +205,7 @@ class ASHAFacilitatorsData(SqlData):
                 },
                 columns=[
                     FunctionalityChecklistColumn(
-                        whens={'hv_percent_functionality >= 60': 1},
+                        whens=[['hv_percent_functionality >= 60', 1]],
                         alias='percent_functionality'),
                     AliasColumn('total_ashas_checklist')
                 ],

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -187,7 +187,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.10
 sqlparse==0.3.0           # via django-debug-toolbar

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -152,7 +152,7 @@ simplejson==3.16.0
 six==1.13.0
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy==1.3.10
 stripe==1.67.0
 suds-jurko==0.6

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -138,7 +138,7 @@ simplejson==3.16.0
 six==1.13.0
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy==1.3.10
 stripe==1.67.0
 suds-jurko==0.6

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -152,7 +152,7 @@ six==1.13.0
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.10
 stripe==1.67.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -187,7 +187,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.10
 sqlparse==0.3.0           # via django-debug-toolbar

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -152,7 +152,7 @@ simplejson==3.16.0
 six==1.13.0
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy==1.3.10
 stripe==1.67.0
 suds-jurko==0.6

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -56,7 +56,7 @@ openpyxl~=2.6
 six~=1.11
 socketpool==0.5.3
 markdown==2.2.1
-sqlagg>=0.13.0
+sqlagg>=0.14.0
 django-redis~=4.9
 redis==2.10.6
 redis-py-cluster==1.3.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -138,7 +138,7 @@ simplejson==3.16.0
 six==1.13.0
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy==1.3.10
 stripe==1.67.0
 suds-jurko==0.6

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -152,7 +152,7 @@ six==1.13.0
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.13.0
+sqlagg==0.14.0
 sqlalchemy-postgres-copy==0.5.0
 sqlalchemy==1.3.10
 stripe==1.67.0


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-871

##### SUMMARY
This adds a variation on SumWhen columns that accepts a templated expression with parameters. This will allow ICDS's static reports to be written as dynamic reports; standard sum whens aren't allowed in dynamic UCRs because of the risk of SQL injection.

This PR is a proof of concept. If it looks decent, I'll update the UCR docs and ICDS's report definitions. They have 180 sum when usages that involve ~40 distinct expressions.

This implements "Option 2" in the [writeup](https://docs.google.com/document/d/1UxS--Zb4ISyVSEore2rjiDWbA2C7PhQNwacfluzdUJE/).

Depends on https://github.com/dimagi/sql-agg/pull/60

##### FEATURE FLAG
UCR

##### PRODUCT DESCRIPTION
Probably not worth announcing, as using this functionality requires dev intervention.