### PR TITLE
replace existing form instead of deprecate if no case transactions exist

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -311,17 +311,18 @@ class SubmissionErrorTestSQL(SubmissionErrorTest):
         ).all()
         self.assertEqual(1, len(stubs))
 
-        form = FormAccessors(self.domain).get_form(FORM_WITH_CASE_ID)
-        self.assertTrue(form.is_error)
-        self.assertTrue(form.initial_processing_complete)
+        old_form = FormAccessors(self.domain).get_form(FORM_WITH_CASE_ID)
+        self.assertTrue(old_form.is_error)
+        self.assertTrue(old_form.initial_processing_complete)
         expected_problem_message = f'{type(error).__name__}: {error}'
-        self.assertEqual(form.problem, expected_problem_message)
+        self.assertEqual(old_form.problem, expected_problem_message)
 
         _, resp = self._submit('form_with_case.xml')
         self.assertEqual(resp.status_code, 201)
-        form = FormAccessors(self.domain).get_form(FORM_WITH_CASE_ID)
-        self.assertTrue(form.is_normal)
-        old_form = FormAccessors(self.domain).get_form(form.deprecated_form_id)
+        new_form = FormAccessors(self.domain).get_form(FORM_WITH_CASE_ID)
+        self.assertTrue(new_form.is_normal)
+
+        old_form.refresh_from_db()  # can't fetch by form_id since form_id changed
         self.assertEqual(old_form.orig_id, FORM_WITH_CASE_ID)
         self.assertEqual(old_form.problem, expected_problem_message)
 

--- a/corehq/form_processor/backends/couch/processor.py
+++ b/corehq/form_processor/backends/couch/processor.py
@@ -240,6 +240,10 @@ class FormProcessorCouch(object):
         return [fetch_and_wrap_form(id) for id in form_ids]
 
     @staticmethod
+    def form_has_case_transactions(form_id):
+        raise NotImplementedError
+
+    @staticmethod
     def get_case_with_lock(case_id, lock=False, wrap=False):
 
         def _get_case():

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -1204,13 +1204,11 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         return owner_ids
 
     @staticmethod
-    def get_case_transactions_for_form(form_id, limit_to_cases):
-        for db_name, case_ids in split_list_by_db_partition(limit_to_cases):
-            resultset = CaseTransaction.objects.using(db_name).filter(
-                case_id__in=case_ids, form_id=form_id
-            )
-            for trans in resultset:
-                yield trans
+    def form_has_case_transactions(form_id):
+        for db_name in get_db_aliases_for_partitioned_query():
+            if CaseTransaction.objects.using(db_name).filter(form_id=form_id).exists():
+                return True
+        return False
 
     @staticmethod
     def get_case_transactions_by_case_id(case, updated_xforms=None):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -314,6 +314,10 @@ class FormProcessorSQL(object):
         return FormAccessorSQL.get_forms_with_attachments_meta(xform_ids)
 
     @staticmethod
+    def form_has_case_transactions(form_id):
+        return CaseAccessorSQL.form_has_case_transactions(form_id)
+
+    @staticmethod
     def get_case_with_lock(case_id, lock=False, wrap=False):
         try:
             if lock:

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -113,6 +113,9 @@ class FormProcessorInterface(object):
     def get_case_forms(self, case_id):
         return self.processor.get_case_forms(case_id)
 
+    def form_has_case_transactions(self, form_id):
+        self.processor.form_has_case_transactions(form_id)
+
     def store_attachments(self, xform, attachments):
         """
         Takes a list of Attachment namedtuples with content, name, and content_type and stores them to the XForm

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -114,7 +114,7 @@ class FormProcessorInterface(object):
         return self.processor.get_case_forms(case_id)
 
     def form_has_case_transactions(self, form_id):
-        self.processor.form_has_case_transactions(form_id)
+        return self.processor.form_has_case_transactions(form_id)
 
     def store_attachments(self, xform, attachments):
         """

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -195,6 +195,20 @@ def _handle_duplicate(new_doc):
         new_md5 = new_doc.xml_md5()
 
     if existing_md5 is None or existing_md5 != new_md5:
+
+        def _deprecate_old_form():
+            NotAllowed.check(new_doc.domain)
+            existing, new = apply_deprecation(existing_doc, new_doc, interface)
+            return new, existing
+
+        def _replace_old_form():
+            if not interface.use_sql_domain:
+                new_doc._rev, existing_doc._rev = existing_doc._rev, new_doc._rev
+            interface.assign_new_id(existing_doc)
+            existing_doc.orig_id = new_doc.form_id
+            existing_doc.save()
+            return new_doc, None
+
         _soft_assert = soft_assert(to='{}@{}.com'.format('skelly', 'dimagi'), exponential_backoff=False)
         if new_doc.xmlns != existing_doc.xmlns:
             # if the XMLNS has changed this probably isn't a form edit
@@ -213,26 +227,25 @@ def _handle_duplicate(new_doc):
             )
             return xform, None
         else:
-            if existing_doc.is_error and not existing_doc.initial_processing_complete:
+            if existing_doc.is_error:
                 # edge case from ICDS where a form errors and then future re-submissions of the same
                 # form do not have the same MD5 hash due to a bug on mobile:
                 # see https://dimagi-dev.atlassian.net/browse/ICDS-376
-
-                # since we have a new form and the old one was not successfully processed
-                # we can effectively ignore this form and process the new one as normal
-                if not interface.use_sql_domain:
-                    new_doc._rev, existing_doc._rev = existing_doc._rev, new_doc._rev
-                interface.assign_new_id(existing_doc)
-                existing_doc.save()
-                return new_doc, None
+                if not existing_doc.initial_processing_complete:
+                    # since we have a new form and the old one was not successfully processed
+                    # we can effectively ignore this form and process the new one as normal
+                    return _replace_old_form()
+                elif interface.use_sql_domain and not interface.form_has_case_transactions(existing_doc.form_id):
+                    # likely an error during saving
+                    return _replace_old_form()
+                else:
+                    return _deprecate_old_form()
             else:
                 # if the form contents are not the same:
                 #  - "Deprecate" the old form by making a new document with the same contents
                 #    but a different ID and a doc_type of XFormDeprecated
                 #  - Save the new instance to the previous document to preserve the ID
-                NotAllowed.check(new_doc.domain)
-                existing_doc, new_doc = apply_deprecation(existing_doc, new_doc, interface)
-                return new_doc, existing_doc
+                return _deprecate_old_form()
     else:
         # follow standard dupe handling, which simply saves a copy of the form
         # but a new doc_id, and a doc_type of XFormDuplicate


### PR DESCRIPTION
##### SUMMARY
Yet another revision to this ICDS edge case where a form errors during processing and then is retried by the mobile.

Although the current code works it causes lots of case rebuilds which this PR should prevent by only doing the full deprecation workflow if there are saved case transactions for the form.

Replaces https://github.com/dimagi/commcare-hq/pull/26643