### PR TITLE
revert partitioning of temp child table

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -562,9 +562,6 @@ def _child_health_monthly_data(state_ids, day):
     with get_cursor(ChildHealthMonthly) as cursor:
         cursor.execute(helper.drop_temporary_table())
         cursor.execute(helper.create_temporary_table())
-        for state in state_ids:
-            cursor.execute(helper.drop_partition(state))
-            cursor.execute(helper.create_partition(state))
 
     # https://github.com/celery/celery/issues/4274
     sub_aggregations = [
@@ -1530,9 +1527,6 @@ def _child_health_monthly_aggregation(day, state_ids):
     with get_cursor(ChildHealthMonthly) as cursor:
         cursor.execute(helper.drop_temporary_table())
         cursor.execute(helper.create_temporary_table())
-        for state in state_ids:
-            cursor.execute(helper.drop_partition(state))
-            cursor.execute(helper.create_partition(state))
 
     greenlets = []
     pool = Pool(20)

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -382,7 +382,7 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
 
     def create_temporary_table(self):
         return """
-        CREATE UNLOGGED TABLE \"{table}\" (LIKE child_health_monthly) PARTITION BY LIST (state_id);
+        CREATE UNLOGGED TABLE \"{table}\" (LIKE child_health_monthly, PRIMARY KEY (supervisor_id, case_id, month));
         SELECT create_distributed_table('{table}', 'supervisor_id');
         """.format(table=self.temporary_tablename)
 

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -322,7 +322,7 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
             ("state_id", "child_health.state_id")
         )
         return """
-        INSERT INTO "{child_tablename}" (
+        INSERT INTO "{tablename}" (
             {columns}
         ) (SELECT
             {calculations}
@@ -359,7 +359,6 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
             ORDER BY child_health.supervisor_id, child_health.awc_id
         )
         """.format(
-            child_tablename='{}_{}'.format(self.temporary_tablename, state_id),
             tablename=self.temporary_tablename,
             columns=", ".join([col[0] for col in columns]),
             calculations=", ".join([col[1] for col in columns]),
@@ -389,15 +388,6 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
 
     def drop_temporary_table(self):
         return "DROP TABLE IF EXISTS \"{}\"".format(self.temporary_tablename)
-
-    def drop_partition(self, state_id):
-        return "DROP TABLE IF EXISTS \"{}_{}\"".format(self.temporary_tablename, state_id)
-
-    def create_partition(self, state_id):
-        return "CREATE TABLE \"{tmp_tablename}_{state_id}\" PARTITION OF \"{tmp_tablename}\" FOR VALUES IN ('{state_id}')".format(
-            tmp_tablename=self.temporary_tablename,
-            state_id=state_id
-        )
 
     def aggregation_query(self):
         return "INSERT INTO \"{tablename}\" (SELECT * FROM \"{tmp_tablename}\")".format(


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Unknown issues in this implementation were causing errors in the aggregation. I believe it is related to table names being truncated, and will investigate that theory next week, but in the meantime want to get this in in case someone deploys