### PR TITLE
Skip icds_reports TestExportData until flakiness issue is resolved

### DIFF
--- a/custom/icds_reports/tests/agg_tests/test_export_data.py
+++ b/custom/icds_reports/tests/agg_tests/test_export_data.py
@@ -1,5 +1,8 @@
 from datetime import date, datetime
 import json
+
+from unittest import skip
+
 from custom.icds_reports.utils import india_now
 from django.core.serializers.json import DjangoJSONEncoder
 from django.test.testcases import TestCase
@@ -16,6 +19,33 @@ from custom.icds_reports.reports.incentive import IncentiveReport
 from custom.icds_reports.reports.take_home_ration import TakeHomeRationExport
 
 
+@skip("""
+This test produces intermittent failures such as the one in
+https://travis-ci.org/dimagi/commcare-hq/jobs/639801623:
+
+    FAIL: custom.icds_reports.tests.agg_tests.test_export_data:TestExportData.test_thr_report
+    ----------------------------------------------------------------------
+    Traceback (most recent call last):
+      File "/mnt/commcare-hq-ro/custom/icds_reports/tests/agg_tests/test_export_data.py", line 2300, in test_thr_report
+        ['Year', 2017]]
+    AssertionError: Lists differ: [...]
+
+    First differing element 1:
+
+    [...]
+
+       ['Export Info',
+    -   [['Generated at', '13:03:07 21 January 2020'],
+    ?                             ^
+    +   [['Generated at', '13:03:08 21 January 2020'],
+    ?                             ^
+         ['State', 'st1'],
+         ['District', 'd1'],
+         ['Block', 'b1'],
+         ['Month', 'May'],
+         ['Year', 2017]]]]
+
+""")
 class TestExportData(TestCase):
     maxDiff = None
 


### PR DESCRIPTION
##### SUMMARY

This is one of the more common intermittent failures of travis tests,
so I'm going to take these tests out of rotation and leave it up to the
ICDS division to decide if and when it's worth fixing to get them
running again.

Offhand it looks like something that freezegun might be able to help with.

@snopoke @calellowitz feel free to pull in the right people to be informed of this if it's not you
