### PR TITLE
Remove indexes when creating child_health_monthly staging table

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -381,7 +381,7 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
 
     def create_temporary_table(self):
         return """
-        CREATE UNLOGGED TABLE \"{table}\" (LIKE child_health_monthly INCLUDING INDEXES);
+        CREATE UNLOGGED TABLE \"{table}\" (LIKE child_health_monthly, PRIMARY KEY (supervisor_id, case_id, month));
         SELECT create_distributed_table('{table}', 'supervisor_id');
         """.format(table=self.temporary_tablename)
 


### PR DESCRIPTION
`INCLUDING INDEXES` is likely included for the primary key, but there are a few other indexes that are never used in the staging table. The indexes (including primary key) take up almost as much space as the table (22 GB for table, 20 GB for indexes). If citus doesn't require a primary key, we could probably even get away with removing the the primary key entirely, or at least removing the `month` parameter 