### PR TITLE
Removed management_commands from readthedocs index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,6 @@ Welcome to CommCareHQ's documentation!
    class_views
    testing
    forms
-   management_commands
    migrations
    commtrack
    cloudcare


### PR DESCRIPTION
I deleted this a while back but missed removing it here.