### PR TITLE
[Exports] Improve performance of get_column in TableConfiguration

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -22,6 +22,7 @@ from couchdbkit import (
 from memoized import memoized
 
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS
+from corehq.toggles import USE_NEW_GET_COLUMN
 from couchexport.models import Format
 from couchexport.transforms import couch_to_excel_datetime
 from dimagi.ext.couchdbkit import (
@@ -532,6 +533,50 @@ class TableConfiguration(DocumentSchema):
                 ))
         return rows
 
+    def get_column_new(self, item_path, item_doc_type, column_transform):
+        """
+        Given a path and transform, will return the column and its index. If not found, will
+        return None, None.
+
+        NOTE: This method is in QA for accuracy to test against get_column
+        as a more efficient replacement.
+
+        :param item_path: A list of path nodes that identify a column
+        :param item_doc_type: The doc type of the item (often just ExportItem). If getting
+                UserDefinedExportColumn, set this to None
+        :param column_transform: A transform that is applied on the column
+        :returns index, column: The index of the column in the list and an ExportColumn
+        """
+        string_item_path = _path_nodes_to_string(item_path)
+
+        # Previously we iterated over self.columns with each call to return the
+        # index. Now we do an index lookup on the string-ified path names for
+        # self.columns and regenerate it only when the length of self.columns
+        # changes, which probably happens due to some couch db magic in the bg:
+        if (not hasattr(self, '_string_column_paths')
+                or len(self._string_column_paths) != len(self.columns)):
+            self._string_column_paths = [
+                _path_nodes_to_string(column.item.path) for column in
+                self.columns
+            ]
+
+        try:
+            index = self._string_column_paths.index(string_item_path)
+        except ValueError:
+            return None, None
+
+        column = self.columns[index]
+        if (column.item.path == item_path
+                and column.item.transform == column_transform
+                and column.item.doc_type == item_doc_type):
+            return index, column
+        # No item doc type searches for a UserDefinedExportColumn
+        elif (isinstance(column, UserDefinedExportColumn)
+                and column.custom_path == item_path
+                and item_doc_type is None):
+            return index, column
+        return None, None
+
     def get_column(self, item_path, item_doc_type, column_transform):
         """
         Given a path and transform, will return the column and its index. If not found, will
@@ -799,9 +844,15 @@ class ExportInstance(BlobMixin, Document):
 
             prev_index = 0
             for item in group_schema.items:
-                index, column = table.get_column(
-                    item.path, item.doc_type, None
-                )
+                if (hasattr(instance, 'domain')
+                        and USE_NEW_GET_COLUMN.enabled(instance.domain)):
+                    index, column = table.get_column_new(
+                        item.path, item.doc_type, None
+                    )
+                else:
+                    index, column = table.get_column(
+                        item.path, item.doc_type, None
+                    )
                 if not column:
                     column = ExportColumn.create_default_from_export_item(
                         table.path,
@@ -920,16 +971,24 @@ class ExportInstance(BlobMixin, Document):
         insert_fn = self._get_insert_fn(table, top)
 
         for static_column in properties:
-            index, existing_column = table.get_column(
-                static_column.item.path,
-                static_column.item.doc_type,
-                static_column.item.transform,
-            )
+            domain = column_initialization_data.get('domain')
+            if domain and USE_NEW_GET_COLUMN.enabled(domain):
+                index, existing_column = table.get_column_new(
+                    static_column.item.path,
+                    static_column.item.doc_type,
+                    static_column.item.transform,
+                )
+            else:
+                index, existing_column = table.get_column(
+                    static_column.item.path,
+                    static_column.item.doc_type,
+                    static_column.item.transform,
+                )
             column = (existing_column or static_column)
             if isinstance(column, RowNumberColumn):
                 column.update_nested_repeat_count(column_initialization_data.get('repeat'))
             elif isinstance(column, StockExportColumn):
-                column.update_domain(column_initialization_data.get('domain'))
+                column.update_domain(domain)
 
             if not existing_column:
                 if static_column.label in ['case_link', 'form_link'] and self.get_id:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -142,7 +142,12 @@ class PathNode(DocumentSchema):
         return (type(self), self.doc_type, self.name, self.is_repeat)
 
     def __eq__(self, other):
-        return self.__key() == other.__key()
+        # First we try a least expensive comparison (name vs name) to rule the
+        # majority of failed comparisons. This improves performance by nearly
+        # a factor of 2 when __eq__ is used on large data sets.
+        if self.name == other.name:
+            return self.__key() == other.__key()
+        return False
 
     def __hash__(self):
         return hash(self.__key())

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1813,3 +1813,12 @@ SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS = StaticToggle(
     [NAMESPACE_DOMAIN],
     always_enabled={'icds-cas'}
 )
+
+
+USE_NEW_GET_COLUMN = StaticToggle(
+    'use_new_get_column',
+    'Uses the new get_column method when loading edit exports '
+    '(strictly for QA right now).',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10103

##### SUMMARY
I was able to improve performance by nearly a factor of 2x at first with just the simple change to `__eq__`. On my data set, with HQ in the same conditions, it was roughly `58 sec` vs `30 sec` (with the first change).

Then I tackled our wee iteration problem in `get_column`. Yeah, it might look a little unorthodox, but against the dataset I was using, it was accurate. Performance went down to `8.5 sec`, with an overall improvement of nearly 7x from the baseline. 

Since I'm still very skeptical the second change didn't introduce inaccuracies, I've wrapped it in a feature flag for now until we can confirm exports are accurate with it on vs with it off.

##### FEATURE FLAG
`USE_NEW_GET_COLUMN` (One-Off until QA verifies no detrimental impact to exports). When this is deployed, [you can find it here](http://localhost:8000/hq/flags/edit/use_new_get_column/).
