### PR TITLE
Use Enterprise Subscription on Enterprise environments

### DIFF
--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from corehq.apps.accounting.models import (
     FeatureType,
     SoftwarePlanEdition,
@@ -203,12 +205,10 @@ def _ensure_feature_rates(feature_rates, features, edition, verbose, apps):
 
 
 def _clear_cache(software_plans, default_plans):
-    # Copy of clear_plan_version_cache()
-    # To run in a migration context it needs to get the objects from apps.get_model
-    from corehq.apps.accounting.models import (
-        SoftwarePlan, DefaultProductPlan, clear_get_default_plan_version_cache
-    )
+    from corehq.apps.accounting.models import SoftwarePlan, DefaultProductPlan
     for software_plan in software_plans:
         SoftwarePlan.get_version.clear(software_plan)
     for plan in default_plans:
-        clear_get_default_plan_version_cache(plan)
+        DefaultProductPlan.get_default_plan_version.clear(
+            DefaultProductPlan, plan.edition, plan.is_trial, plan.is_report_builder_enabled,
+        )

--- a/corehq/apps/accounting/bootstrap/utils.py
+++ b/corehq/apps/accounting/bootstrap/utils.py
@@ -94,7 +94,7 @@ def ensure_plans(config, verbose, apps):
                     % (default_product_plan.edition, is_trial)
                 )
 
-    _clear_cache(SoftwarePlan.objects.all())
+    _clear_cache(SoftwarePlan.objects.all(), DefaultProductPlan.objects.all())
 
 
 def _ensure_role(role_slug, apps):
@@ -202,7 +202,13 @@ def _ensure_feature_rates(feature_rates, features, edition, verbose, apps):
     return db_feature_rates
 
 
-def _clear_cache(software_plans):
-    from corehq.apps.accounting.models import SoftwarePlan
+def _clear_cache(software_plans, default_plans):
+    # Copy of clear_plan_version_cache()
+    # To run in a migration context it needs to get the objects from apps.get_model
+    from corehq.apps.accounting.models import (
+        SoftwarePlan, DefaultProductPlan, clear_get_default_plan_version_cache
+    )
     for software_plan in software_plans:
         SoftwarePlan.get_version.clear(software_plan)
+    for plan in default_plans:
+        clear_get_default_plan_version_cache(plan)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1727,16 +1727,16 @@ class Subscription(models.Model):
 
     @classmethod
     def get_active_subscription_by_domain(cls, domain_name_or_obj):
+        if settings.ENTERPRISE_MODE:
+            # Use the default plan, which is Enterprise when in ENTERPRISE_MODE
+            return None
         if isinstance(domain_name_or_obj, Domain):
             return cls._get_active_subscription_by_domain(domain_name_or_obj.name)
         return cls._get_active_subscription_by_domain(domain_name_or_obj)
 
     @classmethod
-    @quickcache(['domain_name'], timeout=60 * 60, skip_arg=lambda *args: settings.ENTERPRISE_MODE)
+    @quickcache(['domain_name'], timeout=60 * 60)
     def _get_active_subscription_by_domain(cls, domain_name):
