### PR TITLE
report fixture index

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -123,6 +123,13 @@ class BaseReportFixturesProvider(FixtureProvider):
         return filters_elem
 
 
+def _get_report_index_fixture(restore_user):
+    return E.fixture(
+        E.report_index(E.reports(last_update=_last_sync_time(restore_user.domain, restore_user.user_id))),
+        id='commcare-reports:index', user_id=restore_user.user_id,
+    )
+
+
 class ReportFixturesProvider(BaseReportFixturesProvider):
     id = 'commcare:reports'
 
@@ -143,6 +150,7 @@ class ReportFixturesProvider(BaseReportFixturesProvider):
         }
 
         if needed_versions.intersection({MOBILE_UCR_VERSION_1, MOBILE_UCR_MIGRATING_TO_2}):
+            fixtures.append(_get_report_index_fixture(restore_user))
             fixtures.extend(self._v1_fixture(restore_user, list(self._get_report_configs(apps).values())))
         else:
             fixtures.extend(self._empty_v1_fixture(restore_user))
@@ -279,6 +287,8 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
         }
 
         if needed_versions.intersection({MOBILE_UCR_MIGRATING_TO_2, MOBILE_UCR_VERSION_2}):
+            fixtures.append(_get_report_index_fixture(restore_user))
+
             report_configs = list(self._get_report_configs(apps).values())
             synced_fixtures, purged_fixture_ids = self._relevant_report_configs(restore_state, report_configs)
             fixtures.extend(self._v2_fixtures(restore_user, synced_fixtures))

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -123,9 +123,10 @@ class BaseReportFixturesProvider(FixtureProvider):
         return filters_elem
 
 
-def _get_report_index_fixture(restore_user):
+def _get_report_index_fixture(restore_user, oldest_sync_time=None):
+    last_sync_time = _format_last_sync_time(restore_user.domain, restore_user.user_id, oldest_sync_time)
     return E.fixture(
-        E.report_index(E.reports(last_update=_last_sync_time(restore_user.domain, restore_user.user_id))),
+        E.report_index(E.reports(last_update=last_sync_time)),
         id='commcare-reports:index', user_id=restore_user.user_id,
     )
 
@@ -163,7 +164,7 @@ class ReportFixturesProvider(BaseReportFixturesProvider):
     def _v1_fixture(self, restore_user, report_configs):
         user_id = restore_user.user_id
         root = E.fixture(id=self.id, user_id=user_id)
-        reports_elem = E.reports(last_sync=_last_sync_time(restore_user.domain, user_id))
+        reports_elem = E.reports(last_sync=_format_last_sync_time(restore_user.domain, user_id))
         for report_config in report_configs:
             try:
                 reports_elem.append(self.report_config_to_v1_fixture(report_config, restore_user))
@@ -287,17 +288,38 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
         }
 
         if needed_versions.intersection({MOBILE_UCR_MIGRATING_TO_2, MOBILE_UCR_VERSION_2}):
-            fixtures.append(_get_report_index_fixture(restore_user))
-
             report_configs = list(self._get_report_configs(apps).values())
             synced_fixtures, purged_fixture_ids = self._relevant_report_configs(restore_state, report_configs)
+
+            oldest_sync_time = self._get_oldest_sync_time(restore_state, synced_fixtures, purged_fixture_ids)
+            fixtures.append(_get_report_index_fixture(restore_user, oldest_sync_time))
             fixtures.extend(self._v2_fixtures(restore_user, synced_fixtures))
             for report_uuid in purged_fixture_ids:
                 fixtures.extend(self._empty_v2_fixtures(report_uuid))
 
         return fixtures
 
