### PR TITLE
Fix smsforms sticky sessions by basing them on user_id

### DIFF
--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -289,54 +289,56 @@ def get_response(data):
         raise e
 
 
-def get_raw_instance(session_id, domain=None):
-    """
-    Gets the raw xml instance of the current session regardless of the state that we're in (used for logging partially complete
-    forms to couch when errors happen).
-    """
+class FormplayerInterface:
+    def __init__(self, session_id, domain):
+        self.session_id = session_id
+        self.domain = domain
 
-    data = {
-        "action":"get-instance",
-        "session-id": session_id,
-        "domain": domain
-    }
+    def get_raw_instance(self):
+        """
+        Gets the raw xml instance of the current session regardless of the state that we're in (used for logging partially complete
+        forms to couch when errors happen).
+        """
 
-    response = post_data(json.dumps(data))
-    if "error" in response:
-        error = response["error"]
-        if error == "Form session not found":
-            raise InvalidSessionIdException("Invalid Session Id")
-        else:
-            raise TouchformsError(error)
-    return response
+        data = {
+            "action":"get-instance",
+            "session-id": self.session_id,
+            "domain": self.domain
+        }
 
+        response = post_data(json.dumps(data))
+        if "error" in response:
+            error = response["error"]
+            if error == "Form session not found":
+                raise InvalidSessionIdException("Invalid Session Id")
+            else:
+                raise TouchformsError(error)
+        return response
 
-def answer_question(session_id, answer, domain):
-    """
-    Answer a question. 
-    """
-    data = {"action": "answer",
-            "session-id": session_id,
-            "answer": answer,
-            "domain": domain}
-    return get_response(json.dumps(data))
+    def answer_question(self, answer):
+        """
+        Answer a question.
+        """
+        data = {"action": "answer",
+                "session-id": self.session_id,
+                "answer": answer,
+                "domain": self.domain}
+        return get_response(json.dumps(data))
 
+    def current_question(self):
+        """
+        Retrieves information about the current question.
+        """
+        data = {"action": "current",
+                "session-id": self.session_id,
+                "domain": self.domain}
+        return get_response(json.dumps(data))
 
-def current_question(session_id, domain):
-    """
-    Retrieves information about the current question.
-    """
-    data = {"action": "current",
-            "session-id": session_id,
-            "domain": domain}
-    return get_response(json.dumps(data))
-
-
-def next(session_id, domain):
-    """
-    Moves to the next question.
-    """
-    data = {"action": "next",
-            "session-id": session_id,
-            "domain": domain}
-    return get_response(json.dumps(data))
+    def next(self):
+        """
+        Moves to the next question.
+        """
+        data = {"action": "next",
+                "session-id": self.session_id,
+                "domain": self.domain}
+        return get_response(json.dumps(data))

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -129,7 +129,7 @@ def select_to_text_compact(caption, choices):
     [question] 1:[choice1], 2:[choice2]...
     """
     return "{} {}.".format(
-        caption, ", ".join(["{}:{}".format(i+1, val) for i, val in enumerate(choices)]))
+        caption, ", ".join(["{}:{}".format(i + 1, val) for i, val in enumerate(choices)]))
 
 
 class XformsResponse(object):

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -27,27 +27,14 @@ class InvalidSessionIdException(TouchformsError):
     pass
 
 
-class XFormsConfigException(ValueError):
-    pass
-
-
 class XFormsConfig(object):
 
-    def __init__(self, form_path=None, form_content=None, language="",
-                 session_data=None, preloader_data={}, instance_content=None,
+    def __init__(self, form_content, language="", session_data=None,
                  domain=None, restore_as=None, restore_as_case_id=None):
 
-        if bool(form_path) == bool(form_content):
-            raise XFormsConfigException(
-                "Can specify file path or content but not both!\n"
-                "File Path: {}, Form Content: {}".format(form_path, form_content))
-
-        self.form_path = form_path
         self.form_content = form_content
         self.language = language
         self.session_data = session_data
-        self.preloader_data = preloader_data
-        self.instance_content = instance_content
         self.restore_as = restore_as
         self.restore_as_case_id = restore_as_case_id
         self.domain = domain
@@ -66,13 +53,9 @@ class XFormsConfig(object):
 
         ret = {
             "action": "new-form",
-            "form-name": self.form_path,
             "form-content": self.form_content,
-            "instance-content": self.instance_content,
-            "preloader-data": self.preloader_data,
             "session-data": self.session_data,
             "lang": self.language,
-            "form-url": self.form_path,
             'username': self.session_data.get('username'),
             'domain': self.session_data.get('domain'),
             'app_id': self.session_data.get('app_id'),

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -94,7 +94,7 @@ class XFormsConfig(object):
         Start a new session based on this configuration
         """
 
