### PR TITLE
Removed LOGIN_AS_ALWAYS_OFF feature flag

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -263,9 +263,6 @@ def can_use_restore_as(request):
     if request.couch_user.is_superuser:
         return True
 
-    if toggles.LOGIN_AS_ALWAYS_OFF.enabled(request.domain):
-        return False
-
     return (
         request.couch_user.can_edit_commcare_users() and
         has_privilege(request, privileges.LOGIN_AS)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1377,13 +1377,6 @@ PAGINATED_EXPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-LOGIN_AS_ALWAYS_OFF = StaticToggle(
-    'always_turn_login_as_off',
-    'Always turn login as off',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN]
-)
-
 PUBLISH_CUSTOM_REPORTS = StaticToggle(
     'publish_custom_reports',
     "Publish custom reports (No needed Authorization)",


### PR DESCRIPTION
##### SUMMARY
This was originally added as a temporary flag for ICDS in https://github.com/dimagi/commcare-hq/pull/15749

No one is using it anymore.

##### FEATURE FLAG
Always turn login as off