### PR TITLE
Stopped fetching case types for edit conditional alert page

### DIFF
--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -3636,6 +3636,16 @@ class ConditionalAlertCriteriaForm(CaseRuleCriteriaForm):
         # doesn't change makes it easier to run the rule for this alert.
         self.fields['case_type'].disabled = True
 
+    def set_case_type_choices(self, initial):
+        # If this is an edit form, case type won't be editable (see set_read_only_fields_during_editing),
+        # so don't bother fetching case types.
+        if self.initial_rule:
+            self.fields['case_type'].choices = (
+                (case_type, case_type) for case_type in [initial or '']
+            )
+        else:
+            super().set_case_type_choices(initial)
+
     def __init__(self, *args, **kwargs):
         super(ConditionalAlertCriteriaForm, self).__init__(*args, **kwargs)
         if self.initial_rule:


### PR DESCRIPTION
##### SUMMARY
Fixes https://sentry.io/organizations/dimagi/issues/1444579599

##### PRODUCT DESCRIPTION
The edit conditional alert page is 500ing for ICDS due to ongoing ES problems...but the ES call is to fetch the domain's case types, which are then used to populate a dropdown that's disabled on this page. This PR removes that ES call from the edit page. The page to create a new alert will still 500 when ES is doing poorly.

This doesn't need to be announced; the code change is for everyone but only ICDS is having frequent enough ES trouble for this to be an issue.