### PR TITLE
drop chm indices before insert

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/child_health_monthly.py
@@ -39,6 +39,8 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
         drop_query, drop_params = self.drop_table_query()
 
         cursor.execute(drop_query, drop_params)
+        for query in self.drop_indices():
+            cursor.execute(query)
         cursor.execute(self.aggregation_query())
         for query in self.indexes():
             cursor.execute(query)
@@ -403,6 +405,14 @@ class ChildHealthMonthlyAggregationDistributedHelper(BaseICDSAggregationDistribu
     def aggregation_query(self):
         return "INSERT INTO \"{tablename}\" (SELECT * FROM \"{tmp_tablename}\")".format(
             tablename=self.tablename, tmp_tablename=self.temporary_tablename)
+
+    def drop_indices(self):
+        return [
+            'DROP INDEX IF EXISTS chm_case_idx',
+            'DROP INDEX IF EXISTS chm_awc_idx',
+            'DROP INDEX IF EXISTS chm_mother_dob',
+            'DROP INDEX IF EXISTS chm_month_supervisor_id',
+        ]
 
     def indexes(self):
         return [

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/child-health-monthly.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/child-health-monthly.distributed.txt
@@ -1,5 +1,13 @@
 DELETE FROM "child_health_monthly" WHERE month=%(month)s
 {"month": "2019-01-01T00:00:00"}
+DROP INDEX IF EXISTS chm_case_idx
+{}
+DROP INDEX IF EXISTS chm_awc_idx
+{}
+DROP INDEX IF EXISTS chm_mother_dob
+{}
+DROP INDEX IF EXISTS chm_month_supervisor_id
+{}
 INSERT INTO "child_health_monthly" (SELECT * FROM "tmp_child_health_monthly_2019-01-01")
 {}
 CREATE INDEX IF NOT EXISTS chm_case_idx ON "child_health_monthly" (case_id)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This should potentially speed up the insert to child health (currently one of the slowest stages). I tried it manually today and got the fastest execution we had seen in a while on that step. It is mostly a stop gap until I can implement partitioning, which I am hoping to do next week, although it may take a bit longer. Depending on how timings go for this, we may want to move the drops into a separate task, since they can happen at any point in the agg. It is also not clear to me how transaction semantics affect the utility of this, but we can pull it into a separate transaction if it does not work as well tomorrow.