### PR TITLE
Remove fire_signals from user saves for reporting data

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -334,7 +334,7 @@ def process_reporting_metadata_staging():
                     record.sync_date, record.device_id, save=False
                 )
             if save:
-                user.save()
+                user.save(fire_signals=False)
 
             record.delete()
 

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -175,6 +175,6 @@ def mark_latest_submission(domain, user, app_id, build_id, version, metadata, re
         update_device_meta(user, device_id, app_version_info.commcare_version, app_meta, save=False)
 
         if save:
-            user.save()
+            user.save(fire_signals=False)
         return True
     return False


### PR DESCRIPTION
##### SUMMARY
@dannyroberts I think we figured out that https://github.com/dimagi/commcare-hq/pull/25825 wasn't the real solution, but it was that the pillow_retry_queue was accidentally deleted. I think that this is safe to reintroduce now right? 

The main benefit here is that it doesn't trigger an ES when we're just updating the reporting data https://github.com/dimagi/commcare-hq/blob/f08bcbdcf3b2075f5b594c62f683699807f76faf/corehq/apps/users/signals.py#L33-L39 It should be sufficient to wait for the pillow to pick itup