### PR TITLE
Pin django-celery-results more tightly at ~=1.0.0

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -41,7 +41,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -35,7 +35,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -34,7 +34,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -38,7 +38,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -41,7 +41,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -35,7 +35,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,7 +10,7 @@ git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=
 decorator==4.0.11
 django>=1.11.23,<2  # security update
 django-braces==1.13.0
-django-celery-results~=1.0
+django-celery-results~=1.0.0
 django-crispy-forms==1.7.0
 jsonfield==1.0.3
 dropbox==9.3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -34,7 +34,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -38,7 +38,7 @@ django-angular==0.7.16
 django-appconf==1.0.3     # via django-compressor, django-statici18n
 django-braces==1.13.0
 django-bulk-update==2.2.0
-django-celery-results==1.1.2
+django-celery-results==1.0.4
 django-compressor==2.1
 django-countries==4.6
 django-crispy-forms==1.7.0


### PR DESCRIPTION
##### SUMMARY

Attempt to fix https://dimagi-dev.atlassian.net/browse/SAASP-10161.
Regardless, the version conflict could signal real incompatibility
so it is a good thing to align anyway.
