### PR TITLE
Remove automatic addition of indexes

### DIFF
--- a/corehq/apps/userreports/rebuild.py
+++ b/corehq/apps/userreports/rebuild.py
@@ -1,4 +1,5 @@
-from collections import defaultdict, namedtuple
+import logging
+from collections import defaultdict
 
 import attr
 from alembic.autogenerate import compare_metadata
@@ -14,7 +15,8 @@ from fluff.signals import (
 
 from corehq.apps.userreports.exceptions import TableRebuildError
 from corehq.apps.userreports.models import id_is_static
-from corehq.util.soft_assert import soft_assert
+
+logger = logging.getLogger(__name__)
 
 
 def get_redis_key_for_config(config):
@@ -113,15 +115,14 @@ def apply_index_changes(engine, diffs):
     remove_indexes = [index.index for index in index_diffs if index.type == DiffTypes.REMOVE_INDEX]
     add_indexes = [index.index for index in index_diffs if index.type == DiffTypes.ADD_INDEX]
 
-    with engine.begin() as conn:
-        for index in add_indexes:
-            index.create(conn)
+    for index in add_indexes:
+        column_names = ', '.join(c.name for c in index.columns)
+        logger.error(f'CREATE INDEX CONCURRENTLY "{index.name}" ON {index.table.name} ({column_names})')
 
     # don't remove indexes automatically because we want to be able to add them
     # concurrently without the code removing them
-    _assert = soft_assert(to="@".join(["jemord", "dimagi.com"]))
     for index in remove_indexes:
-        _assert(False, "Index {} can be removed".format(index.name))
+        logger.error(f'DROP INDEX CONCURRENTLY "{index.name}"')
 
     return index_diffs
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -438,9 +438,7 @@ def get_indicator_table(indicator_config, metadata, override_table_name=None):
                 *index.column_ids
             ))
         else:
-            _assert = soft_assert('{}@{}'.format('jemord', 'dimagi.com'))
-            _assert(False, "Invalid index specified on {}".format(table_name))
-            break
+            logger.error(f"Invalid index specified on {table_name} ({index.column_ids})")
     constraints = [PrimaryKeyConstraint(*indicator_config.pk_columns)]
     columns_and_indices = sql_columns + extra_indices + constraints
     # todo: needed to add extend_existing=True to support multiple calls to this function for the same table.

--- a/corehq/apps/userreports/tests/test_rebuild_migrate.py
+++ b/corehq/apps/userreports/tests/test_rebuild_migrate.py
@@ -69,7 +69,8 @@ class RebuildTableTest(TestCase):
         self.assertFalse(pillow.processors[0].rebuild_table.called)
         engine = adapter.engine
         insp = reflection.Inspector.from_engine(engine)
-        self.assertEqual(len(insp.get_indexes(table_name)), 1)
+        # note the index is not yet created
+        self.assertEqual(len(insp.get_indexes(table_name)), 0)
 
     def test_add_non_nullable_column(self):
         self._setup_data_source('add_non_nullable_col')


### PR DESCRIPTION
##### SUMMARY
This would make the indexes in the UCR docs, informational only. Right now if you want to remove an index, you need to remove the index from the UCR first, and if you want to add one to an existing UCR, realistically you need to add it yourself before the deploy.

This will make creating new data sources more annoying if they have indexes, but would make something like https://dimagi-dev.atlassian.net/browse/IIO-596 easier. I couldn't find an easy way to automatically create the index if it was new UCR, but open to ideas.

Are there any objections to this? As a follow up I can make a mgmt command that pulls out the queries from the logs to give a nicer interface of what commands need to be run.