### PR TITLE
SMS: Don't require translations for all languages

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -353,6 +353,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     use_default_sms_response = BooleanProperty(default=False)
     default_sms_response = StringProperty()
     chat_message_count_threshold = IntegerProperty()
+    sms_language_fallback = StringProperty()
     custom_chat_template = StringProperty()  # See settings.CUSTOM_CHAT_TEMPLATES
     custom_case_username = StringProperty()  # Case property to use when showing the case's name in a chat window
     # If empty, sms can be sent at any time. Otherwise, only send during

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -34,7 +34,6 @@ from corehq.apps.sms.models import (
 )
 from corehq.apps.sms.util import (
     ALLOWED_SURVEY_DATE_FORMATS,
-    get_or_create_translation_doc,
     get_sms_backend_classes,
     strip_plus,
     validate_phone_number,
@@ -386,21 +385,18 @@ class SettingsForm(Form):
                     "configured in the SMS languages and translations page "
                     "(Messaging -> Languages -> Messaging Translations)."),
             ),
-        ]
-
-        tdoc = get_or_create_translation_doc(self.domain)
-        if len(tdoc.langs) > 1:
-            fields.append(hqcrispy.FieldWithHelpBubble(
+            hqcrispy.FieldWithHelpBubble(
                 'language_fallback',
                 help_bubble_text=_("""
                     Choose what should happen when a broadcast or alert should be sent to a recipient but no
                     translations exists in the user's preferred language. You may choose not to send a message in
-                    that case, or to try one of several backups. The first backup uses the broadcast or alert's
-                    default language. If that translation is also unavailable, the second backup is text in
+                    that case, or to try one of several backups.<br><br>The first backup uses the broadcast or
+                    alert's default language. If that translation is also unavailable, the second backup is text in
                     the project's default SMS language. If that translation is also unavailable, you may choose
                     to use untranslated text, if there is any.
                 """),
-            ))
+            ),
+        ]
 
         return crispy.Fieldset(
             _("Registration Settings"),

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -90,6 +90,20 @@ WELCOME_RECIPIENT_CHOICES = (
     (WELCOME_RECIPIENT_ALL, ugettext_lazy('Cases and Mobile Workers')),
 )
 
+LANGUAGE_FALLBACK_NONE = 'NONE'
+LANGUAGE_FALLBACK_SCHEDULE = 'SCHEDULE'
+LANGUAGE_FALLBACK_DOMAIN = 'DOMAIN'
+LANGUAGE_FALLBACK_UNTRANSLATED = 'UNTRANSLATED'
+
+LANGUAGE_FALLBACK_CHOICES = (
+    (LANGUAGE_FALLBACK_NONE, ugettext_lazy("Only send message if available in recipient's preferred language")),
+    (LANGUAGE_FALLBACK_SCHEDULE, ugettext_lazy("Use the alert or broadcasts's default language as a backup")),
+    (LANGUAGE_FALLBACK_DOMAIN, ugettext_lazy("""
+        Use the project's default language as a backup if the alert or broadcast's language is also unavailable
+    """)),
+    (LANGUAGE_FALLBACK_UNTRANSLATED, ugettext_lazy("Use all available backups, including untranslated content")),
+)
+
 
 class LoadBalancingBackendFormMixin(Form):
     phone_numbers = CharField(required=False)
@@ -242,6 +256,10 @@ class SettingsForm(Form):
         choices=WELCOME_RECIPIENT_CHOICES,
         label=ugettext_lazy("Send registration welcome message to"),
     )
+    language_fallback = ChoiceField(
+        choices=LANGUAGE_FALLBACK_CHOICES,
+        label=ugettext_lazy("Backup behavior for missing translations"),
+    )
 
     # Internal settings
     override_daily_outbound_sms_limit = ChoiceField(
@@ -360,7 +378,19 @@ class SettingsForm(Form):
                     "configured in the SMS languages and translations page "
                     "(Messaging -> Languages -> Messaging Translations)."),
             ),
+            hqcrispy.FieldWithHelpBubble(   # TODO: hide if project only has one language
+                'language_fallback',
+                help_bubble_text=_("""
+                    Choose what should happen when a broadcast or alert should be sent to a recipient but no
+                    translations exists in the user's preferred language. You may choose not to send a message in
+                    that case, or to try one of several backups. The first backup is the broadcast or alert's
+                    default language. If that translation is also unavailable, the second backup is the project's
+                    default SMS language. If that translation is also unavailable, you may choose to use
+                    untranslated content, if there is any.
+                """),
+            ),
         ]
