### PR TITLE
ICDS Dashboard: enable password reset from mobile embed

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/password_reset_form.html
+++ b/corehq/apps/domain/templates/login_and_password/password_reset_form.html
@@ -7,7 +7,8 @@
 {% block title %}{% trans "Password Reset" %}{% endblock title %}
 
 {% block registration-content %}
-  <form name="form" method="post" action="{% url "password_reset_email" %}">
+  {% url "password_reset_email" as default_form_submit_url %}
+  <form name="form" method="post" action="{{ form_submit_url|default:default_form_submit_url }}">
     <h2 class="text-center">
       {% trans "Reset Password" %}
     </h2>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/_wizard_forms.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/_wizard_forms.html
@@ -10,7 +10,8 @@
       {% endfor %}
       {% if field.name == "password" %}
         <p class="help-block">
-          <a href="{% url "password_reset_email" %}">{% trans "Forgot your password?" %}</a>
+          {% url "password_reset_email" as default_password_reset_link %}
+          <a href="{{ password_reset_url|default:default_password_reset_link }}">{% trans "Forgot your password?" %}</a>
         </p>
       {% endif %}
     </div>

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -93,6 +93,12 @@ PASSWORD_RESET_KWARGS = {
     'extra_context': {'current_page': {'page_name': _('Password Reset')}}
 }
 
