### PR TITLE
Allow moving locs w children, disallow changing their type

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -255,10 +255,10 @@ class LocationForm(forms.Form):
                     'The site code cannot contain spaces or special characters.'
                 ))
             if (SQLLocation.objects
-                .filter(domain=self.domain,
-                        site_code__iexact=site_code)
-                .exclude(location_id=self.location.location_id)
-                .exists()):
+                    .filter(domain=self.domain,
+                            site_code__iexact=site_code)
+                    .exclude(location_id=self.location.location_id)
+                    .exists()):
                 raise forms.ValidationError(_(
                     'another location already uses this site code'
                 ))


### PR DESCRIPTION
Described in detail in https://github.com/dimagi/commcare-hq/issues/26279

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
This change allows users to move locations from one parent to another in the normal UI, even when the location has children.  Currently, this is disallowed.  It also adds a new constraint - you cannot change the location type (level) of a location with children.

The problems with reparenting a location are actually problems with changing the type of a location with children.  My understanding is that the former operation is more common, and doesn't often require changing the type anyways, so this change should provide for a lot more flexibility in managing existing locations.
