### PR TITLE
Take the launched numbers from the agg_Awc table only for the current date

### DIFF
--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -545,13 +545,13 @@ def _run_custom_sql_script(commands, day=None, db_alias=None):
 @track_time
 def aggregate_awc_daily(day):
 
-    agg_daily_dates = [force_to_date(day) - timedelta(days=2),
-                       force_to_date(day) - timedelta(days=1),
-                       force_to_date(day)]
+    agg_daily_dates = [(force_to_date(day) - timedelta(days=2), False),
+                       (force_to_date(day) - timedelta(days=1), False),
+                       (force_to_date(day), True)]
 
     for daily_date in agg_daily_dates:
         with transaction.atomic(using=router.db_for_write(AggAwcDaily)):
-            AggAwcDaily.aggregate(daily_date)
+            AggAwcDaily.aggregate(*daily_date)
 
 
 @track_time

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -545,13 +545,17 @@ def _run_custom_sql_script(commands, day=None, db_alias=None):
 @track_time
 def aggregate_awc_daily(day):
 
-    agg_daily_dates = [(force_to_date(day) - timedelta(days=2), False),
-                       (force_to_date(day) - timedelta(days=1), False),
-                       (force_to_date(day), True)]
+    agg_daily_dates = [{
+        'date': force_to_date(day) - timedelta(days=2),
+        'use_agg_awc': False},
+        {'date': force_to_date(day) - timedelta(days=1),
+        'use_agg_awc': False},
+        {'date': force_to_date(day),
+         'use_agg_awc': True}]
 
     for daily_date in agg_daily_dates:
         with transaction.atomic(using=router.db_for_write(AggAwcDaily)):
-            AggAwcDaily.aggregate(*daily_date)
+            AggAwcDaily.aggregate(**daily_date)
 
 
 @track_time

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -555,7 +555,7 @@ def aggregate_awc_daily(day):
 
     for daily_date in agg_daily_dates:
         with transaction.atomic(using=router.db_for_write(AggAwcDaily)):
-            AggAwcDaily.aggregate(daily_date['date'], daily_date['use_agg_awc'])
+            AggAwcDaily.aggregate(date=daily_date['date'], use_agg_awc=daily_date['use_agg_awc'])
 
 
 @track_time

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -555,7 +555,7 @@ def aggregate_awc_daily(day):
 
     for daily_date in agg_daily_dates:
         with transaction.atomic(using=router.db_for_write(AggAwcDaily)):
-            AggAwcDaily.aggregate(**daily_date)
+            AggAwcDaily.aggregate(daily_date['date'], daily_date['use_agg_awc'])
 
 
 @track_time

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
@@ -59,6 +59,12 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
 
     def aggregation_query(self):
 
+        def use_agg_awc_data_or_zero(col_name):
+            if self.use_agg_awc:
+                return (col_name,)
+            else:
+                return (col_name, '0')
+
         columns = (
             ('state_id',),
             ('district_id',),
@@ -67,7 +73,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
             ('awc_id',),
             ('aggregation_level',),
             ('date', '%(date)s'),
-            ('cases_household',) if self.use_agg_awc else ('cases_household', '0'),
+            use_agg_awc_data_or_zero('cases_household'),
             ('cases_person',),
             ('cases_person_all',),
             ('cases_person_has_aadhaar',),
@@ -84,11 +90,11 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
             ('cases_person_adolescent_girls_15_18_all',),
             ('daily_attendance_open', '0'),
             ('num_awcs',),
-            ('num_launched_states', ) if self.use_agg_awc else ('num_launched_states', '0'),
-            ('num_launched_districts',) if self.use_agg_awc else ('num_launched_districts', '0'),
-            ('num_launched_blocks',) if self.use_agg_awc else ('num_launched_blocks', '0'),
-            ('num_launched_supervisors',) if self.use_agg_awc else ('num_launched_supervisors', '0'),
-            ('num_launched_awcs',) if self.use_agg_awc else ('num_launched_awcs', '0'),
+            use_agg_awc_data_or_zero('num_launched_states'),
+            use_agg_awc_data_or_zero('num_launched_districts'),
+            use_agg_awc_data_or_zero('num_launched_blocks'),
+            use_agg_awc_data_or_zero('num_launched_supervisors'),
+            use_agg_awc_data_or_zero('num_launched_awcs'),
             ('cases_person_has_aadhaar_v2',),
             ('cases_person_beneficiary_v2',),
             ('state_is_test', "state_is_test"),
@@ -144,7 +150,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
                 sum(open_count) AS cases_household,
                 count(*) AS all_cases_household
             FROM "{household_cases}"
-            WHERE opened_on< %(end_date)s
+            WHERE opened_on < %(end_date)s
             GROUP BY owner_id, supervisor_id;
         UPDATE "{tablename}" agg_awc SET
            cases_household = ut.cases_household,

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
@@ -1,19 +1,22 @@
+from datetime import timedelta
 from custom.icds_reports.utils.aggregation_helpers import transform_day_to_month
 from custom.icds_reports.utils.aggregation_helpers.distributed.base import BaseICDSAggregationDistributedHelper
 from corehq.apps.userreports.util import get_table_name
+
 
 class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelper):
     helper_key = 'agg-awc-daily'
     aggregate_parent_table = 'agg_awc_daily'
 
