### PR TITLE
Refactor stagnant case calculation

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -699,14 +699,14 @@ def recalculate_stagnant_cases():
 def _recalculate_stagnant_cases(config_id):
     config, is_static = get_datasource_config(config_id, DASHBOARD_DOMAIN)
     adapter = get_indicator_adapter(config, load_source='find_stagnant_cases')
-    stagnant_case_ids = _find_stagnant_cases(adapter)
-    num_cases = len(stagnant_case_ids)
+    num_cases = 0
+    for case_id in _find_stagnant_cases(adapter):
+        AsyncIndicator.update_record(case_id, 'CommCareCase', DASHBOARD_DOMAIN, [config_id])
+        num_cases += 1
     adapter.track_load(num_cases)
     celery_task_logger.info(
         "Found {} stagnant cases in config {}".format(num_cases, config_id)
     )
-    for case_id in stagnant_case_ids:
-        AsyncIndicator.update_record(case_id, 'CommCareCase', DASHBOARD_DOMAIN, [config_id])
 
 
 def _find_stagnant_cases(adapter):

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -687,13 +687,18 @@ def email_dashboad_team(aggregation_date, aggregation_start_time, force_citus=Fa
     run_every=crontab(day_of_week='tuesday,thursday,saturday', minute=0, hour=16),
     acks_late=True
 )
-def recalculate_stagnant_cases():
-    config_ids = [
-        'static-icds-cas-static-ccs_record_cases_monthly_v2',
-        'static-icds-cas-static-child_cases_monthly_v2',
-    ]
-    for config_id in config_ids:
-        _recalculate_stagnant_cases(config_id)
+def recalculate_stagnant_child_health_cases():
+    _recalculate_stagnant_cases('static-icds-cas-static-child_cases_monthly_v2')
+
+
+@periodic_task_on_envs(
+    settings.ICDS_ENVS,
+    queue='background_queue',
+    run_every=crontab(day_of_week='tuesday,thursday,saturday', minute=0, hour=16),
+    acks_late=True
+)
+def recalculate_stagnant_ccs_record_cases():
+    _recalculate_stagnant_cases('static-icds-cas-static-ccs_record_cases_monthly_v2')
 
 
 def _recalculate_stagnant_cases(config_id):


### PR DESCRIPTION
Following up from https://github.com/dimagi/commcare-hq/pull/25934#discussion_r346095280

##### SUMMARY
This does two main things. It makes each individual query much smaller (only returning 10k records at a time) and makes the task recursive so that each execution only processes those 10k records instead of potentially millions