### PR TITLE
[ICDS dashboard] Alternative adolescent girls query

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
@@ -100,8 +100,8 @@
            cases_person_adolescent_girls_15_18 = ut.cases_person_adolescent_girls_15_18,
            cases_person_adolescent_girls_15_18_all = ut.cases_person_adolescent_girls_15_18_all,
            cases_person_referred = ut.cases_person_referred,
-           cases_person_adolescent_girls_11_14_out_of_school = ut.girls_out_of_schoool,
-           cases_person_adolescent_girls_11_14_all_v2 = ut.cases_person_adolescent_girls_11_14_all_v2
+           cases_person_adolescent_girls_11_14_all_v2 = ut.cases_person_adolescent_girls_11_14_all_v2,
+           cases_person_adolescent_girls_11_14_out_of_school=0
         FROM (
         SELECT
             ucr.awc_id,
@@ -116,8 +116,6 @@
                 CASE WHEN %(month_end_11yr)s > dob AND %(month_start_15yr)s <= dob AND sex = 'F'
                 THEN 1 ELSE 0 END
             ) as cases_person_adolescent_girls_11_14_all,
-            SUM(CASE WHEN ( (out_of_school or re_out_of_school) AND
-                                 (not admitted_in_school )AND  migration_status IS DISTINCT FROM 1) THEN 1 ELSE 0 END ) as girls_out_of_schoool,
             sum(
                 CASE WHEN %(month_end_11yr)s > dob AND %(month_start_14yr)s <= dob AND sex = 'F'
                     AND migration_status IS DISTINCT FROM 1
@@ -135,11 +133,7 @@
                 CASE WHEN last_referral_date BETWEEN %(start_date)s AND %(end_date)s
                 THEN 1 ELSE 0 END
             ) as cases_person_referred
-        FROM "ucr_icds-cas_static-person_cases_v3_2ae0879a" ucr LEFT JOIN
-             "icds_dashboard_adolescent_girls_registration" adolescent_girls_table ON
-                ucr.doc_id = adolescent_girls_table.person_case_id AND
-                ucr.supervisor_id = adolescent_girls_table.supervisor_id AND
-                adolescent_girls_table.month= %(start_date)s
+        FROM "ucr_icds-cas_static-person_cases_v3_2ae0879a" ucr
         WHERE (opened_on <= %(end_date)s AND
               (closed_on IS NULL OR closed_on >= %(start_date)s ))
 
@@ -147,6 +141,29 @@
         WHERE ut.awc_id = agg_awc.awc_id and ut.supervisor_id=agg_awc.supervisor_id;
         
 {"end_date": "2019-01-31T23:59:59", "month_end_11yr": "2008-01-31T23:59:59", "month_end_15yr": "2004-01-31T23:59:59", "month_start_14yr": "2005-01-01T00:00:00", "month_start_15yr": "2004-01-01T00:00:00", "month_start_18yr": "2001-01-01T00:00:00", "start_date": "2019-01-01T00:00:00"}
+
+        UPDATE "tmp_agg_awc_2019-01-01_5" agg_awc SET
+        cases_person_adolescent_girls_11_14_out_of_school = ut.girls_out_of_schoool
+        FROM (
+        select
+            ucr.awc_id,
+            ucr.supervisor_id,
+            SUM(CASE WHEN ( (out_of_school or re_out_of_school) AND
+                        (not admitted_in_school )) THEN 1 ELSE 0 END ) as girls_out_of_schoool
+            from "ucr_icds-cas_static-person_cases_v3_2ae0879a" ucr INNER JOIN
+                 "icds_dashboard_adolescent_girls_registration" adolescent_girls_table ON (
+                    ucr.doc_id = adolescent_girls_table.person_case_id AND
+                    ucr.supervisor_id = adolescent_girls_table.supervisor_id AND
+                    adolescent_girls_table.month=%(start_date)s
+                    )
+            WHERE (opened_on <= %(end_date)s AND
+              (closed_on IS NULL OR closed_on >= %(start_date)s )) AND
+              migration_status IS DISTINCT FROM 1
+              GROUP BY ucr.awc_id, ucr.supervisor_id
+        )ut
+        where agg_awc.awc_id = ut.awc_id and ut.supervisor_id=agg_awc.supervisor_id;
+        
+{"end_date": "2019-01-31T23:59:59", "start_date": "2019-01-01T00:00:00"}
 
         UPDATE "tmp_agg_awc_2019-01-01_5" agg_awc SET
             cases_person_has_aadhaar_v2 = ut.child_has_aadhar,


### PR DESCRIPTION
Separated out the out of school query and query looks reduced than existing join.


Cost of person case query without join :
```
/*
 HashAggregate  (cost=0.00..0.00 rows=0 width=0)
   Group Key: remote_scan.awc_id, remote_scan.supervisor_id
   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
         Task Count: 64
         Tasks Shown: One of 64
         ->  Task
               Node: host=100.71.184.232 port=6432 dbname=icds_ucr
               ->  Finalize GroupAggregate  (cost=529086.43..1253192.97 rows=721437 width=122)
                     Group Key: awc_id, supervisor_id
                     ->  Gather Merge  (cost=529086.43..1148584.60 rows=4328622 width=122)
                           Workers Planned: 6
                           ->  Partial GroupAggregate  (cost=528086.33..621497.75 rows=721437 width=122)
                                 Group Key: awc_id, supervisor_id
                                 ->  Sort  (cost=528086.33..530959.57 rows=1149294 width=80)
                                       Sort Key: awc_id, supervisor_id
                                       ->  Parallel Seq Scan on "ucr_icds-cas_static-person_cases_v3_2ae0879a_103866" ucr  (cost=0.00..322661.93 rows=1149294 width=80)
                                             Filter: (((closed_on IS NULL) OR (closed_on >= '2019-12-01 00:00:00'::timestamp without time zone)) AND (opened_on <= '2019-12-31 00:00:00'::timestamp without time zone))
(17 rows)

```


