### PR TITLE
Fix import

### DIFF
--- a/custom/icds/tasks/__init__.py
+++ b/custom/icds/tasks/__init__.py
@@ -9,7 +9,6 @@ from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query
 from corehq.util.datadog.gauges import datadog_counter
-from custom.icds.tasks.hosted_ccz import setup_ccz_file_for_hosting
 
 if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
     from custom.icds.tasks.sms import send_monthly_sms_report

--- a/custom/icds/tasks/__init__.py
+++ b/custom/icds/tasks/__init__.py
@@ -12,6 +12,7 @@ from corehq.util.datadog.gauges import datadog_counter
 from custom.icds.tasks.hosted_ccz import setup_ccz_file_for_hosting
 
 if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+    from custom.icds.tasks.sms import send_monthly_sms_report
     @periodic_task(run_every=crontab(minute=0, hour='22'))
     def delete_old_images(cutoff=None):
         cutoff = cutoff or datetime.utcnow()

--- a/custom/icds/tasks/sms.py
+++ b/custom/icds/tasks/sms.py
@@ -20,7 +20,7 @@ from corehq.util.files import file_extention_from_filename
 if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
     @periodic_task(run_every=crontab(day_of_month='2', minute=0, hour=0), queue='sms_queue')
     def send_monthly_sms_report():
-        subject = _('Monthy SMS report')
+        subject = _('Monthly SMS report')
         recipients = ['jschweers@dimagi.com', 'mkangia@dimagi.com', 'ayogi@dimagi.com',
                       'adhaar.kaul@gmail.com', 'umra.liaqat@gmail.com']
         try:

--- a/custom/icds/tests/models/test_hosted_ccz.py
+++ b/custom/icds/tests/models/test_hosted_ccz.py
@@ -8,7 +8,7 @@ from custom.icds.models import (
 )
 
 
-@mock.patch('custom.icds.tasks.setup_ccz_file_for_hosting.delay')
+@mock.patch('custom.icds.tasks.hosted_ccz.setup_ccz_file_for_hosting.delay')
 class TestHostedCCZ(TestCase):
     def setUp(self):
         super(TestHostedCCZ, self).setUp()

--- a/custom/icds/tests/tasks/test_setup_ccz_file_for_hosting.py
+++ b/custom/icds/tests/tasks/test_setup_ccz_file_for_hosting.py
@@ -2,7 +2,7 @@ import mock
 from django.template.defaultfilters import linebreaksbr
 from django.test import SimpleTestCase
 
-from custom.icds.tasks import setup_ccz_file_for_hosting
+from custom.icds.tasks.hosted_ccz import setup_ccz_file_for_hosting
 from custom.icds.models import (
     HostedCCZ,
     HostedCCZLink,


### PR DESCRIPTION
The task to send monthly SMS report was not triggering.
It was because it was not getting registered as a celery task because it was not getting called anywhere.
So included that in the `__init__` file,
also removed an import that was not needed.

Environment
ICDS