### PR TITLE
Strip loc_type name in view

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -351,6 +351,7 @@ class LocationTypesView(BaseDomainView):
             pk = loc_type['pk']
             if not _is_fake_pk(pk):
                 pks.append(loc_type['pk'])
+            loc_type['name'] = loc_type['name'].strip()
             payload_loc_type_name_by_pk[loc_type['pk']] = loc_type['name']
             if loc_type.get('code'):
                 payload_loc_type_code_by_pk[loc_type['pk']] = loc_type['code']


### PR DESCRIPTION
[Jira](https://dimagi-dev.atlassian.net/browse/SAASP-10141)

##### SUMMARY
Spaces at the end of location type names break the Edit Location form. e.g.
![facility_space](https://user-images.githubusercontent.com/708421/68666206-2a169d80-054c-11ea-8746-e3605cd1dc50.png)

This change strips spaces from the name when the location type is saved.
