### PR TITLE
re-enable reporting data update on ICDS

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 from distutils.version import LooseVersion
 
-from django.conf import settings
 from django.http import (
     Http404,
     HttpResponse,
@@ -310,15 +309,13 @@ def heartbeat(request, domain, app_build_id):
         info.update(LatestAppInfo(brief_app_id, domain).get_info())
 
     else:
-        if settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS:
-            # disable on icds for now since couch still not happy
-            couch_user = request.couch_user
-            try:
-                update_user_reporting_data(app_build_id, app_id, couch_user, request)
-            except ResourceConflict:
-                # https://sentry.io/dimagi/commcarehq/issues/521967014/
-                couch_user = CouchUser.get(couch_user.user_id)
-                update_user_reporting_data(app_build_id, app_id, couch_user, request)
+        couch_user = request.couch_user
+        try:
+            update_user_reporting_data(app_build_id, app_id, couch_user, request)
+        except ResourceConflict:
+            # https://sentry.io/dimagi/commcarehq/issues/521967014/
+            couch_user = CouchUser.get(couch_user.user_id)
+            update_user_reporting_data(app_build_id, app_id, couch_user, request)
 
     if _should_force_log_submission(request):
         info['force_logs'] = True

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1809,3 +1809,10 @@ RATE_LIMIT_RESTORES = DynamicallyPredictablyRandomToggle(
     To turn it off, set to 0.
     """
 )
+
+SKIP_UPDATING_USER_REPORTING_METADATA = StaticToggle(
+    'skip_updating_user_reporting_metadata',
+    'ICDS: Skip updates to user reporting metadata to avoid expected load on couch',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
This PR reverts https://github.com/dimagi/commcare-hq/pull/20296 which was added temporarily

This is coming from [ticket](https://dimagi-dev.atlassian.net/browse/ICDS-909) which needs to track build profile being used by user via heartbeat requests for App Status Report.
