### PR TITLE
override X-Frame-Options header for mobile dashboard

### DIFF
--- a/custom/icds_reports/mobile_views.py
+++ b/custom/icds_reports/mobile_views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
 
 from corehq.apps.hqwebapp import views as hqwebapp_views
@@ -9,6 +10,7 @@ from custom.icds_reports.dashboard_utils import get_dashboard_template_context
 from custom.icds_reports.views import DASHBOARD_CHECKS
 
 
+@xframe_options_exempt
 def login(request, domain):
     if request.user.is_authenticated:
         return HttpResponseRedirect(reverse('cas_mobile_dashboard', args=[domain]))
@@ -24,6 +26,7 @@ def login(request, domain):
 
 @location_safe
 @method_decorator(DASHBOARD_CHECKS, name='dispatch')
+@method_decorator(xframe_options_exempt, name='dispatch')
 class MobileDashboardView(TemplateView):
     template_name = 'icds_reports/mobile/dashboard/mobile_dashboard.html'
 


### PR DESCRIPTION
Allows the mobile login and dashboard to be embedded in iframes / android webview apps.

https://docs.google.com/document/d/1gg1sAJ6Qd9yb5mzIwfTKw7h8CyVTWG8EMJpIrvYIBbU/edit
