### PR TITLE
Don't strip is_location_safe prop from view fn

### DIFF
--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -135,6 +135,7 @@ def always_allow_project_access(view_func):
     (typically because the subscription was paused).
     Remember: Order matters.
     """
+    @wraps(view_func)
     def shim(request, *args, **kwargs):
         request.always_allow_project_access = True
         return view_func(request, *args, **kwargs)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1169

##### SUMMARY
This new decorator inadvertently stripped properties being set on view functions by replacing them with new callables.  This uses the `wraps` decorator to preserve the function's original appearance.

```python
# before
>>> from corehq.apps.users.views import change_password
>>> change_password.is_location_safe
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-cf5512f82dda> in <module>()
----> 1 change_password.is_location_safe

# after
>>> from corehq.apps.users.views import change_password
>>> change_password.is_location_safe
True
```

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
There was a bug where some location-safe views were being incorrectly treated as not location-safe.  This restores the previous behavior.
