### PR TITLE
Fix migration of SMS keywords that use surveys

### DIFF
--- a/corehq/apps/ivr/management/commands/populate_app_id_for_call.py
+++ b/corehq/apps/ivr/management/commands/populate_app_id_for_call.py
@@ -1,0 +1,35 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
+from corehq.apps.ivr.models import Call
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Populate any Call models that contain a form_unique_id with the associated app_id."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help='Do not actually modify the database, just verbosely log what will happen',
+        )
+
+    def handle(self, dry_run=False, **options):
+        for call in Call.objects.distinct('domain', 'form_unique_id').filter(app_id__isnull=True,
+                                                                             form_unique_id__isnull=False):
+            log_prefix = "{} Domain {}, form unique_id {}".format("[DRY RUN]" if dry_run else "",
+                                                                  call.domain,
+                                                                  call.form_unique_id)
+            app_id = get_app_id_from_form_unique_id(call.domain, call.form_unique_id)
+            if app_id:
+                to_update = Call.objects.filter(form_unique_id=call.form_unique_id)
+                if not dry_run:
+                    to_update.update(app_id=app_id)
+                logger.info("{}: Updated {} calls to use app id {}".format(log_prefix, to_update.count(), app_id))
+            else:
+                logger.info("{}: Could not find app".format(log_prefix))

--- a/corehq/apps/ivr/migrations/0002_call_app_id.py
+++ b/corehq/apps/ivr/migrations/0002_call_app_id.py
@@ -1,17 +1,14 @@
+from django.core.management import call_command
 from django.db import migrations, models
 
-from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
 @skip_on_fresh_install
 def _populate_app_id(apps, schema_editor):
     Call = apps.get_model('ivr', 'Call')
-    for call in Call.objects.distinct('domain', 'form_unique_id').filter(app_id__isnull=True,
-                                                                         form_unique_id__isnull=False):
-        app_id = get_app_id_from_form_unique_id(call.domain, call.form_unique_id)
-        if app_id:
-            Call.objects.filter(form_unique_id=call.form_unique_id).update(app_id=app_id)
+    if Call.objects.exists():
+        call_command('populate_app_id_for_call')
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/reminders/management/commands/populate_app_id_for_survey_keyword.py
+++ b/corehq/apps/reminders/management/commands/populate_app_id_for_survey_keyword.py
@@ -1,0 +1,57 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
+from corehq.apps.reminders.models import SurveyKeyword
+from corehq.dbaccessors.couchapps.all_docs import (
+    get_deleted_doc_ids_by_class,
+    get_doc_ids_by_class,
+)
+from corehq.util.couch import DocUpdate, iter_update
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Populate any SurveyKeyword models that contain a form_unique_id with the associated app_id."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help='Do not actually modify the database, just verbosely log what will happen',
+        )
+
+    def handle(self, dry_run=False, **options):
+        def _add_field(doc):
+            updated = False
+            log_prefix = "{} Domain {}, form unique_id {}".format("[DRY RUN]" if dry_run else "",
+                                                                  doc['domain'],
+                                                                  doc['form_unique_id'])
+
+            if doc.get('form_unique_id', None) and not doc.get('app_id', None):
+                doc['app_id'] = get_app_id_from_form_unique_id(doc['domain'], doc['form_unique_id'])
+                if doc['app_id']:
+                    updated = True
+                    logger.info("{}: Updated {} to use app id {}".format(log_prefix, doc['_id'], doc['app_id']))
+                else:
+                    logger.info("{}: Could not find app".format(log_prefix))
+
+            for action in doc['actions']:
+                if action.get('form_unique_id', None) and not action.get('app_id', None):
+                    action['app_id'] = get_app_id_from_form_unique_id(doc['domain'], action['form_unique_id'])
+                    if action['app_id']:
+                        updated = True
+                        logger.info("{}: Updated action in {} to use app id {}".format(log_prefix,
+                                                                                       doc['_id'],
+                                                                                       action['app_id']))
+                    else:
+                        logger.info("{}: Could not find app".format(log_prefix))
+
+            if updated and not dry_run:
+                return DocUpdate(doc)
+
+        doc_ids = get_doc_ids_by_class(SurveyKeyword) + get_deleted_doc_ids_by_class(SurveyKeyword)
+        iter_update(SurveyKeyword.get_db(), _add_field, doc_ids)

--- a/corehq/apps/reminders/migrations/0002_app_id.py
+++ b/corehq/apps/reminders/migrations/0002_app_id.py
@@ -1,27 +1,12 @@
+from django.core.management import call_command
 from django.db import migrations
 
