### PR TITLE
[ICDS Dashboard][fix]: Tabs remains consistent while drilling down from the P.S. to AWC report

### DIFF
--- a/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
+++ b/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
@@ -107,17 +107,23 @@ function MapOrSectorController($location, storageService, locationsService) {
                         storageService.setKey('search', $location.search());
                         if (location.location_type_name === 'awc') {
                             var awcReportPath = 'awc_reports';
-                            if ($location.path().indexOf('maternal_child') !== -1 || $location.path().indexOf('maternal_and_child') !== -1) {
-                                awcReportPath += '/maternal_child';
-                            } else if ($location.path().indexOf('demographics') !== -1) {
-                                awcReportPath += '/demographics';
-                            } else if ($location.path().indexOf('awc_infrastructure') !== -1) {
-                                awcReportPath += '/awc_infrastructure';
-                            } else if ($location.path().indexOf('icds_cas_reach') !== -1) {
-                                awcReportPath += '/pse';
-                            } else {
-                                awcReportPath += '/pse';
+                            // Routes for various tabs on PS page
+                            var tabRoutes = {
+                                'maternal_child': '/maternal_child',
+                                'maternal_and_child': '/maternal_child',
+                                'demographics': '/demographics',
+                                'awc_infrastructure': '/awc_infrastructure',
+                                'icds_cas_reach': '/pse'
                             }
+                            for(var tab in tabRoutes) {
+                                if($location.path().indexOf(tab) !== -1) {
+                                    awcReportPath += tabRoutes[tab];
+                                    break;    
+                                }
+                            }
+                            // PSE is the deafult tab
+                            if(awcReportPath === 'awc_reports')
+                                awcReportPath += '/pse';
                             $location.path(awcReportPath);
                         }
                     });

--- a/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
+++ b/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
@@ -121,10 +121,6 @@ function MapOrSectorController($location, storageService, locationsService) {
                                     break;    
                                 }
                             }
-                            // PSE is the deafult tab
-                            if (awcReportPath === 'awc_reports') {
-                                awcReportPath += '/pse';
-                            }
                             $location.path(awcReportPath);
                         }
                     });

--- a/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
+++ b/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
@@ -104,10 +104,21 @@ function MapOrSectorController($location, storageService, locationsService) {
                         var location = locations[0];
                         $location.search('location_name', location.name);
                         $location.search('location_id', location.location_id);
-
                         storageService.setKey('search', $location.search());
                         if (location.location_type_name === 'awc') {
-                            $location.path('awc_reports');
+                            var awcReportPath = 'awc_reports';
+                            if ($location.path().indexOf('maternal_child') !== -1 || $location.path().indexOf('maternal_and_child') !== -1) {
+                                awcReportPath += '/maternal_child';
+                            } else if ($location.path().indexOf('demographics') !== -1) {
+                                awcReportPath += '/demographics';
+                            } else if ($location.path().indexOf('awc_infrastructure') !== -1) {
+                                awcReportPath += '/awc_infrastructure';
+                            } else if ($location.path().indexOf('icds_cas_reach') !== -1) {
+                                awcReportPath += '/pse';
+                            } else {
+                                awcReportPath += '/pse';
+                            }
+                            $location.path(awcReportPath);
                         }
                     });
                 });

--- a/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
+++ b/custom/icds_reports/static/js/directives/map-or-sector-view/map-or-sector-view.directive.js
@@ -113,17 +113,18 @@ function MapOrSectorController($location, storageService, locationsService) {
                                 'maternal_and_child': '/maternal_child',
                                 'demographics': '/demographics',
                                 'awc_infrastructure': '/awc_infrastructure',
-                                'icds_cas_reach': '/pse'
-                            }
-                            for(var tab in tabRoutes) {
-                                if($location.path().indexOf(tab) !== -1) {
+                                'icds_cas_reach': '/pse',
+                            };
+                            for (var tab in tabRoutes) {
+                                if ($location.path().indexOf(tab) !== -1) {
                                     awcReportPath += tabRoutes[tab];
                                     break;    
                                 }
                             }
                             // PSE is the deafult tab
-                            if(awcReportPath === 'awc_reports')
+                            if (awcReportPath === 'awc_reports') {
                                 awcReportPath += '/pse';
+                            }
                             $location.path(awcReportPath);
                         }
                     });


### PR DESCRIPTION
- JIRA Issue:
https://dimagi-dev.atlassian.net/browse/ICDS-1097

##### SUMMARY
As of now if someone goes down from the Program Summary page to the AWC report, it always lands up on the PSE tab of the AWC report although if the person selected any other tab like demographics on Program Summary Page. After applying the fix the mapping would be like this.

- maternal_child of PS -> maternal_child of awc report
- cas_Reach of PS -> pse of awc_report
- demographics of PS -> demographics of awc_reports
- awc infra of PS -> awc infra of awc_report
