### PR TITLE
Send error-type info to pillow error DD metrics

### DIFF
--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -17,5 +17,6 @@ def record_pillow_error_queue_size():
         datadog_gauge('commcare.pillowtop.error_queue', row['num_errors'], tags=[
             'pillow_name:%s' % row['pillow'],
             'host:celery',
-            'group:celery'
+            'group:celery',
+            'error_type:%s' % row['error_type']
         ])


### PR DESCRIPTION
This is useful info. We used to have this info in old PillowError admin report. 

@mkangia 