### PR TITLE
Fix edge case in app stauts

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2796,6 +2796,15 @@ class UserReportingMetadataStaging(models.Model):
 
     @classmethod
     def add_submission(cls, domain, user_id, app_id, build_id, version, metadata, received_on):
+        params = {
+            'domain': domain,
+            'user_id': user_id,
+            'app_id': app_id,
+            'build_id': build_id,
+            'xform_version': version,
+            'form_meta': json.dumps(metadata),
+            'received_on': received_on,
+        }
         with connection.cursor() as cursor:
             cursor.execute(f"""
                 INSERT INTO {cls._meta.db_table} AS staging (
@@ -2815,19 +2824,18 @@ class UserReportingMetadataStaging(models.Model):
                     form_meta = EXCLUDED.form_meta,
                     received_on = EXCLUDED.received_on
                 WHERE staging.received_on IS NULL OR EXCLUDED.received_on > staging.received_on
-                """, {
-                    'domain': domain,
-                    'user_id': user_id,
-                    'app_id': app_id,
-                    'build_id': build_id,
-                    'xform_version': version,
-                    'form_meta': json.dumps(metadata),
-                    'received_on': received_on,
-                }
-            )
+                """, params)
 
     @classmethod
     def add_sync(cls, domain, user_id, app_id, build_id, sync_date, device_id):
+        params = {
+            'domain': domain,
+            'user_id': user_id,
+            'app_id': app_id,
+            'build_id': build_id,
+            'sync_date': sync_date,
+            'device_id': device_id,
+        }
         with connection.cursor() as cursor:
             cursor.execute(f"""
                 INSERT INTO {cls._meta.db_table} AS staging (
@@ -2846,15 +2854,7 @@ class UserReportingMetadataStaging(models.Model):
                     sync_date = EXCLUDED.sync_date,
                     device_id = EXCLUDED.device_id
                 WHERE staging.sync_date IS NULL OR EXCLUDED.sync_date > staging.sync_date
-                """, {
-                    'domain': domain,
-                    'user_id': user_id,
-                    'app_id': app_id,
-                    'build_id': build_id,
-                    'sync_date': sync_date,
-                    'device_id': device_id,
-                }
-            )
+                """, params)
 
     class Meta(object):
         unique_together = ('domain', 'user_id', 'app_id')

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -8,7 +8,7 @@ from xml.etree import cElementTree as ElementTree
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import JSONField
-from django.db import connection, models, transaction, router
+from django.db import connection, models, router
 from django.template.loader import render_to_string
 from django.utils.translation import override as override_language
 from django.utils.translation import ugettext as _
@@ -2774,9 +2774,6 @@ class AnonymousCouchUser(object):
 
     def can_view_roles(self):
         return False
-
-
-reporting_update_freq = timedelta(minutes=settings.USER_REPORTING_METADATA_UPDATE_FREQUENCY)
 
 
 class UserReportingMetadataStaging(models.Model):

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -326,12 +326,12 @@ def process_reporting_metadata_staging():
             if record.received_on:
                 save = mark_latest_submission(
                     record.domain, user, record.app_id, record.build_id,
-                    record.xform_version, record.form_meta, record.received_on, save=False
+                    record.xform_version, record.form_meta, record.received_on, save_user=False
                 )
             if record.device_id or record.sync_date:
                 save |= mark_last_synclog(
                     record.domain, user, record.app_id, record.build_id,
-                    record.sync_date, record.device_id, save=False
+                    record.sync_date, record.device_id, save_user=False
                 )
             if save:
                 user.save(fire_signals=False)

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -329,7 +329,7 @@ def process_reporting_metadata_staging():
                     record.xform_version, record.form_meta, record.received_on, save=False
                 )
             if record.device_id or record.sync_date:
-                save = mark_last_synclog(
+                save |= mark_last_synclog(
                     record.domain, user, record.app_id, record.build_id,
                     record.sync_date, record.device_id, save=False
                 )

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -120,7 +120,7 @@ def _last_submission_needs_update(last_submission, received_on_datetime, build_v
     return time_difference > update_frequency
 
 
-def mark_latest_submission(domain, user, app_id, build_id, version, metadata, received_on, save=True):
+def mark_latest_submission(domain, user, app_id, build_id, version, metadata, received_on, save_user=True):
     try:
         received_on_datetime = string_to_utc_datetime(received_on)
     except ValueError:
@@ -174,7 +174,7 @@ def mark_latest_submission(domain, user, app_id, build_id, version, metadata, re
         )
         update_device_meta(user, device_id, app_version_info.commcare_version, app_meta, save=False)
 
-        if save:
+        if save_user:
             user.save(fire_signals=False)
         return True
     return False

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -88,7 +88,7 @@ class UserSyncHistoryProcessor(PillowProcessor):
             mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id)
 
 
-def mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id, save=True):
+def mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id, save_user=True):
     version = None
     if build_id:
         version = get_version_from_build_id(domain, build_id)
@@ -103,7 +103,7 @@ def mark_last_synclog(domain, user, app_id, build_id, sync_date, device_id, save
             app_meta = DeviceAppMeta(app_id=app_id, build_id=build_id, last_sync=sync_date)
         local_save |= update_device_meta(user, device_id, device_app_meta=app_meta, save=False)
 
-    if local_save and save:
+    if local_save and save_user:
         user.save(fire_signals=False)
     return local_save
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1060

##### SUMMARY
The real fix is in https://github.com/dimagi/commcare-hq/commit/ee7f188e103c8b9eda97fe715802bd8ece9c30bb. A form and synclog could have been added to the staging table, but if the synclog code decided not to save, then the form update would also be skipped because it was not ORd.

During investigation I also found that there were quite a few `IntegrityError`s in the pillow error table which is fine as they get retried later, but I moved to using upserts to avoid it. I followed https://www.peterbe.com/plog/simple-or-fancy-upsert-in-postgresql-with-django and agreed with the author of not adding `django-postgres-extra` as a dependency. Happy to add that dependency instead, or remove the upserts completely if preferred. The first commit is the main one to get through