### PR TITLE
Add index on state_id, timeend for dashboard THR forms

### DIFF
--- a/custom/icds_reports/ucr/data_sources/dashboard/thr_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/thr_forms.json
@@ -96,8 +96,7 @@
           },
           "location_type": "state",
           "location_property": "_id"
-        },
-        "create_index": true
+        }
       },
       {
         "display_name": "Supervisor ID",
@@ -217,6 +216,9 @@
     "sql_column_indexes": [
       {
         "column_ids": ["doc_id"]
+      },
+      {
+        "column_ids": ["state_id", "timeend"]
       }
     ],
     "disable_destructive_rebuild": true


### PR DESCRIPTION
This is actually aggregated on twice. 

https://github.com/dimagi/commcare-hq/blob/1fd8791745a49e405a0387619ad6d96f9ec43395/custom/icds_reports/utils/aggregation_helpers/distributed/thr_forms_ccs_record.py#L40-L41

https://github.com/dimagi/commcare-hq/blob/1fd8791745a49e405a0387619ad6d96f9ec43395/custom/icds_reports/utils/aggregation_helpers/distributed/thr_forms_child_health.py#L39-L40


The full table is ~105 GB not including indexes