### PR TITLE
change ICDS UCRs to use 'location' filter type instead of 'owner'

### DIFF
--- a/custom/icds_reports/ucr/reports/ls/ls_report_child_names.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_child_names.json
@@ -78,7 +78,7 @@
         "show_all": true,
         "datatype": "string",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "required": false,
         "display": "Owner Name",

--- a/custom/icds_reports/ucr/reports/ls/ls_report_child_nutrition_status.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_child_nutrition_status.json
@@ -99,7 +99,7 @@
         "show_all": true,
         "datatype": "string",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "required": false,
         "display": "Owner Name",

--- a/custom/icds_reports/ucr/reports/ls/ls_report_lbw_pre_term.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_lbw_pre_term.json
@@ -78,7 +78,7 @@
         "show_all": true,
         "datatype": "string",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "required": false,
         "display": "Owner Name",

--- a/custom/icds_reports/ucr/reports/ls/ls_report_pregnant_women_names.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_pregnant_women_names.json
@@ -91,7 +91,7 @@
         "slug": "owner_id",
         "field": "owner_id",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "display": "Owner Name"
       },

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
@@ -99,7 +99,7 @@
         "slug": "owner_id",
         "field": "awc_id",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "display": "Owner Name"
       }

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2bii_child_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2bii_child_death_list.json
@@ -98,7 +98,7 @@
         "slug": "owner_id",
         "field": "owner_id",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "display": "Owner Name"
       }

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2ci_child_birth_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2ci_child_birth_list.json
@@ -98,7 +98,7 @@
         "slug": "owner_id",
         "field": "owner_id",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "display": "Owner Name"
       }

--- a/custom/icds_reports/ucr/reports/other/list_pnc_delivery_complications.json
+++ b/custom/icds_reports/ucr/reports/other/list_pnc_delivery_complications.json
@@ -78,7 +78,7 @@
         "show_all": true,
         "datatype": "string",
         "choice_provider": {
-          "type": "owner"
+          "type": "location"
         },
         "required": false,
         "display": "Owner Name",


### PR DESCRIPTION
'owner' is an alias for 'group or user or location'. Since all
ICDS cases are owned by locations it makes sense to specify it
more directly. This also prevents us doing a group and user lookup
for each filter.

https://dimagi-dev.atlassian.net/browse/IIO-672