### PR TITLE
Hard rate limit submissions

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -5,6 +5,7 @@ from corehq.project_limits.rate_limiter import (
     RateDefinition,
     RateLimiter,
 )
+from corehq.toggles import RATE_LIMIT_SUBMISSIONS
 from corehq.util.datadog.gauges import datadog_counter
 from corehq.util.datadog.utils import bucket_value
 from corehq.util.decorators import run_only_when, silence_and_report_error
@@ -46,7 +47,29 @@ SHOULD_RATE_LIMIT_SUBMISSIONS = not settings.ENTERPRISE_MODE and not settings.UN
 @run_only_when(SHOULD_RATE_LIMIT_SUBMISSIONS)
 @silence_and_report_error("Exception raised in the submission rate limiter",
                           'commcare.xform_submissions.rate_limiter_errors')
-def rate_limit_submission_by_delaying(domain, max_wait):
+def rate_limit_submission(domain):
+    if RATE_LIMIT_SUBMISSIONS.enabled(domain):
+        return _rate_limit_submission(domain)
+    else:
+        _rate_limit_submission_by_delaying(domain, max_wait=15)
+        return False
+
+
+def _rate_limit_submission(domain):
+
+    allow_usage = submission_rate_limiter.allow_usage(domain)
+
+    if allow_usage:
+        submission_rate_limiter.report_usage(domain)
+    else:
+        datadog_counter('commcare.xform_submissions.rate_limited', tags=[
+            'domain:{}'.format(domain),
+        ])
+
+    return not allow_usage
+
+
+def _rate_limit_submission_by_delaying(domain, max_wait):
     if not submission_rate_limiter.allow_usage(domain):
         with TimingContext() as timer:
             acquired = submission_rate_limiter.wait(domain, timeout=max_wait)

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -5,7 +5,7 @@ from corehq.project_limits.rate_limiter import (
     RateDefinition,
     RateLimiter,
 )
-from corehq.toggles import RATE_LIMIT_SUBMISSIONS
+from corehq.toggles import RATE_LIMIT_SUBMISSIONS, NAMESPACE_DOMAIN
 from corehq.util.datadog.gauges import datadog_counter
 from corehq.util.datadog.utils import bucket_value
 from corehq.util.decorators import run_only_when, silence_and_report_error
@@ -48,7 +48,7 @@ SHOULD_RATE_LIMIT_SUBMISSIONS = not settings.ENTERPRISE_MODE and not settings.UN
 @silence_and_report_error("Exception raised in the submission rate limiter",
                           'commcare.xform_submissions.rate_limiter_errors')
 def rate_limit_submission(domain):
-    if RATE_LIMIT_SUBMISSIONS.enabled(domain):
+    if RATE_LIMIT_SUBMISSIONS.enabled(domain, namespace=NAMESPACE_DOMAIN):
         return _rate_limit_submission(domain)
     else:
         _rate_limit_submission_by_delaying(domain, max_wait=15)

--- a/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
+++ b/corehq/apps/toggle_ui/static/toggle_ui/js/flags.js
@@ -17,7 +17,7 @@ hqDefine('toggle_ui/js/flags', [
             if (viewModel.tagFilter() === 'all') {
                 return true;
             }
-            var tag = aData[0].replace(/\n/g," ").replace(/<.*?>/g, "");
+            var tag = aData[0].replace(/\s+/g," ").replace(/<.*?>/g, "").replace(/^\d+ /, "");
             if (viewModel.tagFilter() === "Solutions" && tag.includes("Solutions")) {
                 return true;
             }

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1779,3 +1779,18 @@ mwcd_indicators = StaticToggle(
     TAG_CUSTOM,
     [NAMESPACE_USER],
 )
+
+RATE_LIMIT_SUBMISSIONS = DynamicallyPredictablyRandomToggle(
+    'rate_limit_submissions',
+    'Rate limit submissions with a 429 TOO MANY REQUESTS response',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+    description="""
+    While we are gaining an understanding of the effects of rate limiting,
+    we want to force rate limiting on certain domains, while also being to
+    toggle on and off global rate limiting quickly in response to issues.
+
+    To turn on global rate limiting, set Randomness Level to 1.
+    To turn it off, set to 0.
+    """
+)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -323,7 +323,7 @@ class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):
         label,
         tag,
         namespaces,
-        default_randomness=0,
+        default_randomness=0.0,
         help_link=None,
         description=None,
         always_disabled=None


### PR DESCRIPTION
##### SUMMARY
Adds a toggle we can use to rate limit specific domains, as well as to turn it on for all domains if we want (and off again quickly in response to any issues).

See also https://github.com/dimagi/commcare-hq/pull/25982 (analogous change but for restores)

##### FEATURE FLAG
RATE_LIMIT_SUBMISSIONS_AND_RESTORES

##### PRODUCT DESCRIPTION
Allows the internal tech team / support to turn off and on hard rate-limiting of submissions dynamically.
