### PR TITLE
Set serializer to picker

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -1769,7 +1769,7 @@ def update_governance_dashboard(target_date):
     _agg_governance_dashboard.delay(current_month)
 
 
-@task(queue='icds_aggregation_queue')
+@task(queue='icds_aggregation_queue', serializer='pickle')
 def _agg_governance_dashboard(current_month):
     previous_month = current_month - relativedelta(months=1)
     for month in [previous_month, current_month]:


### PR DESCRIPTION
Setting the serializer to picker because of default(json) serializer, function is not getting invoked bceause python object date() is passed. 