### PR TITLE
Reconcile location searches

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -272,13 +272,6 @@ class BaseFilterExportDownloadForm(forms.Form):
         return [n[1] for n in matches]
 
 
-location_query_help_text = ugettext_lazy(mark_safe(
-    '<i class="fa fa-info-circle"></i> To quick search for a '
-    '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations" '
-    'target="_blank">location</a>, write your query as "parent"/descendant.'
-))
-
-
 class DashboardFeedFilterForm(forms.Form):
     """
     A form used to configure the filters on a Dashboard Feed export
@@ -287,13 +280,13 @@ class DashboardFeedFilterForm(forms.Form):
         label=ugettext_lazy("Case Owner(s)"),
         required=False,
         widget=Select2Ajax(multiple=True),
-        help_text=location_query_help_text,
+        help_text=ExpandedMobileWorkerFilter.location_search_help,
     )
     emwf_form_filter = forms.Field(
         label=ugettext_lazy("User(s)"),
         required=False,
         widget=Select2Ajax(multiple=True),
-        help_text=location_query_help_text,
+        help_text=ExpandedMobileWorkerFilter.location_search_help,
     )
     date_range = forms.ChoiceField(
         label=ugettext_lazy("Date Range"),

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -45,16 +45,13 @@ from .signals import location_edited
 
 
 class LocationSelectWidget(forms.Widget):
-    def __init__(self, domain, attrs=None, id='supply-point', multiselect=False, query_url=None, placeholder=None):
+    def __init__(self, domain, attrs=None, id='supply-point', multiselect=False, placeholder=None):
         super(LocationSelectWidget, self).__init__(attrs)
         self.domain = domain
         self.id = id
         self.multiselect = multiselect
         self.placeholder = placeholder
-        if query_url:
-            self.query_url = query_url
-        else:
-            self.query_url = reverse('child_locations_for_select2', args=[self.domain])
+        self.query_url = reverse('location_search', args=[self.domain])
         self.template = 'locations/manage/partials/autocomplete_select_widget.html'
 
     def render(self, name, value, attrs=None, renderer=None):

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -372,13 +372,6 @@ class LocationForm(forms.Form):
         return location
 
 
-class LocationUserForm(NewMobileWorkerForm):
-    def clean_location_id(self):
-        # The user form class doesn't handle location. `LocationFormSet` adds
-        # the location to the user after.
-        return None
-
-
 class LocationFormSet(object):
     """Ties together the forms for location, location data, user, and user data."""
     _location_form_class = LocationForm

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -30,7 +30,7 @@ hqDefine("locations/js/widgets", [
                     delay: 500,
                     data: function (params) {
                         return {
-                            name: params.term,
+                            q: params.term,
                             page: params.page,
                         };
                     },

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -15,7 +15,7 @@ hqDefine("locations/js/widgets", [
         });
     }
 
-    function initAutocomplete($select, url) {
+    function initAutocomplete($select) {
         var options = $select.data();
         $select.select2({
             multiple: options.multiselect,

--- a/corehq/apps/locations/static/locations/js/widgets.js
+++ b/corehq/apps/locations/static/locations/js/widgets.js
@@ -15,49 +15,52 @@ hqDefine("locations/js/widgets", [
         });
     }
 
+    function initAutocomplete($select, url) {
+        var options = $select.data();
+        $select.select2({
+            multiple: options.multiselect,
+            allowClear: !options.multiselect,
+            placeholder: options.placeholder || gettext("Select a Location"),
+            width: '100%',
+            ajax: {
+                url: options.queryUrl,
+                dataType: 'json',
+                delay: 500,
+                data: function (params) {
+                    return {
+                        q: params.term,
+                        page: params.page,
+                    };
+                },
+                processResults: function (data, params) {
+                    var more = (params.page || 1) * 10 < data.total;
+                    return {
+                        results: data.results,
+                        pagination: { more: more },
+                    };
+                },
+            },
+            templateResult: function (result) { return result.text || result.name; },
+            templateSelection: function (result) { return result.text || result.name; },
+        });
+
+        var initial = options.initial;
+        if (initial) {
+            if (!_.isArray(initial)) {
+                initial = [initial];
+            }
+            _.each(initial, function (result) {
+                $select.append(new Option(result.text, result.id));
+            });
+            $select.val(_.pluck(initial, 'id')).trigger('change');
+        }
+
+        $select.trigger('select-ready');
+    }
+
     $(function () {
         $(".locations-widget-autocomplete").each(function () {
-            var $select = $(this),
-                options = $select.data();
-            $select.select2({
-                multiple: options.multiselect,
-                allowClear: !options.multiselect,
-                placeholder: options.placeholder || gettext("Select a Location"),
-                width: '100%',
-                ajax: {
-                    url: options.queryUrl,
-                    dataType: 'json',
-                    delay: 500,
-                    data: function (params) {
-                        return {
-                            q: params.term,
-                            page: params.page,
-                        };
-                    },
-                    processResults: function (data, params) {
-                        var more = (params.page || 1) * 10 < data.total;
-                        return {
-                            results: data.results,
-                            pagination: { more: more },
-                        };
-                    },
-                },
-                templateResult: function (result) { return result.text || result.name; },
-                templateSelection: function (result) { return result.text || result.name; },
-            });
-
-            var initial = options.initial;
-            if (initial) {
-                if (!_.isArray(initial)) {
-                    initial = [initial];
-                }
-                _.each(initial, function (result) {
-                    $select.append(new Option(result.text, result.id));
-                });
-                $select.val(_.pluck(initial, 'id')).trigger('change');
-            }
-
-            $select.trigger('select-ready');
+            initAutocomplete($(this));
         });
 
         $(".locations-widget-primary").each(function () {
@@ -100,4 +103,8 @@ hqDefine("locations/js/widgets", [
             });
         });
     });
+
+    return {
+        initAutocomplete: initAutocomplete,
+    };
 });

--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -115,13 +115,7 @@
         </button>
 
         <span class="help-block">
-          <i class="fa fa-info-circle"></i>
-          {% blocktrans %}
-            To quick search for a location, write your query as "parent"/descendant.
-            For more info, see the
-            <a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations" target="_blank">Location Search</a>
-            help page.
-          {% endblocktrans %}
+          {{ location_search_help }}
         </span>
 
       </div>

--- a/corehq/apps/locations/urls.py
+++ b/corehq/apps/locations/urls.py
@@ -13,7 +13,6 @@ from .views import (
     LocationTypesView,
     NewLocationView,
     archive_location,
-    child_locations_for_select2,
     default,
     delete_location,
     location_descendants_count,
@@ -27,7 +26,6 @@ from .views import (
 
 settings_urls = [
     url(r'^$', default, name='default_locations_view'),
-    url(r'^child_locations/$', child_locations_for_select2, name='child_locations_for_select2'),
     url(r'^list/$', LocationsListView.as_view(), name=LocationsListView.urlname),
     url(r'^location_search/$', LocationsSearchView.as_view(), name='location_search'),
     url(r'^location_types/$', LocationTypesView.as_view(), name=LocationTypesView.urlname),

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -244,7 +244,7 @@ class FilteredLocationDownload(BaseLocationView):
 
 
 class LocationOptionsController(EmwfOptionsController):
-    include_suffixes = False
+    display_types = False
 
     @property
     def data_sources(self):

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -39,6 +39,7 @@ from corehq.apps.locations.tasks import (
 from corehq.apps.products.models import Product, SQLProduct
 from corehq.apps.reports.filters.api import EmwfOptionsView
 from corehq.apps.reports.filters.controllers import EmwfOptionsController
+from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.users.forms import MultipleSelectionForm
 from corehq.util import reverse
 from corehq.util.files import file_extention_from_filename
@@ -204,6 +205,7 @@ class LocationsListView(BaseLocationView):
             'show_inactive': self.show_inactive,
             'has_location_types': has_location_types,
             'can_edit_root': self.can_access_all_locations,
+            'location_search_help': ExpandedMobileWorkerFilter.location_search_help,
         }
 
     def get_visible_locations(self):
@@ -255,7 +257,7 @@ class LocationsSearchView(EmwfOptionsView):
 
     @method_decorator(locations_access_required)
     def dispatch(self, request, *args, **kwargs):
-        return super(LocationFieldsView, self).dispatch(request, *args, **kwargs)
+        return super().dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -242,6 +242,7 @@ class FilteredLocationDownload(BaseLocationView):
 
 
 class LocationOptionsController(EmwfOptionsController):
+    include_suffixes = False
 
     @property
     def data_sources(self):

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -253,6 +253,10 @@ class LocationOptionsController(EmwfOptionsController):
 
 class LocationsSearchView(EmwfOptionsView):
 
+    @method_decorator(locations_access_required)
+    def dispatch(self, request, *args, **kwargs):
+        return super(LocationFieldsView, self).dispatch(request, *args, **kwargs)
+
     @property
     @memoized
     def options_controller(self):

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -1060,31 +1060,6 @@ class DownloadLocationStatusView(BaseLocationView):
         return reverse(self.urlname, args=self.args, kwargs=self.kwargs)
 
 
-@locations_access_required
-@location_safe
-def child_locations_for_select2(request, domain):
-    from django.core.paginator import Paginator
-    query = request.GET.get('name', '').lower()
-    page = int(request.GET.get('page', 1))
-    user = request.couch_user
-
-    def loc_to_payload(loc):
-        return {'id': loc.location_id, 'name': loc.get_path_display()}
-
-    locs = (SQLLocation.objects
-            .accessible_to_user(domain, user)
-            .filter(domain=domain, is_archived=False))
-    if query:
-        locs = locs.filter(name__icontains=query)
-
-    # 10 results per page
-    paginator = Paginator(locs, 10)
-    return json_response({
-        'results': list(map(loc_to_payload, paginator.page(page))),
-        'total': paginator.count,
-    })
-
-
 class DowngradeLocationsView(BaseDomainView):
     """
     This page takes the place of the location pages if a domain gets

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -253,11 +253,8 @@ class LocationOptionsController(EmwfOptionsController):
         ]
 
 
