### PR TITLE
Repeater retries

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -632,7 +632,7 @@ class RepeatRecord(Document):
     payload_id = StringProperty()
 
     overall_tries = IntegerProperty(default=0)
-    max_possible_tries = IntegerProperty(default=5)
+    max_possible_tries = IntegerProperty(default=6)
 
     attempts = ListProperty(RepeatRecordAttempt)
 

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -729,27 +729,15 @@ class RepeatRecord(Document):
         self.save()
 
     def make_set_next_try_attempt(self, failure_reason):
-        # we use an exponential back-off to avoid submitting to bad urls
-        # too frequently.
         assert self.succeeded is False
         assert self.next_check is not None
         now = datetime.utcnow()
-        window = timedelta(minutes=0)
-        if self.last_checked:
-            window = now - self.last_checked
-            window *= 3
-        if window < MIN_RETRY_WAIT:
-            window = MIN_RETRY_WAIT
-        elif window > MAX_RETRY_WAIT:
-            window = MAX_RETRY_WAIT
-        # Retries will typically be after 1h, 3h, 9h, 27h, 81h -- 5d 3h total
-
         return RepeatRecordAttempt(
             cancelled=False,
             datetime=now,
             failure_reason=failure_reason,
             success_response=None,
-            next_check=now + window,
+            next_check=now + _get_retry_interval(self.last_checked, now),
             succeeded=False,
         )
 
@@ -893,6 +881,27 @@ class RepeatRecord(Document):
         self.failure_reason = ''
         self.overall_tries = 0
         self.next_check = datetime.utcnow()
+
+
+def _get_retry_interval(last_checked, now):
+    """
+    Returns a timedelta between MIN_RETRY_WAIT and MAX_RETRY_WAIT that
+    is roughly three times as long as the previous interval.
+
+    We use an exponential back-off to avoid submitting to bad URLs
+    too frequently. Retries will typically be after 1h, 3h, 9h, 27h,
+    81h, so that the last attempt will be at least 5d 1h after the
+    first attempt.
+    """
+    interval = timedelta(minutes=0)
+    if last_checked:
+        interval = now - last_checked
+        interval *= 3
+    if interval < MIN_RETRY_WAIT:
+        interval = MIN_RETRY_WAIT
+    elif interval > MAX_RETRY_WAIT:
+        interval = MAX_RETRY_WAIT
+    return interval
 
 
 def _is_response(duck):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -893,14 +893,12 @@ def _get_retry_interval(last_checked, now):
     81h, so that the last attempt will be at least 5d 1h after the
     first attempt.
     """
-    interval = timedelta(minutes=0)
     if last_checked:
-        interval = now - last_checked
-        interval *= 3
-    if interval < MIN_RETRY_WAIT:
-        interval = MIN_RETRY_WAIT
-    elif interval > MAX_RETRY_WAIT:
-        interval = MAX_RETRY_WAIT
+        interval = 3 * (now - last_checked)
+    else:
+        interval = timedelta(0)
+    interval = max(MIN_RETRY_WAIT, interval)
+    interval = min(MAX_RETRY_WAIT, interval)
     return interval
 
 

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1169,7 +1169,6 @@ class TestGetRetryInterval(SimpleTestCase):
             self.assertEqual(interval, timedelta(hours=expected_interval_hours))
 
 
-# TODO: When we upgrade to Python 3.7, use datetime.fromisoformat() instead
 def fromisoformat(isoformat):
     """
     Return a datetime from a string in ISO 8601 date time format
@@ -1178,5 +1177,7 @@ def fromisoformat(isoformat):
     datetime.datetime(2019, 12, 31, 23, 59, 59)
 
     """
-    args = [int(x) for x in re.split("[ :-]", isoformat)]
-    return datetime(*args)
+    try:
+        return datetime.fromisoformat(isoformat)  # Python >= 3.7
+    except AttributeError:
+        return datetime.strptime(isoformat, "%Y-%m-%d %H:%M:%S")

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1,5 +1,4 @@
 import json
-import re
 import uuid
 from collections import namedtuple
 from datetime import datetime, timedelta

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1156,6 +1156,18 @@ class TestGetRetryInterval(SimpleTestCase):
         interval = _get_retry_interval(last_checked, now)
         self.assertEqual(interval, timedelta(hours=3))
 
+    def test_five_retries(self):
+        # (Five retries because RepeatRecord.max_possible_tries is 6)
+        for last_checked, now, expected_interval_hours in [
+            (None, fromisoformat("2020-01-01 00:00:00"), 1),
+            (fromisoformat("2020-01-01 00:00:00"), fromisoformat("2020-01-01 01:00:00"), 3),
+            (fromisoformat("2020-01-01 01:00:00"), fromisoformat("2020-01-01 04:00:00"), 9),
+            (fromisoformat("2020-01-01 04:00:00"), fromisoformat("2020-01-01 13:00:00"), 27),
+            (fromisoformat("2020-01-01 13:00:00"), fromisoformat("2020-01-02 16:00:00"), 81),
+        ]:
+            interval = _get_retry_interval(last_checked, now)
+            self.assertEqual(interval, timedelta(hours=expected_interval_hours))
+
 
 # TODO: When we upgrade to Python 3.7, use datetime.fromisoformat() instead
 def fromisoformat(isoformat):


### PR DESCRIPTION
##### SUMMARY
Repeaters are supposed to retry failed attempts over a total period of at least 5 days to accommodate remote servers offline over a long weekend. This change adds one more retry to make that happen.

Review by commit
