### PR TITLE
Memoize Domain.get_by_name for ICDS env

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -122,7 +122,7 @@ def cached_property(method):
 
 
 def icds_conditional_session_key():
-    if settings.SERVER_ENVIRONMENT == 'icds':
+    if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
         # memoize for process lifecycle
         return None
     else:

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -604,7 +604,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     @classmethod
     @quickcache(['name'], skip_arg='strict', timeout=30*60,
-        memoize_timeout=10, session_function=icds_conditional_session_key)
+        memoize_timeout=10, session_function=icds_conditional_session_key())
     def get_by_name(cls, name, strict=False):
         if not name:
             # get_by_name should never be called with name as None (or '', etc)

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -604,7 +604,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     @classmethod
     @quickcache(['name'], skip_arg='strict', timeout=30*60,
-        memoize_timeout=10, session_function=icds_conditional_session_key())
+        session_function=icds_conditional_session_key())
     def get_by_name(cls, name, strict=False):
         if not name:
             # get_by_name should never be called with name as None (or '', etc)

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -60,7 +60,7 @@ from corehq.blobs.mixin import BlobMixin
 from corehq.dbaccessors.couchapps.all_docs import (
     get_all_doc_ids_for_domain_grouped_by_db,
 )
-from corehq.util.quickcache import quickcache
+from corehq.util.quickcache import quickcache, get_session_key
 from corehq.util.soft_assert import soft_assert
 from langcodes import langs as all_langs
 
@@ -119,6 +119,15 @@ def cached_property(method):
             self.save()
             return self.cached_properties[method.__name__]
     return find_cached
+
+
+def icds_conditional_session_key():
+    if settings.SERVER_ENVIRONMENT == 'icds':
+        # memoize for process lifecycle
+        return None
+    else:
+        # memoize for request lifecycle
+        return get_session_key
 
 
 class UpdatableSchema(object):
@@ -594,7 +603,8 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         return ', '.join(lang_lookup[lang] or lang for lang in self.languages())
 
     @classmethod
-    @quickcache(['name'], skip_arg='strict', timeout=30*60)
+    @quickcache(['name'], skip_arg='strict', timeout=30*60,
+        memoize_timeout=10, session_function=icds_conditional_session_key)
     def get_by_name(cls, name, strict=False):
         if not name:
             # get_by_name should never be called with name as None (or '', etc)


### PR DESCRIPTION
This is a high usage cache key on ICDS env and the value is not updated frequently at all. Memoizing for 10 seconds for ICDS env should be okay without worrying about invalidation. For non-ICDS envs this is memoized for request lifecycle, so invalidation shouldn't be a concern for SaaS envs.

@mkangia  @snopoke 

https://dimagi-dev.atlassian.net/browse/IIO-658