### PR TITLE
Use string encoding in dump/reload code

### DIFF
--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -71,9 +71,8 @@ class CouchDataDumper(DataDumper):
         for doc in iter_docs(couch_db, doc_ids, chunksize=500):
             count += 1
             doc = _get_doc_with_attachments(couch_db, doc)
-            json_dump = json.dumps(doc).encode('utf-8')
-            output_stream.write(json_dump)
-            output_stream.write(b'\n')
+            output_stream.write(json.dumps(doc))
+            output_stream.write('\n')
         self.stdout.write('Dumped {} {}\n'.format(count, model_label))
         return Counter({model_label: count})
 
@@ -94,9 +93,8 @@ class ToggleDumper(DataDumper):
         count = 0
         for toggle in self._get_toggles_to_migrate():
             count += 1
-            json_dump = json.dumps(toggle).encode('utf-8')
-            output_stream.write(json_dump)
-            output_stream.write(b'\n')
+            output_stream.write(json.dumps(toggle))
+            output_stream.write('\n')
 
         self.stdout.write('Dumped {} Toggles\n'.format(count))
         return Counter({'Toggle': count})

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
 
         for dumper in dumpers:
             filename = _get_dump_stream_filename(dumper.slug, domain_name, utcnow)
-            stream = self.stdout if console else gzip.open(filename, 'wb')
+            stream = self.stdout if console else gzip.open(filename, 'wt')
             try:
                 stats += dumper(domain_name, excludes).dump(stream)
             except Exception as e:

--- a/corehq/apps/dump_reload/sql/serialization.py
+++ b/corehq/apps/dump_reload/sql/serialization.py
@@ -21,7 +21,6 @@ class JsonLinesSerializer(JsonSerializer):
         json_kwargs = copy(self.json_kwargs)
         json_kwargs['cls'] = CommCareJSONEncoder
         json_dump = json.dumps(self.get_dump_object(obj), **json_kwargs)
-        json_dump = json_dump.encode('utf-8')
         self.stream.write(json_dump)
-        self.stream.write(b"\n")
+        self.stream.write("\n")
         self._current = None

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -3,7 +3,7 @@ import os
 import random
 import uuid
 from collections import Counter
-from io import BytesIO
+from io import StringIO
 
 from django.test import SimpleTestCase, TestCase
 
@@ -57,7 +57,7 @@ class CouchDumpLoadTest(TestCase):
             self.assertEqual(0, len(get_docs(db, doc_ids)))
 
     def _dump_and_load(self, expected_objects, not_expected_objects=None, doc_to_doc_class=None):
-        output_stream = BytesIO()
+        output_stream = StringIO()
         CouchDataDumper(self.domain_name, []).dump(output_stream)
 
         self._delete_couch_data()
@@ -66,8 +66,8 @@ class CouchDumpLoadTest(TestCase):
         objects_remaining = _get_doc_counts_from_db(self.domain_name)
         self.assertEqual({}, objects_remaining, 'Not all data deleted: {}'.format(objects_remaining))
 
-        dump_output = output_stream.getvalue()
-        dump_lines = [line.strip() for line in dump_output.split(b'\n') if line.strip()]
+        dump_output = output_stream.getvalue().split('\n')
+        dump_lines = [line.strip() for line in dump_output if line.strip()]
 
         with mock_out_couch() as fake_db:
             total_object_count, loaded_object_count = CouchDataLoader().load_objects(dump_lines)
@@ -183,7 +183,7 @@ class TestDumpLoadToggles(SimpleTestCase):
         dumper = ToggleDumper(self.domain_name, [])
         dumper._user_ids_in_domain = Mock(return_value={'user1', 'user2', 'user3'})
 
-        output_stream = BytesIO()
+        output_stream = StringIO()
 
         with mock_out_couch(docs=[doc.to_json() for doc in self.mocked_toggles.values()]):
             dumper.dump(output_stream)

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -3,7 +3,7 @@ import json
 import uuid
 from collections import Counter
 from datetime import datetime
-from io import BytesIO
+from io import StringIO
 
 from django.contrib.admin.utils import NestedObjects
 from django.core import serializers
@@ -82,7 +82,7 @@ class BaseDumpLoadTest(TestCase):
         models = list(expected_object_counts)
         self._check_signals_handle_raw(models)
 
-        output_stream = BytesIO()
+        output_stream = StringIO()
         SqlDataDumper(self.domain_name, []).dump(output_stream)
 
         self.delete_sql_data()
@@ -93,8 +93,8 @@ class BaseDumpLoadTest(TestCase):
         counts = Counter(object_classes)
         self.assertEqual([], objects_remaining, 'Not all data deleted: {}'.format(counts))
 
-        dump_output = output_stream.getvalue()
-        dump_lines = [line.strip() for line in dump_output.split(b'\n') if line.strip()]
+        dump_output = output_stream.getvalue().split('\n')
+        dump_lines = [line.strip() for line in dump_output if line.strip()]
         total_object_count, loaded_model_counts = SqlDataLoader().load_objects(dump_lines)
 
         expected_model_counts = _normalize_object_counter(expected_object_counts)


### PR DESCRIPTION

##### SUMMARY
The management command `dump_domain_data` currently fails because some stuff doesn't coerce to bytecode before writing to the gzip stream.  This PR switches everything to use text-encoded streams, since it plays nicer with builtins.

@millerdev pinging you since you probably have strong opinions on this.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
