### PR TITLE
Set permissions to empty list when populating SQLApiUser

### DIFF
--- a/corehq/apps/api/management/commands/populate_apiuser.py
+++ b/corehq/apps/api/management/commands/populate_apiuser.py
@@ -16,6 +16,6 @@ class Command(PopulateSQLCommand):
             id=doc['_id'],
             defaults={
                 "password": doc.get("password"),
-                "permissions": doc.get("permissions"),
+                "permissions": doc.get("permissions", []),
             })
         return (model, created)


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/26618 did not do what I thought it would; seems that passing in `None` for permissions in `update_or_create` means it still gets set to None, not to the default value.