### PR TITLE
Revert "add buildProfileID to profile"

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/profile.xml
+++ b/corehq/apps/app_manager/templates/app_manager/profile.xml
@@ -5,8 +5,7 @@
          requiredMinor="{{ app.build_spec.minor_release.1 }}"
          uniqueid="{{ uniqueid }}"
          name="{{ name }}"
-         descriptor="{{ descriptor }}"
-         buildProfileID="{% if build_profile_id %}{{ build_profile_id }}{% endif %}">
+         descriptor="{{ descriptor }}">
     <property key="BackupMode" value="file_mode" force="true"/>
     <property key="backup-url" value="file:///E:/CommCare.Backup" force="true"/>
     <property key="restore-url" value="file:///E:/CommCare.Backup" force="true"/>


### PR DESCRIPTION
Reverts dimagi/commcare-hq#25627

We are going to just add the build profile id as a part of the url itself which mobile would use directly, so this is not needed anymore.

For further context, https://github.com/dimagi/commcare-hq/pull/26035#discussion_r351053999