### PR TITLE
Make case importer timing buckets cover a more relevent range

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -189,7 +189,7 @@ class _TimedAndThrottledImporter(_Importer):
         # Add 1 to smooth / prevent denominator from ever being zero
         active_duration_per_case = active_duration / (rows_created + rows_updated + rows_failed + 1)
         active_duration_per_case_bucket = bucket_value(
-            active_duration_per_case * 1000, [1, 4, 9, 16, 25, 36, 49], unit='ms')
+            active_duration_per_case * 1000, [50, 70, 100, 150, 250, 350, 500], unit='ms')
 
         for rows, status in ((rows_created, 'created'),
                              (rows_updated, 'updated'),
@@ -213,7 +213,7 @@ class _TimedAndThrottledImporter(_Importer):
                 'commcare.case_importer.import_delays', tags=[
                     'domain:{}'.format(self.domain),
                     'duration:{}'.format(bucket_value(
-                        self._last_submission_duration, [.5, 1, 2, 4, 8, 16, 32], unit='s'))
+                        self._last_submission_duration, [5, 7, 10, 15, 25, 35, 50], unit='s'))
                 ]
             )
             self._total_delayed_duration += self._last_submission_duration


### PR DESCRIPTION
##### SUMMARY
My initial guess was off by an order of magnitude and a real example didn't fall in the range at all. The example I ran points to around 60ms per case, so I changed the range start a little below there and go high enough to capture a range of less good timings as well.
