### PR TITLE
Fixed dropdown that isn't searching

### DIFF
--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -19,7 +19,7 @@ from django.forms.fields import (
 )
 from django.forms.forms import Form
 from django.forms.formsets import BaseFormSet, formset_factory
-from django.forms.widgets import CheckboxSelectMultiple, HiddenInput, SelectMultiple
+from django.forms.widgets import CheckboxSelectMultiple, HiddenInput, Select, SelectMultiple
 from django.utils.functional import cached_property
 from memoized import memoized
 
@@ -2763,6 +2763,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
     visit_scheduler_app_and_form_unique_id = CharField(
         label=ugettext_lazy("Scheduler: Form"),
         required=False,
+        widget=Select(choices=[]),
     )
 
     visit_number = IntegerField(


### PR DESCRIPTION
##### FEATURE FLAG
Visit scheduler

##### PRODUCT DESCRIPTION
The ajax-based "Scheduler: Form" dropdown when editing a conditional alert has been failing to search for forms, not even attempting to hit the server. Turns out the problem is that the underlying DOM element was a text input instead of a select. Took forever to figure this out.

<img width="823" alt="Screen Shot 2020-01-22 at 5 59 11 PM" src="https://user-images.githubusercontent.com/1486591/72942406-56674b00-3d41-11ea-8714-ad9a7b52cec8.png">

