### PR TITLE
Revert "Send error-type info to pillow error DD metrics"

### DIFF
--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -17,6 +17,5 @@ def record_pillow_error_queue_size():
         datadog_gauge('commcare.pillowtop.error_queue', row['num_errors'], tags=[
             'pillow_name:%s' % row['pillow'],
             'host:celery',
-            'group:celery',
-            'error_type:%s' % row['error_type']
+            'group:celery'
         ])


### PR DESCRIPTION
Reverts dimagi/commcare-hq#26306

https://sentry.io/organizations/dimagi/issues/1422005413/?project=1545828&query=is%3Aunresolved+record_pillow_error_queue_size&statsPeriod=14d affecting all environments (including ICDS and production). As a result `commcare.pillowtop.error_queue` [is no longer reporting](https://app.datadoghq.com/dashboard/ewu-jyr-udt/change-feeds-pillows?from_ts=1577311707932&live=true&tile_size=m&to_ts=1579903707932&tpl_var_env=production&tpl_var_pillow=%2A&fullscreen_widget=253784658&fullscreen_section=overview).

Just something I noticed when I was looking at sentry