### PR TITLE
Add monitoring information for pillows

### DIFF
--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -16,8 +16,13 @@ from corehq.util.couchdb_management import couch_config
 
 
 class KafkaProcessor(PillowProcessor):
-    """
-    Processor that pushes changes to Kafka
+    """Generic processor for CouchDB changes to put those changes in a kafka topic
+
+    Reads from:
+      - CouchDB change feed
+
+    Writes to:
+      - Specified kafka topic
     """
 
     def __init__(self, data_source_type, data_source_name, default_topic):

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -71,6 +71,14 @@ def get_application_db_kafka_pillow(pillow_id, **kwargs):
 
 
 def get_change_feed_pillow_for_db(pillow_id, couch_db, default_topic=None):
+    """Generic pillow for inserting Couch documents into Kafka.
+
+    Reads from:
+      - CouchDB
+
+    Writes to:
+      - Kafka
+    """
     processor = KafkaProcessor(
         data_source_type=data_sources.SOURCE_COUCH,
         data_source_name=couch_db.dbname,

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -256,6 +256,16 @@ class ConfigurableReportTableManagerMixin(object):
 
 
 class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, BulkPillowProcessor):
+    """Generic processor for UCR.
+
+    Reads from:
+      - SQLLocation
+      - Form data source
+      - Case data source
+
+    Writes to:
+      - UCR database
+    """
 
     domain_timing_context = Counter()
 
@@ -520,7 +530,13 @@ def get_kafka_ucr_static_pillow(pillow_id='kafka-ucr-static', ucr_division=None,
 
 def get_location_pillow(pillow_id='location-ucr-pillow', include_ucrs=None,
                         num_processes=1, process_num=0, ucr_configs=None, **kwargs):
-    # Todo; is ucr_division needed?
+    """Processes updates to locations for UCR
+
+    Note this is only applicable if a domain on the environment has `LOCATIONS_IN_UCR` flag enabled.
+
+    Processors:
+      - :py:func:`corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor`
+    """
     change_feed = KafkaChangeFeed(
         [LOCATION_TOPIC], client_id=pillow_id, num_processes=num_processes, process_num=process_num
     )

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -41,6 +41,17 @@ MAX_RETRIES = 4  # exponential factor threshold for alerts
 
 
 class ElasticProcessor(PillowProcessor):
+    """Generic processor to transform documents and insert into ES.
+
+    Processes one document at a time.
+
+    Reads from:
+      - Usually Couch
+      - Sometimes SQL
+
+    Writes to:
+      - ES
+    """
 
     def __init__(self, elasticsearch, index_info, doc_prep_fn=None, doc_filter_fn=None):
         self.doc_filter_fn = doc_filter_fn or noop_filter
@@ -101,6 +112,18 @@ class ElasticProcessor(PillowProcessor):
 
 
 class BulkElasticProcessor(ElasticProcessor, BulkPillowProcessor):
+    """Generic processor to transform documents and insert into ES.
+
+    Processes one "chunk" of changes at a time (chunk size specified by pillow).
+
+    Reads from:
+      - Usually Couch
+      - Sometimes SQL
+
+    Writes to:
+      - ES
+    """
+
     def process_changes_chunk(self, changes_chunk):
         with self._datadog_timing('bulk_extract'):
             bad_changes, docs = bulk_fetch_changes_docs(changes_chunk)

--- a/corehq/ex-submodules/pillowtop/processors/form.py
+++ b/corehq/ex-submodules/pillowtop/processors/form.py
@@ -28,9 +28,21 @@ ONE_DAY = 24 * 60 * 60
 
 
 class FormSubmissionMetadataTrackerProcessor(PillowProcessor):
-    """
-    Processor used to process each form and mark the corresponding application as
-    having submissions (has_submissions = True).
+    """Updates the user document with reporting metadata when a user submits a form
+
+    Also marks the application as having submissions.
+
+    Note when USER_REPORTING_METADATA_BATCH_ENABLED is True that this is written to a postgres table.
+    Entries in that table are then batched and processed separately
+
+    Reads from:
+      - CouchDB (user and app)
+      - XForm data source
+
+    Writes to:
+      - CouchDB (app)
+      - CouchDB (user) (when batch processing disabled) (default)
+      - UserReportingMetadataStaging (SQL)  (when batch processing enabled)
     """
 
     def process_change(self, change):

