### PR TITLE
Add option to migrate skipped forms

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -617,6 +617,24 @@ class CasesReceivedCounter:
         self.queue.clean_break = value
 
 
+class NoCaseDiff(object):
+
+    def __init__(self, statedb):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        pass
+
+    def update(self, case_ids, form_id):
+        pass
+
+    def enqueue(self, case_id):
+        pass
+
+
 def prune_premature_diffs(couch_cases, statedb):
     n_forms = 0
     case_ids = []

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -82,7 +82,7 @@ from corehq.util.pagination import (
 from corehq.util.timer import TimingContext
 
 from .asyncforms import AsyncFormProcessor
-from .casediff import CaseDiffProcess, CaseDiffQueue
+from .casediff import CaseDiffProcess, CaseDiffQueue, NoCaseDiff
 from .statedb import init_state_db
 from .staterebuilder import iter_unmigrated_docs
 from .system_action import do_system_action
@@ -137,7 +137,12 @@ class CouchSqlDomainMigrator(object):
         self.counter = DocCounter(self.statedb)
         if rebuild_state:
             self.statedb.is_rebuild = True
-        diff_queue = CaseDiffProcess if diff_process else CaseDiffQueue
+        if diff_process is None:
+            diff_queue = NoCaseDiff
+        elif diff_process:
+            diff_queue = CaseDiffProcess
+        else:
+            diff_queue = CaseDiffQueue
         self.case_diff_queue = diff_queue(self.statedb)
 
     def migrate(self):

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -129,6 +129,9 @@ class Command(BaseCommand):
                 local: diff cases in the migration process.
                 none: do not diff cases.
             ''')
+        parser.add_argument('--skipped-forms',
+            dest="skipped_forms", action='store_true', default=False,
+            help="Migrate forms skipped by previous migration")
         parser.add_argument('--to', dest="rewind", help="Rewind iteration state.")
 
     def handle(self, domain, action, **options):
@@ -142,6 +145,7 @@ class Command(BaseCommand):
             "live_migrate",
             "case_diff",
             "rebuild_state",
+            "skipped_forms",
             "rewind",
         ]:
             setattr(self, opt, options[opt])
@@ -173,6 +177,7 @@ class Command(BaseCommand):
             live_migrate=self.live_migrate,
             diff_process=CASE_DIFF[self.case_diff],
             rebuild_state=self.rebuild_state,
+            skipped_forms=self.skipped_forms
         )
 
         return_code = 0

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -133,7 +133,8 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
         self.assert_backend("couch", domain)
         self.migration_success = None
         options.setdefault("no_input", True)
-        options.setdefault("diff_process", False)
+        options.setdefault("case_diff", "local")
+        assert "diff_process" not in options, options  # old/invalid option
         with mock.patch(
             "corehq.form_processor.backends.sql.dbaccessors.transaction.atomic",
             atomic_savepoint,
@@ -1117,7 +1118,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.submit_form(make_test_form("arch"), timedelta(minutes=-93)).archive()
         with self.patch_migration_chunk_size(1), \
                 self.on_doc("XFormInstance", "one", interrupt, **kw):
-            self._do_migration(live=True, diff_process=True)
+            self._do_migration(live=True, case_diff="process")
         self.assert_backend("sql")
         self.assertFalse(self._get_form_ids("XFormArchived"))
 
@@ -1230,7 +1231,7 @@ class MigrationTestCase(BaseMigrationTestCase):
 
     def test_form_with_missing_xml(self):
         create_form_with_missing_xml(self.domain_name)
-        self._do_migration_and_assert_flags(self.domain_name, diff_process=True)
+        self._do_migration_and_assert_flags(self.domain_name, case_diff="process")
 
         # This may change in the future: it may be possible to rebuild the
         # XML using parsed form JSON from couch.


### PR DESCRIPTION
The new option allows a very fast scan over all forms in couch, migrating any that are not already present in SQL. The state of the iteration is removed on successful completion so it can be run multiple times.

🐡 Review by commit.