### PR TITLE
Fixed get_or_create calls in couch to sql data migrations

### DIFF
--- a/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
+++ b/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
@@ -18,7 +18,7 @@ class Command(PopulateSQLCommand):
         return GlobalAppConfig
 
     def update_or_create_sql_object(self, doc):
-        model, created = self.sql_class().objects.get_or_create(
+        model, created = self.sql_class().objects.update_or_create(
             domain=doc['domain'],
             app_id=doc['app_id'],
             defaults={

--- a/corehq/apps/hqadmin/management/commands/populate_sql_hq_deploy.py
+++ b/corehq/apps/hqadmin/management/commands/populate_sql_hq_deploy.py
@@ -12,7 +12,7 @@ class Command(PopulateSQLCommand):
         return SQLHqDeploy
 
     def update_or_create_sql_object(self, doc):
-        model, created = self.sql_class().objects.get_or_create(
+        model, created = self.sql_class().objects.update_or_create(
             couch_id=doc['_id'],
             defaults={
                 'date': doc.get('date'),


### PR DESCRIPTION
These should use `update_or_create` so the migration runs properly if this command is run more than once.