### PR TITLE
Make auto-escalation workflow reuse delegate case on re-escalation

### DIFF
--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -173,7 +173,7 @@ def submit_case_block_from_template(domain, template, context, xmlns=None,
     )
 
 
-def _get_update_or_close_case_block(case_id, case_properties=None, close=False):
+def _get_update_or_close_case_block(case_id, case_properties=None, close=False, owner_id=None):
     kwargs = {
         'create': False,
         'user_id': SYSTEM_USER_ID,
@@ -181,12 +181,14 @@ def _get_update_or_close_case_block(case_id, case_properties=None, close=False):
     }
     if case_properties:
         kwargs['update'] = case_properties
+    if owner_id:
+        kwargs['owner_id'] = owner_id
 
     return CaseBlock(case_id, **kwargs)
 
 
 def update_case(domain, case_id, case_properties=None, close=False,
-                xmlns=None, device_id=None):
+                xmlns=None, device_id=None, owner_id=None):
     """
     Updates or closes a case (or both) by submitting a form.
     domain - the case's domain
@@ -197,7 +199,7 @@ def update_case(domain, case_id, case_properties=None, close=False,
     xmlns - pass in an xmlns to use it instead of the default
     device_id - see submit_case_blocks device_id docs
     """
-    caseblock = _get_update_or_close_case_block(case_id, case_properties, close)
+    caseblock = _get_update_or_close_case_block(case_id, case_properties, close, owner_id)
     return submit_case_blocks(
         ElementTree.tostring(caseblock.as_xml()).decode('utf-8'),
         domain,

--- a/custom/icds/rules/custom_actions.py
+++ b/custom/icds/rules/custom_actions.py
@@ -63,11 +63,11 @@ def _update_tech_issue_for_escalation(case, escalated_ticket_level):
     )
 
 
-def _get_escalated_tech_issue_delegate(tech_issue, escalated_location_id):
+def _get_escalated_tech_issue_delegate(tech_issue, location_id):
     for subcase in tech_issue.get_subcases(index_identifier='parent'):
         if (
             subcase.type == 'tech_issue_delegate' and
-            subcase.owner_id == escalated_location_id and
+            subcase.owner_id == location_id and
             not subcase.closed
         ):
             return subcase
@@ -85,6 +85,12 @@ def escalate_tech_issue(case, rule):
         'district': 'state',
     }
 
+    current_location_id_map = {
+        'supervisor': case.get_case_property('supervisor_location_id'),
+        'block': case.get_case_property('block_location_id'),
+        'district': case.get_case_property('district_location_id'),
+    }
+
     escalated_location_id_map = {
         'supervisor': case.get_case_property('block_location_id'),
         'block': case.get_case_property('district_location_id'),
@@ -93,6 +99,7 @@ def escalate_tech_issue(case, rule):
 
     current_ticket_level = case.get_case_property('ticket_level')
     escalated_ticket_level = escalated_ticket_level_map.get(current_ticket_level)
+    current_location_id = current_location_id_map.get(current_ticket_level)
     escalated_location_id = escalated_location_id_map.get(current_ticket_level)
 
     if not escalated_ticket_level or not escalated_location_id:
@@ -103,7 +110,7 @@ def escalate_tech_issue(case, rule):
 
     num_creates = 0
     num_related_updates = 0
-    tech_issue_delegate = _get_escalated_tech_issue_delegate(case, escalated_location_id)
+    tech_issue_delegate = _get_escalated_tech_issue_delegate(case, current_location_id)
 
     if tech_issue_delegate:
         delegate_update_result = _update_existing_tech_issue_delegate(tech_issue_delegate)

--- a/custom/icds/rules/custom_actions.py
+++ b/custom/icds/rules/custom_actions.py
@@ -30,7 +30,7 @@ def _create_tech_issue_delegate_for_escalation(tech_issue, owner_id):
     )
 
 
-def _update_existing_tech_issue_delegate(tech_issue_delegate):
+def _update_existing_tech_issue_delegate(tech_issue_delegate, owner_id):
     if tech_issue_delegate.get_case_property('change_in_level') == '1':
         change_in_level = '2'
     else:
@@ -43,6 +43,7 @@ def _update_existing_tech_issue_delegate(tech_issue_delegate):
         close=False,
         xmlns=AUTO_UPDATE_XMLNS,
         device_id=__name__ + "._update_existing_tech_issue_delegate",
+        owner_id=owner_id,
     )
 
 
@@ -113,7 +114,7 @@ def escalate_tech_issue(case, rule):
     tech_issue_delegate = _get_escalated_tech_issue_delegate(case, current_location_id)
 
     if tech_issue_delegate:
-        delegate_update_result = _update_existing_tech_issue_delegate(tech_issue_delegate)
+        delegate_update_result = _update_existing_tech_issue_delegate(tech_issue_delegate, escalated_location_id)
         rule.log_submission(delegate_update_result[0].form_id)
         num_related_updates = 1
     else:

--- a/custom/icds/tests/test_custom_rules.py
+++ b/custom/icds/tests/test_custom_rules.py
@@ -123,9 +123,7 @@ class AutoEscalationTest(BaseCaseRuleTest):
             [tech_issue_delegate] = subcases
             self.assertEqual(tech_issue_delegate.get_case_property('change_in_level'), '1')
 
-            update_case(self.domain, tech_issue.case_id, case_properties={'ticket_level': 'block'})
             tech_issue = CaseAccessors(self.domain).get_case(tech_issue.case_id)
-
             result = rule.run_actions_when_case_matches(tech_issue)
             self.assertEqual(result.num_updates, 1)
             self.assertEqual(result.num_creates, 0)

--- a/custom/icds/tests/test_custom_rules.py
+++ b/custom/icds/tests/test_custom_rules.py
@@ -122,6 +122,7 @@ class AutoEscalationTest(BaseCaseRuleTest):
             self.assertEqual(len(subcases), 1)
             [tech_issue_delegate] = subcases
             self.assertEqual(tech_issue_delegate.get_case_property('change_in_level'), '1')
+            self.assertEqual(tech_issue_delegate.owner_id, 'district_id')
 
             tech_issue = CaseAccessors(self.domain).get_case(tech_issue.case_id)
             result = rule.run_actions_when_case_matches(tech_issue)
@@ -134,6 +135,7 @@ class AutoEscalationTest(BaseCaseRuleTest):
             self.assertEqual(len(subcases), 1)
             [tech_issue_delegate] = subcases
             self.assertEqual(tech_issue_delegate.get_case_property('change_in_level'), '2')
+            self.assertEqual(tech_issue_delegate.owner_id, 'state_id')
 
 
 @use_sql_backend


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-939

##### PRODUCT DESCRIPTION
Updates ICDS's custom case rule action for escalating tech issues. Previously, an issue that was escalated and then re-escalated would spawn a new case. Instead, update the existing case.
