### PR TITLE
Couch to SQL forms & cases: parallel case diff

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -702,6 +702,7 @@ def diff_case(sql_case, couch_case, statedb):
     diffs = json_diff(couch_case, sql_case_json, track_list_indices=False)
     diffs = filter_case_diffs(couch_case, sql_case_json, diffs, statedb)
     if diffs and not sql_case.is_deleted:
+        # TODO rebuild SQL case with couch action order
         try:
             couch_case, diffs = rebuild_couch_case_and_re_diff(
                 couch_case, sql_case_json, statedb)

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -675,14 +675,16 @@ def diff_cases(couch_cases, statedb):
     case_ids = list(couch_cases)
     sql_cases = CaseAccessorSQL.get_cases(case_ids)
     sql_case_ids = set()
+    all_diffs = []
     for sql_case in sql_cases:
         sql_case_ids.add(sql_case.case_id)
         couch_case = couch_cases[sql_case.case_id]
         couch_case, diffs = diff_case(sql_case, couch_case, statedb)
-        statedb.replace_case_diffs(couch_case['doc_type'], sql_case.case_id, diffs)
+        all_diffs.append((couch_case['doc_type'], sql_case.case_id, diffs))
         counts[couch_case['doc_type']] += 1
 
-    diff_ledgers(case_ids, statedb)
+    all_diffs.extend(iter_ledger_diffs(case_ids))
+    statedb.replace_case_diffs(all_diffs)
 
     if len(case_ids) != len(sql_case_ids):
         couch_ids = set(case_ids)
@@ -724,7 +726,7 @@ def rebuild_couch_case_and_re_diff(couch_case, sql_case_json, statedb):
     return rebuilt_case_json, diffs
 
 
