### PR TITLE
Revert "Make bypass-sessions into a random toggle"

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -215,7 +215,7 @@ class SentryContextMiddleware(MiddlewareMixin):
                 scope.set_tag('domain', request.domain)
 
 
-class BypassSessionMiddleware(SessionMiddleware):
+class SelectiveSessionMiddleware(SessionMiddleware):
 
     def __init__(self, get_response=None):
         super().__init__(get_response)

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -4,9 +4,7 @@ import mimetypes
 import os
 import datetime
 import re
-import traceback
 from django.conf import settings
-from django.contrib.sessions.backends.cache import SessionStore
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponseRedirect
@@ -14,13 +12,12 @@ from django.urls import reverse
 from django.contrib.auth.views import logout as django_logout
 from django.utils.deprecation import MiddlewareMixin
 
-from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import legacy_domain_re
 from corehq.const import OPENROSA_DEFAULT_VERSION
 from dimagi.utils.logging import notify_exception
 
-from dimagi.utils.parsing import json_format_datetime, string_to_utc_datetime
+from dimagi.utils.parsing import string_to_utc_datetime
 
 try:
     import psutil
@@ -218,37 +215,7 @@ class SentryContextMiddleware(MiddlewareMixin):
                 scope.set_tag('domain', request.domain)
 
 
-session_logger = logging.getLogger('session_access_log')
-
-
-def log_call(func):
-    def with_logging(*args, **kwargs):
-        session_logger.info("\n\n\n")
-        session_logger.info(func.__name__ + " was called")
-        session_logger.info("\n\n\n")
-        for line in traceback.format_stack():
-            white_list = ['corehq/', 'custom/', func.__name__]
-            if any([c in line for c in white_list]):
-                session_logger.info(line.strip())
-        return func(*args, **kwargs)
-    return with_logging
-
-
-def decorate_all_methods(decorator):
-    def decorate(cls):
-        for attr in dir(cls):
-            if "__" not in attr and callable(getattr(cls, attr)):
-                setattr(cls, attr, decorator(getattr(cls, attr)))
-        return cls
-    return decorate
-
-
-@decorate_all_methods(log_call)
-class LoggingSessionStore(SessionStore):
-    pass
-
-
-class LoggingSessionMiddleware(SessionMiddleware):
+class BypassSessionMiddleware(SessionMiddleware):
 
     def __init__(self, get_response=None):
         super().__init__(get_response)
@@ -262,23 +229,6 @@ class LoggingSessionMiddleware(SessionMiddleware):
             any(rx.match(request.path_info) for rx in self.bypass_re))
 
     def process_request(self, request):
-        try:
-            match = re.search(r'/a/[0-9a-z-]+', request.path)
-            if match:
-                domain = match.group(0).split('/')[-1]
-                if self._bypass_sessions(request):
-                    session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME)
-                    request.session = self.SessionStore(session_key)
-                    request.session.save = lambda *x: None
-                    return
-                elif toggles.SESSION_MIDDLEWARE_LOGGING.enabled(domain):
-                    session_logger.info(
-                        "Logging session access for URL {}".format(request.path))
-                    self.SessionStore = LoggingSessionStore
-        except Exception as e:
-            session_logger.error(
-                "Exception {} in LoggingSessionMiddleware for url {}".format(
-                    str(e), request.path)
-            )
-            pass
         super().process_request(request)
+        if self._bypass_sessions(request):
+            request.session.save = lambda *x: None

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -257,8 +257,8 @@ class LoggingSessionMiddleware(SessionMiddleware):
             re.compile(regex.format(domain=legacy_domain_re)) for regex in regexes
         ]
 
-    def _bypass_sessions(self, request, domain):
-        return (toggles.BYPASS_SESSIONS.enabled(domain) and
+    def _bypass_sessions(self, request):
+        return (settings.BYPASS_SESSIONS_FOR_MOBILE and
             any(rx.match(request.path_info) for rx in self.bypass_re))
 
     def process_request(self, request):
@@ -266,7 +266,7 @@ class LoggingSessionMiddleware(SessionMiddleware):
             match = re.search(r'/a/[0-9a-z-]+', request.path)
             if match:
                 domain = match.group(0).split('/')[-1]
-                if self._bypass_sessions(request, domain):
+                if self._bypass_sessions(request):
                     session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME)
                     request.session = self.SessionStore(session_key)
                     request.session.save = lambda *x: None

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1762,7 +1762,8 @@ BYPASS_SESSIONS = StaticToggle(
     'bypass_sessions',
     'Bypass sessions for select mobile URLS',
     TAG_CUSTOM,
-    [NAMESPACE_DOMAIN]
+    [NAMESPACE_DOMAIN],
+    always_enabled={'icds-cas'}
 )
 
 DAILY_INDICATORS = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1751,13 +1751,6 @@ PHI_CAS_INTEGRATION = StaticToggle(
 )
 
 
