### PR TITLE
make df aggregation national

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -47,7 +47,6 @@ STATE_TASKS = {
     'agg_ls_awc_mgt_form': _agg_ls_awc_mgt_form,
     'agg_ls_vhnd_form': _agg_ls_vhnd_form,
     'agg_beneficiary_form': _agg_beneficiary_form,
-    'aggregate_df_forms': _aggregate_df_forms,
 }
 
 ALL_STATES_TASKS = {
@@ -66,6 +65,7 @@ NORMAL_TASKS = {
     'agg_ccs_record': _agg_ccs_record_table,
     'agg_awc_table': _agg_awc_table,
     'aggregate_awc_daily': aggregate_awc_daily,
+    'aggregate_df_forms': _aggregate_df_forms,
 }
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is from our skype conversation. Based on incomplete indices, current cost of running this task for large states was very similar to just running it nationally so now it will just do that. Those large states take about 15 minutes now, while I expect it to be longer than that (since there is more data to insert), it should still be a marked improvement. We can go back to statewise aggregation with a proper index later, but the cost seems low enough now that this feels more efficient.

*Relevant Explains*
These are the `select` component of the insert
For just AP
```
   QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=0.00..0.00 rows=0 width=0)
   ->  Sort  (cost=0.00..0.00 rows=0 width=0)
         Sort Key: remote_scan.case_id
         ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
               Task Count: 64
               Tasks Shown: One of 64
               ->  Task
                     Node: host=100.71.184.232 port=6432 dbname=icds_ucr
                     ->  Unique  (cost=98698.06..98701.72 rows=732 width=159)
                           ->  Sort  (cost=98698.06..98699.89 rows=732 width=159)
                                 Sort Key: ucr.child_health_case_id
                                 ->  WindowAgg  (cost=98644.93..98663.23 rows=732 width=159)
                                       ->  Sort  (cost=98644.93..98646.76 rows=732 width=115)
                                             Sort Key: ucr.supervisor_id, ucr.child_health_case_id
                                             ->  Gather  (cost=1001.24..98610.10 rows=732 width=115)
                                                   Workers Planned: 6
                                                   ->  Nested Loop  (cost=1.24..97536.90 rows=122 width=115)
                                                         ->  Parallel Index Only Scan using daily_attendance_pkey_102776 on daily_attendance_102776 daily_attendance  (cost=0.55..44061.68 rows=19107 width=70)
                                                               Index Cond: (month = '2019-10-01'::date)
                                                         ->  Index Scan using "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_pkey_103098" on "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_103098" ucr  (cost=0.69..2.79 rows=1 width=152)
                                                               Index Cond: ((supervisor_id = daily_attendance.supervisor_id) AND (doc_id = daily_attendance.doc_id))
                                                               Filter: ((child_health_case_id IS NOT NULL) AND (timeend >= '2019-10-01 00:00:00'::timestamp without time zone) AND (timeend < '2019-11-01 00:00:00'::timestamp without time zone) AND (state_id = 'f98e91aa003accb7b849a0f18ebd7039'::text))
(22 rows)
```

For all states
```
 QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=0.00..0.00 rows=0 width=0)
   ->  Sort  (cost=0.00..0.00 rows=0 width=0)
         Sort Key: remote_scan.case_id
         ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
               Task Count: 64
               Tasks Shown: One of 64
               ->  Task
                     Node: host=100.71.184.232 port=6432 dbname=icds_ucr
                     ->  Unique  (cost=99205.31..99220.20 rows=2979 width=159)
                           ->  Sort  (cost=99205.31..99212.75 rows=2979 width=159)
                                 Sort Key: ucr.child_health_case_id
                                 ->  WindowAgg  (cost=98958.93..99033.41 rows=2979 width=159)
                                       ->  Sort  (cost=98958.93..98966.38 rows=2979 width=115)
                                             Sort Key: ucr.supervisor_id, ucr.child_health_case_id
                                             ->  Gather  (cost=1001.24..98787.04 rows=2979 width=115)
                                                   Workers Planned: 6
                                                   ->  Nested Loop  (cost=1.24..97489.14 rows=496 width=115)
                                                         ->  Parallel Index Only Scan using daily_attendance_pkey_102776 on daily_attendance_102776 daily_attendance  (cost=0.55..44061.68 rows=19107 width=70)
                                                               Index Cond: (month = '2019-10-01'::date)
                                                         ->  Index Scan using "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_pkey_103098" on "ucr_icds-cas_dashboard_child_health_daily_2cd9a7c1_103098" ucr  (cost=0.69..2.79 rows=1 width=152)
                                                               Index Cond: ((supervisor_id = daily_attendance.supervisor_id) AND (doc_id = daily_attendance.doc_id))
                                                               Filter: ((child_health_case_id IS NOT NULL) AND (timeend >= '2019-10-01 00:00:00'::timestamp without time zone) AND (timeend < '2019-11-01 00:00:00'::timestamp without time zone))
(22 rows)
```

