### PR TITLE
FIX FOR JS ISSUES

### DIFF
--- a/corehq/apps/analytics/static/analytix/js/appcues.js
+++ b/corehq/apps/analytics/static/analytix/js/appcues.js
@@ -28,7 +28,7 @@ hqDefine('analytix/js/appcues', [
 
     $(function () {
         window.AppcuesSettings = {
-            skipAMD: true
+            skipAMD: true,
         };
         var apiId = _get('apiId'),
             scriptUrl = "//fast.appcues.com/" + apiId + '.js';

--- a/corehq/apps/analytics/static/analytix/js/appcues.js
+++ b/corehq/apps/analytics/static/analytix/js/appcues.js
@@ -27,6 +27,9 @@ hqDefine('analytix/js/appcues', [
         };
 
     $(function () {
+        window.AppcuesSettings = {
+            skipAMD: true
+        };
         var apiId = _get('apiId'),
             scriptUrl = "//fast.appcues.com/" + apiId + '.js';
 


### PR DESCRIPTION
##### SUMMARY
It looks like appcues might have changed how their module behaves around AMD setups since when we first implemented it and now, and this has been causing intermittent failures on staging and prod.

Sometimes (or often???) the appcues script loads before the final js bundle (being triggered by `analytix/appcues` in the definition of `base_main`), causing a `requirejs` mismatch error to throw, subsequently causing the final bundle modules to not execute properly even though the bundle itself loads. This is because appcues now detects if an AMD system like `requirejs` is present and defines itself as a module once the script gets loaded onto the page. This, of course, messes up how we then deal with the `Appcues` global, and might even cause `analytix/appcues` to try and load the `appcues` js script again because it can't find the global.

Anyway, long story short, following the [first set of instructions here](https://docs.appcues.com/article/303-using-appcues-with-requirejs) fixes the issue. It skips appcues loading as a module (since some pages using it are not on require.js yet).

The good news in all of this? At least it didn't affect ICDS...lol