+PASSWORD_RESET_DONE_KWARGS = {
+    'template_name': 'login_and_password/password_reset_done.html',
+    'extra_context': {'current_page': {'page_name': _('Reset My Password')}}
+}
+
+
 urlpatterns = [
     url(r'^domain/select/$', select, name='domain_select'),
     url(r'^domain/select_redirect/$', select, {'do_not_redirect': True}, name='domain_select_redirect'),
@@ -109,11 +115,8 @@ urlpatterns = [
         name='password_change_done'),
 
     url(r'^accounts/password_reset_email/$', password_reset, PASSWORD_RESET_KWARGS, name='password_reset_email'),
-    url(r'^accounts/password_reset_email/done/$', password_reset_done,
-        {'template_name': 'login_and_password/password_reset_done.html',
-         'extra_context': {'current_page': {'page_name': _('Reset My Password')}}},
+    url(r'^accounts/password_reset_email/done/$', password_reset_done, PASSWORD_RESET_DONE_KWARGS,
         name='password_reset_done'),
-
     url(r'^accounts/password_reset_confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>.+)/$',
         PasswordResetView.as_view(),
         {'template_name': 'login_and_password/password_reset_confirm.html', 'set_password_form': HQSetPasswordForm,

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -86,6 +86,13 @@ from corehq.motech.repeaters.views import (
     requeue_repeat_record,
 )
 
+PASSWORD_RESET_KWARGS = {
+    'template_name': 'login_and_password/password_reset_form.html',
+    'password_reset_form': ConfidentialPasswordResetForm,
+    'from_email': settings.DEFAULT_FROM_EMAIL,
+    'extra_context': {'current_page': {'page_name': _('Password Reset')}}
+}
+
 urlpatterns = [
     url(r'^domain/select/$', select, name='domain_select'),
     url(r'^domain/select_redirect/$', select, {'do_not_redirect': True}, name='domain_select_redirect'),
@@ -93,7 +100,6 @@ urlpatterns = [
         ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),
     url(r'^domain/transfer/(?P<guid>\w+)/deactivate$',
         DeactivateTransferDomainView.as_view(), name='deactivate_transfer_domain'),
-
     url(r'^accounts/password_change/$', password_change,
         {'template_name': 'login_and_password/password_change_form.html'},
         name='password_change'),
@@ -102,11 +108,7 @@ urlpatterns = [
          'extra_context': {'current_page': {'page_name': _('Password Change Complete')}}},
         name='password_change_done'),
 
-    url(r'^accounts/password_reset_email/$', password_reset,
-        {'template_name': 'login_and_password/password_reset_form.html',
-         'password_reset_form': ConfidentialPasswordResetForm, 'from_email': settings.DEFAULT_FROM_EMAIL,
-         'extra_context': {'current_page': {'page_name': _('Password Reset')}}},
-        name='password_reset_email'),
+    url(r'^accounts/password_reset_email/$', password_reset, PASSWORD_RESET_KWARGS, name='password_reset_email'),
     url(r'^accounts/password_reset_email/done/$', password_reset_done,
         {'template_name': 'login_and_password/password_reset_done.html',
          'extra_context': {'current_page': {'page_name': _('Reset My Password')}}},

--- a/custom/icds_reports/mobile_views.py
+++ b/custom/icds_reports/mobile_views.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.contrib.auth import views as auth_views
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -6,7 +8,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
 
 from corehq.apps.domain.decorators import two_factor_exempt
-from corehq.apps.domain.urls import PASSWORD_RESET_KWARGS
+from corehq.apps.domain.urls import PASSWORD_RESET_KWARGS, PASSWORD_RESET_DONE_KWARGS
 from corehq.apps.hqwebapp import views as hqwebapp_views
 from corehq.apps.locations.permissions import location_safe
 from custom.icds_reports.dashboard_utils import get_dashboard_template_context
@@ -37,7 +39,17 @@ def logout(req, domain):
 
 @xframe_options_exempt
 def password_reset(request, domain):
-    return auth_views.password_reset(request, **PASSWORD_RESET_KWARGS)
+    kwargs = copy.deepcopy(PASSWORD_RESET_KWARGS)
+    # submit the form back to this view instead of the default
+    kwargs['extra_context']['form_submit_url'] = reverse('cas_mobile_dashboard_password_reset', args=[domain])
+    # so that we can redirect to a custom "done" page
+    kwargs['post_reset_redirect'] = reverse('cas_mobile_dashboard_password_reset_done', args=[domain])
+    return auth_views.password_reset(request, **kwargs)
+
+
+@xframe_options_exempt
+def password_reset_done(request, domain):
+    return auth_views.password_reset_done(request, **PASSWORD_RESET_DONE_KWARGS)
 
 
 @location_safe

--- a/custom/icds_reports/mobile_views.py
+++ b/custom/icds_reports/mobile_views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import views as auth_views
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -5,6 +6,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
 
 from corehq.apps.domain.decorators import two_factor_exempt
+from corehq.apps.domain.urls import PASSWORD_RESET_KWARGS
 from corehq.apps.hqwebapp import views as hqwebapp_views
 from corehq.apps.locations.permissions import location_safe
 from custom.icds_reports.dashboard_utils import get_dashboard_template_context
@@ -20,7 +22,7 @@ def login(request, domain):
         custom_template_name='icds_reports/mobile_login.html',
         extra_context={
             'domain': domain,
-            'next': reverse('cas_mobile_dashboard', args=[domain])
+            'next': reverse('cas_mobile_dashboard', args=[domain]),
         }
     )
 
@@ -30,6 +32,11 @@ def login(request, domain):
 def logout(req, domain):
     # override logout so you are redirected to the right login page afterwards
     return hqwebapp_views.logout(req, default_domain_redirect='cas_mobile_dashboard_login')
+
+
+@xframe_options_exempt
+def password_reset(request, domain):
+    return auth_views.password_reset(request, **PASSWORD_RESET_KWARGS)
 
 
 @location_safe

--- a/custom/icds_reports/mobile_views.py
+++ b/custom/icds_reports/mobile_views.py
@@ -23,6 +23,7 @@ def login(request, domain):
         extra_context={
             'domain': domain,
             'next': reverse('cas_mobile_dashboard', args=[domain]),
+            'password_reset_url': reverse('cas_mobile_dashboard_password_reset', args=[domain]),
         }
     )
 

--- a/custom/icds_reports/urls.py
+++ b/custom/icds_reports/urls.py
@@ -135,6 +135,7 @@ awc_infrastructure_urls = [
 mobile_dashboard_urls = [
     url(r'^login/$', mobile_views.login, name="cas_mobile_dashboard_login"),
     url(r'^logout/$', mobile_views.logout, name="cas_mobile_dashboard_logout"),
+    url(r'^password_reset/$', mobile_views.password_reset, name="cas_mobile_dashboard_password_reset"),
     url(r'^$', mobile_views.MobileDashboardView.as_view(), name="cas_mobile_dashboard"),
 ]
 

--- a/custom/icds_reports/urls.py
+++ b/custom/icds_reports/urls.py
@@ -136,6 +136,8 @@ mobile_dashboard_urls = [
     url(r'^login/$', mobile_views.login, name="cas_mobile_dashboard_login"),
     url(r'^logout/$', mobile_views.logout, name="cas_mobile_dashboard_logout"),
     url(r'^password_reset/$', mobile_views.password_reset, name="cas_mobile_dashboard_password_reset"),
+    url(r'^password_reset/done$', mobile_views.password_reset_done,
+        name="cas_mobile_dashboard_password_reset_done"),
     url(r'^$', mobile_views.MobileDashboardView.as_view(), name="cas_mobile_dashboard"),
 ]
 


### PR DESCRIPTION
https://trello.com/c/xg36gmnU/268-forgot-password-link-is-broken

this overrides password reset views as passthroughs for ICDS mobile dashboard so we can allow overriding with `@xframe_options_exempt` (which is required for them to work in the mobile app)

review by commit

there will likely be a second PR that overrides the templates, since the current templates have links to other pages that aren't mobile-embeddable.