### PR TITLE
Fix update_domain_date logic for first access for a domain_membership

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -295,7 +295,10 @@ def update_domain_date(user_id, domain):
     if domain_membership and (
             not domain_membership.last_accessed or domain_membership.last_accessed < today):
         domain_membership.last_accessed = today
-        user.save()
+        try:
+            user.save()
+        except ResourceConflict:
+            pass
 
 
 @periodic_task(

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -292,8 +292,8 @@ def update_domain_date(user_id, domain):
     user = WebUser.get_by_user_id(user_id, domain)
     domain_membership = user.get_domain_membership(domain)
     today = datetime.today().date()
-    if (domain_membership and domain_membership.last_accessed
-            and today > domain_membership.last_accessed):
+    if domain_membership and (
+            not domain_membership.last_accessed or domain_membership.last_accessed < today):
         domain_membership.last_accessed = today
         user.save()
 


### PR DESCRIPTION
##### SUMMARY

Currently if a domain_membership has never been given a last_accessed value
it never will be.

Genealogy of this issue:

- Gabriella makes https://github.com/dimagi/commcare-hq/pull/24243 to keep track of the last time each web user accesses each domain it's a member of, for an enterprise report to show inactive web users
- @snopoke makes https://github.com/dimagi/commcare-hq/pull/25191 to reduce the number of saves. There's not a lot of context in that ticket, but I can imagine if a web user enters a domain and makes multiple requests fairly quickly, they could each trip fire off a `update_domain_date` task, and which could result in more saves than necessary
- @emord makes https://github.com/dimagi/commcare-hq/pull/25197 to make it not 500 the first time a web user accesses a project
- *This PR* This left it not erroring, but also never setting the `last_accessed` value on any web user that doesn't have it already. As a result, for such users, a new `update_domain_date` task is fired off for _every request_ they make on that project, each with no effect. This PR fixes the logic to save if it's never been set before

As a side note, I'd be in favor of storing analytics like this outside of the user model and outside of couchdb, but rewriting this seemed like more than I'd bargained for for something I just came across locally.

Fun graph: watch [number of `update_domain_date` tasks over the last 4 months](https://app.datadoghq.com/dashboard/bdu-k5b-bz5/celery-overview?from_ts=1563834960000&is_auto=false&live=false&page=0&tile_size=m&to_ts=1574375760000&tpl_var_celery_queue=%2A&tpl_var_celery_task=corehq.apps.users.tasks.update_domain_date&tpl_var_environment=production&fullscreen_widget=1387517464532404&fullscreen_section=overview) grow linearly since Aug 28 as web users join projects.