### PR TITLE
make agg child indices on staging table

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
@@ -362,13 +362,12 @@ class AggChildHealthAggregationDistributedHelper(AggregationPartitionedHelper):
         """
 
     def indexes(self):
-        final_tablename = self.monthly_tablename
         staging_tablename = self.staging_tablename
         return [
-            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_1" ON "{staging_tablename}" (aggregation_level, state_id)',
-            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_2" ON "{staging_tablename}" (aggregation_level, gender)',
-            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_3" ON "{staging_tablename}" (aggregation_level, age_tranche)',
-            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_4" ON "{staging_tablename}" (aggregation_level, district_id) WHERE aggregation_level > 1',
-            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_5" ON "{staging_tablename}" (aggregation_level, block_id) WHERE aggregation_level > 2',
-            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_6" ON "{staging_tablename}" (aggregation_level, supervisor_id) WHERE aggregation_level > 3',
+            f'CREATE INDEX ON "{staging_tablename}" (aggregation_level, state_id)',
+            f'CREATE INDEX ON "{staging_tablename}" (aggregation_level, gender)',
+            f'CREATE INDEX ON "{staging_tablename}" (aggregation_level, age_tranche)',
+            f'CREATE INDEX ON "{staging_tablename}" (aggregation_level, district_id) WHERE aggregation_level > 1',
+            f'CREATE INDEX ON "{staging_tablename}" (aggregation_level, block_id) WHERE aggregation_level > 2',
+            f'CREATE INDEX ON "{staging_tablename}" (aggregation_level, supervisor_id) WHERE aggregation_level > 3',
         ]

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
@@ -362,12 +362,13 @@ class AggChildHealthAggregationDistributedHelper(AggregationPartitionedHelper):
         """
 
     def indexes(self):
-        tablename = self.monthly_tablename
+        final_tablename = self.monthly_tablename
+        staging_tablename = self.staging_tablename
         return [
-            f'CREATE INDEX IF NOT EXISTS "{tablename}_idx_1" ON "{tablename}" (aggregation_level, state_id)',
-            f'CREATE INDEX IF NOT EXISTS "{tablename}_idx_2" ON "{tablename}" (aggregation_level, gender)',
-            f'CREATE INDEX IF NOT EXISTS "{tablename}_idx_3" ON "{tablename}" (aggregation_level, age_tranche)',
-            f'CREATE INDEX IF NOT EXISTS "{tablename}_idx_4" ON "{tablename}" (aggregation_level, district_id) WHERE aggregation_level > 1',
-            f'CREATE INDEX IF NOT EXISTS "{tablename}_idx_5" ON "{tablename}" (aggregation_level, block_id) WHERE aggregation_level > 2',
-            f'CREATE INDEX IF NOT EXISTS "{tablename}_idx_6" ON "{tablename}" (aggregation_level, supervisor_id) WHERE aggregation_level > 3',
+            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_1" ON "{staging_tablename}" (aggregation_level, state_id)',
+            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_2" ON "{staging_tablename}" (aggregation_level, gender)',
+            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_3" ON "{staging_tablename}" (aggregation_level, age_tranche)',
+            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_4" ON "{staging_tablename}" (aggregation_level, district_id) WHERE aggregation_level > 1',
+            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_5" ON "{staging_tablename}" (aggregation_level, block_id) WHERE aggregation_level > 2',
+            f'CREATE INDEX IF NOT EXISTS "{final_tablename}_idx_6" ON "{staging_tablename}" (aggregation_level, supervisor_id) WHERE aggregation_level > 3',
         ]

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
@@ -404,17 +404,17 @@ DROP TABLE IF EXISTS staging_agg_child_health
 {}
 DROP TABLE IF EXISTS "previous_agg_child_health_2019-01-01"
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_1" ON "agg_child_health_2019-01-01" (aggregation_level, state_id)
+CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_1" ON "staging_agg_child_health" (aggregation_level, state_id)
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_2" ON "agg_child_health_2019-01-01" (aggregation_level, gender)
+CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_2" ON "staging_agg_child_health" (aggregation_level, gender)
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_3" ON "agg_child_health_2019-01-01" (aggregation_level, age_tranche)
+CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_3" ON "staging_agg_child_health" (aggregation_level, age_tranche)
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_4" ON "agg_child_health_2019-01-01" (aggregation_level, district_id) WHERE aggregation_level > 1
+CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_4" ON "staging_agg_child_health" (aggregation_level, district_id) WHERE aggregation_level > 1
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_5" ON "agg_child_health_2019-01-01" (aggregation_level, block_id) WHERE aggregation_level > 2
+CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_5" ON "staging_agg_child_health" (aggregation_level, block_id) WHERE aggregation_level > 2
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_6" ON "agg_child_health_2019-01-01" (aggregation_level, supervisor_id) WHERE aggregation_level > 3
+CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_6" ON "staging_agg_child_health" (aggregation_level, supervisor_id) WHERE aggregation_level > 3
 {}
 DROP TABLE IF EXISTS "agg_child_health_2019-01-01_1"
 {}

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
@@ -404,17 +404,17 @@ DROP TABLE IF EXISTS staging_agg_child_health
 {}
 DROP TABLE IF EXISTS "previous_agg_child_health_2019-01-01"
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_1" ON "staging_agg_child_health" (aggregation_level, state_id)
+CREATE INDEX ON "staging_agg_child_health" (aggregation_level, state_id)
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_2" ON "staging_agg_child_health" (aggregation_level, gender)
+CREATE INDEX ON "staging_agg_child_health" (aggregation_level, gender)
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_3" ON "staging_agg_child_health" (aggregation_level, age_tranche)
+CREATE INDEX ON "staging_agg_child_health" (aggregation_level, age_tranche)
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_4" ON "staging_agg_child_health" (aggregation_level, district_id) WHERE aggregation_level > 1
+CREATE INDEX ON "staging_agg_child_health" (aggregation_level, district_id) WHERE aggregation_level > 1
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_5" ON "staging_agg_child_health" (aggregation_level, block_id) WHERE aggregation_level > 2
+CREATE INDEX ON "staging_agg_child_health" (aggregation_level, block_id) WHERE aggregation_level > 2
 {}
-CREATE INDEX IF NOT EXISTS "agg_child_health_2019-01-01_idx_6" ON "staging_agg_child_health" (aggregation_level, supervisor_id) WHERE aggregation_level > 3
+CREATE INDEX ON "staging_agg_child_health" (aggregation_level, supervisor_id) WHERE aggregation_level > 3
 {}
 DROP TABLE IF EXISTS "agg_child_health_2019-01-01_1"
 {}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We were creating the indices on the existing table rather than the staging table, so after the rename, the indices did not exist.