### PR TITLE
Updated translations to use get_modules and get_forms more often

### DIFF
--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -187,7 +187,7 @@ class AppTranslationsGenerator(object):
         :param module_index: index of module in the app
         :return: name like module_moduleUniqueId
         """
-        _module = self.app.get_module(module_index])
+        _module = self.app.get_module(module_index)
         sheet_name = "_".join(["module", _module.unique_id])
         self.slug_to_name[_module.unique_id] = _module.name
         return sheet_name

--- a/corehq/apps/translations/generators.py
+++ b/corehq/apps/translations/generators.py
@@ -71,7 +71,7 @@ class EligibleForTransifexChecker(object):
         labels_to_skip = defaultdict(set)
         necessary_labels = defaultdict(set)
 
-        for module in self.app.modules:
+        for module in self.app.get_modules():
             for form in module.get_forms():
                 questions = form.get_questions(self.app.langs, include_triggers=True,
                                                include_groups=True, include_translations=True)
@@ -187,7 +187,7 @@ class AppTranslationsGenerator(object):
         :param module_index: index of module in the app
         :return: name like module_moduleUniqueId
         """
-        _module = self.app.modules[module_index]
+        _module = self.app.get_module(module_index])
         sheet_name = "_".join(["module", _module.unique_id])
         self.slug_to_name[_module.unique_id] = _module.name
         return sheet_name
@@ -200,8 +200,8 @@ class AppTranslationsGenerator(object):
         :param form_index: index of form in the module
         :return: name like form_formUniqueId
         """
-        _module = self.app.modules[module_index]
-        form = _module.forms[form_index]
+        _module = self.app.get_module(module_index)
+        form = _module.get_form(form_index)
         sheet_name = "_".join(["form", form.unique_id])
         self.slug_to_name[form.unique_id][self.source_lang] = "%s > %s" % (
             _module.name.get(self.source_lang, _module.default_name()),


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1343160794/events/b2b52bafa5a048b2bf0286dd83f9c71a/

##### SUMMARY
See https://github.com/dimagi/commcare-hq/pull/24375 for explanation of issue. The first line changed here, inside `get_labels_to_skip`, is what I think will fix the bug, as the sentry stack trace includes a line inside that loop.

##### FEATURE FLAG
Transifex

##### PRODUCT DESCRIPTION
Fixes intermittent bug with translations pushes to transifex failing.