### PR TITLE
Add "corehq.pillows" to INSTALLED_APPS to load its tasks

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -258,6 +258,7 @@ HQ_APPS = (
     'corehq.sql_accessors',
     'corehq.sql_proxy_accessors',
     'corehq.sql_proxy_standby_accessors',
+    'corehq.pillows',
     'couchforms',
     'couchexport',
     'dimagi.utils',


### PR DESCRIPTION
##### SUMMARY
It didn't occur to me in https://github.com/dimagi/commcare-hq/pull/26154 that it would be unable to load tasks. I'm surprised (but also not surprised) that celery doesn't make it fail harder on startup.

Fixes https://sentry.io/organizations/dimagi/issues/1381573552/?project=136860&query=is%3Aunresolved

> Received unregistered task of type KeyError('corehq.pillows.tasks.resave_es_forms_with_unknown_user_type',).
> The message has been ignored and discarded.