### PR TITLE
Removed couch_class from PopulateSQLCommand

### DIFF
--- a/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
+++ b/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
@@ -17,7 +17,7 @@ class Command(PopulateSQLCommand):
             return None
 
     @property
-    def couch_class_key(self):
+    def couch_key(self):
         return set(['domain', 'app_id'])
 
     @property

--- a/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
+++ b/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
@@ -9,12 +9,12 @@ class Command(PopulateSQLCommand):
     """
 
     @property
-    def couch_class(self):
-        try:
-            from corehq.apps.app_manager.models import GlobalAppConfig
-            return GlobalAppConfig
-        except ImportError:
-            return None
+    def couch_db_slug(self):
+        return 'apps'
+
+    @property
+    def couch_doc_type(self):
+        return 'GlobalAppConfig'
 
     @property
     def couch_key(self):

--- a/corehq/apps/app_manager/migrations/0009_add_sqlglobalappconfig.py
+++ b/corehq/apps/app_manager/migrations/0009_add_sqlglobalappconfig.py
@@ -4,13 +4,6 @@
 from django.core.management import call_command
 from django.db import migrations, models
 
-from corehq.util.django_migrations import skip_on_fresh_install
-
-
-@skip_on_fresh_install
-def _populate_sql_global_app_config(apps, schema_editor):
-    call_command('populate_sql_global_app_config')
-
 
 class Migration(migrations.Migration):
 
@@ -37,7 +30,4 @@ class Migration(migrations.Migration):
             name='sqlglobalappconfig',
             unique_together=set([('domain', 'app_id')]),
         ),
-        migrations.RunPython(_populate_sql_global_app_config,
-                             reverse_code=migrations.RunPython.noop,
-                             elidable=True),
     ]

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -5,7 +5,8 @@ from django.db import transaction
 
 from dimagi.utils.couch.database import iter_docs
 
-from corehq.dbaccessors.couchapps.all_docs import get_doc_ids_by_class
+from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types, get_doc_count_by_type
+from corehq.util.couchdb_management import couch_config
 
 logger = logging.getLogger(__name__)
 
@@ -25,11 +26,25 @@ class PopulateSQLCommand(BaseCommand):
         )
 
     @property
-    def couch_class(self):
+    def couch_db(self):
+        return couch_config.get_db(self.couch_db_slug)
+
+    @property
+    def couch_db_slug(self):
+        # Override this if couch model was not stored in the main commcarehq database
+        return None
+
+    @property
+    def couch_doc_type(self):
         raise NotImplementedError()
 
     @property
     def couch_key(self):
+        """
+        Set of doc keys to uniquely identify a couch document.
+        For most documents this is set(["id"]), but sometimes it's useful to use a more
+        human-readable key, typically for documents that have at most one doc per domain.
+        """
         raise NotImplementedError()
 
     @property
@@ -45,17 +60,14 @@ class PopulateSQLCommand(BaseCommand):
     def handle(self, dry_run=False, **options):
         log_prefix = "[DRY RUN] " if dry_run else ""
 
-        couch_class = self.couch_class
-
-        doc_ids = get_doc_ids_by_class(couch_class)
         logger.info("{}Found {} {} docs and {} {} models".format(
             log_prefix,
-            len(doc_ids),
-            couch_class.__name__,
+            get_doc_count_by_type(self.couch_db, self.couch_doc_type),
+            self.couch_doc_type,
             self.sql_class.objects.count(),
             self.sql_class.__name__,
         ))
-        for doc in iter_docs(couch_class.get_db(), doc_ids):
+        for doc in get_all_docs_with_doc_types(self.couch_db, [self.couch_doc_type]):
             logger.info("{}Looking at doc with key {}".format(log_prefix, self.doc_key(doc)))
             with transaction.atomic():
                 model, created = self.update_or_create_sql_object(doc)

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -29,7 +29,7 @@ class PopulateSQLCommand(BaseCommand):
         raise NotImplementedError()
 
     @property
-    def couch_class_key(self):
+    def couch_key(self):
         raise NotImplementedError()
 
     @property
@@ -37,7 +37,7 @@ class PopulateSQLCommand(BaseCommand):
         raise NotImplementedError()
 
     def doc_key(self, doc):
-        return {key: doc[key] for key in doc if key in self.couch_class_key}
+        return {key: doc[key] for key in doc if key in self.couch_key}
 
     def update_or_create_sql_object(self, doc):
         raise NotImplementedError()

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -46,15 +46,14 @@ class PopulateSQLCommand(BaseCommand):
         log_prefix = "[DRY RUN] " if dry_run else ""
 
         couch_class = self.couch_class
-        sql_class = self.sql_class
 
         doc_ids = get_doc_ids_by_class(couch_class)
         logger.info("{}Found {} {} docs and {} {} models".format(
             log_prefix,
             len(doc_ids),
             couch_class.__name__,
-            sql_class.objects.count(),
-            sql_class.__name__,
+            self.sql_class.objects.count(),
+            self.sql_class.__name__,
         ))
         for doc in iter_docs(couch_class.get_db(), doc_ids):
             logger.info("{}Looking at doc with key {}".format(log_prefix, self.doc_key(doc)))

--- a/corehq/apps/cloudcare/management/commands/populate_application_access.py
+++ b/corehq/apps/cloudcare/management/commands/populate_application_access.py
@@ -16,7 +16,7 @@ class Command(PopulateSQLCommand):
             return None
 
     @property
-    def couch_class_key(self):
+    def couch_key(self):
         return set(['domain'])
 
     @property

--- a/corehq/apps/cloudcare/management/commands/populate_application_access.py
+++ b/corehq/apps/cloudcare/management/commands/populate_application_access.py
@@ -8,12 +8,8 @@ class Command(PopulateSQLCommand):
     """
 
     @property
-    def couch_class(self):
-        try:
-            from corehq.apps.cloudcare.models import ApplicationAccess
-            return ApplicationAccess
-        except ImportError:
-            return None
+    def couch_doc_type(self):
+        return 'ApplicationAccess'
 
     @property
     def couch_key(self):

--- a/corehq/motech/dhis2/management/commands/populate_sql_dhis2_connection.py
+++ b/corehq/motech/dhis2/management/commands/populate_sql_dhis2_connection.py
@@ -7,12 +7,8 @@ class Command(PopulateSQLCommand):
     """
 
     @property
-    def couch_class(self):
-        try:
-            from corehq.motech.dhis2.models import Dhis2Connection
-            return Dhis2Connection
-        except ImportError:
-            return None
+    def couch_doc_type(self):
+        return 'Dhis2Connection'
 
     @property
     def couch_key(self):

--- a/corehq/motech/dhis2/management/commands/populate_sql_dhis2_connection.py
+++ b/corehq/motech/dhis2/management/commands/populate_sql_dhis2_connection.py
@@ -15,7 +15,7 @@ class Command(PopulateSQLCommand):
             return None
 
     @property
-    def couch_class_key(self):
+    def couch_key(self):
         return set(['domain'])
 
     @property


### PR DESCRIPTION
Realized in conversation with @millerdev that it isn't necessary to keep the old couch class around. This will allow anyone localhosting to run the `populate_x` migrations without needing to check out an old version of HQ that still has the old couch class defined, plus it'll make it easier to rename the `SQLFoo` classes I've been creating back to `Foo`.

@dannyroberts This does mean that for now, I'm not going to implement deploying from a commit in commcare-cloud.

Review by commit.