### PR TITLE
Set local less version back to one that works for app builder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "underscore": "1.8.3",
     "leaflet": "0.7.7",
     "select2": "4.0.0",
-    "less": "3.10.3",
+    "less": "1.7.3",
     "xpath": "dimagi/js-xpath#f4f0c78",
     "blazy": "1.6.2",
     "datatables": "1.10.9",

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/less_debug.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/less_debug.html
@@ -16,5 +16,5 @@
       relativeUrls: false
     };
   </script>
-  <script src="{% static 'less/dist/less.min.js' %}"></script>
+  <script src="{% static 'less/dist/less-1.7.3.min.js' %}"></script>
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
This is essentially a revert of https://github.com/dimagi/commcare-hq/commit/4697bf99919140e8210afce7d539db385b65e2d8
though other changes have been applied over it that make it not strictly revertible.

That commit caused an issue that blocks local dev on the app builder.

This change should only affect local dev. It is not a super clean thing and it does not address the existing issue of there being different versions being used in production and in dev, ~or there of there being multiple different versions of less/lessc being installed in production~ (this was based on a misunderstanding on my part and is wrong). So I just wanted to acknowledge that there is unaddressed tech debt / versioning mess before and after this revert, that this just gets us back to the status quo, not to some better place.

A note about reverting. It makes me feel like a jerk, but it's been repeatedly impressed upon me that the right way to deal with issues introduced by another division is to revert the changes and ping the author(s). While conceptually there's a difference between "things were great and I introduce a change that broke them" and "things were in a jenky state and I tried to fix them which caused other problems", I think in both cases reverting to the status quo and leaving next steps up to the author(s) driving the change in another division is the way we're supposed to handle it.

