### PR TITLE
ICDS Dashboard: remove openstreetmap option from dashboard

### DIFF
--- a/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
+++ b/custom/icds_reports/static/js/directives/awc-reports/awc-reports.directive.js
@@ -2652,11 +2652,6 @@ function AwcReportsController($scope, $http, $location, $routeParams, $log, DTOp
                     apikey: mapboxAccessToken,
                 },
             },
-            osm: {
-                name: 'OpenStreetMap',
-                url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                type: 'xyz',
-            },
         },
     };
 


### PR DESCRIPTION
signed off by Saket / product team. In addition to the fact that most of our team didn't know this option existed, it's also a likely violation of OpenStreetMap's terms