### PR TITLE
Reduce couchdb writes for reporting metadata

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -319,16 +319,20 @@ def process_reporting_metadata_staging():
             if not user or user.is_deleted():
                 continue
 
+            save = False
             if record.received_on:
-                mark_latest_submission(
+                save = mark_latest_submission(
                     record.domain, user, record.app_id, record.build_id,
-                    record.xform_version, record.form_meta, record.received_on
+                    record.xform_version, record.form_meta, record.received_on, save=False
                 )
             if record.device_id or record.sync_date:
-                mark_last_synclog(
+                save = mark_last_synclog(
                     record.domain, user, record.app_id, record.build_id,
-                    record.sync_date, record.device_id
+                    record.sync_date, record.device_id, save=False
                 )
+            if save:
+                user.save()
+
             record.delete()
 
     if UserReportingMetadataStaging.objects.exists():

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -74,8 +74,12 @@ class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
                     domain, user_id, app_id, build_id, version, metadata, received_on
                 )
             else:
+                user = CouchUser.get_by_user_id(user_id, domain)
+                if not user or user.is_deleted():
+                    return
+
                 mark_latest_submission(
-                    domain, user_id, app_id, build_id, version, metadata, received_on
+                    domain, user, app_id, build_id, version, metadata, received_on
                 )
 
 
@@ -116,12 +120,7 @@ def _last_submission_needs_update(last_submission, received_on_datetime, build_v
     return time_difference > update_frequency
 
 
-def mark_latest_submission(domain, user_id, app_id, build_id, version, metadata, received_on):
-    user = CouchUser.get_by_user_id(user_id, domain)
-
-    if not user or user.is_deleted():
-        return
-
+def mark_latest_submission(domain, user, app_id, build_id, version, metadata, received_on):
     try:
         received_on_datetime = string_to_utc_datetime(received_on)
     except ValueError:

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -120,11 +120,11 @@ def _last_submission_needs_update(last_submission, received_on_datetime, build_v
     return time_difference > update_frequency
 
 
-def mark_latest_submission(domain, user, app_id, build_id, version, metadata, received_on):
+def mark_latest_submission(domain, user, app_id, build_id, version, metadata, received_on, save=True):
     try:
         received_on_datetime = string_to_utc_datetime(received_on)
     except ValueError:
-        return
+        return False
 
     last_submission = filter_by_app(user.reporting_metadata.last_submissions, app_id)
 
@@ -174,4 +174,7 @@ def mark_latest_submission(domain, user, app_id, build_id, version, metadata, re
         )
         update_device_meta(user, device_id, app_version_info.commcare_version, app_meta, save=False)
 
-        user.save()
+        if save:
+            user.save()
+        return True
+    return False

--- a/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_form_submission_metadata_tracker_processor.py
@@ -28,9 +28,8 @@ class MarkLatestSubmissionTest(TestCase):
         )
 
     def tearDown(self):
-        user = CouchUser.get_by_user_id(self.user._id, self.domain)
-        user.reporting_metadata.last_submissions = []
-        user.save()
+        self.user.reporting_metadata.last_submissions = []
+        self.user.save()
 
     @classmethod
     def tearDownClass(cls):
@@ -41,7 +40,7 @@ class MarkLatestSubmissionTest(TestCase):
         submission_date = "2017-02-05T00:00:00.000000Z"
         mark_latest_submission(
             self.domain,
-            self.user._id,
+            self.user,
             self.app_id,
             self.build_id,
             self.version,
@@ -80,7 +79,7 @@ class MarkLatestSubmissionTest(TestCase):
 
         mark_latest_submission(
             self.domain,
-            self.user._id,
+            self.user,
             self.app_id,
             self.build_id,
             self.version,
@@ -92,7 +91,7 @@ class MarkLatestSubmissionTest(TestCase):
 
         mark_latest_submission(
             self.domain,
-            self.user._id,
+            self.user,
             self.app_id,
             self.build_id,
             self.version,
@@ -109,30 +108,7 @@ class MarkLatestSubmissionTest(TestCase):
         submission_date = "bad-date"
         mark_latest_submission(
             self.domain,
-            self.user._id,
-            self.app_id,
-            self.build_id,
-            self.version,
-            self.metadata,
-            submission_date,
-        )
-        self.assertListEqual(self.user.reporting_metadata.last_submissions, [])
-
-        submission_date = "2017-02-05T00:00:00.000000Z"
-        mark_latest_submission(
-            'bad-domain',
-            self.user._id,
-            self.app_id,
-            self.build_id,
-            self.version,
-            self.metadata,
-            submission_date,
-        )
-        self.assertListEqual(self.user.reporting_metadata.last_submissions, [])
-
-        mark_latest_submission(
-            self.domain,
-            'bad-user',
+            self.user,
             self.app_id,
             self.build_id,
             self.version,
@@ -145,7 +121,7 @@ class MarkLatestSubmissionTest(TestCase):
         submission_date = "2017-02-05T00:00:00.000000Z"
         mark_latest_submission(
             self.domain,
-            self.user._id,
+            self.user,
             self.app_id,
             self.build_id,
             self.version,
@@ -154,7 +130,7 @@ class MarkLatestSubmissionTest(TestCase):
         )
         mark_latest_submission(
             self.domain,
-            self.user._id,
+            self.user,
             'other-app-id',
             self.build_id,
             self.version,

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -88,23 +88,24 @@ class UserSyncHistoryProcessor(PillowProcessor):
             mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id)
 
 
-def mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id):
+def mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id, save=True):
     version = None
     if build_id:
         version = get_version_from_build_id(domain, build_id)
 
-    save = update_last_sync(user, app_id, sync_date, version)
+    local_save = update_last_sync(user, app_id, sync_date, version)
     if version:
-        save |= update_latest_builds(user, app_id, sync_date, version)
+        local_save |= update_latest_builds(user, app_id, sync_date, version)
 
     app_meta = None
     if device_id:
         if app_id:
             app_meta = DeviceAppMeta(app_id=app_id, build_id=build_id, last_sync=sync_date)
-        save |= update_device_meta(user, device_id, device_app_meta=app_meta, save=False)
+        local_save |= update_device_meta(user, device_id, device_app_meta=app_meta, save=False)
 
-    if save:
+    if local_save and save:
         user.save(fire_signals=False)
+    return local_save
 
 
 class UserSyncHistoryReindexerDocProcessor(BaseDocProcessor):

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -82,14 +82,13 @@ class UserSyncHistoryProcessor(PillowProcessor):
         if app_id and settings.USER_REPORTING_METADATA_BATCH_ENABLED:
             UserReportingMetadataStaging.add_sync(domain, user_id, app_id, build_id, sync_date, device_id)
         else:
-            mark_last_synclog(domain, user_id, app_id, build_id, sync_date, device_id)
+            user = CouchUser.get_by_user_id(user_id)
+            if not user:
+                return
+            mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id)
 
 
-def mark_last_synclog(domain, user_id, app_id, build_id, sync_date, device_id):
-    user = CouchUser.get_by_user_id(user_id)
-    if not user:
-        return
-
+def mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id):
     version = None
     if build_id:
         version = get_version_from_build_id(domain, build_id)


### PR DESCRIPTION
This optimizes `process_reporting_metadata_staging` by ensuring that there can only be 1 couch save at most per loop instead of 2