### PR TITLE
Upgrade pip-tools to fix `make requirements` test

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -127,7 +127,7 @@ pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.22
 pickleshare==0.7.5        # via ipython
 pillow==6.2.1
-pip-tools==4.2.0
+pip-tools==4.4.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prompt-toolkit==1.0.18    # via ipython

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -110,7 +110,7 @@ pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.22
 pillow==6.2.1
-pip-tools==4.2.0
+pip-tools==4.4.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -127,7 +127,7 @@ pexpect==4.7.0            # via ipython
 phonenumberslite==8.10.22
 pickleshare==0.7.5        # via ipython
 pillow==6.2.1
-pip-tools==4.2.0
+pip-tools==4.4.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prompt-toolkit==1.0.18    # via ipython

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -6,7 +6,7 @@ git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 fakecouch==0.0.15
 nose==1.3.7
 nose-exclude==0.5.0
-pip-tools>4.0.0
+pip-tools>4.2.0
 testil
 unittest2
 requests-mock

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -110,7 +110,7 @@ pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.10.22
 pillow==6.2.1
-pip-tools==4.2.0
+pip-tools==4.4.0
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 psycogreen==1.0.1


### PR DESCRIPTION
##### SUMMARY
Tests are routinely failing on this now. It's an error I recognized; seems to happen with some percentage of each pip version upgrade released. Tests run fine until the build fails with

```
pip-compile -o requirements/requirements.txt requirements/requirements.in --allow-unsafe
Traceback (most recent call last):
  File "/vendor/bin/pip-compile", line 5, in <module>
    from piptools.scripts.compile import cli
  File "/vendor/lib/python3.6/site-packages/piptools/scripts/compile.py", line 11, in <module>
    from .._compat import install_req_from_line, parse_requirements
  File "/vendor/lib/python3.6/site-packages/piptools/_compat/__init__.py", line 7, in <module>
    from .pip_compat import (
  File "/vendor/lib/python3.6/site-packages/piptools/_compat/pip_compat.py", line 39, in <module>
    PackageFinder = do_import("index", "PackageFinder")
  File "/vendor/lib/python3.6/site-packages/piptools/_compat/pip_compat.py", line 26, in do_import
    return getattr(imported, package)
AttributeError: module 'pip._internal.index' has no attribute 'PackageFinder'
Makefile:11: recipe for target 'requirements' failed
make: *** [requirements] Error 1
The command "scripts/docker test --noinput --stop --verbosity=2 --divide-depth=1 --with-timing --threshold=10" exited with 2.
Done. Your build exited with 1.
```