### PR TITLE
[Community/Trial Revamp] Community & Trial Banners

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1142,6 +1142,10 @@ class Subscription(models.Model):
         Subscription._get_active_subscription_by_domain.clear(Subscription, self.subscriber.domain)
 
     @property
+    def is_community(self):
+        return self.plan_version.plan.edition == SoftwarePlanEdition.COMMUNITY
+
+    @property
     def allowed_attr_changes(self):
         """
         These are the attributes of a Subscription that can always be

--- a/corehq/apps/analytics/static/analytix/js/kissmetrix.js
+++ b/corehq/apps/analytics/static/analytix/js/kissmetrix.js
@@ -183,7 +183,7 @@ hqDefine('analytix/js/kissmetrix', [
     */
     _ready.done(function () {
         trackOutboundLink("#cta-trial-days-remaining", "clicked on Days Remaining CTA in trial banner", {});
-        internalClick('#cta-trial-tour-button', 'clicked Get Tour CTA in trial banner', {});
+        trackOutboundLink("#cta-community-sub", "clicked on Subscribe to Professional Plan in Community Banner", {});
     });
 
     return {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -19,7 +19,7 @@ hqDefine("cloudcare/js/formplayer/main", function () {
 
         var $menuToggle = $('#commcare-menu-toggle'),
             $navbar = $('#hq-navigation'),
-            $trialBanner = $('#cta-get-demo-banner');
+            $trialBanner = $('#cta-trial-banner');
         var hideMenu = function () {
             $menuToggle.data('minimized', 'yes');
             $navbar.hide();

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -183,8 +183,11 @@
     {% endif %}
     {% block background_content %}{% endblock %}
     {% maintenance_alert request %}
-    {% if request.user.is_authenticated and is_demo_visible %}
-      {% include "hqwebapp/partials/get_demo_banner.html" %}
+    {% if show_trial_banner %}
+      {% include "hqwebapp/partials/trial_banner.html" %}
+    {% endif %}
+    {% if show_community_banner %}
+      {% include "hqwebapp/partials/community_banner.html" %}
     {% endif %}
     <div class="hq-container">
       {% block navigation %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/community_banner.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/community_banner.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+
+<div class="alert alert-warning alert-trial" id="cta-community-banner">
+  <i class="fa fa-info-circle"></i>
+  {% url 'domain_subscription_view' domain as url_sub %}
+  {% blocktrans %}
+    You are on the CommCare Community Plan.
+    <a href="{{ url_sub }}" id="cta-community-sub">Subscribe to a professional plan</a>.
+  {% endblocktrans %}
+</div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/trial_banner.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/trial_banner.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-<div class="alert alert-warning alert-trial" id="cta-get-demo-banner">
+<div class="alert alert-warning alert-trial" id="cta-trial-banner">
   <i class="fa fa-info-circle"></i>
   {% url 'domain_subscription_view' domain as url_sub %}
   {% with num_trial_days_remaining|pluralize as days_plural %}
@@ -9,12 +9,6 @@
       You have <a href="{{ url_sub }}" id="cta-trial-days-remaining">{{ num_trial_days_remaining }}
       day{{ days_plural }} remaining</a> in
       your CommCare Trial.
-      Have questions?
     {% endblocktrans %}
-    &nbsp;&nbsp;&nbsp;
-    <a href="#cta-form-get-demo"
-       class="btn btn-purple"
-       id="cta-trial-tour-button"
-       data-toggle="modal">{% trans 'Get A Tour' %}</a>
   {% endwith %}
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/trial_banner.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/trial_banner.html
@@ -4,11 +4,17 @@
 <div class="alert alert-warning alert-trial" id="cta-trial-banner">
   <i class="fa fa-info-circle"></i>
   {% url 'domain_subscription_view' domain as url_sub %}
-  {% with num_trial_days_remaining|pluralize as days_plural %}
+  {% if num_trial_days_remaining %}
+    {% with num_trial_days_remaining|pluralize as days_plural %}
+      {% blocktrans %}
+        You have <a href="{{ url_sub }}" id="cta-trial-days-remaining">{{ num_trial_days_remaining }}
+        day{{ days_plural }} remaining</a> in
+        your CommCare {{ trial_edition }} Edition Trial.
+      {% endblocktrans %}
+    {% endwith %}
+  {% else %}
     {% blocktrans %}
-      You have <a href="{{ url_sub }}" id="cta-trial-days-remaining">{{ num_trial_days_remaining }}
-      day{{ days_plural }} remaining</a> in
-      your CommCare Trial.
+        You are on a <a href="{{ url_sub }}" id="cta-trial-days-remaining">trial</a> of CommCare {{ trial_edition }} Edition.
     {% endblocktrans %}
-  {% endwith %}
+  {% endif %}
 </div>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1652,13 +1652,6 @@ PARTIAL_UI_TRANSLATIONS = StaticToggle(
 )
 
 
-DEMO_WORKFLOW_V2_AB_VARIANT = DynamicallyPredictablyRandomToggle(
-    'demo_workflow_v2_ab_variant',
-    'Enables the "variant" version of the Demo Workflow A/B test after login',
-    TAG_INTERNAL,
-    namespaces=[NAMESPACE_USER],
-)
-
 PARALLEL_MPR_ASR_REPORT = StaticToggle(
     'parallel_mpr_asr_report',
     'Release parallel loading of MPR and ASR report',

--- a/settings.py
+++ b/settings.py
@@ -1000,6 +1000,7 @@ TEMPLATES = [
                 'corehq.util.context_processors.enterprise_mode',
                 'corehq.util.context_processors.mobile_experience',
                 'corehq.util.context_processors.get_demo',
+                'corehq.util.context_processors.banners',
                 'corehq.util.context_processors.js_api_keys',
                 'corehq.util.context_processors.js_toggles',
                 'corehq.util.context_processors.websockets_override',


### PR DESCRIPTION
Note that this merges into `bmb/saas-q4-models`, as it's dependent on those changes.

##### SUMMARY
This PR implements a banner on community plans that shows that they are in a trial. It also replaces the demo banner with a trial notification banner for plans that are on trial.

Note: I discovered that we have multiple ways of how we designate something a trial. There is either a boolean `is_trial` set on `Subscription` or a `service_type` on the `Subscription` set to `SubscriptionType.TRIAL` or `SubscriptionType.EXTENDED_TRIAL`. I suspect the boolean `is_trial` was only for the former automated `Advanced` trial, as there is no checkbox in the billing UI to set it—you may only set the `SubscriptionType` (`service_type`). I don't want to tackle this issue right now, but we should probably consider this for the billing backlog.

banner for community
![Screen Shot 2019-11-14 at 10 29 35 AM](https://user-images.githubusercontent.com/716573/68883916-a38ec700-06d7-11ea-8542-1cab9a5df61a.png)

banner for trial
![Screen Shot 2019-11-14 at 11 58 10 AM](https://user-images.githubusercontent.com/716573/68883917-a38ec700-06d7-11ea-8b3d-4f8d99bcded2.png)

banner for trial without end date present
![Screen Shot 2019-11-14 at 11 59 41 AM](https://user-images.githubusercontent.com/716573/68883919-a38ec700-06d7-11ea-81c2-115b0523dcc9.png)