### PR TITLE
Couch to SQL: case diff improvements and fixes

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -14,6 +14,7 @@ from gevent.pool import Group, Pool
 from casexml.apps.case.xform import get_case_ids_from_form
 from casexml.apps.stock.models import StockReport, StockTransaction
 from dimagi.utils.chunked import chunked
+from dimagi.utils.couch.database import retry_on_couch_error
 
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.locations.models import SQLLocation
@@ -187,7 +188,7 @@ class CaseDiffQueue:
         loaded_case_ids = set()
         case_records = []
         stock_forms = get_stock_forms_by_case_id(case_ids)
-        for case in CaseAccessorCouch.get_cases(case_ids):
+        for case in get_couch_cases(case_ids):
             loaded_case_ids.add(case.case_id)
             case_stock_forms = stock_forms.get(case.case_id, [])
             rec = CaseRecord(case, case_stock_forms, pending[case.case_id])
@@ -228,7 +229,7 @@ class CaseDiffQueue:
                 else:
                     couch_cases.append(case)
             popped_cases = list(couch_cases)
-            couch_cases.extend(CaseAccessorCouch.get_cases(to_load))
+            couch_cases.extend(get_couch_cases(to_load))
             prune = (iter if self._is_flushing
                 else partial(prune_premature_diffs, statedb=self.statedb))
             json_by_id = {c.case_id: c.to_json() for c in prune(couch_cases)}
@@ -747,12 +748,9 @@ def diff_case(sql_case, couch_case, dd_count):
         return couch_case, diffs
     diffs = diff(couch_case, sql_json)
     if diffs:
-        domain = couch_case["domain"]
         try:
             with convert_rebuild_error():
-                couch_case = FormProcessorCouch.hard_rebuild_case(
-                    domain, case_id, None, save=False, lock=False
-                ).to_json()
+                couch_case = hard_rebuild(couch_case)
             dd_count("commcare.couchsqlmigration.case.rebuild.couch")
             diffs = diff(couch_case, sql_json)
             if diffs:
@@ -785,6 +783,13 @@ def check_domains(case_id, couch_json, sql_json):
         diffs = json_diff({"domain": couch_json["domain"]}, {"domain": _diff_state.domain})
     assert diffs, "expected domain diff"
     return diffs
+
+
+@retry_on_couch_error
+def hard_rebuild(couch_case):
+    return FormProcessorCouch.hard_rebuild_case(
+        couch_case["domain"], couch_case['_id'], None, save=False, lock=False
+    ).to_json()
 
 
 def iter_ledger_diffs(case_ids, dd_count):
@@ -947,6 +952,11 @@ class CaseRecord:
     def should_memorize_case(self):
         # do not keep cases with large history in memory
         return self.total_forms <= MAX_FORMS_PER_MEMORIZED_CASE
+
+
+@retry_on_couch_error
+def get_couch_cases(case_ids):
+    return CaseAccessorCouch.get_cases(case_ids)
 
 
 def get_case_form_ids(couch_case):

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -749,18 +749,18 @@ def diff_case(sql_case, couch_case, dd_count):
     diffs = diff(couch_case, sql_json)
     if diffs:
         try:
-            with convert_rebuild_error():
+            with convert_rebuild_error("couch"):
                 couch_case = hard_rebuild(couch_case)
             dd_count("commcare.couchsqlmigration.case.rebuild.couch")
             diffs = diff(couch_case, sql_json)
             if diffs:
                 if should_sort_sql_transactions(sql_case, couch_case):
-                    with convert_rebuild_error():
+                    with convert_rebuild_error("sql"):
                         sql_case = rebuild_case_with_couch_action_order(sql_case)
                     dd_count("commcare.couchsqlmigration.case.rebuild.sql.sort")
                     diffs = diff(couch_case, sql_case.to_json())
                 elif not was_rebuilt(sql_case):
-                    with convert_rebuild_error():
+                    with convert_rebuild_error("sql"):
                         sql_case = rebuild_case(sql_case)
                     dd_count("commcare.couchsqlmigration.case.rebuild.sql")
                     diffs = diff(couch_case, sql_case.to_json())
@@ -869,11 +869,11 @@ def filter_missing_cases(missing_cases):
 
 
 @contextmanager
