### PR TITLE
fix caching issue with citus standby reads

### DIFF
--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -619,7 +619,7 @@ class TestSavingToUCRDatabase(BaseCCTests):
         self.cc_user.delete()
         self.cc_domain.delete()
 
-        connection_manager.dispose_engine('ucr')
+        connection_manager.dispose_engines('ucr')
         self.db_context.__exit__(None, None, None)
 
     @patch('corehq.apps.callcenter.indicator_sets.get_case_types_for_domain_es',

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -256,7 +256,7 @@ class TestExpandedColumn(TestCase):
     def tearDown(self):
         adapter = get_indicator_adapter(self.data_source_config)
         adapter.drop_table()
-        connection_manager.dispose_engine(UCR_ENGINE_ID)
+        connection_manager.dispose_engines(UCR_ENGINE_ID)
         super(TestExpandedColumn, self).tearDown()
 
     def test_getting_distinct_values(self):

--- a/corehq/ex-submodules/fluff/tests/test_alembic_diffs.py
+++ b/corehq/ex-submodules/fluff/tests/test_alembic_diffs.py
@@ -45,7 +45,7 @@ class TestAlembicDiffs(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.metadata.drop_all(cls.engine)
-        connection_manager.dispose_engine()
+        connection_manager.dispose_engines()
         super(TestAlembicDiffs, cls).tearDownClass()
 
     def setUp(self):

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -88,6 +88,7 @@ def create_engine(connection_url: str, connect_args: dict=None):
     # paramstyle='format' allows you to use column names that include the ')' character
     # otherwise queries will sometimes be misformated/error when formatting
     # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
+    connect_args = connect_args or {}
     return sqlalchemy.create_engine(connection_url, paramstyle='format', connect_args=connect_args)
 
 

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -84,7 +84,7 @@ def is_citus(connection_url: str, engine=None):
     return _IS_CITUS_URLS[connection_url]
 
 
-def create_engine(connection_url: str, connect_args: dict=None):
+def create_engine(connection_url: str, connect_args: dict = None):
     # paramstyle='format' allows you to use column names that include the ')' character
     # otherwise queries will sometimes be misformated/error when formatting
     # https://github.com/zzzeek/sqlalchemy/blob/ff20903/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L173
@@ -97,7 +97,7 @@ class SessionHelper(object):
     Shim class helper for a single connection/session factory
     """
 
-    def __init__(self, connection_url: str, connect_args: dict=None):
+    def __init__(self, connection_url: str, connect_args: dict = None):
         self.engine = create_engine(connection_url, connect_args)
         self._session_factory = sessionmaker(bind=self.engine)
         # Session is the actual constructor object

--- a/corehq/sql_db/connections.py
+++ b/corehq/sql_db/connections.py
@@ -74,13 +74,21 @@ def is_citus(connection_url: str, citus_list=[], non_citus_list=[], engine=None)
     if connection_url in non_citus_list:
         return False
 
-    engine = engine or create_engine(connection_url)
-    if is_citus_db(engine):
-        citus_list.append(engine.url)
-        return True
-    else:
-        non_citus_list.append(engine.url)
-        return False
+    dispose = False
+    if not engine:
+        engine = create_engine(connection_url)
+        dispose = True
+
+    try:
+        if is_citus_db(engine):
+            citus_list.append(engine.url)
+            return True
+        else:
+            non_citus_list.append(engine.url)
+            return False
+    finally:
+        if dispose:
+            engine.dispose()
 
 
 def create_engine(connection_url: str, connect_args: dict=None):

--- a/corehq/sql_db/tests/test_connections.py
+++ b/corehq/sql_db/tests/test_connections.py
@@ -1,14 +1,15 @@
 from collections import Counter
+from unittest import SkipTest
 
 from django.db import DEFAULT_DB_ALIAS
 from django.test import override_settings
-from django.test.testcases import SimpleTestCase
+from django.test.testcases import SimpleTestCase, TestCase
 
 import mock
 from decorator import contextmanager
 from testil import eq
 from corehq.sql_db.connections import ConnectionManager, read_from_citus_standbys, \
-    allow_read_from_citus_standbys
+    allow_read_from_citus_standbys, connection_manager, ICDS_UCR_CITUS_ENGINE_ID
 from corehq.sql_db.tests.test_partition_config import (
     PARTITION_CONFIG_WITH_STANDBYS,
 )
@@ -18,7 +19,7 @@ from corehq.sql_db.util import (
     get_replication_delay_for_shard_standbys,
     get_standbys_with_acceptible_delay,
 )
-
+from corehq.util.test_utils import trap_extra_setup
 
 
 def _get_db_config(db_name, master=None, delay=None):
@@ -142,16 +143,34 @@ class ConnectionManagerTests(SimpleTestCase):
         )
 
 
-class TestReadsFromCitusStandbys(SimpleTestCase):
+def test_read_from_citus_standbys_context_manager():
+    @read_from_citus_standbys()
+    def read():
+        eq(allow_read_from_citus_standbys(), True)
 
-    def test_basic(self):
-        @read_from_citus_standbys()
-        def read():
-            self.assertTrue(allow_read_from_citus_standbys())
+    eq(allow_read_from_citus_standbys(), False)
+    read()
+    eq(allow_read_from_citus_standbys(), False)
 
-        self.assertFalse(allow_read_from_citus_standbys())
-        read()
-        self.assertFalse(allow_read_from_citus_standbys())
+
+class TestReadFromCitusStandbys(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        helper = connection_manager.get_session_helper(ICDS_UCR_CITUS_ENGINE_ID)
+        if not helper.is_citus_db:
+            raise SkipTest('Test only applies when CitusDB is in use')
+
+    def test_citus_reads_from_standby(self):
+        def _assert_use_secondary_nodes(expected_value):
+            engine = connection_manager.get_engine(ICDS_UCR_CITUS_ENGINE_ID)
+            results = list(engine.execute('show citus.use_secondary_nodes'))
+            eq(results[0][0], expected_value)
+
+        _assert_use_secondary_nodes('never')
+        with read_from_citus_standbys():
+            _assert_use_secondary_nodes('always')
+        _assert_use_secondary_nodes('never')
 
 
 @override_settings(DATABASES=PARTITION_CONFIG_WITH_STANDBYS)

--- a/corehq/sql_db/tests/test_connections.py
+++ b/corehq/sql_db/tests/test_connections.py
@@ -6,10 +6,13 @@ from django.test import override_settings
 from django.test.testcases import SimpleTestCase, TestCase
 
 import mock
-from decorator import contextmanager
-from testil import eq
-from corehq.sql_db.connections import ConnectionManager, read_from_citus_standbys, \
-    allow_read_from_citus_standbys, connection_manager, ICDS_UCR_CITUS_ENGINE_ID
+from corehq.sql_db.connections import (
+    ICDS_UCR_CITUS_ENGINE_ID,
+    ConnectionManager,
+    allow_read_from_citus_standbys,
+    connection_manager,
+    read_from_citus_standbys,
+)
 from corehq.sql_db.tests.test_partition_config import (
     PARTITION_CONFIG_WITH_STANDBYS,
 )
@@ -19,7 +22,8 @@ from corehq.sql_db.util import (
     get_replication_delay_for_shard_standbys,
     get_standbys_with_acceptible_delay,
 )
-from corehq.util.test_utils import trap_extra_setup
+from decorator import contextmanager
+from testil import eq
 
 
 def _get_db_config(db_name, master=None, delay=None):


### PR DESCRIPTION
##### SUMMARY
The SessionHelper get's cached based only on the connection URL meaning that once a helper is created it will not get re-created even if different connection options are desired.

Solved this by adding the connection args to the cache key.

Includes tests.

FYI @dannyroberts 