### PR TITLE
[Excel Formatting] Fix percentages in excel being multiplied by 100

### DIFF
--- a/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
+++ b/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
@@ -48,10 +48,10 @@ def test_decimal_eur():
 
 
 def test_percentage():
-    yield check, '80%', 80, numbers.FORMAT_PERCENTAGE, int
-    yield check, '-50%', -50, numbers.FORMAT_PERCENTAGE, int
-    yield check, '3.45%', 3.45, numbers.FORMAT_PERCENTAGE_00, float
-    yield check, '-4.35%', -4.35, numbers.FORMAT_PERCENTAGE_00, float
+    yield check, '80%', 0.8, numbers.FORMAT_PERCENTAGE, float
+    yield check, '-50%', -0.5, numbers.FORMAT_PERCENTAGE, float
+    yield check, '3.45%', 0.0345, numbers.FORMAT_PERCENTAGE_00, float
+    yield check, '-4.35%', -0.0435, numbers.FORMAT_PERCENTAGE_00, float
 
 
 def test_comma_separated_us():

--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -286,7 +286,7 @@ def get_excel_format_value(value):
     if re.match(r"^[+-]?\d+%$", value):
         try:
             return ExcelFormatValue(numbers.FORMAT_PERCENTAGE,
-                                    float(int(value.replace('%', ''))/100))
+                                    float(int(value.replace('%', '')) / 100))
         except (ValueError, OverflowError):
             pass
 
@@ -294,7 +294,7 @@ def get_excel_format_value(value):
     if re.match(r"^[+-]?\d+(\.)\d*%$", value):
         try:
             return ExcelFormatValue(numbers.FORMAT_PERCENTAGE_00,
-                                    float(float(value.replace('%', ''))/100))
+                                    float(float(value.replace('%', '')) / 100))
         except (ValueError, OverflowError):
             pass
 

--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -285,14 +285,16 @@ def get_excel_format_value(value):
     # percentage without decimals
     if re.match(r"^[+-]?\d+%$", value):
         try:
-            return ExcelFormatValue(numbers.FORMAT_PERCENTAGE, int(value.replace('%', '')))
+            return ExcelFormatValue(numbers.FORMAT_PERCENTAGE,
+                                    float(int(value.replace('%', ''))/100))
         except (ValueError, OverflowError):
             pass
 
     # percentage with decimals
     if re.match(r"^[+-]?\d+(\.)\d*%$", value):
         try:
-            return ExcelFormatValue(numbers.FORMAT_PERCENTAGE_00, float(value.replace('%', '')))
+            return ExcelFormatValue(numbers.FORMAT_PERCENTAGE_00,
+                                    float(float(value.replace('%', ''))/100))
         except (ValueError, OverflowError):
             pass
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1007

##### SUMMARY
This divides the float value being returned to excel by 100 if the formatting is set to percentage because excel automatically multiplies the result by 100.

##### FEATURE FLAG
`EXCEL_EXPORT_DATA_TYPING` => "Enable the "Automatically format cells for Excel 2007+" checkbox in form and case exports, so that excel export cells are correctly data-typed"