### PR TITLE
Fix single case api, broken by ES refactor

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -124,11 +124,10 @@ class ESView(View):
 
     def get_document(self, doc_id):
         try:
-            result = self.es.get(self.index, doc_id)
+            doc = self.es_interface.get_doc(self.index, '_all', doc_id)
         except NotFoundError:
             raise object_does_not_exist(self.doc_type, doc_id)
 
-        doc = result['_source']
         if doc.get('domain') != self.domain:
             raise object_does_not_exist(self.doc_type, doc_id)
 


### PR DESCRIPTION
##### SUMMARY
Broken in https://github.com/dimagi/commcare-hq/pull/25743. That stopped
saving the _id field to the ES doc source, instead adding it back in
from metadata in a wrapper. This was necessary for compatability with ES
2 because ES 2 no longer allows haivng a _id field in doc source. The
issue was that in this one place we were accessing the doc directly
instead of through the wrapper, which caused the _id field to be
missing.

Fixes https://dimagi-dev.atlassian.net/browse/SAASP-10143