### PR TITLE
Parse DHIS2 import summaries

### DIFF
--- a/corehq/motech/dhis2/parse_response.py
+++ b/corehq/motech/dhis2/parse_response.py
@@ -1,0 +1,53 @@
+from operator import eq
+
+from jsonpath_rw import Child, Fields, Slice, Where, Root
+
+from corehq.motech.openmrs.jsonpath import Cmp
+
+
+def get_errors(response: dict) -> dict:
+    """
+    Searches response from DHIS2 for import errors, and returns a
+    dictionary of {jsonpath: error message}
+    """
+    if "response" in response:
+        response = response["response"]
+
+    errors = get_entity_errors(response)
+    errors.update(get_enrollments_errors(response))
+    errors.update(get_events_errors(response))
+    return errors
+
+
+def get_entity_errors(response: dict) -> dict:
+    # $[?(@.status='ERROR')].description
+    jsonpath_expr = Child(Where(
+        Root(),
+        Cmp(Fields("status"), eq, "ERROR")
+    ), Fields("description"))
+    # We write the JSONPath expression programmatically because
+    # currently jsonpath-rw does not support parsing comparison
+    # expressions like ``[?(@.status='ERROR')]``
+    matches = jsonpath_expr.find(response)
+    return {str(match.full_path): match.value for match in matches}
+
+
+def get_enrollments_errors(response: dict) -> dict:
+    # $.enrollments.importSummaries[*][?(@.status='ERROR')].description
+    jsonpath_expr = Child(Where(Child(Child(
+        Fields("enrollments"), Fields("importSummaries")), Slice()),
+        Cmp(Fields("status"), eq, "ERROR")
+    ), Fields("description"))
+    matches = jsonpath_expr.find(response)
+    return {str(match.full_path): match.value for match in matches}
+
+
+def get_events_errors(response: dict) -> dict:
+    # $.enrollments.importSummaries[*].events.importSummaries[*][?(@.status='ERROR')].description
+    jsonpath_expr = Child(Where(Child(Child(Child(Child(Child(
+        Fields("enrollments"), Fields("importSummaries")), Slice()),
+        Fields("events")), Fields("importSummaries")), Slice()),
+        Cmp(Fields("status"), eq, "ERROR")
+    ), Fields("description"))
+    matches = jsonpath_expr.find(response)
+    return {str(match.full_path): match.value for match in matches}

--- a/corehq/motech/dhis2/tests/data/ignored.json
+++ b/corehq/motech/dhis2/tests/data/ignored.json
@@ -1,0 +1,95 @@
+{
+  "httpStatus": "OK",
+  "httpStatusCode": 200,
+  "message": "Import was successful.",
+  "response": {
+    "enrollments": {
+      "deleted": 0,
+      "ignored": 0,
+      "importSummaries": [
+        {
+          "events": {
+            "deleted": 0,
+            "ignored": 1,
+            "importSummaries": [
+              {
+                "description": "Event date is required. ",
+                "importCount": {
+                  "deleted": 0,
+                  "ignored": 1,
+                  "imported": 0,
+                  "updated": 0
+                },
+                "responseType": "ImportSummary",
+                "status": "ERROR"
+              }
+            ],
+            "imported": 0,
+            "responseType": "ImportSummaries",
+            "status": "ERROR",
+            "total": 1,
+            "updated": 0
+          },
+          "importCount": {
+            "deleted": 0,
+            "ignored": 0,
+            "imported": 1,
+            "updated": 0
+          },
+          "reference": "ai8ZoNkAxVA",
+          "responseType": "ImportSummary",
+          "status": "SUCCESS"
+        }
+      ],
+      "imported": 1,
+      "responseType": "ImportSummaries",
+      "status": "SUCCESS",
+      "total": 1,
+      "updated": 0
+    },
+    "importCount": {
+      "deleted": 0,
+      "ignored": 0,
+      "imported": 0,
+      "updated": 1
+    },
+    "importOptions": {
+      "async": false,
+      "datasetAllowsPeriods": false,
+      "dryRun": false,
+      "firstRowIsHeader": true,
+      "force": false,
+      "idSchemes": {},
+      "ignoreEmptyCollection": false,
+      "importStrategy": "CREATE_AND_UPDATE",
+      "mergeMode": "REPLACE",
+      "reportMode": "FULL",
+      "requireAttributeOptionCombo": false,
+      "requireCategoryOptionCombo": false,
+      "sharing": false,
+      "skipAudit": false,
+      "skipExistingCheck": false,
+      "skipLastUpdated": false,
+      "skipNotifications": false,
+      "skipPatternValidation": false,
+      "strictAttributeOptionCombos": false,
+      "strictCategoryOptionCombos": false,
+      "strictDataElements": false,
+      "strictOrganisationUnits": false,
+      "strictPeriods": false
+    },
+    "reference": "o81lWl2ZC9y",
+    "relationships": {
+      "deleted": 0,
+      "ignored": 0,
+      "imported": 0,
+      "responseType": "ImportSummaries",
+      "status": "SUCCESS",
+      "total": 0,
+      "updated": 0
+    },
+    "responseType": "ImportSummary",
+    "status": "SUCCESS"
+  },
+  "status": "OK"
+}

