### PR TITLE
Ce/dist loc update

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -1,3 +1,5 @@
+import logging
+
 from dateutil.relativedelta import relativedelta
 
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
@@ -6,6 +8,8 @@ from corehq.apps.userreports.util import get_table_name
 from custom.icds_reports.utils.aggregation_helpers import get_child_health_temp_tablename, transform_day_to_month
 from custom.icds_reports.const import AGG_CCS_RECORD_CF_TABLE, AGG_THR_V2_TABLE
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
+
+logger = logging.getLogger(__name__)
 
 
 class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
@@ -35,12 +39,21 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
 
         cursor.execute(self.create_temporary_table())
         cursor.execute(agg_query, agg_params)
+        i = 0
         for query, params in update_queries:
+            logger.info(f"running update {i}")
             cursor.execute(query, params)
+            i += 1
+        i = 0
         for query in rollup_queries:
+            logger.info(f"running rollup {i}")
             cursor.execute(query)
+            i += 1
+        i = 0
         for query in index_queries:
+            logger.info(f"creating index {i}")
             cursor.execute(query)
+            i += 1
 
 
     def _tablename_func(self, agg_level):

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
@@ -192,14 +192,7 @@ class AggChildHealthAggregationDistributedHelper(AggregationPartitionedHelper):
 
     def update_queries(self):
         yield f"""
-            CREATE TABLE "local_tmp_agg_child_health" AS SELECT * FROM "{self.temporary_tablename}";
-            INSERT INTO "{self.staging_tablename}" SELECT * from "local_tmp_agg_child_health";
-            DROP TABLE "local_tmp_agg_child_health";
-        """, {
-        }
-
-        yield f"""
-        UPDATE "{self.staging_tablename}" agg SET
+            UPDATE "{self.temporary_tablename}" agg SET
               state_is_test = ut.state_is_test,
               district_is_test = ut.district_is_test,
               block_is_test = ut.block_is_test,
@@ -213,8 +206,8 @@ class AggChildHealthAggregationDistributedHelper(AggregationPartitionedHelper):
                     MAX(block_is_test) as block_is_test,
                     MAX(supervisor_is_test) as supervisor_is_test,
                     MAX(awc_is_test) as awc_is_test
-                FROM "awc_location_local"
-                GROUP BY awc_id
+                FROM "awc_location"
+                GROUP BY awc_id, supervisor_id
             ) ut
             WHERE ut.awc_id = agg.awc_id AND (
                 (
@@ -231,6 +224,13 @@ class AggChildHealthAggregationDistributedHelper(AggregationPartitionedHelper):
                   ut.awc_is_test != agg.awc_is_test
                 )
             );
+        """, {
+        }
+
+        yield f"""
+            CREATE TABLE "local_tmp_agg_child_health" AS SELECT * FROM "{self.temporary_tablename}";
+            INSERT INTO "{self.staging_tablename}" SELECT * from "local_tmp_agg_child_health";
+            DROP TABLE "local_tmp_agg_child_health";
         """, {
         }
 

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/base.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/base.py
@@ -180,16 +180,25 @@ class AggregationPartitionedHelper(BaseICDSAggregationDistributedHelper):
         """)
 
         logger.info(f"Inserting inital data into staging table for {self.helper_key}")
+        i = 0
         for staging_query, params in staging_queries:
+            logger.info(f"Running staging query {i}")
             cursor.execute(staging_query, params)
+            i += 1
 
         logger.info(f"Updating data into staging table for {self.helper_key}")
+        i = 0
         for query, params in update_queries:
+            logger.info(f"Running update query {i}")
             cursor.execute(query, params)
+            i += 1
 
         logger.info(f"Rolling up data into staging table for {self.helper_key}")
+        i = 0
         for query in rollup_queries:
+            logger.info(f"Running rollup query {i}")
             cursor.execute(query)
+            i += 1
 
         logger.info(f"Creating new table for {self.helper_key} {self.month}")
         cursor.execute(f"""
@@ -203,8 +212,11 @@ class AggregationPartitionedHelper(BaseICDSAggregationDistributedHelper):
         cursor.execute(f'DROP TABLE IF EXISTS "{self.previous_agg_table_name}"')
 
         logger.info(f"Creating indexes for {self.helper_key} {self.month}")
+        i = 0
         for index_query in self.indexes():
+            logger.info(f"creating index {i}")
             cursor.execute(index_query)
+            i += 1
 
         db_alias = router.db_for_write(self.model)
         with transaction.atomic(using=db_alias):

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
@@ -306,13 +306,7 @@ DROP TABLE IF EXISTS staging_agg_child_health
             
 {"start_date": "2019-01-01T00:00:00"}
 
-            CREATE TABLE "local_tmp_agg_child_health" AS SELECT * FROM "tmp_agg_child_health_5";
-            INSERT INTO "staging_agg_child_health" SELECT * from "local_tmp_agg_child_health";
-            DROP TABLE "local_tmp_agg_child_health";
-        
-{}
-
-        UPDATE "staging_agg_child_health" agg SET
+            UPDATE "tmp_agg_child_health_5" agg SET
               state_is_test = ut.state_is_test,
               district_is_test = ut.district_is_test,
               block_is_test = ut.block_is_test,
@@ -326,8 +320,8 @@ DROP TABLE IF EXISTS staging_agg_child_health
                     MAX(block_is_test) as block_is_test,
                     MAX(supervisor_is_test) as supervisor_is_test,
                     MAX(awc_is_test) as awc_is_test
-                FROM "awc_location_local"
-                GROUP BY awc_id
+                FROM "awc_location"
+                GROUP BY awc_id, supervisor_id
             ) ut
             WHERE ut.awc_id = agg.awc_id AND (
                 (
@@ -344,6 +338,12 @@ DROP TABLE IF EXISTS staging_agg_child_health
                   ut.awc_is_test != agg.awc_is_test
                 )
             );
+        
+{}
+
+            CREATE TABLE "local_tmp_agg_child_health" AS SELECT * FROM "tmp_agg_child_health_5";
+            INSERT INTO "staging_agg_child_health" SELECT * from "local_tmp_agg_child_health";
+            DROP TABLE "local_tmp_agg_child_health";
         
 {}
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Pushed the test location queries to the distributed temp table for agg child health, after the success of pushing the rest there.

Also added some of the logging we discussed for steps with multiple queries. It's a bit hacky, but I don't have a good way to get info about the queries, and figure it is at least consistent (ie comparable across runs) and a start.