-def convert_rebuild_error():
+def convert_rebuild_error(backend):
     try:
         yield
     except Exception as err:
-        raise RebuildError(f"{type(err).__name__}: {err}")
+        raise RebuildError(f"{backend} {type(err).__name__}: {err}")
 
 
 class RebuildError(Exception):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -32,7 +32,6 @@ from corehq.apps.tzmigration.api import (
     force_phone_timezones_should_be_processed,
 )
 from corehq.blobs import CODES, get_blob_db
-from corehq.blobs.models import BlobMeta
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseAccessorSQL,
     FormAccessorSQL,
@@ -923,7 +922,11 @@ class MigrationPaginationEventHandler(PaginationEventHandler):
 def _iter_docs(domain, doc_type, resume_key, stopper):
     @retry_on_couch_error
     def data_function(**view_kwargs):
-        return couch_db.view('by_domain_doc_type_date/view', **view_kwargs)
+        view_name = 'by_domain_doc_type_date/view'
+        results = list(couch_db.view(view_name, **view_kwargs))
+        assert all(r['key'][0] == domain for r in results), \
+            _repr_bad_results(view_name, view_kwargs, results, domain)
+        return results
 
     if "." in doc_type:
         doc_type, row_key = doc_type.split(".")
@@ -951,7 +954,6 @@ def _iter_docs(domain, doc_type, resume_key, stopper):
     row = None
     try:
         for row in rows:
-            assert row['key'][0] == domain, row
             yield row[row_key]
     finally:
         if row is not None:
@@ -962,6 +964,32 @@ def _iter_docs(domain, doc_type, resume_key, stopper):
 
 
 _iter_docs.chunk_size = 1000
+
+
+def _repr_bad_results(view, kwargs, results, domain):
+    def dropdoc(row):
+        if kwargs["include_docs"]:
+            row = dict(row)
+            row.pop("doc")
+        return row
+
+    def itr_ix(i, seen=set()):
+        if i > 0 and (i - 1) not in seen:
+            yield i - 1, "good"
+        seen.add(i)
+        yield i, "bad"
+
+    context_rows = [
+        f"{j} {status} {dropdoc(results[j])}"
+        for i, result in enumerate(results)
+        if result['key'][0] != domain
+        for j, status in itr_ix(i)
+    ]
+    if len(context_rows) > 20:
+        context_rows = context_rows[:20]
+        context_rows.append(f"... {len(context_rows) - 20} results omitted")
+    context = '\n'.join(context_rows)
+    return f"bad results from {view} {kwargs}:\n{context}"
 
 
 def _iter_skipped_forms(domain, migration_id, stopper, with_progress):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -23,7 +23,7 @@ from casexml.apps.case.xml.parser import CaseNoopAction
 from couchforms.models import XFormInstance, all_known_formlike_doc_types
 from couchforms.models import doc_types as form_doc_types
 from dimagi.utils.chunked import chunked
-from dimagi.utils.couch.database import iter_docs
+from dimagi.utils.couch.database import iter_docs, retry_on_couch_error
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_type
@@ -921,6 +921,7 @@ class MigrationPaginationEventHandler(PaginationEventHandler):
 
 
 def _iter_docs(domain, doc_type, resume_key, stopper):
+    @retry_on_couch_error
     def data_function(**view_kwargs):
         return couch_db.view('by_domain_doc_type_date/view', **view_kwargs)
 

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -225,10 +225,10 @@ class CaseDiffTool:
 
 
 def load_and_diff_cases(case_ids, log_cases=False):
-    from ...casediff import _diff_state, diff_cases
+    from ...casediff import _diff_state, get_couch_cases, diff_cases
     should_diff = _diff_state.should_diff
     couch_cases = {c.case_id: c.to_json()
-        for c in CaseAccessorCouch.get_cases(case_ids) if should_diff(c)}
+        for c in get_couch_cases(case_ids) if should_diff(c)}
     if log_cases:
         skipped = [id for id in case_ids if id not in couch_cases]
         if skipped:

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -212,7 +212,12 @@ class CaseDiffTool:
 
     @property
     def pool(self):
-        return Pool(initializer=init_worker, initargs=self.initargs, maxtasksperchild=100)
+        return Pool(
+            processes=os.cpu_count() * 2,
+            initializer=init_worker,
+            initargs=self.initargs,
+            maxtasksperchild=100,
+        )
 
     @property
     def initargs(self):

