### PR TITLE
"Soft" Rollback Data-Typing in Exports

### DIFF
--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -13,6 +13,10 @@ from dimagi.ext.couchdbkit import Property
 from dimagi.utils.modules import to_function
 from dimagi.utils.web import json_handler
 
+_dirty_chars = re.compile(
+    '[\x00-\x08\x0b-\x1f\x7f-\x84\x86-\x9f\ud800-\udfff\ufdd0-\ufddf\ufffe-\uffff]'
+)
+
 
 def force_tag_to_list(export_tag):
     if isinstance(export_tag, str):
@@ -316,8 +320,15 @@ def get_excel_format_value(value):
             pass
 
     # no formats matched...clean and return as text
-    dirty_chars = re.compile(
-        '[\x00-\x08\x0b-\x1f\x7f-\x84\x86-\x9f\ud800-\udfff\ufdd0-\ufddf\ufffe-\uffff]'
-    )
-    value = dirty_chars.sub('?', value)
+    value = _dirty_chars.sub('?', value)
     return ExcelFormatValue(numbers.FORMAT_TEXT, value)
+
+
+def get_excel_safe_text_value(value):
+    if isinstance(value, bytes):
+        value = value.decode('utf-8')
+    elif value is not None:
+        value = str(value)
+    else:
+        value = ''
+    return _dirty_chars.sub('?', value)

--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -324,7 +324,9 @@ def get_excel_format_value(value):
     return ExcelFormatValue(numbers.FORMAT_TEXT, value)
 
 
-def get_excel_safe_text_value(value):
+def get_legacy_excel_safe_value(value):
+    if isinstance(value, (int, float)):
+        return value
     if isinstance(value, bytes):
         value = value.decode('utf-8')
     elif value is not None:

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -19,7 +19,7 @@ from couchexport.models import Format
 from openpyxl.styles import numbers
 from openpyxl.cell import WriteOnlyCell
 
-from couchexport.util import get_excel_format_value, get_excel_safe_text_value
+from couchexport.util import get_excel_format_value, get_legacy_excel_safe_value
 
 MAX_XLS_COLUMNS = 256
 

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -362,9 +362,10 @@ class Excel2007ExportWriter(ExportWriter):
     format = Format.XLS_2007
     max_table_name_size = 31
 
-    def __init__(self, format_as_text=False):
+    def __init__(self, format_as_text=False, use_data_typed_cells=False):
         super(Excel2007ExportWriter, self).__init__()
         self.format_as_text = format_as_text
+        self.use_data_typed_cells = use_data_typed_cells
 
     def _init(self):
         # https://openpyxl.readthedocs.io/en/latest/optimized.html
@@ -385,14 +386,18 @@ class Excel2007ExportWriter(ExportWriter):
 
         cells = []
         for col_ind, val in enumerate(row):
-            if ((isinstance(row, FormattedRow) and col_ind in row.skip_excel_formatting)
-                    or self.format_as_text):
-                cell = WriteOnlyCell(sheet, get_excel_safe_text_value(val))
-                cell.number_format = numbers.FORMAT_TEXT
-            else:
+            skip_formatting_on_row = (isinstance(row, FormattedRow)
+                                      and col_ind in row.skip_excel_formatting)
+
+            if self.use_data_typed_cells and not skip_formatting_on_row:
                 excel_format, val_fmt = get_excel_format_value(val)
                 cell = WriteOnlyCell(sheet, val_fmt)
                 cell.number_format = excel_format
+            else:
+                cell = WriteOnlyCell(sheet, get_legacy_excel_safe_value(val))
+                if self.format_as_text:
+                    cell.number_format = numbers.FORMAT_TEXT
+
             cells.append(cell)
 
         if isinstance(row, FormattedRow):

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -19,7 +19,7 @@ from couchexport.models import Format
 from openpyxl.styles import numbers
 from openpyxl.cell import WriteOnlyCell
 
-from couchexport.util import get_excel_format_value
+from couchexport.util import get_excel_format_value, get_excel_safe_text_value
 
 MAX_XLS_COLUMNS = 256
 
@@ -387,7 +387,7 @@ class Excel2007ExportWriter(ExportWriter):
         for col_ind, val in enumerate(row):
             if ((isinstance(row, FormattedRow) and col_ind in row.skip_excel_formatting)
                     or self.format_as_text):
-                cell = WriteOnlyCell(sheet, val)
+                cell = WriteOnlyCell(sheet, get_excel_safe_text_value(val))
                 cell.number_format = numbers.FORMAT_TEXT
             else:
                 excel_format, val_fmt = get_excel_format_value(val)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
This makes sure that the default Excel 2007 export writer functionality is to behave as it did previously before the Exports data-typing change from https://github.com/dimagi/commcare-hq/pull/26291 ([see original behavior here](https://github.com/dimagi/commcare-hq/pull/26291/files#diff-5fe4ce2e18624b1a325fb22b1b0a01b7L385-L399)). I will deal with re-implementing / enabling data-typing for form / case exports (or perhaps making it a UI option!!) when I get back to this on Tuesday.