### PR TITLE
Remove unused indexes from child_health_monthly and ccs_record_monthly

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/ccs_record_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/ccs_record_monthly.py
@@ -295,7 +295,4 @@ class CcsRecordMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribute
     def indexes(self):
         return [
             'CREATE INDEX IF NOT EXISTS crm_awc_case_idx ON "{}" (awc_id, case_id)'.format(self.tablename),
-            'CREATE INDEX IF NOT EXISTS crm_person_add_case_idx ON "{}" (person_case_id, add, case_id)'.format(
-                self.tablename
-            )
         ]

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -396,6 +396,4 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
         return [
             'CREATE INDEX IF NOT EXISTS chm_case_idx ON "{}" (case_id)'.format(self.tablename),
             'CREATE INDEX IF NOT EXISTS chm_awc_idx ON "{}" (awc_id)'.format(self.tablename),
-            'CREATE INDEX IF NOT EXISTS chm_mother_dob ON "{}" (mother_case_id, dob)'.format(self.tablename),
-            'CREATE INDEX IF NOT EXISTS chm_month_supervisor_id ON "{}" (month, supervisor_id)'.format(self.tablename),
         ]


### PR DESCRIPTION
I ran a [postgres-checkup](https://gitlab.com/postgres-ai/postgres-checkup/) on citusworker23 and it revealed a few unused indexes. 

I have a report of this checkup, but am making sure that it is safe to share before posting (i think it is, but want to check a few more times because it is quite large)