### PR TITLE
Removed add_resource_overrides call from migration

### DIFF
--- a/corehq/apps/app_manager/migrations/0009_resourceoverride.py
+++ b/corehq/apps/app_manager/migrations/0009_resourceoverride.py
@@ -6,11 +6,6 @@ from django.db import migrations, models
 from corehq.util.django_migrations import skip_on_fresh_install
 
 
-@skip_on_fresh_install
-def _add_overrides_for_all_builds(apps, schema_editor):
-    call_command('add_resource_overrides')
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -33,7 +28,4 @@ class Migration(migrations.Migration):
             name='resourceoverride',
             unique_together=set([('domain', 'app_id', 'root_name', 'pre_id')]),
         ),
-        migrations.RunPython(_add_overrides_for_all_builds,
-                             reverse_code=migrations.RunPython.noop,
-                             elidable=True),
     ]


### PR DESCRIPTION
##### SUMMARY
Followup for https://github.com/dimagi/commcare-hq/pull/25803/

Updating this migration so that problems with `add_resource_overrides` don't block deploy.

New plan is to merge this, deploy, run `add_resource_overrides` manually on our environments, and then add this code to https://github.com/dimagi/commcare-hq/pull/25998 so `add_resource_overrides` gets run for any third-party HQ instances.