### PR TITLE
fix generator in reconciliation task

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -1636,7 +1636,10 @@ def reconcile_data_not_in_ucr(reconciliation_status_pk):
     known_bad_doc_ids = doc_ids_in_pillow_error.intersection(invalid_doc_ids)
 
     # republish_kafka_changes
-    for doc_id, doc_subtype, sql_modified_on in data_not_in_ucr:
+    # running the data accessor again to avoid storing all doc ids in memory
+    # since run time is relatively short and does not scale with number of errors
+    # but the number of doc ids will increase with the number of errors
+    for doc_id, doc_subtype, sql_modified_on in get_data_not_in_ucr(status_record):
         if doc_id in known_bad_doc_ids:
             # These docs will either get retried or are invalid
             continue


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The generator was exhausted in https://github.com/dimagi/commcare-hq/compare/ce/reconciliation-pillow?expand=1#diff-b8c5a5e308a203bcaee8ed83e6837edfR1631 so this loop (the part of the task that actually fixed the issue) was doing nothing. This likely means we will need to rerun the task for every day in the past.