### PR TITLE
Route formplayer requests based on user_id, not sessionid

### DIFF
--- a/corehq/apps/cloudcare/middleware.py
+++ b/corehq/apps/cloudcare/middleware.py
@@ -1,0 +1,30 @@
+from django.utils.deprecation import MiddlewareMixin
+
+
+FORMPLAYER_SESSION_COOKIE_NAME = 'formplayer_session'
+
+
+class CloudcareMiddleware(MiddlewareMixin):
+
+    def process_response(self, request, response):
+        self._set_formplayer_session_cookie(request, response)
+        return response
+
+    @staticmethod
+    def _set_formplayer_session_cookie(request, response):
+        """
+        Set the formplayer_session cookie for sticky routing
+
+        This is what makes all requests from a given user go to the same formplayer machine,
+        along with https://git.io/JeDjr in commcare-cloud.
+
+        For years previously, we routed based on the django sessionid, but that was brittle
+        and the log out / log in cycle broke sticky routing because it changes the sessionid.
+        Sticky routing with a high degree of consistency is essential to providing consistent
+        phone-like state, and cracks in sticky routing lead to cases not being present in the
+        formplayer local db when they should be and unintuitve behavior.
+        """
+        couch_user = getattr(request, 'couch_user', None)
+        if couch_user:
+            if request.COOKIES.get(FORMPLAYER_SESSION_COOKIE_NAME) != couch_user.user_id:
+                response.set_cookie(FORMPLAYER_SESSION_COOKIE_NAME, couch_user.user_id)

--- a/corehq/apps/formplayer_api/smsforms/api.py
+++ b/corehq/apps/formplayer_api/smsforms/api.py
@@ -226,9 +226,8 @@ def _post_data(data, user_id):
             "Content-Type": "application/json",
             "content-length": str(len(data_bytes)),
             "X-MAC-DIGEST": get_hmac_digest(settings.FORMPLAYER_INTERNAL_AUTH_KEY, data_bytes),
-            # todo: stop defaulting to session-id
-            "X-FORMPLAYER-SESSION": user_id or data.get('session-id'),
-        }
+            "X-FORMPLAYER-SESSION": user_id,
+        },
     )
     if response.status_code == 404:
         raise Http404(response.reason)

--- a/settings.py
+++ b/settings.py
@@ -159,6 +159,7 @@ MIDDLEWARE = [
     'auditcare.middleware.AuditMiddleware',
     'no_exceptions.middleware.NoExceptionsMiddleware',
     'corehq.apps.locations.middleware.LocationAccessMiddleware',
+    'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
 ]
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"


### PR DESCRIPTION
##### SUMMARY

To fix https://dimagi-dev.atlassian.net/browse/SAASP-10114

This change by itself is a safe noop which just adds an unused cookie. Once it's rolled out then rolling https://github.com/dimagi/commcare-cloud/pull/3452 out will enable the change by routing based on that cookie.