-    def _relevant_report_configs(self, restore_state, report_configs):
+    @staticmethod
+    def _get_oldest_sync_time(restore_state, synced_fixtures, purged_fixture_ids):
+        """
+        Get the oldest sync time for all reports.
+        """
+        last_sync_log = restore_state.last_sync_log
+        now = _utcnow()
+        if not last_sync_log or restore_state.overwrite_cache:
+            return now
+
+        # ignore reports that are being purged or are being synced now
+        reports_to_ignore = purged_fixture_ids | {config.uuid for config in synced_fixtures}
+        last_sync_times = [
+            log.datetime
+            for log in last_sync_log.last_ucr_sync_times
+            if log.report_uuid not in reports_to_ignore
+        ]
+        return sorted(last_sync_times)[0] if last_sync_times else now
+
+    @staticmethod
+    def _relevant_report_configs(restore_state, report_configs):
         """
         Filter out any UCRs that are already synced. This can't exist in V1,
         because in V1 we send all reports as one fixture.
@@ -400,7 +422,7 @@ class ReportFixturesProviderV2(BaseReportFixturesProvider):
             data_source,
             {f.field for f in defer_filters},
             filter_options_by_field,
-            _last_sync_time(domain, restore_user.user_id),
+            _format_last_sync_time(domain, restore_user.user_id),
             restore_user
         )
         filters_elem = BaseReportFixturesProvider._get_filters_elem(
@@ -470,9 +492,10 @@ def _utcnow():
     return datetime.utcnow()
 
 
-def _last_sync_time(domain, user_id):
+def _format_last_sync_time(domain, user_id, sync_time=None):
+    sync_time = sync_time or _utcnow()
     timezone = get_timezone_for_user(user_id, domain)
-    return ServerTime(_utcnow()).user_time(timezone).done().isoformat()
+    return ServerTime(sync_time).user_time(timezone).done().isoformat()
 
 
 report_fixture_generator = ReportFixturesProvider()

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -234,7 +234,8 @@ class ReportFiltersSuiteTest(TestCase, TestXmlMixin):
                 with mock.patch('corehq.apps.app_manager.fixtures.mobile_ucr.get_apps_in_domain',
                                 lambda domain, include_remote: [cls.app]):
                     with mock_datasource_config():
-                        fixture, = call_fixture_generator(report_fixture_generator, cls.user)
+                        fixtures = call_fixture_generator(report_fixture_generator, cls.user)
+                        fixture = [f for f in fixtures if f.attrib.get('id') == report_fixture_generator.id][0]
         cls.fixture = ElementTree.tostring(fixture)
 
     def test_filter_entry(self):

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -70,7 +70,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
 
         with mock_report_configuration_get({report_id: MAKE_REPORT_CONFIG('test_domain', report_id)}), \
                 patch('corehq.apps.app_manager.fixtures.mobile_ucr.ConfigurableReportDataSource') as report_datasource, \
-                patch('corehq.apps.app_manager.fixtures.mobile_ucr._last_sync_time') as last_sync_time_patch:
+                patch('corehq.apps.app_manager.fixtures.mobile_ucr._format_last_sync_time') as last_sync_time_patch:
 
             report_datasource.from_spec.return_value = self.get_data_source_mock()
             last_sync_time_patch.return_value = datetime(2017, 9, 11, 6, 35, 20).isoformat()
@@ -96,7 +96,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
         with mock_report_configuration_get({report_id: MAKE_REPORT_CONFIG('test_domain', report_id)}), \
              patch(
                  'corehq.apps.app_manager.fixtures.mobile_ucr.ConfigurableReportDataSource') as report_datasource, \
-            patch('corehq.apps.app_manager.fixtures.mobile_ucr._last_sync_time') as last_sync_time_patch:
+            patch('corehq.apps.app_manager.fixtures.mobile_ucr._format_last_sync_time') as last_sync_time_patch:
             mock = self.get_data_source_mock()
             mock.has_total_row = True
             mock.total_column_ids = ['baz']
@@ -150,7 +150,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
             configs = provider._relevant_report_configs(restore_state, [])
             self.assertEqual(configs, ([], {report_app_config.uuid}))
 
-    @patch('corehq.apps.app_manager.fixtures.mobile_ucr._last_sync_time')
+    @patch('corehq.apps.app_manager.fixtures.mobile_ucr._format_last_sync_time')
     def test_get_report_index_fixture(self, last_sync_time_patch):
         last_sync_time_patch.return_value = datetime(2017, 9, 11, 6, 35, 20).isoformat()
         restore_user = Mock(domain='mock-domain', user_id='mock-user-id')
@@ -166,3 +166,32 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
             </fixture>
             """
         )
