### PR TITLE
Sort group_ids in user api to normalize the output

### DIFF
--- a/corehq/apps/api/query_adapters.py
+++ b/corehq/apps/api/query_adapters.py
@@ -67,7 +67,7 @@ class WrappedUser(CommCareUser):
     @classmethod
     def wrap(cls, data):
         self = super().wrap(data)
-        self._group_ids = data['__group_ids']
+        self._group_ids = sorted(data['__group_ids'])
         return self
 
     def get_group_ids(self):


### PR DESCRIPTION
##### SUMMARY
This will make it easier to take diffs of the API output before and after to test my new ES user API backend

Followup to https://github.com/dimagi/commcare-hq/pull/25913.

##### FEATURE FLAG
USER_API_USE_ES_BACKEND
