### PR TITLE
update to notify only when above 2.44.0

### DIFF
--- a/corehq/apps/receiverwrapper/tests/data/simple_form_before_2.44.0.xml
+++ b/corehq/apps/receiverwrapper/tests/data/simple_form_before_2.44.0.xml
@@ -7,7 +7,7 @@
 	    <username>someuser</username>
 	    <userID>someuserid</userID>
 	    <uid>ad38211be256653bceac8e2156475664</uid>
-        <appVersion>CommCare Android, version &quot;2.44.0&quot;(433774). App v16. CommCare Version 2.36. Build 433774, built on: 2017-10-12</appVersion>
+        <appVersion>CommCare Android, version &quot;2.36.0&quot;(433774). App v16. CommCare Version 2.36. Build 433774, built on: 2017-10-12</appVersion>
 	</meta>
 	<foo>bar</foo>
 	<baz>

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -216,6 +216,23 @@ class NormalModeSubmissionTest(BaseSubmissionTest):
         self.assertTrue(response.status_code, 422)
         self.assertTrue("There was an error processing the form: Invalid XML" in response.content.decode('utf-8'))
 
+    @patch('corehq.apps.receiverwrapper.util.IGNORE_ALL_DEMO_USER_SUBMISSIONS', True)
+    @patch('corehq.apps.receiverwrapper.util._notify_ignored_form_submission')
+    @patch('corehq.apps.users.models.CommCareUser.get_by_user_id')
+    def test_notification(self, user_stub, notification, *_):
+        user_stub.return_value = self.couch_user
+        self.couch_user.is_demo_user = True
+
+        response = self._submit('simple_form_before_2.44.0.xml')
+        self.assertFalse('X-CommCareHQ-FormID' in response,
+                         'Practice mobile worker form processed in non-demo mode')
+        self.assertFalse(notification.called)
+
+        response = self._submit('simple_form.xml')
+        self.assertFalse('X-CommCareHQ-FormID' in response,
+                         'Practice mobile worker form processed in non-demo mode')
+        self.assertTrue(notification.called)
+
 
 @use_sql_backend
 class SubmissionTestSQL(SubmissionTest):

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -206,17 +206,13 @@ DEMO_SUBMIT_MODE = 'demo'
 IGNORE_ALL_DEMO_USER_SUBMISSIONS = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
 
 
-def _submitted_by_demo_user(form_json, domain):
+def _submitted_by_demo_user(form_meta, domain):
     from corehq.apps.users.util import DEMO_USER_ID
-    try:
-        user_id = form_json['meta']['userID']
-    except (KeyError, ValueError):
-        pass
-    else:
-        if user_id and user_id != DEMO_USER_ID:
-            user = CommCareUser.get_by_user_id(user_id, domain)
-            if user and user.is_demo_user:
-                return True
+    user_id = form_meta.get('userID')
+    if user_id and user_id != DEMO_USER_ID:
+        user = CommCareUser.get_by_user_id(user_id, domain)
+        if user and user.is_demo_user:
+            return True
     return False
 
 
@@ -232,7 +228,7 @@ def _notify_ignored_form_submission(request, form_meta):
         "[%s] Unexpected practice mobile user submission received" % settings.SERVER_ENVIRONMENT,
         message,
         settings.DEFAULT_FROM_EMAIL,
-        ['mkangia@dimagi.com']
+        ['mkangia@dimagi.com', 'sgoyal@dimagi.com']
     )
 
 
@@ -252,10 +248,9 @@ def should_ignore_submission(request):
             # let the usual workflow handle response for invalid xml
             return False
         else:
-            if _submitted_by_demo_user(form_json, request.domain):
-                if not request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:
-                    # notify the case where the form would have gotten processed
-                    _notify_ignored_form_submission(request, form_json['meta'])
+            form_meta = form_json.get('meta')
+            if form_meta and _submitted_by_demo_user(form_meta, request.domain):
+                _notify_submission_if_applicable(request, form_meta)
                 return True
 
     if not request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:
@@ -265,3 +260,13 @@ def should_ignore_submission(request):
         instance, _ = couchforms.get_instance_and_attachment(request)
         form_json = convert_xform_to_json(instance)
     return False if from_demo_user(form_json) else True
+
+
+def _notify_submission_if_applicable(request, form_meta):
+    # notify the submission if form would have gotten processed due to missing param
+    if not request.GET.get('submit_mode') == DEMO_SUBMIT_MODE:
+        app_version_text = form_meta.get('appVersion')
+        if app_version_text:
+            commcare_version = get_commcare_version_from_appversion_text(app_version_text)
+            if commcare_version and commcare_version >= '2.44.0':
+                _notify_ignored_form_submission(request, form_meta)


### PR DESCRIPTION
Possibly the last change for this notification, following up on https://github.com/dimagi/commcare-hq/pull/25988
From last change, got a number of form submissions, one example of which is 
```
Method: POST
URL: https://cas.commcarehq.org/a/icds-cas/receiver/secure/3ed4e4d0c2194d938ec4aca7a697f7cc/
GET Params: {}
Form Meta: {
"@xmlns": "http://openrosa.org/jr/xforms", 
"deviceID": "---", 
"timeStart": "---", 
"timeEnd": "---", 
"username": "aww.test", 
"userID": "253006c0418a97f1e3887f35a385b7e2", 
"instanceID": "---", 
"appVersion": {"@xmlns": "http://commcarehq.org/xforms", "#text": "CommCare Android, version \"2.36.3\"(433774). App v10561. CommCare Version 2.36. Build 433774, built on: 2017-10-12"}}
```
and happened also for
`CommCare Android, version \"2.36.2\"(433765). App v10326. CommCare Version 2.36. Build 433765, built on: 2017-07-17`

As the example highlights, both the params are missing, main one being `submit_mode`.
@shubham1g5 suggested we update the notification to check for the latest version 2.44.0 and above that since this is happening in an older version, from which the code has changed a lot now in CommCare and isn't worth looking into. So added that check and added his email address as well.

fyi @ctsims 