### PR TITLE
[Community / Trial Revamp] Update Downgrade Warnings to Paused instead of Community

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -829,7 +829,7 @@ def _apply_downgrade_process(oldest_unpaid_invoice, total, today, subscription=N
 
 def _send_downgrade_notice(invoice, context):
     send_html_email_async.delay(
-        _('Oh no! Your CommCare subscription for {} has been downgraded'.format(invoice.get_domain())),
+        _('Oh no! Your CommCare subscription for {} has been paused'.format(invoice.get_domain())),
         invoice.contact_emails,
         render_to_string('accounting/email/downgrade.html', context),
         render_to_string('accounting/email/downgrade.txt', context),
@@ -853,7 +853,7 @@ def _downgrade_domain(subscription):
 def _send_downgrade_warning(invoice, context):
     if invoice.is_customer_invoice:
         subject = _(
-            "CommCare Alert: {}'s subscriptions will be downgraded to Community Plan after tomorrow!".format(
+            "CommCare Alert: {}'s subscriptions will be paused after tomorrow!".format(
                 invoice.account.name
             ))
         subscriptions_to_downgrade = _(
@@ -862,7 +862,7 @@ def _send_downgrade_warning(invoice, context):
         bcc = None
     else:
         subject = _(
-            "CommCare Alert: {}'s subscription will be downgraded to Community Plan after tomorrow!".format(
+            "CommCare Alert: {}'s subscription will be paused after tomorrow!".format(
                 invoice.get_domain()
             ))
         subscriptions_to_downgrade = _(

--- a/corehq/apps/accounting/templates/accounting/email/30_days.html
+++ b/corehq/apps/accounting/templates/accounting/email/30_days.html
@@ -22,8 +22,8 @@
 <p>
   {% blocktrans %}
     <b><i>Please make a payment as soon as possible for the amount due.</i></b>
-    If you are not able to make a payment, your account will be downgraded to our free Community edition on {{ date_60 }}.
-    As of this date, you will lose access to all paid features and direct email support from CommCare support team.
+    If you are not able to make a payment, your subscription will be paused on {{ date_60 }}.
+    As of this date, you will lose access to your project space until you re-subscribe to a paid plan.
   {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/30_days.txt
+++ b/corehq/apps/accounting/templates/accounting/email/30_days.txt
@@ -9,8 +9,8 @@ As a reminder, payments can be made via credit card, Electronic Fund Transfer (E
 You can also pre-pay for several months at any time by following the steps at https://confluence.dimagi.com/display/commcarepublic/CommCare+Pricing+FAQs#CommCarePricingFAQs-Pre-payment
 
 Please make a payment as soon as possible for the amount due.
-If you are not able to make a payment, your account will be downgraded to our free Community edition on {{ date_60 }}.
-As of this date, you will lose access to all paid features and direct email support from CommCare support team.
+If you are not able to make a payment, your subscription will be paused on {{ date_60 }}.
+As of this date, you will lose access to your project space until you re-subscribe to a paid plan.
 
 If you have any questions or if you think your recent payments haven’t been reflected in this balance, please don’t hesitate to contact {{ contact_email }}.
 

--- a/corehq/apps/accounting/templates/accounting/email/downgrade.html
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade.html
@@ -8,7 +8,8 @@
 
 <p>
   {% blocktrans %}
-    Your CommCare project space {{ domain }} has been downgraded to the Community plan. You still have access to your data, but no longer have access to any pay-only features and direct email support.
+    Your subscription has been paused for the CommCare project space {{ domain }}.
+    You can regain access to your data and project space by re-subscribing to a plan.
   {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/downgrade.txt
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade.txt
@@ -2,7 +2,7 @@
 {% blocktrans %}
 Dear {{ domain }} administrator,
 
-Your CommCare project space {{ domain }} has been downgraded to the Community plan. You still have access to your data, but no longer have access to any pay-only features and direct email support.
+Your subscription has been paused for the CommCare project space {{ domain }}. You can regain access to your data and project space by re-subscribing to a plan.
 
 To see the full list of unpaid invoices you can follow this link: {{ statements_url }}
 As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment

--- a/corehq/apps/accounting/templates/accounting/email/downgrade_warning.html
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade_warning.html
@@ -7,7 +7,8 @@
 
 <p>
   {% blocktrans %}
-    Your CommCare {{ subscriptions_to_downgrade }} will be downgraded <b><i>after tomorrow</i></b> because your CommCare Billing Statements are more than 60 days overdue. If you do not make a payment before tomorrow, you will automatically be subscribed to the CommCare Community plan and lose access to all pay-only features and direct email support!
+    Your CommCare {{ subscriptions_to_downgrade }} will be paused <b><i>after tomorrow</i></b> because your CommCare Billing Statements are more than 60 days overdue.
+    If you do not make a payment before tomorrow, your subscription will automatically be paused and you will lose access to your project space and data until you re-subscribe to paid plan.
   {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/downgrade_warning.txt
+++ b/corehq/apps/accounting/templates/accounting/email/downgrade_warning.txt
@@ -2,7 +2,8 @@
 {% blocktrans %}
 Dear {{ domain_or_account }} administrator,
 
-Your CommCare {{ subscriptions_to_downgrade }} will be downgraded after tomorrow because your CommCare Billing Statements are more than 60 days overdue. If you do not make a payment before tomorrow, you will automatically be subscribed to the CommCare Community plan and lose access to all pay-only features and direct email support!
+Your CommCare {{ subscriptions_to_downgrade }} will be paused after tomorrow because your CommCare Billing Statements are more than 60 days overdue.
+If you do not make a payment before tomorrow, your subscription will automatically be paused and you will lose access to your project space and data until you re-subscribe to paid plan.
 
 To see the full list of unpaid invoices you can follow this link: {{ statements_url }}
 As a reminder, payments can be made via credit card, Electronic Fund Transfer (EFT), or check by following the instructions at https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment


### PR DESCRIPTION
Note this is another sub PR being merged into `bmb/saas-q4`

##### SUMMARY
In the future downgraded plans will be paused instead of downgrading to Community. This updates the language explaining that. 
