### PR TITLE
Add schema check for DHIS2 Event requests

### DIFF
--- a/corehq/motech/dhis2/events_helpers.py
+++ b/corehq/motech/dhis2/events_helpers.py
@@ -11,10 +11,7 @@ from corehq.motech.value_source import (
 
 def send_dhis2_event(request, form_config, payload):
     event = get_event(request.domain_name, form_config, payload)
-    try:
-        Schema(get_event_schema()).validate(event)
-    except SchemaError as err:
-        raise ConfigurationError from err
+    validate_event_schema(event)
     return request.post('/api/%s/events' % DHIS2_API_VERSION, json=event,
                         raise_for_status=True)
 
@@ -78,6 +75,17 @@ def _get_datavalues(config, case_trigger_info):
             'value': data_value.value.get_value(case_trigger_info)
         })
     return {'dataValues': values}
+
+
+def validate_event_schema(event):
+    """
+    Raises ConfigurationError if ``event`` is missing required
+    properties, or value data types are invalid.
+    """
+    try:
+        Schema(get_event_schema()).validate(event)
+    except SchemaError as err:
+        raise ConfigurationError from err
 
 
 def get_event_schema() -> dict:

--- a/corehq/motech/dhis2/repeaters.py
+++ b/corehq/motech/dhis2/repeaters.py
@@ -12,6 +12,7 @@ from dimagi.ext.couchdbkit import SchemaProperty
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.motech.dhis2.dhis2_config import Dhis2Config
 from corehq.motech.dhis2.events_helpers import send_dhis2_event
+from corehq.motech.exceptions import ConfigurationError
 from corehq.motech.repeaters.models import FormRepeater, Repeater
 from corehq.motech.repeaters.repeater_generators import (
     FormRepeaterJsonPayloadGenerator,
@@ -88,7 +89,7 @@ class Dhis2Repeater(FormRepeater):
                         form_config,
                         payload,
                     )
-                except (RequestException, HTTPError) as err:
+                except (RequestException, HTTPError, ConfigurationError) as err:
                     requests.notify_error(f"Error sending Events to {self}: {err}")
                     raise
         return True

--- a/corehq/motech/dhis2/tests/test_events_helpers.py
+++ b/corehq/motech/dhis2/tests/test_events_helpers.py
@@ -1,3 +1,4 @@
+import doctest
 import json
 
 from django.test.testcases import TestCase
@@ -117,3 +118,10 @@ class TestDhisHandler(TestCase):
             },
             event
         )
+
+
+def test_doctests():
+    from corehq.motech.dhis2 import events_helpers
+
+    results = doctest.testmod(events_helpers)
+    assert results.failed == 0

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -167,6 +167,7 @@ requests-mock==1.7.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 sh==1.09
 simpleeval==0.9.8

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -143,6 +143,7 @@ reportlab==3.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 setproctitle==1.1.9
 sh==1.09

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -131,6 +131,7 @@ reportlab==3.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 sh==1.09
 simpleeval==0.9.8

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -144,6 +144,7 @@ requests-mock==1.7.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 sh==1.09
 simpleeval==0.9.8

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -167,6 +167,7 @@ requests-mock==1.7.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 sh==1.09
 simpleeval==0.9.8

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -143,6 +143,7 @@ reportlab==3.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 setproctitle==1.1.9
 sh==1.09

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -42,6 +42,7 @@ python-magic~=0.4.13
 pytz>=2017.2
 PyYAML~=5.1
 requests~=2.20
+schema
 suds-jurko==0.6
 tropo-webapi-python==0.1.3
 Unidecode==0.04.20

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -131,6 +131,7 @@ reportlab==3.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 sh==1.09
 simpleeval==0.9.8

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -144,6 +144,7 @@ requests-mock==1.7.0
 requests==2.22.0
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
+schema==0.7.1
 sentry-sdk==0.11.1
 sh==1.09
 simpleeval==0.9.8


### PR DESCRIPTION
Context: [QA-879](https://dimagi-dev.atlassian.net/browse/QA-879)

##### SUMMARY
Validates the body of an outgoing request to DHIS2 against its schema. This allows us to report configuration errors before the request is sent.

##### FEATURE FLAG
DHIS2 integration

##### PRODUCT DESCRIPTION
Improved configuration error checking for DHIS2 integration.
