### PR TITLE
drop and recreate indices for df

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -109,9 +109,9 @@ def run_task(agg_record, query_name):
     state_ids = agg_record.state_ids
     query = function_map[query_name]
     pre_query, agg_query, post_query = query.funcs
-    if pre:
+    if pre_query:
         logger.info('Running pre aggregration queries')
-        pre(agg_date)
+        pre_query(agg_date)
         logger.info('Finished pre aggregration queries')
     if query.by_state == SINGLE_STATE:
         greenlets = []
@@ -131,9 +131,9 @@ def run_task(agg_record, query_name):
         agg_query(agg_date)
     else:
         agg_query(agg_date, state_ids)
-    if post:
+    if post_query:
         logger.info('Running post aggregration queries')
-        post(agg_date)
+        post_query(agg_date)
         logger.info('Finished post aggregration queries')
 
 

--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -35,47 +35,49 @@ from custom.icds_reports.tasks import (
     setup_aggregation,
     update_agg_child_health,
     update_child_health_monthly_table,
-    _agg_adolescent_girls_registration_table
+    _agg_adolescent_girls_registration_table,
+    create_df_indices,
+    drop_df_indices,
 )
 
 
 logger = logging.getLogger(__name__)
 
 STATE_TASKS = {
-    'aggregate_gm_forms': _aggregate_gm_forms,
-    'aggregate_cf_forms': _aggregate_cf_forms,
-    'aggregate_ccs_cf_forms': _aggregate_ccs_cf_forms,
-    'aggregate_child_health_thr_forms': _aggregate_child_health_thr_forms,
-    'aggregate_ccs_record_thr_forms': _aggregate_ccs_record_thr_forms,
-    'aggregate_child_health_pnc_forms': _aggregate_child_health_pnc_forms,
-    'aggregate_ccs_record_pnc_forms': _aggregate_ccs_record_pnc_forms,
-    'aggregate_delivery_forms': _aggregate_delivery_forms,
-    'aggregate_bp_forms': _aggregate_bp_forms,
-    'aggregate_awc_infra_forms': _aggregate_awc_infra_forms,
-    'agg_ls_awc_mgt_form': _agg_ls_awc_mgt_form,
-    'agg_ls_vhnd_form': _agg_ls_vhnd_form,
-    'agg_beneficiary_form': _agg_beneficiary_form,
-    'aggregate_df_forms': _aggregate_df_forms,
-    'aggregate_ag_forms': _agg_adolescent_girls_registration_table
+    'aggregate_gm_forms': (None, _aggregate_gm_forms, None),
+    'aggregate_cf_forms': (None, _aggregate_cf_forms, None),
+    'aggregate_ccs_cf_forms': (None, _aggregate_ccs_cf_forms, None),
+    'aggregate_child_health_thr_forms': (None, _aggregate_child_health_thr_forms, None),
+    'aggregate_ccs_record_thr_forms': (None, _aggregate_ccs_record_thr_forms, None),
+    'aggregate_child_health_pnc_forms': (None, _aggregate_child_health_pnc_forms, None),
+    'aggregate_ccs_record_pnc_forms': (None, _aggregate_ccs_record_pnc_forms, None),
+    'aggregate_delivery_forms': (None, _aggregate_delivery_forms, None),
+    'aggregate_bp_forms': (None, _aggregate_bp_forms, None),
+    'aggregate_awc_infra_forms': (None, _aggregate_awc_infra_forms, None),
+    'agg_ls_awc_mgt_form': (None, _agg_ls_awc_mgt_form, None),
+    'agg_ls_vhnd_form': (None, _agg_ls_vhnd_form, None),
+    'agg_beneficiary_form': (None, _agg_beneficiary_form, None),
+    'aggregate_df_forms': (drop_df_indices, _aggregate_df_forms, create_df_indices),
+    'aggregate_ag_forms': (None, _agg_adolescent_girls_registration_table None),
 }
 
 ALL_STATES_TASKS = {
-    'child_health_monthly': _child_health_monthly_aggregation,
-    'update_child_health_monthly_table': update_child_health_monthly_table,
-    'create_mbt_for_month': create_all_mbt,
+    'child_health_monthly': (None, _child_health_monthly_aggregation, None),
+    'update_child_health_monthly_table': (None, update_child_health_monthly_table, None),
+    'create_mbt_for_month': (None, create_all_mbt, None),
 }
 
 NORMAL_TASKS = {
-    'setup_aggregation': setup_aggregation,
-    'agg_ls_table': _agg_ls_table,
-    'update_months_table': _update_months_table,
-    'daily_attendance': _daily_attendance_table,
-    'agg_child_health_temp': agg_child_health_temp,
-    'ccs_record_monthly': _ccs_record_monthly_table,
-    'agg_ccs_record': _agg_ccs_record_table,
-    'agg_awc_table': _agg_awc_table,
-    'aggregate_awc_daily': aggregate_awc_daily,
-    'update_agg_child_health': update_agg_child_health,
+    'setup_aggregation': (None, setup_aggregation, None),
+    'agg_ls_table': (None, _agg_ls_table, None),
+    'update_months_table': (None, _update_months_table, None),
+    'daily_attendance': (None, _daily_attendance_table, None),
+    'agg_child_health_temp': (None, agg_child_health_temp, None),
+    'ccs_record_monthly': (None, _ccs_record_monthly_table, None),
+    'agg_ccs_record': (None, _agg_ccs_record_table, None),
+    'agg_awc_table': (None, _agg_awc_table, None),
+    'aggregate_awc_daily': (None, aggregate_awc_daily, None),
+    'update_agg_child_health': (None, update_agg_child_health, None),
 }
 
 
