### PR TITLE
Add STALE_EXPORT_THRESHOLD

### DIFF
--- a/corehq/apps/export/exceptions.py
+++ b/corehq/apps/export/exceptions.py
@@ -20,3 +20,7 @@ class ExportAsyncException(Exception):
 
 class ExportODataDuplicateLabelException(Exception):
     pass
+
+
+class RejectedStaleExport(Exception):
+    pass

--- a/settings.py
+++ b/settings.py
@@ -951,6 +951,11 @@ SESSION_BYPASS_URLS = [
 ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE = False
 RATE_LIMIT_SUBMISSIONS = False
 
+# If set to a positive number, exports requested more than this many seconds ago
+# without the email option will be quickly rejected.
+# This is useful for load-shedding in times of crisis.
+STALE_EXPORT_THRESHOLD = None
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)


### PR DESCRIPTION
##### SUMMARY
Motivated by https://dimagi-dev.atlassian.net/browse/SAASP-10280. When the lag in the `export_download_queue` is larger than STALE_EXPORT_THRESHOLD, there's a thundering herd problem of rage retries, causing us to generate exports people no longer care about and not ever get to the exports people care about that they just requested. This is failover behavior and should be treated as a fire, but rejecting requests older than some threshold is better than the current failure scenario of a permanently backed up queue.

Parter PR: https://github.com/dimagi/commcare-cloud/pull/3575

##### PRODUCT DESCRIPTION
For environments that do not explicitly set their STALE_EXPORT_THRESHOLD value in commcare-cloud, there is no change.
