### PR TITLE
reverse order_by on previous_subscription 

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1186,7 +1186,7 @@ class Subscription(models.Model):
     @property
     def previous_subscription(self):
         try:
-            return self.previous_subscription_filter.order_by('date_end')[0]
+            return self.previous_subscription_filter.order_by('-date_end')[0]
         except (Subscription.DoesNotExist, IndexError):
             return None
 


### PR DESCRIPTION
##### SUMMARY
The wrong plan is showing up as the `previous_subscription` when the plan is paused for domains that have a pretty long history of subscriptions. This makes sure that the right subscription shows up when calling `self.previous_subscription` on a `Subscription` instance.