### PR TITLE
Fail build if there are pip package conflicts in test-requirements.txt

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -14,6 +14,7 @@ function setup() {
 
     scripts/uninstall-requirements.sh
     pip install -r requirements/test-requirements.txt
+    pip check  # make sure there are no incompatibilities in test-requirements.txt
 
     # compile pyc files
     python -m compileall -q corehq custom submodules testapps *.py


### PR DESCRIPTION
##### SUMMARY

Taking suggestion in https://dimagi-dev.atlassian.net/browse/SAASP-10161, failing build if there's a package config in test-requirements.txt.

I couldn't find a way to run this on a requirements _file_, just on the currently installed requirements. Ideally we'd run it on each of the files `requirements/*requirements.txt`, but if the only way to do that is to install each of them one by one in a clean env, testing just test-requirements.txt seems almost as good and doesn't add almost any time to the build.
