### PR TITLE
Lower parallelism for agg

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -98,7 +98,7 @@ def run_task(agg_record, query_name):
     query = function_map[query_name]
     if query.by_state == SINGLE_STATE:
         greenlets = []
-        pool = Pool(10)
+        pool = Pool(5)
         for state in state_ids:
             greenlets.append(pool.spawn(query.func, state, agg_date))
         pool.join(raise_error=True)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In an effort to make the stage 1 tasks go faster, this will lower the amount running at once, hopefully to allow each one more dedicated processing time and possibly to lower thrashing in the cache