### PR TITLE
Change logging.error to info

### DIFF
--- a/corehq/apps/userreports/rebuild.py
+++ b/corehq/apps/userreports/rebuild.py
@@ -117,12 +117,12 @@ def apply_index_changes(engine, diffs):
 
     for index in add_indexes:
         column_names = ', '.join(c.name for c in index.columns)
-        logger.error(f'CREATE INDEX CONCURRENTLY "{index.name}" ON {index.table.name} ({column_names})')
+        logger.info(f'CREATE INDEX CONCURRENTLY "{index.name}" ON {index.table.name} ({column_names})')
 
     # don't remove indexes automatically because we want to be able to add them
     # concurrently without the code removing them
     for index in remove_indexes:
-        logger.error(f'DROP INDEX CONCURRENTLY "{index.name}"')
+        logger.info(f'DROP INDEX CONCURRENTLY "{index.name}"')
 
     return index_diffs
 


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1356545400/?project=1545828&query=is%3Aunresolved

##### SUMMARY
Sentry captures error logging, and I don't think that this is necessarily an error. info seems better