### PR TITLE
[ICDS Dashboard] Make the middleware avoid APIs

### DIFF
--- a/custom/icds_reports/middleware.py
+++ b/custom/icds_reports/middleware.py
@@ -8,7 +8,9 @@ from custom.icds_reports.urls import DASHBOARD_URL_GROUPS
 exclude_urls = (
     'have_access_to_location',
     'icds-ng-template',
-    'locations'
+    'locations',
+    'mwcd_indicators',
+    'data_export_api'
 )
 
 AUDIT_URLS = frozenset(

--- a/custom/icds_reports/urls.py
+++ b/custom/icds_reports/urls.py
@@ -20,7 +20,6 @@ from custom.icds_reports.views import (
 dashboard_urls = [
     url(r'^icds_image_accessor/(?P<form_id>[\w\-:]+)/(?P<attachment_id>.*)$',
         ICDSImagesAccessorAPI.as_view(), name='icds_image_accessor'),
-    url(r'^data_export', CasDataExportAPIView.as_view(), name='data_export_api'),
     url('^', DashboardView.as_view(), name='icds_dashboard'),
 ]
 
@@ -170,6 +169,7 @@ urlpatterns = [
     url(r'^ap_webservice', APWebservice.as_view(), name='ap_webservice'),
     url(r'^daily_indicators', DailyIndicators.as_view(), name='daily_indicators'),
     url(r'^mwcd_indicators', MWCDDataView.as_view(), name='mwcd_indicators'),
+    url(r'^data_export', CasDataExportAPIView.as_view(), name='data_export_api'),
 
 ]
 

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -1925,7 +1925,7 @@ class CasDataExportAPIView(View):
         data_type = request.GET.get('type')
         if data_type not in self.valid_types:
             return JsonResponse(self.message('invalid_type'), status=400)
-        type_code = self.get_type_code(data_type)
+        type_code = CasDataExportAPIView.get_type_code(data_type)
 
         sync, blob_id = get_cas_data_blob_file(type_code, state_id, selected_date)
 
@@ -1946,7 +1946,7 @@ class CasDataExportAPIView(View):
         return ('woman', 'child', 'awc')
 
     @staticmethod
-    def get_type_code(self, data_type):
+    def get_type_code(data_type):
         type_map = {
             "child": 'child_health_monthly',
             "woman": 'ccs_record_monthly',


### PR DESCRIPTION
Ignore the APIs from the middleware.
Having middleware in between preventing these to be functional and throwing this ERROR

```
  File "/Users/dsi/projects/commcare-hq/custom/icds_reports/middleware.py", line 53, in process_response
    ICDSAuditEntryRecord.create_entry(request, response)
  File "/Users/dsi/projects/commcare-hq/custom/icds_reports/models/util.py", line 69, in create_entry
    record.save()
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/architect/orms/django/features.py", line 110, in wrapper
    method(instance, *args, **kwargs)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/models/base.py", line 808, in save
    force_update=force_update, update_fields=update_fields)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/models/base.py", line 838, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/models/base.py", line 924, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/models/base.py", line 963, in _do_insert
    using=using, raw=raw)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/models/query.py", line 1079, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1112, in execute_sql
    cursor.execute(sql, params)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/backends/utils.py", line 79, in execute
    return super(CursorDebugWrapper, self).execute(sql, params)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/utils/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/Users/dsi/projects/commcare-hq/care/lib/python3.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: null value in column "session_key" violates not-null constraint
DETAIL:  Failing row contains (6929e704-7df6-4629-b9a2-e467a8de1cee, rnegi@dimagi.com, {}, 127.0.0.1, /a/icds-cas/mwcd_indicators, {}, {}, null, 2019-11-19 11:50:05.473834+00, 200).
CONTEXT:  SQL statement "INSERT INTO icds_audit_entry_record_y2019m11 VALUES (($1).*);"
PL/pgSQL function icds_audit_entry_record_insert_child() line 30 at EXECUTE

```



@czue @snopoke @emord 