### PR TITLE
Added output to preindex_everything --check

### DIFF
--- a/corehq/apps/hqadmin/management/commands/preindex_everything.py
+++ b/corehq/apps/hqadmin/management/commands/preindex_everything.py
@@ -56,7 +56,11 @@ class Command(BaseCommand):
         head = git_snapshot['commits'][0]
 
         if options['check']:
-            exit(0 if get_preindex_complete(head) else 1)
+            if get_preindex_complete(head):
+                print("Preindex is complete")
+                exit(0)
+            print("Preindex is not yet complete")
+            exit(1)
 
         if get_preindex_complete(head) and email:
             mail_admins('Already preindexed', "Skipping this step")

--- a/corehq/apps/hqadmin/management/commands/preindex_everything.py
+++ b/corehq/apps/hqadmin/management/commands/preindex_everything.py
@@ -59,7 +59,10 @@ class Command(BaseCommand):
             if get_preindex_complete(head):
                 print("Preindex is complete")
                 exit(0)
-            print("Preindex is not yet complete")
+            print("Preindex is not yet complete.")
+            print("")
+            print("  It could either still be running (most common),")
+            print("  or it could have died without completing (less common).")
             exit(1)
 
         if get_preindex_complete(head) and email:


### PR DESCRIPTION
https://github.com/dimagi/commcare-cloud/pull/3394/ reminded me of this - it'd be nice to not need to remember how to check the return code.