### PR TITLE
[Community/Trial Revamp] Allowing Pausing of Plans and improvements to self-service subscription workflow

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1778,15 +1778,15 @@ class EnterprisePlanContactForm(forms.Form):
             'company_name',
             'message',
             hqcrispy.FormActions(
-                StrictButton(
-                    _("Request Quote"),
-                    type="submit",
-                    css_class="btn-primary",
-                ),
                 hqcrispy.LinkButton(
                     _("Select different plan"),
                     reverse(SelectPlanView.urlname, args=[self.domain]),
                     css_class="btn btn-default"
+                ),
+                StrictButton(
+                    _("Request Quote"),
+                    type="submit",
+                    css_class="btn-primary",
                 ),
             )
         )
@@ -1848,15 +1848,15 @@ class AnnualPlanContactForm(forms.Form):
             'company_name',
             'message',
             hqcrispy.FormActions(
-                StrictButton(
-                    _("Submit"),
-                    type="submit",
-                    css_class="btn-primary",
-                ),
                 hqcrispy.LinkButton(
                     _(back_button_text),
                     reverse(urlname, args=[self.domain]),
                     css_class="btn btn-default"
+                ),
+                StrictButton(
+                    _("Submit"),
+                    type="submit",
+                    css_class="btn-primary",
                 ),
             )
         )

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -18,22 +18,28 @@ hqDefine('accounting/js/confirm_plan', [
     var MORE_FEATURES = gettext("I need additional/custom features");
     var OTHER = gettext("Other");
 
-    var confirmPlanModel = function (isUpgrade, currentPlan) {
+    var confirmPlanModel = function (isUpgrade, isSameEdition, isPaused, currentPlan) {
         'use strict';
         var self = {};
 
         self.isUpgrade = isUpgrade;
+        self.isSameEdition = isSameEdition;
+        self.isPaused = isPaused;
         self.currentPlan = currentPlan;
 
         // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
-        self.userAgreementSigned = ko.observable(!isUpgrade);
+        self.oUserAgreementSigned = ko.observable(!(isUpgrade || isSameEdition));
 
         self.downgradeReasonList = [
             PROJECT_ENDED,
             FUNDING_ENDED,
-            CONTINUE_COMMCARE,
             SWITCH_TOOLS,
         ];
+
+        if (!self.isPaused) {
+            self.downgradeReasonList.push(CONTINUE_COMMCARE);
+        }
+
         self.newToolReasonList = [
             BUDGET_REASONS,
             LIMITED_FEATURES,
@@ -41,37 +47,38 @@ hqDefine('accounting/js/confirm_plan', [
             OTHER,
         ];
 
-        self.downgradeReason = ko.observable("");
-        self.newTool = ko.observable("");
-        self.newToolReason = ko.observable("");
-        self.otherNewToolReason = ko.observable("");
-        self.requiredQuestionsAnswered = ko.observable(false);
+        self.oDowngradeReason = ko.observableArray();
+        self.oNewTool = ko.observable("");
+        self.oNewToolReason = ko.observableArray();
+        self.oOtherNewToolReason = ko.observable("");
+        self.oWillProjectRestart = ko.observable("");
+        self.oFeedback = ko.observable("");
 
-        self.projectEnded = ko.computed(function () {
-            return self.downgradeReason() === PROJECT_ENDED;
+        self.oProjectEnded = ko.computed(function () {
+            return _.contains(self.oDowngradeReason(), PROJECT_ENDED);
         });
-        self.newToolNeeded = ko.computed(function () {
-            return self.downgradeReason() === SWITCH_TOOLS;
+        self.oNewToolNeeded = ko.computed(function () {
+            return _.contains(self.oDowngradeReason(), SWITCH_TOOLS);
         });
-        self.otherSelected = ko.computed(function () {
-            return self.newToolReason() === OTHER;
+        self.oOtherSelected = ko.computed(function () {
+            return _.contains(self.oNewToolReason(), OTHER);
         });
-        self.requiredQuestionsAnswered = ko.computed(function () {
-            if (!self.downgradeReason()) {
+        self.oRequiredQuestionsAnswered = ko.computed(function () {
+            if (!self.oDowngradeReason()) {
                 return false;
             }
-            var newToolNeeded = self.downgradeReason() === SWITCH_TOOLS;
-            var newToolAnswered = self.newTool() !== "";
-            var newToolReasonAnswered = (self.newToolReason() && self.newToolReason() !== OTHER) ||
-                (self.otherNewToolReason() && self.newToolReason() === OTHER);
+            var newToolNeeded = _.contains(self.oDowngradeReason(), SWITCH_TOOLS),
+                newToolAnswered = self.oNewTool() !== "",
+                newToolReasonAnswered = (self.oNewToolReason() && !_.contains(self.oNewToolReason(), OTHER))
+                    || (self.oOtherNewToolReason() && _.contains(self.oNewToolReason(), OTHER));
 
-            return (self.downgradeReason() && !newToolNeeded) || (newToolNeeded && newToolAnswered && newToolReasonAnswered);
+            return (self.oDowngradeReason() && !newToolNeeded) || (newToolNeeded && newToolAnswered && newToolReasonAnswered);
         });
 
         self.form = undefined;
         self.openDowngradeModal = function (confirmPlanModel, e) {
             self.form = $(e.currentTarget).closest("form");
-            if (confirmPlanModel.isUpgrade) {
+            if (confirmPlanModel.isUpgrade || confirmPlanModel.isSameEdition) {
                 self.form.submit();
             } else {
                 var $modal = $("#modal-downgrade");
@@ -82,16 +89,16 @@ hqDefine('accounting/js/confirm_plan', [
             var $button = $(e.currentTarget);
             $button.disableButton();
             if (self.form) {
-                if (self.otherSelected()) {
-                    document.getElementById("new-tool-reason").value = document.getElementById("text-tool-reason").value;
-                } else {
-                    document.getElementById("new-tool-reason").value = $("#select-tool-reason").val().join(", ");
+                var newToolReason = self.oNewToolReason().join(", ");
+                if (self.oOtherSelected()) {
+                    newToolReason = newToolReason + ': "' + self.oOtherNewToolReason() + '"';
                 }
+                $('#new-tool').val(self.oNewTool());
+                $("#new-tool-reason").val(newToolReason);
 
-                document.getElementById("downgrade-reason").value = $("#select-downgrade-reason").val().join(", ");
-                document.getElementById("will-project-restart").value = document.getElementById("select-project-restart").value;
-                document.getElementById("new-tool").value = document.getElementById("text-new-tool").value;
-                document.getElementById("feedback").value = document.getElementById("text-feedback").value;
+                $('#downgrade-reason').val(self.oDowngradeReason().join(", "));
+                $('#will-project-restart').val(self.oWillProjectRestart());
+                $('#feedback').val(self.oFeedback());
 
                 self.form.submit();
             }
@@ -104,6 +111,8 @@ hqDefine('accounting/js/confirm_plan', [
     $(function () {
         var confirmPlan = confirmPlanModel(
             initialPageData.get('is_upgrade'),
+            initialPageData.get('is_same_edition'),
+            initialPageData.get('is_paused'),
             initialPageData.get('current_plan')
         );
 

--- a/corehq/apps/accounting/static/accounting/js/confirm_plan.js
+++ b/corehq/apps/accounting/static/accounting/js/confirm_plan.js
@@ -28,7 +28,7 @@ hqDefine('accounting/js/confirm_plan', [
         self.currentPlan = currentPlan;
 
         // If the user is upgrading, don't let them continue until they agree to the minimum subscription terms
-        self.oUserAgreementSigned = ko.observable(!(isUpgrade || isSameEdition));
+        self.oUserAgreementSigned = ko.observable(!isUpgrade || isSameEdition);
 
         self.downgradeReasonList = [
             PROJECT_ENDED,

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -50,6 +50,10 @@ hqDefine('accounting/js/pricing_table', [
             return !! self.selectedPlan() && !(self.selectedPlan() === self.currentPlan());
         });
 
+        self.isSubmitDisabled = ko.computed(function () {
+            return !self.selectedPlan() || (self.selectedPlan() === self.currentPlan());
+        });
+
         self.isCurrentPlanCommunity = ko.observable(options.currentPlan === 'community');
 
         self.selectPausedPlan = function () {

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -52,15 +52,15 @@ hqDefine('accounting/js/pricing_table', [
 
         self.isCurrentPlanCommunity = ko.observable(options.currentPlan === 'community');
 
-        self.selectCommunityPlan = function () {
-            self.selectedPlan('community');
+        self.selectPausedPlan = function () {
+            self.selectedPlan('paused');
         };
         self.isDowngrade = function () {
             return self.editions.indexOf(self.selectedPlan()) < self.editions.indexOf(self.currentPlan());
         };
 
-        self.communityCss = ko.computed(function () {
-            if (self.selectedPlan() === 'community') {
+        self.pausedCss = ko.computed(function () {
+            if (self.selectedPlan() === 'paused') {
                 return "selected-plan";
             }
             return "";
@@ -71,7 +71,7 @@ hqDefine('accounting/js/pricing_table', [
         }));
 
         self.showNext = ko.computed(function () {
-            return self.selectedPlan() === 'community' || !self.showAnnualPricing();
+            return !self.showAnnualPricing();
         });
 
         self.form = undefined;

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -28,7 +28,7 @@ hqDefine('accounting/js/pricing_table', [
         'use strict';
         var self = {};
 
-        self.currentPlan = ko.observable(options.currentPlan);
+        self.oCurrentPlan = ko.observable(options.currentPlan);
         self.editions = options.editions;
         self.isRenewal = options.isRenewal;
         self.startDateAfterMinimumSubscription = options.startDateAfterMinimum;
@@ -36,46 +36,42 @@ hqDefine('accounting/js/pricing_table', [
         self.nextSubscriptionEdition = options.nextSubscriptionEdition;
         self.invoicingContact = options.invoicingContact;
 
-        self.selectedPlan = ko.observable(options.currentPlan);
+        self.oSelectedPlan = ko.observable(options.currentPlan);
 
-        self.showAnnualPricing = ko.observable(false);
+        self.oShowAnnualPricing = ko.observable(false);
 
-        self.refundCss = ko.computed(function () {
-            if (self.showAnnualPricing()) {
+        self.oRefundCss = ko.computed(function () {
+            if (self.oShowAnnualPricing()) {
                 return "show-refund";
             }
         });
 
-        self.isSubmitVisible = ko.computed(function () {
-            return !! self.selectedPlan() && !(self.selectedPlan() === self.currentPlan());
+        self.oIsSubmitDisabled = ko.computed(function () {
+            return !self.oSelectedPlan() || (self.oSelectedPlan() === self.oCurrentPlan());
         });
 
-        self.isSubmitDisabled = ko.computed(function () {
-            return !self.selectedPlan() || (self.selectedPlan() === self.currentPlan());
-        });
-
-        self.isCurrentPlanCommunity = ko.observable(options.currentPlan === 'community');
+        self.oIsCurrentPlanCommunity = ko.observable(options.currentPlan === 'community');
 
         self.selectPausedPlan = function () {
-            self.selectedPlan('paused');
+            self.oSelectedPlan('paused');
         };
         self.isDowngrade = function () {
-            return self.editions.indexOf(self.selectedPlan()) < self.editions.indexOf(self.currentPlan());
+            return self.editions.indexOf(self.oSelectedPlan()) < self.editions.indexOf(self.oCurrentPlan());
         };
 
-        self.pausedCss = ko.computed(function () {
-            if (self.selectedPlan() === 'paused') {
+        self.oPausedCss = ko.computed(function () {
+            if (self.oSelectedPlan() === 'paused') {
                 return "selected-plan";
             }
             return "";
         });
 
-        self.planOptions = ko.observableArray(_.map(options.planOptions, function (opt) {
+        self.oPlanOptions = ko.observableArray(_.map(options.planOptions, function (opt) {
             return new PlanOption(opt, self);
         }));
 
-        self.showNext = ko.computed(function () {
-            return !self.showAnnualPricing();
+        self.oShowNext = ko.computed(function () {
+            return !self.oShowAnnualPricing();
         });
 
         self.form = undefined;
@@ -84,13 +80,13 @@ hqDefine('accounting/js/pricing_table', [
 
             var mailto = "<a href='mailto:" + self.invoicingContact + "'>" + self.invoicingContact + "</a>";
             if (self.isDowngrade() && self.subscriptionBelowMinimum) {
-                var oldPlan = utils.capitalize(self.currentPlan());
-                var newPlan = utils.capitalize(self.selectedPlan());
+                var oldPlan = utils.capitalize(self.oCurrentPlan());
+                var newPlan = utils.capitalize(self.oSelectedPlan());
                 var newStartDate = "<strong>" + self.startDateAfterMinimumSubscription + "</strong>";
 
                 var message = "",
                     title = gettext("Downgrading?");
-                if (self.selectedPlan() === 'paused') {
+                if (self.oSelectedPlan() === 'paused') {
                     title = gettext("Pausing Subscription?");
                     message = _.template(gettext(
                         "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
@@ -156,7 +152,7 @@ hqDefine('accounting/js/pricing_table', [
             $button.disableButton();
 
             self.form = $(e.currentTarget).closest("form");
-            self.currentPlan = self.currentPlan + " - annual pricing";
+            self.oCurrentPlan(self.oCurrentPlan() + " - annual pricing");
             self.form.submit();
         };
 
@@ -171,52 +167,52 @@ hqDefine('accounting/js/pricing_table', [
         'use strict';
         var self = this;
 
-        self.name = ko.observable(data.name);
-        self.slug = ko.observable(data.name.toLowerCase());
+        self.oName = ko.observable(data.name);
+        self.oSlug = ko.observable(data.name.toLowerCase());
 
-        self.monthlyPrice = ko.observable(data.monthly_price);
-        self.annualPrice = ko.observable(data.annual_price);
-        self.description = ko.observable(data.description);
+        self.oMonthlyPrice = ko.observable(data.monthly_price);
+        self.oAnnualPrice = ko.observable(data.annual_price);
+        self.oDescription = ko.observable(data.description);
 
-        self.isCurrentPlan = ko.computed(function () {
-            return self.slug() === parent.currentPlan();
+        self.oIsCurrentPlan = ko.computed(function () {
+            return self.oSlug() === parent.oCurrentPlan();
         });
 
-        self.isSelectedPlan = ko.computed(function () {
-            return self.slug() === parent.selectedPlan();
+        self.oIsSelectedPlan = ko.computed(function () {
+            return self.oSlug() === parent.oSelectedPlan();
         });
 
-        self.cssClass = ko.computed(function () {
-            var cssClass = "tile-" + self.slug();
-            if (self.isSelectedPlan()) {
+        self.oCssClass = ko.computed(function () {
+            var cssClass = "tile-" + self.oSlug();
+            if (self.oIsSelectedPlan()) {
                 cssClass = cssClass + " selected-plan";
             }
             return cssClass;
         });
 
         self.selectPlan = function () {
-            parent.selectedPlan(self.slug());
+            parent.oSelectedPlan(self.oSlug());
         };
 
-        self.pricingTypeText = ko.computed(function () {
-            if (parent.showAnnualPricing()) {
+        self.oPricingTypeText = ko.computed(function () {
+            if (parent.oShowAnnualPricing()) {
                 return django.gettext("Billed Annually");
             }
             return django.gettext("Billed Monthly");
         });
 
-        self.pricingTypeCssClass = ko.computed(function () {
-            if (parent.showAnnualPricing()) {
+        self.oPricingTypeCssClass = ko.computed(function () {
+            if (parent.oShowAnnualPricing()) {
                 return 'pricing-type-annual';
             }
             return 'pricing-type-monthly';
         });
 
-        self.displayPrice = ko.computed(function () {
-            if (parent.showAnnualPricing()) {
-                return self.annualPrice();
+        self.oDisplayPrice = ko.computed(function () {
+            if (parent.oShowAnnualPricing()) {
+                return self.oAnnualPrice();
             }
-            return self.monthlyPrice();
+            return self.oMonthlyPrice();
         });
 
     };

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -84,8 +84,23 @@ hqDefine('accounting/js/pricing_table', [
                 var newPlan = utils.capitalize(self.selectedPlan());
                 var newStartDate = "<strong>" + self.startDateAfterMinimumSubscription + "</strong>";
 
-                var message = "";
-                if (self.nextSubscriptionEdition) {
+                var message = "",
+                    title = gettext("Downgrading?");
+                if (self.selectedPlan() === 'paused') {
+                    title = gettext("Pausing Subscription?");
+                    message = _.template(gettext(
+                        "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
+                        "<p>Continuing ahead will allow you to schedule your current <%= oldPlan %> " +
+                        "Edition Plan subscription to be paused on <%= date %>.</p>" +
+                        "<p>If you have questions or if you would like to speak to us about your subscription, " +
+                        "please reach out to <%= email %>.</p>"
+                    ))({
+                        date: newStartDate,
+                        newPlan: newPlan,
+                        oldPlan: oldPlan,
+                        email: mailto,
+                    });
+                } else if (self.nextSubscriptionEdition) {
                     message = _.template(gettext(
                         "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
                         "<p>Your current <%= oldPlan %> Edition Plan subscription is scheduled to be downgraded " +
@@ -119,6 +134,7 @@ hqDefine('accounting/js/pricing_table', [
                 }
                 var $modal = $("#modal-minimum-subscription");
                 $modal.find('.modal-body')[0].innerHTML = message;
+                $modal.find('.modal-title')[0].innerHTML = title;
                 $modal.modal('show');
             } else {
                 self.form.submit();

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -38,11 +38,11 @@ hqDefine('accounting/js/pricing_table', [
 
         self.selectedPlan = ko.observable(options.currentPlan);
 
-        self.showMonthlyPricing = ko.observable(false);
+        self.showAnnualPricing = ko.observable(false);
 
         self.refundCss = ko.computed(function () {
-            if (self.showMonthlyPricing()) {
-                return "hide-refund";
+            if (self.showAnnualPricing()) {
+                return "show-refund";
             }
         });
 
@@ -71,7 +71,7 @@ hqDefine('accounting/js/pricing_table', [
         }));
 
         self.showNext = ko.computed(function () {
-            return self.selectedPlan() === 'community' || self.showMonthlyPricing();
+            return self.selectedPlan() === 'community' || !self.showAnnualPricing();
         });
 
         self.form = undefined;
@@ -179,24 +179,24 @@ hqDefine('accounting/js/pricing_table', [
         };
 
         self.pricingTypeText = ko.computed(function () {
-            if (parent.showMonthlyPricing()) {
-                return django.gettext("Billed Monthly");
+            if (parent.showAnnualPricing()) {
+                return django.gettext("Billed Annually");
             }
-            return django.gettext("Billed Annually");
+            return django.gettext("Billed Monthly");
         });
 
         self.pricingTypeCssClass = ko.computed(function () {
-            if (parent.showMonthlyPricing()) {
-                return 'pricing-type-monthly';
+            if (parent.showAnnualPricing()) {
+                return 'pricing-type-annual';
             }
-            return 'pricing-type-annual';
+            return 'pricing-type-monthly';
         });
 
         self.displayPrice = ko.computed(function () {
-            if (parent.showMonthlyPricing()) {
-                return self.monthlyPrice();
+            if (parent.showAnnualPricing()) {
+                return self.annualPrice();
             }
-            return self.annualPrice();
+            return self.monthlyPrice();
         });
 
     };

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -243,9 +243,9 @@ hqDefine('accounting/js/pricing_table', [
 
         self.oPricingTypeText = ko.computed(function () {
             if (parent.oShowAnnualPricing()) {
-                return django.gettext("Billed Annually");
+                return gettext("Billed Annually");
             }
-            return django.gettext("Billed Monthly");
+            return gettext("Billed Monthly");
         });
 
         self.oPricingTypeCssClass = ko.computed(function () {

--- a/corehq/apps/accounting/static/accounting/js/pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/js/pricing_table.js
@@ -23,17 +23,21 @@ hqDefine('accounting/js/pricing_table', [
             'isSubscriptionBelowMin',
             'nextSubscriptionEdition',
             'invoicingContact',
+            'isPriceDiscounted',
+            'currentPrice',
         ]);
 
         'use strict';
         var self = {};
 
         self.oCurrentPlan = ko.observable(options.currentPlan);
+        self.oNextSubscription = ko.observable(options.nextSubscriptionEdition);
+        self.oStartDateAfterMinimumSubscription = ko.observable(options.startDateAfterMinimum);
+        self.oCurrentPrice = ko.observable(options.currentPrice);
+        self.oIsPriceDiscounted = ko.observable(options.isPriceDiscounted);
         self.editions = options.editions;
         self.isRenewal = options.isRenewal;
-        self.startDateAfterMinimumSubscription = options.startDateAfterMinimum;
         self.subscriptionBelowMinimum = options.isSubscriptionBelowMin;
-        self.nextSubscriptionEdition = options.nextSubscriptionEdition;
         self.invoicingContact = options.invoicingContact;
 
         self.oSelectedPlan = ko.observable(options.currentPlan);
@@ -47,10 +51,21 @@ hqDefine('accounting/js/pricing_table', [
         });
 
         self.oIsSubmitDisabled = ko.computed(function () {
-            return !self.oSelectedPlan() || (self.oSelectedPlan() === self.oCurrentPlan());
+            var isCurrentPlan = self.oSelectedPlan() === self.oCurrentPlan() && !self.oNextSubscription(),
+                isNextPlan = self.oNextSubscription() && self.oSelectedPlan() === self.oNextSubscription().toLowerCase();
+            return !self.oSelectedPlan() || isNextPlan || isCurrentPlan;
         });
 
         self.oIsCurrentPlanCommunity = ko.observable(options.currentPlan === 'community');
+        self.oIsCurrentPlanPaused = ko.observable(options.currentPlan === 'paused');
+
+        self.oIsNextPlanPaused = ko.computed(function () {
+            return self.oNextSubscription() === 'Paused';
+        });
+
+        self.oIsNextPlanDowngrade = ko.computed(function () {
+            return self.oNextSubscription() && !self.oIsNextPlanPaused();
+        });
 
         self.selectPausedPlan = function () {
             self.oSelectedPlan('paused');
@@ -82,7 +97,7 @@ hqDefine('accounting/js/pricing_table', [
             if (self.isDowngrade() && self.subscriptionBelowMinimum) {
                 var oldPlan = utils.capitalize(self.oCurrentPlan());
                 var newPlan = utils.capitalize(self.oSelectedPlan());
-                var newStartDate = "<strong>" + self.startDateAfterMinimumSubscription + "</strong>";
+                var newStartDate = "<strong>" + self.oStartDateAfterMinimumSubscription() + "</strong>";
 
                 var message = "",
                     title = gettext("Downgrading?");
@@ -100,7 +115,23 @@ hqDefine('accounting/js/pricing_table', [
                         oldPlan: oldPlan,
                         email: mailto,
                     });
-                } else if (self.nextSubscriptionEdition) {
+                } else if (self.oIsNextPlanPaused()) {
+                    message = _.template(gettext(
+                        "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
+                        "<p>Your current <%= oldPlan %> Edition Plan subscription is scheduled to be paused " +
+                        "on <%= date %>.</p>" +
+                        "<p>Continuing ahead will allow you to schedule your current <%= oldPlan %> Edition " +
+                        "Plan subscription to be downgraded to the <%= newPlan %> Edition Plan " +
+                        "on <%= date %>.</p>" +
+                        "<p>If you have questions or if you would like to speak to us about your subscription, " +
+                        "please reach out to <%= email %>.</p>"
+                    ))({
+                        oldPlan: oldPlan,
+                        date: newStartDate,
+                        newPlan: newPlan,
+                        email: mailto,
+                    });
+                } else if (self.oIsNextPlanDowngrade()) {
                     message = _.template(gettext(
                         "<p>All CommCare subscriptions require a 30 day minimum commitment.</p>" +
                         "<p>Your current <%= oldPlan %> Edition Plan subscription is scheduled to be downgraded " +
@@ -112,7 +143,7 @@ hqDefine('accounting/js/pricing_table', [
                         "please reach out to <%= email %>.</p>"
                     ))({
                         oldPlan: oldPlan,
-                        nextSubscription: self.nextSubscriptionEdition,
+                        nextSubscription: self.oNextSubscription(),
                         date: newStartDate,
                         newPlan: newPlan,
                         email: mailto,
@@ -182,6 +213,22 @@ hqDefine('accounting/js/pricing_table', [
             return self.oSlug() === parent.oSelectedPlan();
         });
 
+        self.oShowDowngradeNotice = ko.computed(function () {
+            return self.oIsCurrentPlan() && parent.oIsNextPlanDowngrade();
+        });
+
+        self.oNextPlan = ko.computed(function () {
+            return parent.oNextSubscription();
+        });
+
+        self.oNextDate = ko.computed(function () {
+            return parent.oStartDateAfterMinimumSubscription();
+        });
+
+        self.oShowPausedNotice = ko.computed(function () {
+            return parent.oIsNextPlanPaused() && self.oIsCurrentPlan();
+        });
+
         self.oCssClass = ko.computed(function () {
             var cssClass = "tile-" + self.oSlug();
             if (self.oIsSelectedPlan()) {
@@ -208,7 +255,14 @@ hqDefine('accounting/js/pricing_table', [
             return 'pricing-type-monthly';
         });
 
+        self.oDisplayDiscountNotice = ko.computed(function () {
+            return self.oIsCurrentPlan() && parent.oIsPriceDiscounted() && !parent.oShowAnnualPricing();
+        });
+
         self.oDisplayPrice = ko.computed(function () {
+            if (self.oDisplayDiscountNotice()) {
+                return parent.oCurrentPrice();
+            }
             if (parent.oShowAnnualPricing()) {
                 return self.oAnnualPrice();
             }
@@ -228,6 +282,8 @@ hqDefine('accounting/js/pricing_table', [
             isSubscriptionBelowMin: initialPageData.get('subscription_below_minimum'),
             nextSubscriptionEdition: initialPageData.get('next_subscription_edition'),
             invoicingContact: initialPageData.get('invoicing_contact_email'),
+            currentPrice: initialPageData.get('current_price'),
+            isPriceDiscounted: initialPageData.get('is_price_discounted'),
         });
 
         // Applying bindings is a bit weird here, because we need logic in the modal,

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_pause_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_pause_summary.html
@@ -1,0 +1,61 @@
+{% load i18n %}
+
+<p>
+  <strong>
+    {% blocktrans %}
+      What happens after your subscription gets paused?
+    {% endblocktrans %}
+  </strong>
+</p>
+
+<ul>
+  <li>
+    {% blocktrans %}
+      You will lose access to your project space, but you will be able to
+      re-subscribe any time in the future.
+    {% endblocktrans %}
+  </li>
+  <li>
+    {% blocktrans %}
+      You will no longer be billed. However, based on your payment method
+      you may have an open invoice for the service provided this month.
+    {% endblocktrans %}
+  </li>
+  <li>
+    {% blocktrans %}
+      Re-subscribing will restore full access to your project space, including
+      your data, apps, report, and configurations.
+    {% endblocktrans %}
+  </li>
+</ul>
+
+<p>
+  {% blocktrans %}
+    If you don't intend to use this project space again and would like to delete it,
+    please inform us at <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a>.
+  {% endblocktrans %}
+</p>
+
+<div class="alert alert-warning alert-subscription">
+  {% if is_downgrade_before_minimum %}
+    <h4>
+      {% trans "We hope to see you soon!" %}
+    </h4>
+    <p>
+      {% blocktrans with current_plan as p %}
+        You’ll have access to the features on your
+        <strong>{{ p }} Edition Software Plan </strong> through {{ current_subscription_end_date }}.<br />
+        On {{ current_subscription_end_date }} your current subscription will be paused.
+      {% endblocktrans %}
+    </p>
+  {% else %}
+    <h4>
+      {% trans "We hope to see you soon!" %}
+    </h4>
+    <p>
+      {% blocktrans with current_plan as p %}
+        Your subscription will be paused immediately upon clicking the Confirm Pause button.
+      {% endblocktrans %}
+    </p>
+  {% endif %}
+</div>

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -1,0 +1,121 @@
+{% load i18n %}
+
+<p class="lead text-center">
+  {% blocktrans with plan.name as p %}
+    You have selected the <strong>{{ p }} Edition</strong> subscription.
+  {% endblocktrans %}
+</p>
+<div class="confirm-plan-summary">
+  <div class="tile {{ tile_css }}">
+    <h3>
+      {% blocktrans with plan.name as p %}
+        {{ p }} Edition
+      {% endblocktrans %}
+    </h3>
+    <p class="plan-price">
+      {{ plan.monthly_fee }}
+    </p>
+    <p class="plan-monthly-label">
+      <strong>
+        {% trans "Monthly Fee" %}
+      </strong>
+    </p>
+    <h4>
+      {% trans 'Included each month' %}
+    </h4>
+    <div class="plan-included well well-sm">
+      <dl class="dl-horizontal">
+        {% for rate in plan.rates %}
+          <dt>{{ rate.name }}</dt>
+          <dd>{{ rate.included }}</dd>
+        {% endfor %}
+      </dl>
+    </div>
+    <p class="plan-desc">
+      {{ plan.description }}
+    </p>
+  </div>
+</div>
+{% if current_plan %}
+  <div class="alert {% if is_same_edition %}alert-info{% else %}alert-warning{% endif %} alert-subscription">
+    {% if is_upgrade %}
+      <h4>
+        <i class="fa fa-warning"></i>
+        {% trans "Note: Continuing will change your current subscription." %}
+      </h4>
+      <p class="text-community">
+        {% blocktrans with next_invoice_date as invoice_date %}
+          CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
+          You should expect your first invoice on {{ invoice_date }}, or you can prepay for your
+          subscription by following the instructions
+          <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
+        {% endblocktrans %}
+      </p>
+      <p class="text-community">
+        {% blocktrans %}
+          Once you subscribe to a paid plan, you will be able to pause your subscription after 30 days,
+          but you will no longer be able to downgrade to the CommCare Community plan.
+        {% endblocktrans %}
+      </p>
+      <p>
+        <strong>
+          {% blocktrans %}
+            <input type="checkbox" data-bind="checked: oUserAgreementSigned"> I understand and wish to continue.
+          {% endblocktrans %}
+        </strong>
+      </p>
+    {% elif is_same_edition %}
+      <h4>
+        {% blocktrans %}
+          Thank you for staying with your current subscription.
+        {% endblocktrans %}
+      </h4>
+      <p>
+        {% blocktrans with current_plan as p %}
+          Continuing will keep you on <strong>{{ p }} Edition Software Plan</strong> and any
+          pending subscriptions will be cancelled.
+        {% endblocktrans %}
+      </p>
+    {% elif is_downgrade_before_minimum %}
+      <h4>
+        {% trans "We're sorry to see you downgrade!" %}
+      </h4>
+      <p>
+        {% blocktrans with current_plan as p %}
+          You’ll have access to the features on your
+          <strong>{{ p }} Edition Software Plan </strong> through {{ current_subscription_end_date }}.<br />
+          On {{ start_date_after_minimum_subscription }} your current subscription will be downgraded
+          to the {{ new_plan_edition }} Edition Software Plan.
+        {% endblocktrans %}
+      </p>
+    {% else %}
+      <h4>
+        <i class="fa fa-warning"></i>
+        {% trans "Note: Continuing will change your current subscription." %}
+      </h4>
+      <p>
+        {% blocktrans with current_plan as p %}
+          We're sorry to see you downgrade! You are currently subscribed to the
+          <strong>{{ p }} Software Plan.</strong>
+        {% endblocktrans %}
+      </p>
+    {% endif %}
+  </div>
+{% endif %}
+
+{% if downgrade_messages and not is_same_edition %}
+  <hr />
+  <h4 class="text-center">
+    {% trans 'Note: Selecting this plan will result in the following changes to your project.' %}
+  </h4>
+  {% for message in downgrade_messages %}
+    <div class="alert alert-warning alert-downgrade">
+      {{ message.message }}
+      <ul>
+        {% for detail in message.details %}
+          <li>{{ detail|safe }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endfor %}
+{% endif %}

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -30,6 +30,10 @@ DESC_BY_EDITION = {
                          "the full CommCare feature set. Your organization will receive discounted "
                          "pricing and dedicated enterprise-level support from Dimagi.")
     },
+    SoftwarePlanEdition.PAUSED: {
+        'name': _("Paused"),
+        'description': _("Paused"),
+    },
     SoftwarePlanEdition.RESELLER: {
         'name': _("Reseller"),
         'description': _("Reseller")

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -346,6 +346,50 @@ def cancel_future_subscriptions(domain_name, from_date, web_user):
         )
 
 
+def pause_current_subscription(domain_name, web_user, current_subscription):
+    from corehq.apps.accounting.models import (
+        Subscription,
+        DefaultProductPlan,
+        SoftwarePlanEdition,
+        SubscriptionAdjustmentMethod,
+        SubscriptionType,
+        ProBonoStatus,
+        FundingSource,
+    )
+    cancel_future_subscriptions(domain_name, datetime.date.today(), web_user)
+    paused_plan_version = DefaultProductPlan.get_default_plan_version(
+        SoftwarePlanEdition.PAUSED
+    )
+    if current_subscription.is_below_minimum_subscription:
+        current_subscription.update_subscription(
+            date_start=current_subscription.date_start,
+            date_end=current_subscription.date_start + datetime.timedelta(days=30)
+        )
+        return Subscription.new_domain_subscription(
+            account=current_subscription.account,
+            domain=domain_name,
+            plan_version=paused_plan_version,
+            date_start=current_subscription.date_start + datetime.timedelta(days=30),
+            web_user=web_user,
+            adjustment_method=SubscriptionAdjustmentMethod.USER,
+            service_type=SubscriptionType.PRODUCT,
+            pro_bono_status=ProBonoStatus.NO,
+            funding_source=FundingSource.CLIENT,
+            do_not_invoice=True,
+            no_invoice_reason='Paused plan',
+        )
+    else:
+        return current_subscription.change_plan(
+            paused_plan_version,
+            web_user=web_user,
+            adjustment_method=SubscriptionAdjustmentMethod.USER,
+            service_type=SubscriptionType.PRODUCT,
+            pro_bono_status=ProBonoStatus.NO,
+            do_not_invoice=True,
+            no_invoice_reason='Paused plan',
+        )
+
+
 def is_downgrade(current_edition, next_edition):
     from corehq.apps.accounting.models import SoftwarePlanEdition
     plans = SoftwarePlanEdition.SELF_SERVICE_ORDER + [SoftwarePlanEdition.ENTERPRISE]

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1710,7 +1710,12 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
 
                 cancel_future_subscriptions(self.domain, datetime.date.today(), self.creating_user)
                 if self.current_subscription is not None:
-                    if self.is_downgrade_from_paid_plan() and \
+                    if self.is_same_edition():
+                        self.current_subscription.update_subscription(
+                            date_start=self.current_subscription.date_start,
+                            date_end=None
+                        )
+                    elif self.is_downgrade_from_paid_plan() and \
                             self.current_subscription.is_below_minimum_subscription:
                         self.current_subscription.update_subscription(
                             date_start=self.current_subscription.date_start,
@@ -1754,6 +1759,9 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                 show_stack_trace=True,
             )
             return False
+
+    def is_same_edition(self):
+        return self.current_subscription.plan_version.plan.edition == self.plan_version.plan.edition
 
     def is_downgrade_from_paid_plan(self):
         if self.current_subscription is None:

--- a/corehq/apps/domain/templates/domain/base_change_plan.html
+++ b/corehq/apps/domain/templates/domain/base_change_plan.html
@@ -1,5 +1,23 @@
 {% extends "hqwebapp/base_section.html" %}
 {% load i18n %}
+{% load hq_shared_tags %}
+{% load compress %}
+
+{% block stylesheets %}{{ block.super }}
+  {% if less_debug %}
+    <link type="text/less"
+          rel="stylesheet"
+          media="all"
+          href="{% static 'accounting/less/pricing.debug.less' %}" />
+  {% else %}
+    {% compress css %}
+      <link type="text/less"
+            rel="stylesheet"
+            media="all"
+            href="{% static 'accounting/less/pricing.less' %}" />
+    {% endcompress %}
+  {% endif %}
+{% endblock %}
 
 {% block page_content %}
   <ol class="breadcrumb">
@@ -9,7 +27,7 @@
       </li>
     {% endfor %}
   </ol>
-  <div class="page-header">
+  <div class="select-plan-header">
     <h2>{{ step_title }}</h2>
   </div>
   {% block form_content %}

--- a/corehq/apps/domain/templates/domain/confirm_billing_info.html
+++ b/corehq/apps/domain/templates/domain/confirm_billing_info.html
@@ -16,21 +16,22 @@
   {% initial_page_data "stripe_public_key" stripe_public_key %}
   {% initial_page_data "downgrade_email_note" downgrade_email_note %}
   {% registerurl "cards_view" domain %}
-  <p class="lead">
+  <p class="lead text-center">
     {% blocktrans with plan.name as p%}
-      You are about to subscribe to the {{ p }} Software Plan.
-    {% endblocktrans %}
-  </p>
-  <p>
-    {% blocktrans %}
+      You are about to subscribe to the <strong>{{ p }} Software Plan</strong>.<br/>
       Please update your billing information below before continuing.
     {% endblocktrans %}
   </p>
-  <hr />
-  <div id="billing-info">
-    {% crispy billing_account_info_form %}
+
+  <div class="panel panel-modern-gray panel-form-only" id="billing-info">
+    <div class="panel-body">
+      {% crispy billing_account_info_form %}
+    </div>
   </div>
-  <div id="card-manager">
-    {% include 'domain/stripe_cards.html' %}
+
+  <div class="panel panel-modern-gray panel-form-only" id="card-manager">
+    <div class="panel-body">
+      {% include 'domain/stripe_cards.html' %}
+    </div>
   </div>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -13,98 +13,14 @@
   {% initial_page_data 'start_date_after_minimum_subscription' start_date_after_minimum_subscription %}
   {% registerurl 'email_on_downgrade' domain %}
   {% registerurl 'confirm_billing_account_info' domain %}
-  <div class="container" id="confirm-plan-content">
-  <p class="lead">
-    {% blocktrans with plan.name as p %}
-      You have selected the <strong>{{ p }} Software Plan</strong>.
-    {% endblocktrans %}
-  </p>
-  <dl class="dl-horizontal">
-    <dt>{% trans 'Monthly Fee' %}</dt>
-    <dd>{{ plan.monthly_fee }}</dd>
-  </dl>
-  <h4>{% trans 'Included each month' %}</h4>
-  <div class="well well-sm">
-    <dl class="dl-horizontal" style="margin-bottom: 0;">
-      {% for rate in plan.rates %}
-        <dt>{{ rate.name }}</dt>
-        <dd>{{ rate.included }}</dd>
-      {% endfor %}
-    </dl>
-  </div>
-  <p>{{ plan.description }}</p>
-  {% if show_community_notice %}
-    <p>
-      {% blocktrans %}
-        All projects are enrolled in the Community Plan automatically. You will not have to do anything until
-        you are charged for extra users or SMS messaging.
-      {% endblocktrans %}
-    </p>
-  {% endif %}
-  {% if current_plan %}
-    {% if is_upgrade %}
-      <hr />
-      <div class="alert alert-danger">
-        {% blocktrans with next_invoice_date as invoice_date %}
-          <h4>Note: Continuing will change your current subscription.</h4>
-          <p>CommCare is billed on a monthly basis, and all subscriptions require a 30 day minimum commitment.
-            You should expect your first invoice on {{ invoice_date }}, or you can prepay for your
-            subscription by following the instructions
-            <a href="https://confluence.dimagi.com/display/commcarepublic/How+to+Pay+by+Credit+Card+or+Wire+Payment">here</a>.
-          </p>
-          <input type="checkbox" data-bind="checked: userAgreementSigned"> I understand and wish to continue.<br>
-        {% endblocktrans %}
-      </div>
-    {% elif is_downgrade_before_minimum %}
-      <hr />
-      <div class="alert alert-danger">
-        {% blocktrans with current_plan as p %}
-          <p>We're sorry to see you downgrade! You’ll have access to the features on your
-            <strong>{{ p }} Edition Software Plan </strong> through {{ current_subscription_end_date }}.
-            On {{ start_date_after_minimum_subscription }} your current subscription will be downgraded
-            to the {{ new_plan_edition }} Edition Software Plan.
-          </p>
-        {% endblocktrans %}
-      </div>
+
+  <div class="ko-template" id="confirm-plan-content">
+    {% if is_paused %}
+      {% include 'accounting/partials/confirm_pause_summary.html' %}
     {% else %}
-      <hr />
-      <div class="alert alert-danger">
-        {% blocktrans with current_plan as p %}
-          <h4>Note: Continuing will change your current subscription.</h4>
-          <p>We're sorry to see you downgrade! You are currently subscribed to the
-            <strong>{{ p }} Software Plan</strong></p>
-        {% endblocktrans %}
-      </div>
+      {% include 'accounting/partials/confirm_plan_summary.html' %}
     {% endif %}
-  {% endif %}
 
-  {% if downgrade_messages %}
-    <hr />
-    <h4>
-      {% if show_community_notice %}
-        {% trans 'Note: If you do not upgrade from the Community Plan the following changes will take place.' %}
-      {% else %}
-        {% trans 'Note: Selecting this plan will result in the following changes to your project.' %}
-      {% endif %}
-    </h4>
-  {% endif %}
-  {% for message in downgrade_messages %}
-    <div class="alert alert-warning">
-      {{ message.message }}
-      <ul>
-        {% for detail in message.details %}
-          <li>{{ detail|safe }}</li>
-        {% endfor %}
-      </ul>
-    </div>
-  {% endfor %}
-
-  {% if show_community_notice %}
-    <div class="form-actions">
-      <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-      <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans 'Stay with Community Plan' %}</a>
-    </div>
-  {% else %}
     <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
       {% csrf_token %}
       <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
@@ -128,9 +44,9 @@
         </div>
       </div>
     </form>
-  {% endif %}
+
+  </div>
 {% endblock %}
-</div>
 
 {% block modals %}{{ block.super }}
   <div class="modal fade" id="modal-downgrade">

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -5,6 +5,8 @@
 
 {% block form_content %}
   {% initial_page_data 'is_upgrade' is_upgrade %}
+  {% initial_page_data 'is_same_edition' is_same_edition %}
+  {% initial_page_data 'is_paused' is_paused %}
   {% initial_page_data 'next_invoice_date' next_invoice_date %}
   {% initial_page_data 'current_plan' current_plan %}
   {% initial_page_data 'new_plan_edition' new_plan_edition %}
@@ -29,19 +31,30 @@
       <input type="hidden" value="" name="new_tool" id="new-tool"/>
       <input type="hidden" value="" name="new_tool_reason" id="new-tool-reason"/>
       <input type="hidden" value="" name="feedback" id="feedback"/>
-      <hr />
-      <p>
-        {% blocktrans %}
-          Clicking the 'Confirm Plan' button below will bring you to a page where you can confirm your billing information.
-        {% endblocktrans %}
-      </p>
-      <div class="form-actions">
-        <div class="col-sm-6">
-          <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default">{% trans 'Select different plan' %}</a>
-          <button class="btn btn-primary" data-bind="enable: userAgreementSigned, click: openDowngradeModal">
-            {% trans 'Confirm Plan' %}
-          </button>
-        </div>
+      {% if not is_paused %}
+        <hr />
+        <p class="text-center">
+          {% blocktrans %}
+            Clicking the 'Confirm Plan' button below will bring you to a page where you can confirm your billing information.
+          {% endblocktrans %}
+        </p>
+      {% endif %}
+      <div class="text-center plan-next">
+        <a href="{% url 'domain_select_plan' domain %}" class="btn btn-default btn-lg">
+          {% if is_paused %}
+            {% trans 'Select different option' %}
+          {% else %}
+            {% trans 'Select different plan' %}
+          {% endif %}
+        </a>
+        <button class="btn btn-primary btn-lg"
+                data-bind="enable: oUserAgreementSigned, click: openDowngradeModal">
+          {% if is_paused %}
+            {% trans 'Confirm Pause' %}
+          {% else %}
+            {% trans "Confirm Plan" %}
+          {% endif %}
+        </button>
       </div>
     </form>
 
@@ -57,60 +70,101 @@
             <span aria-hidden="true">&times;</span>
             <span class="sr-only">{% trans "Close" %}</span>
           </button>
-          <h4 class="modal-title">{% trans 'Downgrading?' %}</h4>
+          <h4 class="modal-title">
+            {% if is_paused %}
+              {% trans 'Before you pause...' %}
+            {% else %}
+              {% trans 'Downgrading?' %}
+            {% endif %}
+          </h4>
         </div>
         <div class="modal-body">
-          {% blocktrans %}
-            We’d love to make CommCare work better for you.
-            Please help us, by answering these simple questions.
-          {% endblocktrans %}
-
-          <br><br>
-          {% blocktrans %}
-            Why are you downgrading your subscription today?
-          {% endblocktrans %}
-          <select multiple="multiple" class="form-control" id="select-downgrade-reason" data-bind="value: downgradeReason, options: downgradeReasonList"></select>
-          <br><br>
-
-          <div data-bind="visible: projectEnded">
+          <p class="lead">
             {% blocktrans %}
-              Is there a chance your project may start again?
+              We'd love to make CommCare work better for you.
+              Please help us by answering these simple questions.
             {% endblocktrans %}
-            <select class="form-control" id="select-project-restart">
-              <option value='yes'>{% trans "Yes" %}</option>
-              <option value='no' selected="selected">{% trans "No" %}</option>
-            </select>
-            <br><br>
-          </div>
+          </p>
 
-          <div data-bind="visible: newToolNeeded">
-            {% blocktrans %}
-              Could you indicate which new tool you’re using?
-            {% endblocktrans %}
-            <textarea class="form-control" id="text-new-tool" data-bind="textInput: newTool"></textarea>
-            <br><br>
-            {% blocktrans %}
-              Why are you switching to a new tool?
-            {% endblocktrans %}
-            <select multiple="multiple" class="form-control" id="select-tool-reason" data-bind="options: newToolReasonList, value: newToolReason"></select>
-            <br><br>
+          <p>
+            {% if is_paused %}
+              {% blocktrans %}
+                Why are you pausing your subscription today?
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans %}
+                Why are you downgrading your subscription today?
+              {% endblocktrans %}
+            {% endif %}
+            <select multiple="multiple"
+                    class="form-control"
+                    data-bind="selectedOptions: oDowngradeReason,
+                               options: downgradeReasonList"></select>
+          </p>
 
-            <div data-bind="visible: otherSelected">
+          <!-- ko if: oProjectEnded -->
+            <p>
+              {% blocktrans %}
+                Do you think your project may start again?
+              {% endblocktrans %}
+              <select class="form-control"
+                      data-bind="value: oWillProjectRestart">
+                <option value="yes">
+                  {% trans "Yes" %}
+                </option>
+                <option value="no"
+                        selected="selected">
+                  {% trans "No" %}
+                </option>
+              </select>
+            </p>
+          <!-- /ko -->
+
+          <!-- ko if: oNewToolNeeded -->
+            <p>
+              {% blocktrans %}
+                Could you indicate which new tool you’re using?
+              {% endblocktrans %}
+              <textarea class="form-control"
+                        data-bind="textInput: oNewTool"></textarea>
+            </p>
+            <p>
+              {% blocktrans %}
+                Why are you switching to a new tool?
+              {% endblocktrans %}
+              <select multiple="multiple"
+                      class="form-control"
+                      data-bind="selectedOptions: oNewToolReason,
+                                 options: newToolReasonList"></select>
+            </p>
+          <!-- /ko -->
+
+          <!-- ko if: oOtherSelected -->
+            <p>
               {% blocktrans %}
                 Please specify
               {% endblocktrans %}
-              <textarea class="form-control" id="text-tool-reason" data-bind="textInput: otherNewToolReason"></textarea>
-              <br><br>
-            </div>
-          </div>
+              <textarea class="form-control"
+                        data-bind="textInput: oOtherNewToolReason"></textarea>
+            </p>
+          <!-- /ko -->
 
-          {% blocktrans %}
-            Please let us know any other feedback you have
-          {% endblocktrans %}
-          <textarea class="form-control" id="text-feedback"></textarea>
+          <p>
+            {% blocktrans %}
+              Please let us know any other feedback you have
+            {% endblocktrans %}
+            <textarea class="form-control"
+                      data-bind="textInput: oFeedback"></textarea>
+          </p>
+
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-bind="click: submitDowngrade, enable: requiredQuestionsAnswered">{% trans "Continue" %}</button>
+          <button type="button"
+                  class="btn btn-primary"
+                  data-bind="click: submitDowngrade,
+                             enable: oRequiredQuestionsAnswered">
+            {% trans "Continue" %}
+          </button>
         </div>
       </div>
     </div>

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -23,7 +23,9 @@
       {% include 'accounting/partials/confirm_plan_summary.html' %}
     {% endif %}
 
-    <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
+    <form action="{% if is_paused %}{% url 'pause_subscription' domain %}{% else %}{% url 'confirm_billing_account_info' domain %}{% endif %}"
+          method="post"
+          class="form">
       {% csrf_token %}
       <input type="hidden" value="{{ plan.edition }}" name="plan_edition" />
       <input type="hidden" value="" name="downgrade_reason" id="downgrade-reason"/>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -22,20 +22,30 @@
           <label class="control-label col-sm-2">{% trans 'Plan' %}</label>
           <div class="col-sm-10">
             <div class="{{ plan.css_class }}">
-              <h4>{% if plan.is_trial %}
-                {{ plan.trial_length }}{% trans ' Day Trial' %}
-              {% else %}
-                {{ plan.name }}
-              {% endif %}</h4>
+              <h4>
+                {% if plan.is_paused %}
+                  {% blocktrans %}
+                    Your Subscription is Paused
+                  {% endblocktrans %}
+                {% elif plan.is_trial %}
+                  {{ plan.trial_length }}{% trans ' Day Trial' %}
+                {% else %}
+                  {{ plan.name }}
+                {% endif %}
+              </h4>
               <p><i class="fa fa-info-circle"></i>
-                {% if plan.is_trial %}
+                {% if plan.is_paused %}
+                  {% blocktrans with date_paused=plan.date_start pe=plan.previous_subscription_edition %}
+                    Your {{ pe }} Edition subscription was paused on {{ date_paused }}. Please subscribe to a plan to gain access to your project again.
+                  {% endblocktrans %}
+                {% elif plan.is_trial %}
                   {% blocktrans with pn=plan.name trial_length=plan.trial_length %}
                     The {{ trial_length }} Day Trial includes all the features present in the
                     {{ pn }} Software Plan, which is our full set of features.
                   {% endblocktrans %}
                 {% else %}{{ plan.description }}{% endif %}</p>
             </div>
-            {% if plan.do_not_invoice %}
+            {% if plan.do_not_invoice and not plan.is_paused %}
               <div class="alert alert-info">
                 {% blocktrans %}
                   <strong>Note:</strong> This subscription will not be invoiced.
@@ -55,9 +65,21 @@
               {% else %}
                 <p>
                   <a class="btn btn-primary" style="margin-top:10px;" href="{{ change_plan_url }}">
-                    {% trans "Change Plan" %}
+                    {% if plan.is_paused %}
+                      {% trans "Subscribe to Plan" %}
+                    {% else %}
+                      {% trans "Change Plan" %}
+                    {% endif %}
                   </a>
                 </p>
+              {% endif %}
+              {% if plan.next_subscription.exists and plan.next_subscription.is_paused %}
+                <div class="alert alert-warning">
+                  <i class="fa fa-warning"></i>
+                  {% blocktrans with plan.next_subscription.date_start as next_date %}
+                    This subscription will be paused on {{ next_date }}.
+                  {% endblocktrans %}
+                </div>
               {% endif %}
             {% endif %}
 
@@ -71,7 +93,7 @@
             {% endif %}
           </div>
         </div>
-        {% if not plan.is_trial %}
+        {% if not plan.is_trial and not plan.is_paused %}
           {% if plan.date_start %}
             <div class="form-group">
               <label class="control-label col-sm-2">{% trans 'Date Started' %}</label>
@@ -104,7 +126,7 @@
             </div>
           </div>
         {% endif %}
-        {% if plan.next_subscription.exists %}
+        {% if plan.next_subscription.exists and not plan.next_subscription.is_paused %}
           <div class="form-group">
             <label class="control-label col-sm-2">
               {% trans "Next Subscription Begins" %}
@@ -240,55 +262,57 @@
             {% endif %}
           </div>
         {% endif %}
-        <legend>{% trans 'Usage Summary' %}</legend>
-        {% if plan.has_credits_in_non_general_credit_line %}
-          <table class="table table-bordered table-striped">
-            <thead>
-            <tr>
-              <th>{% trans "Feature" %}</th>
-              <th>{% trans "Current Use" %}</th>
-              <th>{% trans "Remaining" %}</th>
-              <th>{% trans "Credits Available" %}</th>
-              {% if show_account_credits %}
-                <th>{% trans "Account Credits Available" %}</th>
-              {% endif %}
-            </tr>
-            </thead>
-            <tbody data-bind="foreach: features">
-            <tr>
-              <td data-bind="text: name"></td>
-              <td data-bind="text: usage"></td>
-              <td data-bind="text: remaining"></td>
-              <td data-bind="text: amount"></td>
-              {% if show_account_credits %}
-                <td data-bind="text: accountAmount"></td>
-              {% endif %}
-            </tr>
-            </tbody>
-          </table>
-        {% else %}
-          <table class="table table-bordered table-striped">
-            <thead>
-            <tr>
-              <th>{% trans "Feature" %}</th>
-              <th>{% trans "Included in Software Plan" %}</th>
-              <th>{% trans "Current Usage" %}</th>
-              {% if show_account_credits %}
-                <th>{% trans "Account Credits Available" %}</th>
-              {% endif %}
-            </tr>
-            </thead>
-            <tbody data-bind="foreach: features">
-            <tr>
-              <td data-bind="text: name"></td>
-              <td data-bind="text: limit"></td>
-              <td data-bind="text: usage"></td>
-              {% if show_account_credits %}
-                <td data-bind="text: accountAmount"></td>
-              {% endif %}
-            </tr>
-            </tbody>
-          </table>
+        {% if not plan.is_paused %}
+          <legend>{% trans 'Usage Summary' %}</legend>
+          {% if plan.has_credits_in_non_general_credit_line %}
+            <table class="table table-bordered table-striped">
+              <thead>
+              <tr>
+                <th>{% trans "Feature" %}</th>
+                <th>{% trans "Current Use" %}</th>
+                <th>{% trans "Remaining" %}</th>
+                <th>{% trans "Credits Available" %}</th>
+                {% if show_account_credits %}
+                  <th>{% trans "Account Credits Available" %}</th>
+                {% endif %}
+              </tr>
+              </thead>
+              <tbody data-bind="foreach: features">
+              <tr>
+                <td data-bind="text: name"></td>
+                <td data-bind="text: usage"></td>
+                <td data-bind="text: remaining"></td>
+                <td data-bind="text: amount"></td>
+                {% if show_account_credits %}
+                  <td data-bind="text: accountAmount"></td>
+                {% endif %}
+              </tr>
+              </tbody>
+            </table>
+          {% else %}
+            <table class="table table-bordered table-striped">
+              <thead>
+              <tr>
+                <th>{% trans "Feature" %}</th>
+                <th>{% trans "Included in Software Plan" %}</th>
+                <th>{% trans "Current Usage" %}</th>
+                {% if show_account_credits %}
+                  <th>{% trans "Account Credits Available" %}</th>
+                {% endif %}
+              </tr>
+              </thead>
+              <tbody data-bind="foreach: features">
+              <tr>
+                <td data-bind="text: name"></td>
+                <td data-bind="text: limit"></td>
+                <td data-bind="text: usage"></td>
+                {% if show_account_credits %}
+                  <td data-bind="text: accountAmount"></td>
+                {% endif %}
+              </tr>
+              </tbody>
+            </table>
+          {% endif %}
         {% endif %}
       </article>
     </div>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -26,7 +26,7 @@
   <section id="plans">
 
     <p class="community-plan-notice text-center"
-       data-bind="visible: isCurrentPlanCommunity">
+       data-bind="visible: oIsCurrentPlanCommunity">
       {% blocktrans %}
         You are currently on the FREE CommCare Community plan.
       {% endblocktrans %}
@@ -35,7 +35,7 @@
     <p class="switch-label text-center">
       {% trans "Pay Monthly" %}
       <label class="switch">
-        <input type="checkbox" id="pricing-toggle" data-bind="{checked: showAnnualPricing}">
+        <input type="checkbox" id="pricing-toggle" data-bind="{checked: oShowAnnualPricing}">
         <span class="slider round slider-blue slider-blue-on"></span>
       </label>
       {% trans "Pay Annually" %}
@@ -48,7 +48,7 @@
     </p>
 
     <p class="refund-text text-center"
-       data-bind="css: refundCss">
+       data-bind="css: oRefundCss">
       <i class="fa fa-check"></i>
       <a href="https://dimagi.com/terms/latest/tos/"
          class="check-icon blue">
@@ -57,26 +57,26 @@
     </p>
 
     <div class="select-plan-row">
-      <!-- ko foreach: planOptions -->
+      <!-- ko foreach: oPlanOptions -->
       <div class="select-plan-col">
         <a href="#"
            class="tile"
-           data-bind="css: cssClass, click: selectPlan">
-          <h3 data-bind="text: name"></h3>
+           data-bind="css: oCssClass, click: selectPlan">
+          <h3 data-bind="text: oName"></h3>
           <p class="pricing-type"
-             data-bind="text: pricingTypeText, css: pricingTypeCssClass"></p>
+             data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"></p>
 
-          <p class="plan-price" data-bind="text: displayPrice"></p>
+          <p class="plan-price" data-bind="text: oDisplayPrice"></p>
           <p class="plan-monthly-label">{% trans "monthly" %}</p>
-          <p class="plan-desc" data-bind="text: description"></p>
+          <p class="plan-desc" data-bind="text: oDescription"></p>
 
           <div class="btn btn-current"
-               data-bind="visible: isCurrentPlan">
+               data-bind="visible: oIsCurrentPlan">
             {% trans "Current Plan" %}
           </div>
 
           <div class="btn btn-select"
-               data-bind="visible: !isCurrentPlan()">
+               data-bind="visible: !oIsCurrentPlan()">
             {% trans "Select Plan" %}
           </div>
         </a>
@@ -84,10 +84,10 @@
       <!-- /ko -->
     </div>
 
-    <div data-bind="visible: !isCurrentPlanCommunity()">
+    <div data-bind="visible: !oIsCurrentPlanCommunity()">
       <a href="#"
          class="tile tile-paused"
-         data-bind="click: selectPausedPlan, css: pausedCss">
+         data-bind="click: selectPausedPlan, css: oPausedCss">
         <div class="pause-icon">
           <i class="fa fa-pause-circle-o"></i>
         </div>
@@ -126,7 +126,7 @@
         class="form"
         id="select-plan-form"
         method="post"
-        data-bind="visible: showNext"
+        data-bind="visible: oShowNext"
         style="display: none;"
         action="{% url 'confirm_selected_plan' domain %}">
       {% csrf_token %}
@@ -134,20 +134,20 @@
         <input type="hidden" name="from_plan_page" value="true">
       {% endif %}
 
-      <input type="hidden" name="plan_edition" data-bind="value: selectedPlan">
+      <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
       <div class="text-center plan-next">
         <button type="submit"
                 class="btn btn-primary btn-lg"
-                data-bind="click: openMinimumSubscriptionModal, disable: isSubmitDisabled">
+                data-bind="click: openMinimumSubscriptionModal, disable: oIsSubmitDisabled">
           {% trans 'Next' %}
         </button>
       </div>
     </form>
 
     <form action="{% url 'annual_plan_request_quote' domain %}"
-          data-bind="visible: !showNext()">
+          data-bind="visible: !oShowNext()">
       {% csrf_token %}
-      <input type="hidden" name="plan_edition" data-bind="value: selectedPlan">
+      <input type="hidden" name="plan_edition" data-bind="value: oSelectedPlan">
       <div class="text-center plan-next">
         <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
           {% trans 'Talk to Sales' %}

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -23,7 +23,7 @@
     </a>
   </p>
 
-  <section id="plans">
+  <section id="plans" class="ko-template">
 
     <p class="community-plan-notice text-center"
        data-bind="visible: oIsCurrentPlanCommunity">

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -1,24 +1,7 @@
 {% extends "domain/base_change_plan.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
-{% load compress %}
 {% load menu_tags %}
-
-{% block stylesheets %}{{ block.super }}
-  {% if less_debug %}
-    <link type="text/less"
-          rel="stylesheet"
-          media="all"
-          href="{% static 'accounting/less/pricing.debug.less' %}" />
-  {% else %}
-    {% compress css %}
-      <link type="text/less"
-            rel="stylesheet"
-            media="all"
-            href="{% static 'accounting/less/pricing.less' %}" />
-    {% endcompress %}
-  {% endif %}
-{% endblock %}
 
 {% requirejs_main 'accounting/js/pricing_table' %}
 

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -84,29 +84,37 @@
       <!-- /ko -->
     </div>
 
-    <div class="row"
-         data-bind="visible: !isCurrentPlanCommunity()">
-      <div class="col-xs-4 col-xs-offset-4">
-        <a href="#"
-           class="tile tile-community"
-           data-bind="click: selectCommunityPlan, css: communityCss">
-          <h4>
+    <div data-bind="visible: !isCurrentPlanCommunity()">
+      <a href="#"
+         class="tile tile-paused"
+         data-bind="click: selectPausedPlan, css: pausedCss">
+        <div class="pause-icon">
+          <i class="fa fa-pause-circle-o"></i>
+        </div>
+        <h4 class="text-center">
+          {% blocktrans %}
+            Pause Subscription
+          {% endblocktrans %}
+        </h4>
+        <p>
+          {% blocktrans %}
+            What happens if you pause?
+          {% endblocktrans %}
+        </p>
+        <ul>
+          <li>
             {% blocktrans %}
-              Select FREE CommCare Community Plan
+              You will lose access to your project space, but you will be
+              able to re-subscribe anytime in the future.
             {% endblocktrans %}
-          </h4>
-          <p>
+          </li>
+          <li>
             {% blocktrans %}
-              This does not include any paid features.
+              You will no longer be billed.
             {% endblocktrans %}
-          </p>
-
-          <div class="btn btn-select">
-            {% trans "Select Plan" %}
-          </div>
-        </a>
-      </div>
-
+          </li>
+        </ul>
+      </a>
     </div>
 
     <form

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -14,6 +14,8 @@
   {% initial_page_data 'subscription_below_minimum' subscription_below_minimum %}
   {% initial_page_data 'next_subscription_edition' next_subscription_edition %}
   {% initial_page_data 'invoicing_contact_email' INVOICING_CONTACT_EMAIL %}
+  {% initial_page_data 'current_price' current_price %}
+  {% initial_page_data 'is_price_discounted' is_price_discounted %}
   {% registerurl 'email_on_downgrade' domain %}
 
   <p class="lead text-center">
@@ -24,13 +26,6 @@
   </p>
 
   <section id="plans" class="ko-template">
-
-    <p class="community-plan-notice text-center"
-       data-bind="visible: oIsCurrentPlanCommunity">
-      {% blocktrans %}
-        You are currently on the FREE CommCare Community plan.
-      {% endblocktrans %}
-    </p>
 
     <p class="switch-label text-center">
       {% trans "Pay Monthly" %}
@@ -67,8 +62,30 @@
              data-bind="text: oPricingTypeText, css: oPricingTypeCssClass"></p>
 
           <p class="plan-price" data-bind="text: oDisplayPrice"></p>
-          <p class="plan-monthly-label">{% trans "monthly" %}</p>
+          <p class="plan-monthly-label">
+            {% trans "monthly" %}
+            <span data-bind="visible: oDisplayDiscountNotice">({% trans 'discounted' %})</span>
+          </p>
           <p class="plan-desc" data-bind="text: oDescription"></p>
+
+          <p class="plan-downgrade-notice text-warning"
+             data-bind="visible: oShowDowngradeNotice">
+            <i class="fa fa-warning"></i>
+            {% blocktrans %}
+              This plan will be downgrading to
+              <span data-bind="text: oNextPlan"></span> on
+              <span data-bind="text: oNextDate"></span>.
+            {% endblocktrans %}
+          </p>
+
+          <p class="plan-downgrade-notice text-warning"
+             data-bind="visible: oShowPausedNotice">
+            <i class="fa fa-warning"></i>
+            {% blocktrans %}
+              This plan will be pausing on<br />
+              <span data-bind="text: oNextDate"></span>.
+            {% endblocktrans %}
+          </p>
 
           <div class="btn btn-current"
                data-bind="visible: oIsCurrentPlan">
@@ -84,13 +101,10 @@
       <!-- /ko -->
     </div>
 
-    <div data-bind="visible: !oIsCurrentPlanCommunity()">
+    <div data-bind="visible: !oIsCurrentPlanCommunity() && !oIsNextPlanPaused() && !oIsCurrentPlanPaused()">
       <a href="#"
          class="tile tile-paused"
          data-bind="click: selectPausedPlan, css: oPausedCss">
-        <div class="pause-icon">
-          <i class="fa fa-pause-circle-o"></i>
-        </div>
         <h4 class="text-center">
           {% blocktrans %}
             Pause Subscription
@@ -98,7 +112,7 @@
         </h4>
         <p>
           {% blocktrans %}
-            What happens if you pause?
+            What happens after you pause?
           {% endblocktrans %}
         </p>
         <ul>
@@ -115,6 +129,47 @@
           </li>
         </ul>
       </a>
+    </div>
+
+    <div class="alert alert-info text-center"
+         data-bind="visible: oIsCurrentPlanPaused">
+      <p class="lead">
+        <i class="fa fa-pause-circle-o"></i>
+        {% blocktrans %}
+          Your subscription is currently paused.
+        {% endblocktrans %}
+      </p>
+    </div>
+
+    <div class="alert alert-warning text-center"
+         data-bind="visible: oIsNextPlanPaused">
+      <i class="fa fa-warning"></i>
+      {% blocktrans %}
+        Your subscription will be pausing on
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
+        you select a different plan above.
+      {% endblocktrans %}
+    </div>
+
+    <div class="alert alert-warning text-center"
+         style="margin-top: 20px;"
+         data-bind="visible: oIsNextPlanDowngrade">
+      <i class="fa fa-warning"></i>
+      {% blocktrans %}
+        Your subscription will be downgrading to
+        <span data-bind="text: oNextSubscription"></span> on
+        <span data-bind="text: oStartDateAfterMinimumSubscription"></span> unless
+        you select a different plan above.
+      {% endblocktrans %}
+    </div>
+
+    <div class="community-plan-notice alert alert-info text-center"
+         data-bind="visible: oIsCurrentPlanCommunity">
+      <p class="lead">
+        {% blocktrans %}
+          You are currently on the FREE CommCare Community plan.
+        {% endblocktrans %}
+      </p>
     </div>
 
     <form

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -33,12 +33,12 @@
     </p>
 
     <p class="switch-label text-center">
-      {% trans "Pay Annually" %}
+      {% trans "Pay Monthly" %}
       <label class="switch">
-        <input type="checkbox" id="pricing-toggle" data-bind="{checked: showMonthlyPricing}">
+        <input type="checkbox" id="pricing-toggle" data-bind="{checked: showAnnualPricing}">
         <span class="slider round slider-blue slider-blue-on"></span>
       </label>
-      {% trans "Pay Monthly" %}
+      {% trans "Pay Annually" %}
     </p>
 
     <p class="text-center">

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -135,14 +135,12 @@
       {% endif %}
 
       <input type="hidden" name="plan_edition" data-bind="value: selectedPlan">
-      <div class="form-actions" data-bind="visible: isSubmitVisible">
-        <div class="text-center">
-          <button type="submit"
-                  class="btn btn-primary btn-lg"
-                  data-bind="click: openMinimumSubscriptionModal">
-            {% trans 'Next' %}
-          </button>
-        </div>
+      <div class="text-center plan-next">
+        <button type="submit"
+                class="btn btn-primary btn-lg"
+                data-bind="click: openMinimumSubscriptionModal, disable: isSubmitDisabled">
+          {% trans 'Next' %}
+        </button>
       </div>
     </form>
 
@@ -150,12 +148,10 @@
           data-bind="visible: !showNext()">
       {% csrf_token %}
       <input type="hidden" name="plan_edition" data-bind="value: selectedPlan">
-      <div class="form-actions ">
-        <div class="text-center">
-          <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
-            {% trans 'Talk to Sales' %}
-          </button>
-        </div>
+      <div class="text-center plan-next">
+        <button class="btn btn-primary btn-lg" data-bind="click: contactSales">
+          {% trans 'Talk to Sales' %}
+        </button>
       </div>
     </form>
 

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -56,9 +56,9 @@
       </a>
     </p>
 
-    <div class="row select-plan-row">
+    <div class="select-plan-row">
       <!-- ko foreach: planOptions -->
-      <div class="col-xs-3">
+      <div class="select-plan-col">
         <a href="#"
            class="tile"
            data-bind="css: cssClass, click: selectPlan">

--- a/corehq/apps/domain/templates/domain/selected_annual_plan.html
+++ b/corehq/apps/domain/templates/domain/selected_annual_plan.html
@@ -3,27 +3,29 @@
 {% load i18n %}
 
 {% block form_content %}
-  {% if selected_enterprise_plan %}
-    <p class="lead">
+  <p class="lead text-center">
+    {% if selected_enterprise_plan %}
       {% blocktrans with edition as e %}
-        Dimagi handles Enterprise plans on a case-by-case basis. Please submit the following form if you would like
-        to sign up for or have questions regarding an Enterprise plan. Our sales team will be in touch shortly.
+        Dimagi handles Enterprise plans on a case-by-case basis. <br />
+        Please submit the following form if you would like to sign up for or
+        have questions regarding an Enterprise plan. Our sales team will be in touch shortly.
       {% endblocktrans %}
-    </p>
-  {% elif on_annual_plan %}
-    <p class="lead">
+    {% elif on_annual_plan %}
       {% blocktrans with edition as e %}
         Please submit the following form if you would like to sign up for or have questions regarding your
         annual {{ e }} Plan. Our sales team will be in touch shortly.
       {% endblocktrans %}
-    </p>
-  {% else %}
-    <p class="lead">
+    {% else %}
       {% blocktrans with edition as e %}
-        Please submit the following form to request your project space be set up for an annual {{ e }} Plan.
+        Please submit the following form to request your project space be set up for an <strong>annual {{ e }} Plan</strong>.<br/>
         Our sales team will reach out shortly.
       {% endblocktrans %}
-    </p>
-  {% endif %}
-  {% crispy annual_plan_contact_form %}
+    {% endif %}
+  </p>
+
+  <div class="panel panel-modern-gray panel-form-only">
+    <div class="panel-body">
+      {% crispy annual_plan_contact_form %}
+    </div>
+  </div>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/selected_enterprise_plan.html
+++ b/corehq/apps/domain/templates/domain/selected_enterprise_plan.html
@@ -3,12 +3,16 @@
 {% load i18n %}
 
 {% block form_content %}
-  <p class="lead">
+  <p class="lead text-center">
     {% blocktrans %}
-      Dimagi handles Enterprise plans on a case-by-case basis. Please fill out your information
-      below to request a quote.
+      Dimagi handles Enterprise plans on a case-by-case basis. <br />
+      Please fill out your information below to request a quote.
     {% endblocktrans %}
   </p>
 
-  {% crispy enterprise_contact_form %}
+  <div class="panel panel-modern-gray panel-form-only">
+    <div class="panel-body">
+      {% crispy enterprise_contact_form %}
+    </div>
+  </div>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/stripe_cards.html
+++ b/corehq/apps/domain/templates/domain/stripe_cards.html
@@ -1,20 +1,20 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-<fieldset style="margin-top: 20px;">
+<fieldset>
   <legend>{% trans 'Saved Credit Cards' %}</legend>
   <table class='table table-striped'>
     <tbody data-bind="template: {name: 'card-row', foreach: cards}"></tbody>
   </table>
-</fieldset>
 
-<!-- ko with: newCard -->
-<button type='button' class="btn btn-primary new-card" data-toggle="modal" href="#card-modal">
-  <i class='fa fa-plus'></i> {% trans 'Add Card' %}
-</button>
-<div data-bind="template: {name: 'new-stripe-card-template'}"></div>
-{% include 'accounting/partials/new_stripe_card_template.html' %}
-<!-- /ko -->
+  <!-- ko with: newCard -->
+    <button type='button' class="btn btn-primary new-card" data-toggle="modal" href="#card-modal">
+      <i class='fa fa-plus'></i> {% trans 'Add Card' %}
+    </button>
+    <div data-bind="template: {name: 'new-stripe-card-template'}"></div>
+    {% include 'accounting/partials/new_stripe_card_template.html' %}
+  <!-- /ko -->
+</fieldset>
 
 <div class="modal fade" id="success-modal">
   <div class="modal-dialog">

--- a/corehq/apps/domain/templates/domain/update_billing_contact_info.html
+++ b/corehq/apps/domain/templates/domain/update_billing_contact_info.html
@@ -15,7 +15,7 @@
   <div id="billing-info">
     {% crispy billing_account_info_form %}
   </div>
-  <div id="card-manager">
+  <div id="card-manager" style="margin-top:20px;">
     {% include 'domain/stripe_cards.html' %}
   </div>
 {% endblock %}

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -36,6 +36,7 @@ from corehq.apps.domain.views.accounting import (
     SelectPlanView,
     SubscriptionRenewalView,
     WireInvoiceView,
+    pause_subscription,
 )
 from corehq.apps.domain.views.base import select
 from corehq.apps.domain.views.exchange import (
@@ -139,6 +140,7 @@ domain_settings = [
         name=SelectedAnnualPlanView.urlname),
     url(r'^subscription/change/account/$', ConfirmBillingAccountInfoView.as_view(),
         name=ConfirmBillingAccountInfoView.urlname),
+    url(r'^subscription/change/pause/$', pause_subscription, name='pause_subscription'),
     url(r'^subscription/change/email/$', EmailOnDowngradeView.as_view(), name=EmailOnDowngradeView.urlname),
     url(r'^subscription/pro_bono/$', ProBonoView.as_view(), name=ProBonoView.urlname),
     url(r'^subscription/credits/make_payment/$', CreditsStripePaymentView.as_view(),

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1249,6 +1249,10 @@ class ConfirmSelectedPlanView(SelectPlanView):
             )
 
     @property
+    def is_same_edition(self):
+        return self.current_subscription.plan_version.plan.edition == self.edition
+
+    @property
     def is_downgrade_before_minimum(self):
         if self.is_upgrade:
             return False
@@ -1277,6 +1281,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
         return {
             'downgrade_messages': self.downgrade_messages,
             'is_upgrade': self.is_upgrade,
+            'is_same_edition': self.is_same_edition,
             'next_invoice_date': self.next_invoice_date.strftime(USER_DATE_FORMAT),
             'current_plan': (self.current_subscription.plan_version.plan.edition
                              if self.current_subscription is not None else None),
@@ -1292,7 +1297,8 @@ class ConfirmSelectedPlanView(SelectPlanView):
     def main_context(self):
         context = super(ConfirmSelectedPlanView, self).main_context
         context.update({
-            'plan': self.selected_plan_version.user_facing_description,
+            'plan': (self.current_subscription.plan_version.user_facing_description if self.is_same_edition
+                     else self.selected_plan_version.user_facing_description),
         })
         return context
 

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1050,6 +1050,14 @@ class SelectPlanView(DomainAccountingSettings):
 
     @property
     def page_context(self):
+        if self.current_subscription is not None and not self.current_subscription.is_trial:
+            current_price = self.current_subscription.plan_version.product_rate.monthly_fee
+            default_price = DefaultProductPlan.get_default_plan_version(
+                edition=self.current_subscription.plan_version.plan.edition
+            ).product_rate.monthly_fee
+        else:
+            current_price = 0
+            default_price = 0
         return {
             'editions': [
                 edition.lower()
@@ -1066,6 +1074,8 @@ class SelectPlanView(DomainAccountingSettings):
                                 if self.current_subscription is not None
                                 and not self.current_subscription.is_trial
                                 else ""),
+            'current_price': "${0:.0f}".format(current_price),
+            'is_price_discounted': current_price < default_price,
             'start_date_after_minimum_subscription': self.start_date_after_minimum_subscription,
             'subscription_below_minimum': (self.current_subscription.is_below_minimum_subscription
                                            if self.current_subscription is not None else False),

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -860,6 +860,7 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
     page_title = ugettext_lazy("Dimagi Internal Subscription Management")
     form_classes = INTERNAL_SUBSCRIPTION_MANAGEMENT_FORMS
 
+    @method_decorator(always_allow_project_access)
     @method_decorator(require_superuser)
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1362,19 +1362,9 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
     def downgrade_email_note(self):
         if self.is_upgrade:
             return None
-
-        downgrade_reason = self.request.POST.get('downgrade_reason')
-        will_project_restart = self.request.POST.get('will_project_restart')
-        new_tool = self.request.POST.get('new_tool')
-        new_tool_reason = self.request.POST.get('new_tool_reason')
-        feedback = self.request.POST.get('feedback')
-        if not downgrade_reason:
+        if self.is_same_edition:
             return None
-        return 'Why are you downgrading your subscription today?:\n' + downgrade_reason + '\n\n' +\
-               'Is there a chance your project may start again?:\n' + will_project_restart + '\n\n' +\
-               'Could you indicate which new tool you are using?\n' + new_tool + '\n\n' +\
-               'Why are you switching to a new tool?\n' + new_tool_reason + '\n\n' +\
-               'Additional feedback:\n' + feedback
+        return _get_downgrade_or_pause_note(self.request)
 
     @property
     @memoized
@@ -1414,9 +1404,20 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
             next_subscription = self.current_subscription.next_subscription
 
             if is_saved:
-                if self.billing_account_info_form.is_downgrade_from_paid_plan() and not request.user.is_superuser:
-                    self.send_downgrade_email()
-                if next_subscription is not None:
+                if not request.user.is_superuser:
+                    if self.billing_account_info_form.is_same_edition():
+                        self.send_keep_subscription_email()
+                    elif self.billing_account_info_form.is_downgrade_from_paid_plan():
+                        self.send_downgrade_email()
+                if self.billing_account_info_form.is_same_edition():
+                    # Choosing to keep the same subscription
+                    message = _(
+                        "Thank you for choosing to stay with your %(software_plan_name)s "
+                        "Edition Plan subscription."
+                    ) % {
+                        'software_plan_name': software_plan_name,
+                    }
+                elif next_subscription is not None:
                     # New subscription has been scheduled for the future
                     current_subscription_edition = self.current_subscription.plan_version.plan.edition
                     start_date = next_subscription.date_start.strftime(USER_DATE_FORMAT)
@@ -1466,6 +1467,22 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
 
         send_mail_async.delay(
             '{}Subscription downgrade for {}'.format(
+                '[staging] ' if settings.SERVER_ENVIRONMENT == "staging" else "",
+                self.request.domain
+            ), message, settings.DEFAULT_FROM_EMAIL, [settings.GROWTH_EMAIL]
+        )
+
+    def send_keep_subscription_email(self):
+        message = '\n'.join([
+            '{user} decided to keep their subscription for {domain} of {new_plan}',
+        ]).format(
+            user=self.request.couch_user.username,
+            domain=self.request.domain,
+            old_plan=self.request.POST.get('old_plan', 'unknown'),
+        )
+
+        send_mail_async.delay(
+            '{}Subscription kept for {}'.format(
                 '[staging] ' if settings.SERVER_ENVIRONMENT == "staging" else "",
                 self.request.domain
             ), message, settings.DEFAULT_FROM_EMAIL, [settings.GROWTH_EMAIL]
@@ -1686,6 +1703,30 @@ class CardsView(BaseCardView):
             return self._generic_error()
 
         return json_response({'cards': self.payment_method.all_cards_serialized(self.account)})
+
+
+def _get_downgrade_or_pause_note(request, is_pause=False):
+    downgrade_reason = request.POST.get('downgrade_reason')
+    will_project_restart = request.POST.get('will_project_restart')
+    new_tool = request.POST.get('new_tool')
+    new_tool_reason = request.POST.get('new_tool_reason')
+    feedback = request.POST.get('feedback')
+    if not downgrade_reason:
+        return None
+    return "\n".join([
+        "Why are you {method} your subscription today?\n{reason}\n",
+        "Do you think your project may start again?\n{will_project_restart}\n",
+        "Could you indicate which new tool you are using?\n{new_tool}\n",
+        "Why are you switching to a new tool?\n{new_tool_reason}\n",
+        "Additional feedback:\n{feedback}\n\n"
+    ]).format(
+        method="pausing" if is_pause else "downgrading",
+        reason=downgrade_reason,
+        will_project_restart=will_project_restart,
+        new_tool=new_tool,
+        new_tool_reason=new_tool_reason,
+        feedback=feedback,
+    )
 
 
 @require_POST

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1524,10 +1524,17 @@ class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
             current_privs, return_plan=False,
         ).lower()
 
-        context['current_edition'] = (plan
-                                      if self.current_subscription is not None
-                                      and not self.current_subscription.is_trial
-                                      else "")
+        current_edition = (plan
+                           if self.current_subscription is not None
+                           and not self.current_subscription.is_trial
+                           else "")
+
+        # never allow renewal into community
+        if current_edition == SoftwarePlanEdition.COMMUNITY:
+            raise Http404
+
+        context['current_edition'] = current_edition
+
         return context
 
 

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -226,6 +226,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
                 if subscription.is_renewed:
                     next_subscription.update({
                         'exists': True,
+                        'is_paused': subscription.next_subscription.plan_version.is_paused,
                         'date_start': subscription.next_subscription.date_start.strftime(USER_DATE_FORMAT),
                         'name': subscription.next_subscription.plan_version.plan.name,
                         'price': (
@@ -274,7 +275,12 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'cards': cards,
             'next_subscription': next_subscription,
             'has_credits_in_non_general_credit_line': has_credits_in_non_general_credit_line,
-            'is_annual_plan': plan_version.plan.is_annual_plan
+            'is_annual_plan': plan_version.plan.is_annual_plan,
+            'is_paused': subscription.plan_version.is_paused,
+            'previous_subscription_edition': (
+                subscription.previous_subscription.plan_version.plan.edition
+                if subscription.previous_subscription else ""
+            ),
         }
         info['has_account_level_credit'] = (
             any(

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1191,16 +1191,25 @@ class SelectedAnnualPlanView(SelectPlanView):
 class ConfirmSelectedPlanView(SelectPlanView):
     template_name = 'domain/confirm_plan.html'
     urlname = 'confirm_selected_plan'
-    step_title = ugettext_lazy("Confirm Plan")
+
+    @property
+    def step_title(self):
+        if self.is_paused:
+            return _("Confirm Pause")
+        return _("Confirm Subscription")
 
     @property
     def steps(self):
         last_steps = super(ConfirmSelectedPlanView, self).steps
         last_steps.append({
-            'title': _("2. Confirm Plan"),
+            'title': _("2. Confirm Pause") if self.is_paused else _("2. Confirm Subscription"),
             'url': reverse(SelectPlanView.urlname, args=[self.domain]),
         })
         return last_steps
+
+    @property
+    def is_paused(self):
+        return self.edition == SoftwarePlanEdition.PAUSED
 
     @property
     @memoized
@@ -1271,12 +1280,12 @@ class ConfirmSelectedPlanView(SelectPlanView):
             'next_invoice_date': self.next_invoice_date.strftime(USER_DATE_FORMAT),
             'current_plan': (self.current_subscription.plan_version.plan.edition
                              if self.current_subscription is not None else None),
-            'show_community_notice': (self.edition == SoftwarePlanEdition.COMMUNITY
-                                      and self.current_subscription is None),
             'is_downgrade_before_minimum': self.is_downgrade_before_minimum,
             'current_subscription_end_date': self.current_subscription_end_date.strftime(USER_DATE_FORMAT),
             'start_date_after_minimum_subscription': self.start_date_after_minimum_subscription,
-            'new_plan_edition': self.edition
+            'new_plan_edition': self.edition,
+            'is_paused': self.is_paused,
+            'tile_css': 'tile-{}'.format(self.edition.lower()),
         }
 
     @property

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1778,12 +1778,10 @@ def pause_subscription(request, domain):
             )
 
             if current_subscription.is_below_minimum_subscription:
-                messages.success(
-                    request, _("Your project's subscription will be paused on {}. "
-                               "We hope to see you again!".format(
-                                paused_subscription.date_start.strftime(USER_DATE_FORMAT)
-                                ))
-                )
+                messages.success(request, _(
+                    "Your project's subscription will be paused on {}. "
+                    "We hope to see you again!"
+                ).format(paused_subscription.date_start.strftime(USER_DATE_FORMAT)))
             else:
                 messages.success(
                     request, _("Your project's subscription has now been paused. "

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1781,8 +1781,8 @@ def pause_subscription(request, domain):
                 messages.success(
                     request, _("Your project's subscription will be paused on {}. "
                                "We hope to see you again!".format(
-                        paused_subscription.date_start.strftime(USER_DATE_FORMAT)
-                    ))
+                                paused_subscription.date_start.strftime(USER_DATE_FORMAT)
+                                ))
                 )
             else:
                 messages.success(

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -23,6 +23,7 @@ from couchdbkit import ResourceNotFound
 from django_prbac.utils import has_privilege
 from memoized import memoized
 
+from corehq.apps.accounting.decorators import always_allow_project_access
 from dimagi.utils.web import json_response
 
 from corehq import privileges
@@ -172,6 +173,7 @@ class SubscriptionUpgradeRequiredView(LoginAndDomainMixin, BasePageView, DomainV
 
 class DomainAccountingSettings(BaseProjectSettingsView):
 
+    @method_decorator(always_allow_project_access)
     @method_decorator(require_permission(Permissions.edit_billing))
     def dispatch(self, request, *args, **kwargs):
         return super(DomainAccountingSettings, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1499,6 +1499,8 @@ class SubscriptionMixin(object):
             raise Http404
         if subscription.is_renewed:
             raise Http404
+        if subscription.plan_version.is_paused:
+            raise Http404
         return subscription
 
 

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -73,9 +73,10 @@ input:checked + .slider:before {
 .refund-text {
   transition: .4s opacity ease-in-out;
   color: @cc-brand-mid;
-}
-.hide-refund {
   opacity: 0;
+}
+.show-refund {
+  opacity: 1.0;
 }
 
 .tile {
@@ -187,16 +188,26 @@ input:checked + .slider:before {
   height: 350px;
   position: relative;
 
+  &:not(.tile-paused) {
+    @media (max-width: 1199px) {
+      width: 95%;
+    }
+
+    @media (max-width: 939px) {
+      height: 400px;
+    }
+  }
+
   h3 {
     color: @_color-tile !important;
   }
 
   .btn {
     color: @_color-tile !important;
-    width: 140px;
     position: absolute;
     bottom: 30px;
-    left: 50px;
+    width: 76%;
+    left: 12%;
   }
 
   .btn-current {
@@ -242,12 +253,19 @@ input:checked + .slider:before {
   margin-bottom: 20px;
   margin-top: 20px;
   text-align: center;
+  vertical-align: top;
 }
 
 .select-plan-col {
   display: inline-block;
   width: 240px;
   text-align: center;
+  vertical-align: top;
+
+  @media (max-width: 1199px) {
+    width: 24%;
+  }
+
 
   .tile {
     margin: 0 auto;
@@ -266,15 +284,13 @@ input:checked + .slider:before {
   height: auto;
   text-align: left;
   margin: 0 auto;
+  padding-bottom: 15px;
+  padding-top: 20px;
 
   h4 {
     margin-top: 0;
     text-transform: uppercase;
-    margin-bottom: 20px;
-  }
-
-  h4,
-  .pause-icon {
+    margin-bottom: 10px;
     color: @cc-neutral-mid;
 
     &:hover {
@@ -293,16 +309,46 @@ input:checked + .slider:before {
   }
 }
 
-.pause-icon {
-  text-align: center;
-  font-size: 4em;
-  line-height: 60px;
-}
-
 .select-plan-header {
   text-align: center;
   padding-top: 10px;
   padding-bottom: 10px;
 }
+
+.confirm-plan-summary {
+  text-align: center;
+
+  .tile {
+    width: 320px;
+    height: auto;
+    margin: 0 auto;
+
+    .plan-included {
+      text-align: left;
+
+      dl {
+        margin-bottom: 0;
+      }
+    }
+
+    &:after {
+      border-color: transparent;
+    }
+  }
+}
+
+.alert-subscription {
   margin-top: 20px;
+  text-align: center;
+}
+
+.alert-downgrade {
+  width: 505px;
+  margin: 10px auto;
+}
+
+.text-community {
+  text-align: left;
+  max-width: 600px;
+  margin: 0 auto;
 }

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -230,10 +230,6 @@ input:checked + .slider:before {
   ._make-color-tile(@cc-brand-mid);
 }
 
-.tile-community {
-  ._make-color-tile(@cc-neutral-mid);
-}
-
 .select-plan-row {
   margin-bottom: 20px;
   margin-top: 20px;
@@ -243,8 +239,39 @@ input:checked + .slider:before {
   ._make-color-tile(@cc-brand-mid);
 }
 
-.tile-community {
+
+.tile-paused {
   ._make-color-tile(@cc-neutral-mid);
+
+  width: 475px;
+  height: auto;
+  text-align: left;
+  margin: 0 auto;
+
+  h4 {
+    margin-top: 0;
+    text-transform: uppercase;
+    margin-bottom: 20px;
+  }
+
+  h4,
+  .pause-icon {
+    color: @cc-neutral-mid;
+
+    &:hover {
+      color: @cc-neutral-mid;
+    }
+  }
+
+  p {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  ul {
+    padding-left: 40px;
+    padding-right: 40px;
+  }
 }
 
 .select-plan-row {

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -183,12 +183,20 @@ input:checked + .slider:before {
 }
 
 ._make-color-tile(@_color-tile) {
+  width: 230px;
+  height: 350px;
+  position: relative;
+
   h3 {
     color: @_color-tile !important;
   }
 
   .btn {
     color: @_color-tile !important;
+    width: 140px;
+    position: absolute;
+    bottom: 30px;
+    left: 50px;
   }
 
   .btn-current {
@@ -233,10 +241,17 @@ input:checked + .slider:before {
 .select-plan-row {
   margin-bottom: 20px;
   margin-top: 20px;
+  text-align: center;
 }
 
-.tile-enterprise {
-  ._make-color-tile(@cc-brand-mid);
+.select-plan-col {
+  display: inline-block;
+  width: 240px;
+  text-align: center;
+
+  .tile {
+    margin: 0 auto;
+  }
 }
 
 .plan-next {
@@ -278,7 +293,16 @@ input:checked + .slider:before {
   }
 }
 
-.select-plan-row {
-  margin-bottom: 20px;
+.pause-icon {
+  text-align: center;
+  font-size: 4em;
+  line-height: 60px;
+}
+
+.select-plan-header {
+  text-align: center;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
   margin-top: 20px;
 }

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -239,6 +239,10 @@ input:checked + .slider:before {
   ._make-color-tile(@cc-brand-mid);
 }
 
+.plan-next {
+  margin-top: 20px;
+  margin-bottom: 30px;
+}
 
 .tile-paused {
   ._make-color-tile(@cc-neutral-mid);

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/panels.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/panels.less
@@ -58,8 +58,15 @@
 
 
 .panel-form-only {
+  legend {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
   legend:first-child {
     padding-top: 0;
+  }
+  fieldset {
+    padding-bottom: 20px;
   }
 }
 


### PR DESCRIPTION
Note that this merges into `bmb/saas-q4-models`.

##### SUMMARY
This allows projects to pause their subscription on their own. It also includes improvements to the plan subscription process including several UX improvements and changes to verbiage.

Sorry this PR is so enormous, but this was a changes-build-on-other-changes and other changes kind of thing here... happy to go to voice if there's any confusion.

Some notable screen caps...

![Screen Shot 2019-11-14 at 4 20 02 PM](https://user-images.githubusercontent.com/716573/68901683-fc705680-06fb-11ea-9574-5f77c7ed9bbf.png)
![Screen Shot 2019-11-14 at 4 20 14 PM](https://user-images.githubusercontent.com/716573/68901684-fc705680-06fb-11ea-83b5-c342725bb210.png)
![Screen Shot 2019-11-14 at 4 23 07 PM](https://user-images.githubusercontent.com/716573/68901685-fc705680-06fb-11ea-892a-8e53ba472b3c.png)
![Screen Shot 2019-11-14 at 4 23 52 PM](https://user-images.githubusercontent.com/716573/68901686-fd08ed00-06fb-11ea-8485-78e1eb02a50f.png)
![Screen Shot 2019-11-14 at 4 24 16 PM](https://user-images.githubusercontent.com/716573/68901687-fd08ed00-06fb-11ea-9a2f-1a5302dcdfa3.png)
![Screen Shot 2019-11-14 at 4 24 33 PM](https://user-images.githubusercontent.com/716573/68901688-fd08ed00-06fb-11ea-8f55-172086f9c290.png)
