### PR TITLE
Ce/split agg child

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -11,7 +11,6 @@ from custom.icds_reports.tasks import (
     _agg_awc_table,
     _agg_beneficiary_form,
     _agg_ccs_record_table,
-    _agg_child_health_table,
     _agg_ls_awc_mgt_form,
     _agg_ls_table,
     _agg_ls_vhnd_form,
@@ -30,9 +29,11 @@ from custom.icds_reports.tasks import (
     _child_health_monthly_aggregation,
     _daily_attendance_table,
     _update_months_table,
+    agg_child_health_temp,
     aggregate_awc_daily,
     create_all_mbt,
     setup_aggregation,
+    update_agg_child_health,
     update_child_health_monthly_table,
 )
 
@@ -67,11 +68,12 @@ NORMAL_TASKS = {
     'agg_ls_table': _agg_ls_table,
     'update_months_table': _update_months_table,
     'daily_attendance': _daily_attendance_table,
-    'agg_child_health': _agg_child_health_table,
+    'agg_child_health_temp': agg_child_health_temp,
     'ccs_record_monthly': _ccs_record_monthly_table,
     'agg_ccs_record': _agg_ccs_record_table,
     'agg_awc_table': _agg_awc_table,
     'aggregate_awc_daily': aggregate_awc_daily,
+    'update_agg_child_health': update_agg_child_health,
 }
 
 

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -141,7 +141,8 @@ from custom.icds_reports.utils import (
 )
 from custom.icds_reports.utils.aggregation_helpers.distributed import (
     ChildHealthMonthlyAggregationDistributedHelper,
-    AggAwcDistributedHelper
+    AggAwcDistributedHelper,
+    AggChildHealthAggregationDistributedHelper
 )
 from custom.icds_reports.utils.aggregation_helpers.distributed.mbt import (
     AwcMbtDistributedHelper,
@@ -614,6 +615,16 @@ def _daily_attendance_table(day):
 @track_time
 def _agg_child_health_table(day):
     AggChildHealth.aggregate(force_to_date(day))
+
+
+def agg_child_health_temp(day):
+    helper = AggChildHealthAggregationDistributedHelper(force_to_date(day))
+    helper.aggregate_temp()
+
+
+def update_agg_child_health(day):
+    helper = AggChildHealthAggregationDistributedHelper(force_to_date(day))
+    helper.update_table()
 
 
 @track_time

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -619,12 +619,14 @@ def _agg_child_health_table(day):
 
 def agg_child_health_temp(day):
     helper = AggChildHealthAggregationDistributedHelper(force_to_date(day))
-    helper.aggregate_temp()
+    with get_cursor(AggChildHealth) as cursor:
+        helper.aggregate_temp(cursor)
 
 
 def update_agg_child_health(day):
     helper = AggChildHealthAggregationDistributedHelper(force_to_date(day))
-    helper.update_table()
+    with get_cursor(AggChildHealth) as cursor:
+        helper.update_table(cursor)
 
 
 @track_time

--- a/custom/icds_reports/utils/aggregation_helpers/__init__.py
+++ b/custom/icds_reports/utils/aggregation_helpers/__init__.py
@@ -17,6 +17,10 @@ def get_child_health_temp_tablename(month):
     return f"tmp_{base_tablename}_{month_string}"
 
 
+def get_agg_child_temp_tablename():
+    return 'tmp_agg_child_health_5'
+
+
 class AggregationHelper(object):
     """Base class used to tag aggregation helpers
 

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -512,7 +512,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         ) ut
         WHERE ut.month = agg_awc.month AND ut.awc_id = agg_awc.awc_id and ut.supervisor_id=agg_awc.supervisor_id;
         """.format(
-            tablename=self.tablename,
+            tablename=self.temporary_tablename,
             agg_child_temp_tablename=self.agg_child_temp_tablename,
         ), {
             'start_date': self.month_start

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.util import get_table_name
 
-from custom.icds_reports.utils.aggregation_helpers import get_child_health_temp_tablename, transform_day_to_month
+from custom.icds_reports.utils.aggregation_helpers import get_child_health_temp_tablename, transform_day_to_month, get_agg_child_temp_tablename
 from custom.icds_reports.const import AGG_CCS_RECORD_CF_TABLE, AGG_THR_V2_TABLE, AGG_ADOLESCENT_GIRLS_REGISTRATION_TABLE
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
 
@@ -30,6 +30,10 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
     @property
     def child_temp_tablename(self):
         return get_child_health_temp_tablename(self.month_start)
+
+    @property
+    def agg_child_temp_tablename(self):
+        return get_agg_child_temp_tablename()
 
     def aggregate(self, cursor):
         agg_query, agg_params = self.aggregation_query()
@@ -480,17 +484,6 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         }
 
         yield """
-        DROP TABLE IF EXISTS "tmp_agg_awc_5";
-        CREATE UNLOGGED TABLE "tmp_agg_awc_5" AS SELECT * FROM "{temporary_tablename}";
-        INSERT INTO "{tablename}" (SELECT * FROM "tmp_agg_awc_5");
-        DROP TABLE "tmp_agg_awc_5";
-        """.format(
-            tablename=self.tablename,
-            temporary_tablename=self.temporary_tablename,
-        ), {
-        }
-
-        yield """
         UPDATE "{tablename}" agg_awc SET
             cases_child_health = ut.cases_child_health,
             cases_child_health_all = ut.cases_child_health_all,
@@ -514,14 +507,26 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
                 sum(CASE WHEN age_tranche in ('0','6','12','24') THEN nutrition_status_weighed ELSE 0 END) AS wer_weighed_0_2,
                 sum(thr_eligible) as thr_eligible,
                 sum(rations_21_plus_distributed) as rations_21_plus_distributed
-            FROM agg_child_health
+            FROM {agg_child_temp_tablename}
             WHERE month = %(start_date)s AND aggregation_level = 5 GROUP BY awc_id, month, supervisor_id
         ) ut
         WHERE ut.month = agg_awc.month AND ut.awc_id = agg_awc.awc_id and ut.supervisor_id=agg_awc.supervisor_id;
         """.format(
             tablename=self.tablename,
+            agg_child_temp_tablename=self.agg_child_temp_tablename,
         ), {
             'start_date': self.month_start
+        }
+
+        yield """
+        DROP TABLE IF EXISTS "tmp_agg_awc_5";
+        CREATE UNLOGGED TABLE "tmp_agg_awc_5" AS SELECT * FROM "{temporary_tablename}";
+        INSERT INTO "{tablename}" (SELECT * FROM "tmp_agg_awc_5");
+        DROP TABLE "tmp_agg_awc_5";
+        """.format(
+            tablename=self.tablename,
+            temporary_tablename=self.temporary_tablename,
+        ), {
         }
 
         yield """

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_child_health.py
@@ -1,4 +1,4 @@
-from custom.icds_reports.utils.aggregation_helpers import get_child_health_temp_tablename
+from custom.icds_reports.utils.aggregation_helpers import get_child_health_temp_tablename, get_agg_child_temp_tablename
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import (
     AggregationPartitionedHelper,
 )
@@ -28,7 +28,7 @@ class AggChildHealthAggregationDistributedHelper(AggregationPartitionedHelper):
 
     @property
     def temporary_tablename(self):
-        return 'tmp_agg_child_health_5'
+        return get_agg_child_temp_tablename()
 
     def staging_queries(self):
         columns = (

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
@@ -332,13 +332,6 @@
         
 {}
 
-        DROP TABLE IF EXISTS "tmp_agg_awc_5";
-        CREATE UNLOGGED TABLE "tmp_agg_awc_5" AS SELECT * FROM "tmp_agg_awc_2019-01-01_5";
-        INSERT INTO "agg_awc_2019-01-01_5" (SELECT * FROM "tmp_agg_awc_5");
-        DROP TABLE "tmp_agg_awc_5";
-        
-{}
-
         UPDATE "agg_awc_2019-01-01_5" agg_awc SET
             cases_child_health = ut.cases_child_health,
             cases_child_health_all = ut.cases_child_health_all,
@@ -362,12 +355,19 @@
                 sum(CASE WHEN age_tranche in ('0','6','12','24') THEN nutrition_status_weighed ELSE 0 END) AS wer_weighed_0_2,
                 sum(thr_eligible) as thr_eligible,
                 sum(rations_21_plus_distributed) as rations_21_plus_distributed
-            FROM agg_child_health
+            FROM tmp_agg_child_health_5
             WHERE month = %(start_date)s AND aggregation_level = 5 GROUP BY awc_id, month, supervisor_id
         ) ut
         WHERE ut.month = agg_awc.month AND ut.awc_id = agg_awc.awc_id and ut.supervisor_id=agg_awc.supervisor_id;
         
 {"start_date": "2019-01-01T00:00:00"}
+
+        DROP TABLE IF EXISTS "tmp_agg_awc_5";
+        CREATE UNLOGGED TABLE "tmp_agg_awc_5" AS SELECT * FROM "tmp_agg_awc_2019-01-01_5";
+        INSERT INTO "agg_awc_2019-01-01_5" (SELECT * FROM "tmp_agg_awc_5");
+        DROP TABLE "tmp_agg_awc_5";
+        
+{}
 
         DROP TABLE IF EXISTS "tmp_home_visit";
         CREATE UNLOGGED TABLE "tmp_home_visit" AS SELECT

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
@@ -332,7 +332,7 @@
         
 {}
 
-        UPDATE "agg_awc_2019-01-01_5" agg_awc SET
+        UPDATE "tmp_agg_awc_2019-01-01_5" agg_awc SET
             cases_child_health = ut.cases_child_health,
             cases_child_health_all = ut.cases_child_health_all,
             wer_weighed = ut.wer_weighed,

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-child-health.distributed.txt
@@ -7,16 +7,6 @@
         SELECT create_distributed_table('tmp_agg_child_health_5', 'supervisor_id');
         
 {}
-DROP TABLE IF EXISTS staging_agg_child_health
-{}
-
-        CREATE TABLE staging_agg_child_health (
-            LIKE agg_child_health
-            INCLUDING INDEXES INCLUDING CONSTRAINTS INCLUDING DEFAULTS,
-            CHECK (month = DATE '2019-01-01')
-        )
-        
-{}
 
             INSERT INTO "tmp_agg_child_health_5" (state_id, district_id, block_id, supervisor_id, awc_id, month, gender, age_tranche, caste, disabled, minority, resident, valid_in_month, nutrition_status_weighed, nutrition_status_unweighed, nutrition_status_normal, nutrition_status_moderately_underweight, nutrition_status_severely_underweight, wer_eligible, thr_eligible, rations_21_plus_distributed, pse_eligible, pse_attended_16_days, pse_attended_21_days, lunch_count_21_days, born_in_month, low_birth_weight_in_month, bf_at_birth, ebf_eligible, ebf_in_month, cf_eligible, cf_in_month, cf_diet_diversity, cf_diet_quantity, cf_demo, cf_handwashing, counsel_increase_food_bf, counsel_manage_breast_problems, counsel_ebf, counsel_adequate_bf, counsel_pediatric_ifa, counsel_play_cf_video, fully_immunized_eligible, fully_immunized_on_time, fully_immunized_late, has_aadhar_id, aggregation_level, pnc_eligible, height_eligible, wasting_moderate, wasting_severe, stunting_moderate, stunting_severe, cf_initiation_in_month, cf_initiation_eligible, height_measured_in_month, wasting_normal, stunting_normal, valid_all_registered_in_month, ebf_no_info_recorded, weighed_and_height_measured_in_month, weighed_and_born_in_month, zscore_grading_hfa_normal, zscore_grading_hfa_moderate, zscore_grading_hfa_severe, wasting_normal_v2, wasting_moderate_v2, wasting_severe_v2, zscore_grading_hfa_recorded_in_month, zscore_grading_wfh_recorded_in_month, days_ration_given_child)
             SELECT
@@ -305,6 +295,16 @@ DROP TABLE IF EXISTS staging_agg_child_health
                          coalesce_disabled, coalesce_minority, coalesce_resident;
             
 {"start_date": "2019-01-01T00:00:00"}
+DROP TABLE IF EXISTS staging_agg_child_health
+{}
+
+        CREATE TABLE staging_agg_child_health (
+            LIKE agg_child_health
+            INCLUDING INDEXES INCLUDING CONSTRAINTS INCLUDING DEFAULTS,
+            CHECK (month = DATE '2019-01-01')
+        )
+        
+{}
 
             UPDATE "tmp_agg_child_health_5" agg SET
               state_is_test = ut.state_is_test,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This splits the agg child health aggregation into two separate components, so they can be called separately. It does not change those queries at all.

It also makes agg_awc dependent on only the first part of the agg_child_health, the temporary distributed table.

A following airflow PR, will change the DAG accordingly.