Cost of same query with join:
```
/*
 HashAggregate  (cost=0.00..0.00 rows=0 width=0)
   Group Key: remote_scan.awc_id, remote_scan.supervisor_id
   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
         Task Count: 64
         Tasks Shown: One of 64
         ->  Task
               Node: host=100.71.184.232 port=6432 dbname=icds_ucr
               ->  Finalize GroupAggregate  (cost=555406.72..1279513.26 rows=721437 width=122)
                     Group Key: ucr.awc_id, ucr.supervisor_id
                     ->  Gather Merge  (cost=555406.72..1174904.90 rows=4328622 width=122)
                           Workers Planned: 6
                           ->  Partial GroupAggregate  (cost=554406.62..647818.04 rows=721437 width=122)
                                 Group Key: ucr.awc_id, ucr.supervisor_id
                                 ->  Sort  (cost=554406.62..557279.86 rows=1149294 width=80)
                                       Sort Key: ucr.awc_id, ucr.supervisor_id
                                       ->  Hash Left Join  (cost=461.17..348982.22 rows=1149294 width=80)
                                             Hash Cond: ((ucr.doc_id = adolescent_girls_table.person_case_id) AND (ucr.supervisor_id = adolescent_girls_table.supervisor_id))
                                             ->  Parallel Seq Scan on "ucr_icds-cas_static-person_cases_v3_2ae0879a_103866" ucr  (cost=0.00..322661.93 rows=1149294 width=117)
                                                   Filter: (((closed_on IS NULL) OR (closed_on >= '2019-12-01 00:00:00'::timestamp without time zone)) AND (opened_on <= '2019-12-31 00:00:00'::timestamp without time zone))
                                             ->  Hash  (cost=455.56..455.56 rows=374 width=70)
                                                   ->  Bitmap Heap Scan on "ucr_icds-cas_static-adolescent_girls_reg__e97c245b_142076" adolescent_girls_table  (cost=163.05..455.56 rows=374 width=70)
                                                         Recheck Cond: ((timeend >= '2019-12-01 00:00:00'::timestamp without time zone) AND (timeend <= '2019-12-31 00:00:00'::timestamp without time zone))
                                                         ->  Bitmap Index Scan on "ix_ucr_icds-cas_static-adolescent_girls_reg__e97c2_2fc81_142076"  (cost=0.00..162.95 rows=374 width=0)
                                                               Index Cond: ((timeend >= '2019-12-01 00:00:00'::timestamp without time zone) AND (timeend <= '2019-12-31 00:00:00'::timestamp without time zone))
(24 rows)*/

```




cost of outofschool query when separated out:

```
 HashAggregate  (cost=0.00..0.00 rows=0 width=0)
   Group Key: remote_scan.awc_id, remote_scan.supervisor_id
   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
         Task Count: 64
         Tasks Shown: One of 64
         ->  Task
               Node: host=100.71.184.232 port=6432 dbname=icds_ucr
               ->  GroupAggregate  (cost=1294.80..1294.83 rows=1 width=74)
                     Group Key: ucr.awc_id, ucr.supervisor_id
                     ->  Sort  (cost=1294.80..1294.81 rows=1 width=75)
                           Sort Key: ucr.awc_id, ucr.supervisor_id
                           ->  Nested Loop  (cost=165.39..1294.79 rows=1 width=75)
                                 ->  Bitmap Heap Scan on "ucr_icds-cas_static-adolescent_girls_reg__e97c245b_142076" adolescent_girls_table  (cost=165.39..457.93 rows=375 width=79)
                                       Recheck Cond: ((timeend >= '2019-12-01 00:00:00'::timestamp without time zone) AND (timeend <= '2019-12-31 00:00:00'::timestamp without time zone))
                                       ->  Bitmap Index Scan on "ix_ucr_icds-cas_static-adolescent_girls_reg__e97c2_2fc81_142076"  (cost=0.00..165.29 rows=375 width=0)
                                             Index Cond: ((timeend >= '2019-12-01 00:00:00'::timestamp without time zone) AND (timeend <= '2019-12-31 00:00:00'::timestamp without time zone))
                                 ->  Index Scan using "ix_ucr_icds-cas_person_cases_v3_doc_id_hash_103866" on "ucr_icds-cas_static-person_cases_v3_2ae0879a_103866" ucr  (cost=0.00..2.22 rows=1 width=103)
                                       Index Cond: (doc_id = adolescent_girls_table.person_case_id)
                                       Filter: (((closed_on IS NULL) OR (closed_on >= '2019-12-01 00:00:00'::timestamp without time zone)) AND (opened_on <= '2019-12-31 00:00:00'::timestamp without time zone) AND (migration_status IS DISTINCT FROM 1) AND (adolescent_girls_table.supervisor_id = supervisor_id))
(19 rows)

```

