### PR TITLE
[ci skip] fix indicator name in docs

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -870,7 +870,7 @@ This spec would produce the following columns in the data source:
 
 If the ledger you're using is a due list and you wish to save the dates
 instead of integers, you can change the "type" from "ledger_balances" to
-"due_list_dates".
+"due_list_date".
 
 Practical notes for creating indicators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
random thing i noticed. https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/indicators/factory.py#L165