### PR TITLE
Check whether value is for export

### DIFF
--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -138,31 +138,32 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
         """
         if form_config.openmrs_start_datetime:
             value_source = as_value_source(form_config.openmrs_start_datetime)
-            cc_start_datetime_str = value_source.get_commcare_value(self.info)
-            if cc_start_datetime_str is None:
-                raise ConfigurationError(
-                    'A form config for form XMLNS "{}" uses "openmrs_start_datetime" to get the start of '
-                    'the visit but no value was found in the form.'.format(form_config.xmlns)
-                )
-            try:
-                cc_start_datetime = string_to_utc_datetime(cc_start_datetime_str)
-            except ValueError:
-                raise ConfigurationError(
-                    'A form config for form XMLNS "{}" uses "openmrs_start_datetime" to get the start of '
-                    'the visit but an invalid value was found in the form.'.format(form_config.xmlns)
-                )
-            cc_stop_datetime = cc_start_datetime + timedelta(days=1) - timedelta(seconds=1)
-            # We need to serialize both values with the data type of
-            # openmrs_start_datetime because they could be either
-            # OpenMRS datetimes or OpenMRS dates, and their data
-            # types must match.
-            start_datetime = value_source.serialize(cc_start_datetime)
-            stop_datetime = value_source.serialize(cc_stop_datetime)
-        else:
-            cc_start_datetime = string_to_utc_datetime(self.form_json['form']['meta']['timeEnd'])
-            cc_stop_datetime = cc_start_datetime + timedelta(days=1) - timedelta(seconds=1)
-            start_datetime = to_omrs_datetime(cc_start_datetime)
-            stop_datetime = to_omrs_datetime(cc_stop_datetime)
+            if value_source.can_export:
+                cc_start_datetime_str = value_source.get_commcare_value(self.info)
+                if cc_start_datetime_str is None:
+                    raise ConfigurationError(
+                        'A form config for form XMLNS "{}" uses "openmrs_start_datetime" to get the start of '
+                        'the visit but no value was found in the form.'.format(form_config.xmlns)
+                    )
+                try:
+                    cc_start_datetime = string_to_utc_datetime(cc_start_datetime_str)
+                except ValueError:
+                    raise ConfigurationError(
+                        'A form config for form XMLNS "{}" uses "openmrs_start_datetime" to get the start of '
+                        'the visit but an invalid value was found in the form.'.format(form_config.xmlns)
+                    )
+                cc_stop_datetime = cc_start_datetime + timedelta(days=1) - timedelta(seconds=1)
+                # We need to serialize both values with the data type of
+                # openmrs_start_datetime because they could be either
+                # OpenMRS datetimes or OpenMRS dates, and their data
+                # types must match.
+                start_datetime = value_source.serialize(cc_start_datetime)
+                stop_datetime = value_source.serialize(cc_stop_datetime)
+                return start_datetime, stop_datetime
+        cc_start_datetime = string_to_utc_datetime(self.form_json['form']['meta']['timeEnd'])
+        cc_stop_datetime = cc_start_datetime + timedelta(days=1) - timedelta(seconds=1)
+        start_datetime = to_omrs_datetime(cc_start_datetime)
+        stop_datetime = to_omrs_datetime(cc_stop_datetime)
         return start_datetime, stop_datetime
 
     def _get_values_for_concept(self, form_config):


### PR DESCRIPTION
##### SUMMARY
This change fixes a bug where MOTECH failed to check whether a value source was configured for importing or exporting its value. The failure to check results in an error ("... no value was found in the form") on a valid configuration.

Unit test to follow in a subsequent PR I'm afraid.

Best to [review ignoring whitespace](https://github.com/dimagi/commcare-hq/pull/26226/files?w=1).

##### FEATURE FLAG
OpenMRS integration
