### PR TITLE
[Excel Formatting] Hide checkbox in Excel Dashboard Feeds and remove Feature Flag

### DIFF
--- a/corehq/apps/export/export.py
+++ b/corehq/apps/export/export.py
@@ -24,7 +24,7 @@ from corehq.apps.export.models.new import (
     SMSExportInstance,
 )
 from corehq.elastic import iter_es_docs_from_query
-from corehq.toggles import PAGINATED_EXPORTS, EXCEL_EXPORT_DATA_TYPING
+from corehq.toggles import PAGINATED_EXPORTS
 from corehq.util.datadog.gauges import datadog_histogram, datadog_track_errors
 from corehq.util.datadog.utils import DAY_SCALE_TIME_BUCKETS, load_counter
 from corehq.util.files import TransientTempfile, safe_filename
@@ -276,10 +276,7 @@ def get_export_writer(export_instances, temp_path, allow_pagination=True):
 
     if len(export_instances) == 1:
         format = export_instances[0].export_format
-        format_data_in_excel = (
-            export_instances[0].format_data_in_excel
-            and EXCEL_EXPORT_DATA_TYPING.enabled(export_instances[0].domain)
-        )
+        format_data_in_excel = export_instances[0].format_data_in_excel
 
     legacy_writer = get_writer(format, use_formatted_cells=format_data_in_excel)
 

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -131,7 +131,7 @@
                 </label>
               </div>
 
-              {% if request|toggle_enabled:"EXCEL_EXPORT_DATA_TYPING" and export_instance.type == 'form' %}
+              {% if request|toggle_enabled:"EXCEL_EXPORT_DATA_TYPING" and export_instance.type == 'form' and export_instance.export_format != 'html' %}
               <div class="checkbox">
                 <label>
                   <input type="checkbox"

--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -118,20 +118,16 @@
                   <input type="checkbox"
                          id="transform-dates-checkbox"
                          data-bind="checked: transform_dates" />
-                  {% if request|toggle_enabled:"EXCEL_EXPORT_DATA_TYPING" %}
-                    <strong>{% trans "Automatically convert dates and multimedia links for Excel" %}</strong><br/>
-                    {% blocktrans %}
-                      Leaving this checked will ensure dates appear in excel format.
-                      Otherwise they will appear as a normal text format. This also allows for
-                      hyperlinks to the multimedia captured by your form submission.
-                    {% endblocktrans %}
-                  {% else %}
-                    {% trans "Automatically convert dates and links for Excel" %}
-                  {% endif %}
+                  <strong>{% trans "Automatically convert dates and multimedia links for Excel" %}</strong><br/>
+                  {% blocktrans %}
+                    Leaving this checked will ensure dates appear in excel format.
+                    Otherwise they will appear as a normal text format. This also allows for
+                    hyperlinks to the multimedia captured by your form submission.
+                  {% endblocktrans %}
                 </label>
               </div>
 
-              {% if request|toggle_enabled:"EXCEL_EXPORT_DATA_TYPING" and export_instance.type == 'form' and export_instance.export_format != 'html' %}
+              {% if export_instance.type == 'form' and export_instance.export_format != 'html' %}
               <div class="checkbox">
                 <label>
                   <input type="checkbox"

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1796,13 +1796,6 @@ LIVEQUERY_READ_FROM_STANDBYS = DynamicallyPredictablyRandomToggle(
     """
 )
 
-EXCEL_EXPORT_DATA_TYPING = StaticToggle(
-    'excel_export_data_typing',
-    'Enable the "Automatically format cells for Excel 2007+" checkbox in form '
-    'and case exports, so that excel export cells are correctly data-typed.',
-    TAG_PRODUCT,
-    [NAMESPACE_DOMAIN],
-)
 
 RUN_CUSTOM_DATA_PULL_REQUESTS = StaticToggle(
     'run_custom_data_pull_requests',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-982
https://dimagi-dev.atlassian.net/browse/SAASP-10249

##### SUMMARY
This removes the checkbox for excel formatting from excel dashboard feeds since the formatting in dashboard feeds is always determined by excel automatically.

This also removes the `EXCEL_EXPORT_DATA_TYPING` feature flag as QA is now finished on the excel dashboard feed change and the other changes related to this update under the feature flag