+
         return crispy.Fieldset(
             _("Registration Settings"),
             *fields

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -98,7 +98,7 @@ LANGUAGE_FALLBACK_UNTRANSLATED = 'UNTRANSLATED'
 
 LANGUAGE_FALLBACK_CHOICES = (
     (LANGUAGE_FALLBACK_NONE, ugettext_lazy("Only send message if available in recipient's preferred language")),
-    (LANGUAGE_FALLBACK_SCHEDULE, ugettext_lazy("Use the alert or broadcasts's default language as a backup")),
+    (LANGUAGE_FALLBACK_SCHEDULE, ugettext_lazy("Use the alert or broadcast's default language as a backup")),
     (LANGUAGE_FALLBACK_DOMAIN, ugettext_lazy("""
         Use the project's default language as a backup if the alert or broadcast's language is also unavailable
     """)),

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -97,12 +97,19 @@ LANGUAGE_FALLBACK_DOMAIN = 'DOMAIN'
 LANGUAGE_FALLBACK_UNTRANSLATED = 'UNTRANSLATED'
 
 LANGUAGE_FALLBACK_CHOICES = (
-    (LANGUAGE_FALLBACK_NONE, ugettext_lazy("Only send message if available in recipient's preferred language")),
-    (LANGUAGE_FALLBACK_SCHEDULE, ugettext_lazy("Use the alert or broadcast's default language as a backup")),
-    (LANGUAGE_FALLBACK_DOMAIN, ugettext_lazy("""
-        Use the project's default language as a backup if the alert or broadcast's language is also unavailable
+    (LANGUAGE_FALLBACK_NONE, ugettext_lazy("""
+        Only send message if text is available in recipient's preferred language
     """)),
-    (LANGUAGE_FALLBACK_UNTRANSLATED, ugettext_lazy("Use all available backups, including untranslated content")),
+    (LANGUAGE_FALLBACK_SCHEDULE, ugettext_lazy("""
+        Use text from the alert or broadcast's default language as a backup
+    """)),
+    (LANGUAGE_FALLBACK_DOMAIN, ugettext_lazy("""
+        Use text from the project's default language as a backup
+        if the alert or broadcast's language is also unavailable
+    """)),
+    (LANGUAGE_FALLBACK_UNTRANSLATED, ugettext_lazy("""
+        Use all available text backups, including untranslated content
+    """)),
 )
 
 
@@ -388,10 +395,10 @@ class SettingsForm(Form):
                 help_bubble_text=_("""
                     Choose what should happen when a broadcast or alert should be sent to a recipient but no
                     translations exists in the user's preferred language. You may choose not to send a message in
-                    that case, or to try one of several backups. The first backup is the broadcast or alert's
-                    default language. If that translation is also unavailable, the second backup is the project's
-                    default SMS language. If that translation is also unavailable, you may choose to use
-                    untranslated content, if there is any.
+                    that case, or to try one of several backups. The first backup uses the broadcast or alert's
+                    default language. If that translation is also unavailable, the second backup is text in
+                    the project's default SMS language. If that translation is also unavailable, you may choose
+                    to use untranslated text, if there is any.
                 """),
             ))
 

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -34,6 +34,7 @@ from corehq.apps.sms.models import (
 )
 from corehq.apps.sms.util import (
     ALLOWED_SURVEY_DATE_FORMATS,
+    get_or_create_translation_doc,
     get_sms_backend_classes,
     strip_plus,
     validate_phone_number,
@@ -378,7 +379,11 @@ class SettingsForm(Form):
                     "configured in the SMS languages and translations page "
                     "(Messaging -> Languages -> Messaging Translations)."),
             ),
-            hqcrispy.FieldWithHelpBubble(   # TODO: hide if project only has one language
+        ]
+
+        tdoc = get_or_create_translation_doc(self.domain)
+        if len(tdoc.langs) > 1:
+            fields.append(hqcrispy.FieldWithHelpBubble(
                 'language_fallback',
                 help_bubble_text=_("""
                     Choose what should happen when a broadcast or alert should be sent to a recipient but no
@@ -388,8 +393,7 @@ class SettingsForm(Form):
                     default SMS language. If that translation is also unavailable, you may choose to use
                     untranslated content, if there is any.
                 """),
-            ),
-        ]
+            ))
 
         return crispy.Fieldset(
             _("Registration Settings"),

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -84,6 +84,7 @@ from corehq.apps.sms.forms import (
     DISABLED,
     ENABLED,
     HIDE_ALL,
+    LANGUAGE_FALLBACK_UNTRANSLATED,
     SHOW_ALL,
     SHOW_INVALID,
     WELCOME_RECIPIENT_ALL,
@@ -587,7 +588,7 @@ class GlobalBackendMap(BaseAdminSectionView):
                         backend_id=new_catchall_backend_id
                     )
 
-            messages.success(request, _("Changes Saved."))
+            messages.success(request, _("Changes saved."))
             return HttpResponseRedirect(reverse(self.urlname))
         return self.get(request, *args, **kwargs)
 
@@ -1818,6 +1819,8 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
                     enabled_disabled(domain_obj.sms_mobile_worker_registration_enabled),
                 "registration_welcome_message":
                     self.get_welcome_message_recipient(domain_obj),
+                "language_fallback":
+                    domain_obj.sms_language_fallback or LANGUAGE_FALLBACK_UNTRANSLATED,
                 "override_daily_outbound_sms_limit":
                     ENABLED if domain_obj.custom_daily_outbound_sms_limit else DISABLED,
                 "custom_daily_outbound_sms_limit":
@@ -1854,6 +1857,8 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
                  "sms_survey_date_format"),
                 ("sms_conversation_length",
                  "sms_conversation_length"),
+                ("sms_language_fallback",
+                 "language_fallback"),
                 ("count_messages_as_read_by_anyone",
                  "count_messages_as_read_by_anyone"),
                 ("chat_message_count_threshold",
@@ -1905,7 +1910,7 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
                 form.enable_registration_welcome_sms_for_mobile_worker
 
             domain_obj.save()
-            messages.success(request, _("Changes Saved."))
+            messages.success(request, _("Changes saved."))
         return self.get(request, *args, **kwargs)
 
     @method_decorator(domain_admin_required)

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -216,9 +216,8 @@ class ContentForm(Form):
                 raise ValidationError(_("This field is required"))
             return cleaned_value
 
-        for expected_language_code in self.schedule_form.language_list:
-            if not cleaned_value.get(expected_language_code):
-                raise ValidationError(_("Please fill out all translations"))
+        if not any(cleaned_value.values()):
+            raise ValidationError(_("Please fill out at least one translation"))
 
         return cleaned_value
 

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -3,8 +3,14 @@ import uuid
 from memoized import memoized
 from django.db import models, transaction
 from corehq.apps.data_interfaces.utils import property_references_parent
+from corehq.apps.domain.models import Domain
 from corehq.apps.reminders.util import get_one_way_number_for_recipient, get_two_way_number_for_recipient
 from corehq.apps.sms.api import MessageMetadata, send_sms, send_sms_to_verified_number
+from corehq.apps.sms.forms import (
+    LANGUAGE_FALLBACK_NONE,
+    LANGUAGE_FALLBACK_SCHEDULE,
+    LANGUAGE_FALLBACK_DOMAIN,
+)
 from corehq.apps.sms.models import (
     MessagingEvent,
     PhoneNumber,
@@ -415,20 +421,35 @@ class Content(models.Model):
     def get_lang_doc(self, domain):
         return StandaloneTranslationDoc.get_obj(domain, 'sms')
 
-    def get_translation_from_message_dict(self, domain, message_dict, preferred_language_code):
+    def get_translation_from_message_dict(self, domain_obj, message_dict, preferred_language_code):
         """
-        :param domain: the domain
+        Attempt to get translated content. If content is not available in the user's preferred language,
+        attempt to fall back to other languages, as allowed by domain setting sms_language_fallback.
+
+        By default, try all possible fallbacks before giving up (same as LANGUAGE_FALLBACK_UNTRANSLATED).
+
+        :param domain_obj: the domain object
         :param message_dict: a dictionary of {language code: message}
         :param preferred_language_code: the language code of the user's preferred language
         """
         result = Content.get_cleaned_message(message_dict, preferred_language_code)
 
+        if domain_obj.sms_language_fallback == LANGUAGE_FALLBACK_NONE:
+            return result
+
         if not result and self.schedule_instance:
             schedule = self.schedule_instance.memoized_schedule
             result = Content.get_cleaned_message(message_dict, schedule.default_language_code)
 
-        if not result and self.get_lang_doc(domain):
-            result = Content.get_cleaned_message(message_dict, self.get_lang_doc(domain).default_lang)
+        if domain_obj.sms_language_fallback == LANGUAGE_FALLBACK_SCHEDULE:
+            return result
+
+        if not result:
+            tdoc = self.get_lang_doc(domain_obj.name)
+            result = Content.get_cleaned_message(message_dict, tdoc.default_lang)
+
+        if domain_obj.sms_language_fallback == LANGUAGE_FALLBACK_DOMAIN:
+            return result
 
         if not result:
             result = Content.get_cleaned_message(message_dict, '*')

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -3,7 +3,6 @@ import uuid
 from memoized import memoized
 from django.db import models, transaction
 from corehq.apps.data_interfaces.utils import property_references_parent
-from corehq.apps.domain.models import Domain
 from corehq.apps.reminders.util import get_one_way_number_for_recipient, get_two_way_number_for_recipient
 from corehq.apps.sms.api import MessageMetadata, send_sms, send_sms_to_verified_number
 from corehq.apps.sms.forms import (

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from corehq.apps.accounting.utils import domain_is_on_trial
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.exceptions import FormNotFoundException
+from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.smsforms.app import start_session
 from corehq.apps.smsforms.util import form_requires_input, critical_section_for_smsforms_sessions
@@ -70,7 +71,7 @@ class SMSContent(Content):
             return
 
         message = self.get_translation_from_message_dict(
-            logged_event.domain,
+            Domain.get_by_name(logged_event.domain),
             self.message,
             recipient.get_language_code()
         )
@@ -102,6 +103,7 @@ class EmailContent(Content):
     def send(self, recipient, logged_event, phone_entry=None):
         email_usage = EmailUsage.get_or_create_usage_record(logged_event.domain)
         is_trial = domain_is_on_trial(logged_event.domain)
+        domain_obj = Domain.get_by_name(logged_event.domain)
 
         logged_subevent = logged_event.create_subevent_from_contact_and_content(
             recipient,
@@ -110,14 +112,14 @@ class EmailContent(Content):
         )
 
         subject = self.get_translation_from_message_dict(
-            logged_event.domain,
+            domain_obj,
             self.subject,
             recipient.get_language_code()
         )
 
         message = self.get_translation_from_message_dict(
             logged_event.domain,
-            self.message,
+            domain_obj,
             recipient.get_language_code()
         )
 

--- a/corehq/messaging/scheduling/templates/scheduling/partials/message_configuration.html
+++ b/corehq/messaging/scheduling/templates/scheduling/partials/message_configuration.html
@@ -13,7 +13,6 @@
   <p class="help-block">
     <i class="fa fa-info-circle"></i>
     {% blocktrans %}
-      Mandatory for SMS/Email.
       See the <a href="https://confluence.dimagi.com/display/commcarepublic/Conditional+Alerts#ConditionalAlerts-Content" target="_blank">help site</a>
       for some optional formatting that can be applied to this message.
     {% endblocktrans %}

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -1,3 +1,4 @@
+from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.models import CommCareUser
 from corehq.messaging.scheduling.models import Schedule, Content, CustomContent
@@ -26,8 +27,11 @@ class TestContent(TestCase):
     def setUpClass(cls):
         super(TestContent, cls).setUpClass()
         cls.domain = 'test-content'
+        cls.domain_obj = create_domain(cls.domain)
         cls.user = CommCareUser(phone_numbers=['9990000000000'], language='es')
-        cls.translation_doc = StandaloneTranslationDoc(domain=cls.domain, area='sms', langs=['en', 'es'])
+        from corehq.apps.sms.util import get_or_create_translation_doc
+        cls.translation_doc = get_or_create_translation_doc(cls.domain)
+        cls.translation_doc.set_translations('es', {})
         cls.translation_doc.save()
 
     @classmethod
@@ -54,7 +58,7 @@ class TestContent(TestCase):
 
         self.assertEqual(
             content.get_translation_from_message_dict(
-                self.domain,
+                self.domain_obj,
                 message_dict,
                 self.user.get_language_code()
             ),
@@ -70,7 +74,7 @@ class TestContent(TestCase):
 
         self.assertEqual(
             content.get_translation_from_message_dict(
-                self.domain,
+                self.domain_obj,
                 message_dict,
                 self.user.get_language_code()
             ),
@@ -87,7 +91,7 @@ class TestContent(TestCase):
 
         self.assertEqual(
             content.get_translation_from_message_dict(
-                self.domain,
+                self.domain_obj,
                 message_dict,
                 self.user.get_language_code()
             ),
@@ -107,7 +111,7 @@ class TestContent(TestCase):
 
         self.assertEqual(
             content.get_translation_from_message_dict(
-                self.domain,
+                self.domain_obj,
                 message_dict,
                 self.user.get_language_code()
             ),
@@ -128,7 +132,7 @@ class TestContent(TestCase):
 
         self.assertEqual(
             content.get_translation_from_message_dict(
-                self.domain,
+                self.domain_obj,
                 message_dict,
                 self.user.get_language_code()
             ),

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -1,4 +1,10 @@
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.sms.forms import (
+    LANGUAGE_FALLBACK_NONE,
+    LANGUAGE_FALLBACK_SCHEDULE,
+    LANGUAGE_FALLBACK_DOMAIN,
+    LANGUAGE_FALLBACK_UNTRANSLATED,
+)
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.models import CommCareUser
 from corehq.messaging.scheduling.models import Schedule, Content, CustomContent
@@ -137,4 +143,63 @@ class TestContent(TestCase):
                 self.user.get_language_code()
             ),
             message_dict['es']
+        )
+
+    def test_sms_language_fallback(self):
+        message_dict = {
+            '*': 'non-translated message',
+            'en': 'english message',            # project default
+            'hin': 'hindi message',             # schedule default
+            'es': 'spanish message',            # user's preferred language
+        }
+        user_lang = self.user.get_language_code()
+        content = Content()
+        content.set_context(
+            schedule_instance=Mock(memoized_schedule=Schedule(domain=self.domain, default_language_code='hin'))
+        )
+
+        self.domain_obj.sms_language_fallback = LANGUAGE_FALLBACK_NONE
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            message_dict['es']
+        )
+        message_dict.pop('es')
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            ''
+        )
+
+        self.domain_obj.sms_language_fallback = LANGUAGE_FALLBACK_SCHEDULE
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            message_dict['hin']
+        )
+        message_dict.pop('hin')
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            ''
+        )
+
+        self.domain_obj.sms_language_fallback = LANGUAGE_FALLBACK_DOMAIN
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            message_dict['en']
+        )
+        message_dict.pop('en')
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            ''
+        )
+
+        self.domain_obj.sms_language_fallback = LANGUAGE_FALLBACK_UNTRANSLATED
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            message_dict['*']
+        )
+
+        # Default: same as LANGUAGE_FALLBACK_UNTRANSLATED
+        self.domain_obj.sms_language_fallback = None
+        self.assertEqual(
+            content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
+            message_dict['*']
         )


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1205

The old logic for translating SMS content was:
1. Look for translation in user's language
2. If nothing found, look for translation in broadcast/alert's default language
3. If nothing found, look for translation in project's default language for SMS
4. If nothing found, look for untranslated content
5. If nothing found, throw error code `ERROR_NO_MESSAGE`

This PR adds a new domain-level SMS setting that lets the user decide how far into those steps to go before giving up and throwing the `ERROR_NO_MESSAGE`:
<img width="821" alt="Screen Shot 2020-02-06 at 5 25 51 PM" src="https://user-images.githubusercontent.com/1486591/73984064-c9f28600-4905-11ea-9998-9d7805bd9627.png">

The default is the bottom option, which is the same as the old behavior.

This PR also removes the UI requirement that the user enter content for all languages. The user is still required to enter at least one translation.

The intent is that ICDS will no longer need to have all translations available to create an SMS and can also pick the strictest setting (only use user's language) to prevent HQ from falling back to sending Hindi content for users in states that don't have translations yet.

@dimagi/product FYI this will be visible to everyone, although again, the default setting will keep the current production behavior. Let me know if you have feedback.