### PR TITLE
Make ES default timeout configurable per env and try to filter before agg

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -341,31 +341,33 @@ def get_form_counts_by_user_xmlns(domain, startdate, enddate, user_ids=None,
     es_instance = ES_EXPORT_INSTANCE if export else ES_DEFAULT_INSTANCE
     query = (FormES(es_instance_alias=es_instance)
              .domain(domain)
-             .filter(date_filter_fn(gte=startdate, lt=enddate)))
+             .filter(date_filter_fn(gte=startdate, lt=enddate))
+             .aggregation(
+                 TermsAggregation('user_id', 'form.meta.userID').aggregation(
+                     TermsAggregation('app_id', 'app_id').aggregation(
+                         TermsAggregation('xmlns', 'xmlns')
+                     )
+                 )
+             )
+             .size(0)
+    )
 
     if user_ids:
         query = (query
             .user_ids_handle_unknown(user_ids)
             .remove_default_filter('has_user'))
         missing_users = None in user_ids
+        if missing_users:
+            query = query.aggregation(
+                MissingAggregation('missing_user_id', 'form.meta.userID').aggregation(
+                    TermsAggregation('app_id', 'app_id').aggregation(
+                        TermsAggregation('xmlns', 'xmlns')
+                    )
+                )
+            )
 
     if xmlnss:
         query = query.xmlns(xmlnss)
-
-    query = query.aggregation(
-        TermsAggregation('user_id', 'form.meta.userID').aggregation(
-            TermsAggregation('app_id', 'app_id').aggregation(
-                TermsAggregation('xmlns', 'xmlns')
-            )
-        )).size(0)
-    if user_ids and missing_users:
-        query = query.aggregation(
-            MissingAggregation('missing_user_id', 'form.meta.userID').aggregation(
-                TermsAggregation('app_id', 'app_id').aggregation(
-                    TermsAggregation('xmlns', 'xmlns')
-                )
-            )
-        )
 
     counts = defaultdict(lambda: 0)
     aggregations = query.run().aggregations

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -78,7 +78,7 @@ def get_es_new():
     Returns an elasticsearch.Elasticsearch instance.
     """
     hosts = _es_hosts()
-    return Elasticsearch(hosts, timeout=30, serializer=ESJSONSerializer())
+    return Elasticsearch(hosts, timeout=settings.ES_SEARCH_TIMEOUT, serializer=ESJSONSerializer())
 
 
 @memoized

--- a/settings.py
+++ b/settings.py
@@ -752,6 +752,8 @@ SUMOLOGIC_URL = None
 ELASTICSEARCH_HOST = 'localhost'
 ELASTICSEARCH_PORT = 9200
 ELASTICSEARCH_MAJOR_VERSION = 1
+# If elasticsearch queries take more than this, they result in timeout errors
+ES_SEARCH_TIMEOUT = 30
 
 BITLY_LOGIN = ''
 BITLY_APIKEY = ''


### PR DESCRIPTION
The ICDS queries are timing out while working with larger timeouts. This will enable ICDS reports to work, albeit slowly