### PR TITLE
[Amazon SES] Responses to #26353

### DIFF
--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -109,12 +109,11 @@ def mail_admins_async(self, subject, message, fail_silently=False, connection=No
 def process_bounced_emails():
     if settings.RETURN_PATH_EMAIL and settings.RETURN_PATH_EMAIL_PASSWORD:
         try:
-            bounced_manager = BouncedEmailManager(
+            with BouncedEmailManager(
                 delete_processed_messages=True
-            )
-            bounced_manager.process_bounces()
-            bounced_manager.process_complaints()
-            bounced_manager.logout()
+            ) as bounced_manager:
+                bounced_manager.process_bounces()
+                bounced_manager.process_complaints()
         except Exception as e:
             notify_exception(
                 None,

--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -25,11 +25,11 @@ def get_valid_recipients(recipients):
     :return: list of recipient emails not marked as bounced
     """
     from corehq.util.models import BouncedEmail
-    valid_recipients = []
-    for recipient in recipients:
-        if not BouncedEmail.objects.filter(email=recipient).exists():
-            valid_recipients.append(recipient)
-    return valid_recipients
+    bounced_emails = set(
+        BouncedEmail.objects.filter(email__in=recipients).values_list(
+            'email', flat=True)
+    )
+    return [recipient for recipient in recipients if recipient not in bounced_emails]
 
 
 def send_HTML_email(subject, recipient, html_content, text_content=None,

--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -18,11 +18,18 @@ class BouncedEmailManager(object):
 
     def __init__(self, delete_processed_messages=True):
         self.delete_processed_messages = delete_processed_messages
+
+    def __enter__(self):
         self.mail = imaplib.IMAP4_SSL(EMAIL_SERVER)
         self.mail.login(
             settings.RETURN_PATH_EMAIL,
             settings.RETURN_PATH_EMAIL_PASSWORD
         )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.mail.close()
+        self.mail.logout()
 
     def _get_messages(self, header_search):
         result, data = self.mail.uid('search', None, header_search)

--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -13,6 +13,11 @@ EMAIL_SERVER = 'imap.gmail.com'
 BOUNCE_DAEMON = 'MAILER-DAEMON@amazonses.com'
 COMPLAINTS_DAEMON = 'complaints@email-abuse.amazonses.com'
 
+# From http://regexlib.com/REDetails.aspx?regexp_id=295
+EMAIL_REGEX = r'(([A-Za-z0-9]+_+)|([A-Za-z0-9]+\-+)|([A-Za-z0-9]+\.+)|' \
+              r'([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+\-+)|(\w+\.))' \
+              r'*\w{1,63}\.[a-zA-Z]{2,6}'
+
 
 class BouncedEmailManager(object):
 
@@ -97,7 +102,7 @@ class BouncedEmailManager(object):
             f'From "{BOUNCE_DAEMON}")'
         ):
             email_regex = re.search(
-                r'(\w+[.|\w])*@(\w+[.])*\w+',
+                EMAIL_REGEX,
                 self._get_message_body(message)
             )
             if email_regex:

--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -101,14 +101,21 @@ class BouncedEmailManager(object):
             f'Subject "{subject}" '
             f'From "{BOUNCE_DAEMON}")'
         ):
-            email_regex = re.search(
-                EMAIL_REGEX,
-                self._get_message_body(message)
-            )
-            if email_regex:
-                bounced_email = email_regex.group()
+            bounced_email = self._get_forwarded_message_recipient(message)
+            if bounced_email:
                 self._mark_email_as_bounced(bounced_email, uid)
                 processed_emails.append(bounced_email)
+            else:
+                # fall back to using the REGEX as a last resort, in case these
+                # messages don't contain a forwarded email
+                email_regex = re.search(
+                    EMAIL_REGEX,
+                    self._get_message_body(message)
+                )
+                if email_regex:
+                    bounced_email = email_regex.group()
+                    self._mark_email_as_bounced(bounced_email, uid)
+                    processed_emails.append(bounced_email)
         return processed_emails
 
     def process_bounces(self):

--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -78,11 +78,8 @@ class BouncedEmailManager(object):
 
         self.mail.select('inbox')
         for uid, message in self._get_messages(
-            '(Header Delivered-To "{}" '
-            'From "{}")'.format(
-                settings.RETURN_PATH_EMAIL,
-                COMPLAINTS_DAEMON
-            )
+            f'(Header Delivered-To "{settings.RETURN_PATH_EMAIL}" '
+            f'From "{COMPLAINTS_DAEMON}")'
         ):
             complaint_email = self._get_forwarded_message_recipient(message)
             if complaint_email:
@@ -95,13 +92,9 @@ class BouncedEmailManager(object):
         processed_emails = []
         self.mail.select('inbox')
         for uid, message in self._get_messages(
-            '(Header Delivered-To "{}" '
-            'Subject "{}" '
-            'From "{}")'.format(
-                settings.RETURN_PATH_EMAIL,
-                subject,
-                BOUNCE_DAEMON
-            )
+            f'(Header Delivered-To "{settings.RETURN_PATH_EMAIL}" '
+            f'Subject "{subject}" '
+            f'From "{BOUNCE_DAEMON}")'
         ):
             email_regex = re.search(
                 r'(\w+[.|\w])*@(\w+[.])*\w+',

--- a/corehq/util/management/commands/process_bounced_emails.py
+++ b/corehq/util/management/commands/process_bounced_emails.py
@@ -38,17 +38,16 @@ class Command(BaseCommand):
             self.stdout.write(
                 '\n\nLogging into account for {}\n'.format(settings.RETURN_PATH_EMAIL)
             )
-            bounced_manager = BouncedEmailManager(
+            with BouncedEmailManager(
                 delete_processed_messages=delete_messages
-            )
+            ) as bounced_manager:
 
-            self.stdout.write('\n\nProcessing Bounces\n')
-            self._print_processed_emails(bounced_manager.process_bounces())
+                self.stdout.write('\n\nProcessing Bounces\n')
+                self._print_processed_emails(bounced_manager.process_bounces())
 
-            self.stdout.write('\n\nProcessing Complaints\n')
-            self._print_processed_emails(bounced_manager.process_complaints())
+                self.stdout.write('\n\nProcessing Complaints\n')
+                self._print_processed_emails(bounced_manager.process_complaints())
 
-            self.stdout.write('\nLogging Out\n\n')
-            bounced_manager.logout()
+            self.stdout.write('\nDone\n\n')
         except OSError:
             self.stdout.write('Not able to connect at this time\n')


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10227

##### SUMMARY
This addresses some of the feedback left in the previous PR https://github.com/dimagi/commcare-hq/pull/26353. 

Still remaining:
- process / UI for checking what emails have been bounced and re-enabling them
- error throwing and handling root issues upstream
    - clean-up any scheduled reports that are only sending to bouncing emails
    - flag accounts with bounced emails for deletion
- add a way to archive soft bounces and internal Dimagi emails (ie all-hands notifications)
- monitoring system for flagging if any emails went unprocessed so that someone checks the `commcarehq-bounces@dimagi.com` inbox directly for any missed edge cases
