### PR TITLE
Fix intermittent js test failures: don't overwrite initial_page_data urls

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/initial_page_data.js
@@ -89,7 +89,7 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
         var args = arguments;
         var index = 1;
         if (!urls[name]) {
-            urls = gather(url_selector, urls);
+            _.extend(urls, gather(url_selector, urls));
             if (!urls[name]) {
                 throw new Error("URL '" + name + "' not found in registry");
             }
@@ -101,7 +101,7 @@ hqDefine('hqwebapp/js/initial_page_data', ['jquery', 'underscore'], function ($,
 
     $(function () {
         _initData = gather(data_selector, _initData);
-        urls = gather(url_selector, urls);
+        _.extend(urls, gather(url_selector, urls));
     });
 
     return {


### PR DESCRIPTION
##### SUMMARY

The aaa and icds js tests intermittently fail with URL errors like this:

<img width="569" alt="Screen Shot 2019-11-15 at 8 51 22 AM" src="https://user-images.githubusercontent.com/1486591/68948100-24f06300-0785-11ea-8a86-d828df12a40c.png">

My theory is that depending on timing, the tests call `registerUrl` and the urls are later overwritten by the document ready handler. Even if that isn't the source of the test failures, this code should be more correct now.