### PR TITLE
A Y2K20 bug?

### DIFF
--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1,6 +1,5 @@
 from django.http import HttpRequest
 from django.test import TestCase
-from datetime import datetime
 
 from corehq.apps.userreports.exceptions import BadSpecError, UserReportsError
 from corehq.apps.userreports.models import (
@@ -563,12 +562,12 @@ class TestReportAggregationSQL(ConfigurableReportTestMixin, TestCase):
 class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
     @classmethod
     def _relative_date(cls, month, day, year_offset=0):
-        year = datetime.utcnow().year + year_offset
+        year = 2019 + year_offset
         return f"{year}-{month:02}-{day:02}"
 
     @classmethod
     def _relative_month(cls, month, year_offset=0):
-        year = datetime.utcnow().year + year_offset
+        year = 2019 + year_offset
         return f"{year}-{month:02}"
 
     @classmethod


### PR DESCRIPTION
This seems to be breaking the build.

I'm not sure if my change is the best approach. A better approach might be to make the test more resilient to year changes than just to hard code the year. But I figured the lowest effort solution was worth putting past you.
