### PR TITLE
[Community / Trial Revamp] q4 data forwarding quick fix

### DIFF
--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -5,7 +5,7 @@ from django.dispatch import receiver
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.signals import case_post_save
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.privileges import DATA_FORWARDING
+from corehq.privileges import ZAPIER_INTEGRATION
 from couchforms.signals import successful_form_received
 
 from corehq.apps.locations.models import SQLLocation
@@ -41,7 +41,11 @@ def create_repeat_records(repeater_cls, payload):
     if settings.REPEATERS_WHITELIST is not None and repeater_name not in settings.REPEATERS_WHITELIST:
         return
     domain = payload.domain
-    if domain and domain_has_privilege(domain, DATA_FORWARDING):
+
+    # todo reconcile ZAPIER_INTEGRATION and DATA_FORWARDING
+    #  they each do two separate things and are priced differently,
+    #  but use the same infrastructure
+    if domain and domain_has_privilege(domain, ZAPIER_INTEGRATION):
         repeaters = repeater_cls.by_domain(domain)
         for repeater in repeaters:
             repeater.register(payload)

--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -7,7 +7,7 @@ from celery.task import periodic_task, task
 from celery.utils.log import get_task_logger
 
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.privileges import DATA_FORWARDING
+from corehq.privileges import ZAPIER_INTEGRATION
 from dimagi.utils.couch import get_redis_lock
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
@@ -82,7 +82,10 @@ def process_repeat_record(repeat_record):
     # A RepeatRecord should ideally never get into this state, as the
     # domain_has_privilege check is also triggered in the create_repeat_records
     # in signals.py. But if it gets here, forcefully cancel the RepeatRecord.
-    if not domain_has_privilege(repeat_record.domain, DATA_FORWARDING):
+    # todo reconcile ZAPIER_INTEGRATION and DATA_FORWARDING
+    #  they each do two separate things and are priced differently,
+    #  but use the same infrastructure
+    if not domain_has_privilege(repeat_record.domain, ZAPIER_INTEGRATION):
         repeat_record.cancel()
         repeat_record.save()
 


### PR DESCRIPTION
note this merges into `bmb/saas-q4`

##### SUMMARY
While attempting to fix the tests in `bmb/saas-q4` I noticed that `DATA_FORWARDING` and `ZAPIER_INTEGRATION` use the same backend infrastructure (repeaters) but are on two different plans. `DATA_FORWARDING` is on Pro, and `ZAPIER_INTEGRATION` is on Standard. I will revisit this issue with Dev in Q1 so that we have consistency in what we actually want for this feature.

For now, `DATA_FORWARDING` is correctly limited on the UI-level (which Dev mentioned earlier was an ok starting point). It is just not possible to prevent the repeater from firing if it's already created.

Paused and Community plans will never be able to integrate Zapier or use data forwarding.