### PR TITLE
Clear UserReportingMetadataStaging records when users are deleted

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -348,6 +348,3 @@ def process_reporting_metadata_staging():
                 user.save(fire_signals=False)
 
             record.delete()
-
-    if UserReportingMetadataStaging.objects.exists():
-        process_reporting_metadata_staging.delay()

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -320,6 +320,7 @@ def process_reporting_metadata_staging():
         for record in records:
             user = CouchUser.get_by_user_id(record.user_id, record.domain)
             if not user or user.is_deleted():
+                record.delete()
                 continue
 
             save = False

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -348,3 +348,6 @@ def process_reporting_metadata_staging():
                 user.save(fire_signals=False)
 
             record.delete()
+
+    if UserReportingMetadataStaging.objects.exists():
+        process_reporting_metadata_staging.delay()


### PR DESCRIPTION
On India, there are four old users for which `UserReportingMetadataStaging` records exist. Current code keeps spawning more tasks recursively if there are any records that exist. There is a condition where records were not deleted, so each task kept triggering more tasks. This aggravated after this [PR](https://github.com/dimagi/commcare-hq/pull/26305/files) on India specifically, because only on India the schedule is set to every 5 minutes (whereas on ICDS it's restricted to a certain time of the day) and has old records for deleted users.

This fix deletes the records that aren't to be processed and ~~stops spawning more subtasks~~