-        return get_response(json.dumps(self.get_touchforms_dict()))
+        return _get_response(json.dumps(self.get_touchforms_dict()))
 
 
 class XformsEvent(object):
@@ -237,7 +237,7 @@ def formplayer_post_data_helper(d, content_type, url):
     return response.json()
 
 
-def post_data(data, content_type="application/json"):
+def _post_data(data, content_type="application/json"):
     try:
         d = json.loads(data)
     except TypeError:
@@ -268,9 +268,9 @@ def get_formplayer_session_data(data):
     return data
 
 
-def get_response(data):
+def _get_response(data):
     try:
-        response_json = post_data(data)
+        response_json = _post_data(data)
     except socket.error:
         return XformsResponse.server_down()
     try:
@@ -296,7 +296,7 @@ class FormplayerInterface:
             "domain": self.domain
         }
 
-        response = post_data(json.dumps(data))
+        response = _post_data(json.dumps(data))
         if "error" in response:
             error = response["error"]
             if error == "Form session not found":
@@ -313,7 +313,7 @@ class FormplayerInterface:
                 "session-id": self.session_id,
                 "answer": answer,
                 "domain": self.domain}
-        return get_response(json.dumps(data))
+        return _get_response(json.dumps(data))
 
     def current_question(self):
         """
@@ -322,7 +322,7 @@ class FormplayerInterface:
         data = {"action": "current",
                 "session-id": self.session_id,
                 "domain": self.domain}
-        return get_response(json.dumps(data))
+        return _get_response(json.dumps(data))
 
     def next(self):
         """
@@ -331,4 +331,4 @@ class FormplayerInterface:
         data = {"action": "next",
                 "session-id": self.session_id,
                 "domain": self.domain}
-        return get_response(json.dumps(data))
+        return _get_response(json.dumps(data))

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -1,4 +1,9 @@
-import copy
+"""
+A set of wrappers that return the JSON bodies you use to interact with the formplayer
+backend for various sets of tasks.
+
+This API is currently highly beta and could use some hardening.
+"""
 import json
 import socket
 
@@ -6,27 +11,10 @@ from django.conf import settings
 from django.http import Http404
 
 import requests
-import six.moves.http_client
 from requests import HTTPError
-from six.moves.urllib.parse import urlparse
-
-from dimagi.utils.couch.cache.cache_core import get_redis_client
-
 from corehq.apps.formplayer_api.smsforms.exceptions import BadDataError
 from corehq.apps.formplayer_api.utils import get_formplayer_url
-from corehq.form_processor.utils.general import use_sqlite_backend
-from corehq.util.hmac_request import (
-    convert_to_bytestring_if_unicode,
-    get_hmac_digest,
-)
-
-
-"""
-A set of wrappers that return the JSON bodies you use to interact with the formplayer
-backend for various sets of tasks.
-
-This API is currently highly beta and could use some hardening. 
-"""
+from corehq.util.hmac_request import get_hmac_digest
 
 
 class TouchformsError(ValueError):
@@ -45,32 +33,31 @@ class XFormsConfigException(ValueError):
 
 
 class XFormsConfig(object):
