### PR TITLE
Fix test_aggregate date on certain days

### DIFF
--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -2,6 +2,8 @@ from django.http import HttpRequest
 from django.test import TestCase
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from corehq.apps.userreports.exceptions import BadSpecError, UserReportsError
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,
@@ -580,6 +582,7 @@ class TestReportAggregationSQL(ConfigurableReportAggregationTestMixin, TestCase)
         )
 
 
+@freeze_time("2020-01-15")
 class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, TestCase):
     # Note that these constants are subtracted from today's date, so the month parts of the names
     # are approximations: the first one will usually fall one year and two months ago, but will


### PR DESCRIPTION
##### SUMMARY

On Jan 28, 2020 the test began failing with

```
======================================================================
FAIL: corehq.apps.userreports.tests.test_report_aggregation:TestReportMultipleAggregationsSQL.test_aggregate_date
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/commcare-hq-ro/corehq/apps/userreports/tests/test_report_aggregation.py", line 914, in test_aggregate_date
    ['TN', self._relative_month(self.MORE_THAN_TWO_YEARS), 1]]]]
AssertionError: Lists differ: [['fo[92 chars]11', 7], ['MA', '2018-10', 2], ['TN', '2017-11', 1]]]] != [['fo[92 chars]11', 4], ['MA', '2018-11', 3], ['MA', '2018-10[25 chars]1]]]]
First differing element 0:
['foo[91 chars]11', 7], ['MA', '2018-10', 2], ['TN', '2017-11', 1]]]
['foo[91 chars]11', 4], ['MA', '2018-11', 3], ['MA', '2018-10[24 chars] 1]]]
  [['foo',
    [['report_column_display_state', 'month', 'report_column_display_number'],
-    ['MA', '2018-11', 7],
?                      ^
+    ['MA', '2018-11', 4],
?                      ^
+    ['MA', '2018-11', 3],
     ['MA', '2018-10', 2],
     ['TN', '2017-11', 1]]]]
----------------------------------------------------------------------
```

I suspect it fails this way towards the end of every month or certain
months depending on their length or something like that. Anyway,
freezing it to a specific date fixes it, so I'm going to go with that.
Judging from the comment https://github.com/dimagi/commcare-hq/blob/0c1fa0f40b76b9fe06a7943ce9b4d52e6037aeeb/corehq/apps/userreports/tests/test_report_aggregation.py#L584-L587
this was probably known already by someone at some point and just not
addressed.
<!--- Describe the change below, including rationale and design decisions -->
