### PR TITLE
[AWS SES] Add datadog counters and error tracking to bounced email manager

### DIFF
--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -139,7 +139,7 @@ class BouncedEmailManager(object):
                 ))
         else:
             datadog_counter(
-                'commcare.util.bounced_email_manager.unknown_notification_type'
+                'commcare.bounced_email_manager.unknown_notification_type'
             )
             self._label_problem_email(
                 uid,
@@ -244,7 +244,7 @@ class BouncedEmailManager(object):
                             self._handle_undetermined_bounce(aws_meta, uid)
                         else:
                             datadog_counter(
-                                'commcare.util.bounced_email_manager.unexpected_bounce_type'
+                                'commcare.bounced_email_manager.unexpected_bounce_type'
                             )
                             self._label_problem_email(
                                 uid,
@@ -258,7 +258,7 @@ class BouncedEmailManager(object):
                     elif aws_meta.notification_type == NotificationType.COMPLAINT:
                         self._record_complaint(aws_meta, uid)
             except Exception as e:
-                datadog_counter('commcare.util.bounced_email_manager.formatting_issues')
+                datadog_counter('commcare.bounced_email_manager.formatting_issues')
                 self._label_problem_email(
                     uid,
                     extra_labels=["FormattingIssues"]
@@ -328,7 +328,7 @@ class BouncedEmailManager(object):
                 BouncedEmail.objects.update_or_create(
                     email=recipient,
                 )
-                datadog_counter('commcare.util.bounced_email_manager.sns_notification_missing')
+                datadog_counter('commcare.bounced_email_manager.sns_notification_missing')
                 self._label_problem_email(
                     uid,
                     extra_labels=["SNSNotificationMissing"]
@@ -340,7 +340,7 @@ class BouncedEmailManager(object):
                 )
             elif not exists:
                 # this email failed to validate, find out why
-                datadog_counter('commcare.util.bounced_email_manager.validation_failed')
+                datadog_counter('commcare.bounced_email_manager.validation_failed')
                 self._label_problem_email(
                     uid,
                     extra_labels=["ValidationFailed"]
@@ -372,7 +372,7 @@ class BouncedEmailManager(object):
                 if recipients:
                     self._handle_raw_bounced_recipients(recipients, uid)
                 else:
-                    datadog_counter('commcare.util.bounced_email_manager.recipient_unknown')
+                    datadog_counter('commcare.bounced_email_manager.recipient_unknown')
                     self._label_problem_email(
                         uid,
                         extra_labels=["RecipientUnknown"]

--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -183,6 +183,7 @@ class BouncedEmailManager(object):
             )
         if self.delete_processed_messages:
             self._delete_message_with_uid(uid)
+        datadog_counter('commcare.bounced_email_manager.permanent_bounce_recorded')
 
     def _record_transient_bounce(self, aws_meta, uid):
         exists = TransientBounceEmail.objects.filter(
@@ -197,6 +198,7 @@ class BouncedEmailManager(object):
             )
         if self.delete_processed_messages:
             self._delete_message_with_uid(uid)
+        datadog_counter('commcare.bounced_email_manager.transient_bounce_recorded')
 
     def _handle_undetermined_bounce(self, aws_meta, uid):
         _bounced_email_soft_assert(
@@ -225,6 +227,7 @@ class BouncedEmailManager(object):
             )
         if self.delete_processed_messages:
             self._delete_message_with_uid(uid)
+        datadog_counter('commcare.bounced_email_manager.complaint_recorded')
 
     def process_aws_notifications(self):
         self.mail.select('inbox')

--- a/corehq/util/bounced_email_manager.py
+++ b/corehq/util/bounced_email_manager.py
@@ -138,7 +138,9 @@ class BouncedEmailManager(object):
                     destination=mail_info.get('destination', []),
                 ))
         else:
-            datadog_counter('bounced_email_manager.unknown_notification_type')
+            datadog_counter(
+                'commcare.util.bounced_email_manager.unknown_notification_type'
+            )
             self._label_problem_email(
                 uid,
                 extra_labels=['UnknownAWSNotificationType']
@@ -241,7 +243,9 @@ class BouncedEmailManager(object):
                         elif aws_meta.main_type == BounceType.UNDETERMINED:
                             self._handle_undetermined_bounce(aws_meta, uid)
                         else:
-                            datadog_counter('bounced_email_manager.unexpected_bounce_type')
+                            datadog_counter(
+                                'commcare.util.bounced_email_manager.unexpected_bounce_type'
+                            )
                             self._label_problem_email(
                                 uid,
                                 extra_labels=["UnexpectedBounceType"]
@@ -254,7 +258,7 @@ class BouncedEmailManager(object):
                     elif aws_meta.notification_type == NotificationType.COMPLAINT:
                         self._record_complaint(aws_meta, uid)
             except Exception as e:
-                datadog_counter('bounced_email_manager.formatting_issues')
+                datadog_counter('commcare.util.bounced_email_manager.formatting_issues')
                 self._label_problem_email(
                     uid,
                     extra_labels=["FormattingIssues"]
@@ -324,7 +328,7 @@ class BouncedEmailManager(object):
                 BouncedEmail.objects.update_or_create(
                     email=recipient,
                 )
-                datadog_counter('bounced_email_manager.sns_notification_missing')
+                datadog_counter('commcare.util.bounced_email_manager.sns_notification_missing')
                 self._label_problem_email(
                     uid,
                     extra_labels=["SNSNotificationMissing"]
@@ -336,7 +340,7 @@ class BouncedEmailManager(object):
                 )
             elif not exists:
                 # this email failed to validate, find out why
-                datadog_counter('bounced_email_manager.validation_failed')
+                datadog_counter('commcare.util.bounced_email_manager.validation_failed')
                 self._label_problem_email(
                     uid,
                     extra_labels=["ValidationFailed"]
@@ -368,7 +372,7 @@ class BouncedEmailManager(object):
                 if recipients:
                     self._handle_raw_bounced_recipients(recipients, uid)
                 else:
-                    datadog_counter('bounced_email_manager.recipient_unknown')
+                    datadog_counter('commcare.util.bounced_email_manager.recipient_unknown')
                     self._label_problem_email(
                         uid,
                         extra_labels=["RecipientUnknown"]


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAASP-10229

##### SUMMARY
This adds some additional tracking in datadog for any errors that come up during the `process_bounced_emails` periodic task and counts the number of different error types when processing emails.