### PR TITLE
controlled rollout / testing of using standby DBs in livequery restore

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -36,14 +36,14 @@ from casexml.apps.phone.data_providers.case.utils import get_case_sync_updates
 from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.sql_db.routers import read_from_plproxy_standbys
-from corehq.toggles import LIVEQUERY_READ_FROM_STANDBYS
+from corehq.toggles import LIVEQUERY_READ_FROM_STANDBYS, NAMESPACE_USER
 from corehq.util.datadog.utils import case_load_counter
 
 
 def livequery_read_from_standbys(func):
     @wraps(func)
     def _inner(timing_context, restore_state, response, async_task=None):
-        if LIVEQUERY_READ_FROM_STANDBYS.enabled(restore_state.restore_user.user_id):
+        if LIVEQUERY_READ_FROM_STANDBYS.enabled(restore_state.restore_user.user_id, NAMESPACE_USER):
             with read_from_plproxy_standbys():
                 return func(timing_context, restore_state, response, async_task)
         else:

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/livequery.py
@@ -23,20 +23,36 @@ Example case graphs with outcomes:
 """
 import logging
 from collections import defaultdict
+from functools import wraps
 from itertools import chain, islice
 
 from casexml.apps.case.const import CASE_INDEX_EXTENSION as EXTENSION
+from casexml.apps.phone.const import ASYNC_RETRY_AFTER
 from casexml.apps.phone.data_providers.case.load_testing import (
     get_xml_for_response,
 )
-from casexml.apps.phone.const import ASYNC_RETRY_AFTER
 from casexml.apps.phone.data_providers.case.stock import get_stock_payload
 from casexml.apps.phone.data_providers.case.utils import get_case_sync_updates
 from casexml.apps.phone.tasks import ASYNC_RESTORE_SENT
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.sql_db.routers import read_from_plproxy_standbys
+from corehq.toggles import LIVEQUERY_READ_FROM_STANDBYS
 from corehq.util.datadog.utils import case_load_counter
 
 
+def livequery_read_from_standbys(func):
+    @wraps(func)
+    def _inner(timing_context, restore_state, response, async_task=None):
+        if LIVEQUERY_READ_FROM_STANDBYS.enabled(restore_state.restore_user.user_id):
+            with read_from_plproxy_standbys():
+                return func(timing_context, restore_state, response, async_task)
+        else:
+            return func(timing_context, restore_state, response, async_task)
+
+    return _inner
+
+
+@livequery_read_from_standbys
 def do_livequery(timing_context, restore_state, response, async_task=None):
     """Get case sync restore response
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1782,3 +1782,14 @@ USE_NEW_GET_COLUMN = StaticToggle(
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN],
 )
+
+LIVEQUERY_READ_FROM_STANDBYS = DynamicallyPredictablyRandomToggle(
+    'livequery_read_from_standbys',
+    'Allow livequery restore to read data from plproxy standbys if they are available',
+    TAG_INTERNAL,
+    [NAMESPACE_USER],
+    description="""
+    To allow a gradual rollout and testing of using the standby
+    databases to generate restore payloads.
+    """
+)


### PR DESCRIPTION
##### SUMMARY
Dynamic toggle controlled activation of standby DB reads for livequery restore.