### PR TITLE
Added restrictions on all django tags except static to TestDjangoComp…

### DIFF
--- a/corehq/apps/hqwebapp/tests/test_compress_command.py
+++ b/corehq/apps/hqwebapp/tests/test_compress_command.py
@@ -12,8 +12,8 @@ COMPRESS_JS = ' compress js '
 COMPRESS_CSS = ' compress css '
 ENDCOMPRESS = ' endcompress '
 
-DISALLOWED_TAGS = [
-    ('{% if', 'You cannot use "if" tags in a compress block'),
+DISALLOWED_REGEXES = [
+    ('{% (?!static)', 'You cannot use django template tags other than static'),
     ('^</script>$', 'You cannot use inline JS in a compress block'),
 ]
 
@@ -28,7 +28,7 @@ class TestDjangoCompressOffline(SimpleTestCase):
     def _assert_valid_import(self, line, filename):
         if not line.strip():
             return
-        for tag in DISALLOWED_TAGS:
+        for tag in DISALLOWED_REGEXES:
             self.assertNotRegexpMatches(line.strip(), tag[0], '{}: {}'.format(tag[1], filename))
 
     @attr("slow")

--- a/corehq/apps/reports/templates/reports/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/standard/base_template.html
@@ -51,8 +51,8 @@
             rel="stylesheet"
             media="all"
             href="{% static 'reports/less/reports.less' %}" />
-      {% include 'reports/partials/filters_css.html' %}
     {% endcompress %}
+    {% include 'reports/partials/filters_css.html' %}
   {% endif %}
 
   {% block reports-css %}{% endblock %}


### PR DESCRIPTION
…ressOffline

@czue This is what I was thinking would have prevented https://github.com/dimagi/commcare-hq/pull/26158/

@biyeun `static` is the only tag that **reliably** works within compress blocks, right, since it's deterministic? I think it's reasonable to not allow things like `include` even though they do work occasionally. The bit of extra compression doesn't seem worth the disruption compression bugs can cause.