### PR TITLE
add XFrameOptionsMiddleware

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -128,6 +128,7 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.common.BrokenLinkEmailsMiddleware',


### PR DESCRIPTION
this will allow django to control the setting of this header at the view-level, and prevent the need for it being handled in the nginx / proxy server config

https://docs.google.com/document/d/1gg1sAJ6Qd9yb5mzIwfTKw7h8CyVTWG8EMJpIrvYIBbU/edit
