### PR TITLE
Clean up the async queue

### DIFF
--- a/corehq/apps/userreports/management/commands/clean_async_indicators.py
+++ b/corehq/apps/userreports/management/commands/clean_async_indicators.py
@@ -1,0 +1,71 @@
+import logging
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+
+from pillowtop.feed.interface import ChangeMeta
+
+from corehq.apps.change_feed import data_sources, topics
+from corehq.apps.change_feed.producer import producer
+from corehq.apps.userreports.models import AsyncIndicator
+from corehq.util.argparse_types import date_type
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            dest='cleanup_date',
+            type=date_type,
+            help="The date before which to send the indicators through kafka",
+        )
+
+    def handle(self, cleanup_date, **options):
+        indicators = AsyncIndicator.objects.filter(date_created__lt=cleanup_date).all()
+        indicators_by_domain_doc_type = defaultdict(list)
+        for indicator in indicators:
+            indicators_by_domain_doc_type[(indicator.domain, indicator.doc_type)].append(indicator)
+
+        for domain_doc_type, indicators in indicators_by_domain_doc_type.values():
+            doc_store = data_sources.get_document_store_for_doc_type(
+                domain_doc_type[0], domain_doc_type[1], load_source="clean_async_indicators",
+            )
+            doc_ids = [indicator.doc_id for indicator in indicators]
+
+            for doc in doc_store.iter_documents(doc_ids):
+                doc_id = doc['_id']
+                if domain_doc_type[0] == 'XFormInstance':
+                    producer.send_change(
+                        topics.FORM_SQL,
+                        ChangeMeta(
+                            document_id=doc_id,
+                            data_source_type=data_sources.SOURCE_SQL,
+                            data_source_name=data_sources.FORM_SQL,
+                            document_type='XFormInstance',
+                            document_subtype=doc['xmlns'],
+                            domain=doc['domain'],
+                            is_deletion=False,
+                        )
+                    )
+                    logging.info(f"XForm {doc_id} sent through kafka")
+                elif domain_doc_type[0] == 'CommCareCase':
+                    producer.send_change(
+                        topics.CASE_SQL,
+                        ChangeMeta(
+                            document_id=doc_id,
+                            data_source_type=data_sources.SOURCE_SQL,
+                            data_source_name=data_sources.CASE_SQL,
+                            document_type='CommCareCase',
+                            document_subtype=doc['type'],
+                            domain=doc['domain'],
+                            is_deletion=False,
+                        )
+                    )
+                    logging.info(f"Case {doc_id} sent through kafka")
+
+        # if everything went well, delete the records
+        AsyncIndicator.objects.filter(date_created__lt=cleanup_date).delete()

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -263,10 +263,6 @@ class DataSourceConfiguration(CachedCouchDocumentMixin, Document, AbstractUCRDat
         filter_fn = self._get_main_filter()
         return filter_fn(document, eval_context)
 
-    def deleted_filter(self, document):
-        filter_fn = self._get_deleted_filter()
-        return filter_fn and filter_fn(document, EvaluationContext(document, 0))
-
     @property
     def has_validations(self):
         return len(self.validations) > 0

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -791,22 +791,6 @@ class IndicatorConfigFilterTest(SimpleTestCase):
             dict(doc_type="CommCareCase", domain='user-reports', type='ticket')
         ))
 
-    def test_deleted_filter(self):
-        not_matching = [
-            dict(doc_type="CommCareCase", domain='user-reports', type='ticket'),
-            dict(doc_type="CommCareCase-Deleted", domain='not-user-reports', type='ticket'),
-        ]
-        for document in not_matching:
-            self.assertFalse(self.config.deleted_filter(document), 'Failing dog: %s' % document)
-
-        matching = [
-            dict(doc_type="CommCareCase-Deleted", domain='user-reports', type='ticket'),
-            dict(doc_type="CommCareCase-Deleted", domain='user-reports', type='bot-ticket'),
-            dict(doc_type="CommCareCase-Deleted", domain='user-reports'),
-        ]
-        for document in matching:
-            self.assertTrue(self.config.deleted_filter(document), 'Failing dog: %s' % document)
-
 
 def _save_sql_case(doc):
     system_props = ['_id', '_rev', 'opened_on', 'owner_id', 'doc_type', 'domain', 'type']

