### PR TITLE
CasePropertyConstantValue

### DIFF
--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -225,6 +225,11 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                                 "yes": "PRIMARY",
                                 "no": "SECONDARY"
                             }
+                        },
+                        {
+                            "doc_type": "CasePropertyConstantValue",
+                            "case_property": "code",
+                            "value": "T68 (ICD 10 - WHO)"
                         }
                     ]
                 }
@@ -369,6 +374,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
               <update>
                 <date_opened>{date_opened}</date_opened>
                 <certainty>CONFIRMED</certainty>
+                <code>T68 (ICD 10 - WHO)</code>
                 <is_primary>yes</is_primary>
               </update>
               <index>

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -218,10 +218,14 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                             "case_property": "certainty",
                         },
                         {
-                            "doc_type": "JsonPathCaseProperty",
+                            "doc_type": "JsonPathCasePropertyMap",
                             "jsonpath": "order",
-                            "case_property": "primary_or_secondary",
-                        },
+                            "case_property": "is_primary",
+                            "value_map": {
+                                "yes": "PRIMARY",
+                                "no": "SECONDARY"
+                            }
+                        }
                     ]
                 }
             }
@@ -365,7 +369,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
               <update>
                 <date_opened>{date_opened}</date_opened>
                 <certainty>CONFIRMED</certainty>
-                <primary_or_secondary>PRIMARY</primary_or_secondary>
+                <is_primary>yes</is_primary>
               </update>
               <index>
                 <parent case_type="patient" relationship="extension">test-case-id</parent>

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -18,7 +18,7 @@ from corehq.motech.value_source import (
     ConstantValue,
     FormQuestionMap,
     JsonPathCaseProperty,
-    JsonPathConstantValue,
+    CasePropertyConstantValue,
     ValueSource,
     get_form_question_values,
 )
@@ -266,11 +266,11 @@ class JsonPathCasePropertyTests(SimpleTestCase):
         self.assertEqual(external_value, ["baz", "qux"])
 
 
-class JsonPathConstantValueTests(SimpleTestCase):
+class CasePropertyConstantValueTests(SimpleTestCase):
 
     def test_one_value(self):
         json_doc = {"foo": {"bar": "baz"}}
-        value_source = JsonPathConstantValue.wrap({
+        value_source = CasePropertyConstantValue.wrap({
             "value": "qux",
             "jsonpath": "foo.bar",
         })

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -407,10 +407,10 @@ class JsonPathCasePropertyMap(CasePropertyMap, JsonPathMixin):
     pass
 
 
-class JsonPathConstantValue(ConstantValue, JsonPathMixin):
+class CasePropertyConstantValue(ConstantValue, CaseProperty):
 
-    def _get_external_value(self, external_data):
-        pass  # ConstantValue doesn't use external value
+    def get_import_value(self, external_data):
+        return self.deserialize(None)
 
 
 def get_form_question_values(form_json):


### PR DESCRIPTION
##### SUMMARY
`JsonPathConstantValue` was intended to be able to set a case property to a constant value. But it did not have a "case_property" property, and it ignored its "jsonpath" property.

The `CasePropertyConstantValue` does what it is meant to do.

(Builds on the single-commit PR #25924 )