### PR TITLE
Fix bulk archive bug

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_xform_management.py
+++ b/corehq/apps/data_interfaces/tests/test_xform_management.py
@@ -5,12 +5,15 @@ from django.test import TestCase, Client
 from corehq.apps.data_interfaces.views import XFormManagementView
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
+from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
+from corehq.util.elastic import reset_es_index
 
 
 class XFormManagementTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        reset_es_index(XFORM_INDEX_INFO)
         cls.domain = create_domain('xform-management-test')
         cls.web_user = WebUser.create('xform-management-test', 'test', 'test',
                                       is_superuser=True)

--- a/corehq/apps/data_interfaces/tests/test_xform_management.py
+++ b/corehq/apps/data_interfaces/tests/test_xform_management.py
@@ -1,0 +1,37 @@
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpRequest, QueryDict
+from django.test import TestCase, Client
+
+from corehq.apps.data_interfaces.views import XFormManagementView
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser
+
+
+class XFormManagementTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = create_domain('xform-management-test')
+        cls.web_user = WebUser.create('xform-management-test', 'test', 'test',
+                                      is_superuser=True)
+        Client().force_login(cls.web_user.get_django_user())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.web_user.delete()
+        cls.domain.delete()
+
+    def test_get_xform_ids__sanity_check(self):
+        # This helper has to mock a request in a brittle way.
+        # If permissions are wrong, instead of returning a list,
+        # it will return an HttpResponse containing the permission error.
+        # This can break when permissions change.
+        # So, just test that we aren't hitting that situation and that the response is a list.
+        request = HttpRequest()
+        request.POST = QueryDict('select_all=')
+        request.couch_user = self.web_user
+        SessionMiddleware().process_request(request)
+        view = XFormManagementView()
+        view.args = (self.domain.name,)
+        view.request = request
+        assert isinstance(view.get_xform_ids(request), list)

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -518,6 +518,7 @@ class XFormManagementView(DataInterfaceSection):
             _request.couch_user.current_domain = self.domain
             _request.can_access_all_locations = request.couch_user.has_permission(self.domain,
                                                                                   'access_all_locations')
+            _request.always_allow_project_access = True
             _request.session = request.session
 
             _request.GET = QueryDict(form_query_string)


### PR DESCRIPTION
##### SUMMARY
Fixes https://dimagi-dev.atlassian.net/browse/SAASP-10215

This may not seem like much, but it actually took me quite a while to figure out how to address the original issue, and then almost as long to figure out what things I needed to set up to make the test pass after the fix—and fail before the fix.

The overall issue was that an internal call that previously returned a list of xforms (the ones to archive) is now returning an HttpResponse object for the “Sorry, you do not have access to Project Features” page. At first, my instinct was to rewrite this hacky call, which essentially mocks a request to the helper object that manages the page the user was just on, using a more sane function call, but that turned out to be surprisingly difficult, and I tried a few different ways. In order to make sure the behavior is really the same as what the user just saw, mocking a request to the same helper object seems to be the only viable option, barring a bigger rewrite.

The test I put in place should fail or error if another future permissions change triggers something like this in the future.

##### PRODUCT DESCRIPTION
Bulk Archive was broken if you selected the checkbox to archive (or unarchive) all forms in a search.