-from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
-from corehq.apps.reminders.models import SurveyKeyword
-from corehq.dbaccessors.couchapps.all_docs import (
-    get_deleted_doc_ids_by_class,
-    get_doc_ids_by_class,
-)
-from corehq.util.couch import DocUpdate, iter_update
 from corehq.util.django_migrations import skip_on_fresh_install
-from corehq.util.log import with_progress_bar
 
 
 @skip_on_fresh_install
 def _populate_app_id(apps, schema_editor):
-    doc_ids = get_doc_ids_by_class(SurveyKeyword) + get_deleted_doc_ids_by_class(SurveyKeyword)
-    iter_update(SurveyKeyword.get_db(), _add_field, with_progress_bar(doc_ids))
-
-
-def _add_field(doc):
-    if doc.get('form_unique_id', None) and not doc.get('app_id', None):
-        doc['app_id'] = get_app_id_from_form_unique_id(doc['domain'], doc['form_unique_id'])
-        if doc['app_id']:
-            return DocUpdate(doc)
+    call_command('populate_app_id_for_survey_keyword')
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/sms/management/commands/populate_app_id_for_sms.py
+++ b/corehq/apps/sms/management/commands/populate_app_id_for_sms.py
@@ -1,0 +1,51 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
+from corehq.apps.sms.models import Keyword, KeywordAction, MessagingEvent, MessagingSubEvent
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+        Populate any KeywordAction, MessagingEvent, and MessagingSubEvent models
+        that contain a form_unique_id with the associated app_id.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help='Do not actually modify the database, just verbosely log what will happen',
+        )
+
+    def handle(self, dry_run=False, **options):
+        def _update_objects(model, domain, form_unique_id):
+            log_prefix = "{} Domain {}, {}, form unique_id {}".format("[DRY RUN]" if dry_run else "",
+                                                                      model.__name__,
+                                                                      domain,
+                                                                      form_unique_id)
+            app_id = get_app_id_from_form_unique_id(domain, form_unique_id)
+            if app_id:
+                to_update = model.objects.filter(form_unique_id=action.form_unique_id, app_id__isnull=True)
+                if not dry_run:
+                    to_update.update(app_id=app_id)
+                logger.info("{}: Updated {} models to use app id {}".format(log_prefix, to_update.count(), app_id))
+            else:
+                logger.info("{}: Could not find app".format(log_prefix))
+
+        for domain_keyword in Keyword.objects.distinct('domain'):
+            for keyword in Keyword.objects.filter(domain=domain_keyword.domain):
+                for action in keyword.keywordaction_set.filter(form_unique_id__isnull=False, app_id__isnull=True):
+                    _update_objects(KeywordAction, keyword.domain, action.form_unique_id)
+
+        events = MessagingEvent.objects.filter(form_unique_id__isnull=False, app_id__isnull=True)
+        for event in events.distinct('domain', 'form_unique_id'):
+            _update_objects(MessagingEvent, event.domain, event.form_unique_id)
+
+        subevents = MessagingSubEvent.objects.filter(form_unique_id__isnull=False, app_id__isnull=True)
+        for subevent in subevents.distinct('parent__domain', 'form_unique_id'):
+            _update_objects(MessagingSubEvent, subevent.parent.domain, subevent.form_unique_id)

--- a/corehq/apps/sms/migrations/0037_app_id.py
+++ b/corehq/apps/sms/migrations/0037_app_id.py
@@ -1,33 +1,12 @@
+from django.core.management import call_command
 from django.db import migrations, models
 
-from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
 @skip_on_fresh_install
 def _populate_app_id(apps, schema_editor):
-
-    Keyword = apps.get_model('sms', 'Keyword')
-    KeywordAction = apps.get_model('sms', 'KeywordAction')
-    for keyword in Keyword.objects.distinct('domain'):
-        for action in keyword.keywordaction_set.filter(form_unique_id__isnull=False):
-            app_id = get_app_id_from_form_unique_id(keyword.domain, action.form_unique_id)
-            if app_id:
-                KeywordAction.objects.filter(form_unique_id=action.form_unique_id).update(app_id=app_id)
-
-    MessagingEvent = apps.get_model('sms', 'MessagingEvent')
-    for event in MessagingEvent.objects.distinct('domain', 'form_unique_id'):
-        if event.form_unique_id:
-            app_id = get_app_id_from_form_unique_id(event.domain, event.form_unique_id)
-            if app_id:
-                MessagingEvent.objects.filter(form_unique_id=event.form_unique_id).update(app_id=app_id)
-
-    MessagingSubEvent = apps.get_model('sms', 'MessagingSubEvent')
-    for subevent in MessagingSubEvent.objects.distinct('parent__domain', 'form_unique_id'):
-        if subevent.form_unique_id:
-            app_id = get_app_id_from_form_unique_id(subevent.parent.domain, subevent.form_unique_id)
-            if app_id:
-                MessagingSubEvent.objects.filter(form_unique_id=subevent.form_unique_id).update(app_id=app_id)
+    call_command('populate_app_id_for_sms')
 
 
 class Migration(migrations.Migration):