-    def __init__(self, date):
+    def __init__(self, date, use_agg_awc=False):
         self.date = date
         self.month = transform_day_to_month(date)
+        self.use_agg_awc = use_agg_awc
 
     def aggregate(self, cursor):
         agg_query, agg_params = self.aggregation_query()
         update_query, update_params = self.update_query()
-        update_launched_query, update_launched_params = self.update_launched_query()
+
         rollup_queries = [self.rollup_query(i) for i in range(4, 0, -1)]
         index_queries = self.indexes()
 
@@ -21,7 +24,10 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
         cursor.execute(*self.create_table_query())
         cursor.execute(agg_query, agg_params)
         cursor.execute(update_query, update_params)
-        cursor.execute(update_launched_query, update_launched_params)
+
+        if not self.use_agg_awc:
+            update_launched_query, update_launched_params = self.update_launched_query()
+            cursor.execute(update_launched_query, update_launched_params)
         for query in rollup_queries:
             cursor.execute(query)
         for query in index_queries:
@@ -61,7 +67,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
             ('awc_id',),
             ('aggregation_level',),
             ('date', '%(date)s'),
-            ('cases_household',),
+            ('cases_household',) if self.use_agg_awc else ('cases_household', '0'),
             ('cases_person',),
             ('cases_person_all',),
             ('cases_person_has_aadhaar',),
@@ -78,11 +84,11 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
             ('cases_person_adolescent_girls_15_18_all',),
             ('daily_attendance_open', '0'),
             ('num_awcs',),
-            ('num_launched_states', '0'),
-            ('num_launched_districts', '0'),
-            ('num_launched_blocks', '0'),
-            ('num_launched_supervisors', '0'),
-            ('num_launched_awcs', '0'),
+            ('num_launched_states', ) if self.use_agg_awc else ('num_launched_states', '0'),
+            ('num_launched_districts',) if self.use_agg_awc else ('num_launched_districts', '0'),
+            ('num_launched_blocks',) if self.use_agg_awc else ('num_launched_blocks', '0'),
+            ('num_launched_supervisors',) if self.use_agg_awc else ('num_launched_supervisors', '0'),
+            ('num_launched_awcs',) if self.use_agg_awc else ('num_launched_awcs', '0'),
             ('cases_person_has_aadhaar_v2',),
             ('cases_person_beneficiary_v2',),
             ('state_is_test', "state_is_test"),
@@ -138,7 +144,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
                 sum(open_count) AS cases_household,
                 count(*) AS all_cases_household
             FROM "{household_cases}"
-            WHERE opened_on<= %(end_date)s
+            WHERE opened_on< %(end_date)s
             GROUP BY owner_id, supervisor_id;
         UPDATE "{tablename}" agg_awc SET
            cases_household = ut.cases_household,
