### PR TITLE
[reports / analytics / esaccessors] make sure form.@name is never null

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -169,6 +169,7 @@ def get_form_name_from_last_submission_for_xmlns(domain, xmlns):
         .sort('received_on', desc=True)
         .source(['form.@name'])
         .size(1)
+        .non_null('form.@name')
     )
 
     results = query.run().hits


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10257

##### SUMMARY
Sometimes `get_form_name_from_last_submission_for_xmlns` throws a `KeyError` because `@name` isn't present in system forms. This has been breaking the List Forms API. ([here is the error](https://sentry.io/organizations/dimagi/issues/1453328978/?project=136860&query=is%3Aunresolved)). This looks related to https://github.com/dimagi/commcare-hq/commit/9f327e6e3b5f520e88c1d9dad6402f953b9d1a21, so cc @snopoke 

