### PR TITLE
Removed some dead Product/Program code

### DIFF
--- a/corehq/apps/products/models.py
+++ b/corehq/apps/products/models.py
@@ -152,17 +152,6 @@ class Product(Document):
             clear_fixture_cache(domain, prefix)
 
     @classmethod
-    def get_by_code(cls, domain, code):
-        if not code:
-            return None
-        try:
-            sql_product = SQLProduct.objects.get(domain=domain, code__iexact=code)
-        except SQLProduct.DoesNotExist:
-            return None
-        else:
-            return cls.get(sql_product.product_id)
-
-    @classmethod
     def by_domain(cls, domain, wrap=True, include_archived=False):
         queryset = SQLProduct.objects.filter(domain=domain)
         if not include_archived:

--- a/corehq/apps/programs/models.py
+++ b/corehq/apps/programs/models.py
@@ -96,14 +96,6 @@ class Program(Document):
         self.is_archived = False
         self.save()
 
-    @classmethod
-    def get_by_code(cls, domain, code):
-        result = cls.view("program_by_code/view",
-                          key=[domain, code],
-                          include_docs=True,
-                          limit=1).first()
-        return result
-
     def get_products_count(self):
         return (SQLProduct.objects
                 .filter(domain=self.domain, program_id=self.get_id)


### PR DESCRIPTION
While looking at couch views that aren't used much, briefly thought I could kill `program_by_code`. Can't do that until programs are on SQL, but I can remove this usage.