### PR TITLE
return only active pillows by default

### DIFF
--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -128,6 +128,9 @@ def system_ajax(request):
         pass
     elif type == 'pillowtop':
         pillow_meta = get_all_pillows_json()
+        active_pillows = getattr(settings, 'ACTIVE_PILLOW_NAMES', None)
+        if active_pillows:
+            pillow_meta = [pillow for pillow in pillow_meta if pillow['name'] in active_pillows]
         return json_response(sorted(pillow_meta, key=lambda m: m['name'].lower()))
     elif type == 'stale_pillows':
         es_index_status = [

--- a/corehq/apps/hqadmin/views/system.py
+++ b/corehq/apps/hqadmin/views/system.py
@@ -128,9 +128,6 @@ def system_ajax(request):
         pass
     elif type == 'pillowtop':
         pillow_meta = get_all_pillows_json()
-        active_pillows = getattr(settings, 'ACTIVE_PILLOW_NAMES', None)
-        if active_pillows:
-            pillow_meta = [pillow for pillow in pillow_meta if pillow['name'] in active_pillows]
         return json_response(sorted(pillow_meta, key=lambda m: m['name'].lower()))
     elif type == 'stale_pillows':
         es_index_status = [

--- a/corehq/ex-submodules/pillowtop/tasks.py
+++ b/corehq/ex-submodules/pillowtop/tasks.py
@@ -13,11 +13,6 @@ def pillow_datadog_metrics():
         return pillow['seq_format'] == 'text'
 
     pillow_meta = get_all_pillows_json()
-
-    active_pillows = getattr(settings, 'ACTIVE_PILLOW_NAMES', None)
-    if active_pillows:
-        pillow_meta = [pillow for pillow in pillow_meta if pillow['name'] in active_pillows]
-
     for pillow in pillow_meta:
         # The host and group tags are added here to ensure they remain constant
         # regardless of which celery worker the task get's executed on.

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -153,8 +153,12 @@ def _get_consumer():
     ))
 
 
-def get_all_pillows_json():
+def get_all_pillows_json(active_only=True):
     pillow_configs = get_all_pillow_configs()
+    active_pillows = getattr(settings, 'ACTIVE_PILLOW_NAMES', None)
+    if active_only and active_pillows:
+        pillow_configs = [config for config in pillow_configs if config.name in active_pillows]
+
     consumer = _get_consumer()
     with consumer:
         return [get_pillow_json(pillow_config, consumer) for pillow_config in pillow_configs]


### PR DESCRIPTION
This filters the pillows before instantiating them which also prevents checkpoints from being created if the pillow is not active.

The function is called in two places:
* `pillow_datadog_metrics` task
* `system_ajax` view (for system dashboard)