### PR TITLE
Updated blank/None logic in default consumption migration

### DIFF
--- a/corehq/apps/consumption/management/commands/populate_defaultconsumption.py
+++ b/corehq/apps/consumption/management/commands/populate_defaultconsumption.py
@@ -21,6 +21,6 @@ class Command(PopulateSQLCommand):
                 "supply_point_type": doc.get("supply_point_type"),
                 "supply_point_id": doc.get("supply_point_id"),
                 "default_consumption": round(float(doc["default_consumption"]), 8)
-                                       if "default_consumption" in doc else None,
+                                       if doc.get("default_consumption", None) else None,
             })
         return (model, created)


### PR DESCRIPTION
Sometimes `default_consumption` **is** in doc...but it's still None.