### PR TITLE
Added CommCare version check for multi master

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -2,6 +2,8 @@ from distutils.version import LooseVersion, Version
 
 from django.conf import settings
 
+from corehq import toggles
+
 
 class CommCareFeatureSupportMixin(object):
     # overridden by subclass
@@ -156,3 +158,10 @@ class CommCareFeatureSupportMixin(object):
     @property
     def enable_training_modules(self):
         return self._require_minimum_version('2.43')
+
+    @property
+    def enable_multi_master(self):
+        return (
+            self._require_minimum_version('2.47.4')
+            or toggles.MULTI_MASTER_BYPASS_VERSION_CHECK.enabled(self.domain)
+        ) and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(self.domain)

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -315,7 +315,7 @@ def get_app_view_context(request, app):
         context.update({
             'master_briefs': master_briefs,
             'master_versions_by_id': master_versions_by_id,
-            'multiple_masters': len(master_briefs) > 1 and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(app.domain),
+            'multiple_masters': app.enable_multi_master and len(master_briefs) > 1,
             'upstream_version': app.upstream_version,
             'upstream_brief': upstream_brief,
             'upstream_url': _get_upstream_url(app, request.couch_user),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1429,6 +1429,13 @@ MULTI_MASTER_LINKED_DOMAINS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+MULTI_MASTER_BYPASS_VERSION_CHECK = StaticToggle(
+    'MULTI_MASTER_BYPASS_VERSION_CHECK',
+    "Bypass minimum CommCare version check for multi master usage. For use only by ICDS.",
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)
+
 SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(
     'sumologic_logs',
     'Send logs to sumologic',


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1142

##### FEATURE FLAG
Multi master

##### PRODUCT DESCRIPTION
Limits multi master to CommCare 2.47.4+, and adds a flag for ICDS only to bypass this check.