### PR TITLE
Rewrite ES "not (A and B)" like we do for "or"

### DIFF
--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -53,6 +53,10 @@ def NOT(filter_):
         # but accepts the same logic
         # formulated as {"and": [{"not": A}, {"not": B}]} (e.g. not A and not B)
         return AND(*(NOT(condition) for condition in filter_['or']))
+    elif 'and' in filter_:
+        # Same ES 2.4 issue as above.
+        # Rewrite "not (A and B)" as "not A or not B"
+        return OR(*(NOT(condition) for condition in filter_['and']))
     elif 'not' in filter_:
         # This may not be strictly necessary
         # but prevents {'not': {'not': A}}, in favor of just A

--- a/corehq/apps/es/tests/test_filters.py
+++ b/corehq/apps/es/tests/test_filters.py
@@ -109,6 +109,46 @@ class TestFilters(ElasticTestMixin, SimpleTestCase):
 
         self.checkQuery(query, json_output)
 
+    def test_not_and_rewrite(self):
+        json_output = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "and": [
+                            {
+                                'or': (
+                                    {
+                                        "not": {
+                                            "term": {
+                                                "type": "A"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "not": {
+                                            "term": {
+                                                "type": "B"
+                                            }
+                                        }
+                                    },
+                                )
+                            },
+                            {"match_all": {}}
+                        ]
+                    },
+                    "query": {"match_all": {}}
+                }
+            },
+            "size": SIZE_LIMIT
+        }
+        query = HQESQuery('cases').filter(
+            filters.NOT(
+                filters.AND(filters.term('type', 'A'), filters.term('type', 'B'))
+            )
+        )
+
+        self.checkQuery(query, json_output)
+
 
 class TestSourceFiltering(ElasticTestMixin, SimpleTestCase):
 

--- a/corehq/apps/es/tests/test_sms.py
+++ b/corehq/apps/es/tests/test_sms.py
@@ -14,12 +14,14 @@ class TestSMSES(ElasticTestMixin, SimpleTestCase):
                         "and": [
                             {"term": {"domain.exact": "demo"}},
                             {
-                                "not": {
-                                    "and": (
-                                        {"term": {"direction": "o"}},
-                                        {"term": {"processed": False}},
-                                    )
-                                }
+                                "or": (
+                                    {
+                                        "not": {"term": {"direction": "o"}},
+                                    },
+                                    {
+                                        "not": {"term": {"processed": False}},
+                                    }
+                                ),
                             },
                             {"match_all": {}},
                         ]


### PR DESCRIPTION
##### SUMMARY
The same problem exists for not-and as for not-or, and I just had not bumped into it previously.

Fixes https://dimagi-dev.atlassian.net/browse/QA-965

Only affects envs with ES 2.4 which is currently staging but soon to be all of them.