-def diff_ledgers(case_ids, statedb):
+def iter_ledger_diffs(case_ids):
     log.debug('Calculating ledger diffs for {} cases'.format(len(case_ids)))
     couch_state_map = {
         state.ledger_reference: state
@@ -734,9 +736,10 @@ def diff_ledgers(case_ids, statedb):
         couch_state = couch_state_map.get(ledger_value.ledger_reference, None)
         couch_json = couch_state.to_json() if couch_state is not None else {}
         diffs = json_diff(couch_json, ledger_value.to_json(), track_list_indices=False)
-        statedb.add_diffs(
-            'stock state', ledger_value.ledger_reference.as_id(),
-            filter_ledger_diffs(diffs)
+        yield (
+            'stock state',
+            ledger_value.ledger_reference.as_id(),
+            filter_ledger_diffs(diffs),
         )
 
 

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -427,7 +427,7 @@ class CouchSqlDomainMigrator:
         yield from _iter_skipped_forms(
             self.domain, migration_id, self.stopper, self._with_progress)
 
-    def _get_resumable_iterator(self, doc_types):
+    def _get_resumable_iterator(self, doc_types, **kw):
         # resumable iteration state is associated with statedb.unique_id,
         # so it will be reset (orphaned in couch) if that changes
         migration_id = self.statedb.unique_id
@@ -435,7 +435,7 @@ class CouchSqlDomainMigrator:
             yield from iter_unmigrated_docs(
                 self.domain, doc_types, migration_id, self.counter)
         docs = self._iter_docs(doc_types, migration_id)
-        yield from self._with_progress(doc_types, docs)
+        yield from self._with_progress(doc_types, docs, **kw)
 
     def _iter_docs(self, doc_types, migration_id):
         for doc_type in doc_types:
@@ -1002,6 +1002,7 @@ class DocCounter:
 
     def __enter__(self):
         self.timing.start()
+        return self
 
     def __exit__(self, *exc_info):
         self.timing.stop()

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -101,6 +101,7 @@ load_ignore_rules = memoized(lambda: add_duplicate_rules({
         # CASE_IGNORED_DIFFS
         Ignore('type', 'name', old='', new=None),
         Ignore('type', 'closed_by', old='', new=None),
+        Ignore('diff', 'closed_by', old=''),
         Ignore('missing', 'location_id', old=MISSING, new=None),
         Ignore('missing', 'referrals', new=MISSING),
         Ignore('missing', 'location_', new=MISSING),

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -210,8 +210,7 @@ class CaseDiffTool:
                 yield data
                 diffs = {case_id: diffs for x, case_id, diffs in data.diffs if diffs}
                 if diffs:
-                    log.info("found cases with diffs:\n%s",
-                        "\n".join(sorted(diffs)))
+                    log.info("found cases with diffs:\n%s", format_diffs(diffs))
                     if stop:
                         pdb.set_trace()
 
@@ -314,6 +313,23 @@ def add_missing_docs(data, couch_cases, sql_case_ids):
         log.debug("Found %s missing SQL cases", len(missing_cases))
         for doc_type, doc_ids in filter_missing_cases(missing_cases):
             data.missing_docs.append((doc_type, doc_ids))
+
+
+def format_diffs(diff_dict):
+    lines = []
+    for doc_id, diffs in sorted(diff_dict.items()):
+        lines.append(doc_id)
+        for diff in diffs:
+            if len(repr(diff.old_value) + repr(diff.new_value)) > 60:
+                lines.append(f"  {diff.diff_type} {list(diff.path)}")
+                lines.append(f"    - {diff.old_value!r}")
+                lines.append(f"    + {diff.new_value!r}")
+            else:
+                lines.append(
+                    f"  {diff.diff_type} {list(diff.path)}"
+                    f" {diff.old_value!r} -> {diff.new_value!r}"
+                )
+    return "\n".join(lines)
 
 
 def init_worker(domain, *args):

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -105,13 +105,14 @@ class CaseDiffTool:
         self.migrator = migrator
         self.domain = migrator.domain
         self.statedb = migrator.statedb
-        if migrator.live_migrate:
-            assert not hasattr(migrator.stopper, "stop_date")  # TODO use if set
+        if not migrator.live_migrate:
+            cutoff_date = None
+        elif hasattr(migrator.stopper, "stop_date"):
+            cutoff_date = migrator.stopper.stop_date
+        else:
             cutoff_date = get_main_forms_iteration_stop_date(
                 self.domain, self.statedb.unique_id)
             migrator.stopper.stop_date = cutoff_date
-        else:
-            cutoff_date = None
         self.cutoff_date = cutoff_date
 
     @contextmanager

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -28,6 +28,7 @@ from ...casediff import ProcessNotAllowed, filter_missing_cases, get_casediff_st
 from ...couchsqlmigration import (
     CouchSqlDomainMigrator,
     get_main_forms_iteration_stop_date,
+    migration_patches,
     setup_logging,
 )
 from ...diff import filter_case_diffs, filter_ledger_diffs
@@ -163,9 +164,9 @@ class CaseDiffTool:
     def iter_diff_specific_cases(self):
         case_ids = get_ids_from_string_or_file(self.cases)
         batches = chunked(case_ids, DIFF_BATCH_SIZE, list)
-        init_worker(*self.initargs)
-        for batch in batches:
-            yield diff_cases(batch, log_cases=True)
+        with init_worker(*self.initargs):
+            for batch in batches:
+                yield diff_cases(batch, log_cases=True)
 
     def resumable_iter_diff_cases(self):
         batches = chunked(self.iter_case_ids(), DIFF_BATCH_SIZE, self.diff_batch)
@@ -306,6 +307,7 @@ def init_worker(domain, *args):
     clean_break = False
     signal.signal(signal.SIGINT, on_break)
     set_local_domain_sql_backend_override(domain)
+    return migration_patches()
 
 
 @attr.s

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -1,0 +1,216 @@
+import logging
+import os
+import sys
+from contextlib import contextmanager
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+import attr
+
+from dimagi.utils.chunked import chunked
+
+from corehq.apps.commtrack.models import StockState
+from corehq.apps.domain.models import Domain
+from corehq.apps.tzmigration.timezonemigration import json_diff
+from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
+from corehq.form_processor.backends.sql.dbaccessors import (
+    CaseAccessorSQL,
+    LedgerAccessorSQL,
+)
+from corehq.form_processor.utils import should_use_sql_backend
+from corehq.form_processor.utils.general import set_local_domain_sql_backend_override
+
+from ...casediff import filter_missing_cases
+from ...couchsqlmigration import (
+    CouchSqlDomainMigrator,
+    get_main_forms_iteration_stop_date,
+    setup_logging,
+)
+from ...diff import filter_case_diffs, filter_ledger_diffs
+from ...parallel import Pool
+
+log = logging.getLogger(__name__)
+
+DIFF_BATCH_SIZE = 100
+
+
+class Command(BaseCommand):
+    help = "Diff data in couch and SQL with parallel worker processes"
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain')
+        parser.add_argument('--no-input', action='store_true', default=False)
+        parser.add_argument('--debug', action='store_true', default=False)
+        parser.add_argument('--state-dir',
+            default=os.environ.get("CCHQ_MIGRATION_STATE_DIR"),
+            required="CCHQ_MIGRATION_STATE_DIR" not in os.environ,
+            help="""
+                Directory for couch2sql logs and migration state. This must not
+                reside on an NFS volume for migration state consistency.
+                Can be set in environment: CCHQ_MIGRATION_STATE_DIR
+            """)
+        parser.add_argument('--live',
+            dest="live", action='store_true', default=False,
+            help='''
+                Do not diff cases modified after the most recently
+                migrated form.
+            ''')
+
+    def handle(self, domain, **options):
+        if should_use_sql_backend(domain):
+            raise CommandError('It looks like {} has already been migrated.'.format(domain))
+
+        for opt in ["no_input", "state_dir", "live"]:
+            setattr(self, opt, options[opt])
+
+        if self.no_input and not settings.UNIT_TESTING:
+            raise CommandError('--no-input only allowed for unit testing')
+
+        assert Domain.get_by_name(domain), f'Unknown domain "{domain}"'
+        setup_logging(self.state_dir, "case_diff", options['debug'])
+        migrator = get_migrator(domain, self.state_dir, self.live)
+        msg = do_case_diffs(migrator)
+        if msg:
+            sys.exit(msg)
+
+
+def get_migrator(domain, state_dir, live):
+    # Set backend for CouchSqlDomainMigrator._check_for_migration_restrictions
+    set_local_domain_sql_backend_override(domain)
+    return CouchSqlDomainMigrator(
+        domain, state_dir, live_migrate=live, diff_process=None)
+
+
+def do_case_diffs(migrator):
+    def save_result(data):
+        log.debug(data)
+        add_cases(len(data.doc_ids))
+        statedb.add_diffed_cases(data.doc_ids)
+        for doc_type, doc_id, diffs in data.diffs:
+            statedb.add_diffs(doc_type, doc_id, diffs)
+        for doc_type, doc_ids in data.missing_docs:
+            statedb.add_missing_docs(doc_type, doc_ids)
+
+    casediff = CaseDiffTool(migrator)
+    statedb = casediff.statedb
+    with casediff.context() as add_cases:
+        for data in casediff.iter_case_diff_results():
+            save_result(data)
+
+
+class CaseDiffTool:
+
+    def __init__(self, migrator):
+        self.migrator = migrator
+        self.domain = migrator.domain
+        self.statedb = migrator.statedb
+        if migrator.live_migrate:
+            assert not hasattr(migrator.stopper, "stop_date")  # TODO use if set
+            cutoff_date = get_main_forms_iteration_stop_date(
+                self.domain, self.statedb.unique_id)
+            migrator.stopper.stop_date = cutoff_date
+        else:
+            cutoff_date = None
+        self.cutoff_date = cutoff_date
+
+    @contextmanager
+    def context(self):
+        with self.migrator.counter as counter, self.migrator.stopper:
+            with counter('diff_cases', 'CommCareCase') as add_cases:
+                yield add_cases
+
+    def iter_case_diff_results(self):
+        batches = chunked(self.iter_case_ids(), DIFF_BATCH_SIZE, list)
+        pool = Pool(initializer=init_worker, initargs=self.initargs, maxtasksperchild=100)
+        yield from pool.imap_unordered(diff_cases, batches)
+
+    def is_stopped(self):
+        return self.migrator.stopper.clean_break
+
+    def iter_case_ids(self):
+        return self.migrator._get_resumable_iterator(
+            ['CommCareCase.id'],
+            progress_name="Diff",
+            offset_key='CommCareCase.id',
+        )
+
+    @property
+    def initargs(self):
+        return self.statedb.get_no_action_case_forms(), self.cutoff_date
+
+
+def diff_cases(case_ids):
+    couch_cases = {c.case_id: c.to_json()
+        for c in CaseAccessorCouch.get_cases(case_ids) if _state.should_diff(c)}
+    case_ids = list(couch_cases)
+    data = DiffData(case_ids)
+    sql_case_ids = set()
+    for sql_case in CaseAccessorSQL.get_cases(case_ids):
+        case_id = sql_case.case_id
+        sql_case_ids.add(case_id)
+        couch_case = couch_cases[case_id]
+        diffs = diff_case(sql_case, couch_case)
+        data.diffs.append((couch_case['doc_type'], case_id, diffs))
+
+    data.diffs.extend(iter_ledger_diffs(case_ids))
+    add_missing_docs(data, couch_cases, sql_case_ids)
+    return data
+
+
+def diff_case(sql_case, couch_case):
+    sql_case_json = sql_case.to_json()
+    diffs = json_diff(couch_case, sql_case_json, track_list_indices=False)
+    return filter_case_diffs(couch_case, sql_case_json, diffs, _state)
+
+
+def iter_ledger_diffs(case_ids):
+    couch_state_map = {
+        state.ledger_reference: state
+        for state in StockState.objects.filter(case_id__in=case_ids)
+    }
+    for ledger_value in LedgerAccessorSQL.get_ledger_values_for_cases(case_ids):
+        couch_state = couch_state_map.get(ledger_value.ledger_reference, None)
+        couch_json = couch_state.to_json() if couch_state is not None else {}
+        diffs = json_diff(couch_json, ledger_value.to_json(), track_list_indices=False)
+        ref_id = ledger_value.ledger_reference.as_id()
+        yield "stock state", ref_id, filter_ledger_diffs(diffs)
+
+
+def add_missing_docs(data, couch_cases, sql_case_ids):
+    if len(couch_cases) != len(sql_case_ids):
+        only_in_sql = sql_case_ids - couch_cases.keys()
+        assert not only_in_sql, only_in_sql
+        only_in_couch = couch_cases.keys() - sql_case_ids
+        missing_cases = [couch_cases[x] for x in only_in_couch]
+        log.debug("Found %s missing SQL cases", len(missing_cases))
+        for doc_type, doc_ids in filter_missing_cases(missing_cases):
+            data.missing_docs.append((doc_type, doc_ids))
+
+
+def init_worker(*args):
+    global _state
+    _state = WorkerState(*args)
+
+
+@attr.s
+class DiffData:
+    doc_ids = attr.ib()
+    diffs = attr.ib(factory=list)
+    missing_docs = attr.ib(factory=list)
+
+
+@attr.s
+class WorkerState:
+    forms = attr.ib(repr=lambda v: f"[{len(v)} ids]")
+    cutoff_date = attr.ib()
+
+    def __attrs_post_init__(self):
+        if self.cutoff_date is None:
+            self.should_diff = lambda case: True
+
+    def get_no_action_case_forms(self):
+        return self.forms
+
+    def should_diff(self, case):
+        return case.server_modified_on < self.cutoff_date

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -106,11 +106,7 @@ def do_case_diffs(migrator, cases):
         log.debug(data)
         add_cases(len(data.doc_ids))
         statedb.add_diffed_cases(data.doc_ids)
-        for doc_type, doc_id, diffs in data.diffs:
-            if doc_type == "stock state":
-                statedb.add_diffs(doc_type, doc_id, diffs)
-            else:
-                statedb.replace_case_diffs(doc_type, doc_id, diffs)
+        statedb.replace_case_diffs(data.diffs)
         for doc_type, doc_ids in data.missing_docs:
             statedb.add_missing_docs(doc_type, doc_ids)
 

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import signal
 import sys
 from contextlib import contextmanager
 
@@ -198,8 +199,17 @@ def add_missing_docs(data, couch_cases, sql_case_ids):
 
 
 def init_worker(*args):
+    def on_break(signum, frame):
+        nonlocal clean_break
+        if clean_break:
+            raise KeyboardInterrupt
+        print("clean break... (Ctrl+C to abort)")
+        clean_break = True
+
     global _state
     _state = WorkerState(*args)
+    clean_break = False
+    signal.signal(signal.SIGINT, on_break)
 
 
 @attr.s

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -132,8 +132,10 @@ class Command(BaseCommand):
         parser.add_argument('--forms', default=None,
             help="""
                 Migrate specific forms. The value of this option should
-                be a space-delimited list of form ids OR 'skipped' to
-                migrate forms skipped by previous migration.
+                be a space-delimited list of form ids OR a file path to
+                a file having one form id per line OR 'skipped' to
+                migrate forms skipped by previous migration. The file
+                path must begin with / or ./
             """)
         parser.add_argument('-x', '--stop-on-error',
             dest="stop_on_error", action='store_true', default=False,

--- a/corehq/apps/couch_sql_migration/rebuildcase.py
+++ b/corehq/apps/couch_sql_migration/rebuildcase.py
@@ -1,0 +1,161 @@
+from datetime import timedelta
+
+from dimagi.ext.jsonobject import DictProperty, StringProperty
+
+from corehq.form_processor.backends.sql.processor import FormProcessorSQL
+from corehq.form_processor.backends.sql.update_strategy import (
+    _transaction_sort_key_function as transaction_key
+)
+from corehq.form_processor.models import RebuildWithReason
+
+
+def is_action_order_equal(sql_case, couch_json):
+    """Check if sql and couch cases had forms applied in the same order
+
+    :param sql_case: `CommCareCaseSQL` object.
+    :param couch_json: `CommCareCase` JSON (dict, not string).
+    :returns: True if (trans)action order matches else false.
+    """
+    def dedup(items):
+        return list(dict.fromkeys(items))
+    sql_ids = dedup(t.form_id for t in sql_case.transactions if t.form_id)
+    couch_ids = dedup(a["xform_id"] for a in couch_json["actions"] if a["xform_id"])
+    return sql_ids == couch_ids
+
+
+def was_rebuilt(sql_case):
+    """Check if most recent case transaction is a sort rebuild"""
+    details = sql_case.transactions[-1].details if sql_case.transactions else None
+    return details and details["reason"] == SortTransactionsRebuild._REASON
+
+
+def rebuild_case_with_couch_action_order(sql_case):
+    server_dates = update_transaction_order(sql_case)
+    detail = SortTransactionsRebuild(original_server_dates=server_dates)
+    return FormProcessorSQL.hard_rebuild_case(
+        sql_case.domain, sql_case.case_id, detail)
+
+
+def update_transaction_order(sql_case):
+    """Update SQL case transactions so they match couch actions
+
+    SQL case transactions are sorted by `transaction.server_date`.
+    See corehq/sql_accessors/sql_templates/get_case_transactions_by_type.sql
+    """
+    server_dates = {}
+    transactions = sorted(sql_case.transactions, key=transaction_key(sql_case))
+    old_dates = [t.server_date for t in transactions]
+    new_dates = iter_ascending_dates(old_dates)
+    for trans, new_date in zip(transactions, new_dates):
+        if trans.server_date != new_date:
+            server_dates[trans.id] = trans.server_date
+            trans.server_date = new_date
+            trans.save()
+    return server_dates
+
+
+class SortTransactionsRebuild(RebuildWithReason):
+    _REASON = 'Couch to SQL: sort transactions'
+    reason = StringProperty(default=_REASON)
+    original_server_dates = DictProperty()
+
+
+def iter_ascending_dates(dates):
+    """Adjust unordered dates so they are in ascending order
+
+    Adjust a minimal number of dates so the resulting sequence of dates
+    is in ascending order. Each non-ascending date is replaced with a
+    new date that falls between the dates before and after in the
+    sequence.
+
+    :param dates: Sequence of `datetime` objects.
+    :returns: Sequence of `datetime` objects in ascending order.
+    """
+    if is_strictly_ascending(dates):
+        yield from dates
+        return
+
+    def getnext(i):
+        j = i + 1
+        if j in next_cache:
+            return next_cache.pop(j)
+        if j in keepset:
+            next_cache[j] = dates[j], 1
+        elif j < len(dates):
+            nxt, span = getnext(j)
+            next_cache[j] = nxt, (span + 1 if span else None)
+        else:
+            next_cache[j] = None, None
+        return next_cache[j]
+
+    keepset = set(longest_increasing_subsequence_indices(dates))
+    next_cache = {}
+    prev = None
+    minute = timedelta(minutes=1)
+    for i, value in enumerate(dates):
+        if i not in keepset:
+            nxt, span = getnext(i)
+            if not nxt:
+                value = prev + minute
+            elif not prev:
+                value = nxt - (minute * span)
+            else:
+                step = (nxt - prev) / (span + 1)
+                value = prev + step
+        yield value
+        prev = value
+
+
+def longest_increasing_subsequence_indices(values):
+    """Get indices of the longest strictly increasing subsequence of values
+
+    O(n log n) algorithm based on solution form Wikipedia
+    https://en.wikipedia.org/wiki/Longest_increasing_subsequence#Efficient_algorithms
+
+    - Use more descriptive variable names.
+    - Use < rather than <= when comparing values in binary search
+      to make the result strictly increasing (no equal values).
+
+    :param values: A sequence of values.
+    :returns: A list of indices.
+    """
+    if not values:
+        return values
+    n = len(values)
+    predecessor_index = []
+    longest_seq_start = [None] * (n + 1)
+    longest = 0
+    for i, current in enumerate(values):
+        # Binary search for the largest positive j <= longest
+        # such that values[longest_seq_start[j]] < current
+        lo = 1
+        hi = longest
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            if values[longest_seq_start[mid]] < current:
+                lo = mid + 1
+            else:
+                hi = mid - 1
+
+        # After searching, lo is 1 greater than the
+        # length of the longest prefix of current
+        new_longest = lo
+
+        # The predecessor of current is the last index of
+        # the subsequence of length new_longest - 1
+        predecessor_index.append(longest_seq_start[new_longest - 1])
+        longest_seq_start[new_longest] = i
+
+        if new_longest > longest:
+            longest = new_longest
+
+    solution = [None] * longest
+    k = longest_seq_start[longest]
+    for i in range(longest - 1, -1, -1):
+        solution[i] = k
+        k = predecessor_index[k]
+    return solution
+
+
+def is_strictly_ascending(items):
+    return all(a < b for a, b in zip(items, items[1:]))

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -192,6 +192,15 @@ class StateDB(DiffDB):
             query = session.query(CaseForms.total_forms).filter_by(case_id=case_id)
             return query.scalar() or 0
 
+    def add_diffed_cases(self, case_ids):
+        with self.session() as session:
+            session.bulk_save_objects([DiffedCase(id=id) for id in case_ids])
+
+    def iter_diffed_cases(self):
+        query = self.Session().query(DiffedCase.id)
+        for case_id, in iter_large(query, DiffedCase.id):
+            yield case_id
+
     def add_problem_form(self, form_id):
         """Add form to be migrated with "unprocessed" forms
 
@@ -413,6 +422,12 @@ class CaseForms(Base):
     case_id = Column(String(50), nullable=False, primary_key=True)
     total_forms = Column(Integer, nullable=False)
     processed_forms = Column(Integer, nullable=False, default=0)
+
+
+class DiffedCase(Base):
+    __tablename__ = 'diffed_case'
+
+    id = Column(String(50), nullable=False, primary_key=True)
 
 
 class DocCount(Base):

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -318,6 +318,8 @@ class StateDB(DiffDB):
 
     def replace_case_diffs(self, case_diffs):
         from .couchsqlmigration import CASE_DOC_TYPES
+        if not case_diffs:
+            return
         new_diffs = []
         conditions = []
         seen = set()
@@ -340,6 +342,7 @@ class StateDB(DiffDB):
                     and_(Diff.kind == "stock state", Diff.doc_id.startswith(case_id + "/")),
                 ))
             )
+        assert conditions, case_diffs  # avoid deleting all existing diffs
         with self.session() as session:
             session.query(Diff).filter(or_(*conditions)).delete(synchronize_session=False)
         for kind, case_id, diffs in new_diffs:

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     func,
     or_,
 )
+from sqlalchemy.event import listen
 from sqlalchemy.exc import IntegrityError
 
 from corehq.apps.tzmigration.planning import Base, DiffDB, PlanningDiff as Diff
@@ -70,6 +71,7 @@ class StateDB(DiffDB):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
+        listen(self.engine, "connect", case_sensitive_like)
         self.is_rebuild = False
 
     def __enter__(self):
@@ -314,19 +316,33 @@ class StateDB(DiffDB):
         if diffs:
             self.add_diffs(doc_type, doc_id, diffs)
 
-    def replace_case_diffs(self, kind, case_id, diffs):
+    def replace_case_diffs(self, case_diffs):
         from .couchsqlmigration import CASE_DOC_TYPES
-        assert kind in CASE_DOC_TYPES, kind
-        with self.session() as session:
-            (
-                session.query(Diff)
-                .filter(or_(
-                    and_(Diff.kind == "CommCareCase", Diff.doc_id == case_id),
+        new_diffs = []
+        conditions = []
+        seen = set()
+        for kind, case_id, diffs in case_diffs:
+            if diffs:
+                new_diffs.append((kind, case_id, diffs))
+            if kind == "stock state":
+                assert case_id.count("/") == 2, case_id
+                case_id = case_id.split("/", 1)[0]
+                kind = "CommCareCase"
+            else:
+                assert kind in CASE_DOC_TYPES, kind
+            if case_id in seen:
+                continue
+            seen.add(case_id)
+            # optimized for one index scan per condition; profile after editing
+            conditions.append(
+                and_(Diff.doc_id.startswith(case_id), or_(
+                    and_(Diff.kind == kind, Diff.doc_id == case_id),
                     and_(Diff.kind == "stock state", Diff.doc_id.startswith(case_id + "/")),
                 ))
-                .delete(synchronize_session=False)
             )
-        if diffs:
+        with self.session() as session:
+            session.query(Diff).filter(or_(*conditions)).delete(synchronize_session=False)
+        for kind, case_id, diffs in new_diffs:
             self.add_diffs(kind, case_id, diffs)
 
     def increment_counter(self, kind, value):
@@ -515,3 +531,10 @@ def iter_large(query, pk_attr, maxrq=1000):
         if rec is None:
             break
         first_id = getattr(rec, pk_attr.name)
+
+
+def case_sensitive_like(dbapi_connection, connection_record):
+    # so replace_case_diffs queries use diff_doc_id_idx
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA case_sensitive_like = ON")
+    cursor.close()

--- a/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import timedelta
 
 from gevent.pool import Pool
@@ -29,10 +30,10 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         self.submit_form(make_test_form("form-1", case_id="case-1"))
         self._do_migration(case_diff="none")
         clear_local_domain_sql_backend_override(self.domain_name)
-        case = self._get_case("case-1")
-        case.age = '35'
-        case.save()
-        self.do_case_diffs()
+        with self.augmented_couch_case("case-1") as case:
+            case.age = '35'
+            case.save()
+            self.do_case_diffs()
         self._compare_diffs([
             ('CommCareCase', Diff('diff', ['age'], old='35', new='27')),
         ])
@@ -41,10 +42,10 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         self.submit_form(make_test_form("form-1", case_id="case-1"))
         self._do_migration(case_diff="none")
         clear_local_domain_sql_backend_override(self.domain_name)
-        case = self._get_case("case-1")
-        case.age = '35'
-        case.save()
-        self.do_case_diffs(cases="case-1")
+        with self.augmented_couch_case("case-1") as case:
+            case.age = '35'
+            case.save()
+            self.do_case_diffs(cases="case-1")
         self._compare_diffs([
             ('CommCareCase', Diff('diff', ['age'], old='35', new='27')),
         ])
@@ -55,13 +56,13 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         self.submit_form(make_test_form("form-1", case_id="case-1"))
         self._do_migration(case_diff='none')
         clear_local_domain_sql_backend_override(self.domain_name)
-        case = self._get_case("case-1")
-        case.age = '35'
-        case.save()
-        with patch.object(mod, "diff_cases", diff_none):
-            result = self.do_case_diffs()
-        self.assertEqual(result, mod.PENDING_WARNING)
-        self.do_case_diffs(cases="pending")
+        with self.augmented_couch_case("case-1") as case:
+            case.age = '35'
+            case.save()
+            with patch.object(mod, "diff_cases", diff_none):
+                result = self.do_case_diffs()
+            self.assertEqual(result, mod.PENDING_WARNING)
+            self.do_case_diffs(cases="pending")
         self._compare_diffs([
             ('CommCareCase', Diff('diff', ['age'], old='35', new='27')),
         ])
@@ -108,11 +109,81 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         server_dates = details["original_server_dates"]
         self.assertEqual(len(server_dates), 1, server_dates)
 
+    def test_couch_with_missing_forms(self):
+        form1 = make_test_form("form-1", age="33", date="2016-08-04T18:25:56.656Z")
+        form2 = make_test_form("form-2", age="32", date="2015-08-04T18:25:56.656Z")
+        self.submit_form(THING_FORM)
+        self.submit_form(form1)
+        self.submit_form(form2)
+        case = self._get_case("test-case")
+        self.assertEqual(case.age, "33")
+        self.assertEqual(case.thing, "1")
+        del case.thing
+        case.actions = [a for a in case.actions if a.form_id != "thing"]
+        case.save()
+        with self.assertRaises(AttributeError):
+            self._get_case("test-case").thing
+        self._do_migration(case_diff="local")
+        self._compare_diffs([
+            ('CommCareCase', Diff('diff', ['age'], old='33', new='32')),
+        ])
+        clear_local_domain_sql_backend_override(self.domain_name)
+        self.do_case_diffs()
+        sql_case = self._get_case("test-case")
+        self.assertEqual(sql_case.dynamic_case_properties()["age"], "33")
+        self._compare_diffs([], ignore_fail=True)
+
     def do_case_diffs(self, live=False, cases=None):
         migrator = mod.get_migrator(self.domain_name, self.state_dir, live)
         return mod.do_case_diffs(migrator, cases)
+
+    @contextmanager
+    def augmented_couch_case(self, case_id):
+        def no_rebuild(*args, **kw):
+            return case
+        case = self._get_case(case_id)
+        with patch.object(mod.FormProcessorCouch, "hard_rebuild_case", no_rebuild):
+            yield case
 
 
 def MockPool(initializer=lambda: None, initargs=(), maxtasksperchild=None):
     initializer(*initargs)
     return Pool()
+
+
+THING_FORM = """
+<?xml version="1.0" ?>
+<data
+    name="Thing"
+    uiVersion="1"
+    version="11"
+    xmlns="http://openrosa.org/formdesigner/thing-form"
+    xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+>
+    <thing>1</thing>
+    <n0:case
+        case_id="test-case"
+        date_modified="2014-08-04T18:25:56.656Z"
+        user_id="a362027f228d"
+        xmlns:n0="http://commcarehq.org/case/transaction/v2"
+    >
+        <n0:create>
+            <n0:case_name>Thing</n0:case_name>
+            <n0:owner_id>a362027f228d</n0:owner_id>
+            <n0:case_type>testing</n0:case_type>
+        </n0:create>
+        <n0:update>
+            <n0:thing>1</n0:thing>
+        </n0:update>
+    </n0:case>
+    <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
+        <n1:deviceID>cloudcare</n1:deviceID>
+        <n1:timeStart>2014-07-13T11:20:11.381Z</n1:timeStart>
+        <n1:timeEnd>2014-08-04T18:25:56.656Z</n1:timeEnd>
+        <n1:username>thing-1</n1:username>
+        <n1:userID>a362027f228d</n1:userID>
+        <n1:instanceID>thing</n1:instanceID>
+        <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">2.0</n2:appVersion>
+    </n1:meta>
+</data>
+""".strip()

--- a/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
@@ -1,0 +1,57 @@
+from datetime import timedelta
+
+from gevent.pool import Pool
+from mock import patch
+
+from corehq.form_processor.utils.general import (
+    clear_local_domain_sql_backend_override,
+)
+
+from .test_migration import BaseMigrationTestCase, Diff, make_test_form
+from ..management.commands import couch_sql_diff as mod
+
+
+class TestCouchSqlDiff(BaseMigrationTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pool_mock = patch.object(mod, "Pool", MockPool)
+        cls.pool_mock.start()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.pool_mock.stop()
+
+    def test_diff(self):
+        self.submit_form(make_test_form("form-1", case_id="case-1"))
+        self._do_migration(case_diff="none")
+        clear_local_domain_sql_backend_override(self.domain_name)
+        case = self._get_case("case-1")
+        case.age = '35'
+        case.save()
+        self.do_case_diffs()
+        self._compare_diffs([
+            ('CommCareCase', Diff('diff', ['age'], old='35', new='27')),
+        ])
+
+    def test_live_diff(self):
+        # do not diff case modified since most recent case created in SQL
+        self.submit_form(make_test_form("form-1", case_id="case-1"), timedelta(minutes=-90))
+        self.submit_form(make_test_form("form-2", case_id="case-1", age=35))
+        self._do_migration(live=True, chunk_size=1, case_diff="none")
+        self.assert_backend("sql")
+        case = self._get_case("case-1")
+        self.assertEqual(case.dynamic_case_properties()["age"], '27')
+        self.do_case_diffs(live=True)
+        self._compare_diffs([])
+
+    def do_case_diffs(self, live=False):
+        migrator = mod.get_migrator(self.domain_name, self.state_dir, live)
+        return mod.do_case_diffs(migrator)
+
+
+def MockPool(initializer=lambda: None, initargs=(), maxtasksperchild=None):
+    initializer(*initargs)
+    return Pool()

--- a/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
@@ -136,7 +136,7 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
 
     def do_case_diffs(self, live=False, cases=None):
         migrator = mod.get_migrator(self.domain_name, self.state_dir, live)
-        return mod.do_case_diffs(migrator, cases)
+        return mod.do_case_diffs(migrator, cases, stop=False, batch_size=100)
 
     @contextmanager
     def augmented_couch_case(self, case_id):

--- a/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
@@ -36,6 +36,18 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
             ('CommCareCase', Diff('diff', ['age'], old='35', new='27')),
         ])
 
+    def test_diff_specific_case(self):
+        self.submit_form(make_test_form("form-1", case_id="case-1"))
+        self._do_migration(case_diff="none")
+        clear_local_domain_sql_backend_override(self.domain_name)
+        case = self._get_case("case-1")
+        case.age = '35'
+        case.save()
+        self.do_case_diffs(cases="case-1")
+        self._compare_diffs([
+            ('CommCareCase', Diff('diff', ['age'], old='35', new='27')),
+        ])
+
     def test_live_diff(self):
         # do not diff case modified since most recent case created in SQL
         self.submit_form(make_test_form("form-1", case_id="case-1"), timedelta(minutes=-90))
@@ -47,9 +59,9 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
         self.do_case_diffs(live=True)
         self._compare_diffs([])
 
-    def do_case_diffs(self, live=False):
+    def do_case_diffs(self, live=False, cases=None):
         migrator = mod.get_migrator(self.domain_name, self.state_dir, live)
-        return mod.do_case_diffs(migrator)
+        return mod.do_case_diffs(migrator, cases)
 
 
 def MockPool(initializer=lambda: None, initargs=(), maxtasksperchild=None):

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -615,3 +615,22 @@ class DiffTestCases(SimpleTestCase):
         diffs = json_diff(couch_case, sql_case, track_list_indices=False)
         filtered = filter_case_diffs(couch_case, sql_case, diffs)
         self.assertEqual(filtered, [])
+
+    def test_case_with_closed_by_diff(self):
+        couch_case = {
+            "doc_type": "CommCareCase",
+            "actions": [
+                {
+                    "action_type": "close",
+                    "user_id": "somebody",
+                },
+            ],
+            "closed_by": "",
+        }
+        sql_case = {
+            "doc_type": "CommCareCase",
+            "closed_by": "somebody",
+        }
+        diffs = json_diff(couch_case, sql_case, track_list_indices=False)
+        filtered = filter_case_diffs(couch_case, sql_case, diffs)
+        self.assertEqual(filtered, [])

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -1417,7 +1417,8 @@ class TestHelperFunctions(TestCase):
             user_id=couch_form.user_id,
         )
         self.addCleanup(delete_blob)
-        mod._migrate_form_attachments(sql_form, couch_form)
+        with mod.patch_XFormInstance_get_xml():
+            mod._migrate_form_attachments(sql_form, couch_form)
         self.assertEqual(sql_form.form_data, couch_form.form_data)
         xml = sql_form.get_xml()
         self.assertEqual(convert_xform_to_json(xml), couch_form.form_data)

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -1468,15 +1468,22 @@ def create_form_with_extra_xml_blob_metadata(domain_name):
 
 
 @nottest
-def make_test_form(form_id, age=27, case_id="test-case", case_name="Xeenax"):
+def make_test_form(form_id, **data):
+    fields = {
+        "age": (27, ">{}<", 2),
+        "case_id": ("test-case", '"{}"', 1),
+        "case_name": ("Xeenax", ">{}<", 2),
+        "date": ("2015-08-04T18:25:56.656Z", "{}", 2),
+    }
     form = TEST_FORM
-    assert form.count(">test-form<") == 1
-    assert form.count(">27<") == 2
-    assert form.count('"test-case"') == 1
-    assert form.count('>Xeenax<') == 2
-    form = form.replace(">27<", f">{age}<")
-    form = form.replace('"test-case"', f'"{case_id}"')
-    form = form.replace('>Xeenax<', f'>{case_name}<')
+    for name, value in data.items():
+        if name not in fields:
+            raise ValueError(f"unknown field: {name}")
+        default_value, template, occurs = fields[name]
+        old = template.format(default_value)
+        new = template.format(value)
+        assert form.count(old) == occurs, (name, old, new, occurs)
+        form = form.replace(old, new)
     return form.replace(">test-form<", f">{form_id}<")
 
 

--- a/corehq/apps/couch_sql_migration/tests/test_rebuildcase.py
+++ b/corehq/apps/couch_sql_migration/tests/test_rebuildcase.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from testil import Config, eq
+
+from .. import rebuildcase as mod
+
+
+def test_is_action_order_equal():
+    def test(sql_form_ids, couch_form_ids, expect):
+        sql_case = Config(
+            transactions=[Config(form_id=x) for x in sql_form_ids]
+        )
+        couch_json = {
+            "actions": [{"xform_id": x} for x in couch_form_ids]
+        }
+        print(sql_case)
+        print(couch_json)
+        eq(mod.is_action_order_equal(sql_case, couch_json), expect)
+
+    yield test, "abc", "abc", True
+    yield test, "abc", "aabbcc", True
+    yield test, "abc", "acb", False
+
+
+def test_iter_ascending_dates():
+    def test(indices, expect):
+        dates = [dx(i) for i in indices]
+        actual_deltas = deltas(mod.iter_ascending_dates(dates))
+        expect_deltas = deltas(dx(i) for i in expect)
+        assert mod.is_strictly_ascending(expect_deltas), expect_deltas
+        eq(actual_deltas, expect_deltas)
+
+    yield test, [0, 1], [0, 1]
+    yield test, [0, 10, 20], [0, 10, 20]
+    yield test, [30, 10, 20], [9, 10, 20]
+    yield test, [30, 30, 30, 10, 20], [7, 8, 9, 10, 20]
+    yield test, [1, 3, 3, 3, 3, 2], [1, 1.2, 1.4, 1.6, 1.8, 2]
+    yield test, [0, 20, 10], [0, 5, 10]
+    yield test, [0, 10, 20, 10], [0, 10, 20, 21]
+    yield test, [40, 50, 60, 70, 10, 20, 30], [40, 50, 60, 70, 71, 72, 73]
+
+
+def test_longest_increasing_subsequence_indices():
+    def test(seq, expect):
+        eq(mod.longest_increasing_subsequence_indices(seq), expect)
+
+    yield test, [], []
+    yield test, [2], [0]
+    yield test, [7, 2], [1]
+    yield test, [3, 7], [0, 1]
+    yield test, [3, 6, 9], [0, 1, 2]
+    yield test, [3, 9, 6], [0, 2]
+    yield test, [3, 6, 6], [0, 2]
+    yield test, [3, 6, 6, 6, 6, 9], [0, 4, 5]
+    yield test, [7, 2, 6, 4, 5, 1], [1, 3, 4]
+    yield test, [18, 12, 17, 16, 14, 15, 16, 11], [1, 4, 5, 6]
+
+
+def dx(minutes_since_epoch):
+    return datetime.fromtimestamp(minutes_since_epoch * 60)
+
+
+def deltas(dates, d0=dx(0)):
+    return [str(d - d0) for d in dates]

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -138,6 +138,13 @@ def test_get_forms_count():
         eq(db.get_forms_count("c"), 0)
 
 
+def test_add_diffed_cases():
+    with init_db() as db:
+        case_ids = ["a", "b", "c"]
+        db.add_diffed_cases(case_ids)
+        eq(list(db.iter_diffed_cases()), case_ids)
+
+
 @with_setup(teardown=delete_db)
 def test_problem_forms():
     with init_db(memory=False) as db:
@@ -314,6 +321,7 @@ def test_clone_casediff_data_from_tables():
     eq(set(mod.Base.metadata.tables), {m.__tablename__ for m in [
         mod.CaseForms,
         mod.Diff,
+        mod.DiffedCase,
         mod.KeyValue,
         mod.DocCount,
         mod.MissingDoc,

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -138,11 +138,16 @@ def test_get_forms_count():
         eq(db.get_forms_count("c"), 0)
 
 
-def test_add_diffed_cases():
+def test_case_diff_lifecycle():
     with init_db() as db:
         case_ids = ["a", "b", "c"]
+        db.add_cases_to_diff(case_ids)
+        db.add_cases_to_diff(["d"])
         db.add_diffed_cases(case_ids)
-        eq(list(db.iter_diffed_cases()), case_ids)
+        eq(list(db.iter_undiffed_case_ids()), ["d"])
+        eq(db.count_undiffed_cases(), 1)
+        db.add_diffed_cases(case_ids)  # add again should not error
+        db.add_diffed_cases([])  # no ids should not error
 
 
 @with_setup(teardown=delete_db)
@@ -320,6 +325,7 @@ def test_clone_casediff_data_from_tables():
     # to be updated.
     eq(set(mod.Base.metadata.tables), {m.__tablename__ for m in [
         mod.CaseForms,
+        mod.CaseToDiff,
         mod.Diff,
         mod.DiffedCase,
         mod.KeyValue,

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -206,20 +206,28 @@ def test_replace_case_diffs():
     with init_db() as db:
         case_id = "865413246874321"
         # add old diffs
-        db.replace_case_diffs("CommCareCase", case_id, [make_diff(0)])
-        db.replace_case_diffs("CommCareCase", "unaffected", [make_diff(1)])
-        db.add_diffs("stock state", case_id + "/x/y", [make_diff(2)])
-        db.add_diffs("stock state", "unaffected/x/y", [make_diff(3)])
+        db.replace_case_diffs([
+            ("CommCareCase", case_id, [make_diff(0)]),
+            ("stock state", case_id + "/x/y", [make_diff(1)]),
+            ("CommCareCase", "unaffected", [make_diff(2)]),
+            ("stock state", "unaffected/x/y", [make_diff(3)]),
+            ("CommCareCase", "stock-only", [make_diff(4)]),
+            ("stock state", "stock-only/x/y", [make_diff(5)]),
+        ])
         # add new diffs
-        db.replace_case_diffs("CommCareCase", case_id, [make_diff(4)])
-        db.add_diffs("stock state", case_id + "/y/z", [make_diff(5)])
+        db.replace_case_diffs([
+            ("CommCareCase", case_id, [make_diff(6)]),
+            ("stock state", case_id + "/y/z", [make_diff(7)]),
+            ("stock state", "stock-only/y/z", [make_diff(8)]),
+        ])
         eq(
             {(d.kind, d.doc_id, d.json_diff) for d in db.get_diffs()},
             {(kind, doc_id, make_diff(x)) for kind, doc_id, x in [
-                ("CommCareCase", "unaffected", 1),
+                ("CommCareCase", "unaffected", 2),
                 ("stock state", "unaffected/x/y", 3),
-                ("CommCareCase", case_id, 4),
-                ("stock state", case_id + "/y/z", 5),
+                ("CommCareCase", case_id, 6),
+                ("stock state", case_id + "/y/z", 7),
+                ("stock state", "stock-only/y/z", 8),
             ]},
         )
 
@@ -286,8 +294,8 @@ def test_clone_casediff_data_from():
                     Config(id="c", total_forms=2, processed_forms=1),
                 ])
                 cddb.add_missing_docs("CommCareCase-couch", ["missing"])
-                cddb.replace_case_diffs("CommCareCase", "a", [diffs[0]])
-                cddb.replace_case_diffs("CommCareCase-Deleted", "b", [diffs[1]])
+                cddb.add_diffs("CommCareCase", "a", [diffs[0]])
+                cddb.add_diffs("CommCareCase-Deleted", "b", [diffs[1]])
                 cddb.add_diffs("stock state", "c/ledger", [diffs[2]])
                 cddb.increment_counter("CommCareCase", 3)           # case, a, c
                 cddb.increment_counter("CommCareCase-Deleted", 1)   # b

--- a/corehq/apps/couch_sql_migration/util.py
+++ b/corehq/apps/couch_sql_migration/util.py
@@ -1,11 +1,30 @@
 import logging
 from contextlib import contextmanager
+from datetime import datetime
 from functools import wraps
 
 import gevent
 from greenlet import GreenletExit
 
+from dimagi.utils.parsing import ISO_DATETIME_FORMAT
+
 log = logging.getLogger(__name__)
+
+
+def get_ids_from_string_or_file(ids):
+    if ids.startswith(("./", "/")):
+        log.info("loading ids from file: %s", ids)
+        with open(ids, encoding="utf-8") as fh:
+            return [x.rstrip("\n") for x in fh if x.strip()]
+    return [x for x in ids.split() if x]
+
+
+def str_to_datetime(value):
+    try:
+        return datetime.strptime(value, ISO_DATETIME_FORMAT)
+    except ValueError:
+        sans_micros = ISO_DATETIME_FORMAT.replace(".%f", "")
+        return datetime.strptime(value, sans_micros)
 
 
 def exit_on_error(func):

--- a/corehq/apps/tzmigration/timezonemigration.py
+++ b/corehq/apps/tzmigration/timezonemigration.py
@@ -212,10 +212,11 @@ def is_datetime_string(string):
         return True
 
 
-class MissingType(object):
+class MissingType(type):
 
     def __repr__(self):
         return "MISSING"
 
 
-MISSING = MissingType()
+class MISSING(metaclass=MissingType):
+    pass

--- a/corehq/ex-submodules/dimagi/test_utils/base.py
+++ b/corehq/ex-submodules/dimagi/test_utils/base.py
@@ -93,6 +93,14 @@ class DimagiUtilsTestCase(TestCase):
             (8, 9)
         ])
 
+    def test_chunked_stop(self):
+        def list_or_stop(items):
+            items = list(items)
+            if items[0] == 0:
+                return items
+            raise StopIteration
+        self.assertEqual(list(chunked(range(10), 2, list_or_stop)), [[0, 1]])
+
     def test_ReadOnlyObject(self):
 
         from couchdbkit import Document, StringListProperty

--- a/corehq/ex-submodules/dimagi/utils/chunked.py
+++ b/corehq/ex-submodules/dimagi/utils/chunked.py
@@ -18,7 +18,10 @@ def chunked(it, n, collection=tuple):
     """
     itr = iter(it)
     while True:
-        items = take(n, itr, collection)
+        try:
+            items = take(n, itr, collection)
+        except StopIteration:
+            break
         if not items:
             break
         yield items


### PR DESCRIPTION
Main new things here:

- use gevent-compatible process pool (added in #26360) for parallel processing.
- https://github.com/dimagi/commcare-hq/commit/3454376c5d0dbb25f92b546878025dd7f76e3d40 rearrange SQL case transactions to match couch order.
- https://github.com/dimagi/commcare-hq/commit/030c7187991e5f5c55776254d5b42e78090afe4c, https://github.com/dimagi/commcare-hq/commit/b3836b454a04ba1ec361c94692a4f7913abb791c options to diff important subsets of cases.
- https://github.com/dimagi/commcare-hq/commit/19ded6ae34713d3bcdfc27d9ee62df04d2af1bac rebuild XML from couch JSON more aggressively.
- https://github.com/dimagi/commcare-hq/commit/a8a2d9b8ee5e8ab4308aaceea0c11d34ffc0f2c0 options to make it easier to inspect diffs as they are found.

There are still more kinds of case diffs to resolve, but this PR got pretty big, so I'll do that work in follow-up PRs. It's probably easiest to review this ~all at once~ by commit 🐡 

NOTE: right now there are two different case diff implementations, one of which is mostly a subset of the other. I plan to eventually replace most of the old one (in `...couch_sql_migration.casediff`) with the new one (in `...couch_sql_migration.management.commands.couch_sql_diff`). Also the new one should be moved out of the management command module anyway.
