### PR TITLE
[Amazon SES] Use the new metadata from SNS

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/django/email.py
+++ b/corehq/ex-submodules/dimagi/utils/django/email.py
@@ -25,10 +25,7 @@ def get_valid_recipients(recipients):
     :return: list of recipient emails not marked as bounced
     """
     from corehq.util.models import BouncedEmail
-    bounced_emails = set(
-        BouncedEmail.objects.filter(email__in=recipients).values_list(
-            'email', flat=True)
-    )
+    bounced_emails = BouncedEmail.get_hard_bounced_emails(recipients)
     return [recipient for recipient in recipients if recipient not in bounced_emails]
 
 

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -36,9 +36,51 @@ class BounceSubType(object):
     )
 
 
+# The number of General bounces we accept before rejecting an email hard
+GENERAL_BOUNCE_THRESHOLD = 3
+
+
 class BouncedEmail(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     email = models.EmailField(db_index=True, unique=True)
+
+    @staticmethod
+    def get_hard_bounced_emails(list_of_emails):
+        # these are any Bounced Email Records we have
+        bounced_emails = set(
+            BouncedEmail.objects.filter(email__in=list_of_emails).values_list(
+                'email', flat=True)
+        )
+
+        # These are emails that were marked as Suppressed or Undetermined
+        # by SNS metadata, meaining they definitely hard bounced
+        bad_emails = set(
+            PermanentBounceMeta.objects.filter(sub_type__in=[
+                BounceSubType.UNDETERMINED, BounceSubType.SUPPRESSED
+            ], bounced_email__email__in=bounced_emails).values_list(
+                'bounced_email__email', flat=True)
+        )
+
+        # These are definite complaints against us
+        complaints = set(
+            ComplaintBounceMeta.objects.filter(
+                bounced_email__email__in=bounced_emails.difference(bad_emails)
+            ).values_list('bounced_email__email', flat=True)
+        )
+        bad_emails.union(complaints)
+
+        for remaining_email in bounced_emails.difference(bad_emails):
+            meta_query = PermanentBounceMeta.objects.filter(
+                bounced_email__email=remaining_email)
+            if not meta_query.exists():
+                # There is no metadata for this email, so we assume
+                # a hard bounce
+                bad_emails.add(remaining_email)
+            elif meta_query.count() > GENERAL_BOUNCE_THRESHOLD:
+                # This email has too many general bounces recorded against it
+                bad_emails.add(remaining_email)
+
+        return bad_emails
 
 
 class TransientBounceEmail(models.Model):

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -67,7 +67,7 @@ class BouncedEmail(models.Model):
                 bounced_email__email__in=bounced_emails.difference(bad_emails)
             ).values_list('bounced_email__email', flat=True)
         )
-        bad_emails.union(complaints)
+        bad_emails.update(complaints)
 
         for remaining_email in bounced_emails.difference(bad_emails):
             meta_query = PermanentBounceMeta.objects.filter(

--- a/corehq/util/tests/test_bounced_emails.py
+++ b/corehq/util/tests/test_bounced_emails.py
@@ -1,0 +1,92 @@
+import datetime
+
+from django.test import TestCase
+
+from corehq.util.models import (
+    BouncedEmail,
+    PermanentBounceMeta,
+    BounceSubType,
+    GENERAL_BOUNCE_THRESHOLD,
+    ComplaintBounceMeta,
+)
+
+
+class TestBouncedEmails(TestCase):
+    SUPPRESSED_BOUNCE = 'permanent_bounce@gmail.com'
+    UNDETERMINED_BOUNCE = 'undetermined_bounce@gmail.com'
+    GENERAL_BOUNCE = 'general_bounce@gmail.com'
+    GENERAL_AT_TRESH = 'general_bounce_stillok@gmail.com'
+    GENERAL_ABOVE_THRESH = 'general_bounce_bad@gmail.com'
+    COMPLAINT = 'complaint@gmail.com'
+    NO_META_BOUNCE = 'no_meta@gmail.com'
+
+    @staticmethod
+    def _create_permanent_meta(email_address, sub_type, num_records=1):
+        bounced_email = BouncedEmail.objects.create(email=email_address)
+        for rec_num in range(0, num_records):
+            PermanentBounceMeta.objects.create(
+                bounced_email=bounced_email,
+                timestamp=datetime.datetime.now(),
+                sub_type=sub_type,
+            )
+
+    def setUp(self):
+        super().setUp()
+        self._create_permanent_meta(
+            self.SUPPRESSED_BOUNCE,
+            BounceSubType.SUPPRESSED
+        )
+        self._create_permanent_meta(
+            self.UNDETERMINED_BOUNCE,
+            BounceSubType.UNDETERMINED
+        )
+        self._create_permanent_meta(
+            self.GENERAL_BOUNCE,
+            BounceSubType.GENERAL
+        )
+        self._create_permanent_meta(
+            self.GENERAL_AT_TRESH,
+            BounceSubType.GENERAL,
+            GENERAL_BOUNCE_THRESHOLD,
+        )
+        self._create_permanent_meta(
+            self.GENERAL_ABOVE_THRESH,
+            BounceSubType.GENERAL,
+            GENERAL_BOUNCE_THRESHOLD + 1,
+        )
+        BouncedEmail.objects.create(email=self.NO_META_BOUNCE)
+        complaint_email = BouncedEmail.objects.create(email=self.COMPLAINT)
+        ComplaintBounceMeta.objects.create(
+            bounced_email=complaint_email,
+            timestamp=datetime.datetime.now(),
+        )
+
+    def tearDown(self):
+        ComplaintBounceMeta.objects.all().delete()
+        PermanentBounceMeta.objects.all().delete()
+        BouncedEmail.objects.all().delete()
+        super().tearDown()
+
+    def test_hard_bounce_emails(self):
+        recipients = [
+            'imok@gmail.com',
+            self.SUPPRESSED_BOUNCE,
+            self.UNDETERMINED_BOUNCE,
+            self.GENERAL_BOUNCE,
+            self.GENERAL_AT_TRESH,
+            self.GENERAL_ABOVE_THRESH,
+            self.COMPLAINT,
+            self.NO_META_BOUNCE,
+        ]
+
+        bounced_emails = BouncedEmail.get_hard_bounced_emails(recipients)
+        self.assertEqual(
+            bounced_emails,
+            {
+                self.SUPPRESSED_BOUNCE,
+                self.UNDETERMINED_BOUNCE,
+                self.GENERAL_ABOVE_THRESH,
+                self.COMPLAINT,
+                self.NO_META_BOUNCE,
+            }
+        )


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10242

##### SUMMARY
This properly lets through "General" bounced emails until a certain threshold. I still need to do some work to make sure we don't have any `BouncedEmail` objects without SNS metadata.