### PR TITLE
Add link to raw doc on project tombstones page

### DIFF
--- a/corehq/apps/domain/templates/domain/tombstone_management.html
+++ b/corehq/apps/domain/templates/domain/tombstone_management.html
@@ -25,6 +25,7 @@
                 {% else %}
                   Normal Project
                 {% endif %}
+                (<a href="{% url "raw_doc" %}?id={{ project.get_id }}">raw doc</a>)
               {% endwith %}
             {% else %}
               Multiple Projects with this name!
@@ -38,6 +39,7 @@
                   Normal Projects:
                 {% endif %}
                 {{ doc_type.list|length }}
+                ({% for project in doc_type.list %}{% if not forloop.first %}, {% endif %}<a href="{% url "raw_doc" %}?id={{ project.get_id }}">raw doc</a>{% endfor %})
                 </li>
               {% endfor %}
               </ul>


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAASP-10243

Adds these little "raw doc" links seen in the screenshot below:
<img width="1071" alt="Screen Shot 2020-01-30 at 2 58 57 PM" src="https://user-images.githubusercontent.com/137212/73490032-4a970c80-4371-11ea-9dd1-b76858102f8d.png">
