### PR TITLE
Fix ICDS reconciliation task and improve stagnant case task.

### DIFF
--- a/custom/icds_reports/models/util.py
+++ b/custom/icds_reports/models/util.py
@@ -164,14 +164,14 @@ class UcrReconciliationStatus(models.Model):
                 ]
             },
             cls.CommCareCase: {
-                'commcare-user': ['static-commcare_user_cases'],
-                'ccs_record': ['static-ccs_record_cases'],
-                'child_health': ['static-child_health_cases'],
-                'hardware': ['static-hardware_cases'],
-                'household': ['static-household_cases'],
-                'person': ['static-person_cases_v3'],
-                'tasks': ['static-tasks_cases'],
-                'tech_issue': ['static-tech_issue_cases'],
+                'static-commcare_user_cases': ['commcare-user'],
+                'static-ccs_record_cases': ['ccs_record'],
+                'static-child_health_cases': ['child_health'],
+                'static-hardware_cases': ['hardware'],
+                'static-household_cases': ['household'],
+                'static-person_cases_v3': ['person'],
+                'static-tasks_cases': ['tasks'],
+                'static-tech_issue_cases': ['tech_issue'],
             },
         }
 

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -747,7 +747,8 @@ def _find_stagnant_cases(adapter, latest_datetime):
     query_object = adapter.get_query_object()
     return (
         query_object.with_entities(table.c.doc_id, table.c.inserted_at).filter(
-            table.c.inserted_at >= latest_datetime
+            table.c.inserted_at >= latest_datetime,
+            table.c.inserted_at <= datetime.utcnow()  # This filter is used to force postgres to use the index
         ).distinct().order_by(table.c.inserted_at)[:BATCH_SIZE]
     )
 

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -748,7 +748,7 @@ def _find_stagnant_cases(adapter, latest_datetime):
     return (
         query_object.with_entities(table.c.doc_id, table.c.inserted_at).filter(
             table.c.inserted_at >= latest_datetime
-        ).distinct().order_by(table.c.inserted_at, table.c.doc_id)[:BATCH_SIZE]
+        ).distinct().order_by(table.c.inserted_at)[:BATCH_SIZE]
     )
 
 

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -721,7 +721,7 @@ def recalculate_stagnant_ccs_record_cases(latest_datetime='1970-01-01'):
     if latest_datetime == last_processed_datetime:
         notify_exception(None, message="BATCH_SIZE not large enough in stagnant case calculations")
         return
-    recalculate_stagnant_child_health_cases.delay(last_processed_datetime)
+    recalculate_stagnant_ccs_record_cases.delay(last_processed_datetime)
 
 
 def _recalculate_stagnant_cases(config_id, latest_datetime):


### PR DESCRIPTION
##### SUMMARY
Fixes a couple of recent tasks for ICDS.

I also saw some bad performance by one of the stagnant case queries. Including the doc_id and not including a <= inserted_at filter was causing the query to do a full sequential scan for reasons i haven't fully understood yet.