### PR TITLE
Handle voided OpenMRS patients.

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -390,22 +390,19 @@ def find_or_create_patient(requests, domain, info, openmrs_config):
 
 
 def get_patient(requests, domain, info, openmrs_config):
-    patient = None
     for id_ in openmrs_config.case_config.match_on_ids:
-        identifier_config = openmrs_config.case_config.patient_identifiers[id_]  # type: JsonDict
+        identifier_config: JsonDict = openmrs_config.case_config.patient_identifiers[id_]
         identifier_case_property = identifier_config["case_property"]
         # identifier_case_property must be in info.extra_fields because OpenmrsRepeater put it there
         assert identifier_case_property in info.extra_fields, 'identifier case_property missing from extra_fields'
         patient = get_patient_by_id(requests, id_, info.extra_fields[identifier_case_property])
         if patient:
-            break
-    else:
-        # Definitive IDs did not match a patient in OpenMRS.
-        if openmrs_config.case_config.patient_finder:
-            # Search for patients based on other case properties
-            patient = find_or_create_patient(requests, domain, info, openmrs_config)
+            return patient
 
-    return patient
+    # Definitive IDs did not match a patient in OpenMRS.
+    if openmrs_config.case_config.patient_finder:
+        # Search for patients based on other case properties
+        return find_or_create_patient(requests, domain, info, openmrs_config)
 
 
 def delete_case_property(

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -397,6 +397,13 @@ def get_patient(requests, domain, info, openmrs_config):
         assert identifier_case_property in info.extra_fields, 'identifier case_property missing from extra_fields'
         patient = get_patient_by_id(requests, id_, info.extra_fields[identifier_case_property])
         if patient:
+            if patient["voided"]:
+                # The patient associated with the case has been merged with
+                # another patient in OpenMRS, or deleted. Delete the OpenMRS
+                # identifier on the case, and try again.
+                delete_case_property(domain, info.case_id, identifier_case_property)
+                info.extra_fields[identifier_case_property] = None
+                return get_patient(requests, domain, info, openmrs_config)
             return patient
 
     # Definitive IDs did not match a patient in OpenMRS.

--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 from collections import defaultdict
 
@@ -405,6 +406,24 @@ def get_patient(requests, domain, info, openmrs_config):
             patient = find_or_create_patient(requests, domain, info, openmrs_config)
 
     return patient
+
+
+def delete_case_property(
+    domain: str,
+    case_id: str,
+    case_property: str,
+):
+    """
+    Delete the OpenMRS identifier on the case.
+    """
+    members = dict(inspect.getmembers(CaseBlock.__init__.__code__))
+    case_block_args = members['co_varnames']
+    if case_property in case_block_args:
+        case_block_kwargs = {case_property: None}
+    else:
+        case_block_kwargs = {"update": {case_property: None}}
+    case_block = CaseBlock(case_id=case_id, create=False, **case_block_kwargs)
+    submit_case_blocks([case_block.as_text()], domain, xmlns=XMLNS_OPENMRS)
 
 
 def get_relevant_case_updates_from_form_json(domain, form_json, case_types, extra_fields,

--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -207,13 +207,13 @@ class OpenmrsRepeater(CaseRepeater):
         return json.loads(payload)
 
     def send_request(self, repeat_record, payload):
-        value_source_configs = chain(
+        value_source_configs: Iterable[JsonDict] = chain(
             self.openmrs_config.case_config.patient_identifiers.values(),
             self.openmrs_config.case_config.person_properties.values(),
             self.openmrs_config.case_config.person_preferred_name.values(),
             self.openmrs_config.case_config.person_preferred_address.values(),
             self.openmrs_config.case_config.person_attributes.values(),
-        )  # type: Iterable[JsonDict]
+        )
         case_trigger_infos = get_relevant_case_updates_from_form_json(
             self.domain, payload, case_types=self.white_listed_case_types,
             extra_fields=[conf["case_property"] for conf in value_source_configs if "case_property" in conf],

--- a/corehq/motech/openmrs/tests/data/voided_patient.json
+++ b/corehq/motech/openmrs/tests/data/voided_patient.json
@@ -1,0 +1,170 @@
+{
+  "auditInfo": {
+    "changedBy": {
+      "display": "utsav",
+      "links": [
+        {
+          "rel": "self",
+          "uri": "http://127.0.0.1/openmrs/ws/rest/v1/user/57e96d2a-424d-4256-8386-0276bced9658"
+        }
+      ],
+      "uuid": "57e96d2a-424d-4256-8386-0276bced9658"
+    },
+    "creator": {
+      "display": "utsav",
+      "links": [
+        {
+          "rel": "self",
+          "uri": "http://127.0.0.1/openmrs/ws/rest/v1/user/57e96d2a-424d-4256-8386-0276bced9658"
+        }
+      ],
+      "uuid": "57e96d2a-424d-4256-8386-0276bced9658"
+    },
+    "dateChanged": "2019-07-08T15:34:06.000+0545",
+    "dateCreated": "2019-07-04T14:23:03.000+0545",
+    "dateVoided": "2019-07-08T15:34:06.000+0545",
+    "voidReason": "Merged with patient #3554",
+    "voidedBy": {
+      "display": "utsav",
+      "links": [
+        {
+          "rel": "self",
+          "uri": "http://127.0.0.1/openmrs/ws/rest/v1/user/57e96d2a-424d-4256-8386-0276bced9658"
+        }
+      ],
+      "uuid": "57e96d2a-424d-4256-8386-0276bced9658"
+    }
+  },
+  "display": "",
+  "identifiers": [],
+  "links": [
+    {
+      "rel": "self",
+      "uri": "http://127.0.0.1/openmrs/ws/rest/v1/patient/94d60c79-59b5-4a2c-90a5-325d6e32b3db"
+    }
+  ],
+  "person": {
+    "addresses": [],
+    "age": 21,
+    "attributes": [],
+    "auditInfo": {
+      "changedBy": {
+        "display": "utsav",
+        "links": [
+          {
+            "rel": "self",
+            "uri": "http://127.0.0.1/openmrs/ws/rest/v1/user/57e96d2a-424d-4256-8386-0276bced9658"
+          }
+        ],
+        "uuid": "57e96d2a-424d-4256-8386-0276bced9658"
+      },
+      "creator": {
+        "display": "utsav",
+        "links": [
+          {
+            "rel": "self",
+            "uri": "http://127.0.0.1/openmrs/ws/rest/v1/user/57e96d2a-424d-4256-8386-0276bced9658"
+          }
+        ],
+        "uuid": "57e96d2a-424d-4256-8386-0276bced9658"
+      },
+      "dateChanged": "2019-07-08T15:34:06.000+0545",
+      "dateCreated": "2019-07-04T14:23:03.000+0545",
+      "dateVoided": "2019-07-08T15:34:06.000+0545",
+      "voidReason": "Merged with patient #3554",
+      "voidedBy": {
+        "display": "utsav",
+        "links": [
+          {
+            "rel": "self",
+            "uri": "http://127.0.0.1/openmrs/ws/rest/v1/user/57e96d2a-424d-4256-8386-0276bced9658"
+          }
+        ],
+        "uuid": "57e96d2a-424d-4256-8386-0276bced9658"
+      }
+    },
+    "birthdate": "1998-07-03T00:00:00.000+0545",
+    "birthdateEstimated": true,
+    "birthtime": null,
+    "causeOfDeath": null,
+    "dead": false,
+    "deathDate": null,
+    "deathdateEstimated": false,
+    "display": "hira saud",
+    "gender": "F",
+    "links": [
+      {
+        "rel": "self",
+        "uri": "http://127.0.0.1/openmrs/ws/rest/v1/person/94d60c79-59b5-4a2c-90a5-325d6e32b3db"
+      }
+    ],
+    "names": [],
+    "preferredAddress": {
+      "address1": "01",
+      "address10": null,
+      "address11": null,
+      "address12": null,
+      "address13": null,
+      "address14": null,
+      "address15": null,
+      "address2": null,
+      "address3": null,
+      "address4": null,
+      "address5": null,
+      "address6": null,
+      "address7": null,
+      "address8": null,
+      "address9": null,
+      "cityVillage": "Chaurpati Rural Municipality",
+      "country": "Nepal",
+      "countyDistrict": "Achham",
+      "display": "01",
+      "endDate": null,
+      "latitude": null,
+      "links": [
+        {
+          "rel": "self",
+          "uri": "http://127.0.0.1/openmrs/ws/rest/v1/person/94d60c79-59b5-4a2c-90a5-325d6e32b3db/address/fc17f806-bbde-4805-91a4-a1622dec8486"
+        },
+        {
+          "rel": "full",
+          "uri": "http://127.0.0.1/openmrs/ws/rest/v1/person/94d60c79-59b5-4a2c-90a5-325d6e32b3db/address/fc17f806-bbde-4805-91a4-a1622dec8486?v=full"
+        }
+      ],
+      "longitude": null,
+      "postalCode": null,
+      "preferred": false,
+      "resourceVersion": "2.0",
+      "startDate": null,
+      "stateProvince": "Province No. 7",
+      "uuid": "fc17f806-bbde-4805-91a4-a1622dec8486",
+      "voided": true
+    },
+    "preferredName": {
+      "display": "hira saud",
+      "familyName": "saud",
+      "familyName2": null,
+      "givenName": "hira",
+      "links": [
+        {
+          "rel": "self",
+          "uri": "http://127.0.0.1/openmrs/ws/rest/v1/person/94d60c79-59b5-4a2c-90a5-325d6e32b3db/name/db8e2c7d-a2ca-4818-b9d1-9c5025c7f348"
+        },
+        {
+          "rel": "full",
+          "uri": "http://127.0.0.1/openmrs/ws/rest/v1/person/94d60c79-59b5-4a2c-90a5-325d6e32b3db/name/db8e2c7d-a2ca-4818-b9d1-9c5025c7f348?v=full"
+        }
+      ],
+      "middleName": null,
+      "resourceVersion": "1.8",
+      "uuid": "db8e2c7d-a2ca-4818-b9d1-9c5025c7f348",
+      "voided": true
+    },
+    "resourceVersion": "1.11",
+    "uuid": "94d60c79-59b5-4a2c-90a5-325d6e32b3db",
+    "voided": true
+  },
+  "resourceVersion": "1.8",
+  "uuid": "94d60c79-59b5-4a2c-90a5-325d6e32b3db",
+  "voided": true
+}

--- a/corehq/motech/openmrs/tests/test_repeaters.py
+++ b/corehq/motech/openmrs/tests/test_repeaters.py
@@ -645,7 +645,6 @@ class DeleteCasePropertyTests(SimpleTestCase):
             delete_case_property(DOMAIN, "CASE_ID", case_property)
 
     def test_too_much_rope_no_error(self):
-        import ipdb; ipdb.sset_trace()
         case_property = "update"
         case_block_re = strip_xml(f"""
             <case case_id="CASE_ID" »

--- a/corehq/motech/openmrs/tests/utils.py
+++ b/corehq/motech/openmrs/tests/utils.py
@@ -1,0 +1,5 @@
+
+DATETIME_PATTERN = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z"
+
+def strip_xml(xmlstr: str) -> str:
+    return ''.join((l.strip() for l in xmlstr.split('\n'))).replace('»', '')

--- a/corehq/motech/openmrs/tests/utils.py
+++ b/corehq/motech/openmrs/tests/utils.py
@@ -1,5 +1,5 @@
-
 DATETIME_PATTERN = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z"
+
 
 def strip_xml(xmlstr: str) -> str:
     return ''.join((l.strip() for l in xmlstr.split('\n'))).replace('»', '')


### PR DESCRIPTION
##### SUMMARY
When OpenMRS merges or "deletes" patients, it marks them with `voided = true`. If there is a CommCare case associated with the patient by the patient's ID, the case will no longer be able to sync with the patient.

This change deletes the patient's ID from the case, and retries to find the patient.

:blowfish: Review by commit

##### FEATURE FLAG
OpenMRS integration

##### PRODUCT DESCRIPTION
Automatically dissociates CommCare cases from deleted or merged OpenMRS patients, and tries to find the new patient record, if any.
