### PR TITLE
Revert "add notification with some info to begin with"

### DIFF
--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -11,7 +11,6 @@ from couchforms.models import DefaultAuthContext
 
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.models import ApplicationBase
-from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.receiverwrapper.exceptions import LocalSubmissionError
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.submission_post import SubmissionPost
@@ -221,22 +220,6 @@ def _submitted_by_demo_user(form_json, domain):
     return False
 
 
-def _notify_ignored_form_submission(request, user_id):
-    message = """
-        Details:
-        Method: {}
-        URL: {}
-        GET Params: {}
-        User ID: {}
-    """.format(request.method, request.get_raw_uri(), request.GET, user_id)
-    send_mail_async.delay(
-        "[%s] Unexpected practice mobile user submission received" % settings.SERVER_ENVIRONMENT,
-        message,
-        settings.DEFAULT_FROM_EMAIL,
-        ['mkangia@dimagi.com']
-    )
-
-
 def should_ignore_submission(request):
     """
     If IGNORE_ALL_DEMO_USER_SUBMISSIONS is True then ignore submission if from demo user.
@@ -254,7 +237,6 @@ def should_ignore_submission(request):
             return False
         else:
             if _submitted_by_demo_user(form_json, request.domain):
-                _notify_ignored_form_submission(request, form_json['meta']['userID'])
                 return True
 
     if not request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:


### PR DESCRIPTION
Reverts dimagi/commcare-hq#25834

This reverts the email notification i added to check on form submissions we were ignoring now on ICDS for practice mobile worker.

The issue was that the url didn't have `auth=noauth` set and hence was going through normal auth
@shubham1g5  confirmed that
on 2.36 - no_auth is only set for the practice mode (default demo user - demo_user) and not for other practice users.
Should we be adding it for all commcare version submissions before 2.44 or whichever version where this was fixed?
fyi @ctsims 