### PR TITLE
ICDS Dashboard: Only use dynamic map sizing on mobile

### DIFF
--- a/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
+++ b/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
@@ -146,7 +146,7 @@ function IndieMapController($scope, $compile, $location, $filter, storageService
                 var div = vm.scope === "ind" ? 3 : 4;
                 var options = vm.rawTopojson.objects[vm.scope];
                 var projection, path;
-                if (useNewMaps) {
+                if (isMobile) {
                     // load a dummy projection so we can calculate the true size
                     // more here: https://data-map-d3.readthedocs.io/en/latest/steps/step_03.html#step-03
                     projection = d3.geo.equirectangular().scale(1);


### PR DESCRIPTION
Web dashboard does weird stuff that needs the current hard-coded sizes (for now)