### PR TITLE
Added support for user choosing bulk app translation download format

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/settings/translations.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/translations.js
@@ -1,13 +1,18 @@
 hqDefine("app_manager/js/settings/translations", function () {
     var appTranslationsModel = function (options) {
-        hqImport("hqwebapp/js/assert_properties").assertRequired(options, ['baseUrl', 'lang', 'skipBlacklisted']);
+        hqImport("hqwebapp/js/assert_properties").assertRequired(options, ['baseUrl', 'format', 'lang', 'skipBlacklisted']);
         var self = {};
 
         self.file = ko.observable();
+        self.format = ko.observable(options.format);
         self.lang = ko.observable(options.lang);
         self.skipBlacklisted = ko.observable(options.skipBlacklisted);
         self.url = ko.computed(function () {
-            return options.baseUrl + "?lang=" + self.lang() + "&skipbl=" + self.skipBlacklisted();
+            return options.baseUrl + "?lang=" + self.lang() + "&skipbl=" + self.skipBlacklisted() + "&format=" + self.format();
+        });
+
+        self.disableDownload = ko.computed(function () {
+            return self.format() === "single" && !self.lang();
         });
 
         return self;
@@ -27,6 +32,7 @@ hqDefine("app_manager/js/settings/translations", function () {
         if ($translationsPanel.length) {
             $translationsPanel.koApplyBindings(appTranslationsModel({
                 baseUrl: $translationsPanel.find("#download_link").attr("href"),
+                format: $translationsPanel.find("#sheet_format").val(),
                 lang: $translationsPanel.find("select").val() || '',
                 skipBlacklisted: $translationsPanel.find("#skip_blacklisted").val() === "on",
             }));

--- a/corehq/apps/app_manager/static/app_manager/js/settings/translations.js
+++ b/corehq/apps/app_manager/static/app_manager/js/settings/translations.js
@@ -34,7 +34,7 @@ hqDefine("app_manager/js/settings/translations", function () {
                 baseUrl: $translationsPanel.find("#download_link").attr("href"),
                 format: $translationsPanel.find("#sheet_format").val(),
                 lang: $translationsPanel.find("select").val() || '',
-                skipBlacklisted: $translationsPanel.find("#skip_blacklisted").val() === "on",
+                skipBlacklisted: $translationsPanel.find("#skip_blacklisted").val(),
             }));
         }
     });

--- a/corehq/apps/app_manager/templates/app_manager/partials/bulk_upload_app_translations.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bulk_upload_app_translations.html
@@ -17,6 +17,28 @@
         </select>
       </p>
     </li>
+    <li>
+      <p>
+        {% trans "Select a format." %}
+      </p>
+      <p>
+        <select-toggle data-apply-bindings="false"
+                       params="
+                         value: format,
+                         id: 'sheeet_format',
+                         options: [
+                           {
+                             id: 'multi',
+                             text: '{% trans_html_attr 'One sheet for each menu and form' %}',
+                           },
+                           {
+                             id: 'single',
+                             text: '{% trans_html_attr 'Single sheet for all translations' %}',
+                           },
+                         ],
+                       "></select-toggle>
+      </p>
+    </li>
     {% if request|toggle_enabled:'APP_TRANSLATIONS_WITH_TRANSIFEX' %}
     <li>
       <p>
@@ -28,4 +50,25 @@
     </li>
     {% endif %}
   {% endif %}
+{% endblock %}
+
+{% block download_file %}
+  <p>
+    <a id="download_link" href="{{ bulk_upload.download_url }}" data-bind="attr: {href: url}">
+      <button class="btn btn-primary" data-bind="disable: disableDownload">
+        <i class="fa fa-cloud-download"></i>
+        {% blocktrans with plural_noun=bulk_upload.plural_noun %}
+          Download {{ plural_noun }}
+        {% endblocktrans %}
+      </button>
+    </a>
+  </p>
+  <div class="has-error" data-bind="visible: disableDownload">
+    <p class="help-block">
+      {% blocktrans %}
+        The single-sheet format is only available when downloading a single language.
+        <br>Please either select a language or choose the multi-sheet format.
+      {% endblocktrans %}
+    </p>
+  </div>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/bulk_upload_app_translations.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/bulk_upload_app_translations.html
@@ -45,7 +45,21 @@
         {% trans "Download only translations eligible for Transifex?" %}
       </p>
       <p>
-        <input type="checkbox" id="skip_blacklisted" data-bind="checked: skipBlacklisted"/>
+        <select-toggle data-apply-bindings="false"
+                       params="
+                         value: skipBlacklisted,
+                         id: 'skip_blacklisted',
+                         options: [
+                           {
+                             id: 'true',
+                             text: '{% trans_html_attr 'Only Transifex references' %}',
+                           },
+                           {
+                             id: 'false',
+                             text: '{% trans_html_attr 'All translations' %}',
+                           },
+                         ],
+                       "></select-toggle>
       </p>
     </li>
     {% endif %}

--- a/corehq/apps/translations/views.py
+++ b/corehq/apps/translations/views.py
@@ -95,8 +95,7 @@ def download_bulk_app_translations(request, domain, app_id):
     lang = request.GET.get('lang')
     skip_blacklisted = request.GET.get('skipbl', 'false') == 'true'
     app = get_app(domain, app_id)
-    # if there is a lang selected, assume that user wants a single sheet
-    is_single_sheet = bool(lang)
+    is_single_sheet = request.GET.get('format') == "single"
     headers = get_bulk_app_sheet_headers(app, single_sheet=is_single_sheet,
                                          lang=lang, eligible_for_transifex_only=skip_blacklisted)
     if is_single_sheet:


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1140

##### FEATURE FLAG
Bulk multimedia path management

##### PRODUCT DESCRIPTION
Adds option to select either single or multi sheet format for download. Previously, selecting all languages always downloaded the multi-sheet format, and selecting a single language always downloaded the single-sheet format. 

This does block multi-language, single-tab download because it would be a very large file and no one has asked for it. ICDS's request is to be able to download the multi-sheet format for a single language.

<img width="1044" alt="Screen Shot 2020-01-02 at 8 27 49 PM" src="https://user-images.githubusercontent.com/1486591/71702957-3aa30180-2da0-11ea-8874-2bbdb8ef4a3f.png">
