### PR TITLE
support older apps that don't have enable_practice_users attribute

### DIFF
--- a/corehq/apps/app_manager/helpers/validators.py
+++ b/corehq/apps/app_manager/helpers/validators.py
@@ -143,7 +143,7 @@ class ApplicationBaseValidator(object):
     def _validate_practice_users(self):
         # validate practice_mobile_worker of app and all app profiles
         # raises PracticeUserException in case of misconfiguration
-        if not self.app.enable_practice_users:
+        if not hasattr(self.app, 'enable_practice_users') or not self.app.enable_practice_users:
             return []
         try:
             build_profile_id = None


### PR DESCRIPTION
quick fix for https://sentry.io/organizations/dimagi/issues/1395408999/?project=136860&query=domain%3Apact&statsPeriod=14d

##### SUMMARY
erin encountered an issue on an old pact app that wouldn't build because it didn't have the `enable_practice_users` attribute. this fixes that issue