### PR TITLE
Mark case uploads older than threshold missing task as Failed in UI

### DIFF
--- a/corehq/apps/case_importer/static/case_importer/js/import_history.js
+++ b/corehq/apps/case_importer/static/case_importer/js/import_history.js
@@ -109,7 +109,7 @@ hqDefine('case_importer/js/import_history', [
                 },
                 reset: function () {
                     delay = minDelay;
-                }
+                },
             };
         }());
 

--- a/corehq/apps/case_importer/static/case_importer/js/import_history.js
+++ b/corehq/apps/case_importer/static/case_importer/js/import_history.js
@@ -17,6 +17,11 @@ hqDefine('case_importer/js/import_history', [
 
         self.comment = ko.observable(options.comment || '');
         self.task_status = ko.observable(options.task_status);
+        self.isExpiredUpload = function () {
+            var thresholdInDays = 2;
+            var thresholdDate = new Date(new Date().setDate(new Date().getDate() - thresholdInDays));
+            return new Date(self.created) < thresholdDate;
+        };
 
         self.commentUrl = function () {
             return initialPageData.reverse('case_importer_update_upload_comment', self.upload_id);

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -30,10 +30,10 @@
       <!--ko if: task_status().state == $root.states.SUCCESS && !task_status().result-->
       <span class="label label-danger">{% trans "Failed" %}</span>
       <!--/ko-->
-      <!--ko if: task_status().state == $root.states.FAILED-->
+      <!--ko if: task_status().state == $root.states.MISSING && isExpiredUpload() || task_status().state == $root.states.FAILED-->
       <span class="label label-danger">{% trans "Failed" %}</span>
       <!--/ko-->
-      <!--ko if: task_status().state == $root.states.MISSING || task_status().state == $root.states.NOT_STARTED -->
+      <!--ko if: task_status().state == $root.states.MISSING && !isExpiredUpload() || task_status().state == $root.states.NOT_STARTED-->
       {% trans "Waiting to start" %}
       <!--/ko-->
       <!--ko if: task_status().state == $root.states.STARTED-->
@@ -47,7 +47,7 @@
       </div>
       <!--/ko-->
     </td>
-    <td class="col-md-1" data-bind="text: created"></td>
+    <td class="col-md-1" data-bind="text: created_display"></td>
     <td class="col-md-1" data-bind="text: case_type">
     </td>
     <td class="col-md-4" data-bind="with: task_status()">

--- a/corehq/apps/case_importer/tracking/jsmodels.py
+++ b/corehq/apps/case_importer/tracking/jsmodels.py
@@ -10,11 +10,13 @@ from corehq.apps.users.dbaccessors.couch_users import (
 )
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_request
+from dimagi.utils.parsing import json_format_datetime
 
 
 class CaseUploadJSON(jsonobject.StrictJsonObject):
     domain = jsonobject.StringProperty(required=True)
     # In user display format, e.g. Dec 08, 2016 19:19 EST
+    created_display = jsonobject.StringProperty(required=True)
     created = jsonobject.StringProperty(required=True)
     upload_id = jsonobject.StringProperty(required=True)
     task_status = jsonobject.ObjectProperty(lambda: TaskStatus)
@@ -34,7 +36,8 @@ def case_upload_to_user_json(case_upload, request):
 
     return CaseUploadJSON(
         domain=case_upload.domain,
-        created=ServerTime(case_upload.created).user_time(tz).ui_string(),
+        created_display=ServerTime(case_upload.created).user_time(tz).ui_string(),
+        created=json_format_datetime(case_upload.created),
         upload_id=str(case_upload.upload_id),
         task_status=case_upload.get_task_status_json(),
         user_name=get_display_name_for_user_id(


### PR DESCRIPTION
##### SUMMARY
This is useful for rare cases where a task is never properly recorded before it is deleted,
such as in https://dimagi-dev.atlassian.net/browse/SAASP-10152. Previously such tasks were permanently marked as "Waiting to start" which sends the wrong message.

This PR also adds gentle exponential backoff to the case import history page's polling when there are no changes, but keeps polling without backoff while there are active changes (to the progress of a large upload, for example).
