### PR TITLE
[Icds Dashboard] fix tabular report location access

### DIFF
--- a/custom/icds_reports/static/icds_reports/js/spec/download.directive.spec.js
+++ b/custom/icds_reports/static/icds_reports/js/spec/download.directive.spec.js
@@ -21,7 +21,9 @@ describe('Download Directive', function () {
             ]);
             $provide.constant("haveAccessToFeatures", false);
             $provide.constant("userLocationType", 'state');
-        $provide.constant("isAlertActive", false);
+            $provide.constant("haveAccessToAllLocations", false);
+            $provide.constant("allUserLocationId", []);
+            $provide.constant("isAlertActive", false);
         }));
 
         beforeEach(inject(function ($rootScope, $compile, _$httpBackend_) {
@@ -343,6 +345,8 @@ describe('Download Directive', function () {
             $provide.constant("haveAccessToFeatures", true);
             $provide.constant("userLocationType", 'state');
             $provide.constant("isAlertActive", false);
+            $provide.constant("haveAccessToAllLocations", false);
+            $provide.constant("allUserLocationId", []);
         }));
 
         beforeEach(inject(function ($rootScope, $compile, _$httpBackend_) {
@@ -448,6 +452,8 @@ describe('Download Directive', function () {
             $provide.constant("haveAccessToFeatures", false);
             $provide.constant("userLocationType", 'state');
             $provide.constant("isAlertActive", false);
+            $provide.constant("haveAccessToAllLocations", false);
+            $provide.constant("allUserLocationId", []);
         }));
 
         beforeEach(inject(function ($rootScope, $compile, _$httpBackend_) {
@@ -498,6 +504,8 @@ describe('Download Directive', function () {
             $provide.constant("haveAccessToFeatures", true);
             $provide.constant("userLocationType", 'state');
             $provide.constant("isAlertActive", false);
+            $provide.constant("haveAccessToAllLocations", false);
+            $provide.constant("allUserLocationId", []);
         }));
 
         beforeEach(inject(function ($rootScope, $compile, _$httpBackend_) {
@@ -548,6 +556,8 @@ describe('Download Directive', function () {
             $provide.constant("haveAccessToFeatures", true);
             $provide.constant("userLocationType", 'block');
             $provide.constant("isAlertActive", false);
+            $provide.constant("haveAccessToAllLocations", false);
+            $provide.constant("allUserLocationId", []);
         }));
 
         beforeEach(inject(function ($rootScope, $compile, _$httpBackend_) {

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -215,7 +215,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         return userLocationInSorted.length > 0;
     };
 
-    vm.showAllOption = function (locations) {
+    vm.preventShowingAllOption = function (locations) {
         return ((!vm.userLocationIdIsNull() && !vm.userHaveAccessToAllLocations(locations)) || vm.isUserLocationIn(locations)) && !haveAccessToAllLocations;
     };
 
@@ -235,10 +235,9 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
                         var sortedLocations = _.sortBy(locationsGrouppedByParent[parentId], function (o) {
                             return o.name;
                         });
-                        if (vm.showAllOption(sortedLocations)) {
+                        if (vm.preventShowingAllOption(sortedLocations)) {
                             locationsCache[parentId] = sortedLocations;
-                        }
-                        else if (selectedLocation.user_have_access) {
+                        } else if (selectedLocation.user_have_access) {
                             locationsCache[parentId] = [ALL_OPTION].concat(sortedLocations);
                         } else {
                             locationsCache[parentId] = sortedLocations;


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1242.
It was happening because on line here: https://github.com/dimagi/commcare-hq/compare/rn_fix_tabular_report_location_Access?expand=1#diff-57a6e3501ebaf4aff43ac70619c535a6R240, All option was getting added to the list which was causing `disabled` function to return false.
This was working fine on other pages of the dashboard. So referenced from the location filter of the dashboard to fix this. 
Will think about the reusability later as this is P1