### PR TITLE
Fix TestReportMultipleAggregationsSQL more robustly

### DIFF
--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -564,6 +564,15 @@ class TestReportAggregationSQL(ConfigurableReportAggregationTestMixin, TestCase)
 
 
 class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, TestCase):
+    # Note that these constants are subtracted from today's date, so the month parts of the names
+    # are approximations: the first one will usually fall one year and two months ago, but will
+    # sometimes fall one year and three months ago. The only place this matters in tests is
+    # test_aggregate_date, which groups by month, so it matters which rows are in the same month.
+    ONE_YEAR_TWO_MONTHS = 365 + 28 * 2 + 5
+    ONE_YEAR_THREE_MONTHS = 365 + 28 * 3 + 4
+    ONE_YEAR_THREE_MONTHS_OTHER = 365 + 28 * 3 + 5
+    MORE_THAN_TWO_YEARS = 365 * 2 + 75
+
     @classmethod
     def _relative_date(cls, days_offset):
         return (datetime.utcnow() - timedelta(days=days_offset)).strftime("%Y-%m-%d")
@@ -582,28 +591,28 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, 
                 "city": "Boston",
                 "number": 4,
                 "age_at_registration": 1,
-                "date": cls._relative_date(365 + 28 * 2 + 5),
+                "date": cls._relative_date(cls.ONE_YEAR_TWO_MONTHS),
             },
             {
                 "state": "MA",
                 "city": "Boston",
                 "number": 3,
                 "age_at_registration": 5,
-                "date": cls._relative_date(365 + 28 * 3 + 4),
+                "date": cls._relative_date(cls.ONE_YEAR_THREE_MONTHS),
             },
             {
                 "state": "MA",
                 "city": "Cambridge",
                 "number": 2,
                 "age_at_registration": 8,
-                "date": cls._relative_date(365 + 28 * 3 + 5),
+                "date": cls._relative_date(cls.ONE_YEAR_THREE_MONTHS_OTHER),
             },
             {
                 "state": "TN",
                 "city": "Nashville",
                 "number": 1,
                 "age_at_registration": 14,
-                "date": cls._relative_date(365 * 2 + 75),
+                "date": cls._relative_date(cls.MORE_THAN_TWO_YEARS),
             },
         ]:
             cls._new_case(row).save()
@@ -862,15 +871,18 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, 
             ],
         )
         view = self._create_view(report_config)
-        if self._relative_month(365 + 28 * 3 + 4) == self._relative_month(365 + 28 * 3 + 5):
+        if (
+            self._relative_month(self.ONE_YEAR_THREE_MONTHS)
+            == self._relative_month(self.ONE_YEAR_THREE_MONTHS_OTHER)
+        ):
             # Typical use case, the two of the MA rows that are a day apart fall in the same month
             self.assertEqual(
                 view.export_table,
                 [['foo',
                   [['report_column_display_state', 'month', 'report_column_display_number'],
-                   ['MA', self._relative_month(365 + 28 * 2 + 5), 4],
-                   ['MA', self._relative_month(365 + 28 * 3 + 4), 5],
-                   ['TN', self._relative_month(365 * 2 + 75), 1]]]]
+                   ['MA', self._relative_month(self.ONE_YEAR_TWO_MONTHS), 4],
+                   ['MA', self._relative_month(self.ONE_YEAR_THREE_MONTHS), 5],
+                   ['TN', self._relative_month(self.MORE_THAN_TWO_YEARS), 1]]]]
             )
         else:
             # One day each month, those two rows will be in different months.
@@ -879,10 +891,10 @@ class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, 
                 view.export_table,
                 [['foo',
                   [['report_column_display_state', 'month', 'report_column_display_number'],
-                   ['MA', self._relative_month(365 + 28 * 2 + 5), 4],
-                   ['MA', self._relative_month(365 + 28 * 3 + 4), 3],
-                   ['MA', self._relative_month(365 + 28 * 3 + 5), 2],
-                   ['TN', self._relative_month(365 * 2 + 75), 1]]]]
+                   ['MA', self._relative_month(self.ONE_YEAR_TWO_MONTHS), 4],
+                   ['MA', self._relative_month(self.ONE_YEAR_THREE_MONTHS), 3],
+                   ['MA', self._relative_month(self.ONE_YEAR_THREE_MONTHS_OTHER), 2],
+                   ['TN', self._relative_month(self.MORE_THAN_TWO_YEARS), 1]]]]
             )
 
     def test_integer_buckets(self):

--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -1,5 +1,6 @@
 from django.http import HttpRequest
 from django.test import TestCase
+from datetime import datetime
 
 from corehq.apps.userreports.exceptions import BadSpecError, UserReportsError
 from corehq.apps.userreports.models import (
@@ -562,12 +563,12 @@ class TestReportAggregationSQL(ConfigurableReportTestMixin, TestCase):
 class TestReportMultipleAggregationsSQL(ConfigurableReportTestMixin, TestCase):
     @classmethod
     def _relative_date(cls, month, day, year_offset=0):
-        year = 2019 + year_offset
+        year = datetime.utcnow().year + year_offset
         return f"{year}-{month:02}-{day:02}"
 
     @classmethod
     def _relative_month(cls, month, year_offset=0):
-        year = 2019 + year_offset
+        year = datetime.utcnow().year + year_offset
         return f"{year}-{month:02}"
 
     @classmethod


### PR DESCRIPTION
This replaces https://github.com/dimagi/commcare-hq/pull/26336 with a fix based on relative dates, building off of https://github.com/dimagi/commcare-hq/pull/26335 