### PR TITLE
Rate limit by the number of users "allocated"

### DIFF
--- a/corehq/apps/sms/tests/opt_tests.py
+++ b/corehq/apps/sms/tests/opt_tests.py
@@ -36,7 +36,7 @@ class OptTestCase(DomainSubscriptionMixin, TestCase):
         cls.backend_mapping.delete()
         cls.backend.delete()
         FormProcessorTestUtils.delete_all_cases(cls.domain)
-        cls.teardown_subscription()
+        cls.teardown_subscriptions()
         cls.domain_obj.delete()
         clear_plan_version_cache()
         super(OptTestCase, cls).tearDownClass()

--- a/corehq/apps/sms/tests/test_backends.py
+++ b/corehq/apps/sms/tests/test_backends.py
@@ -219,7 +219,7 @@ class AllBackendTest(DomainSubscriptionMixin, TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.teardown_subscription()
+        cls.teardown_subscriptions()
 
         cls.domain_obj.delete()
         cls.unicel_backend.delete()
@@ -645,7 +645,7 @@ class OutgoingFrameworkTestCase(DomainSubscriptionMixin, TestCase):
         cls.backend9.delete()
         cls.backend10.delete()
 
-        cls.teardown_subscription()
+        cls.teardown_subscriptions()
 
         cls.domain_obj.delete()
         clear_plan_version_cache()

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -74,7 +74,7 @@ class BaseSMSTest(BaseAccountingTest, DomainSubscriptionMixin):
         cls.setup_subscription(domain_name, SoftwarePlanEdition.ADVANCED)
 
     def tearDown(self):
-        self.teardown_subscription()
+        self.teardown_subscriptions()
         clear_plan_version_cache()
         super(BaseSMSTest, self).tearDown()
 
@@ -333,7 +333,7 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
         self.site.delete()
         self.backend_mapping.delete()
         self.backend.delete()
-        self.teardown_subscription()
+        self.teardown_subscriptions()
         clear_plan_version_cache()
 
 

--- a/corehq/project_limits/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/test_get_n_users_for_rate_limiting.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+
+from corehq.apps.accounting.bootstrap.config.testing import BOOTSTRAP_CONFIG_TESTING
+from corehq.apps.accounting.models import SoftwarePlanEdition, FeatureType
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.util import format_username
+from corehq.project_limits.rate_limiter import get_n_users_for_rate_limiting
+
+
+class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
+
+    def test_no_subscription(self):
+        domain = 'domain-no-subscription'
+        domain_obj = create_domain(domain)
+        self.addCleanup(domain_obj.delete)
+
+        get_n_users_for_rate_limiting.clear(domain)
+        self.assertEqual(get_n_users_for_rate_limiting(domain), 0)
+
+        self._set_n_users(domain, 1)
+
+        get_n_users_for_rate_limiting.clear(domain)
+        self.assertEqual(get_n_users_for_rate_limiting(domain), 1)
+
+    def test_with_subscription(self):
+
+        domain = 'domain-with-subscription'
+
+        def _setup():
+            domain_obj = create_domain(domain)
+            self.setup_subscription(domain_obj.name, SoftwarePlanEdition.ADVANCED)
+            self.addCleanup(lambda: self.teardown_subscription(domain))
+            self.addCleanup(domain_obj.delete)
+            assert CommCareUser.total_by_domain(domain, is_active=True) == 0
+
+        def _get_included_in_subscription():
+            n = (
+                BOOTSTRAP_CONFIG_TESTING[(SoftwarePlanEdition.ADVANCED, False, False)]
+                ['feature_rates'][FeatureType.USER]['monthly_limit']
+            )
+            assert n == 8
+            return n
+
+        _setup()
+
+        # With no real users, it's the number of users in the subscription
+        get_n_users_for_rate_limiting.clear(domain)
+        self.assertEqual(get_n_users_for_rate_limiting(domain),
+                         _get_included_in_subscription())
+
+        self._set_n_users(domain, 9)
+
+        # With more users than included in subscription, it's the number of users
+        get_n_users_for_rate_limiting.clear(domain)
+        self.assertEqual(get_n_users_for_rate_limiting(domain), 9)
+
+    def _set_n_users(self, domain, n_users):
+        start_n_users = CommCareUser.total_by_domain(domain, is_active=True)
+        assert n_users >= start_n_users, 'this helper can only add users'
+
+        for i in range(start_n_users, n_users):
+            user = CommCareUser.create(domain, format_username('user{}'.format(i), domain),
+                                       password='123')
+            user.is_active = True
+            user.save()
+            self.addCleanup(user.delete)
+        assert CommCareUser.total_by_domain(domain, is_active=True) == n_users

--- a/corehq/project_limits/tests/test_rate_limiter.py
+++ b/corehq/project_limits/tests/test_rate_limiter.py
@@ -4,7 +4,7 @@ from corehq.project_limits.rate_limiter import RateLimiter, RateDefinition, \
     PerUserRateDefinition
 
 
-@mock.patch('corehq.project_limits.rate_limiter.get_user_count', lambda domain: 10)
+@mock.patch('corehq.project_limits.rate_limiter.get_n_users_for_rate_limiting', lambda domain: 10)
 def test_rate_limit_interface():
     """
     Just test that very basic usage doesn't error


### PR DESCRIPTION
##### SUMMARY
That means the number of users included in the subscription if the project is below that limit.

If a project is on a Pro plan and has 60 users, they'll now be rate limited as if they have 250 users (conceptually the number of users they're "paying for") instead of 60. This mostly makes it so projects that have a small number of users aren't disproportionally affected by rate limiting, and so there isn't this incentive to create a bunch of fake users to get more resources without paying extra, which seems silly to make people do.

##### FEATURE FLAG
Affects behavior of RATE_LIMIT_SUBMISSIONS and RATE_LIMIT_RESTORES, as well as datadog metrics for would-be rate limited submissions and restores.
