### PR TITLE
better icds login screen on smaller devices

### DIFF
--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -16,6 +16,10 @@
     img.logo {
       width: 100%;
     }
+    img.phone {
+      max-height: 300px;
+      width: 100%;
+    }
   </style>
 {% endblock stylesheets %}
 
@@ -42,18 +46,16 @@
             <img class="logo" src="{% static 'icds/img/ICDS-CAS_banner.png' %}" alt="CAS Logo" />
         </div>
     </div>
-
     <div class="row">
         <div class="col-sm-2">
-            <img style="height:300px" src="{% static 'icds/img/phone_left.png' %}">
+            <img class="phone" src="{% static 'icds/img/phone_left.png' %}">
         </div>
-
         <div class="col-sm-8" style="padding-top: 40px">
             <h2 class="text-center">Welcome to ICDS-CAS!</h2>
             {% include "login_and_password/two_factor/core/login.html" %}
         </div>
-        <div class="col-lg-2">
-            <img style="height:300px" src="{% static 'icds/img/phone_right.png' %}">
+        <div class="col-sm-2">
+            <img class="phone" src="{% static 'icds/img/phone_right.png' %}">
         </div>
     </div>
 

--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -7,6 +7,13 @@
 
 {% block title %}{% trans "Login to ICDS CAS" %}{% endblock title %}
 {% block title_context %} {% endblock %}
+{% block stylesheets %}
+  <style>
+    img.logo {
+      width: 100%;
+    }
+  </style>
+{% endblock stylesheets %}
 
 <!-- get rid of navigation menu -->
 {% block navigation %}
@@ -18,7 +25,7 @@
 <div class="container">
     <div class="row">
         <div class="col-sm-2">
-            <img style="width: 100%" src="{% static 'icds/img/poshan-logo.png' %}" alt="CommCare HQ Logo" />
+            <img class="logo" src="{% static 'icds/img/poshan-logo.png' %}" alt="Poshan Logo" />
         </div>
         <div class="col-sm-8">
             <br/>
@@ -28,9 +35,7 @@
             {% endblocktrans %}
         </div>
         <div class="col-sm-2">
-            <a href="{% url "homepage" %}" class="navbar-brand">
-            <img style="width: 100%" src="{% static 'icds/img/ICDS-CAS_banner.png' %}" alt="CommCare HQ Logo" />
-            </a>
+            <img class="logo" src="{% static 'icds/img/ICDS-CAS_banner.png' %}" alt="CAS Logo" />
         </div>
     </div>
 

--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -9,6 +9,10 @@
 {% block title_context %} {% endblock %}
 {% block stylesheets %}
   <style>
+    .vcenter {
+      display: flex;
+      align-items: center;
+    }
     img.logo {
       width: 100%;
     }
@@ -23,7 +27,7 @@
 {% block page_content %}
 {% initial_page_data 'implement_password_obfuscation' implement_password_obfuscation %}
 <div class="container">
-    <div class="row">
+    <div class="row vcenter">
         <div class="col-sm-2">
             <img class="logo" src="{% static 'icds/img/poshan-logo.png' %}" alt="Poshan Logo" />
         </div>

--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -20,6 +20,9 @@
       max-height: 300px;
       width: 100%;
     }
+    #login-footer {
+      margin-top: 60px;
+    }
   </style>
 {% endblock stylesheets %}
 
@@ -58,13 +61,9 @@
             <img class="phone" src="{% static 'icds/img/phone_right.png' %}">
         </div>
     </div>
-
-    <div class="row" style="margin-top:60px">
-        <div class="col-sm-1"></div>
-        <div class="col-sm-11">
-            <h6 style="text-align: center;">Content Managed by Ministry of Women and Child Development, GOI</h6>
-            <hr style="background-color: black; height: 3px; border: 0;"/>
-        </div>
+    <div class="row" id="login-footer">
+      <h6 style="text-align: center;">Content Managed by Ministry of Women and Child Development, GOI</h6>
+      <hr style="background-color: black; height: 3px; border: 0;"/>
     </div>
 </div>
 {% endblock page_content %}

--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -36,29 +36,29 @@
 {% initial_page_data 'implement_password_obfuscation' implement_password_obfuscation %}
 <div class="container">
     <div class="row vcenter">
-        <div class="col-sm-2">
+        <div class="col-xs-2">
             <img class="logo" src="{% static 'icds/img/poshan-logo.png' %}" alt="Poshan Logo" />
         </div>
-        <div class="col-sm-8">
+        <div class="col-xs-8">
             <br/>
             {% blocktrans %}
             <h4 class="text-center">Government of India</h4>
             <h2 class="text-center">Ministry of Women and Child Development</h2>
             {% endblocktrans %}
         </div>
-        <div class="col-sm-2">
+        <div class="col-xs-2">
             <img class="logo" src="{% static 'icds/img/ICDS-CAS_banner.png' %}" alt="CAS Logo" />
         </div>
     </div>
     <div class="row">
-        <div class="col-sm-2">
+        <div class="col-sm-2 hidden-xs">
             <img class="phone" src="{% static 'icds/img/phone_left.png' %}">
         </div>
         <div class="col-sm-8" style="padding-top: 40px">
             <h2 class="text-center">Welcome to ICDS-CAS!</h2>
             {% include "login_and_password/two_factor/core/login.html" %}
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-2 hidden-xs">
             <img class="phone" src="{% static 'icds/img/phone_right.png' %}">
         </div>
     </div>

--- a/custom/icds/templates/icds/login.html
+++ b/custom/icds/templates/icds/login.html
@@ -22,6 +22,7 @@
     }
     #login-footer {
       margin-top: 60px;
+      text-align: center;
     }
   </style>
 {% endblock stylesheets %}
@@ -62,7 +63,7 @@
         </div>
     </div>
     <div class="row" id="login-footer">
-      <h6 style="text-align: center;">Content Managed by Ministry of Women and Child Development, GOI</h6>
+      <h6 >Content Managed by Ministry of Women and Child Development, GOI</h6>
       <hr style="background-color: black; height: 3px; border: 0;"/>
     </div>
 </div>


### PR DESCRIPTION
This also fixes the inability to focus the username/password fields on certain screen sizes.

Review by commit.

Wide Desktop Before 

![image](https://user-images.githubusercontent.com/66555/68949954-d7dfb180-07c3-11ea-8f39-f27522826557.png)

After

![image](https://user-images.githubusercontent.com/66555/68949973-e332dd00-07c3-11ea-9768-c139cb574c24.png)

Narrow Desktop Before

![image](https://user-images.githubusercontent.com/66555/68950213-5e948e80-07c4-11ea-8ecd-378952a80825.png)

After

![image](https://user-images.githubusercontent.com/66555/68950020-fe055180-07c3-11ea-9d32-fe66a5b010c6.png)

Mobile Before
![image](https://user-images.githubusercontent.com/66555/68950312-913e8700-07c4-11ea-8b55-5a5d5a630df4.png)
![image](https://user-images.githubusercontent.com/66555/68950106-255c1e80-07c4-11ea-9038-0a9da3f4a8f1.png)

After
![image](https://user-images.githubusercontent.com/66555/68950125-33aa3a80-07c4-11ea-9eab-2e4bcb7e0fc9.png)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
