### PR TITLE
Directly put stagnant cases in terrible UCR data sources

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -697,7 +697,7 @@ def recalculate_stagnant_cases():
 
 
 def _recalculate_stagnant_cases(config_id):
-    config, is_static = get_datasource_config(config_id, DASHBOARD_USAGE_EXPORT)
+    config, is_static = get_datasource_config(config_id, DASHBOARD_DOMAIN)
     adapter = get_indicator_adapter(config, load_source='find_stagnant_cases')
     stagnant_case_ids = _find_stagnant_cases(adapter)
     num_cases = len(stagnant_case_ids)


### PR DESCRIPTION
I'm not sure why I haven't done this before. The only reason we need to "recalculate" these cases are for the two UCRs mentioned in this task, which ends up in the `AsyncIndicator` queue. Historically we've always sent them through kafka which would also force them through all other pillows introducing a lot of unnecessary work. [Originally this class required using a `Change` object when this was written](https://github.com/dimagi/commcare-hq/blob/c1068e89f1fb1157336f98b39a787752bcd22a26/corehq/apps/userreports/models.py#L751), but that hasn't been the case for some time now. Feel like a total ding dong for not thinking of this earlier