@@ -154,7 +160,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
         """.format(
             tablename=self.tablename, temp_table="temp_launched_{}".format(self.tablename),
             household_cases=get_table_name(self.domain, 'static-household_cases'),
-        ), {'end_date': self.date}
+        ), {'end_date': self.date + timedelta(days=1)}
 
     def rollup_query(self, aggregation_level):
         launched_cols = [

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc_daily.py
@@ -61,9 +61,9 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
 
         def use_agg_awc_data_or_zero(col_name):
             if self.use_agg_awc:
-                return (col_name,)
+                return col_name
             else:
-                return (col_name, '0')
+                return '0'
 
         columns = (
             ('state_id',),
@@ -73,7 +73,7 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
             ('awc_id',),
             ('aggregation_level',),
             ('date', '%(date)s'),
-            use_agg_awc_data_or_zero('cases_household'),
+            ('cases_household', use_agg_awc_data_or_zero('cases_household')),
             ('cases_person',),
             ('cases_person_all',),
             ('cases_person_has_aadhaar',),
@@ -90,11 +90,11 @@ class AggAwcDailyAggregationDistributedHelper(BaseICDSAggregationDistributedHelp
             ('cases_person_adolescent_girls_15_18_all',),
             ('daily_attendance_open', '0'),
             ('num_awcs',),
-            use_agg_awc_data_or_zero('num_launched_states'),
-            use_agg_awc_data_or_zero('num_launched_districts'),
-            use_agg_awc_data_or_zero('num_launched_blocks'),
-            use_agg_awc_data_or_zero('num_launched_supervisors'),
-            use_agg_awc_data_or_zero('num_launched_awcs'),
+            ('num_launched_states', use_agg_awc_data_or_zero('num_launched_states')),
+            ('num_launched_districts', use_agg_awc_data_or_zero('num_launched_districts')),
+            ('num_launched_blocks', use_agg_awc_data_or_zero('num_launched_blocks')),
+            ('num_launched_supervisors', use_agg_awc_data_or_zero('num_launched_supervisors')),
+            ('num_launched_awcs', use_agg_awc_data_or_zero('num_launched_awcs')),
             ('cases_person_has_aadhaar_v2',),
             ('cases_person_beneficiary_v2',),
             ('state_is_test', "state_is_test"),

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc-daily.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc-daily.distributed.txt
@@ -11,7 +11,7 @@ DROP TABLE IF EXISTS "agg_awc_daily_2019-01-01"
         INSERT INTO "agg_awc_daily_2019-01-01" (
             state_id, district_id, block_id, supervisor_id, awc_id, aggregation_level, date, cases_household, cases_person, cases_person_all, cases_person_has_aadhaar, cases_person_beneficiary, cases_child_health, cases_child_health_all, cases_ccs_pregnant, cases_ccs_pregnant_all, cases_ccs_lactating, cases_ccs_lactating_all, cases_person_adolescent_girls_11_14, cases_person_adolescent_girls_15_18, cases_person_adolescent_girls_11_14_all, cases_person_adolescent_girls_15_18_all, daily_attendance_open, num_awcs, num_launched_states, num_launched_districts, num_launched_blocks, num_launched_supervisors, num_launched_awcs, cases_person_has_aadhaar_v2, cases_person_beneficiary_v2, state_is_test, district_is_test, block_is_test, supervisor_is_test, awc_is_test
         ) (SELECT
-            state_id, district_id, block_id, supervisor_id, awc_id, aggregation_level, %(date)s, cases_household, cases_person, cases_person_all, cases_person_has_aadhaar, cases_person_beneficiary, cases_child_health, cases_child_health_all, cases_ccs_pregnant, cases_ccs_pregnant_all, cases_ccs_lactating, cases_ccs_lactating_all, cases_person_adolescent_girls_11_14, cases_person_adolescent_girls_15_18, cases_person_adolescent_girls_11_14_all, cases_person_adolescent_girls_15_18_all, 0, num_awcs, 0, 0, 0, 0, 0, cases_person_has_aadhaar_v2, cases_person_beneficiary_v2, state_is_test, district_is_test, block_is_test, supervisor_is_test, awc_is_test
+            state_id, district_id, block_id, supervisor_id, awc_id, aggregation_level, %(date)s, cases_household, cases_person, cases_person_all, cases_person_has_aadhaar, cases_person_beneficiary, cases_child_health, cases_child_health_all, cases_ccs_pregnant, cases_ccs_pregnant_all, cases_ccs_lactating, cases_ccs_lactating_all, cases_person_adolescent_girls_11_14, cases_person_adolescent_girls_15_18, cases_person_adolescent_girls_11_14_all, cases_person_adolescent_girls_15_18_all, 0, num_awcs, num_launched_states, num_launched_districts, num_launched_blocks, num_launched_supervisors, num_launched_awcs, cases_person_has_aadhaar_v2, cases_person_beneficiary_v2, state_is_test, district_is_test, block_is_test, supervisor_is_test, awc_is_test
             FROM agg_awc
             WHERE aggregation_level = 5 and month = %(start_date)s
         )
@@ -35,29 +35,6 @@ DROP TABLE IF EXISTS "agg_awc_daily_2019-01-01"
         WHERE ut.pse_date = agg_awc.date AND ut.awc_id = agg_awc.awc_id
         
 {"date": "2019-01-01T00:00:00"}
-
-        CREATE TEMPORARY TABLE "temp_launched_agg_awc_daily_2019-01-01" AS
-            SELECT
-                owner_id,
-                supervisor_id,
-                sum(open_count) AS cases_household,
-                count(*) AS all_cases_household
-            FROM "ucr_icds-cas_static-household_cases_eadc276d"
-            WHERE opened_on<= %(end_date)s
-            GROUP BY owner_id, supervisor_id;
-        UPDATE "agg_awc_daily_2019-01-01" agg_awc SET
-           cases_household = ut.cases_household,
-           num_launched_states = CASE WHEN ut.all_cases_household>0 THEN 1 ELSE 0 END,
-           num_launched_districts = CASE WHEN ut.all_cases_household>0 THEN 1 ELSE 0 END,
-           num_launched_blocks = CASE WHEN ut.all_cases_household>0 THEN 1 ELSE 0 END,
-           num_launched_supervisors = CASE WHEN ut.all_cases_household>0 THEN 1 ELSE 0 END,
-           num_launched_awcs = CASE WHEN ut.all_cases_household>0 THEN 1 ELSE 0 END
-        FROM (
-            SELECT * FROM "temp_launched_agg_awc_daily_2019-01-01"
-        ) ut
-        WHERE ut.owner_id = agg_awc.awc_id and ut.supervisor_id=agg_awc.supervisor_id and aggregation_level=5;
-        
-{"end_date": "2019-01-01T00:00:00"}
 
         INSERT INTO "agg_awc_daily_2019-01-01" (
             state_id, district_id, block_id, supervisor_id, awc_id, aggregation_level, date, cases_household, cases_person, cases_person_all, cases_person_has_aadhaar, cases_person_beneficiary, cases_child_health, cases_child_health_all, cases_ccs_pregnant, cases_ccs_pregnant_all, cases_ccs_lactating, cases_ccs_lactating_all, cases_person_adolescent_girls_11_14, cases_person_adolescent_girls_15_18, cases_person_adolescent_girls_11_14_all, cases_person_adolescent_girls_15_18_all, daily_attendance_open, total_attended_pse, num_awcs, num_launched_states, num_launched_districts, num_launched_blocks, num_launched_supervisors, num_launched_awcs, cases_person_has_aadhaar_v2, cases_person_beneficiary_v2, state_is_test, district_is_test, block_is_test, supervisor_is_test, awc_is_test

--- a/custom/icds_reports/utils/aggregation_helpers/tests/tests.py
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/tests.py
@@ -94,6 +94,7 @@ ARGS = {
     'state_id': 'st1',
     'state_ids': ['st1', 'st2'],
     'last_sync': datetime(2019, 1, 5),
+    'use_agg_awc': True
 }
 
 


### PR DESCRIPTION
This is the fix of the P1 which is about mismatching numbers of launched awcs between program summary page and daily status page.
This is because these two pages are taking data from two different sources.
Program summary takes from agg_awc
daily status page takes from agg_awc_daily.

NOTE: Ideally for the latest date agg_awc and agg_awc_daily numbers should be the same.

Initially, agg_awc_daily used to take its launched numbers from agg_awc table only. But with [this](https://github.com/dimagi/commcare-hq/pull/26314/files) it was changed to take from the UCR directly to [fix same launched coming](https://dimagi-dev.atlassian.net/browse/ICDS-1080) up for the last 3 days(because we build agg_awc_daily for last three days).

Now, the difference is arising because of two reasons:
1) there is some time difference between when agg_awc and agg_awc_daily aggregates which may allow more forms to reach to the UCR.
2) Another reason is a [code bug](https://github.com/dimagi/commcare-hq/pull/26314/files#diff-5118b1feecf883c595d34e69c40ef9edR141). when aggregating for date `2020-02-12`, it was not considering the case opened on `2020-02-12 HH:MM:SS` because the filter was opened_on<=`2020-02-12`


Fix: For the Current date(i.e when the aggregation is running), we take the data from agg_awc only which was originally happening before [this](https://github.com/dimagi/commcare-hq/pull/26314). And for past two days we take from the UCR directly to make the number correct and resolve the problem being addressed in above-linked Pr.

This will also make aggregation slightly faster.