--- a/corehq/messaging/pillow.py
+++ b/corehq/messaging/pillow.py
@@ -24,6 +24,16 @@ class CaseRules(object):
 
 
 class CaseMessagingSyncProcessor(BulkPillowProcessor):
+    """
+
+    Reads from:
+      - Case data source
+      - Update Rules
+
+    Writes to:
+      - PhoneNumber
+      - Runs rules for SMS (can be many different things)
+    """
     def __init__(self):
         self.rules_by_domain = {}
 

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -22,6 +22,11 @@ def transform_app_for_es(doc_dict):
 
 def get_app_to_elasticsearch_pillow(pillow_id='ApplicationToElasticsearchPillow', num_processes=1,
                                     process_num=0, **kwargs):
+    """App pillow
+
+    Processors:
+      - :py:class:`pillowtop.processors.elastic.BulkElasticProcessor`
+    """
     assert pillow_id == 'ApplicationToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, APP_INDEX_INFO, [topics.APP])
     app_processor = ElasticProcessor(

--- a/corehq/pillows/cacheinvalidate.py
+++ b/corehq/pillows/cacheinvalidate.py
@@ -36,6 +36,15 @@ class FakeCheckpoint(PillowCheckpoint):
 
 
 class CacheInvalidateProcessor(PillowProcessor):
+    """Invalidates cached CouchDB documents
+
+    Reads from:
+      - CouchDB
+
+    Writes to:
+      - Redis
+    """
+
     def __init__(self):
         self.gen_caches = set(GenerationCache.doc_type_generation_map().values())
 

--- a/corehq/pillows/cacheinvalidate.py
+++ b/corehq/pillows/cacheinvalidate.py
@@ -92,9 +92,10 @@ def get_user_groups_cache_invalidation_pillow(pillow_id, **kwargs):
 
 
 def _get_cache_invalidation_pillow(pillow_id, couch_db, couch_filter=None):
-    """
-    Pillow that listens to changes and invalidates the cache whether it's a
-    a single doc being cached, to a view.
+    """Pillow that listens to changes and invalidates the cache whether it's a single doc being cached or a view.
+
+    Processors:
+      - :py:class:`corehq.pillows.cache_invalidate_pillow.CacheInvalidateProcessor`
     """
     checkpoint = FakeCheckpoint(
         'cache_invalidate_pillow', couch_db

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -78,10 +78,13 @@ def get_case_pillow(
         include_ucrs=None, exclude_ucrs=None,
         num_processes=1, process_num=0, ucr_configs=None, skip_ucr=False,
         processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, topics=None, **kwargs):
-    """
-    Return a pillow that processes cases. The processors include, UCR and elastic processors
-        Args:
-            skip_ucr: Can be set to True to avoid passing UCR processor, useful for tests
+    """Return a pillow that processes cases. The processors include, UCR and elastic processors
+
+    Processors:
+      - :py:class:`corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor` (disabled when skip_ucr=True)
+      - :py:class:`pillowtop.processors.elastic.BulkElasticProcessor`
+      - :py:function:`corehq.pillows.case_search.get_case_search_processor`
+      - :py:class:`corehq.messaging.pillow.CaseMessagingSyncProcessor`
     """
     if topics:
         assert set(topics).issubset(CASE_TOPICS), "This is a pillow to process cases only"

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -112,6 +112,14 @@ class CaseSearchPillowProcessor(ElasticProcessor):
 
 
 def get_case_search_processor():
+    """Case Search
+
+    Reads from:
+      - Case data source
+
+    Writes to:
+      - Case Search ES index
+    """
     return CaseSearchPillowProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_SEARCH_INDEX_INFO,

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -31,6 +31,11 @@ def transform_domain_for_elasticsearch(doc_dict):
 
 def get_domain_kafka_to_elasticsearch_pillow(pillow_id='KafkaDomainPillow', num_processes=1,
                                              process_num=0, **kwargs):
+    """Domain pillow to replicate documents to ES
+
+    Processors:
+      - :py:class:`pillowtop.processors.elastic.ElasticProcessor`
+    """
     assert pillow_id == 'KafkaDomainPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, DOMAIN_INDEX_INFO, [topics.DOMAIN])
     domain_processor = ElasticProcessor(

--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -12,8 +12,14 @@ from pillowtop.reindexer.reindexer import ElasticPillowReindexer, ReindexerFacto
 
 
 def get_group_to_elasticsearch_processor():
-    """
-    This processor adds users from xform submissions that come in to the User Index if they don't exist in HQ
+    """Inserts group changes into ES
+
+    Reads from:
+      - Kafka topics: group
+      - Group data source (CouchDB)
+
+    Writes to:
+      - GroupES index
     """
     return ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/groups_to_user.py
+++ b/corehq/pillows/groups_to_user.py
@@ -54,6 +54,12 @@ def get_group_to_user_pillow(pillow_id='GroupToUserPillow', num_processes=1, pro
 
 
 def get_group_pillow(pillow_id='group-pillow', num_processes=1, process_num=0, **kwargs):
+    """Group pillow
+
+    Processors:
+      - :py:class:`corehq.pillows.groups_to_user.GroupsToUsersProcessor`
+      - :py:func:`corehq.pillows.group.get_group_to_elasticsearch_processor`
+    """
     assert pillow_id == 'group-pillow', 'Pillow ID is not allowed to change'
     to_user_es_processor = GroupsToUsersProcessor()
     to_group_es_processor = get_group_to_elasticsearch_processor()

--- a/corehq/pillows/groups_to_user.py
+++ b/corehq/pillows/groups_to_user.py
@@ -14,6 +14,15 @@ from pillowtop.reindexer.reindexer import PillowChangeProviderReindexer, Reindex
 
 
 class GroupsToUsersProcessor(PillowProcessor):
+    """When a group changes, this updates the user doc in UserES
+
+    Reads from:
+      - Kafka topics: group
+      - Group data source (CouchDB)
+
+    Writes to:
+      - UserES index
+    """
 
     def __init__(self):
         self._es = get_es_new()

--- a/corehq/pillows/ledger.py
+++ b/corehq/pillows/ledger.py
@@ -65,6 +65,16 @@ def _get_ledger_section_combinations(domain):
 
 
 class LedgerProcessor(PillowProcessor):
+    """Updates ledger section and entry combinations (exports), daily consumption and case location ids
+
+    Reads from:
+      - Kafka topics: ledger
+      - Ledger data source
+
+    Writes to:
+      - LedgerSectionEntry postgres table
+      - Ledger data source
+    """
 
     def process_change(self, change):
         ledger = change.get_document()

--- a/corehq/pillows/ledger.py
+++ b/corehq/pillows/ledger.py
@@ -93,9 +93,13 @@ class LedgerProcessor(PillowProcessor):
 
 def get_ledger_to_elasticsearch_pillow(pillow_id='LedgerToElasticsearchPillow', num_processes=1,
                                        process_num=0, **kwargs):
-    """
-    This pillow's id references Elasticsearch, but it no longer saves to ES.
+    """Ledger pillow
+
+    Note that this pillow's id references Elasticsearch, but it no longer saves to ES.
     It has been kept to keep the checkpoint consistent, and can be changed at any time.
+
+    Processors:
+      - :py:class:`corehq.pillows.ledger.LedgerProcessor`
     """
     assert pillow_id == 'LedgerToElasticsearchPillow', 'Pillow ID is not allowed to change'
     IndexInfo = namedtuple('IndexInfo', ['index'])

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -14,6 +14,11 @@ from pillowtop.reindexer.reindexer import ElasticPillowReindexer, ReindexerFacto
 
 def get_sql_sms_pillow(pillow_id='SqlSMSPillow', num_processes=1, process_num=0,
                        processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
+    """SMS Pillow
+
+    Processors:
+      - :py:class:`pillowtop.processors.elastic.BulkElasticProcessor`
+    """
     assert pillow_id == 'SqlSMSPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, SMS_INDEX_INFO, [topics.SMS])
     processor = BulkElasticProcessor(

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -37,8 +37,10 @@ SYNCLOG_SQL_USER_SYNC_GROUP_ID = "synclog_sql_user_sync"
 
 def get_user_sync_history_pillow(
         pillow_id='UpdateUserSyncHistoryPillow', num_processes=1, process_num=0, **kwargs):
-    """
-    This gets a pillow which iterates through all synclogs
+    """Synclog pillow
+
+    Processors:
+      - :py:func:`corehq.pillows.synclog.UserSyncHistoryProcessor`
     """
     change_feed = KafkaChangeFeed(
         topics=[topics.SYNCLOG_SQL], client_id=SYNCLOG_SQL_USER_SYNC_GROUP_ID,

--- a/corehq/pillows/synclog.py
+++ b/corehq/pillows/synclog.py
@@ -56,6 +56,19 @@ def get_user_sync_history_pillow(
 
 
 class UserSyncHistoryProcessor(PillowProcessor):
+    """Updates the user document with reporting metadata when a user syncs
+
+    Note when USER_REPORTING_METADATA_BATCH_ENABLED is True that this is written to a postgres table.
+    Entries in that table are then batched and processed separately.
+
+    Reads from:
+      - CouchDB (user)
+      - SynclogSQL table
+
+    Writes to:
+      - CouchDB (user) (when batch processing disabled) (default)
+      - UserReportingMetadataStaging (SQL)  (when batch processing enabled)
+    """
 
     def process_change(self, change):
         synclog = change.get_document()

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -139,6 +139,12 @@ def get_user_pillow_old(pillow_id='UserPillow', num_processes=1, process_num=0, 
 
 def get_user_pillow(pillow_id='user-pillow', num_processes=1, process_num=0,
         skip_ucr=False, processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
+    """Processes users and sends them to ES and UCRs.
+
+    Processors:
+      - :py:func:`pillowtop.processors.elastic.BulkElasticProcessor`
+      - :py:func:`corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor`
+    """
     # Pillow that sends users to ES and UCR
     assert pillow_id == 'user-pillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO, topics.USER_TOPICS)

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -166,6 +166,14 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
                      include_ucrs=None, exclude_ucrs=None,
                      num_processes=1, process_num=0, ucr_configs=None, skip_ucr=False,
                      processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, topics=None, **kwargs):
+    """Generic XForm change processor
+
+    Processors:
+      - :py:class:`corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor` (disabled when skip_ucr=True)
+      - :py:class:`pillowtop.processors.elastic.BulkElasticProcessor`
+      - :py:class:`corehq.pillows.user.UnknownUsersProcessor` (disabled when RUN_UNKNOWN_USER_PILLOW=False)
+      - :py:class:`pillowtop.form.FormSubmissionMetadataTrackerProcessor` (disabled when RUN_FORM_META_PILLOW=False)
+    """
     # avoid circular dependency
     from corehq.pillows.reportxform import transform_xform_for_report_forms_index, report_xform_filter
     from corehq.pillows.mappings.user_mapping import USER_INDEX

--- a/docs/pillows.rst
+++ b/docs/pillows.rst
@@ -137,3 +137,27 @@ It also won't be clear what documents the pillows has and has not processed. To
 fix this the safest thing will be to force the pillow to go through all relevant
 docs. Once this process is started you can move the checkpoint for that pillow
 to the most recent offset for its topic.
+
+
+Processors
+==========
+
+.. autoclass:: corehq.pillows.user.UnknownUsersProcessor
+
+.. autoclass:: corehq.apps.change_feed.pillow.KafkaProcessor
+
+.. autoclass:: corehq.pillows.group_to_user.GroupsToUsersProcessor
+
+.. autofunction:: corehq.pillows.group.get_group_to_elasticsearch_processor
+
+.. autoclass:: corehq.pillows.ledger.LedgerProcessor
+
+.. autoclass:: corehq.pillows.cacheinvalidate.CacheInvalidateProcessor
+
+.. autoclass:: corehq.pillows.synclog.UserSyncHistoryProcessor
+
+.. autoclass:: pillowtop.form.FormSubmissionMetadataTrackerProcessor
+
+.. autoclass:: pillowtop.processors.elastic.ElasticProcessor
+
+.. autoclass:: pillowtop.processors.elastic.BulkElasticProcessor

--- a/docs/pillows.rst
+++ b/docs/pillows.rst
@@ -139,6 +139,35 @@ docs. Once this process is started you can move the checkpoint for that pillow
 to the most recent offset for its topic.
 
 
+Pillows
+=======
+
+.. autofunction:: corehq.apps.change_feed.pillow.get_change_feed_pillow_for_db
+
+.. autofunction:: corehq.pillows.case.get_case_pillow
+
+.. autofunction:: corehq.pillows.xform.get_xform_pillow
+
+.. autofunction:: corehq.pillows.user.get_user_pillow
+
+.. autofunction:: corehq.apps.userreports.pillow.get_location_pillow
+
+.. autofunction:: corehq.pillows.groups_to_user.get_group_pillow
+
+.. autofunction:: corehq.pillows.ledger.get_ledger_to_elasticsearch_pillow
+
+.. autofunction:: corehq.pillows.domain.get_domain_kafka_to_elasticsearch_pillow
+
+.. autofunction:: corehq.pillows.sms.get_sql_sms_pillow
+
+.. autofunction:: corehq.pillows.cacheinvalidate._get_cache_invalidation_pillow
+
+.. autofunction:: corehq.pillows.synclog.get_user_sync_history_pillow
+
+.. autofunction:: corehq.pillows.application.get_app_to_elasticsearch_pillow
+
+
+
 Processors
 ==========
 
@@ -146,7 +175,7 @@ Processors
 
 .. autoclass:: corehq.apps.change_feed.pillow.KafkaProcessor
 
-.. autoclass:: corehq.pillows.group_to_user.GroupsToUsersProcessor
+.. autoclass:: corehq.pillows.groups_to_user.GroupsToUsersProcessor
 
 .. autofunction:: corehq.pillows.group.get_group_to_elasticsearch_processor
 
@@ -158,6 +187,12 @@ Processors
 
 .. autoclass:: pillowtop.form.FormSubmissionMetadataTrackerProcessor
 
+.. autoclass:: corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor
+
 .. autoclass:: pillowtop.processors.elastic.ElasticProcessor
 
 .. autoclass:: pillowtop.processors.elastic.BulkElasticProcessor
+
+.. autofunction:: corehq.pillows.case_search.get_case_search_processor
+
+.. autoclass:: corehq.messaging.pillow.CaseMessagingSyncProcessor

--- a/docs/pillows.rst
+++ b/docs/pillows.rst
@@ -110,8 +110,8 @@ A pillow is falling behind
 A pillow can fall behind for two reasons:
 
 1. The processor is too slow for the number of changes that are coming in. (i.e. `change_lag` for that pillow is very high)
-2. There has been an issue with the change feed that has caused the checkpoint
-   to be "rewound"
+2. There has been an issue with the change feed that has caused the checkpoint to be "rewound"
+3. Many exceptions happen during the day which requires pillows to process the same changes later.
 
 Optimizing a processor
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -152,6 +152,17 @@ to process changes that have already been processed. This usually happens when
 a couch node fails over to another. If this occurs, stop the pillow, wait for
 confirmation that the couch nodes are up, and fix the checkpoint using:
 `./manage.py fix_checkpoint_after_rewind <pillow_name>`
+
+Many pillow exceptions
+~~~~~~~~~~~~~~~~~~~~~~
+
+`commcare.change_feed.changes.exceptions` has tag `exception_type` that reports the name and path of the exception encountered.
+These exceptions could be from coding errors or from infrastructure issues.
+If they are from infrastructure issues (e.g. ES timeouts) some solutions could be:
+    - Scale ES cluster (more nodes, shards, etc)
+    - Reduce number of pillow processes that are writing to ES
+    - Reduce other usages of ES if possible (e.g. if some custom code relies on ES, could it use UCRs, https://github.com/dimagi/commcare-hq/pull/26241)
+
 
 Problem with checkpoint for pillow name: First available topic offset for topic is num1 but needed num2
 --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
##### SUMMARY
Added quite a bit of documentation around pillows and processors. Hopefully this will make it slightly more obvious what each processor and pillow is doing and how to balance the metrics

I've also been using some graphs in https://app.datadoghq.com/dashboard/4t8-uyq-pr4/pillow-load?from_ts=1576014474351&live=true&tile_size=m&to_ts=1576619274351 recently. The current Change Feeds looks like it has quite a bit of duplicate information but its unclear if those are useful for different people?

Not sure how to best consolidate these, or should they stay as separate dashboards?