### PR TITLE
better handling of missing docs / missing XML in pillows

### DIFF
--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -330,7 +330,7 @@ def bulk_fetch_changes_docs(changes, domain=None):
         doc_store = _changes[0].document_store
         doc_ids_to_query = [change.id for change in _changes if change.should_fetch_document()]
         new_docs = list(doc_store.iter_documents(doc_ids_to_query))
-        docs_queried_prior = [change.document for change in _changes if not change.should_fetch_document()]
+        docs_queried_prior = [change.document for change in _changes if change.document]
         docs.extend(new_docs + docs_queried_prior)
 
     # catch missing docs


### PR DESCRIPTION
This change will ignore DocumentNotFound and MissingFormXML errors in `doc_store.iter_documents()`

In bulk pillows this is handled here: https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/pillowtop/utils.py#L332

The other places where `iter_documents` get's called are:
* [userreports.views.evaluate_data_source](https://github.com/dimagi/commcare-hq/blob/fe9d0b646db0523889f0d3a4b9499ca97768245d/corehq/apps/userreports/views.py#L948)
  * Missing docs isn't likely much of an issue here
* [_build_async_indicators](https://github.com/dimagi/commcare-hq/blob/d64784b1fe7b9d7a1f0bf7eda38af60346277e73/corehq/apps/userreports/tasks.py#L421)
  * this will silently skip docs
* [_build_indicators](https://github.com/dimagi/commcare-hq/blob/d64784b1fe7b9d7a1f0bf7eda38af60346277e73/corehq/apps/userreports/tasks.py#L83)
  *   * this will silently skip docs

@emord for the async indicator calls how much of an issue do you think it is that it won't error?