### PR TITLE
remove numeric id default length restriction in web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -238,7 +238,7 @@ IntEntry.prototype.onPreProcess = function (newValue) {
 function PhoneEntry(question, options) {
     FreeTextEntry.call(this, question, options);
     this.templateType = 'str';
-    this.lengthLimit = options.lengthLimit || 15;
+    this.lengthLimit = options.lengthLimit;
 
     this.getErrorMessage = function (rawAnswer) {
         if (rawAnswer === '') {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10131

##### SUMMARY
This removes the default length limit of `15` for numeric ID / Phone numbers in webapps