-SESSION_MIDDLEWARE_LOGGING = StaticToggle(
-    'session_middleware_logging',
-    'Log all session object method calls on this domain',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN]
-)
-
 DAILY_INDICATORS = StaticToggle(
     'daily_indicators',
     'Enable daily indicators api',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1758,14 +1758,6 @@ SESSION_MIDDLEWARE_LOGGING = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-BYPASS_SESSIONS = StaticToggle(
-    'bypass_sessions',
-    'Bypass sessions for select mobile URLS',
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-    always_enabled={'icds-cas'}
-)
-
 DAILY_INDICATORS = StaticToggle(
     'daily_indicators',
     'Enable daily indicators api',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1758,12 +1758,11 @@ SESSION_MIDDLEWARE_LOGGING = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-BYPASS_SESSIONS = DynamicallyPredictablyRandomToggle(
-    'bypass_sessions_r',
+BYPASS_SESSIONS = StaticToggle(
+    'bypass_sessions',
     'Bypass sessions for select mobile URLS',
     TAG_CUSTOM,
-    namespaces=[NAMESPACE_OTHER],
-    default_randomness=0
+    [NAMESPACE_DOMAIN]
 )
 
 DAILY_INDICATORS = StaticToggle(

--- a/settings.py
+++ b/settings.py
@@ -912,6 +912,8 @@ STATIC_DATA_SOURCE_PROVIDERS = [
     'corehq.apps.callcenter.data_source.call_center_data_source_configuration_provider'
 ]
 
+BYPASS_SESSIONS_FOR_MOBILE = False
+
 SESSION_BYPASS_URLS = [
     r'^/a/{domain}/receiver/',
     r'^/a/{domain}/phone/restore/',

--- a/settings.py
+++ b/settings.py
@@ -111,7 +111,6 @@ FORMPLAYER_TIMING_FILE = "%s/%s" % (FILEPATH, "formplayer.timing.log")
 FORMPLAYER_DIFF_FILE = "%s/%s" % (FILEPATH, "formplayer.diff.log")
 SOFT_ASSERTS_LOG_FILE = "%s/%s" % (FILEPATH, "soft_asserts.log")
 MAIN_COUCH_SQL_DATAMIGRATION = "%s/%s" % (FILEPATH, "main_couch_sql_datamigration.log")
-SESSION_ACCESS_LOG_FILE = "%s/%s" % (FILEPATH, "session_access_log.log")
 
 LOCAL_LOGGING_CONFIG = {}
 
@@ -126,7 +125,7 @@ SECRET_KEY = 'you should really change this'
 MIDDLEWARE = [
     'corehq.middleware.NoCacheMiddleware',
     # 'django.contrib.sessions.middleware.SessionMiddleware',
-    'corehq.middleware.LoggingSessionMiddleware',
+    'corehq.middleware.BypassSessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -1144,14 +1143,6 @@ LOGGING = {
             'maxBytes': 10 * 1024 * 1024,
             'backupCount': 20
         },
-        'session_access_log': {
-            'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'formatter': 'simple',
-            'filename': SESSION_ACCESS_LOG_FILE,
-            'maxBytes': 10 * 1024 * 1024,
-            'backupCount': 20
-        },
     },
     'root': {
         'level': 'INFO',
@@ -1241,11 +1232,6 @@ LOGGING = {
         'kafka': {
             'handlers': ['file'],
             'level': 'ERROR',
-            'propagate': False,
-        },
-        'session_access_log': {
-            'handlers': ['session_access_log'],
-            'level': 'DEBUG',
             'propagate': False,
         },
     }

--- a/settings.py
+++ b/settings.py
@@ -124,8 +124,7 @@ SECRET_KEY = 'you should really change this'
 
 MIDDLEWARE = [
     'corehq.middleware.NoCacheMiddleware',
-    # 'django.contrib.sessions.middleware.SessionMiddleware',
-    'corehq.middleware.BypassSessionMiddleware',
+    'corehq.middleware.SelectiveSessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Reverts dimagi/commcare-hq#25870 Plus additional commit to always enable the toggle for ICDS

This random toggle been enabled on ICDS for 90% of requests since Nov 13th. Since then, the redis key size and memory usage has been dropping massively! See this dd [graph](https://app.datadoghq.com/dashboard/tr7-nw2-bgb/redis-timeboard?from_ts=1571661681731&live=true&tile_size=m&to_ts=1574253681731&tpl_var_environment=icds). The default session expiry is 14 days, so within another week most of the older keys should get expired too which should free up more memory. Since all good, this PR releases it for all requests by default on ICDS.

<img width="634" alt="Screenshot 2019-11-20 at 6 23 46 PM" src="https://user-images.githubusercontent.com/829142/69240691-08a85800-0bc3-11ea-998f-83082c36a446.png">

@snopoke @emord 
cc @rohit-dimagi @esoergel 


