### PR TITLE
Use elasticsearch 5.6.16 in docker setup (for tests)

### DIFF
--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -71,7 +71,7 @@ services:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-redis:}/data
 
   elasticsearch:
-    image: elasticsearch:1.7.4
+    image: elasticsearch:5.6.16
     environment:
       ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
     expose:

--- a/settings.py
+++ b/settings.py
@@ -753,7 +753,7 @@ SUMOLOGIC_URL = None
 # on both a single instance or distributed setup this should assume localhost
 ELASTICSEARCH_HOST = 'localhost'
 ELASTICSEARCH_PORT = 9200
-ELASTICSEARCH_MAJOR_VERSION = 1
+ELASTICSEARCH_MAJOR_VERSION = 2
 
 BITLY_LOGIN = ''
 BITLY_APIKEY = ''


### PR DESCRIPTION
This is just to run the travis tests against the next version we're going to target