+@method_decorator(locations_access_required, name='dispatch')
 class LocationsSearchView(EmwfOptionsView):
-
-    @method_decorator(locations_access_required)
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
 
     @property
     @memoized

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -22,6 +22,7 @@ from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.utils import decode_password
 from corehq.apps.locations.forms import LocationSelectWidget
 from corehq.apps.programs.models import Program
+from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter as EMWF
 from corehq.apps.users.forms import RoleForm
 from corehq.apps.users.models import CouchUser
 
@@ -429,6 +430,7 @@ class AdminInvitesUserForm(RoleForm, _BaseForm, forms.Form):
         if domain_obj and domain_obj.commtrack_enabled:
             self.fields['supply_point'] = forms.CharField(label='Primary Location', required=False,
                                                           widget=LocationSelectWidget(domain_obj.name),
+                                                          help_text=EMWF.location_search_help,
                                                           initial=location.location_id if location else '')
             self.fields['program'] = forms.ChoiceField(label="Program", choices=(), required=False)
             programs = Program.by_domain(domain_obj.name)

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -37,7 +37,7 @@ def paginate_options(data_sources, query, start, size):
 
 
 class EmwfOptionsController(object):
-    include_suffixes = True
+    display_types = True
 
     def __init__(self, request, domain, search):
         self.request = request
