### PR TITLE
signals for management command + DD event

### DIFF
--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -5,6 +5,8 @@ from django.core.management.base import BaseCommand, CommandError
 
 from email_validator import EmailSyntaxError, validate_email
 
+from corehq.util.signals import signalcommand
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +25,7 @@ class Command(BaseCommand):
             if password == getpass.getpass('Repeat Password:'):
                 return password
 
+    @signalcommand
     def handle(self, username, **options):
         from corehq.apps.users.models import WebUser
         try:

--- a/corehq/apps/hqadmin/app_config.py
+++ b/corehq/apps/hqadmin/app_config.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class HqAdminModule(AppConfig):
+    name = 'corehq.apps.hqadmin'
+
+    def ready(self):
+        from corehq.apps.hqadmin import signals  # noqa

--- a/corehq/apps/hqadmin/signals.py
+++ b/corehq/apps/hqadmin/signals.py
@@ -1,0 +1,15 @@
+from django.dispatch import receiver
+
+from corehq.util.datadog.utils import create_datadog_event
+from corehq.util.signals import post_command
+
+
+@receiver(post_command)
+def record_command_event(sender, args, kwargs, outcome, **extra):
+    if isinstance(outcome, BaseException):
+        outcome = f'{outcome.__class__}: {outcome}'
+    text = f'args: {args}\noptions: {kwargs}\noutcome: {outcome}'
+    event = '{}'.format(sender.__name__)
+    create_datadog_event(
+        event, text, aggregation_key=sender.__name__
+    )

--- a/settings.py
+++ b/settings.py
@@ -226,7 +226,7 @@ HQ_APPS = (
     'corehq.apps.domain',
     'corehq.apps.domain_migration_flags',
     'corehq.apps.dump_reload',
-    'corehq.apps.hqadmin',
+    'corehq.apps.hqadmin.app_config.HqAdminModule',
     'corehq.apps.hqcase',
     'corehq.apps.hqwebapp',
     'corehq.apps.hqmedia',


### PR DESCRIPTION
##### SUMMARY
Decorator for management commands that sends signals pre and post.

Also includes one signal handler to send DD events. 

I've only tagged the `make_superuser` command just to indicate it's usage.

Basically the same as this: https://django-extensions.readthedocs.io/en/latest/command_signals.html
But also handles exceptions

Redo of https://github.com/dimagi/commcare-hq/pull/24854