### PR TITLE
Updated info about Dimagi-only test subscription

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2041,12 +2041,13 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
 
         self.helper = hqcrispy.HQFormHelper()
         self.helper.layout = crispy.Layout(
-            crispy.HTML(ugettext_noop(
+            crispy.HTML('<div class="alert alert-info">' + ugettext_noop(
                 '<i class="fa fa-info-circle"></i> You will have access to all '
                 'features for free as soon as you hit "Update".  Please make '
                 'sure this is an internal Dimagi test space, not in use by a '
-                'partner.'
-            )),
+                'partner.<br>Test projects belong to Dimagi and are not subject to '
+                'Dimagi\'s external terms of service.'
+            ) + '</div>'),
             *self.form_actions
         )
 


### PR DESCRIPTION
Based on slack conversation around deleting test domains of former employees.

before
<img width="829" alt="Screen Shot 2019-11-12 at 6 23 51 PM" src="https://user-images.githubusercontent.com/1486591/68719402-e89ce700-0579-11ea-98f9-c0dfe6d91221.png">

after
<img width="1119" alt="Screen Shot 2019-11-12 at 6 21 16 PM" src="https://user-images.githubusercontent.com/1486591/68719412-f05c8b80-0579-11ea-8d4b-1de9f4493c01.png">

fyi @ctsims 