### PR TITLE
make sure reserved properties also contain the `info` tag

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -370,7 +370,7 @@ hqDefine('export/js/models', [
             return false;
         }
         if (tableId === 0) {
-            return column.formatProperty() === 'formid' || column.formatProperty() === 'caseid';
+            return (column.formatProperty() === 'formid' || column.formatProperty() === 'caseid') && column.tags().indexOf('info') !== -1;
         }
         return column.formatProperty() === 'number';
     };


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10194

##### SUMMARY
Fixes an issue in the OData config where there is a custom `caseid` field is present and the UI doesn't allow the user to uncheck or rename it because OData thinks it is reserved. `caseid` is in fact allowed because we actually mark reserved properties in the code with `@` in front—eg `@caseid`. The `@` gets cleaned up in the exports / OData feed. I was originally going to forbid `caseid` from being used as a case property but decided against it since all reserved properties start with `@`.
