### PR TITLE
Fix location search pagination

### DIFF
--- a/corehq/apps/locations/static/locations/js/utils.js
+++ b/corehq/apps/locations/static/locations/js/utils.js
@@ -25,7 +25,7 @@ hqDefine('locations/js/utils', [
                 processResults: function (data, params) {
                     params.page = params.page || 1;
                     var more = data.more || (params.page * 10) < data.total;
-                    return { results: data.results, more: more };
+                    return { results: data.results, pagination: { more: more } };
                 },
             },
         });

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -1050,7 +1050,7 @@ def child_locations_for_select2(request, domain):
     paginator = Paginator(locs, 10)
     return json_response({
         'results': list(map(loc_to_payload, paginator.page(page))),
-        'total_count': paginator.count,
+        'total': paginator.count,
     })
 
 

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -357,10 +357,14 @@ hqDefine("users/js/mobile_workers",[
                     data: function (params) {
                         return {
                             name: params.term,
+                            page_limit: 10,
+                            page: params.page,
                         };
                     },
                     dataType: 'json',
-                    processResults: function (data) {
+                    processResults: function (data, params) {
+                        params.page = params.page || 1;
+                        var more = data.more || (params.page * 10) < data.total;
                         return {
                             results: _.map(data.results, function (r) {
                                 return {
@@ -368,6 +372,7 @@ hqDefine("users/js/mobile_workers",[
                                     id: r.id,
                                 };
                             }),
+                            pagination: { more: more },
                         };
                     },
                 },


### PR DESCRIPTION
Fix location search to show more results when scrolling down on
1. Filter and Downloads Users [Image in the ticket linked below]
2. Searching a location on locations list page
3. Searching a location when creating a new mobile worker

This was raised in https://dimagi-dev.atlassian.net/browse/ICDS-1050.
But then I found two more places where similar thing was happening
I am not sure if pagination was intentionally left to not work[searching a location on locations list] or not implemented[create mobile workers page], but looks like both these places should allow pagination to work

Another nice thing that was done for location search on exports was [exact search](
https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations),
implemented [here](https://github.com/dimagi/commcare-hq/blob/949627d77919c9dcc7b6133956425539cf7ae79a/corehq/apps/reports/filters/controllers.py#L87) that i think is a good ability to add to all location searches, even though i think having multiple location searches is the real problem here.
pinging @esoergel as well for inputs
