### PR TITLE
Delete table if exists

### DIFF
--- a/custom/icds_reports/data_pull/sql_queries/create_dummy_thr_table.sql
+++ b/custom/icds_reports/data_pull/sql_queries/create_dummy_thr_table.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS dummy_thr_table;
 CREATE TEMPORARY TABLE dummy_thr_table AS
   (SELECT supervisor_id,
           SUM(CASE

--- a/custom/icds_reports/data_pull/sql_queries/create_tmp_pse_table.sql
+++ b/custom/icds_reports/data_pull/sql_queries/create_tmp_pse_table.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS temp_pse_data_pull;
-CREATE unlogged TABLE temp_pse_data_pull AS
+CREATE TEMPORARY TABLE temp_pse_data_pull AS
 SELECT   supervisor_id,
          Sum(
          CASE

--- a/custom/icds_reports/data_pull/sql_queries/create_tmp_thr_table.sql
+++ b/custom/icds_reports/data_pull/sql_queries/create_tmp_thr_table.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS temp_thr_data_pull;
-CREATE unlogged TABLE temp_thr_data_pull AS
+CREATE TEMPORARY TABLE temp_thr_data_pull AS
 SELECT   supervisor_id,
          Sum(
          CASE


### PR DESCRIPTION
1. Delete to avoid reusing already present table when running set up queries to create temporary table
2. use temporary table instead of unlogged