### PR TITLE
Speed up User API with an ES backend (under a toggle)

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -5,7 +5,7 @@ from tastypie.exceptions import BadRequest
 
 from dimagi.utils.parsing import string_to_boolean
 
-from corehq.apps.api.query_adapters import UserQuerySetAdapter
+from corehq.apps.api.query_adapters import UserQuerySetAdapterCouch
 from corehq.apps.api.resources import (
     CouchResourceMixin,
     DomainSpecificResourceMixin,
@@ -105,7 +105,7 @@ class CommCareUserResource(UserResource):
                 raise BadRequest('Project %s has no group with id=%s' % (domain, group_id))
             return list(group.get_users(only_commcare=True))
         else:
-            return UserQuerySetAdapter(domain, show_archived=show_archived)
+            return UserQuerySetAdapterCouch(domain, show_archived=show_archived)
 
 
 class WebUserResource(UserResource):

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -39,6 +39,18 @@ class TestCommCareUserResource(APIResourceTest):
         api_users = json.loads(response.content)['objects']
         self.assertEqual(len(api_users), 1)
         self.assertEqual(api_users[0]['id'], backend_id)
+        self.assertEqual(api_users[0], {
+            'default_phone_number': None,
+            'email': '',
+            'first_name': '',
+            'groups': [],
+            'id': backend_id,
+            'last_name': '',
+            'phone_numbers': [],
+            'resource_uri': '/a/qwerty/api/v0.5/user/{}/'.format(backend_id),
+            'user_data': {'commcare_project': 'qwerty'},
+            'username': 'fake_user'
+        })
 
     @flaky
     def test_get_single(self):
@@ -52,6 +64,18 @@ class TestCommCareUserResource(APIResourceTest):
 
         api_user = json.loads(response.content)
         self.assertEqual(api_user['id'], backend_id)
+        self.assertEqual(api_user, {
+            'default_phone_number': None,
+            'email': '',
+            'first_name': '',
+            'groups': [],
+            'id': backend_id,
+            'last_name': '',
+            'phone_numbers': [],
+            'resource_uri': '/a/qwerty/api/v0.5/user/{}/'.format(backend_id),
+            'user_data': {'commcare_project': 'qwerty'},
+            'username': 'fake_user',
+        })
 
     def test_create(self):
 

--- a/corehq/apps/users/analytics.py
+++ b/corehq/apps/users/analytics.py
@@ -1,5 +1,7 @@
 from corehq.apps.es import UserES
 from corehq.apps.users.models import CommCareUser
+from corehq.elastic import get_es_new
+from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.util.couch import stale_ok
 
 
@@ -11,6 +13,7 @@ def update_analytics_indexes():
     (modeled very closely after the same function in couchforms.analytics)
     """
     CommCareUser.get_db().view('users/by_domain', limit=1).all()
+    get_es_new().indices.refresh(USER_INDEX_INFO.index)
 
 
 def get_count_of_active_commcare_users_in_domain(domain):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1805,6 +1805,14 @@ GROUP_API_USE_COUCH_BACKEND = StaticToggle(
 )
 
 
+USER_API_USE_ES_BACKEND = StaticToggle(
+    'user_api_use_es_backend',
+    'Use new ES backend for User API.',
+    TAG_PRODUCT,
+    [NAMESPACE_DOMAIN, NAMESPACE_USER],
+)
+
+
 PHI_CAS_INTEGRATION = StaticToggle(
     'phi_cas_integration',
     'Integrate with PHI Api to search and validate beneficiaries',


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAASP-10105. Analogous to recent speedups made on the group API.

The plan is to test this in production against real data under this flag, and then release it with the old method under an inverse flag (USER_API_USE_ES_COUCH), and then delete the old method altogether.

##### FEATURE FLAG
USER_API_USE_ES_BACKEND

##### PRODUCT DESCRIPTION
Nothing yet, but user API speed improvements (by up to 80%!) on the way...