### PR TITLE
make partition drop and creation sequential

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -562,6 +562,9 @@ def _child_health_monthly_data(state_ids, day):
     with get_cursor(ChildHealthMonthly) as cursor:
         cursor.execute(helper.drop_temporary_table())
         cursor.execute(helper.create_temporary_table())
+        for state in state_ids:
+            cursor.execute(helper.drop_partition(state))
+            cursor.execute(helper.create_partition(state))
 
     # https://github.com/celery/celery/issues/4274
     sub_aggregations = [

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -1527,6 +1527,9 @@ def _child_health_monthly_aggregation(day, state_ids):
     with get_cursor(ChildHealthMonthly) as cursor:
         cursor.execute(helper.drop_temporary_table())
         cursor.execute(helper.create_temporary_table())
+        for state in state_ids:
+            cursor.execute(helper.drop_partition(state))
+            cursor.execute(helper.create_partition(state))
 
     greenlets = []
     pool = Pool(20)

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -322,8 +322,6 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
             ("state_id", "child_health.state_id")
         )
         return """
-        DROP TABLE IF EXISTS "{child_tablename}";
-        CREATE TABLE "{child_tablename}" PARTITION OF "{tablename}" FOR VALUES IN (%(state_id)s);
         INSERT INTO "{child_tablename}" (
             {columns}
         ) (SELECT
@@ -391,6 +389,15 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
 
     def drop_temporary_table(self):
         return "DROP TABLE IF EXISTS \"{}\"".format(self.temporary_tablename)
+
+    def drop_partition(self, state_id):
+        return "DROP TABLE IF EXISTS \"{}_{}\"".format(self.temporary_tablename, state_id)
+
+    def create_partition(self, state_id):
+        return "CREATE TABLE \"{tmp_tablename}_{state_id}\" PARTITION OF \"{tmp_tablename}\" FOR VALUES IN ('{state_id}')".format(
+            tmp_tablename=self.temporary_tablename,
+            state_id=state_id
+        )
 
     def aggregation_query(self):
         return "INSERT INTO \"{tablename}\" (SELECT * FROM \"{tmp_tablename}\")".format(


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Parallel table drop and creation was causing distributed deadlocks, leading the query to fail.