--- a/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_couch_sql_diff.py
@@ -178,14 +178,13 @@ class TestCouchSqlDiff(BaseMigrationTestCase):
             yield case
 
 
-def MockPool(initializer=lambda: None, initargs=(), maxtasksperchild=None):
-    return NoProcessPool(initializer, initargs)
-
-
 @attr.s
-class NoProcessPool:
+class MockPool:
+    """Pool that uses greenlets rather than processes"""
     initializer = attr.ib()
     initargs = attr.ib()
+    processes = attr.ib(default=None)
+    maxtasksperchild = attr.ib(default=None)
     pool = attr.ib(factory=Pool, init=False)
 
     def imap_unordered(self, *args, **kw):

--- a/corehq/apps/couch_sql_migration/tests/test_parallel.py
+++ b/corehq/apps/couch_sql_migration/tests/test_parallel.py
@@ -66,6 +66,23 @@ def test_consume_error():
             # error should not cause deadlock
 
 
+@timelimit
+def test_produce_error():
+    class Error(Exception):
+        pass
+
+    def producer():
+        yield 1
+        yield 2
+        raise Error
+
+    results = set()
+    with assert_raises(Error):
+        for result in mod.Pool().imap_unordered(square, producer()):
+            results.add(result)
+    eq(results, {1, 4})
+
+
 def test_race_conditions():
     # This test is slow and is not very useful except for finding race
     # conditions which often result in a hung process.

--- a/corehq/ex-submodules/dimagi/utils/tests/test_database.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_database.py
@@ -1,0 +1,75 @@
+from mock import patch
+from testil import Config, assert_raises, eq
+
+from requests.exceptions import RequestException
+
+from corehq.util.test_utils import timelimit
+from ..couch import database as mod
+
+
+def test_retry_on_couch_error():
+    @timelimit
+    def test(n, error=None):
+        fake_sleep, sleeps = make_sleeper()
+        func, calls = make_retry_function(n, error)
+        with patch.object(mod, "sleep", fake_sleep):
+            eq(func(n), n * 2)
+        eq(sleeps, ([0.1] + [2 ** i for i in range(n - 1)]) if n else [])
+        eq(len(calls), n + 1)
+
+    yield test, 0
+    yield test, 1
+    yield test, 2
+    yield test, 3
+    yield test, 4
+    yield test, 5
+
+    yield test, 1, mod.BulkFetchException
+
+
+@timelimit
+def test_retry_on_couch_error_too_many_retries():
+    fake_sleep, sleeps = make_sleeper()
+    func, calls = make_retry_function(6)
+    with patch.object(mod, "sleep", fake_sleep):
+        with assert_raises(RequestException):
+            func(1)
+    eq(sleeps, [0.1, 1, 2, 4, 8])
+    eq(len(calls), 6)
+
+
+@timelimit
+def test_retry_on_couch_error_non_couch_error():
+    @mod.retry_on_couch_error
+    def func():
+        calls.append(1)
+        raise RequestException()
+
+    calls = []
+    with assert_raises(RequestException):
+        func()
+    eq(calls, [1])
+
+
+def make_retry_function(n_errors, error=None):
+    @mod.retry_on_couch_error
+    def maybe_error(arg):
+        nonlocal n_errors
+        calls.append(1)
+        n_errors -= 1
+        if n_errors < 0:
+            return arg * 2
+        raise error
+    if error is None:
+        couch_url = mod._get_couch_base_urls()[0] + "/some/path"
+        error = mod.RequestException(request=Config(url=couch_url))
+    calls = []
+    return maybe_error, calls
+
+
+def make_sleeper():
+    def fake_sleep(delay):
+        sleeps.append(delay)
+        print(f"fake sleep for {delay}s")
+    sleeps = []
+    return fake_sleep, sleeps


### PR DESCRIPTION
The biggest change here is a decorator to retry when couch fails. Hopefully that should reduce the number of crashes and correspondingly the need to constantly restart the process.

The increase in pool concurrency reduced estimated run time from ~4 days to ~2 days remaining.

Finally, I was able to catch and observe bad couch view results in a debugging session, and have improved the error output if/when that happens again.

Review by commit 🐡 