-        if settings.ENTERPRISE_MODE:
-            # Use the default plan, which is Enterprise when in ENTERPRISE_MODE
-            return None
         try:
             return cls.visible_objects.select_related(
                 'plan_version__role'

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -785,6 +785,7 @@ class DefaultProductPlan(models.Model):
         unique_together = ('edition', 'is_trial', 'is_report_builder_enabled')
 
     @classmethod
+    @quickcache(['edition', 'is_trial', 'is_report_builder_enabled'], timeout=24 * 60 * 60)
     def get_default_plan_version(cls, edition=None, is_trial=False,
                                  is_report_builder_enabled=False):
         if not edition:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -784,22 +784,14 @@ class DefaultProductPlan(models.Model):
         app_label = 'accounting'
         unique_together = ('edition', 'is_trial', 'is_report_builder_enabled')
 
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        clear_get_default_plan_version_cache(self)
-
     @classmethod
+    @quickcache(['edition', 'is_trial', 'is_report_builder_enabled'],
+                skip_arg=lambda *args, **kwargs: not settings.ENTERPRISE_MODE or settings.UNIT_TESTING)
     def get_default_plan_version(cls, edition=None, is_trial=False,
                                  is_report_builder_enabled=False):
-        return cls._get_default_plan_version(
-            settings.ENTERPRISE_MODE, edition, is_trial, is_report_builder_enabled
-        )
-
-    @classmethod
-    @quickcache(['is_enterprise', 'edition', 'is_trial', 'is_report_builder_enabled'], timeout=24 * 60 * 60)
-    def _get_default_plan_version(cls, is_enterprise, edition, is_trial, is_report_builder_enabled):
         if not edition:
-            edition = SoftwarePlanEdition.ENTERPRISE if is_enterprise else SoftwarePlanEdition.COMMUNITY
+            edition = (SoftwarePlanEdition.ENTERPRISE if settings.ENTERPRISE_MODE
+                       else SoftwarePlanEdition.COMMUNITY)
         try:
             default_product_plan = DefaultProductPlan.objects.select_related('plan').get(
                 edition=edition, is_trial=is_trial,
@@ -820,15 +812,6 @@ class DefaultProductPlan(models.Model):
                 return (plan_version if return_plan
                         else plan_version.plan.edition)
         return None if return_plan else SoftwarePlanEdition.ENTERPRISE
-
-
-def clear_get_default_plan_version_cache(plan):
-    DefaultProductPlan._get_default_plan_version.clear(
-        DefaultProductPlan, settings.ENTERPRISE_MODE, plan.edition,
-        plan.is_trial, plan.is_report_builder_enabled,
-    )
-
-
 
 
 class SoftwarePlanVersion(models.Model):
@@ -857,8 +840,6 @@ class SoftwarePlanVersion(models.Model):
     def save(self, *args, **kwargs):
         super(SoftwarePlanVersion, self).save(*args, **kwargs)
         SoftwarePlan.get_version.clear(self.plan)
-        for plan in self.plan.defaultproductplan_set.all():
-            clear_get_default_plan_version_cache(plan)
 
     @property
     def version(self):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1731,7 +1731,7 @@ class Subscription(models.Model):
         return cls._get_active_subscription_by_domain(domain_name_or_obj)
 
     @classmethod
-    @quickcache(['domain_name'], timeout=60 * 60)
+    @quickcache(['domain_name'], timeout=60 * 60, skip_arg=lambda *args: settings.ENTERPRISE_MODE)
     def _get_active_subscription_by_domain(cls, domain_name):
         if settings.ENTERPRISE_MODE:
             # Use the default plan, which is Enterprise when in ENTERPRISE_MODE

--- a/corehq/apps/accounting/tests/test_customer_invoicing.py
+++ b/corehq/apps/accounting/tests/test_customer_invoicing.py
@@ -18,7 +18,6 @@ from corehq.apps.accounting.models import (
     DomainUserHistory,
     FeatureType,
     InvoicingPlan,
-    SoftwarePlan,
     SoftwarePlanEdition,
     Subscription,
 )
@@ -115,8 +114,7 @@ class BaseCustomerInvoiceCase(BaseAccountingTest):
             user.delete()
 
         if self.is_using_test_plans:
-            for software_plan in SoftwarePlan.objects.all():
-                SoftwarePlan.get_version.clear(software_plan)
+            utils.clear_plan_version_cache()
 
         super(BaseAccountingTest, self).tearDown()
 

--- a/corehq/apps/accounting/tests/test_enterprise_mode.py
+++ b/corehq/apps/accounting/tests/test_enterprise_mode.py
@@ -1,0 +1,32 @@
+from django.test import override_settings
+
+from corehq import privileges
+from corehq.apps.accounting.models import SoftwarePlanEdition
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
+from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.domain.shortcuts import create_domain
+
+ADVANCED_PRIVILEGE = privileges.CUSTOM_BRANDING  # chosen arbitrarily, feel free to change
+
+
+class TestEnterpriseMode(DomainSubscriptionMixin, BaseAccountingTest):
+
+    def setUp(self):
+        self.domain_obj = create_domain('test_enterprise_mode')
+
+    def tearDown(self):
+        self.domain_obj.delete()
+        domain_has_privilege.clear(self.domain_obj.name, ADVANCED_PRIVILEGE)
+
+    def test_standard_cant_access_advanced(self):
+        self.setup_subscription(self.domain_obj.name, SoftwarePlanEdition.STANDARD)
+        self.addCleanup(self.teardown_subscriptions)
+        self.assertFalse(self.domain_obj.has_privilege(ADVANCED_PRIVILEGE))
+
+    def test_no_plan_cant_access_anything(self):
+        self.assertFalse(self.domain_obj.has_privilege(ADVANCED_PRIVILEGE))
+
+    def test_enterprise_can_access_anything(self):
+        with override_settings(ENTERPRISE_MODE=True):
+            self.assertTrue(self.domain_obj.has_privilege(ADVANCED_PRIVILEGE))

--- a/corehq/apps/accounting/tests/test_enterprise_mode.py
+++ b/corehq/apps/accounting/tests/test_enterprise_mode.py
@@ -4,7 +4,10 @@ from corehq import privileges
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
-from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.accounting.utils import (
+    clear_plan_version_cache,
+    domain_has_privilege,
+)
 from corehq.apps.domain.shortcuts import create_domain
 
 ADVANCED_PRIVILEGE = privileges.CUSTOM_BRANDING  # chosen arbitrarily, feel free to change
@@ -22,6 +25,7 @@ class TestEnterpriseMode(DomainSubscriptionMixin, BaseAccountingTest):
     def test_standard_cant_access_advanced(self):
         self.setup_subscription(self.domain_obj.name, SoftwarePlanEdition.STANDARD)
         self.addCleanup(self.teardown_subscriptions)
+        self.addCleanup(clear_plan_version_cache)
         self.assertFalse(self.domain_obj.has_privilege(ADVANCED_PRIVILEGE))
 
     def test_no_plan_cant_access_anything(self):

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -20,7 +20,6 @@ from corehq.apps.accounting.models import (
     FeatureType,
     Invoice,
     LineItem,
-    SoftwarePlan,
     SoftwarePlanEdition,
     Subscriber,
     Subscription,
@@ -83,8 +82,7 @@ class BaseInvoiceTestCase(BaseAccountingTest):
         cls.domain.delete()
 
         if cls.is_using_test_plans:
-            for software_plan in SoftwarePlan.objects.all():
-                SoftwarePlan.get_version.clear(software_plan)
+            utils.clear_plan_version_cache()
 
         super(BaseInvoiceTestCase, cls).tearDownClass()
 

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -397,9 +397,13 @@ def is_downgrade(current_edition, next_edition):
 
 
 def clear_plan_version_cache():
-    from corehq.apps.accounting.models import SoftwarePlan
+    from corehq.apps.accounting.models import (
+        SoftwarePlan, DefaultProductPlan, clear_get_default_plan_version_cache
+    )
     for software_plan in SoftwarePlan.objects.all():
         SoftwarePlan.get_version.clear(software_plan)
+    for plan in DefaultProductPlan.objects.all():
+        clear_get_default_plan_version_cache(plan)
 
 
 def get_paused_plan_context(request, domain):

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -397,13 +397,9 @@ def is_downgrade(current_edition, next_edition):
 
 
 def clear_plan_version_cache():
-    from corehq.apps.accounting.models import (
-        SoftwarePlan, DefaultProductPlan, clear_get_default_plan_version_cache
-    )
+    from corehq.apps.accounting.models import SoftwarePlan
     for software_plan in SoftwarePlan.objects.all():
         SoftwarePlan.get_version.clear(software_plan)
-    for plan in DefaultProductPlan.objects.all():
-        clear_get_default_plan_version_cache(plan)
 
 
 def get_paused_plan_context(request, domain):

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -113,18 +113,18 @@ def request_new_domain(request, form, is_new_user=True):
         new_domain.save()  # we need to get the name from the _id
     dom_req.domain = new_domain.name
 
-    with transaction.atomic():
-        if not settings.ENTERPRISE_MODE:
+    if not settings.ENTERPRISE_MODE:
+        with transaction.atomic():
             ensure_community_or_paused_subscription(
                 new_domain.name, date.today(), SubscriptionAdjustmentMethod.USER,
                 web_user=current_user.username,
             )
 
-    # add user's email as contact email for billing account for the domain
-    account = BillingAccount.get_account_by_domain(new_domain.name)
-    billing_contact, _ = BillingContactInfo.objects.get_or_create(account=account)
-    billing_contact.email_list = [current_user.email]
-    billing_contact.save()
+        # add user's email as contact email for billing account for the domain
+        account = BillingAccount.get_account_by_domain(new_domain.name)
+        billing_contact, _ = BillingContactInfo.objects.get_or_create(account=account)
+        billing_contact.email_list = [current_user.email]
+        billing_contact.save()
 
     UserRole.init_domain_with_presets(new_domain.name)
 

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -113,10 +113,11 @@ def request_new_domain(request, form, is_new_user=True):
         new_domain.save()  # we need to get the name from the _id
 
     with transaction.atomic():
-        ensure_community_or_paused_subscription(
-            new_domain.name, date.today(), SubscriptionAdjustmentMethod.USER,
-            web_user=current_user.username,
-        )
+        if not settings.ENTERPRISE_MODE:
+            ensure_community_or_paused_subscription(
+                new_domain.name, date.today(), SubscriptionAdjustmentMethod.USER,
+                web_user=current_user.username,
+            )
 
     UserRole.init_domain_with_presets(new_domain.name)
 

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -111,6 +111,7 @@ def request_new_domain(request, form, is_new_user=True):
     if not new_domain.name:
         new_domain.name = new_domain._id
         new_domain.save()  # we need to get the name from the _id
+    dom_req.domain = new_domain.name
 
     with transaction.atomic():
         if not settings.ENTERPRISE_MODE:
@@ -119,15 +120,13 @@ def request_new_domain(request, form, is_new_user=True):
                 web_user=current_user.username,
             )
 
-    UserRole.init_domain_with_presets(new_domain.name)
-
     # add user's email as contact email for billing account for the domain
     account = BillingAccount.get_account_by_domain(new_domain.name)
     billing_contact, _ = BillingContactInfo.objects.get_or_create(account=account)
     billing_contact.email_list = [current_user.email]
     billing_contact.save()
 
-    dom_req.domain = new_domain.name
+    UserRole.init_domain_with_presets(new_domain.name)
 
     if request.user.is_authenticated:
         if not current_user:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-64

##### PRODUCT DESCRIPTION
Make all domains on enterprise environments use the enterprise subscription

##### SUMMARY
Enterprise environments don't need subscriptions - we typically enable "Dimagi Only CommCare Enterprise Edition" manually on these environments, but it must be done for every domain, and we already hide links to the subscription pages, so doing so is unintuitive.  We instruct people to enable it for the command line, but it's easy to forget to do this, especially on secondary domains.

This PR proposes an alternative approach - setting `ENTERPRISE` as the default plan, and always returning that.  It looks everything goes through `Subscription.get_active_subscription_by_domain` or `Subscription.get_subscribed_plan_by_domain` (which calls the former), and both use `DefaultProductPlan.get_default_plan_version`, so that's what I modified here.

This feels like a fairly impactful change, so I'd be interested to hear if anyone has a proposal for ensuring that it works as I'd hope - are there weird edge cases where it will select a plan through some other means?  It seems to behave well when I click around locally.

@snopoke @calellowitz pinging you as I see your names in git blame for much of the `ENTERPRISE_MODE` stuff.  I'd initially planned on making a new flag for this purpose, but this seems to be very much in-line with how I'd imagine that flag to work.  Have you considered this sort of approach before?  Any concerns I might not have thought of?

An alternative approach here would be to modify `request_new_domain` to always create an enterprise subscription when new domains are created.  That feels a bit messier (there's no need for them, really - and what if they need to be updated?), though perhaps a bit safer.

##### FEATURE FLAG


