### PR TITLE
Consolidate case diff logic

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -184,12 +184,7 @@ class CouchSqlDomainMigrator:
         self._migrate_form_and_associated_models(couch_form)
         self.case_diff_queue.update(case_ids, form_id)
 
-    def _migrate_form_and_associated_models(
-        self,
-        couch_form,
-        form_is_processed=True,
-        replace_diffs=False,
-    ):
+    def _migrate_form_and_associated_models(self, couch_form, form_is_processed=True):
         """
         Copies `couch_form` into a new sql form
         """
@@ -240,12 +235,12 @@ class CouchSqlDomainMigrator:
                 raise err from None
         finally:
             if couch_form.doc_type != 'SubmissionErrorLog':
-                self._save_diffs(couch_form, sql_form, replace_diffs)
+                self._save_diffs(couch_form, sql_form)
 
-    def _save_diffs(self, couch_form, sql_form, replace):
+    def _save_diffs(self, couch_form, sql_form):
         couch_json = couch_form.to_json()
         sql_json = {} if sql_form is None else sql_form_to_json(sql_form)
-        self.statedb.save_form_diffs(couch_json, sql_json, replace)
+        self.statedb.save_form_diffs(couch_json, sql_json)
 
     def _get_case_stock_result(self, sql_form, couch_form):
         case_stock_result = None
@@ -360,7 +355,7 @@ class CouchSqlDomainMigrator:
         for form_id in form_ids:
             log.info("migrating form: %s", form_id)
             form = XFormInstance.get(form_id)
-            self._migrate_form_and_associated_models(form, replace_diffs=True)
+            self._migrate_form_and_associated_models(form)
         self._rediff_already_migrated_forms(migrated_ids)
 
     def _rediff_already_migrated_forms(self, form_ids):
@@ -383,7 +378,7 @@ class CouchSqlDomainMigrator:
                 except Exception:
                     log.exception("Error wrapping form %s", doc)
                 else:
-                    self._migrate_form_and_associated_models(form, replace_diffs=True)
+                    self._migrate_form_and_associated_models(form)
                     add_form()
                     migrated += 1
                     if migrated % 100 == 0:

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -646,6 +646,7 @@ class TestDiffCases(SimpleTestCase):
         assert case_id not in self.couch_cases, self.couch_cases[case_id]
         props.setdefault("domain", "test")
         props.setdefault("doc_type", "CommCareCase")
+        props.setdefault("_id", case_id)
         self.sql_cases[case_id] = Config(
             case_id=case_id,
             props=props,
@@ -683,7 +684,7 @@ class TestDiffCases(SimpleTestCase):
         return [ledgers[c] for c in case_id__in if c in ledgers]
 
     def hard_rebuild_case(self, *args, **kw):
-        raise Exception("unexpected")
+        raise Exception("rebuild disabled")
 
 
 @attr.s

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from copy import deepcopy
 from glob import glob
 from inspect import signature
@@ -33,7 +33,7 @@ class TestCaseDiffQueue(SimpleTestCase):
     def setUp(self):
         super(TestCaseDiffQueue, self).setUp()
         self.patches = [
-            patch.object(mod, "diff_cases", self.diff_cases),
+            patch.object(mod, "diff_cases_and_save_state", self.diff_cases),
             patch(
                 "corehq.form_processor.backends.couch.dbaccessors.CaseAccessorCouch.get_cases",
                 self.get_cases,
@@ -593,46 +593,45 @@ class TestDiffCases(SimpleTestCase):
 
         for patcher in self.patches:
             patcher.start()
+            self.addCleanup(patcher.stop)
         self.statedb = StateDB.init(":memory:")
+        self.addCleanup(self.statedb.close)
         self.sql_cases = {}
         self.sql_ledgers = {}
         self.couch_cases = {}
         self.couch_ledgers = {}
-
-    def tearDown(self):
-        for patcher in self.patches:
-            patcher.stop()
-        self.statedb.close()
-        super(TestDiffCases, self).tearDown()
+        stack = ExitStack()
+        stack.enter_context(mod.global_diff_state({}))
+        self.addCleanup(stack.close)
 
     def test_clean(self):
         self.add_case("a")
-        mod.diff_cases(self.couch_cases, self.statedb)
+        mod.diff_cases_and_save_state(self.couch_cases, self.statedb)
         self.assert_diffs()
 
     def test_diff(self):
         couch_json = self.add_case("a", prop=1)
         couch_json["prop"] = 2
-        mod.diff_cases(self.couch_cases, self.statedb)
+        mod.diff_cases_and_save_state(self.couch_cases, self.statedb)
         self.assert_diffs([Diff("a", path=["prop"], old=2, new=1)])
 
     def test_replace_diff(self):
         self.add_case("a", prop=1)
         different_cases = deepcopy(self.couch_cases)
         different_cases["a"]["prop"] = 2
-        mod.diff_cases(different_cases, self.statedb)
+        mod.diff_cases_and_save_state(different_cases, self.statedb)
         self.assert_diffs([Diff("a", path=["prop"], old=2, new=1)])
-        mod.diff_cases(self.couch_cases, self.statedb)
+        mod.diff_cases_and_save_state(self.couch_cases, self.statedb)
         self.assert_diffs()
 
     def test_replace_ledger_diff(self):
         self.add_case("a")
         stock = self.add_ledger("a", x=1)
         stock.values["x"] = 2
-        mod.diff_cases(self.couch_cases, self.statedb)
+        mod.diff_cases_and_save_state(self.couch_cases, self.statedb)
         self.assert_diffs([Diff("a/stock/a", "stock state", path=["x"], old=2, new=1)])
         stock.values["x"] = 1
-        mod.diff_cases(self.couch_cases, self.statedb)
+        mod.diff_cases_and_save_state(self.couch_cases, self.statedb)
         self.assert_diffs()
 
     def assert_diffs(self, expected=None):
@@ -682,8 +681,8 @@ class TestDiffCases(SimpleTestCase):
         ledgers = self.couch_ledgers
         return [ledgers[c] for c in case_id__in if c in ledgers]
 
-    def hard_rebuild_case(self, domain, case_id, *args, **kw):
-        return Config(to_json=lambda: self.couch_cases[case_id])
+    def hard_rebuild_case(self, *args, **kw):
+        raise Exception("unexpected")
 
 
 @attr.s

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -644,6 +644,7 @@ class TestDiffCases(SimpleTestCase):
     def add_case(self, case_id, **props):
         assert case_id not in self.sql_cases, self.sql_cases[case_id]
         assert case_id not in self.couch_cases, self.couch_cases[case_id]
+        props.setdefault("domain", "test")
         props.setdefault("doc_type", "CommCareCase")
         self.sql_cases[case_id] = Config(
             case_id=case_id,


### PR DESCRIPTION
- Consolidate case diff logic: there were two implementations, now there is one.
- Add datadog diff metrics to answer questions about how many forms and cases have diffs.

Review by commit 🐡 