--- a/corehq/messaging/scheduling/management/commands/populate_app_id_for_scheduling.py
+++ b/corehq/messaging/scheduling/management/commands/populate_app_id_for_scheduling.py
@@ -35,8 +35,9 @@ class Command(BaseCommand):
             if model.app_id:
                 if not dry_run:
                     model.save()
-                logger.info("{}: Updated {} to use app id {}".format(log_prefix, model.__class__.__name__,
-                                                                                 model.app_id))
+                logger.info("{}: Updated {} to use app id {}".format(log_prefix,
+                                                                     model.__class__.__name__,
+                                                                     model.app_id))
             else:
                 logger.info("{}: Could not find app".format(log_prefix))
 

--- a/corehq/messaging/scheduling/management/commands/populate_app_id_for_scheduling.py
+++ b/corehq/messaging/scheduling/management/commands/populate_app_id_for_scheduling.py
@@ -1,0 +1,48 @@
+import logging
+from itertools import chain
+
+from django.core.management.base import BaseCommand
+
+from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
+from corehq.messaging.scheduling.models import AlertSchedule, TimedSchedule
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+        Populate any SMSSurveyContent and IVRSurveyContent models that
+        contain a form_unique_id with the associated app_id.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help='Do not actually modify the database, just verbosely log what will happen',
+        )
+
+    def handle(self, dry_run=False, **options):
+        def _update_model(model, domain):
+            if model.form_unique_id is None or model.app_id is not None:
+                return None
+
+            log_prefix = "{} Domain {}, form unique_id {}".format("[DRY RUN]" if dry_run else "",
+                                                                  domain,
+                                                                  model.form_unique_id)
+            model.app_id = get_app_id_from_form_unique_id(domain, model.form_unique_id)
+            if model.app_id:
+                if not dry_run:
+                    model.save()
+                logger.info("{}: Updated {} to use app id {}".format(log_prefix, model.__class__.__name__,
+                                                                                 model.app_id))
+            else:
+                logger.info("{}: Could not find app".format(log_prefix))
+
+        for schedule in chain(AlertSchedule.objects.all(), TimedSchedule.objects.all()):
+            for event in schedule.memoized_events:
+                if event.sms_survey_content:
+                    _update_model(event.sms_survey_content, schedule.domain)
+                if event.ivr_survey_content:
+                    _update_model(event.ivr_survey_content, schedule.domain)

--- a/corehq/messaging/scheduling/migrations/0024_app_id.py
+++ b/corehq/messaging/scheduling/migrations/0024_app_id.py
@@ -1,3 +1,4 @@
+from django.core.management import call_command
 from django.db import migrations, models
 
 from corehq.util.django_migrations import skip_on_fresh_install

--- a/corehq/messaging/scheduling/migrations/0024_app_id.py
+++ b/corehq/messaging/scheduling/migrations/0024_app_id.py
@@ -1,28 +1,11 @@
 from django.db import migrations, models
-from itertools import chain
 
-from corehq.apps.app_manager.util import get_app_id_from_form_unique_id
-from corehq.messaging.scheduling.models import AlertSchedule, TimedSchedule
 from corehq.util.django_migrations import skip_on_fresh_install
-
-
-def _update_model(model, domain):
-    if model.form_unique_id is None:
-        return None
-
-    model.app_id = get_app_id_from_form_unique_id(domain, model.form_unique_id)
-    if model.app_id:
-        model.save()
 
 
 @skip_on_fresh_install
 def _populate_app_id(apps, schema_editor):
-    for schedule in chain(AlertSchedule.objects.all(), TimedSchedule.objects.all()):
-        for event in schedule.memoized_events:
-            if event.sms_survey_content:
-                _update_model(event.sms_survey_content, schedule.domain)
-            if event.ivr_survey_content:
-                _update_model(event.ivr_survey_content, schedule.domain)
+    call_command('populate_app_id_for_scheduling')
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1055

A client reported problems with keywords using SMS surveys. The problematic keyword was missing an app id, so presumably a problem with the migration from https://github.com/dimagi/commcare-hq/pull/25757/  Not knowing what had gone wrong, I wrote this PR to allow running all of the migrations from the PR as management commands instead of only as django migrations. In the process, I found the bug in the keyword migration. Once this is merged, I'll re-run the sms migration on all environments.

##### PRODUCT DESCRIPTION
This fixes keywords that have not been sending SMS surveys for approximately the last week.