--- a/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
+++ b/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
@@ -1,0 +1,66 @@
+import logging
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+
+from pillowtop.feed.interface import ChangeMeta
+
+from corehq.apps.change_feed import data_sources, topics
+from corehq.apps.change_feed.producer import producer
+from corehq.apps.userreports.models import (
+    AsyncIndicator,
+    StaticDataSourceConfiguration,
+)
+from corehq.apps.userreports.util import get_indicator_adapter
+from corehq.util.argparse_types import date_type
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(dest='start_date', type=date_type)
+        parser.add_argument(dest='end_date', type=date_type)
+        parser.add_argument('--execute', action='store_true')
+
+    def handle(self, start_date, end_date, execute, **options):
+        config_ids = (
+            'static-ccs_record_cases_monthly_v2',
+            'static-child_cases_monthly_v2'
+        )
+        for config_id in config_ids:
+            self.process(config_id, start_date, end_date, execute)
+
+    def process(self, config_id, start_date, end_date, execute):
+        indicators = AsyncIndicator.objects.filter(
+            indicator_config_ids=[config_id],
+            date_created__gte=start_date, date_created__lt=end_date,
+        ).all()
+
+        datasource_id = StaticDataSourceConfiguration.get_doc_id('icds-cas', config_id)
+        data_source = StaticDataSourceConfiguration.by_id(datasource_id)
+        doc_store = data_sources.get_document_store_for_doc_type(
+            'icds-cas', 'CommCareCase', load_source="clean_deleted_async_indicators",
+        )
+        doc_ids = [indicator.doc_id for indicator in indicators]
+        doc_ids_to_delete = [
+            doc['id']
+            for doc in doc_store.iter_documents(doc_ids)
+            if not data_source.filter(doc)
+        ]
+
+        if doc_ids_to_delete:
+            logger.info("Found following doc_ids to delete:")
+            for doc_id in doc_ids_to_delete:
+                logger.info(doc_id)
+
+        if doc_ids_to_delete and execute:
+            adapter = get_indicator_adapter(data_source)
+            logger.info("Deleting from UCR table")
+            adapter.bulk_delete({{'_id': doc_id for doc_id in doc_ids_to_delete}})
+            # if everything went well, delete the records
+            logger.info("Deleting from async indicator table")
+            AsyncIndicator.objects.filter(doc_id__in=doc_ids_to_delete).delete()

--- a/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
+++ b/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         if doc_ids_to_delete and execute:
             adapter = get_indicator_adapter(data_source)
             logger.info("Deleting from UCR table")
-            adapter.bulk_delete({{'_id': doc_id for doc_id in doc_ids_to_delete}})
+            adapter.bulk_delete([{'_id': doc_id} for doc_id in doc_ids_to_delete])
             # if everything went well, delete the records
             logger.info("Deleting from async indicator table")
             AsyncIndicator.objects.filter(doc_id__in=doc_ids_to_delete).delete()

--- a/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
+++ b/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
@@ -51,9 +51,9 @@ class Command(BaseCommand):
 
         if doc_ids_to_delete:
             logger.info("Found following doc_ids to delete:")
-            with open(f'{config_id}_doc_ids_deleted.csv', 'w', newline='') as csvfile:
+            with open(f'{config_id}_{start_date}_{end_date}_deleted.csv', 'w', newline='') as csvfile:
                 for doc_id in doc_ids_to_delete:
-                    csvfile.write(doc_id)
+                    csvfile.write(doc_id + "\n")
 
         if doc_ids_to_delete and execute:
             adapter = get_indicator_adapter(data_source)

--- a/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
+++ b/custom/icds_reports/management/commands/clean_deleted_async_indicators.py
@@ -37,6 +37,7 @@ class Command(BaseCommand):
             indicator_config_ids=[datasource_id],
             date_created__gte=start_date, date_created__lt=end_date,
         ).all()
+        logging.info(len(indicators))
 
         data_source = StaticDataSourceConfiguration.by_id(datasource_id)
         doc_store = data_sources.get_document_store_for_doc_type(


### PR DESCRIPTION
##### SUMMARY
Follow up on https://github.com/dimagi/commcare-hq/pull/26023

I had deleted the old cases from the UCR data source tables, but left the records in `AsyncIndicator` as I thought that they would be fairly quick with the hash index. However they're quite expensive, and there are a lot of records. So I created a mgmt command to delete those if they do not conform to the base_item_expression and deletes them in bulk  (which should be much better than the batching the task does).

I also created a command to "cleanup" task that moves older indicators through kafka becasue some of them are "stuck" in the queue. Basically the async queue doesn't handle erorrs well (it relies on the pillow to do that) and if there are some errors like `MissingFormXML` or something that failes `validation_expression` they stay in the queue indefinitely. I believe all of these are there because they were inserted using a rebuild command for new data source definitions, and were never followed up on

I don't think that these should be merged because they are kind of hacky and probably shouldn't need to be used again now that the queue deletes as it goes. I mostly want to get over this first hump of deletes