@@ -87,31 +89,36 @@ NO_STATES = 'none'
 @attr.s
 class AggregationQuery(object):
     by_state = attr.ib()
-    func = attr.ib()
+    funcs = attr.ib()
 
 
 function_map = {}
 
 
 def setup_tasks():
-    for name, func in STATE_TASKS.items():
-        function_map[name] = AggregationQuery(SINGLE_STATE, func)
-    for name, func in NORMAL_TASKS.items():
-        function_map[name] = AggregationQuery(NO_STATES, func)
-    for name, func in ALL_STATES_TASKS.items():
-        function_map[name] = AggregationQuery(ALL_STATES, func)
+    for name, funcs in STATE_TASKS.items():
+        function_map[name] = AggregationQuery(SINGLE_STATE, funcs)
+    for name, funcs in NORMAL_TASKS.items():
+        function_map[name] = AggregationQuery(NO_STATES, funcs)
+    for name, funcs in ALL_STATES_TASKS.items():
+        function_map[name] = AggregationQuery(ALL_STATES, funcs)
 
 
 def run_task(agg_record, query_name):
     agg_date = agg_record.agg_date
     state_ids = agg_record.state_ids
     query = function_map[query_name]
+    pre_query, agg_query, post_query = query.funcs
+    if pre:
+        logger.info('Running pre aggregration queries')
+        pre(agg_date)
+        logger.info('Finished pre aggregration queries')
     if query.by_state == SINGLE_STATE:
         greenlets = []
         pool = Pool(15)
         logger.info('Spawning greenlets')
         for state in state_ids:
-            greenlets.append(pool.spawn(query.func, state, agg_date))
+            greenlets.append(pool.spawn(agg_query, state, agg_date))
         logger.info('Joining greenlets')
         pool.join(raise_error=True)
         logger.info('Getting greenlets')
@@ -121,10 +128,13 @@ def run_task(agg_record, query_name):
             logger.info('got {}'.format(g))
         logger.info('Done getting greenlets')
     elif query.by_state == NO_STATES:
-        query.func(agg_date)
+        agg_query(agg_date)
     else:
-        state_ids
-        query.func(agg_date, state_ids)
+        agg_query(agg_date, state_ids)
+    if post:
+        logger.info('Running post aggregration queries')
+        post(agg_date)
+        logger.info('Finished post aggregration queries')
 
 
 class Command(BaseCommand):

