### PR TITLE
remove code related to connection args

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -36,7 +36,6 @@ from corehq.apps.userreports.reports.data_source import (
 )
 from corehq.apps.userreports.reports.filters.factory import ReportFilterFactory
 from corehq.apps.userreports.tasks import compare_ucr_dbs
-from corehq.sql_db.connections import read_from_citus_standbys
 from corehq.toggles import COMPARE_UCR_REPORTS, NAMESPACE_OTHER, MOBILE_UCR_TOTAL_ROW_ITERATIVE, NAMESPACE_USER
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
@@ -240,8 +239,7 @@ class ReportFixturesProvider(BaseReportFixturesProvider):
 
         rows_elem = E.rows()
         row_index = 0
-        with read_from_citus_standbys():
-            data = data_source.get_data()
+        data = data_source.get_data()
         for row_index, row in enumerate(data):
             rows_elem.append(_row_to_row_elem(row, row_index))
             total_row_calculator.update_totals(row)
@@ -430,8 +428,7 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
 
         rows_elem = E.rows(last_sync=last_sync)
         row_index = 0
-        with read_from_citus_standbys():
-            data = data_source.get_data()
+        data = data_source.get_data()
         for row_index, row in enumerate(data):
             rows_elem.append(_row_to_row_elem(row, row_index))
             total_row_calculator.update_totals(row)

--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -619,7 +619,7 @@ class TestSavingToUCRDatabase(BaseCCTests):
         self.cc_user.delete()
         self.cc_domain.delete()
 
-        connection_manager.dispose_engines('ucr')
+        connection_manager.dispose_engine('ucr')
         self.db_context.__exit__(None, None, None)
 
     @patch('corehq.apps.callcenter.indicator_sets.get_case_types_for_domain_es',

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -256,7 +256,7 @@ class TestExpandedColumn(TestCase):
     def tearDown(self):
         adapter = get_indicator_adapter(self.data_source_config)
         adapter.drop_table()
-        connection_manager.dispose_engines(UCR_ENGINE_ID)
+        connection_manager.dispose_engine(UCR_ENGINE_ID)
         super(TestExpandedColumn, self).tearDown()
 
     def test_getting_distinct_values(self):

--- a/corehq/ex-submodules/fluff/tests/test_alembic_diffs.py
+++ b/corehq/ex-submodules/fluff/tests/test_alembic_diffs.py
@@ -5,7 +5,7 @@ from alembic.autogenerate import compare_metadata
 from django.test.testcases import TestCase, SimpleTestCase
 from nose.tools import assert_list_equal
 
-from corehq.sql_db.connections import connection_manager
+from corehq.sql_db.connections import connection_manager, DEFAULT_ENGINE_ID
 from fluff.signals import (
     get_migration_context, reformat_alembic_diffs,
     SimpleDiff, DiffTypes, get_tables_to_rebuild
@@ -45,7 +45,7 @@ class TestAlembicDiffs(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.metadata.drop_all(cls.engine)
-        connection_manager.dispose_engines()
+        connection_manager.dispose_engine(DEFAULT_ENGINE_ID)
         super(TestAlembicDiffs, cls).tearDownClass()
 
     def setUp(self):


### PR DESCRIPTION
This routing is now handled by sending queries to the Citus controller standby node: https://github.com/dimagi/commcare-cloud/pull/3480