### PR TITLE
Switch saas rate limiting to use RATE_LIMIT_SUBMISSIONS setting

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -56,7 +56,7 @@ global_submission_rate_limiter = RateLimiter(
 )
 
 
-SHOULD_RATE_LIMIT_SUBMISSIONS = not settings.ENTERPRISE_MODE and not settings.UNIT_TESTING
+SHOULD_RATE_LIMIT_SUBMISSIONS = settings.RATE_LIMIT_SUBMISSIONS and not settings.UNIT_TESTING
 
 
 @run_only_when(SHOULD_RATE_LIMIT_SUBMISSIONS)

--- a/settings.py
+++ b/settings.py
@@ -951,6 +951,7 @@ SESSION_BYPASS_URLS = [
 ]
 
 ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE = False
+RATE_LIMIT_SUBMISSIONS = False
 
 try:
     # try to see if there's an environmental variable set for local_settings


### PR DESCRIPTION
##### SUMMARY
Goes with https://github.com/dimagi/commcare-cloud/pull/3548