--- a/corehq/motech/dhis2/tests/data/imported.json
+++ b/corehq/motech/dhis2/tests/data/imported.json
@@ -1,0 +1,82 @@
+{
+  "httpStatus": "OK",
+  "httpStatusCode": 200,
+  "message": "Import was successful.",
+  "response": {
+    "enrollments": {
+      "deleted": 0,
+      "ignored": 0,
+      "importSummaries": [
+        {
+          "events": {
+            "deleted": 0,
+            "ignored": 0,
+            "imported": 0,
+            "responseType": "ImportSummaries",
+            "status": "SUCCESS",
+            "total": 0,
+            "updated": 0
+          },
+          "importCount": {
+            "deleted": 0,
+            "ignored": 0,
+            "imported": 1,
+            "updated": 0
+          },
+          "reference": "UjIps1Tvpns",
+          "responseType": "ImportSummary",
+          "status": "SUCCESS"
+        }
+      ],
+      "imported": 1,
+      "responseType": "ImportSummaries",
+      "status": "SUCCESS",
+      "total": 1,
+      "updated": 0
+    },
+    "importCount": {
+      "deleted": 0,
+      "ignored": 0,
+      "imported": 0,
+      "updated": 1
+    },
+    "importOptions": {
+      "async": false,
+      "datasetAllowsPeriods": false,
+      "dryRun": false,
+      "firstRowIsHeader": true,
+      "force": false,
+      "idSchemes": {},
+      "ignoreEmptyCollection": false,
+      "importStrategy": "CREATE_AND_UPDATE",
+      "mergeMode": "REPLACE",
+      "reportMode": "FULL",
+      "requireAttributeOptionCombo": false,
+      "requireCategoryOptionCombo": false,
+      "sharing": false,
+      "skipAudit": false,
+      "skipExistingCheck": false,
+      "skipLastUpdated": false,
+      "skipNotifications": false,
+      "skipPatternValidation": false,
+      "strictAttributeOptionCombos": false,
+      "strictCategoryOptionCombos": false,
+      "strictDataElements": false,
+      "strictOrganisationUnits": false,
+      "strictPeriods": false
+    },
+    "reference": "kCArjBkgA5M",
+    "relationships": {
+      "deleted": 0,
+      "ignored": 0,
+      "imported": 0,
+      "responseType": "ImportSummaries",
+      "status": "SUCCESS",
+      "total": 0,
+      "updated": 0
+    },
+    "responseType": "ImportSummary",
+    "status": "SUCCESS"
+  },
+  "status": "OK"
+}

--- a/corehq/motech/dhis2/tests/test_parse_response.py
+++ b/corehq/motech/dhis2/tests/test_parse_response.py
@@ -1,0 +1,23 @@
+import os
+
+from django.test import SimpleTestCase
+
+from corehq.motech.dhis2.parse_response import get_errors
+from corehq.util.test_utils import TestFileMixin
+
+
+class GetErrorTests(SimpleTestCase, TestFileMixin):
+    file_path = ('data',)
+    root = os.path.dirname(__file__)
+
+    def test_imported(self):
+        response_json = self.get_json('imported')
+        errors = get_errors(response_json["response"])
+        self.assertEqual(errors, {})
+
+    def test_ignored(self):
+        response_json = self.get_json('ignored')
+        errors = get_errors(response_json["response"])
+        self.assertEqual(errors, {
+            "enrollments.importSummaries.[0].events.importSummaries.[0].description": "Event date is required. "
+        })


### PR DESCRIPTION
Context: [QA-878](https://dimagi-dev.atlassian.net/browse/QA-878)

##### SUMMARY
If exporting data to DHIS2 is only partially successful, it will return a 200 response, a "SUCCESS" message, and an "import summary". Nested inside the import summary might be an error that needs to be addressed.

This PR adds a function for parsing the import summary, and pulling out any errors inside it.

This function will be used by Anonymous Events and Tracked Entity integration.

##### FEATURE FLAG
DHIS2 integration

##### PRODUCT DESCRIPTION
Adds the ability to parse DHIS2 responses to report errors.
