### PR TITLE
Fix permanent unprocessed archive stubs

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -300,7 +300,7 @@ def reprocess_archive_stubs():
     cutoff = start + timedelta(minutes=4).total_seconds()
     for stub in stubs:
         # Exit this task after 4 minutes so that the same stub isn't ever processed in multiple queues.
-        if time.time() - start > cutoff:
+        if time.time() > cutoff:
             return
         xform = FormAccessors(stub.domain).get_form(form_id=stub.xform_id)
         # If the history wasn't updated the first time around, run the whole thing again.

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -306,9 +306,10 @@ def reprocess_archive_stubs():
         # If the history wasn't updated the first time around, run the whole thing again.
         if not stub.history_updated:
             if stub.archive:
-                xform.archive(user_id=stub.user_id)
+                FormAccessors.do_archive(xform, True, stub.user_id, trigger_signals=True)
             else:
-                xform.unarchive(user_id=stub.user_id)
+                FormAccessors.do_archive(xform, False, stub.user_id, trigger_signals=True)
+
         # If the history was updated the first time around, just send the update to kafka
         else:
             FormAccessors.publish_archive_action_to_kafka(xform, stub.user_id, stub.archive)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -305,10 +305,7 @@ def reprocess_archive_stubs():
         xform = FormAccessors(stub.domain).get_form(form_id=stub.xform_id)
         # If the history wasn't updated the first time around, run the whole thing again.
         if not stub.history_updated:
-            if stub.archive:
-                FormAccessors.do_archive(xform, True, stub.user_id, trigger_signals=True)
-            else:
-                FormAccessors.do_archive(xform, False, stub.user_id, trigger_signals=True)
+            FormAccessors.do_archive(xform, stub.archive, stub.user_id, trigger_signals=True)
 
         # If the history was updated the first time around, just send the update to kafka
         else:

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -269,29 +269,33 @@ class FormAccessorTestsSQL(TestCase):
         self.assertEqual(1, len(transactions))
         self.assertFalse(transactions[0].revoked)
 
-        self.archive_form(form, 'user1')
-        form = FormAccessorSQL.get_form(form.form_id)
-        self.assertEqual(XFormInstanceSQL.ARCHIVED, form.state)
-        operations = form.history
-        self.assertEqual(1, len(operations))
-        self.assertEqual(form.form_id, operations[0].form_id)
-        self.assertEqual('user1', operations[0].user_id)
+        # archive twice to check that it's idempotent
+        for i in range(2):
+            self.archive_form(form, 'user1')
+            form = FormAccessorSQL.get_form(form.form_id)
+            self.assertEqual(XFormInstanceSQL.ARCHIVED, form.state)
+            operations = form.history
+            self.assertEqual(i + 1, len(operations))
+            self.assertEqual(form.form_id, operations[i].form_id)
+            self.assertEqual('user1', operations[i].user_id)
 
-        transactions = CaseAccessorSQL.get_transactions(case_id)
-        self.assertEqual(1, len(transactions), transactions)
-        self.assertTrue(transactions[0].revoked)
+            transactions = CaseAccessorSQL.get_transactions(case_id)
+            self.assertEqual(1, len(transactions), transactions)
+            self.assertTrue(transactions[0].revoked)
 
-        self.unarchive_form(form, 'user2')
-        form = FormAccessorSQL.get_form(form.form_id)
-        self.assertEqual(XFormInstanceSQL.NORMAL, form.state)
-        operations = form.history
-        self.assertEqual(2, len(operations))
-        self.assertEqual(form.form_id, operations[1].form_id)
-        self.assertEqual('user2', operations[1].user_id)
+        # unarchive twice to check that it's idempotent
+        for i in range(2, 4):
+            self.unarchive_form(form, 'user2')
+            form = FormAccessorSQL.get_form(form.form_id)
+            self.assertEqual(XFormInstanceSQL.NORMAL, form.state)
+            operations = form.history
+            self.assertEqual(i + 1, len(operations))
+            self.assertEqual(form.form_id, operations[i].form_id)
+            self.assertEqual('user2', operations[i].user_id)
 
-        transactions = CaseAccessorSQL.get_transactions(case_id)
-        self.assertEqual(1, len(transactions))
-        self.assertFalse(transactions[0].revoked)
+            transactions = CaseAccessorSQL.get_transactions(case_id)
+            self.assertEqual(1, len(transactions))
+            self.assertFalse(transactions[0].revoked)
 
     def test_save_new_form(self):
         unsaved_form = create_form_for_test(DOMAIN, save=False)


### PR DESCRIPTION
##### SUMMARY
Meant to fix https://dimagi-dev.atlassian.net/browse/SAASP-10137.

The only thing I have found is that this will leave a second archive form entry in the form history. Which, actually now that I think of it is pretty reasonable behavior.

Any potential gotchas to archiving an already archived form (or unarchiving and already unarchived form)? I will do further testing locally, but I want to get a sense of this from those of you most familiar with this part of the code.