### PR TITLE
Ignore weird user ids when marking latest submission.

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -14,6 +14,7 @@ from corehq.apps.users.models import (
     UserReportingMetadataStaging,
 )
 from corehq.apps.users.util import (
+    WEIRD_USER_IDS,
     filter_by_app,
     update_device_meta,
     update_latest_builds,
@@ -48,12 +49,15 @@ class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
             # the same effect, an app having has_submissions set to True.
             mark_has_submission(domain, build_id)
 
+        user_id = doc.get('form', {}).get('meta', {}).get('userID')
+        if user_id in WEIRD_USER_IDS:
+            return
+
         try:
             received_on = string_to_utc_datetime(doc.get('received_on'))
         except ValueError:
             return
 
-        user_id = doc.get('form', {}).get('meta', {}).get('userID')
         app_id = doc.get('app_id')
         version = doc.get('version')
 

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -24,6 +24,8 @@ from corehq.util.quickcache import quickcache
 
 from .interface import PillowProcessor
 
+ONE_DAY = 24 * 60 * 60
+
 
 class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
     """
@@ -77,7 +79,7 @@ class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
                 )
 
 
-@quickcache(['domain', 'build_id'], timeout=60 * 60)
+@quickcache(['domain', 'build_id'], timeout=ONE_DAY, memoize_timeout=ONE_DAY)
 def mark_has_submission(domain, build_id):
     app = None
     try:


### PR DESCRIPTION
There are quite a few errors on ICDS from [releasing "batch app status processing"](https://github.com/dimagi/commcare-cloud/pull/3390), but they are all from system forms. System forms don't make sense in this pillow because there aren't actual users associated with them. This would have been caught previously by https://github.com/dimagi/commcare-hq/blob/132f959cd72f737bc0fccd935a68a235c8e5604d/corehq/ex-submodules/pillowtop/processors/form.py#L120-L123

That code would not have been able to find a `CouchUser` with that name and would have exited early.

