### PR TITLE
Improve submission throughput for domains sharing an enterprise account

### DIFF
--- a/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
+++ b/corehq/project_limits/tests/test_get_n_users_for_rate_limiting.py
@@ -67,9 +67,9 @@ class GetNUsersForRateLimitingTest(TestCase, DomainSubscriptionMixin):
         # No change on the original domain
         self._assert_value_equals(domain_1, 9)
 
-        # The new domain should get half the total included users for the shared account
+        # The new domain should get a proportion of total included users for the shared account
 
-        self._assert_value_equals(domain_2, 4)
+        self._assert_value_equals(domain_2, 7.2)
 
     def _assert_value_equals(self, domain, value):
         get_n_users_for_rate_limiting.clear(domain)


### PR DESCRIPTION
##### SUMMARY

Previously it was dividing the total prepaid users across all domains,
which is too conservative, since usually in a given window
one domain's submissions dominate.
