### PR TITLE
fix for create export drilldown not flushing options when new data is passed to it

### DIFF
--- a/corehq/apps/export/static/export/js/create_export.js
+++ b/corehq/apps/export/static/export/js/create_export.js
@@ -141,6 +141,14 @@ hqDefine("export/js/create_export", [
                     $('#div_id_' + fieldSlug).find("label").text(self._labels[fieldSlug]); 
                     var $formElem = $('#id_' + fieldSlug);
                     if ($formElem.length > 0) {
+                        if ($formElem.hasClass("select2-hidden-accessible")) {
+                            // checks to see if select2 has been initialized already.
+                            // if it has, manually clear all existing HTML <options> on
+                            // the <select> element directly. Otherwise, select2
+                            // will prepend the data below to the existing
+                            // <options>.
+                            $formElem.html('');
+                        }
                         $formElem.select2({
                             data: fieldData || [],
                             width: '100%',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-104

##### SUMMARY
When the form type is switched on the `create_export.js` drill down, the options on the `select2` are not replaced with the new options passed to it, instead the new options are appended to the existing options (not ideal). This makes sure that any existing options are cleared by manually clearing all `<options>` tags on the `<select>` element driving `select2`