### PR TITLE
Import observation metadata

### DIFF
--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -1,6 +1,7 @@
 import re
 import uuid
 from datetime import datetime
+from itertools import chain
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from django.utils.translation import ugettext as _
@@ -468,8 +469,9 @@ def get_case_block_kwargs_from_observations(
     case_block_kwargs = {"update": {}}
     for obs in observations:
         concept_uuid = obs.get('concept', {}).get('uuid')
-        if concept_uuid and concept_uuid in mappings:
-            for mapping in mappings[concept_uuid]:
+        if concept_uuid and (concept_uuid in mappings or None in mappings):
+            obs_mappings = chain(mappings.get(concept_uuid, []), mappings.get(None, []))
+            for mapping in obs_mappings:
                 if mapping.case_property:
                     more_kwargs = get_case_block_kwargs_for_case_property(
                         mapping, obs, fallback_value=obs.get('value')
@@ -508,8 +510,9 @@ def get_case_block_kwargs_from_bahmni_diagnoses(
     case_block_kwargs = {"update": {}}
     for diag in diagnoses:
         codedanswer_uuid = diag.get('codedAnswer', {}).get('uuid')
-        if codedanswer_uuid and codedanswer_uuid in mappings:
-            for mapping in mappings[codedanswer_uuid]:
+        if codedanswer_uuid and (codedanswer_uuid in mappings or None in mappings):
+            diag_mappings = chain(mappings.get(codedanswer_uuid, []), mappings.get(None, []))
+            for mapping in diag_mappings:
                 if mapping.case_property:
                     more_kwargs = get_case_block_kwargs_for_case_property(
                         mapping, diag,

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -345,22 +345,22 @@ def import_encounter(repeater, encounter_uuid):
     case_blocks = []
 
     # NOTE: Atom Feed integration requires Patient UUID to be external_id
-    case = get_case(repeater, encounter['patientUuid'])
-    if case:
-        case_id = case.case_id
-        default_owner_id = case.owner_id
+    patient_case = get_case(repeater, encounter['patientUuid'])
+    if patient_case:
+        patient_case_id = patient_case.case_id
+        default_owner_id = patient_case.owner_id
     else:
-        case_block = create_case(repeater, encounter['patientUuid'])
-        case_blocks.append(case_block)
-        case_id = case_block.case_id
-        default_owner_id = case_block.owner_id
+        patient_case_block = create_case(repeater, encounter['patientUuid'])
+        case_blocks.append(patient_case_block)
+        patient_case_id = patient_case_block.case_id
+        default_owner_id = patient_case_block.owner_id
 
-    case_type = repeater.white_listed_case_types[0]
+    patient_case_type = repeater.white_listed_case_types[0]
     more_kwargs, more_case_blocks = get_case_block_kwargs_from_observations(
         encounter['observations'],
         repeater.observation_mappings,
-        case_id,
-        case_type,
+        patient_case_id,
+        patient_case_type,
         default_owner_id,
     )
     deep_update(case_block_kwargs, more_kwargs)
@@ -370,8 +370,8 @@ def import_encounter(repeater, encounter_uuid):
         more_kwargs, more_case_blocks = get_case_block_kwargs_from_bahmni_diagnoses(
             encounter['bahmniDiagnoses'],
             repeater.diagnosis_mappings,
-            case_id,
-            case_type,
+            patient_case_id,
+            patient_case_type,
             default_owner_id,
         )
         deep_update(case_block_kwargs, more_kwargs)
@@ -382,8 +382,8 @@ def import_encounter(repeater, encounter_uuid):
         more_kwargs, more_case_blocks = get_case_block_kwargs_from_bahmni_diagnoses(
             encounter['bahmniDiagnoses'],
             repeater.observation_mappings,
-            case_id,
-            case_type,
+            patient_case_id,
+            patient_case_type,
             default_owner_id,
         )
         deep_update(case_block_kwargs, more_kwargs)
@@ -391,7 +391,7 @@ def import_encounter(repeater, encounter_uuid):
         #  O\ ˙˙˙ ˙˙˙ ˙˙˙ end snip
 
     if has_case_updates(case_block_kwargs) or case_blocks:
-        update_case(repeater, case_id, case_block_kwargs, case_blocks)
+        update_case(repeater, patient_case_id, case_block_kwargs, case_blocks)
 
 
 def get_encounter(repeater, encounter_uuid):

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -36,6 +36,7 @@ from corehq.motech.openmrs.exceptions import (
     OpenmrsFeedDoesNotExist,
 )
 from corehq.motech.openmrs.openmrs_config import (
+    ALL_CONCEPTS,
     ObservationMapping,
     get_property_map,
 )
@@ -558,8 +559,11 @@ def get_case_block_kwargs_from_observations(
     case_block_kwargs = {"update": {}}
     for obs in observations:
         concept_uuid = obs.get('concept', {}).get('uuid')
-        if concept_uuid and (concept_uuid in mappings or None in mappings):
-            obs_mappings = chain(mappings.get(concept_uuid, []), mappings.get(None, []))
+        if concept_uuid:
+            obs_mappings = chain(
+                mappings.get(concept_uuid, []),
+                mappings.get(ALL_CONCEPTS, []),
+            )
             for mapping in obs_mappings:
                 if mapping.case_property:
                     more_kwargs = get_case_block_kwargs_for_case_property(
@@ -617,8 +621,11 @@ def get_case_block_kwargs_from_bahmni_diagnoses(
     case_block_kwargs = {"update": {}}
     for diag in diagnoses:
         codedanswer_uuid = diag.get('codedAnswer', {}).get('uuid')
-        if codedanswer_uuid and (codedanswer_uuid in mappings or None in mappings):
-            diag_mappings = chain(mappings.get(codedanswer_uuid, []), mappings.get(None, []))
+        if codedanswer_uuid:
+            diag_mappings = chain(
+                mappings.get(codedanswer_uuid, []),
+                mappings.get(ALL_CONCEPTS, []),
+            )
             for mapping in diag_mappings:
                 if mapping.case_property:
                     more_kwargs = get_case_block_kwargs_for_case_property(

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -221,7 +221,7 @@ def get_addpatient_caseblock(
     repeater: OpenmrsRepeater,
 ) -> CaseBlock:
 
-    case_block_kwargs = get_case_block_kwargs(patient, repeater)
+    case_block_kwargs = get_case_block_kwargs_from_patient(patient, repeater)
     if default_owner:
         case_block_kwargs.setdefault("owner_id", default_owner.user_id)
     if not case_block_kwargs.get("owner_id"):
@@ -240,7 +240,7 @@ def get_addpatient_caseblock(
 
 
 def get_updatepatient_caseblock(case, patient, repeater):
-    case_block_kwargs = get_case_block_kwargs(patient, repeater, case)
+    case_block_kwargs = get_case_block_kwargs_from_patient(patient, repeater, case)
     return CaseBlock(
         create=False,
         case_id=case.case_id,
@@ -248,7 +248,7 @@ def get_updatepatient_caseblock(case, patient, repeater):
     )
 
 
-def get_case_block_kwargs(patient, repeater, case=None):
+def get_case_block_kwargs_from_patient(patient, repeater, case=None):
     property_map = get_property_map(repeater.openmrs_config.case_config)
     case_block_kwargs = {
         "case_name": patient['person']['display'],

--- a/corehq/motech/openmrs/atom_feed.py
+++ b/corehq/motech/openmrs/atom_feed.py
@@ -42,6 +42,7 @@ from corehq.motech.openmrs.openmrs_config import (
 from corehq.motech.openmrs.repeater_helpers import get_patient_by_uuid
 from corehq.motech.openmrs.repeaters import AtomFeedStatus, OpenmrsRepeater
 from corehq.motech.value_source import (
+    ValueSource,
     as_value_source,
     deserialize,
     get_import_value,
@@ -496,6 +497,21 @@ def get_diagnosis_mappings(
                 concept = diag_mapping.concept or None
                 diag_mappings[concept].append(diag_mapping)
     return diag_mappings
+
+
+def get_encounter_datetime_value_sources(
+    repeater: OpenmrsRepeater
+) -> List[ValueSource]:
+    value_sources = []
+    for form_config in repeater.openmrs_config.form_configs:
+        encounter_datetime_config = form_config.openmrs_start_datetime
+        if encounter_datetime_config and "case_property" in encounter_datetime_config:
+            value_source = as_value_source(encounter_datetime_config)
+            if value_source.can_import:
+                if not value_source.jsonpath:
+                    value_source.jsonpath = "encounterDateTime"
+                value_sources.append(value_source)
+    return value_sources
 
 
 def update_case(repeater, case_id, case_block_kwargs, case_blocks):

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -13,8 +13,6 @@ from dimagi.ext.couchdbkit import (
     DictProperty,
     DocumentSchema,
     ListProperty,
-    SchemaDictProperty,
-    SchemaListProperty,
     SchemaProperty,
     StringProperty,
 )
@@ -27,6 +25,7 @@ INDEX_RELATIONSHIPS = (
     INDEX_RELATIONSHIP_CHILD,
     INDEX_RELATIONSHIP_EXTENSION,
 )
+
 
 class OpenmrsCaseConfig(DocumentSchema):
 

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -21,6 +21,7 @@ from corehq.motech.openmrs.const import OPENMRS_PROPERTIES
 from corehq.motech.openmrs.finders import PatientFinder
 from corehq.motech.openmrs.jsonpath import Cmp, WhereNot
 
+ALL_CONCEPTS = "all"
 INDEX_RELATIONSHIPS = (
     INDEX_RELATIONSHIP_CHILD,
     INDEX_RELATIONSHIP_EXTENSION,
@@ -186,7 +187,7 @@ class ObservationMapping(DocumentSchema):
     # If no concept is specified, this ObservationMapping is used for
     # setting a case property or creating an extension case for any
     # concept
-    concept = StringProperty(required=False, default=None)
+    concept = StringProperty(required=True, default=ALL_CONCEPTS)
     value = DictProperty()
 
     # Import Observations as case updates from Atom feed. (Case type is

--- a/corehq/motech/openmrs/openmrs_config.py
+++ b/corehq/motech/openmrs/openmrs_config.py
@@ -184,7 +184,10 @@ class ObservationMapping(DocumentSchema):
         }
 
     """
-    concept = StringProperty()
+    # If no concept is specified, this ObservationMapping is used for
+    # setting a case property or creating an extension case for any
+    # concept
+    concept = StringProperty(required=False, default=None)
     value = DictProperty()
 
     # Import Observations as case updates from Atom feed. (Case type is

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -1,5 +1,4 @@
 import json
-from collections import defaultdict
 from itertools import chain
 
 from django.utils.functional import cached_property
@@ -50,7 +49,6 @@ from corehq.motech.requests import Requests
 from corehq.motech.utils import pformat_json
 from corehq.motech.value_source import (
     CaseTriggerInfo,
-    as_value_source,
     get_form_question_values,
 )
 from corehq.toggles import OPENMRS_INTEGRATION
@@ -145,20 +143,6 @@ class OpenmrsRepeater(CaseRepeater):
             verify=self.verify,
             notify_addresses=self.notify_addresses,
         )
-
-    @cached_property
-    def diagnosis_mappings(self):
-        diag_mappings = defaultdict(list)
-        for form_config in self.openmrs_config.form_configs:
-            for diag_mapping in form_config.bahmni_diagnoses:
-                value_source = as_value_source(diag_mapping.value)
-                if (
-                    value_source.can_import
-                    and (diag_mapping.case_property or diag_mapping.indexed_case_mapping)
-                ):
-                    concept = diag_mapping.concept or None
-                    diag_mappings[concept].append(diag_mapping)
-        return diag_mappings
 
     @cached_property
     def first_user(self):

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -147,27 +147,6 @@ class OpenmrsRepeater(CaseRepeater):
         )
 
     @cached_property
-    def observation_mappings(self):
-        obs_mappings = defaultdict(list)
-        for form_config in self.openmrs_config.form_configs:
-            for obs_mapping in form_config.openmrs_observations:
-                value_source = as_value_source(obs_mapping.value)
-                if (
-                    value_source.can_import
-                    and (obs_mapping.case_property or obs_mapping.indexed_case_mapping)
-                ):
-                    # If obs_mapping.concept is "" or None, the mapping
-                    # should apply to any concept
-                    concept = obs_mapping.concept or None
-
-                    # It's possible that an OpenMRS concept appears more
-                    # than once in form_configs. We are using a
-                    # defaultdict(list) so that earlier definitions
-                    # don't get overwritten by later ones:
-                    obs_mappings[concept].append(obs_mapping)
-        return obs_mappings
-
-    @cached_property
     def diagnosis_mappings(self):
         diag_mappings = defaultdict(list)
         for form_config in self.openmrs_config.form_configs:

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -156,11 +156,15 @@ class OpenmrsRepeater(CaseRepeater):
                     value_source.can_import
                     and (obs_mapping.case_property or obs_mapping.indexed_case_mapping)
                 ):
+                    # If obs_mapping.concept is "" or None, the mapping
+                    # should apply to any concept
+                    concept = obs_mapping.concept or None
+
                     # It's possible that an OpenMRS concept appears more
                     # than once in form_configs. We are using a
                     # defaultdict(list) so that earlier definitions
                     # don't get overwritten by later ones:
-                    obs_mappings[obs_mapping.concept].append(obs_mapping)
+                    obs_mappings[concept].append(obs_mapping)
         return obs_mappings
 
     @cached_property
@@ -173,7 +177,8 @@ class OpenmrsRepeater(CaseRepeater):
                     value_source.can_import
                     and (diag_mapping.case_property or diag_mapping.indexed_case_mapping)
                 ):
-                    diag_mappings[diag_mapping.concept].append(diag_mapping)
+                    concept = diag_mapping.concept or None
+                    diag_mappings[concept].append(diag_mapping)
         return diag_mappings
 
     @cached_property

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -238,23 +238,28 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                     },
                     "direction": "in",
                 },
+            },
+            {
+                "doc_type": "ObservationMapping",
+                "concept": None,  # Import all diagnoses as extension cases
+                "value": {
+                    "direction": "in",
+                    "value": "[unused when direction='in' and ObservationMapping.case_property not set]",
+                },
                 "indexed_case_mapping": {
                     "identifier": "parent",
                     "case_type": "diagnosis",
                     "relationship": "extension",
                     "case_properties": [
                         {
-                            "doc_type": "JsonPathCaseProperty",
                             "jsonpath": "codedAnswer.name",
                             "case_property": "case_name",
                         },
                         {
-                            "doc_type": "JsonPathCaseProperty",
                             "jsonpath": "certainty",
                             "case_property": "certainty",
                         },
                         {
-                            "doc_type": "JsonPathCasePropertyMap",
                             "jsonpath": "order",
                             "case_property": "is_primary",
                             "value_map": {
@@ -263,9 +268,10 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                             }
                         },
                         {
-                            "doc_type": "CasePropertyConstantValue",
-                            "case_property": "code",
-                            "value": "T68 (ICD 10 - WHO)"
+                            "jsonpath": "diagnosisDateTime",
+                            "case_property": "diagnosis_date",
+                            "external_data_type": "omrs_datetime",
+                            "commcare_data_type": "cc_date",
                         }
                     ]
                 }
@@ -425,7 +431,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
               <update>
                 <date_opened>{date_opened}</date_opened>
                 <certainty>CONFIRMED</certainty>
-                <code>T68 (ICD 10 - WHO)</code>
+                <diagnosis_date>2019-10-18</diagnosis_date>
                 <is_primary>yes</is_primary>
               </update>
               <index>

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -4,9 +4,9 @@ import os
 import re
 from datetime import datetime
 
-import attr
 from django.test import SimpleTestCase
 
+import attr
 from dateutil.tz import tzoffset, tzutc
 from lxml import etree
 from mock import Mock, patch
@@ -16,6 +16,7 @@ from corehq.motech.openmrs.atom_feed import (
     get_case_block_kwargs_from_bahmni_diagnoses,
     get_case_block_kwargs_from_observations,
     get_encounter_uuid,
+    get_observation_mappings,
     get_patient_uuid,
     get_timestamp,
     import_encounter,
@@ -329,7 +330,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
         observations = encounter['observations']
         case_block_kwargs, case_blocks = get_case_block_kwargs_from_observations(
             observations,
-            self.repeater.observation_mappings,
+            get_observation_mappings(self.repeater),
             None, None, None
         )
         self.assertEqual(case_block_kwargs, {'update': {'height': 105}})
@@ -359,7 +360,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
         observations = encounter['observations']
         case_block_kwargs, case_blocks = get_case_block_kwargs_from_observations(
             observations,
-            self.repeater.observation_mappings,
+            get_observation_mappings(self.repeater),
             'test-case-id',
             'patient',
             'default-owner-id'

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -241,7 +241,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
             },
             {
                 "doc_type": "ObservationMapping",
-                "concept": None,  # Import all diagnoses as extension cases
+                "concept": "all",  # Import all diagnoses as extension cases
                 "value": {
                     "direction": "in",
                     "value": "[unused when direction='in' and ObservationMapping.case_property not set]",

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -286,6 +286,13 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                     "xmlns": "http://openrosa.org/formdesigner/9481169B-0381-4B27-BA37-A46AB7B4692D",
                     "openmrs_visit_type": "c22a5000-3f10-11e4-adec-0800271c1b75",
                     "openmrs_encounter_type": "81852aee-3f10-11e4-adec-0800271c1b75",
+                    "openmrs_start_datetime": {
+                        "direction": "in",
+                        "case_property": "last_visit_date",
+                        "external_data_type": "omrs_datetime",
+                        "commcare_data_type": "cc_date",
+                        # "jsonpath": "encounterDateTime",  # get_encounter_datetime_value_sources() default value
+                    },
                     "openmrs_observations": observations,
                     "bahmni_diagnoses": diagnoses
                 }]
@@ -316,6 +323,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
                       xmlns="http://commcarehq.org/case/transaction/v2">
                   <update>
                     <height>105</height>
+                    <last_visit_date>2018-01-18</last_visit_date>
                   </update>
                 </case>"""
             case_block_re = ''.join((l.strip() for l in case_block_re.split('\n'))).replace('»', '')

--- a/corehq/motech/openmrs/tests/test_atom_feed.py
+++ b/corehq/motech/openmrs/tests/test_atom_feed.py
@@ -15,6 +15,7 @@ import corehq.motech.openmrs.atom_feed
 from corehq.motech.openmrs.atom_feed import (
     get_case_block_kwargs_from_bahmni_diagnoses,
     get_case_block_kwargs_from_observations,
+    get_diagnosis_mappings,
     get_encounter_uuid,
     get_observation_mappings,
     get_patient_uuid,
@@ -342,7 +343,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
         bahmni_diagnoses = encounter['bahmniDiagnoses']
         case_block_kwargs, case_blocks = get_case_block_kwargs_from_bahmni_diagnoses(
             bahmni_diagnoses,
-            self.repeater.diagnosis_mappings,
+            get_diagnosis_mappings(self.repeater),
             None, None, None
         )
         self.assertEqual(case_block_kwargs, {
@@ -395,7 +396,7 @@ class ImportEncounterTest(SimpleTestCase, TestFileMixin):
         bahmni_diagnoses = encounter['bahmniDiagnoses']
         case_block_kwargs, case_blocks = get_case_block_kwargs_from_bahmni_diagnoses(
             bahmni_diagnoses,
-            self.repeater.diagnosis_mappings,
+            get_diagnosis_mappings(self.repeater),
             'test-case-id',
             'patient',
             'default-owner-id'

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -19,6 +19,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.models import XFormInstanceSQL
 from corehq.motech.const import DIRECTION_EXPORT, DIRECTION_IMPORT
+from corehq.motech.openmrs.atom_feed import get_observation_mappings
 from corehq.motech.openmrs.const import (
     LOCATION_OPENMRS_UUID,
     OPENMRS_DATA_TYPE_BOOLEAN,
@@ -41,10 +42,7 @@ from corehq.motech.openmrs.repeater_helpers import (
     save_match_ids,
 )
 from corehq.motech.openmrs.repeaters import OpenmrsRepeater
-from corehq.motech.value_source import (
-    CaseTriggerInfo,
-    get_case_location,
-)
+from corehq.motech.value_source import CaseTriggerInfo, get_case_location
 from corehq.util.test_utils import TestFileMixin, _create_case
 
 DOMAIN = 'openmrs-repeater-tests'
@@ -642,7 +640,7 @@ def test_observation_mappings():
             }]
         }
     })
-    observation_mappings = repeater.observation_mappings
+    observation_mappings = get_observation_mappings(repeater)
     eq(observation_mappings, {
         '397b9631-2911-435a-bf8a-ae4468b9c1d4': [
             ObservationMapping(

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -168,6 +168,9 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
     def _get_values_for_concept(self, form_config):
         values_for_concept = {}
         for obs in form_config.openmrs_observations:
+            if not obs.concept:
+                # Skip ObservationMappings for importing all observations.
+                continue
             value_source = as_value_source(obs.value)
             if value_source.can_export and not is_blank(value_source.get_value(self.info)):
                 values_for_concept[obs.concept] = [value_source.get_value(self.info)]


### PR DESCRIPTION
Required by a project to record date of last hospital visit as a case property.

##### SUMMARY
This change allows two features:
* Import encounter datetime as a case property
* Import values from all OpenMRS observations or Bahmni diagnoses as extension cases or case properties, instead of only specific observations/diagnoses

:blowfish: 

##### FEATURE FLAG
OpenMRS integration

##### PRODUCT DESCRIPTION
* Create extensions cases for all diagnoses or observations from Bahmni/OpenMRS
* Set a case property to the datetime of an OpenMRS encounter.
