### PR TITLE
reduce hits to plproxy (part 1)

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -470,7 +470,7 @@ class FormAccessorSQL(AbstractFormAccessor):
 
     @staticmethod
     def get_form_operations(form_id):
-        return list(XFormOperationSQL.objects.plproxy_raw('SELECT * from get_form_operations(%s)', [form_id]))
+        return list(XFormOperationSQL.objects.partitioned_query(form_id).filter(form_id=form_id))
 
     @staticmethod
     def get_forms_with_attachments_meta(form_ids, ordered=False):
@@ -506,10 +506,11 @@ class FormAccessorSQL(AbstractFormAccessor):
 
     @staticmethod
     def form_exists(form_id, domain=None):
-        with XFormInstanceSQL.get_plproxy_cursor() as cursor:
-            cursor.execute('SELECT * FROM check_form_exists(%s, %s)', [form_id, domain])
-            result = fetchone_as_namedtuple(cursor)
-            return result.form_exists
+        query = XFormInstanceSQL.objects.partitioned_query(form_id).filter(form_id=form_id)
+        if domain:
+            query = query.filter(domain=domain)
+
+        return query.exists()
 
     @staticmethod
     def hard_delete_forms(domain, form_ids, delete_attachments=True):
@@ -808,9 +809,8 @@ class CaseAccessorSQL(AbstractCaseAccessor):
 
     @staticmethod
     def get_indices(domain, case_id):
-        return list(CommCareCaseIndexSQL.objects.plproxy_raw(
-            'SELECT * FROM get_case_indices(%s, %s)', [domain, case_id]
-        ))
+        query = CommCareCaseIndexSQL.objects.partitioned_query(case_id)
+        return list(query.filter(case_id=case_id, domain=domain))
 
     @staticmethod
     def get_reverse_indices(domain, case_id):
@@ -922,11 +922,11 @@ class CaseAccessorSQL(AbstractCaseAccessor):
 
     @staticmethod
     def get_attachments(case_id):
-        return list(CaseAttachmentSQL.objects.plproxy_raw('SELECT * from get_case_attachments(%s)', [case_id]))
+        return list(CaseAttachmentSQL.objects.partitioned_query(case_id).filter(case_id=case_id))
 
     @staticmethod
     def get_transactions(case_id):
-        return list(CaseTransaction.objects.plproxy_raw('SELECT * from get_case_transactions(%s)', [case_id]))
+        return list(CaseTransaction.objects.partitioned_query(case_id).filter(case_id=case_id))
 
     @staticmethod
     def get_transaction_by_form_id(case_id, form_id):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -470,7 +470,7 @@ class FormAccessorSQL(AbstractFormAccessor):
 
     @staticmethod
     def get_form_operations(form_id):
-        return list(XFormOperationSQL.objects.partitioned_query(form_id).filter(form_id=form_id))
+        return list(XFormOperationSQL.objects.partitioned_query(form_id).filter(form_id=form_id).order_by('date'))
 
     @staticmethod
     def get_forms_with_attachments_meta(form_ids, ordered=False):
@@ -926,7 +926,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
 
     @staticmethod
     def get_transactions(case_id):
-        return list(CaseTransaction.objects.partitioned_query(case_id).filter(case_id=case_id))
+        return list(CaseTransaction.objects.partitioned_query(case_id).filter(case_id=case_id).order_by('server_date'))
 
     @staticmethod
     def get_transaction_by_form_id(case_id, form_id):

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -225,7 +225,7 @@ class CaseAccessorTestsSQL(TestCase):
         ))
         CaseAccessorSQL.save_case(case)
 
-        with self.assertNumQueries(1, using=self.using):
+        with self.assertNumQueries(1, using=case.db):
             attachments = CaseAccessorSQL.get_attachments(case.case_id)
 
         self.assertEqual(2, len(attachments))

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -188,7 +188,7 @@ class FormAccessorTestsSQL(TestCase):
         self.assertEqual(2, len(forms))
         form = forms[0]
         self.assertEqual(form_with_pic.form_id, form.form_id)
-        with self.assertNumQueries(0, using=self.using):
+        with self.assertNumQueries(0, using=form.db):
             expected = {
                 'form.xml': 'text/xml',
                 'pic.jpg': 'image/jpeg',
@@ -197,7 +197,7 @@ class FormAccessorTestsSQL(TestCase):
             self.assertEqual(2, len(attachments))
             self.assertEqual(expected, {att.name: att.content_type for att in attachments})
 
-        with self.assertNumQueries(0, using=self.using):
+        with self.assertNumQueries(0, using=forms[1].db):
             expected = {
                 'form.xml': 'text/xml',
             }

--- a/corehq/form_processor/tests/test_serialization.py
+++ b/corehq/form_processor/tests/test_serialization.py
@@ -46,6 +46,6 @@ class SerializationTests(TestCase):
             self.assertEqual(form_json['external_blobs']['form.xml']['id'], str(form_xml.key))
 
         # this query goes through pl_proxy
-        with self.assertNumQueries(1, using=self.using):
+        with self.assertNumQueries(1, using=form.db):
             # lazy evaluation of history
             self.assertEqual(0, len(form_json['history']))


### PR DESCRIPTION
##### SUMMARY
Since these queries are executed on a single shard DB they can be routed directly instead of through plproxy. This should slightly reduce the load on plproxy.

SQL functions removed here: https://github.com/dimagi/commcare-hq/pull/26465