@@ -47,7 +47,7 @@ class EmwfOptionsController(object):
     @property
     @memoized
     def utils(self):
-        return EmwfUtils(self.domain, include_suffixes=self.include_suffixes)
+        return EmwfUtils(self.domain, display_types=self.display_types)
 
     def get_all_static_options(self, query):
         return [user_type for user_type in self.utils.static_options

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -37,6 +37,7 @@ def paginate_options(data_sources, query, start, size):
 
 
 class EmwfOptionsController(object):
+    include_suffixes = True
 
     def __init__(self, request, domain, search):
         self.request = request
@@ -46,7 +47,7 @@ class EmwfOptionsController(object):
     @property
     @memoized
     def utils(self):
-        return EmwfUtils(self.domain)
+        return EmwfUtils(self.domain, include_suffixes=self.include_suffixes)
 
     def get_all_static_options(self, query):
         return [user_type for user_type in self.utils.static_options

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -207,21 +207,23 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         user_types = emwf.selected_user_types(mobile_user_and_group_slugs)
         group_ids = emwf.selected_group_ids(mobile_user_and_group_slugs)
     """
+    location_search_help = ugettext_lazy(mark_safe(
+        '<i class="fa fa-info-circle"></i> To quick search for a '
+        '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations" '
+        'target="_blank">location</a>, write your query as "parent"/descendant.'
+    ))
+
     slug = "emw"
     label = ugettext_lazy("User(s)")
     default_options = None
     placeholder = ugettext_lazy("Add users and groups to filter this report.")
     is_cacheable = False
     options_url = 'emwf_options_all_users'
-    filter_help_inline = ugettext_lazy(mark_safe(
-        'See <a href="https://confluence.dimagi.com/display/commcarepublic/Report+and+Export+Filters"'
-        ' target="_blank"> Filter Definitions</a>.'
-    ))
-    search_help_inline = ugettext_lazy(mark_safe(
-        'To quick search for a '
-        '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations" '
-        'target="_blank">location</a>, write your query as "parent"/descendant.'
-    ))
+    filter_help_inline = ugettext_lazy(mark_safe("""
+        <i class="fa fa-info-circle"></i> See
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Report+and+Export+Filters"'
+        ' target="_blank"> Filter Definitions</a>.
+    """))
 
     @property
     @memoized
@@ -327,7 +329,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         context.update({'endpoint': url})
         context.update({'filter_help_inline': self.filter_help_inline})
         if self.request.project.uses_locations:
-            context.update({'search_help_inline': self.search_help_inline})
+            context.update({'search_help_inline': self.location_search_help})
         return context
 
     @classmethod

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -115,8 +115,9 @@ class BaseGroupedMobileWorkerFilter(BaseSingleOptionFilter):
 
 
 class EmwfUtils(object):
-    def __init__(self, domain):
+    def __init__(self, domain, include_suffixes=True):
         self.domain = domain
+        self.include_suffixes = include_suffixes
 
     def user_tuple(self, u):
         user = util._report_user_dict(u)
@@ -141,8 +142,10 @@ class EmwfUtils(object):
         )
 
     def location_tuple(self, location):
-        return ("l__%s" % location.location_id,
-                '%s [location]' % location.get_path_display())
+        text = location.get_path_display()
+        if self.include_suffixes:
+            text = f'{text} [location]'
+        return ("l__%s" % location.location_id, text)
 
     @property
     @memoized

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -115,9 +115,9 @@ class BaseGroupedMobileWorkerFilter(BaseSingleOptionFilter):
 
 
 class EmwfUtils(object):
-    def __init__(self, domain, include_suffixes=True):
+    def __init__(self, domain, display_types=True):
         self.domain = domain
-        self.include_suffixes = include_suffixes
+        self.display_types = display_types
 
     def user_tuple(self, u):
         user = util._report_user_dict(u)
@@ -143,7 +143,7 @@ class EmwfUtils(object):
 
     def location_tuple(self, location):
         text = location.get_path_display()
-        if self.include_suffixes:
+        if self.display_types:
             text = f'{text} [location]'
         return ("l__%s" % location.location_id, text)
 

--- a/corehq/apps/reports/templates/reports/filters/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_option.html
@@ -19,8 +19,9 @@
   {% endif %}
   {% if filter_help_inline or search_help_inline %}
     <span class="help-block">
-      <i class="fa fa-info-circle"></i>
-      {{ filter_help_inline }} {{ search_help_inline }}
+      {{ filter_help_inline }}
+      {% if filter_help_inline and search_help_inline %}<br>{% endif %}
+      {{ search_help_inline }}
     </span>
   {% endif %}
 {% endblock %}

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -42,6 +42,7 @@ from corehq.apps.hqwebapp.widgets import (
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import user_can_access_location_id
 from corehq.apps.programs.models import Program
+from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.users.models import CouchUser, UserRole
 from corehq.apps.users.util import cc_user_domain, format_username
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
@@ -824,6 +825,7 @@ class CommtrackUserForm(forms.Form):
         self.fields['assigned_locations'].widget = LocationSelectWidget(
             self.domain, multiselect=True, id='id_assigned_locations'
         )
+        self.fields['assigned_locations'].help_text = ExpandedMobileWorkerFilter.location_search_help
         self.fields['primary_location'].widget = PrimaryLocationWidget(
             css_id='id_primary_location',
             source_css_id='id_assigned_locations',
@@ -1164,6 +1166,7 @@ class CommCareUserFilterForm(forms.Form):
         self.domain = kwargs.pop('domain')
         super(CommCareUserFilterForm, self).__init__(*args, **kwargs)
         self.fields['location_id'].widget = LocationSelectWidget(self.domain)
+        self.fields['location_id'].help_text = ExpandedMobileWorkerFilter.location_search_help
 
         roles = UserRole.by_domain(self.domain)
         self.fields['role_id'].choices = [('', _('All Roles'))] + [

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -554,6 +554,7 @@ class NewMobileWorkerForm(forms.Form):
             location_field = crispy.Field(
                 'location_id',
                 data_bind='value: location_id',
+                data_query_url=reverse('location_search', args=[self.domain]),
             )
         else:
             location_field = crispy.Hidden(

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1163,10 +1163,7 @@ class CommCareUserFilterForm(forms.Form):
         from corehq.apps.locations.forms import LocationSelectWidget
         self.domain = kwargs.pop('domain')
         super(CommCareUserFilterForm, self).__init__(*args, **kwargs)
-        self.fields['location_id'].widget = LocationSelectWidget(
-            self.domain,
-            query_url=reverse('location_search', args=[self.domain])
-        )
+        self.fields['location_id'].widget = LocationSelectWidget(self.domain)
 
         roles = UserRole.by_domain(self.domain)
         self.fields['role_id'].choices = [('', _('All Roles'))] + [

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1163,7 +1163,10 @@ class CommCareUserFilterForm(forms.Form):
         from corehq.apps.locations.forms import LocationSelectWidget
         self.domain = kwargs.pop('domain')
         super(CommCareUserFilterForm, self).__init__(*args, **kwargs)
-        self.fields['location_id'].widget = LocationSelectWidget(self.domain)
+        self.fields['location_id'].widget = LocationSelectWidget(
+            self.domain,
+            query_url=reverse('location_search', args=[self.domain])
+        )
 
         roles = UserRole.by_domain(self.domain)
         self.fields['role_id'].choices = [('', _('All Roles'))] + [

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -28,8 +28,8 @@ hqDefine("users/js/mobile_workers",[
     'nic_compliance/js/encoder',
     'jquery.rmi/jquery.rmi',
     'zxcvbn/dist/zxcvbn',
+    'locations/js/widgets',
     'hqwebapp/js/components.ko', // for pagination
-    'select2/dist/js/select2.full.min',
 ], function (
     $,
     ko,
@@ -39,7 +39,8 @@ hqDefine("users/js/mobile_workers",[
     googleAnalytics,
     nicEncoder,
     RMI,
-    zxcvbn
+    zxcvbn,
+    locationsWidgets
 ) {
     'use strict';
     // These are used as css classes, so the values of success/warning/error need to be what they are.
@@ -346,31 +347,7 @@ hqDefine("users/js/mobile_workers",[
             self.usernameAvailabilityStatus(null);
             self.usernameStatusMessage(null);
 
-            $("#id_location_id").select2({
-                minimumInputLength: 0,
-                width: '100%',
-                placeholder: gettext("Select location"),
-                allowClear: 1,
-                ajax: {
-                    delay: 100,
-                    url: options.location_url,
-                    data: function (params) {
-                        return {
-                            q: params.term,
-                            page: params.page,
-                        };
-                    },
-                    dataType: 'json',
-                    processResults: function (data, params) {
-                        params.page = params.page || 1;
-                        var more = data.more || (params.page * 10) < data.total;
-                        return {
-                            results: data.results,
-                            pagination: { more: more },
-                        };
-                    },
-                },
-            });
+            locationsWidgets.initAutocomplete($("#id_location_id"));
 
             googleAnalytics.track.event('Manage Mobile Workers', 'New Mobile Worker', '');
         };

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -447,7 +447,7 @@ hqDefine("users/js/mobile_workers",[
             custom_field_slugs: initialPageData.get('custom_field_slugs'),
             draconian_security: initialPageData.get('draconian_security'),
             implement_password_obfuscation: initialPageData.get('implement_password_obfuscation'),
-            location_url: initialPageData.reverse('child_locations_for_select2'),
+            location_url: initialPageData.reverse('location_search'),
             require_location_id: !initialPageData.get('can_access_all_locations'),
             strong_mobile_passwords: initialPageData.get('strong_mobile_passwords'),
         });

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -356,8 +356,7 @@ hqDefine("users/js/mobile_workers",[
                     url: options.location_url,
                     data: function (params) {
                         return {
-                            name: params.term,
-                            page_limit: 10,
+                            q: params.term,
                             page: params.page,
                         };
                     },
@@ -366,12 +365,7 @@ hqDefine("users/js/mobile_workers",[
                         params.page = params.page || 1;
                         var more = data.more || (params.page * 10) < data.total;
                         return {
-                            results: _.map(data.results, function (r) {
-                                return {
-                                    text: r.name,
-                                    id: r.id,
-                                };
-                            }),
+                            results: data.results,
                             pagination: { more: more },
                         };
                     },

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -13,7 +13,7 @@
   {% initial_page_data 'implement_password_obfuscation' implement_password_obfuscation %}
   {% initial_page_data 'pagination_limit_cookie_name' pagination_limit_cookie_name %}
   {% initial_page_data 'strong_mobile_passwords' strong_mobile_passwords %}
-  {% registerurl 'child_locations_for_select2' domain %}
+  {% registerurl 'location_search' domain %}
   {% registerurl 'mobile_workers' domain %}
   {% registerurl 'edit_commcare_user' domain '---' %}
   {% registerurl 'paginate_mobile_workers' domain %}

--- a/corehq/motech/repeaters/forms.py
+++ b/corehq/motech/repeaters/forms.py
@@ -19,6 +19,7 @@ from corehq.apps.reports.analytics.esaccessors import (
 from corehq.apps.users.util import raw_username
 from corehq.motech.repeaters.dbaccessors import get_repeaters_by_domain
 from corehq.motech.repeaters.repeater_generators import RegisterGenerator
+from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 
 from .models import BASIC_AUTH, DIGEST_AUTH
 
@@ -242,6 +243,7 @@ class OpenmrsRepeaterForm(CaseRepeaterForm):
     def __init__(self, *args, **kwargs):
         super(OpenmrsRepeaterForm, self).__init__(*args, **kwargs)
         self.fields['location_id'].widget = LocationSelectWidget(self.domain, id='id_location_id')
+        self.fields['location_id'].help_text = ExpandedMobileWorkerFilter.location_search_help
 
     def get_ordered_crispy_form_fields(self):
         fields = super(OpenmrsRepeaterForm, self).get_ordered_crispy_form_fields()


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1200

##### PRODUCT DESCRIPTION
We use two different algorithms that populate locations-related dropdowns. This PR updates them all to use the better of the two, which supports exact search as described [here](https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations).

The expanded Organization Structure page and the mobile worker filter (the search box in exports and elsewhere that lets you choose users or groups or locations) already used the good search. The following pages were using the other search and have been updated:

- Location assignment on edit mobile worker page
- Create new mobile worker
- Invite web user
- Filtered mobile worker download (feature flagged)
- Related locations (feature flagged)
- OpenMRS repeaters (feature flagged)