### PR TITLE
Add Feature Flag for Using De-Identification in OData Feeds

### DIFF
--- a/corehq/apps/export/templates/export/customize_export_new.html
+++ b/corehq/apps/export/templates/export/customize_export_new.html
@@ -239,7 +239,7 @@
         </fieldset>
       {% endif %}
 
-      {% if allow_deid and not export_instance.is_odata_config %}
+      {% if allow_deid %}
         <fieldset>
           <legend>
             {% trans "Privacy Settings" %}

--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -114,10 +114,15 @@ class BaseExportView(BaseProjectDataView):
             sharing_options = SharingOption.CHOICES
         else:
             sharing_options = [SharingOption.EDIT_AND_EXPORT]
+
+        allow_deid = has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
+        if self.export_instance.is_odata_config:
+            allow_deid = allow_deid and toggles.ALLOW_DEID_ODATA_FEED.enabled(self.domain)
+
         return {
             'export_instance': self.export_instance,
             'export_home_url': self.export_home_url,
-            'allow_deid': has_privilege(self.request, privileges.DEIDENTIFIED_DATA),
+            'allow_deid': allow_deid,
             'has_excel_dashboard_access': domain_has_privilege(self.domain, EXCEL_DASHBOARD),
             'has_daily_saved_export_access': domain_has_privilege(self.domain, DAILY_SAVED_EXPORT),
             'can_edit': self.export_instance.can_edit(self.request.couch_user),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1818,3 +1818,11 @@ RUN_DATA_MANAGEMENT_TASKS = StaticToggle(
     TAG_CUSTOM,
     [NAMESPACE_USER]
 )
+
+
+ALLOW_DEID_ODATA_FEED = StaticToggle(
+    'allow_deid_odata_feed',
+    'Allow De-Identification in OData feeds',
+    TAG_PRODUCT,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10269

##### SUMMARY
This adds the feature flag for De-Id in OData feeds and enables it in the UI. I tested the feeds locally and it looks like De-ID is working right out of the box just by doing this. Unfortunately, I'm not able to pull the local feed up in my Tableau Desktop app because it looks like our license expired. I will get this up on prod so Ben can take a look in PowerBI when he has some time.

I'm looking into the linked permissions ticket in a different PR, and then we should be able to start QA.

##### FEATURE FLAG
`ALLOW_DEID_ODATA_FEED` = "Allow De-Identification in OData feeds"