### PR TITLE
Memoize top redis hits on ICDS

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -20,7 +20,6 @@ import stripe
 from django_prbac.models import Role
 from memoized import memoized
 
-from corehq.apps.domain.models import icds_conditional_session_key
 from corehq.apps.domain.shortcuts import publish_domain_saved
 from dimagi.ext.couchdbkit import (
     BooleanProperty,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1729,8 +1729,7 @@ class Subscription(models.Model):
         return cls._get_active_subscription_by_domain(domain_name_or_obj)
 
     @classmethod
-    @quickcache(['domain_name'], timeout=60 * 60,
-        session_function=icds_conditional_session_key(), memoize_timeout=60 * 60)
+    @quickcache(['domain_name'], timeout=60 * 60)
     def _get_active_subscription_by_domain(cls, domain_name):
         try:
             return cls.visible_objects.select_related(

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -20,6 +20,7 @@ import stripe
 from django_prbac.models import Role
 from memoized import memoized
 
+from corehq.apps.domain.models import icds_conditional_session_key
 from corehq.apps.domain.shortcuts import publish_domain_saved
 from dimagi.ext.couchdbkit import (
     BooleanProperty,
@@ -1728,7 +1729,8 @@ class Subscription(models.Model):
         return cls._get_active_subscription_by_domain(domain_name_or_obj)
 
     @classmethod
-    @quickcache(['domain_name'], timeout=60 * 60)
+    @quickcache(['domain_name'], timeout=60 * 60,
+        session_function=icds_conditional_session_key(), memoize_timeout=60 * 60)
     def _get_active_subscription_by_domain(cls, domain_name):
         try:
             return cls.visible_objects.select_related(

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -597,7 +597,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     @classmethod
     @quickcache(['name'], skip_arg='strict', timeout=30*60,
-        session_function=icds_conditional_session_key())
+        session_function=icds_conditional_session_key(), memoize_timeout=60)
     def get_by_name(cls, name, strict=False):
         if not name:
             # get_by_name should never be called with name as None (or '', etc)

--- a/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore_caching.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import datetime
+from corehq.apps.domain.models import icds_conditional_session_key
 from casexml.apps.phone.const import RESTORE_CACHE_KEY_PREFIX, ASYNC_RESTORE_CACHE_KEY_PREFIX
 from corehq.toggles import ENABLE_LOADTEST_USERS
 from corehq.util.quickcache import quickcache
@@ -48,7 +49,8 @@ def _get_new_arbitrary_value():
     return datetime.datetime.utcnow().isoformat()
 
 
-@quickcache(['domain'], timeout=60 * 24 * 60 * 60)
+@quickcache(['domain'], timeout=60 * 24 * 60 * 60,
+    session_function=icds_conditional_session_key(), memoize_timeout=60 * 60)
 def _get_domain_freshness_token(domain):
     return _get_new_arbitrary_value()
 


### PR DESCRIPTION
From redis-cli monitor

```
(icds) ansible@redis6:~$ cat Jan-16-top-getters.txt
 368318 "5688a2541c9edd77746bcd2385e65ff3639a664f"
 366893 "c3f8721cbb97f72bc19e972846bd7aaf91901658"
 360859 ":1:quickcache.get_case_types_for_domain_es.42c40c47/u7c2a3b6bada25888e23c8c4ad89f3c97,b0"
 114654 ":1:quickcache._get_active_subscription_by_domain.3e58106b/u7c2a3b6bada25888e23c8c4ad89f3c97"
  98051 ":1:quickcache._get_domain_freshness_token.6f26e514/u7c2a3b6bada25888e23c8c4ad89f3c97"
  86776 ":1:quickcache.get_migration_status.73eff139/u7c2a3b6bada25888e23c8c4ad89f3c97,u61b4f9531ba0798e5c810e29309c18ea"
  83648 ":1:quickcache.any_migrations_in_progress.e7334dc2/u7c2a3b6bada25888e23c8c4ad89f3c97"
  75901 ":1:quickcache.get_app_and_build_ids.fbc15d9d/u7c2a3b6bada25888e23c8c4ad89f3c97,u1f36df546e0889abd6a84a4806742323"
  61784 ":1:quickcache.for_domain.20809aee/u7c2a3b6bada25888e23c8c4ad89f3c97"
  54807 ":1:quickcache.get_migration_status.73eff139/u7c2a3b6bada25888e23c8c4ad89f3c97,u44f2ff5a23c6a97243eb3952b342ae18"
(icds) ansible@redis6:~$ grep get_by_name Jan-16-monitor.txt | wc -l
16670
```