-    
-    def __init__(self, form_path=None, form_content=None, language="", 
+
+    def __init__(self, form_path=None, form_content=None, language="",
                  session_data=None, preloader_data={}, instance_content=None,
                  domain=None, restore_as=None, restore_as_case_id=None):
-        
+
         if bool(form_path) == bool(form_content):
-            raise XFormsConfigException\
-                ("Can specify file path or content but not both!\n" 
-                 "File Path: %s, Form Content: %s" % (form_path, form_content))
-        
+            raise XFormsConfigException(
+                "Can specify file path or content but not both!\n"
+                "File Path: %s, Form Content: %s" % (form_path, form_content))
+
         self.form_path = form_path
         self.form_content = form_content
         self.language = language
         self.session_data = session_data
-        self.preloader_data = preloader_data        
+        self.preloader_data = preloader_data
         self.instance_content = instance_content
         self.restore_as = restore_as
         self.restore_as_case_id = restore_as_case_id
         self.domain = domain
-        
+
     def get_touchforms_dict(self):
         """
-        Translates this config into something touchforms wants to 
-        work with
+        Translates this config into something touchforms wants to work with
         """
-        
+
         vals = (("action", "new-form"),
                 ("form-name", self.form_path),
                 ("form-content", self.form_content),
@@ -79,7 +66,7 @@ class XFormsConfig(object):
                 ("session-data", self.session_data),
                 ("lang", self.language),
                 ("form-url", self.form_path))
-        
+
         # only include anything with a value, or touchforms gets mad
         ret = dict([x for x in vals if x[1]])
         self.add_key_helper('username', ret)
@@ -101,20 +88,20 @@ class XFormsConfig(object):
     def add_key_helper(self, key, ret):
         if key in self.session_data:
             ret[key] = self.session_data[key]
-        
+
     def start_session(self):
         """
         Start a new session based on this configuration
         """
 
         return get_response(json.dumps(self.get_touchforms_dict()))
-    
+
 
 class XformsEvent(object):
     """
-    A wrapper for the json event object that comes back from touchforms, which 
+    A wrapper for the json event object that comes back from touchforms, which
     looks approximately like this:n
-    
+
     { "datatype":"select",
       "style":{},
       "choices":["red","green","blue"],
@@ -133,20 +120,20 @@ class XformsEvent(object):
         self.datatype = datadict.get("datatype", "")
         self.output = datadict.get("output", "")
         self.choices = datadict.get("choices", None)
-            
+
     @property
     def text_prompt(self):
         """
         A text-only prompt for this. Used in pure text (or sms) mode.
-        
+
         Kept for backwards compatibility. Should use get_text_prompt, below.
         """
         return self.get_text_prompt()
-    
+
     def get_text_prompt(self):
         """
         Get a text-only prompt for this. Used in pure text (or sms) mode.
-        
+
         """
         if self.datatype == "select" or self.datatype == "multiselect":
             return select_to_text_compact(self.caption, self._dict["choices"])
@@ -158,18 +145,18 @@ def select_to_text_compact(caption, choices):
     """
     A function to convert a select item to text in a compact format.
     Format is:
-    
+
     [question] 1:[choice1], 2:[choice2]...
     """
-    return "%s %s." % (caption,
-                      ", ".join(["%s:%s" % (i+1, val) for i, val in \
-                                 enumerate(choices)])) 
+    return "{} {}.".format(
+        caption, ", ".join(["%s:%s" % (i+1, val) for i, val in enumerate(choices)]))
 
 
 class XformsResponse(object):
     """
-    A wrapper for the json that comes back from touchforms, which 
-    looks approximately like this:
+    A wrapper for the json that comes back from touchforms,
+    which looks approximately like this:
+
     {"event":
         { "datatype":"select",
           "style":{},
@@ -178,15 +165,15 @@ class XformsResponse(object):
      "session_id": 'd0addaa40dbcefefc6a687472a4e65d2',
      "status":"accepted",
      "seq_id":1}
-     
+
     Although errors come back more like this:
-    {'status': 'validation-error', 
-     'seq_id': 2, 
-     'reason': 'some message about constraint', 
+    {'status': 'validation-error',
+     'seq_id': 2,
+     'reason': 'some message about constraint',
      'type': 'constraint'}
-    
+
     """
-    
+
     def __init__(self, datadict):
         self._dict = datadict
         self.is_error = False
@@ -196,17 +183,17 @@ class XformsResponse(object):
             self.text_prompt = self.event.text_prompt
         else:
             self.event = None
-        
-        self.seq_id = datadict.get("seq_id","")
+
+        self.seq_id = datadict.get("seq_id", "")
         self.session_id = datadict.get("session_id", "")
         self.status = datadict.get("status", "")
-        
+
         # custom logic to handle errors
         if self.status == "validation-error":
             assert self.event is None, "There should be no touchforms event for errors"
             self.is_error = True
             self.text_prompt = datadict.get("reason", "that is not a legal answer")
-            
+
         # custom logic to handle http related errors
         elif self.status == "http-error":
             assert self.event is None, "There should be no touchforms event for errors"
@@ -296,12 +283,12 @@ class FormplayerInterface:
 
     def get_raw_instance(self):
         """
-        Gets the raw xml instance of the current session regardless of the state that we're in (used for logging partially complete
-        forms to couch when errors happen).
+        Gets the raw xml instance of the current session regardless of the state that we're in
+        (used for logging partially complete forms to couch when errors happen).
         """
 
         data = {
-            "action":"get-instance",
+            "action": "get-instance",
             "session-id": self.session_id,
             "domain": self.domain
         }

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -48,7 +48,7 @@ class XFormsConfig(object):
     
     def __init__(self, form_path=None, form_content=None, language="", 
                  session_data=None, preloader_data={}, instance_content=None,
-                 touchforms_url=None, auth=None, domain=None, restore_as=None, restore_as_case_id=None):
+                 domain=None, restore_as=None, restore_as_case_id=None):
         
         if bool(form_path) == bool(form_content):
             raise XFormsConfigException\
@@ -61,7 +61,6 @@ class XFormsConfig(object):
         self.session_data = session_data
         self.preloader_data = preloader_data        
         self.instance_content = instance_content
-        self.auth = auth
         self.restore_as = restore_as
         self.restore_as_case_id = restore_as_case_id
         self.domain = domain
@@ -108,7 +107,7 @@ class XFormsConfig(object):
         Start a new session based on this configuration
         """
 
-        return get_response(json.dumps(self.get_touchforms_dict()), auth=self.auth)
+        return get_response(json.dumps(self.get_touchforms_dict()))
     
 
 class XformsEvent(object):
@@ -249,7 +248,7 @@ def formplayer_post_data_helper(d, content_type, url):
     return response.json()
 
 
-def post_data(data, auth=None, content_type="application/json"):
+def post_data(data, content_type="application/json"):
     try:
         d = json.loads(data)
     except TypeError:
@@ -279,10 +278,10 @@ def get_formplayer_session_data(data):
     return data
 
 
-def get_response(data, auth=None):
+def get_response(data):
     try:
-        response_json = post_data(data, auth=auth)
-    except socket.error as e:
+        response_json = post_data(data)
+    except socket.error:
         return XformsResponse.server_down()
     try:
         return XformsResponse(response_json)
@@ -290,7 +289,7 @@ def get_response(data, auth=None):
         raise e
 
 
-def get_raw_instance(session_id, domain=None, auth=None):
+def get_raw_instance(session_id, domain=None):
     """
     Gets the raw xml instance of the current session regardless of the state that we're in (used for logging partially complete
     forms to couch when errors happen).
@@ -302,7 +301,7 @@ def get_raw_instance(session_id, domain=None, auth=None):
         "domain": domain
     }
 
-    response = post_data(json.dumps(data), auth)
+    response = post_data(json.dumps(data))
     if "error" in response:
         error = response["error"]
         if error == "Form session not found":
@@ -312,7 +311,7 @@ def get_raw_instance(session_id, domain=None, auth=None):
     return response
 
 
-def answer_question(session_id, answer, domain, auth=None):
+def answer_question(session_id, answer, domain):
     """
     Answer a question. 
     """
@@ -320,24 +319,24 @@ def answer_question(session_id, answer, domain, auth=None):
             "session-id": session_id,
             "answer": answer,
             "domain": domain}
-    return get_response(json.dumps(data), auth)
+    return get_response(json.dumps(data))
 
 
-def current_question(session_id, domain, auth=None):
+def current_question(session_id, domain):
     """
     Retrieves information about the current question.
     """
     data = {"action": "current",
             "session-id": session_id,
             "domain": domain}
-    return get_response(json.dumps(data), auth)
+    return get_response(json.dumps(data))
 
 
-def next(session_id, domain, auth=None):
+def next(session_id, domain):
     """
     Moves to the next question.
     """
     data = {"action": "next",
             "session-id": session_id,
             "domain": domain}
-    return get_response(json.dumps(data), auth)
+    return get_response(json.dumps(data))

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -52,25 +52,31 @@ class XFormsConfig(object):
         self.restore_as_case_id = restore_as_case_id
         self.domain = domain
 
-    def get_touchforms_dict(self):
+    def start_session(self):
         """
-        Translates this config into something touchforms wants to work with
+        Start a new session based on this configuration
         """
 
-        vals = (("action", "new-form"),
-                ("form-name", self.form_path),
-                ("form-content", self.form_content),
-                ("instance-content", self.instance_content),
-                ("preloader-data", self.preloader_data),
-                ("session-data", self.session_data),
-                ("lang", self.language),
-                ("form-url", self.form_path))
+        return _get_response(self._get_start_session_data())
 
-        # only include anything with a value, or touchforms gets mad
-        ret = dict([x for x in vals if x[1]])
-        self.add_key_helper('username', ret)
-        self.add_key_helper('domain', ret)
-        self.add_key_helper('app_id', ret)
+    def _get_start_session_data(self):
+        """
+        Translates this config into something formplayer wants to work with
+        """
+
+        ret = {
+            "action": "new-form",
+            "form-name": self.form_path,
+            "form-content": self.form_content,
+            "instance-content": self.instance_content,
+            "preloader-data": self.preloader_data,
+            "session-data": self.session_data,
+            "lang": self.language,
+            "form-url": self.form_path,
+            'username': self.session_data.get('username'),
+            'domain': self.session_data.get('domain'),
+            'app_id': self.session_data.get('app_id'),
+        }
 
         if self.restore_as_case_id:
             # The contact starting the survey is a case who will be
@@ -82,18 +88,8 @@ class XFormsConfig(object):
         else:
             raise ValueError("Unable to determine 'restore as' contact for formplayer")
 
-        return ret
-
-    def add_key_helper(self, key, ret):
-        if key in self.session_data:
-            ret[key] = self.session_data[key]
-
-    def start_session(self):
-        """
-        Start a new session based on this configuration
-        """
-
-        return _get_response(self.get_touchforms_dict())
+        # only include anything with a value, or touchforms gets mad
+        return {key: value for key, value in ret.items() if value}
 
 
 class XformsEvent(object):

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -41,7 +41,7 @@ class XFormsConfig(object):
         if bool(form_path) == bool(form_content):
             raise XFormsConfigException(
                 "Can specify file path or content but not both!\n"
-                "File Path: %s, Form Content: %s" % (form_path, form_content))
+                "File Path: {}, Form Content: {}".format(form_path, form_content))
 
         self.form_path = form_path
         self.form_content = form_content
@@ -149,7 +149,7 @@ def select_to_text_compact(caption, choices):
     [question] 1:[choice1], 2:[choice2]...
     """
     return "{} {}.".format(
-        caption, ", ".join(["%s:%s" % (i+1, val) for i, val in enumerate(choices)]))
+        caption, ", ".join(["{}:{}".format(i+1, val) for i, val in enumerate(choices)]))
 
 
 class XformsResponse(object):
@@ -203,8 +203,9 @@ class XformsResponse(object):
             self.args = datadict.get("args")
             self.url = datadict.get("url")
         elif self.event is None:
-            raise TouchformsError("unhandleable response: %s" % json.dumps(datadict),
-                response_data=datadict)
+            raise TouchformsError(
+                "unhandleable response: {}"
+                .format(json.dumps(datadict), response_data=datadict))
 
     @classmethod
     def server_down(cls):
@@ -230,7 +231,8 @@ def formplayer_post_data_helper(d, content_type, url):
     if response.status_code == 404:
         raise Http404(response.reason)
     if 500 <= response.status_code < 600:
-        http_error_msg = '%s Server Error: %s for url: %s' % (response.status_code, response.reason, response.url)
+        http_error_msg = '{} Server Error: {} for url: {}'.format(
+            response.status_code, response.reason, response.url)
         raise HTTPError(http_error_msg, response=response)
     return response.json()
 
@@ -239,7 +241,7 @@ def post_data(data, content_type="application/json"):
     try:
         d = json.loads(data)
     except TypeError:
-        raise BadDataError('unhandleable touchforms query: %s' % data)
+        raise BadDataError('unhandleable touchforms query: {}'.format(data))
 
     domain = d.get("domain")
 
@@ -247,7 +249,8 @@ def post_data(data, content_type="application/json"):
         raise ValueError("Expected domain")
 
     d = get_formplayer_session_data(d)
-    return formplayer_post_data_helper(d, content_type, get_formplayer_url() + "/" + d["action"])
+    return formplayer_post_data_helper(
+        d, content_type, "{}/{}".format(get_formplayer_url(), d["action"]))
 
 
 def get_formplayer_session_data(data):

--- a/corehq/apps/formplayer_api/smsforms/sms.py
+++ b/corehq/apps/formplayer_api/smsforms/sms.py
@@ -30,21 +30,21 @@ def start_session(config):
     return SessionStartInfo(xformsresponse, config.domain)
 
 
-def next_responses(session_id, answer, domain, auth=None):
+def next_responses(session_id, answer, domain):
     if answer:
-        xformsresponse = answer_question(session_id, _tf_format(answer), domain, auth)
+        xformsresponse = answer_question(session_id, _tf_format(answer), domain)
     else:
-        xformsresponse = next(session_id, domain, auth)
-    for resp in _next_responses(xformsresponse, session_id, domain, auth):
+        xformsresponse = next(session_id, domain)
+    for resp in _next_responses(xformsresponse, session_id, domain):
         yield resp
 
 
-def _next_responses(xformsresponse, session_id, domain, auth=None):
+def _next_responses(xformsresponse, session_id, domain):
     if xformsresponse.is_error:
         yield xformsresponse
     elif xformsresponse.event.type == "sub-group":
-        response = next(session_id, domain, auth)
-        for additional_resp in _next_responses(response, session_id, domain, auth):
+        response = next(session_id, domain)
+        for additional_resp in _next_responses(response, session_id, domain):
             yield additional_resp
     elif xformsresponse.event.type == "question":
         yield xformsresponse
@@ -52,8 +52,8 @@ def _next_responses(xformsresponse, session_id, domain, auth=None):
             # We have to deal with Trigger/Label type messages 
             # expecting an 'ok' type response. So auto-send that 
             # and move on to the next question.
-            response = answer_question(session_id, 'ok', domain, auth)
-            for additional_resp in _next_responses(response, session_id, domain, auth):
+            response = answer_question(session_id, 'ok', domain)
+            for additional_resp in _next_responses(response, session_id, domain):
                 yield additional_resp
     elif xformsresponse.event.type == "form-complete":
         sms_form_complete.send(sender="touchforms", session_id=session_id,

--- a/corehq/apps/formplayer_api/smsforms/sms.py
+++ b/corehq/apps/formplayer_api/smsforms/sms.py
@@ -1,4 +1,4 @@
-from corehq.apps.formplayer_api.smsforms.api import answer_question, next
+from corehq.apps.formplayer_api.smsforms.api import FormplayerInterface
 from corehq.apps.formplayer_api.smsforms.signals import sms_form_complete
 
 
@@ -15,9 +15,8 @@ class SessionStartInfo(object):
     @property
     def first_responses(self):
         if self._first_responses is None:
-            self._first_responses = list(_next_responses(self._first_response,
-                                                         self.session_id,
-                                                         self.domain))
+            self._first_responses = list(_next_responses(
+                self._first_response, FormplayerInterface(self.session_id, self.domain)))
         return self._first_responses
 
 
@@ -31,20 +30,21 @@ def start_session(config):
 
 
 def next_responses(session_id, answer, domain):
+    formplayer_interface = FormplayerInterface(session_id, domain)
     if answer:
-        xformsresponse = answer_question(session_id, _tf_format(answer), domain)
+        xformsresponse = formplayer_interface.answer_question(_tf_format(answer))
     else:
-        xformsresponse = next(session_id, domain)
-    for resp in _next_responses(xformsresponse, session_id, domain):
+        xformsresponse = formplayer_interface.next()
+    for resp in _next_responses(xformsresponse, formplayer_interface):
         yield resp
 
 
-def _next_responses(xformsresponse, session_id, domain):
+def _next_responses(xformsresponse, formplayer_interface):
     if xformsresponse.is_error:
         yield xformsresponse
     elif xformsresponse.event.type == "sub-group":
-        response = next(session_id, domain)
-        for additional_resp in _next_responses(response, session_id, domain):
+        response = formplayer_interface.next()
+        for additional_resp in _next_responses(response, formplayer_interface):
             yield additional_resp
     elif xformsresponse.event.type == "question":
         yield xformsresponse
@@ -52,11 +52,11 @@ def _next_responses(xformsresponse, session_id, domain):
             # We have to deal with Trigger/Label type messages 
             # expecting an 'ok' type response. So auto-send that 
             # and move on to the next question.
-            response = answer_question(session_id, 'ok', domain)
-            for additional_resp in _next_responses(response, session_id, domain):
+            response = formplayer_interface.answer_question('ok')
+            for additional_resp in _next_responses(response, formplayer_interface):
                 yield additional_resp
     elif xformsresponse.event.type == "form-complete":
-        sms_form_complete.send(sender="touchforms", session_id=session_id,
+        sms_form_complete.send(sender="touchforms", session_id=formplayer_interface.session_id,
                                form=xformsresponse.event.output)
         yield xformsresponse
 

--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from corehq.apps.domain.models import Domain
-from corehq.apps.formplayer_api.smsforms.api import current_question
+from corehq.apps.formplayer_api.smsforms.api import FormplayerInterface
 from corehq.apps.sms.api import (
     MessageMetadata,
     add_msg_tags,
@@ -75,7 +75,7 @@ def get_single_open_session_or_close_multiple(domain, contact_id):
 
 
 def answer_next_question(v, text, msg, session):
-    resp = current_question(session.session_id, domain=v.domain)
+    resp = FormplayerInterface(session.session_id, v.domain).current_question()
     event = resp.event
     valid, text, error_msg = validate_answer(event, text, v)
 

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -5,8 +5,8 @@ from dimagi.utils.logging import notify_exception
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.formplayer_api.smsforms.api import (
+    FormplayerInterface,
     TouchformsError,
-    current_question,
 )
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import SQLLocation
@@ -112,7 +112,8 @@ def global_keyword_current(v, text, msg, text_words, open_sessions):
             xforms_session_couch_id=session._id,
         )
 
-        resp = current_question(session.session_id, v.domain)
+        resp = FormplayerInterface(session.session_id, v.domain).current_question()
+
         send_sms_to_verified_number(v, resp.event.text_prompt,
             metadata=outbound_metadata)
     return True

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -7,10 +7,10 @@ from corehq.apps.app_manager.util import get_cloudcare_session_data
 from corehq.apps.cloudcare.touchforms_api import CaseSessionDataHelper
 from corehq.apps.formplayer_api.smsforms import sms as tfsms
 from corehq.apps.formplayer_api.smsforms.api import (
+    FormplayerInterface,
     InvalidSessionIdException,
     TouchformsError,
     XFormsConfig,
-    get_raw_instance,
 )
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.models import CouchUser
@@ -115,7 +115,7 @@ def submit_unfinished_form(session):
     """
     # Get and clean the raw xml
     try:
-        response = get_raw_instance(session.session_id, session.domain)
+        response = FormplayerInterface(session.session_id, session.domain).get_raw_instance()
         xml = response['output']
     except InvalidSessionIdException:
         return

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -1,8 +1,5 @@
 import re
-import uuid
 from xml.etree.cElementTree import XML, tostring
-
-from django.conf import settings
 
 from dimagi.utils.parsing import json_format_datetime
 
@@ -20,7 +17,7 @@ from corehq.apps.users.models import CouchUser
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.util import utcnow
 
-from .models import XFORMS_SESSION_SMS, SQLXFormsSession
+from .models import SQLXFormsSession
 
 COMMCONNECT_DEVICE_ID = "commconnect"
 

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -237,7 +237,3 @@ class SQLXFormsSession(models.Model):
         while self.current_action_is_a_reminder and self.current_action_due < utcnow():
             self.current_reminder_num += 1
             self.set_current_action_due_timestamp()
-
-
-def get_session_by_session_id(id):
-    return SQLXFormsSession.by_session_id(id)

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from corehq.apps.formplayer_api.smsforms.api import current_question
+from corehq.apps.formplayer_api.smsforms.api import FormplayerInterface
 from corehq.apps.sms.api import MessageMetadata, send_sms_to_verified_number
 from corehq.apps.sms.models import PhoneNumber
 from corehq.apps.smsforms.models import SQLXFormsSession
@@ -41,7 +41,7 @@ def handle_due_survey_action(domain, contact_id, session_id):
                     workflow=session.workflow,
                     xforms_session_couch_id=session._id,
                 )
-                resp = current_question(session.session_id, domain)
+                resp = FormplayerInterface(session.session_id, domain).current_question()
                 send_sms_to_verified_number(
                     p,
                     resp.event.text_prompt,


### PR DESCRIPTION
##### SUMMARY
This PR is mostly refactoring that leads up to the last commit. Best reviewed commit-by-commit.

I found in the course of https://dimagi-dev.atlassian.net/browse/SAASP-10126 that the initial request to start a session sometimes went to a different formplayer machines from subsequent requests in that session. That is because at the time request to start the session is made, we don't have the session id yet, which we are routing to machines based off of. By routing based on user_id instead, all requests including the one to initiate the session go to the same machine.