### PR TITLE
Fix error in two_factor_setup_rate_limiter

### DIFF
--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -123,7 +123,7 @@ def rate_limit_two_factor_setup(method):
 
 two_factor_setup_rate_limiter = RateLimiter(
     feature_key='two_factor_setup_attempts',
-    get_rate_limits=lambda: get_dynamic_rate_definition(
+    get_rate_limits=lambda scope: get_dynamic_rate_definition(
         'two_factor_setup_attempts',
         default=RateDefinition(
             per_week=15,


### PR DESCRIPTION
##### SUMMARY
The first pass (https://github.com/dimagi/commcare-hq/pull/26217) failed with this (suppressed) error https://sentry.io/organizations/dimagi/issues/1386911301/?environment=production&project=136860&query=is%3Aunresolved

I should figure out a way to write tests for this, but want to wait until we're not in the middle of being exploited