--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -38,13 +38,14 @@ from custom.icds_reports.tasks import (
     _agg_adolescent_girls_registration_table,
     create_df_indices,
     drop_df_indices,
+    drop_gm_indices,
 )
 
 
 logger = logging.getLogger(__name__)
 
 STATE_TASKS = {
-    'aggregate_gm_forms': (None, _aggregate_gm_forms, None),
+    'aggregate_gm_forms': (drop_gm_indices, _aggregate_gm_forms, None),
     'aggregate_cf_forms': (None, _aggregate_cf_forms, None),
     'aggregate_ccs_cf_forms': (None, _aggregate_ccs_cf_forms, None),
     'aggregate_child_health_thr_forms': (None, _aggregate_child_health_thr_forms, None),

--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -58,7 +58,7 @@ STATE_TASKS = {
     'agg_ls_vhnd_form': (None, _agg_ls_vhnd_form, None),
     'agg_beneficiary_form': (None, _agg_beneficiary_form, None),
     'aggregate_df_forms': (drop_df_indices, _aggregate_df_forms, create_df_indices),
-    'aggregate_ag_forms': (None, _agg_adolescent_girls_registration_table None),
+    'aggregate_ag_forms': (None, _agg_adolescent_girls_registration_table, None),
 }
 
 ALL_STATES_TASKS = {

--- a/custom/icds_reports/tests/agg_tests/agg_setup.py
+++ b/custom/icds_reports/tests/agg_tests/agg_setup.py
@@ -13,7 +13,8 @@ from custom.icds_reports.utils.migrations import create_citus_reference_table, c
 from custom.icds_reports.tasks import (
     _aggregate_child_health_pnc_forms,
     _aggregate_bp_forms,
-    _aggregate_gm_forms
+    _aggregate_gm_forms,
+    drop_gm_indices
 )
 
 
@@ -222,6 +223,7 @@ def _distribute_tables_for_citus(engine):
 
 
 def aggregate_state_form_data():
+    drop_gm_indices(datetime(2017, 3, 31))
     for state_id in ('st1', 'st2'):
         _aggregate_child_health_pnc_forms(state_id, datetime(2017, 3, 31))
         _aggregate_gm_forms(state_id, datetime(2017, 3, 31))

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
@@ -17,14 +17,12 @@ class DailyFeedingFormsChildHealthAggregationDistributedHelper(StateBasedAggrega
 
     def drop_index_queries(self):
         return [
-            'DROP INDEX IF EXISTS "icds_dashboard_daily_feeding_forms_case_id_114445ac_like"',
             'DROP INDEX IF EXISTS "icds_dashboard_daily_feeding_forms_state_id_month_273d19dd_idx"',
         ]
 
     def create_index_queries(self):
         return [
             'CREATE INDEX IF NOT EXISTS "icds_dashboard_daily_feeding_forms_state_id_month_273d19dd_idx" ON "{}" (state_id, month)'.format(self.aggregate_parent_table),
-            'CREATE INDEX IF NOT EXISTS "icds_dashboard_daily_feeding_forms_case_id_114445ac_like" ON "{}" (case_id varchar_pattern_ops)'.format(self.aggregate_parent_table),
         ]
 
     def aggregation_query(self):

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py
@@ -15,6 +15,18 @@ class DailyFeedingFormsChildHealthAggregationDistributedHelper(StateBasedAggrega
     ucr_data_source_id = 'dashboard_child_health_daily_feeding_forms'
     aggregate_parent_table = AGG_DAILY_FEEDING_TABLE
 
+    def drop_index_queries(self):
+        return [
+            'DROP INDEX IF EXISTS "icds_dashboard_daily_feeding_forms_case_id_114445ac_like"',
+            'DROP INDEX IF EXISTS "icds_dashboard_daily_feeding_forms_state_id_month_273d19dd_idx"',
+        ]
+
+    def create_index_queries(self):
+        return [
+            'CREATE INDEX IF NOT EXISTS "icds_dashboard_daily_feeding_forms_state_id_month_273d19dd_idx" ON "{}" (state_id, month)'.format(self.aggregate_parent_table),
+            'CREATE INDEX IF NOT EXISTS "icds_dashboard_daily_feeding_forms_case_id_114445ac_like" ON "{}" (case_id varchar_pattern_ops)'.format(self.aggregate_parent_table),
+        ]
+
     def aggregation_query(self):
         current_month_start = month_formatter(self.month)
         next_month_start = month_formatter(self.month + relativedelta(months=1))
@@ -60,3 +72,9 @@ class DailyFeedingFormsChildHealthAggregationDistributedHelper(StateBasedAggrega
           WINDOW w AS (PARTITION BY ucr.supervisor_id, ucr.child_health_case_id)
         )
         """, query_params
+
+    def delete_old_data_query(self):
+        pass
+
+    def delete_previous_run_query(self):
+        pass

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/growth_monitoring_forms.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/growth_monitoring_forms.py
@@ -183,3 +183,9 @@ class GrowthMonitoringFormsAggregationDistributedHelper(StateBasedAggregationDis
             ucr_table_query=ucr_query,
             tablename=self.aggregate_parent_table
         ), query_params
+
+    def delete_old_data_query(self):
+        pass
+
+    def delete_previous_run_query(self):
+        pass

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/daily-feeding-forms-child-health.distributed.txt
@@ -1,5 +1,3 @@
-DELETE FROM "icds_dashboard_daily_feeding_forms" WHERE month=%(month)s AND state_id = %(state)s
-{"month": "2019-01-01", "state": "st1"}
 
         INSERT INTO "icds_dashboard_daily_feeding_forms" (
           state_id, supervisor_id, month, case_id, latest_time_end_processed,

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/growth-monitoring-forms.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/growth-monitoring-forms.distributed.txt
@@ -1,7 +1,3 @@
-DELETE FROM "icds_dashboard_growth_monitoring_forms" WHERE month < %(month)s AND state_id = %(state)s
-{"month": "2018-10-01", "state": "st1"}
-DELETE FROM "icds_dashboard_growth_monitoring_forms" WHERE month=%(month)s AND state_id = %(state)s
-{"month": "2019-01-01", "state": "st1"}
 
         INSERT INTO "icds_dashboard_growth_monitoring_forms" (
             state_id, supervisor_id, month, case_id, latest_time_end_processed,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This continues the trend of dropping indices before insert, since it was so successful with child health monthly. Daily feeding is the second longest stage 1 query, I purposefully did not do the longest, growth monitoring, because its queries appear to use the indices (it does a self join), so I want to be more careful with how we do it.