### PR TITLE
Catch error about missing form XML and proceed

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -31,6 +31,7 @@ from corehq.form_processor.exceptions import (
     CaseSaveError,
     LedgerSaveError,
     LedgerValueNotFound,
+    MissingFormXml,
     NotAllowed,
     XFormNotFound,
     XFormSaveError,
@@ -361,7 +362,10 @@ class FormReindexAccessor(ReindexAccessor):
             pass
 
     def doc_to_json(self, doc):
-        return doc.to_json(include_attachments=self.include_attachments)
+        try:
+            return doc.to_json(include_attachments=self.include_attachments)
+        except MissingFormXml:
+            return {}
 
     def extra_filters(self, for_count=False):
         filters = []


### PR DESCRIPTION
##### SUMMARY
See the corresponding issue for context: https://github.com/dimagi/commcare-hq/issues/25985
I tested this locally by adding `return {}` to the top of this method - it succeeds here, but will be skipped later by https://github.com/dimagi/commcare-hq/blob/8e8243bc80964e6981fcb89a712776e9faf97397/corehq/pillows/xform.py#L60-L68

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