+
+    def _test_get_oldest_sync_time(self, utcnow, synced_ids, purged_ids, expected):
+        sync_log = Mock()
+        sync_log.last_ucr_sync_times = [
+            Mock(report_uuid='a', datetime=datetime(2018, 9, 11, 6, 35, 20)),
+            Mock(report_uuid='b', datetime=datetime(2017, 9, 11, 6, 35, 20))
+        ]
+        restore_state = Mock()
+        restore_state.last_sync_log = sync_log
+        restore_state.overwrite_cache = False
+        synced_fixtures = [
+            Mock(uuid=_id) for _id in synced_ids
+        ]
+        with patch('corehq.apps.app_manager.fixtures.mobile_ucr._utcnow') as utcnow_patch:
+            utcnow_patch.return_value = utcnow
+            oldest_sync_time = ReportFixturesProviderV2._get_oldest_sync_time(
+                restore_state, synced_fixtures, purged_ids
+            )
+        self.assertEqual(oldest_sync_time, expected)
+
+    def test_get_oldest_sync_time_all_sync(self):
+        utcnow = datetime.utcnow()
+        self._test_get_oldest_sync_time(utcnow, ['a', 'b'], set(), utcnow)
+
+    def test_get_oldest_sync_time_old(self):
+        self._test_get_oldest_sync_time(datetime.utcnow(), ['c'], set(), datetime(2017, 9, 11, 6, 35, 20))
+
+    def test_get_oldest_sync_time_excluded(self):
+        self._test_get_oldest_sync_time(datetime.utcnow(), ['c'], {'b'}, datetime(2018, 9, 11, 6, 35, 20))

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -1,4 +1,6 @@
+
 from django.test import TestCase
+from lxml import etree
 
 from mock import patch
 
@@ -82,6 +84,11 @@ class AppAwareSyncTests(TestCase):
         domain.delete()
         super(AppAwareSyncTests, cls).tearDownClass()
 
+    def _get_fixture(self, fixtures, fixture_id):
+        matches = [f for f in fixtures if f.attrib.get('id') == fixture_id]
+        if matches:
+            return matches[0]
+
     def test_report_fixtures_provider_without_app(self):
         """
         ReportFixturesProvider should iterate all apps if app not given
@@ -91,7 +98,8 @@ class AppAwareSyncTests(TestCase):
             get_data_mock.return_value = self.rows
             with mock_datasource_config():
                 fixtures = call_fixture_generator(report_fixture_generator, self.user)
-        reports = fixtures[0].findall('.//report')
+
+        reports = self._get_fixture(fixtures, report_fixture_generator.id).findall('.//report')
         self.assertEqual(len(reports), 2)
         report_ids = {r.attrib.get('id') for r in reports}
         self.assertEqual(report_ids, {'123456', 'abcdef'})
@@ -105,7 +113,8 @@ class AppAwareSyncTests(TestCase):
             get_data_mock.return_value = self.rows
             with mock_datasource_config():
                 fixtures = call_fixture_generator(report_fixture_generator, self.user, app=self.app1)
-        reports = fixtures[0].findall('.//report')
+        reports = self._get_fixture(fixtures, report_fixture_generator.id).findall('.//report')
+
         self.assertEqual(len(reports), 1)
         self.assertEqual(reports[0].attrib.get('id'), '123456')
 
@@ -134,7 +143,7 @@ class AppAwareSyncTests(TestCase):
                     self.user,
                     device_id="WebAppsLogin|user@project.commcarehq.org"
                 )
-        reports = fixtures[0].findall('.//report')
+        reports = self._get_fixture(fixtures, report_fixture_generator.id).findall('.//report')
         self.assertEqual(len(reports), 1)
         self.assertEqual(reports[0].attrib.get('id'), '123456')
 

--- a/corehq/apps/ota/tests/test_app_aware_restore.py
+++ b/corehq/apps/ota/tests/test_app_aware_restore.py
@@ -1,6 +1,4 @@
-
 from django.test import TestCase
-from lxml import etree
 
 from mock import patch
 


### PR DESCRIPTION
Spec: https://docs.google.com/document/d/18wnlqyTaRCEmLHcHyS15Ya5oOhjZ9On9dVVH2QXch3s/edit#heading=h.ruvenm5696d

##### SUMMARY
Adds a small fixture when syncing mobile UCRs that gives access to the oldest date that UCR data was synced to the device. This data is already in the sync but is located in different places depending on if the sync is V1 or V2. 

##### FEATURE FLAG
Mobile UCR

##### PRODUCT DESCRIPTION
This will add a new fixture as follows:
```
<fixture id="commcare-reports:index" user_id="mock-user-id">
  <report_index>
    <reports last_update="2017-09-11T06:35:20"/>
  </report_index>
</fixture>
```

See the feature spec for how this can be accessed in the app.