### PR TITLE
Fix Worker Activity Report Case Counts

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -76,8 +76,8 @@ def _get_case_case_counts_by_owner(domain, datespan, case_types, is_total=False,
     es_instance = ES_EXPORT_INSTANCE if export else ES_DEFAULT_INSTANCE
     case_query = (CaseES(es_instance_alias=es_instance)
          .domain(domain)
-         .opened_range(lte=datespan.enddate)
-         .NOT(closed_range_filter(lt=datespan.startdate))
+         .opened_range(lte=datespan.enddate.date())
+         .NOT(closed_range_filter(lt=datespan.startdate.date()))
          .terms_aggregation('owner_id', 'owner_id')
          .size(0))
 
@@ -88,8 +88,8 @@ def _get_case_case_counts_by_owner(domain, datespan, case_types, is_total=False,
 
     if not is_total:
         case_query = case_query.active_in_range(
-            gte=datespan.startdate,
-            lte=datespan.enddate
+            gte=datespan.startdate.date(),
+            lte=datespan.enddate.date(),
         )
 
     if owner_ids:


### PR DESCRIPTION
##### PRODUCT DESCRIPTION
Two columns in the Worker Activity Report are "# Cases Created" and "# Active Cases"
![image](https://user-images.githubusercontent.com/2367539/69361035-9f275880-0c59-11ea-8aef-7430481fa3ab.png)
This makes the two columns use the same date range calculation, which should resolve some odd discrepancies in the counts.

##### SUMMARY
`datespan.startdate` is a `DateTime` object, confusingly enough.  The similar function to the one modified here, `_get_case_counts_by_user` uses `datespan.startdate.date()`, so these two get different counts.

Elasticsearch compares dates and times as follows:
```
    "2019-05-13T18:10:10.499000Z" <= "2019-05-13"
    "2019-05-13T18:10:10.499000Z" > "2019-05-13T00:00:00"
```
That means that unless this uses `enddate.date()`, the last day is
excluded.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
