### PR TITLE
Throttle and measure case imports

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -85,14 +85,17 @@ class _Importer(object):
 
     def _report_import_timings(self, timer, results):
         active_duration = timer.duration - self._total_delayed_duration
-        success_rows = results['created_count'] + results['match_count']
-        error_rows = results['failed_count']
+        rows_created = results['created_count']
+        rows_updated = results['match_count']
+        rows_failed = results['failed_count']
         # Add 1 to smooth / prevent denominator from ever being zero
-        active_duration_per_case = active_duration / (success_rows + error_rows + 1)
+        active_duration_per_case = active_duration / (rows_created + rows_updated + rows_failed + 1)
         active_duration_per_case_bucket = bucket_value(
             active_duration_per_case, [1, 4, 9, 16, 25, 36, 49], unit='ms')
 
-        for rows, status in ((success_rows, 'success'), (error_rows, 'error')):
+        for rows, status in ((rows_created, 'created'),
+                             (rows_updated, 'updated'),
+                             (rows_failed, 'error')):
             datadog_counter('commcare.case_importer.cases', rows, tags=[
                 'active_duration_per_case:{}'.format(active_duration_per_case_bucket),
                 'status:{}'.format(status),

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -91,7 +91,7 @@ class _Importer(object):
         # Add 1 to smooth / prevent denominator from ever being zero
         active_duration_per_case = active_duration / (rows_created + rows_updated + rows_failed + 1)
         active_duration_per_case_bucket = bucket_value(
-            active_duration_per_case, [1, 4, 9, 16, 25, 36, 49], unit='ms')
+            active_duration_per_case * 1000, [1, 4, 9, 16, 25, 36, 49], unit='ms')
 
         for rows, status in ((rows_created, 'created'),
                              (rows_updated, 'updated'),

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -165,9 +165,10 @@ class _Importer(object):
             # For a fully throttled domain, this will up to double
             # the amount of time the case import takes
             datadog_counter(
-                'commcare.case_importer.import_delayed_duration',
-                self._last_submission_duration, tags=[
-                    'domain:{}'.format(self.domain)
+                'commcare.case_importer.import_delays', tags=[
+                    'domain:{}'.format(self.domain),
+                    'duration:{}'.format(bucket_value(
+                        self._last_submission_duration, [.5, 1, 2, 4, 8, 16, 32], unit='s'))
                 ]
             )
             self._total_delayed_duration += self._last_submission_duration

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -76,12 +76,16 @@ def rate_limit_submission(domain):
         allow_usage = True
         _delay_and_report_rate_limit_submission_test(domain, max_wait=15)
 
-    if allow_usage:
-        submission_rate_limiter.report_usage(domain)
-        global_submission_rate_limiter.report_usage()
-        _report_current_global_submission_thresholds()
-
     return not allow_usage
+
+
+@run_only_when(SHOULD_RATE_LIMIT_SUBMISSIONS)
+@silence_and_report_error("Exception raised reporting usage to the submission rate limiter",
+                          'commcare.xform_submissions.report_usage_errors')
+def report_submission_usage(domain):
+    submission_rate_limiter.report_usage(domain)
+    global_submission_rate_limiter.report_usage()
+    _report_current_global_submission_thresholds()
 
 
 def _report_rate_limit_submission(domain):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -19,6 +19,7 @@ from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestoreP
 import couchforms
 from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, UsesReferrals, InvalidCaseIndex, \
     CaseValueError
+from corehq.apps.receiverwrapper.rate_limiter import report_submission_usage
 from corehq.const import OPENROSA_VERSION_3
 from corehq.middleware import OPENROSA_VERSION_HEADER
 from corehq.toggles import ASYNC_RESTORE, SUMOLOGIC_LOGS, NAMESPACE_OTHER
@@ -215,6 +216,7 @@ class SubmissionPost(object):
 
     def run(self):
         self.track_load()
+        report_submission_usage(self.domain)
         failure_response = self._handle_basic_failure_modes()
         if failure_response:
             return FormProcessingResult(failure_response, None, [], [], 'known_failures')

--- a/corehq/project_limits/rate_limiter.py
+++ b/corehq/project_limits/rate_limiter.py
@@ -3,7 +3,6 @@ import time
 
 import attr
 
-from corehq.apps.accounting.models import Subscription
 from corehq.apps.users.models import CommCareUser
 from corehq.project_limits.models import DynamicRateDefinition
 from corehq.project_limits.rate_counter.presets import (
@@ -112,6 +111,7 @@ def _get_user_count(domain):
 
 
 def _get_users_included_in_subscription(domain):
+    from corehq.apps.accounting.models import Subscription
     subscription = Subscription.get_active_subscription_by_domain(domain)
     if subscription:
         plan_version = subscription.plan_version


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAASP-10196

Review commit by commit. Changes included (more details in the commits):
- Count local form submissions (i.e. case importer, etc.) toward submission rate limits (but don't apply the limits to these requests)
- Throttle case importer fairly and only when servers under high load
- Have case importer send metrics that let us estimate typical import times for N cases