### PR TITLE
Add DELETABLE_COUCH_DOC_TYPES constant to cleanup/deletable_doc_types.py

### DIFF
--- a/corehq/apps/cleanup/deletable_doc_types.py
+++ b/corehq/apps/cleanup/deletable_doc_types.py
@@ -1,0 +1,17 @@
+"""
+This file is currently just documentation as code,
+but is formatted so as to be friendly to tooling we might write in order to
+clean up these docs.
+"""
+
+MAIN_DB = None
+
+# Doc types for classes we've removed from our code
+# but may still have docs lying around from
+DELETABLE_COUCH_DOC_TYPES = {
+    'SurveyKeyword': (MAIN_DB,),
+    'SurveyKeywordAction': (MAIN_DB,),
+    'CaseReminder': (MAIN_DB,),
+    'CaseReminderHandler': (MAIN_DB,),
+    'CaseReminderEvent': (MAIN_DB,),
+}


### PR DESCRIPTION
##### SUMMARY
to document doc_types we have removed the classes for,
and could be cleaned up from the db without issue

This is how I propose we start tracking deleted couch doc types, if we want to decouple the db cleanup from the deletion of the code.

The doc_types here come from code deleted in https://github.com/dimagi/commcare-hq/pull/25588