### PR TITLE
Get any values from Observations

### DIFF
--- a/corehq/motech/exceptions.py
+++ b/corehq/motech/exceptions.py
@@ -1,2 +1,8 @@
 class ConfigurationError(Exception):
     pass
+
+
+class JsonpathError(Exception):
+    # jsonpath_rw raises bare exceptions. This class is to re-raise
+    # them, so we can be smarter about catching them.
+    pass

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -490,7 +490,7 @@ def get_case_block_kwargs_from_observations(
 
 def get_case_block_kwargs_from_bahmni_diagnoses(
     diagnoses: List[dict],
-    mappings: Dict[str, ObservationMapping],
+    mappings: Dict[str, List[ObservationMapping]],
     case_id: str,
     case_type: str,
     default_owner_id: str,

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 from datetime import datetime
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from django.utils.translation import ugettext as _
 
@@ -22,7 +22,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.motech.const import DIRECTION_IMPORT
-from corehq.motech.exceptions import ConfigurationError
+from corehq.motech.exceptions import ConfigurationError, JsonpathError
 from corehq.motech.openmrs.const import (
     ATOM_FEED_NAME_PATIENT,
     ATOM_FEED_NAMES,
@@ -34,7 +34,10 @@ from corehq.motech.openmrs.exceptions import (
     OpenmrsException,
     OpenmrsFeedDoesNotExist,
 )
-from corehq.motech.openmrs.openmrs_config import get_property_map
+from corehq.motech.openmrs.openmrs_config import (
+    ObservationMapping,
+    get_property_map,
+)
 from corehq.motech.openmrs.repeater_helpers import get_patient_by_uuid
 from corehq.motech.openmrs.repeaters import AtomFeedStatus, OpenmrsRepeater
 
@@ -464,7 +467,7 @@ def get_case_block_kwargs_from_observations(
             for mapping in mappings[concept_uuid]:
                 if mapping.case_property:
                     more_kwargs = get_case_block_kwargs_for_case_property(
-                        mapping, obs.get('value')
+                        mapping, obs, fallback_value=obs.get('value')
                     )
                     deep_update(case_block_kwargs, more_kwargs)
                 if mapping.indexed_case_mapping:
@@ -500,7 +503,8 @@ def get_case_block_kwargs_from_bahmni_diagnoses(
             for mapping in mappings[codedanswer_uuid]:
                 if mapping.case_property:
                     more_kwargs = get_case_block_kwargs_for_case_property(
-                        mapping, diag['codedAnswer'].get('name')
+                        mapping, diag,
+                        fallback_value=diag['codedAnswer'].get('name')
                     )
                     deep_update(case_block_kwargs, more_kwargs)
                 if mapping.indexed_case_mapping:
@@ -511,9 +515,18 @@ def get_case_block_kwargs_from_bahmni_diagnoses(
     return case_block_kwargs, case_blocks
 
 
-def get_case_block_kwargs_for_case_property(mapping, external_value):
+def get_case_block_kwargs_for_case_property(
+    mapping: ObservationMapping,
+    external_data: dict,
+    fallback_value: Any,
+) -> dict:
     case_block_kwargs = {"update": {}}
-    value = mapping.value.deserialize(external_value)
+    try:
+        value = mapping.value.get_import_value(external_data)
+    except (AttributeError, JsonpathError):
+        # mapping.value doesn't have get_import_value(), or isn't
+        # configured to parse external_data
+        value = mapping.value.deserialize(fallback_value)
     if mapping.case_property in CASE_BLOCK_ARGS:
         case_block_kwargs[mapping.case_property] = value
     else:

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from django.utils.translation import ugettext as _
 
@@ -489,8 +489,12 @@ def get_case_block_kwargs_from_observations(
 
 
 def get_case_block_kwargs_from_bahmni_diagnoses(
-    diagnoses, mappings, case_id, case_type, default_owner_id
-):
+    diagnoses: List[dict],
+    mappings: Dict[str, ObservationMapping],
+    case_id: str,
+    case_type: str,
+    default_owner_id: str,
+) -> Tuple[dict, List[CaseBlock]]:
     """
     Iterate a list of Bahmni diagnoses, and return the ones mapped to
     case properties.
@@ -535,8 +539,12 @@ def get_case_block_kwargs_for_case_property(
 
 
 def get_case_block_for_indexed_case(
-    mapping, external_data, parent_case_id, parent_case_type, default_owner_id
-):
+    mapping: ObservationMapping,
+    external_data: dict,
+    parent_case_id: str,
+    parent_case_type: str,
+    default_owner_id: str,
+) -> CaseBlock:
     relationship = mapping.indexed_case_mapping.relationship
     case_block_kwargs = {
         "index": {

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -158,13 +158,40 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                 "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
                 "value": {
                     "doc_type": "FormQuestionMap",
-                    "form_question": "/data/bahmni_hypothermia",
+                    "direction": "in",
+                    "form_question": "[unused when direction == 'in']",
                     "value_map": {
                         "emergency_room_user_id": "Hypothermia",  # Value must match diagnosis name
-                    },
-                    "direction": "in",
+                    }
                 },
                 "case_property": "owner_id"
+            },
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
+                "value": {
+                    "doc_type": "JsonPathCasePropertyMap",
+                    "direction": "in",
+                    "jsonpath": "codedAnswer.name",
+                    "case_property": "[unused when direction == 'in']",
+                    "value_map": {
+                        "yes": "Hypothermia"
+                    }
+                },
+                "case_property": "hypothermia_diagnosis"
+            },
+            {
+                "doc_type": "ObservationMapping",
+                "concept": "f7e8da66-f9a7-4463-a8ca-99d8aeec17a0",
+                "value": {
+                    "doc_type": "JsonPathCaseProperty",
+                    "direction": "in",
+                    "jsonpath": "diagnosisDateTime",
+                    "case_property": "[unused when direction == 'in']",
+                    "commcare_data_type": "cc_date",
+                    "external_data_type": "omrs_datetime"
+                },
+                "case_property": "hypothermia_date"
             }
         ]
         self.repeater = OpenmrsRepeater.wrap(self.get_repeater_dict(observations, diagnoses))
@@ -317,7 +344,13 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
             self.repeater.diagnosis_mappings,
             None, None, None
         )
-        self.assertEqual(case_block_kwargs, {'owner_id': 'emergency_room_user_id', 'update': {}})
+        self.assertEqual(case_block_kwargs, {
+            'owner_id': 'emergency_room_user_id',
+            'update': {
+                'hypothermia_diagnosis': 'yes',
+                'hypothermia_date': '2019-10-18'
+            }
+        })
         self.assertEqual(case_blocks, [])
 
     def test_get_case_blocks_from_observations(self):

--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -23,6 +23,7 @@ from corehq.motech.const import (
     DIRECTION_IMPORT,
     DIRECTIONS,
 )
+from corehq.motech.exceptions import JsonpathError
 from corehq.motech.serializers import serializers
 
 
@@ -380,7 +381,10 @@ class JsonPathMixin(DocumentSchema):
     jsonpath = StringProperty(required=True, validators=not_blank)
 
     def _get_external_value(self, external_data):
-        jsonpath = parse_jsonpath(self.jsonpath)
+        try:
+            jsonpath = parse_jsonpath(self.jsonpath)
+        except Exception as err:
+            raise JsonpathError from err
         matches = jsonpath.find(external_data)
         values = [m.value for m in matches]
         if not values:


### PR DESCRIPTION
##### SUMMARY
OpenMRS and Bahmni return a chunk of data about Observations and Diagnoses. Currently MOTECH can set a case property to `Observation.value` or `BahmniDiagnosis.codedAnswer.name`. This change allows users to use JSONPath to set case properties to any property of an Observation or a Diagnosis.

(This change is required by a project that wants to update a patient case with the date on which a diagnosis was made, in order to give CHWs and hospital staff context on the diagnosis.)

Review by commit :tropical_fish: but for context it is probably best to start with the [Tests](https://github.com/dimagi/commcare-hq/commit/cc4f0f06f9db1c3338f02527cef2bb905e98e067) commit.

##### FEATURE FLAG
OpenMRS integration

##### PRODUCT DESCRIPTION
Users can use any data about an OpenMRS observation or a Bahmni diagnosis to set CommCare patient case properties.
