### PR TITLE
display configurable report query

### DIFF
--- a/corehq/apps/reports/api.py
+++ b/corehq/apps/reports/api.py
@@ -43,5 +43,8 @@ class ReportDataSource(object):
 
         return {}
 
+    def get_query_strings(self):
+        return NotImplemented
+
     def get_total_records(self):
         return 0

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -126,5 +126,11 @@
       {% endblock reporttable %}
     </div>
 
+    {% if queries %}
+      <div class="alert alert-info">
+        {% trans 'Base Query' %}
+        <p>{{ queries }}</p>
+      </div>
+    {% endif %}
   {% endblock main_column_content %}
 {% endblock %}

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -345,6 +345,9 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
         context.update(self.pop_report_builder_context_data())
         if isinstance(self.spec, ReportConfiguration) and self.spec.report_meta.builder_report_type == 'map':
             context['report_table']['default_rows'] = 100
+        if self.request.couch_user.is_staff:
+            if not self.data_source._custom_query_provider:
+                context['queries'] = ','.join(self.data_source.data_source.get_query_strings())
         return context
 
     def pop_report_builder_context_data(self):

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -73,6 +73,13 @@ class ConfigurableReportSqlDataSource(ConfigurableReportDataSourceMixin, SqlData
         return ret
 
     @method_decorator(catch_and_raise_exceptions)
+    def get_query_strings(self):
+        qc = self.query_context()
+        session_helper = connection_manager.get_session_helper(self.engine_id, readonly=True)
+        with session_helper.session_context() as session:
+            return qc.get_query_strings(session.connection())
+
+    @method_decorator(catch_and_raise_exceptions)
     def get_total_records(self):
         qc = self.query_context()
         session_helper = connection_manager.get_session_helper(self.engine_id, readonly=True)


### PR DESCRIPTION
Working on UCR's lately i found myself looking for the query that would be run for a report.
I am happy to reconsider this if this does not look like the right or complete solution but i found this useful, so added the base query to the bottom of the page when viewing a report, only for developers.

<img width="1265" alt="Screenshot 2020-01-14 at 9 10 09 PM" src="https://user-images.githubusercontent.com/3864163/72358261-484a7680-3712-11ea-9a3f-0d9fb012fdc2.png">
