### PR TITLE
Attempt not to 429 burst submissions if a delay will do

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -101,7 +101,8 @@ def _delay_and_report_rate_limit_submission(domain, max_wait, datadog_metric):
         duration_tag = 'delayed_reject'
     datadog_counter(datadog_metric, tags=[
         'domain:{}'.format(domain),
-        'duration:{}'.format(duration_tag)
+        'duration:{}'.format(duration_tag),
+        'throttle_method:{}'.format('delay' if acquired else 'reject')
     ])
     return acquired
 

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -70,11 +70,12 @@ def rate_limit_submission(domain):
     if should_allow_usage:
         allow_usage = True
     elif RATE_LIMIT_SUBMISSIONS.enabled(domain, namespace=NAMESPACE_DOMAIN):
-        allow_usage = False
-        _report_rate_limit_submission(domain)
+        allow_usage = _delay_and_report_rate_limit_submission(
+            domain, max_wait=15, datadog_metric='commcare.xform_submissions.rate_limited')
     else:
         allow_usage = True
-        _delay_and_report_rate_limit_submission_test(domain, max_wait=15)
+        _delay_and_report_rate_limit_submission(
+            domain, max_wait=15, datadog_metric='commcare.xform_submissions.rate_limited.test')
 
     return not allow_usage
 
@@ -88,24 +89,21 @@ def report_submission_usage(domain):
     _report_current_global_submission_thresholds()
 
 
-def _report_rate_limit_submission(domain):
-    datadog_counter('commcare.xform_submissions.rate_limited', tags=[
-        'domain:{}'.format(domain),
-    ])
-
-
-def _delay_and_report_rate_limit_submission_test(domain, max_wait):
+def _delay_and_report_rate_limit_submission(domain, max_wait, datadog_metric):
     with TimingContext() as timer:
         acquired = submission_rate_limiter.wait(domain, timeout=max_wait,
-                                                windows_not_to_wait_on=())
+                                                windows_not_to_wait_on=('second', 'minute'))
     if acquired:
-        duration_tag = bucket_value(timer.duration, [1, 5, 10, 15, 20], unit='s')
+        duration_tag = bucket_value(timer.duration, [.5, 1, 5, 10, 15], unit='s')
+    elif timer.duration < max_wait:
+        duration_tag = 'quick_reject'
     else:
-        duration_tag = 'timeout'
-    datadog_counter('commcare.xform_submissions.rate_limited.test', tags=[
+        duration_tag = 'delayed_reject'
+    datadog_counter(datadog_metric, tags=[
         'domain:{}'.format(domain),
         'duration:{}'.format(duration_tag)
     ])
+    return acquired
 
 
 @quickcache([], timeout=60)  # Only report up to once a minute

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -96,7 +96,8 @@ def _report_rate_limit_submission(domain):
 
 def _delay_and_report_rate_limit_submission_test(domain, max_wait):
     with TimingContext() as timer:
-        acquired = submission_rate_limiter.wait(domain, timeout=max_wait)
+        acquired = submission_rate_limiter.wait(domain, timeout=max_wait,
+                                                windows_not_to_wait_on=())
     if acquired:
         duration_tag = bucket_value(timer.duration, [1, 5, 10, 15, 20], unit='s')
     else:

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -91,8 +91,7 @@ def report_submission_usage(domain):
 
 def _delay_and_report_rate_limit_submission(domain, max_wait, datadog_metric):
     with TimingContext() as timer:
-        acquired = submission_rate_limiter.wait(domain, timeout=max_wait,
-                                                windows_not_to_wait_on=('hour', 'day', 'week'))
+        acquired = submission_rate_limiter.wait(domain, timeout=max_wait)
     if acquired:
         duration_tag = bucket_value(timer.duration, [.5, 1, 5, 10, 15], unit='s')
     elif timer.duration < max_wait:

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -92,7 +92,7 @@ def report_submission_usage(domain):
 def _delay_and_report_rate_limit_submission(domain, max_wait, datadog_metric):
     with TimingContext() as timer:
         acquired = submission_rate_limiter.wait(domain, timeout=max_wait,
-                                                windows_not_to_wait_on=('second', 'minute'))
+                                                windows_not_to_wait_on=('hour', 'day', 'week'))
     if acquired:
         duration_tag = bucket_value(timer.duration, [.5, 1, 5, 10, 15], unit='s')
     elif timer.duration < max_wait:


### PR DESCRIPTION
##### SUMMARY
When receiving a request that would be throttled by the second or
minute, wait and retry for up to 15 seconds. This is less load on the
server than rehandling client retries, and a better experience for the
user. This is especially true in the case of API usage, where the script
may not handle 429s well.

This also collects a metric on these throttle delays, and changes the test throttle mode (which we currently don't use) to match this behavior.

Only affects SaaS.