### PR TITLE
Disable new setup of sms/call as a user's default two factor method

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -949,6 +949,8 @@ SESSION_BYPASS_URLS = [
     r'^/a/{domain}/apps/download/',
 ]
 
+ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE = False
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)


### PR DESCRIPTION
##### SUMMARY

https://dimagi-dev.atlassian.net/browse/SAASP-10208

Users already using sms/call as their default two factor method will continue to be able to use it. Any first time setup or setup after resetting two factor auth will not have sms or call as an option.

This is both because call and SMS are widely not considered sufficiently secure to act as two factor methods, and because it is a fraud vulnerability.

I put it under a setting `ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE` to make it discoverable in case a team maintaining a different commcare instance is upset with the new default behavior and wishes to override it, and someone needs to quickly field that change. I'm not anticipating it being an issue, however.

Down the road we can try and push stragglers off call / sms if we want, but I wanted to start by just not having any new users do it. It's also still possible to use call / sms as the backup method, which I'll also address separately.