### PR TITLE
Unblock saved exports by detecting missing/expired task

### DIFF
--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -147,7 +147,9 @@ def get_task_status(task, is_multiple_download_task=False):
             context_error = "%s: %s" % (type(task.result).__name__, task.result)
     elif is_ready:
         state = STATES.success
-    elif task and _is_task_pending(task):
+    elif not _is_real_task(task):
+        state = STATES.missing
+    elif _is_task_pending(task):
         state = STATES.not_started
     elif progress.percent is None:
         state = STATES.missing
@@ -160,6 +162,12 @@ def get_task_status(task, is_multiple_download_task=False):
         error=context_error,
         progress=progress,
     )
+
+
+def _is_real_task(task):
+    # You can look up a task with a made-up ID and it'll give you a meaningless task object
+    # Make sure the task object you have corresponds to an actual celery task
+    return task and task._get_task_meta().get('task_name') is not None
 
 
 def _is_task_pending(task):


### PR DESCRIPTION
##### SUMMARY

For each saved export we keep track of the active task id
so that we do not have more than one task running for it at a time.
However, we recently found a few of them that were pointing to tasks
that do not appear to actually exist, and that put it in a stuck state
of always waiting for a task to finish that never will because it does not exist.
We now detect that and designate the task as "missing" rather than "not started".

##### PRODUCT DESCRIPTION
Fixes https://dimagi-dev.atlassian.net/browse/SAASP-10253 (especially the issue where manually refreshing a saved export doesn't do anything.)
