### PR TITLE
Release User API ES backend and put couch backend behind a flag

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -106,10 +106,10 @@ class CommCareUserResource(UserResource):
                 raise BadRequest('Project %s has no group with id=%s' % (domain, group_id))
             return list(group.get_users(only_commcare=True))
         else:
-            if toggles.USER_API_USE_ES_BACKEND.enabled_for_request(bundle.request):
-                return UserQuerySetAdapterES(domain, show_archived=show_archived)
-            else:
+            if toggles.USER_API_USE_COUCH_BACKEND.enabled_for_request(bundle.request):
                 return UserQuerySetAdapterCouch(domain, show_archived=show_archived)
+            else:
+                return UserQuerySetAdapterES(domain, show_archived=show_archived)
 
 
 class WebUserResource(UserResource):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1734,10 +1734,12 @@ GROUP_API_USE_COUCH_BACKEND = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER],
 )
 
-
-USER_API_USE_ES_BACKEND = StaticToggle(
-    'user_api_use_es_backend',
-    'Use new ES backend for User API.',
+# todo: remove after Dec 25, 2019 if no one is using
+USER_API_USE_COUCH_BACKEND = StaticToggle(
+    'user_api_use_couch_backend',
+    'Use Old Couch backend for User API. '
+    'This is an escape hatch for support '
+    'to immediately revert a domain to old behavior.',
     TAG_PRODUCT,
     [NAMESPACE_DOMAIN, NAMESPACE_USER],
 )


### PR DESCRIPTION
##### SUMMARY
Follow up to https://github.com/dimagi/commcare-hq/pull/25913 and https://github.com/dimagi/commcare-hq/pull/25930

##### FEATURE FLAG
Old backend is now under `USER_API_USE_COUCH_BACKEND`

##### PRODUCT DESCRIPTION
Speed up the User API