### PR TITLE
Add custom rule criteria for ccs_record cases availing services

### DIFF
--- a/custom/icds/case_relationships.py
+++ b/custom/icds/case_relationships.py
@@ -70,6 +70,11 @@ def mother_person_case_from_ccs_record_case(ccs_record_case):
     return _get_exactly_one_parent_case(ccs_record_case, 'parent', CommCareCaseIndexSQL.CHILD, 'person')
 
 
+def child_person_cases_from_mother_person_case(mother_person_case):
+    subcases = mother_person_case.get_subcases(index_identifier='mother')
+    return [case for case in subcases if case.type == 'person']
+
+
 def mother_person_case_from_child_health_case(child_health_case):
     child_person_case = child_person_case_from_child_health_case(child_health_case)
     return mother_person_case_from_child_person_case(child_person_case)

--- a/custom/icds/tests/test_case_relationships.py
+++ b/custom/icds/tests/test_case_relationships.py
@@ -6,6 +6,7 @@ from custom.icds.case_relationships import (
     mother_person_case_from_ccs_record_case,
     mother_person_case_from_child_health_case,
     child_person_case_from_tasks_case,
+    child_person_cases_from_mother_person_case,
 )
 from custom.icds.exceptions import CaseRelationshipError
 from custom.icds.messaging.custom_recipients import skip_notifying_missing_mother_person_case
@@ -54,6 +55,11 @@ class CaseRelationshipTest(BaseICDSTest):
         self.assertEqual(
             child_person_case_from_tasks_case(self.child_tasks_case).case_id,
             self.child_person_case.case_id
+        )
+
+        self.assertEqual(
+            [case.id for case in child_person_cases_from_mother_person_case(self.mother_person_case)],
+            [self.child_person_case.id]
         )
 
     def test_case_type_mismatch(self):

--- a/custom/icds/tests/test_custom_rules.py
+++ b/custom/icds/tests/test_custom_rules.py
@@ -3,6 +3,7 @@ from corehq.apps.data_interfaces.models import AutomaticUpdateRule, CustomMatchD
 from corehq.apps.data_interfaces.tests.test_auto_case_updates import (
     BaseCaseRuleTest,
     _create_empty_rule,
+    set_parent_case,
     _with_case,
 )
 from corehq.apps.data_interfaces.tests.util import create_case, create_empty_rule
@@ -275,3 +276,31 @@ class CustomCriteriaTestCase(BaseCaseRuleTest):
         with create_user_case(self.aww) as aww_uc, create_user_case(self.ls) as ls_uc:
             self.assertFalse(rule.criteria_match(aww_uc, datetime.utcnow()))
             self.assertTrue(rule.criteria_match(ls_uc, datetime.utcnow()))
+
+    def test_ccs_record_case_that_is_availing_services(self):
+        rule = _create_empty_rule(self.domain, case_type='ccs_record')
+        rule.add_criteria(CustomMatchDefinition, name='ICDS_CCS_RECORD_CASE_AVAILING_SERVICES')
+
+        def check(case, add, match):
+            case = self._set_case_props(case, {"add": add})
+            (self.assertTrue if match else self.assertFalse)(
+                rule.criteria_match(case, now),
+                "%s case with add=%s should%s match" % (
+                    case.type, add, "" if match else " not",
+                )
+            )
+
+        now = datetime(2020, 1, 13, 12, 0)
+        with _with_case(self.domain, 'person', datetime.utcnow()) as mother:
+            check(mother, '2020-01-01', False)
+            with _with_case(self.domain, 'person', datetime.utcnow()) as child:
+                self._set_case_props(child, {"dob": '2020-01-01'})
+                set_parent_case(self.domain, child, mother, identifier='mother')
+                with _with_case(self.domain, 'ccs_record', datetime.utcnow()) as ccs:
+                    set_parent_case(self.domain, ccs, mother, identifier='parent')
+                    for match, add in [
+                        (False, None),          # not set
+                        (False, '2020-01-02'),  # no match
+                        (True, '2020-01-01'),   # match
+                    ]:
+                        check(ccs, add, match)

--- a/settings.py
+++ b/settings.py
@@ -1627,6 +1627,8 @@ AVAILABLE_CUSTOM_RULE_CRITERIA = {
         'custom.icds.rules.custom_criteria.person_case_is_under_19_years_old',
     'ICDS_CCS_RECORD_CASE_HAS_FUTURE_EDD':
         'custom.icds.rules.custom_criteria.ccs_record_case_has_future_edd',
+    'ICDS_CCS_RECORD_CASE_AVAILING_SERVICES':
+        'custom.icds.rules.custom_criteria.ccs_record_case_is_availing_services',
     'ICDS_IS_USERCASE_OF_AWW':
         'custom.icds.rules.custom_criteria.is_usercase_of_aww',
     'ICDS_IS_USERCASE_OF_LS':


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1075

##### PRODUCT DESCRIPTION
Adds an ICDS-only case rule criteria for filtering ccs_record cases to those where the associated child is using ICDS services (is registered and has not migrated).

Pinged dashboard devs because I'm guessing you're the most familiar with ICDS's case structure.