### PR TITLE
Casting value source

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -251,8 +251,8 @@ def get_case_block_kwargs(patient, repeater, case=None):
         "case_name": patient['person']['display'],
         "update": {}
     }
-    for prop, (jsonpath, value_source_dict) in property_map.items():
-        value_source = as_value_source(dict(value_source_dict))
+    for prop, (jsonpath, value_source_config) in property_map.items():
+        value_source = as_value_source(value_source_config)
         if not value_source.can_import:
             continue
         matches = jsonpath.find(patient)
@@ -560,8 +560,8 @@ def get_case_block_for_indexed_case(
         },
         "update": {}
     }
-    for value_source_dict in mapping.indexed_case_mapping.case_properties:
-        value_source = as_value_source(dict(value_source_dict))
+    for value_source_config in mapping.indexed_case_mapping.case_properties:
+        value_source = as_value_source(value_source_config)
         value = value_source.get_import_value(external_data)
         if value_source.case_property in CASE_BLOCK_ARGS:
             case_block_kwargs[value_source.case_property] = value

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -252,7 +252,7 @@ def get_case_block_kwargs(patient, repeater, case=None):
         "update": {}
     }
     for prop, (jsonpath, value_source_dict) in property_map.items():
-        value_source = as_value_source(value_source_dict)
+        value_source = as_value_source(dict(value_source_dict))
         if not value_source.can_import:
             continue
         matches = jsonpath.find(patient)

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -196,8 +196,8 @@ def create_patient(requests, info, case_config):
 
     def get_identifiers():
         identifiers = []
-        for patient_identifier_type, value_source_dict in case_config.patient_identifiers.items():
-            value_source = as_value_source(dict(value_source_dict))
+        for patient_identifier_type, value_source_config in case_config.patient_identifiers.items():
+            value_source = as_value_source(value_source_config)
             if (
                 patient_identifier_type != PERSON_UUID_IDENTIFIER_TYPE_ID
                 and value_source.can_export
@@ -429,8 +429,8 @@ def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extr
 
 def get_export_data(config, properties, case_trigger_info):
     export_data = {}
-    for property_, value_source_dict in config.items():
-        value_source = as_value_source(dict(value_source_dict))
+    for property_, value_source_config in config.items():
+        value_source = as_value_source(value_source_config)
         if (
             property_ in properties
             and value_source.can_export

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -151,7 +151,7 @@ class OpenmrsRepeater(CaseRepeater):
         obs_mappings = defaultdict(list)
         for form_config in self.openmrs_config.form_configs:
             for obs_mapping in form_config.openmrs_observations:
-                value_source = as_value_source(dict(obs_mapping.value))
+                value_source = as_value_source(obs_mapping.value)
                 if (
                     value_source.can_import
                     and (obs_mapping.case_property or obs_mapping.indexed_case_mapping)
@@ -168,7 +168,7 @@ class OpenmrsRepeater(CaseRepeater):
         diag_mappings = defaultdict(list)
         for form_config in self.openmrs_config.form_configs:
             for diag_mapping in form_config.bahmni_diagnoses:
-                value_source = as_value_source(dict(diag_mapping.value))
+                value_source = as_value_source(diag_mapping.value)
                 if (
                     value_source.can_import
                     and (diag_mapping.case_property or diag_mapping.indexed_case_mapping)

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -137,7 +137,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
         stop_datetime for the Visit
         """
         if form_config.openmrs_start_datetime:
-            value_source = as_value_source(dict(form_config.openmrs_start_datetime))
+            value_source = as_value_source(form_config.openmrs_start_datetime)
             cc_start_datetime_str = value_source.get_commcare_value(self.info)
             if cc_start_datetime_str is None:
                 raise ConfigurationError(
@@ -168,7 +168,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
     def _get_values_for_concept(self, form_config):
         values_for_concept = {}
         for obs in form_config.openmrs_observations:
-            value_source = as_value_source(dict(obs.value))
+            value_source = as_value_source(obs.value)
             if value_source.can_export and not is_blank(value_source.get_value(self.info)):
                 values_for_concept[obs.concept] = [value_source.get_value(self.info)]
         return values_for_concept


### PR DESCRIPTION
##### SUMMARY

:beetle: The first commit fixes a bug in importing patients via the OpenMRS Atom feed API. :roll_eyes:

:recycle: The second commit renames `as_value_source()` parameter to `value_source_config`, and refactors `as_value_source()` to cast `value_source_config` as a `dict` instead of relying on its caller to do it (which is what resulted in the bug in the first place).

##### FEATURE FLAG
OpenMRS integration

cc @millerdev just cos you are so familiar with this by now
