### PR TITLE
Convert password to bytes

### DIFF
--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -71,7 +71,8 @@ class Dhis2ConnectionForm(forms.Form):
                 # Don't save it if it hasn't been changed. Use simple symmetric encryption. We don't need it to be
                 # strong, considering we'd have to store the algorithm and the key together anyway; it just
                 # shouldn't be plaintext.
-                dhis2_conn.password = b64encode(bz2.compress(self.cleaned_data['password']))
+                plaintext = self.cleaned_data['password'].encode('utf8')
+                dhis2_conn.password = b64encode(bz2.compress(plaintext))
             dhis2_conn.skip_cert_verify = self.cleaned_data['skip_cert_verify']
             dhis2_conn.save()
             return True


### PR DESCRIPTION
Context: [SC-411](https://dimagi-dev.atlassian.net/browse/SC-411)

##### SUMMARY
A Py2 to Py3 bug. This change casts a string submitted by the user to bytes, so that it can be compressed and base64-encoded.

In a follow-up PR I will bring this password management in line with Repeaters, which use AES encryption with the Django SECRET_KEY as the key.
