### PR TITLE
Removed test_couch_dump_load.test_multimedia

### DIFF
--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -141,38 +141,6 @@ class CouchDumpLoadTest(TestCase):
 
         self._dump_and_load(expected_docs, not_expected_docs)
 
-    def test_multimedia(self):
-        from corehq.apps.hqmedia.models import CommCareAudio, CommCareImage, CommCareVideo
-        image_path = os.path.join('corehq', 'apps', 'hqwebapp', 'static', 'hqwebapp', 'images', 'commcare-hq-logo.png')
-        with open(image_path, 'rb') as f:
-            image_data = f.read()
-
-        image = CommCareImage.get_by_data(image_data)
-        image.attach_data(image_data, original_filename='logo.png')
-        image.add_domain(self.domain_name)
-        self.assertEqual(image_data, image.get_display_file(False))
-
-        audio_data = b'fake audio data'
-        audio = CommCareAudio.get_by_data(audio_data)
-        audio.attach_data(audio_data, original_filename='tr-la-la.mp3')
-        audio.add_domain(self.domain_name)
-        self.assertEqual(audio_data, audio.get_display_file(False))
-
-        video_data = b'fake video data'
-        video = CommCareVideo.get_by_data(video_data)
-        video.attach_data(video_data, 'kittens.mp4')
-        video.add_domain(self.domain_name)
-        self.assertEqual(video_data, video.get_display_file(False))
-
-        fakedb = self._dump_and_load([image, audio, video])
-
-        copied_image = CommCareImage.wrap(fakedb.get(image._id))
-        copied_audio = CommCareAudio.wrap(fakedb.get(audio._id))
-        copied_video = CommCareVideo.wrap(fakedb.get(video._id))
-        self.assertEqual(image_data, copied_image.get_display_file(False))
-        self.assertEqual(audio_data, copied_audio.get_display_file(False))
-        self.assertEqual(video_data, copied_video.get_display_file(False))
-
     def test_web_user(self):
         from corehq.apps.users.models import WebUser
         other_domain = Domain(name='other-domain')


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-hq/pull/25919

The code relevant to this test was removed in https://github.com/dimagi/commcare-hq/pull/26006/files#diff-99b45acc269b7481f51669187cee77c8