### PR TITLE
Ability to copy in multimedia from another app

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view.js
@@ -52,6 +52,7 @@ hqDefine("app_manager/js/app_view", function () {
                         success: function (content) {
                             self.load_state('loaded');
                             self.multimedia_page_html(content);
+                            hqImport("hqwebapp/js/widgets").init();
                         },
                         error: function (data) {
                             if (data.hasOwnProperty('responseJSON')) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
@@ -68,7 +68,7 @@
                 <option value=""></option>
                 {% for app in import_apps %}
                   {# Poor readability because any whitespace within the option will also appear in the title attribute and therefore on hover #}
-                  <option value="{{ app.id }}">{{ app.name }} ({% for id, count in import_app_counts.items %}{% if id == app.id %}{% blocktrans with c=count %}{{ c }} items to import{% endblocktrans %}{% endif %}{% endfor %})</option>
+                  <option value="{{ app.id }}">{{ app.name }} ({% for id, count in import_app_counts.items %}{% if id == app.id %}{% blocktrans with c=count %}{{ c }} item(s) to import{% endblocktrans %}{% endif %}{% endfor %})</option>
                 {% endfor %}
               </select>
             </p>

--- a/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/settings/multimedia_ajax.html
@@ -1,3 +1,4 @@
+{% load hq_shared_tags %}
 {% load i18n %}
 {% if multimedia_state.has_media %}
   {% if not is_linked_app %}
@@ -46,6 +47,46 @@
           </button>
         </div>
       </form>
+    </div>
+  {% endif %}
+
+  {% if request|toggle_enabled:"MULTI_MASTER_LINKED_DOMAINS" %}
+    <div class="panel panel-appmanager">
+      <div class="panel-heading">
+        <h4 class="panel-title panel-title-nolink">{% trans 'Copy Multimedia from Another Application' %}</h4>
+      </div>
+      <div class="panel-body">
+        {% if import_apps %}
+          <form action="{% url "copy_multimedia" domain app.id %}" method="POST">
+            <p class="help-block">
+              Select an app to copy over any media that is present in the selected app but missing in this app.
+            </p>
+            <p>
+              {% csrf_token %}
+              <select name="app_id" class="form-control hqwebapp-select2"
+                      data-placeholder="{% trans_html_attr "Select an app" %}">
+                <option value=""></option>
+                {% for app in import_apps %}
+                  {# Poor readability because any whitespace within the option will also appear in the title attribute and therefore on hover #}
+                  <option value="{{ app.id }}">{{ app.name }} ({% for id, count in import_app_counts.items %}{% if id == app.id %}{% blocktrans with c=count %}{{ c }} items to import{% endblocktrans %}{% endif %}{% endfor %})</option>
+                {% endfor %}
+              </select>
+            </p>
+            <p>
+              <button type="submit" class="btn btn-primary">
+                <i class="fa fa-copy"></i>
+                {% trans "Copy Multimedia" %}
+              </button>
+            </p>
+          </form>
+        {% else %}
+          <p>
+            <div class="alert alert-info">
+              There is no multimedia in this app that can be copied from other apps.
+            </div>
+          </p>
+        {% endif %}
+      </div>
     </div>
   {% endif %}
 {% else %}

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -88,6 +88,7 @@ from corehq.apps.app_manager.views import (
 )
 from corehq.apps.app_manager.views.apps import move_child_modules_after_parents
 from corehq.apps.app_manager.views.modules import ExistingCaseTypesView
+from corehq.apps.hqmedia.views import copy_multimedia
 from corehq.apps.hqmedia.urls import application_urls as hqmedia_urls
 from corehq.apps.hqmedia.urls import download_urls as media_download_urls
 from corehq.apps.linked_domain.views import pull_missing_multimedia
@@ -211,6 +212,7 @@ urlpatterns = [
 
     # multimedia stuff
     url(r'^(?P<app_id>[\w-]+)/multimedia/', include(hqmedia_urls)),
+    url(r'^copy_multimedia/(?P<app_id>[\w-]+)/$', copy_multimedia, name='copy_multimedia'),
     url(r'^edit_module_detail_screens/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/$',
         edit_module_detail_screens, name='edit_module_detail_screens'),
     url(r'^edit_module_attr/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/(?P<attr>[\w-]+)/$',

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -900,16 +900,16 @@ class ApplicationMediaMixin(Document, MediaMixin):
         if map_changed:
             self.save()
 
-    def create_mapping(self, multimedia, form_path, save=True):
+    def create_mapping(self, multimedia, path, save=True):
         """
             This creates the mapping of a path to the multimedia in an application to the media object stored in couch.
         """
-        form_path = form_path.strip()
+        path = path.strip()
         map_item = HQMediaMapItem()
         map_item.multimedia_id = multimedia._id
-        map_item.unique_id = HQMediaMapItem.gen_unique_id(map_item.multimedia_id, form_path)
+        map_item.unique_id = HQMediaMapItem.gen_unique_id(map_item.multimedia_id, path)
         map_item.media_type = multimedia.doc_type
-        self.multimedia_map[form_path] = map_item
+        self.multimedia_map[path] = map_item
 
         if save:
             try:

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/widgets.js
@@ -2,7 +2,7 @@ hqDefine("hqwebapp/js/widgets", [
     'jquery',
     'select2/dist/js/select2.full.min',
 ], function ($) {
-    $(function () {
+    var init = function () {
         // .hqwebapp-select2 is a basic select2-based dropdown or multiselect
         _.each($(".hqwebapp-select2"), function (element) {
             $(element).select2({
@@ -54,13 +54,18 @@ hqDefine("hqwebapp/js/widgets", [
                 },
             });
         });
-    });
+    };
 
     var parseEmails = function (input) {
         return $.trim(input).split(/[, ]\s*/);
     };
 
+    $(function () {
+        init();
+    });
+
     return {
+        init: init,
         parseEmails: parseEmails,   // export for testing
     };
 });


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-945

##### FEATURE FLAG
Allow linked apps to pull from multiple master apps in the upstream domain

##### PRODUCT DESCRIPTION
Adds a section to app settings > multimedia that allows user to select another app in the same domain, then copies over any multimedia to app A from app B, provided the media has the same `jr://...`path in both apps and is present in B but missing in A.

This is behind the multi master flag because the use case is app builders making the same change in multiple branches of the same app; the intent is to save them the time of uploading multimedia again in every branch.

![Screen Shot 2019-12-27 at 5 28 24 PM](https://user-images.githubusercontent.com/1486591/71534832-78e77f00-28cf-11ea-9f17-1b4410d40e38.png)
