### PR TITLE
Updated ICDSTableauFilterMixin proportions to match HQ standards

### DIFF
--- a/custom/icds_reports/filters.py
+++ b/custom/icds_reports/filters.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytz
 
 from corehq.apps.domain.models import Domain
+from corehq.apps.hqwebapp.crispy import CSS_FIELD_CLASS, CSS_LABEL_CLASS
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 from corehq.apps.reports.filters.fixtures import AsyncLocationFilter
@@ -74,10 +75,8 @@ def load_locs_json(domain, selected_loc_id=None, user=None, show_test=False):
 class ICDSTableauFilterMixin(object):
     def __init__(self, request, domain=None, timezone=pytz.utc, parent_report=None,
                  css_label=None, css_field=None):
-        css_label = 'col-xs-4 col-md-4 col-lg-4 control-label'
-        css_field = 'col-xs-8 col-md-8 col-lg-8'
         super(ICDSTableauFilterMixin, self).__init__(
-            request, domain, timezone, parent_report, css_label, css_field
+            request, domain, timezone, parent_report, 'control-label ' + CSS_LABEL_CLASS, CSS_FIELD_CLASS
         )
 
 


### PR DESCRIPTION
Fix this:
<img width="1314" alt="Screen Shot 2019-11-21 at 1 50 34 PM" src="https://user-images.githubusercontent.com/1486591/69369153-8757d080-0c69-11ea-9a96-f2a19d846e40.png">

Looks like this file was largely written by Sol Develo. Tagging some ICDS devs for review.