### PR TITLE
Superuser two factor auth: prefactor

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2586,7 +2586,7 @@ class CreateAdminForm(forms.Form):
                 "User '%s' does not exist" % username
             )
         web_user = WebUser.get_by_username(username)
-        if not web_user or not web_user.is_superuser:
+        if not web_user or not web_user.is_superuser:  # is_superuser intentional
             raise CreateAccountingAdminError(
                 "The user '%s' is not a superuser." % username,
             )

--- a/corehq/apps/accounting/mixins.py
+++ b/corehq/apps/accounting/mixins.py
@@ -60,7 +60,7 @@ class BillingModalsMixin(object):
     def _should_display_billing_modals(self):
         return (
             self.request.couch_user
-            and not self.request.couch_user.is_superuser
+            and not self.request.couch_user.invoke_superuser()
             and self.request.couch_user.has_permission(
                 self.domain,
                 get_permission_name(Permissions.edit_billing)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1895,7 +1895,7 @@ class Subscription(models.Model):
             return False
 
     def user_can_change_subscription(self, user):
-        if user.is_superuser:
+        if user.invoke_superuser():
             return True
         elif self.account.is_customer_billing_account:
             return self.account.has_enterprise_admin(user.email)

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -1339,7 +1339,7 @@ class EnterpriseBillingStatementsView(DomainAccountingSettings, CRUDPaginatedVie
 
     @property
     def show_hidden(self):
-        if not self.request.user.is_superuser:
+        if not self.request.user.invoke_superuser():
             return False
         return bool(self.request.POST.get('additionalData[show_hidden]'))
 

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -104,7 +104,7 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
                 json.dumps({"error": msg}),
                 content_type="application/json",
                 status=401))
-        if request.user.is_superuser or domain_has_privilege(request.domain, privileges.API_ACCESS):
+        if request.user.invoke_superuser() or domain_has_privilege(request.domain, privileges.API_ACCESS):
             if isinstance(self, DomainSpecificResourceMixin):
                 track_workflow(request.user.username, "API Request", properties={
                     'domain': request.domain,

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -138,7 +138,7 @@ class AdminAuthentication(LoginAndDomainAuthentication):
     @staticmethod
     def _permission_check(couch_user, domain):
         return (
-            couch_user.is_superuser or
+            couch_user.invoke_superuser() or
             IS_CONTRACTOR.enabled(couch_user.username)
         )
 

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 
 from couchdbkit.exceptions import ResourceConflict
 
+from corehq.apps.users.middleware import SuperuserMiddleware
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 from corehq import toggles
@@ -97,6 +98,7 @@ def safe_cached_download(f):
         # make endpoints that call the user fail hard
         from django.contrib.auth.models import AnonymousUser
         request.user = AnonymousUser()
+        SuperuserMiddleware.reinit_request(request)
         username = request.GET.get('username')
         if request.GET.get('username'):
             request.GET = request.GET.copy()

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -11,7 +11,6 @@ from django.views.decorators.http import require_POST
 
 from couchdbkit.exceptions import ResourceConflict
 
-from corehq.apps.users.middleware import SuperuserMiddleware
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 from corehq import toggles
@@ -98,7 +97,6 @@ def safe_cached_download(f):
         # make endpoints that call the user fail hard
         from django.contrib.auth.models import AnonymousUser
         request.user = AnonymousUser()
-        SuperuserMiddleware.reinit_request(request)
         username = request.GET.get('username')
         if request.GET.get('username'):
             request.GET = request.GET.copy()

--- a/corehq/apps/app_manager/templates/app_manager/app_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view_settings.html
@@ -34,7 +34,7 @@
   {% initial_page_data 'app_view_options' app_view_options %}
   {% initial_page_data 'domain_names' domain_names %}
   {% initial_page_data 'is_remote_app' app.is_remote_app %}
-  {% initial_page_data 'is_superuser' request.user.is_superuser %}
+  {% initial_page_data 'is_superuser' request.user.invoke_superuser %}
   {% initial_page_data 'langs' app.langs %}
   {% initial_page_data 'linked_whitelist' app.linked_whitelist %}
   {% initial_page_data 'media_refs' refs %}

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -344,7 +344,7 @@ def get_commcare_versions(request_user):
 
 
 def get_commcare_builds(request_user):
-    can_view_superuser_builds = (request_user.is_superuser
+    can_view_superuser_builds = (request_user.invoke_superuser()
                                  or toggles.IS_CONTRACTOR.enabled(request_user.username))
     return [
         i.build

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -222,7 +222,7 @@ def get_app_view_context(request, app):
 
     build_config = CommCareBuildConfig.fetch()
     options = build_config.get_menu()
-    if not request.user.is_superuser and not toggles.IS_CONTRACTOR.enabled(request.user.username):
+    if not request.user.invoke_superuser() and not toggles.IS_CONTRACTOR.enabled(request.user.username):
         options = [option for option in options if not option.superuser_only]
     options_map = defaultdict(lambda: {"values": [], "value_names": []})
     for option in options:
@@ -328,7 +328,7 @@ def _get_upstream_url(app, request_user, master_app_id=None):
     """Get the upstream url if the user has access"""
     if (
             app.domain_link and (
-                request_user.is_superuser or (
+                request_user.invoke_superuser() or (
                     not app.domain_link.is_remote
                     and request_user.is_member_of(app.domain_link.master_domain)
                 )

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -162,7 +162,7 @@ def _get_form_designer_view(request, domain, app, module, form):
     })
     context.update(_get_requirejs_context())
 
-    if request.user.is_superuser:
+    if request.user.invoke_superuser():
         context.update({'notification_options': _get_notification_options(request, domain, app, form)})
 
     notify_form_opened(domain, request.couch_user, app.id, form.unique_id)

--- a/corehq/apps/case_search/views.py
+++ b/corehq/apps/case_search/views.py
@@ -2,6 +2,7 @@ import json
 import re
 
 from django.http import Http404
+from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
 from dimagi.utils.web import json_response
@@ -11,7 +12,7 @@ from corehq.apps.case_search.models import (
     case_search_enabled_for_domain,
     merge_queries,
 )
-from corehq.apps.domain.decorators import cls_require_superuser_or_contractor
+from corehq.apps.domain.decorators import require_superuser_or_contractor
 from corehq.apps.domain.views.base import DomainViewMixin
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_MAX_RESULTS
 from corehq.util.view_utils import BadRequest, json_error
@@ -21,7 +22,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
     template_name = 'case_search/case_search.html'
     urlname = 'case_search'
 
-    @cls_require_superuser_or_contractor
+    @method_decorator(require_superuser_or_contractor)
     def get(self, request, *args, **kwargs):
         if not case_search_enabled_for_domain(self.domain):
             raise Http404("Domain does not have case search enabled")
@@ -37,7 +38,7 @@ class CaseSearchView(DomainViewMixin, TemplateView):
         return context
 
     @json_error
-    @cls_require_superuser_or_contractor
+    @method_decorator(require_superuser_or_contractor)
     def post(self, request, *args, **kwargs):
         from corehq.apps.es.case_search import CaseSearchES
         if not case_search_enabled_for_domain(self.domain):

--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -35,7 +35,7 @@
                   {{ section_display }}
                   for <em>{{ product_name }}</em>
                 {% endblocktrans %}
-                {% if request.user.is_superuser and request|toggle_enabled:'SUPPORT' %}
+                {% if request.user.invoke_superuser and request|toggle_enabled:'SUPPORT' %}
                   <form method="post" action="" class="pull-right">
                     {% csrf_token %}
                     <input type="hidden" name="case_id" value="{{ key.case_id }}">

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -765,7 +765,7 @@ class AddCaseRuleView(DataInterfaceSection):
     @property
     @memoized
     def is_system_admin(self):
-        return self.request.couch_user.is_superuser
+        return self.request.couch_user.invoke_superuser()
 
     @property
     @memoized

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -9,6 +9,7 @@ from django.views.decorators.debug import sensitive_variables
 
 from tastypie.authentication import ApiKeyAuthentication
 
+from corehq.apps.users.middleware import SuperuserMiddleware
 from dimagi.utils.django.request import mutable_querydict
 
 from corehq.apps.receiverwrapper.util import DEMO_SUBMIT_MODE
@@ -135,6 +136,7 @@ def basicauth(realm=''):
                 user = authenticate(username=uname, password=passwd)
                 if user is not None and user.is_active:
                     request.user = user
+                    SuperuserMiddleware.reinit_request(request)
                     return view(request, *args, **kwargs)
 
             # Either they did not provide an authorization header or
@@ -156,6 +158,7 @@ def basic_or_api_key(realm=''):
                 user = authenticate(username=username, password=password, request=request)
                 if user is not None and user.is_active:
                     request.user = user
+                    SuperuserMiddleware.reinit_request(request)
                     return view(request, *args, **kwargs)
             response = HttpResponse(status=401)
             response['WWW-Authenticate'] = 'Basic realm="%s"' % realm
@@ -190,6 +193,7 @@ def formplayer_as_user_auth(view):
 
         request.user = couch_user.get_django_user()
         request.couch_user = couch_user
+        SuperuserMiddleware.reinit_request(request)
 
         return view(request, *args, **kwargs)
 

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -9,7 +9,6 @@ from django.views.decorators.debug import sensitive_variables
 
 from tastypie.authentication import ApiKeyAuthentication
 
-from corehq.apps.users.middleware import SuperuserMiddleware
 from dimagi.utils.django.request import mutable_querydict
 
 from corehq.apps.receiverwrapper.util import DEMO_SUBMIT_MODE
@@ -136,7 +135,6 @@ def basicauth(realm=''):
                 user = authenticate(username=uname, password=passwd)
                 if user is not None and user.is_active:
                     request.user = user
-                    SuperuserMiddleware.reinit_request(request)
                     return view(request, *args, **kwargs)
 
             # Either they did not provide an authorization header or
@@ -158,7 +156,6 @@ def basic_or_api_key(realm=''):
                 user = authenticate(username=username, password=password, request=request)
                 if user is not None and user.is_active:
                     request.user = user
-                    SuperuserMiddleware.reinit_request(request)
                     return view(request, *args, **kwargs)
             response = HttpResponse(status=401)
             response['WWW-Authenticate'] = 'Basic realm="%s"' % realm
@@ -193,7 +190,6 @@ def formplayer_as_user_auth(view):
 
         request.user = couch_user.get_django_user()
         request.couch_user = couch_user
-        SuperuserMiddleware.reinit_request(request)
 
         return view(request, *args, **kwargs)
 

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -370,30 +370,6 @@ def _two_factor_required(view_func, domain, couch_user):
     )
 
 
-def cls_to_view(additional_decorator=None):
-    def decorator(func):
-        def __outer__(cls, request, *args, **kwargs):
-            domain = kwargs.get('domain')
-            new_kwargs = kwargs.copy()
-            if not domain:
-                try:
-                    domain = args[0]
-                except IndexError:
-                    pass
-            else:
-                del new_kwargs['domain']
-
-            def __inner__(request, domain, *args, **new_kwargs):
-                return func(cls, request, *args, **kwargs)
-
-            if additional_decorator:
-                return additional_decorator(__inner__)(request, domain, *args, **new_kwargs)
-            else:
-                return __inner__(request, domain, *args, **new_kwargs)
-        return __outer__
-    return decorator
-
-
 def api_domain_view(view):
     """
     Decorate this with any domain view that should be accessed via api only
@@ -487,16 +463,13 @@ def require_superuser_or_pass_check(view_func, check_func):
 
 
 require_superuser = functools.partial(require_superuser_or_pass_check, check_func=None)
-cls_require_superusers = cls_to_view(additional_decorator=require_superuser)
 require_superuser_or_contractor = functools.partial(
     require_superuser_or_pass_check,
     check_func=lambda user: IS_CONTRACTOR.enabled(user.username))
-cls_require_superuser_or_contractor = cls_to_view(additional_decorator=require_superuser_or_contractor)
 
 
 # Parallel to what we did with login_and_domain_required, above
 domain_admin_required = domain_admin_required_ex()
-cls_domain_admin_required = cls_to_view(additional_decorator=domain_admin_required)
 
 
 def check_domain_migration(view_func):

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -104,7 +104,7 @@ def login_and_domain_required(view_func):
                 return _redirect_to_project_access_upgrade(req)
             else:
                 return call_view()
-        elif user.is_superuser:
+        elif user.invoke_superuser():
             if domain_obj.restrict_superusers and not _page_is_whitelisted(req.path, domain_obj.name):
                 from corehq.apps.hqwebapp.views import no_permissions
                 msg = "This project space restricts superuser access.  You must request an invite to access it."
@@ -464,7 +464,7 @@ def domain_admin_required_ex(redirect_page_name=None):
                 raise Http404()
 
             if not (
-                _page_is_whitelisted(request.path, domain_name) and request.user.is_superuser
+                _page_is_whitelisted(request.path, domain_name) and request.user.invoke_superuser()
             ) and not request.couch_user.is_domain_admin(domain_name):
                 return HttpResponseRedirect(reverse(redirect_page_name))
             return view_func(request, domain_name, *args, **kwargs)
@@ -477,7 +477,7 @@ def require_superuser_or_contractor(view_func):
     @wraps(view_func)
     def _inner(request, *args, **kwargs):
         user = request.user
-        if IS_CONTRACTOR.enabled(user.username) or user.is_superuser:
+        if IS_CONTRACTOR.enabled(user.username) or user.invoke_superuser():
             return view_func(request, *args, **kwargs)
         else:
             return HttpResponseRedirect(reverse("no_permissions"))

--- a/corehq/apps/domain/management/commands/make_superuser.py
+++ b/corehq/apps/domain/management/commands/make_superuser.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
             couch_user = WebUser.create(None, username, password)
             logger.info("→ User {} created".format(couch_user.username))
 
-        is_superuser_changed = not couch_user.is_superuser
+        is_superuser_changed = not couch_user.is_superuser  # is_superuser intentional
         is_staff_changed = not couch_user.is_staff
         couch_user.is_superuser = True
         couch_user.is_staff = True

--- a/corehq/apps/domain/project_access/middleware.py
+++ b/corehq/apps/domain/project_access/middleware.py
@@ -12,7 +12,7 @@ from corehq.util.quickcache import quickcache
 
 class ProjectAccessMiddleware(MiddlewareMixin):
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if getattr(request, 'couch_user', None) and request.couch_user.is_superuser \
+        if getattr(request, 'couch_user', None) and request.couch_user.invoke_superuser() \
                 and hasattr(request, 'domain'):
             self.record_superuser_entry(request.domain, request.couch_user.username)
         if getattr(request, 'couch_user', None) and request.couch_user.is_web_user() \

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -30,7 +30,7 @@
     <div class="col-sm-4">
     </div>
     <div class="col-sm-4">
-      {% if not restrict_domain_creation or request.user.is_superuser %}
+      {% if not restrict_domain_creation or request.user.invoke_superuser %}
         <aside class="well">
           <h3>{% trans "Have a new idea?" %}</h3>
           <a class="btn btn-primary" href="{% url "registration_domain" %}">{% trans "Create a Blank Project" %}</a>

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -458,7 +458,7 @@ class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMix
 
     @property
     def show_hidden(self):
-        if not self.request.user.is_superuser:
+        if not self.request.user.invoke_superuser():
             return False
         return bool(self.request.POST.get('additionalData[show_hidden]'))
 
@@ -1408,7 +1408,7 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
             next_subscription = self.current_subscription.next_subscription
 
             if is_saved:
-                if not request.user.is_superuser:
+                if not request.user.invoke_superuser():
                     if self.billing_account_info_form.is_same_edition():
                         self.send_keep_subscription_email()
                     elif self.billing_account_info_form.is_downgrade_from_paid_plan():

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -47,7 +47,7 @@ def select(request, domain_select_template='domain/select.html', do_not_redirect
             # mirrors logic in login_and_domain_required
             if (
                 request.couch_user.is_member_of(domain_obj)
-                or (request.user.is_superuser and not domain_obj.restrict_superusers)
+                or (request.user.invoke_superuser() and not domain_obj.restrict_superusers)
                 or domain_obj.is_snapshot
             ):
                 try:

--- a/corehq/apps/domain/views/internal.py
+++ b/corehq/apps/domain/views/internal.py
@@ -380,7 +380,7 @@ class ActivateTransferDomainView(BasePageView):
 
         if (self.active_transfer and
                 self.active_transfer.to_username != request.user.username and
-                not request.user.is_superuser):
+                not request.user.invoke_superuser()):
             return HttpResponseRedirect(reverse("no_permissions"))
 
         return super(ActivateTransferDomainView, self).get(request, *args, **kwargs)
@@ -391,7 +391,7 @@ class ActivateTransferDomainView(BasePageView):
         if not self.active_transfer:
             raise Http404()
 
-        if self.active_transfer.to_username != request.user.username and not request.user.is_superuser:
+        if self.active_transfer.to_username != request.user.username and not request.user.invoke_superuser():
             return HttpResponseRedirect(reverse("no_permissions"))
 
         self.active_transfer.transfer_domain(ip=get_ip(request))
@@ -416,7 +416,7 @@ class DeactivateTransferDomainView(View):
 
         if (transfer.to_username != request.user.username and
                 transfer.from_username != request.user.username and
-                not request.user.is_superuser):
+                not request.user.invoke_superuser()):
             return HttpResponseRedirect(reverse("no_permissions"))
 
         transfer.active = False

--- a/corehq/apps/hqadmin/templates/hqadmin/superuser_management.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/superuser_management.html
@@ -31,7 +31,7 @@
           <tr>
             <td>{{ user.username }}</td>
             <td>{% if user.is_staff %}<i class="fa fa-check"></i>{% endif %}</td>
-            <td>{% if user.is_superuser %}<i class="fa fa-check"></i>{% endif %}</td>
+            <td>{% if user.is_superuser %}{# is_superuser intentional #}<i class="fa fa-check"></i>{% endif %}</td>
             <td>{% if user.two_factor_enabled %}<i class="fa fa-check"></i>{% endif %}</td>
           </tr>
         {% endfor %}

--- a/corehq/apps/hqadmin/views/reports.py
+++ b/corehq/apps/hqadmin/views/reports.py
@@ -22,7 +22,7 @@ from corehq.apps.hqadmin.views.utils import BaseAdminSectionView
 
 def top_five_projects_by_country(request):
     data = {}
-    internalMode = request.user.is_superuser
+    internalMode = request.user.invoke_superuser()
     attributes = ['internal.area', 'internal.sub_area', 'cp_n_active_cc_users', 'deployment.countries']
 
     if internalMode:

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -34,6 +34,7 @@ from lxml.builder import E
 
 from casexml.apps.phone.xml import SYNC_XMLNS
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
+from corehq.apps.users.middleware import SuperuserMiddleware
 from couchexport.models import Format
 from couchforms.openrosa_response import RESPONSE_XMLNS
 from dimagi.utils.django.email import send_HTML_email
@@ -86,6 +87,7 @@ class AuthenticateAs(UserAdministration):
         form = AuthenticateAsForm(self.request.POST)
         if form.is_valid():
             request.user = User.objects.get(username=form.full_username)
+            SuperuserMiddleware.reinit_request(request)
 
             # http://stackoverflow.com/a/2787747/835696
             # This allows us to bypass the authenticate call

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -131,7 +131,7 @@ class SuperuserManagement(UserAdministration):
             for user in users:
                 # save user object only if needed and just once
                 should_save = False
-                if user.is_superuser is not is_superuser:
+                if user.is_superuser is not is_superuser:  # is_superuser intentional
                     user.is_superuser = is_superuser
                     should_save = True
 
@@ -154,7 +154,7 @@ def superuser_table(request):
     csv_writer.writerow(['Username', 'Developer', 'Superuser', 'Two Factor Enabled'])
     for user in superusers:
         csv_writer.writerow([
-            user.username, user.is_staff, user.is_superuser, user.two_factor_enabled])
+            user.username, user.is_staff, user.is_superuser, user.two_factor_enabled])  # is_superuser intentional
     response = HttpResponse(content_type=Format.from_format('csv').mimetype)
     response['Content-Disposition'] = 'attachment; filename="superuser_table.csv"'
     response.write(f.getvalue())

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -34,7 +34,6 @@ from lxml.builder import E
 
 from casexml.apps.phone.xml import SYNC_XMLNS
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
-from corehq.apps.users.middleware import SuperuserMiddleware
 from couchexport.models import Format
 from couchforms.openrosa_response import RESPONSE_XMLNS
 from dimagi.utils.django.email import send_HTML_email
@@ -87,7 +86,6 @@ class AuthenticateAs(UserAdministration):
         form = AuthenticateAsForm(self.request.POST)
         if form.is_valid():
             request.user = User.objects.get(username=form.full_username)
-            SuperuserMiddleware.reinit_request(request)
 
             # http://stackoverflow.com/a/2787747/835696
             # This allows us to bypass the authenticate call

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
@@ -7,7 +7,7 @@
         {% endfor %}
     {% endif %}
 
-    {% if not restrict_domain_creation or request.user.is_superuser %}
+    {% if not restrict_domain_creation or request.user.invoke_superuser %}
         <li class="divider" />
         <li>
             <a href="{% url 'registration_domain' %}">

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -226,7 +226,7 @@ def can_use_restore_as(request):
     if not hasattr(request, 'couch_user'):
         return False
 
-    if request.couch_user.is_superuser:
+    if request.couch_user.invoke_superuser():
         return True
 
     return (

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -209,7 +209,7 @@ def redirect_to_default(req, domain=None):
         else:
             domains = Domain.active_for_user(req.user)
 
-        if 0 == len(domains) and not req.user.is_superuser:
+        if 0 == len(domains) and not req.user.invoke_superuser():
             from corehq.apps.registration.views import track_domainless_new_user
             track_domainless_new_user(req)
             return redirect('registration_domain')
@@ -1093,14 +1093,14 @@ def quick_find(request):
         return HttpResponseBadRequest('GET param "q" must be provided')
 
     def deal_with_doc(doc, domain, doc_info_fn):
-        if request.couch_user.is_superuser or (domain and request.couch_user.is_member_of(domain)):
+        if request.couch_user.invoke_superuser() or (domain and request.couch_user.is_member_of(domain)):
             doc_info = doc_info_fn(doc)
         else:
             raise Http404()
         if redirect and doc_info.link:
             messages.info(request, _("We've redirected you to the %s matching your query") % doc_info.type_display)
             return HttpResponseRedirect(doc_info.link)
-        elif redirect and request.couch_user.is_superuser:
+        elif redirect and request.couch_user.invoke_superuser():
             return HttpResponseRedirect('{}?id={}'.format(reverse('raw_doc'), doc.get('_id')))
         else:
             return json_response(doc_info)

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -74,7 +74,7 @@ def track_domainless_new_user(request):
         # don't trigger soft assert in a test
         return
     user = request.user
-    is_new_user = not (Domain.active_for_user(user) or user.is_superuser)
+    is_new_user = not (Domain.active_for_user(user) or user.invoke_superuser())
     if is_new_user:
         _domainless_new_user_soft_assert(
             False, ("A new user '{}' was redirected to "
@@ -303,7 +303,7 @@ class RegisterDomainView(TemplateView):
     @memoized
     def is_new_user(self):
         user = self.request.user
-        return not (Domain.active_for_user(user) or user.is_superuser)
+        return not (Domain.active_for_user(user) or user.invoke_superuser())
 
     def post(self, request, *args, **kwargs):
         referer_url = request.GET.get('referer', '')
@@ -313,7 +313,7 @@ class RegisterDomainView(TemplateView):
         if not form.is_valid():
             return self.render_to_response(context)
 
-        if settings.RESTRICT_DOMAIN_CREATION and not request.user.is_superuser:
+        if settings.RESTRICT_DOMAIN_CREATION and not request.user.invoke_superuser():
             context.update({
                 'current_page': {'page_name': _('Oops!')},
                 'error_msg': _('Your organization has requested that project creation be restricted. '

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -15,7 +15,6 @@ from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import (
-    cls_to_view,
     login_and_domain_required,
     track_domain_request,
 )
@@ -234,8 +233,6 @@ class ReportDispatcher(View):
         from django.conf.urls import url
         return url(cls.pattern(), cls.as_view(), name=cls.name())
 
-cls_to_view_login_and_domain = cls_to_view(additional_decorator=login_and_domain_required)
-
 
 class ProjectReportDispatcher(ReportDispatcher):
     prefix = 'project_report' # string. ex: project, custom, billing, interface, admin
@@ -249,7 +246,7 @@ class ProjectReportDispatcher(ReportDispatcher):
             'submit_time_punchcard': 'worker_activity_times',
         }
 
-    @cls_to_view_login_and_domain
+    @method_decorator(login_and_domain_required)
     @track_domain_request(calculated_prop='cp_n_viewed_non_ucr_reports')
     def dispatch(self, request, *args, **kwargs):
         return super(ProjectReportDispatcher, self).dispatch(request, *args, **kwargs)
@@ -291,13 +288,10 @@ class CustomProjectReportDispatcher(ProjectReportDispatcher):
         return super(CustomProjectReportDispatcher, self).permissions_check(report, request, domain)
 
 
+@method_decorator(login_and_domain_required, name='dispatch')
 class DomainReportDispatcher(ReportDispatcher):
     prefix = 'domain_report'
     map_name = 'DOMAIN_REPORTS'
-
-    @cls_to_view_login_and_domain
-    def dispatch(self, request, *args, **kwargs):
-        return super(DomainReportDispatcher, self).dispatch(request, *args, **kwargs)
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
         from corehq.motech.repeaters.views import DomainForwardingRepeatRecords

--- a/corehq/apps/reports/templates/reports/async/project_health_dashboard.html
+++ b/corehq/apps/reports/templates/reports/async/project_health_dashboard.html
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-md-12">
       {% include "reports/project_health/partials/last_month_stats.html" %}
-      {% if request.user.is_superuser %}
+      {% if request.user.invoke_superuser %}
         <p>
           <a href="{% url 'domain_internal_settings' domain %}">
             {% trans "Set Performance Threshold" %}

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -169,6 +169,8 @@ from .standard import ProjectReport, inspect
 from .standard.cases.basic import CaseListReport
 
 # Number of columns in case property history popup
+from ..users.middleware import SuperuserMiddleware
+
 DYNAMIC_CASE_PROPERTIES_COLUMNS = 4
 
 
@@ -844,6 +846,7 @@ def get_scheduled_report_response(couch_user, domain, scheduled_report_id,
         request.user = couch_user.get_django_user()
         request.domain = domain
         request.couch_user.current_domain = domain
+        SuperuserMiddleware.reinit_request(request)
     notification = ReportNotification.get(scheduled_report_id)
     return _render_report_configs(
         request,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -169,7 +169,6 @@ from .standard import ProjectReport, inspect
 from .standard.cases.basic import CaseListReport
 
 # Number of columns in case property history popup
-from ..users.middleware import SuperuserMiddleware
 
 DYNAMIC_CASE_PROPERTIES_COLUMNS = 4
 
@@ -846,7 +845,6 @@ def get_scheduled_report_response(couch_user, domain, scheduled_report_id,
         request.user = couch_user.get_django_user()
         request.domain = domain
         request.couch_user.current_domain = domain
-        SuperuserMiddleware.reinit_request(request)
     notification = ReportNotification.get(scheduled_report_id)
     return _render_report_configs(
         request,

--- a/corehq/apps/settings/templates/settings/my_projects.html
+++ b/corehq/apps/settings/templates/settings/my_projects.html
@@ -73,7 +73,7 @@
     </table>
   </div>
   <p>
-    {% if web_user and not restrict_domain_creation or request.user.is_superuser %}
+    {% if web_user and not restrict_domain_creation or request.user.invoke_superuser %}
       <a class="btn btn-primary" href="{% url "registration_domain" %}?referer={{ request.path }}"><i class="fa fa-plus"></i> {% trans 'Create a New Project' %}</a>
     {% endif %}
   </p>

--- a/corehq/apps/sms/templates/sms/gateway_list.html
+++ b/corehq/apps/sms/templates/sms/gateway_list.html
@@ -32,7 +32,7 @@
       {% endfor %}
       </tbody>
     </table>
-    {% if request.couch_user.is_superuser %}
+    {% if request.couch_user.invoke_superuser %}
       <p class="text-danger">
         <i class="fa fa-info-circle"></i>
         {% blocktrans %}

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -165,7 +165,7 @@ class BaseMessagingSectionView(BaseDomainView):
 
     @cached_property
     def is_system_admin(self):
-        return self.request.couch_user.is_superuser
+        return self.request.couch_user.invoke_superuser()
 
     @cached_property
     def is_granted_messaging_access(self):
@@ -1000,7 +1000,7 @@ class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView)
 
         context = self.pagination_context
         context.update({
-            'initiate_new_form': InitiateAddSMSBackendForm(is_superuser=self.request.couch_user.is_superuser),
+            'initiate_new_form': InitiateAddSMSBackendForm(is_superuser=self.request.couch_user.invoke_superuser()),
             'extra_backend_mappings': extra_backend_mappings,
         })
         return context
@@ -1129,7 +1129,7 @@ class AddGatewayViewMixin(object):
 
     @property
     def is_superuser(self):
-        return self.request.couch_user.is_superuser
+        return self.request.couch_user.invoke_superuser()
 
     @property
     @memoized
@@ -1368,7 +1368,7 @@ class GlobalSmsGatewayListView(CRUDPaginatedViewMixin, BaseAdminSectionView):
     def page_context(self):
         context = self.pagination_context
         context.update({
-            'initiate_new_form': InitiateAddSMSBackendForm(is_superuser=self.request.couch_user.is_superuser),
+            'initiate_new_form': InitiateAddSMSBackendForm(is_superuser=self.request.couch_user.invoke_superuser()),
         })
         return context
 

--- a/corehq/apps/smsbillables/dispatcher.py
+++ b/corehq/apps/smsbillables/dispatcher.py
@@ -1,11 +1,10 @@
-from corehq.apps.domain.decorators import cls_require_superusers
+from django.utils.decorators import method_decorator
+
+from corehq.apps.domain.decorators import require_superuser
 from corehq.apps.reports.dispatcher import ReportDispatcher
 
 
+@method_decorator(require_superuser, name='dispatch')
 class SMSAdminInterfaceDispatcher(ReportDispatcher):
     prefix = 'sms_admin_interface'
     map_name = "SMS_ADMIN_INTERFACES"
-
-    @cls_require_superusers
-    def dispatch(self, request, *args, **kwargs):
-        return super(SMSAdminInterfaceDispatcher, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -66,7 +66,6 @@ from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.reports.daterange import get_simple_dateranges
-from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
 from corehq.apps.saved_reports.models import ReportConfig
 from corehq.apps.userreports.app_manager.data_source_meta import (
     DATA_SOURCE_TYPE_RAW,
@@ -297,7 +296,7 @@ class CreateConfigReportView(BaseEditConfigReportView):
 class ReportBuilderView(BaseDomainView):
 
     @method_decorator(require_permission(Permissions.edit_data))
-    @cls_to_view_login_and_domain
+    @method_decorator(login_and_domain_required)
     @use_daterangepicker
     @use_datatables
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/users/decorators.py
+++ b/corehq/apps/users/decorators.py
@@ -27,7 +27,7 @@ def require_permission_raw(permission_check,
         def _inner(request, domain, *args, **kwargs):
             if not hasattr(request, "couch_user"):
                 return redirect_for_login_or_domain(request)
-            elif request.user.is_superuser or permission_check(request.couch_user, domain):
+            elif request.user.invoke_superuser() or permission_check(request.couch_user, domain):
                 request.is_view_only = False
                 return view_func(request, domain, *args, **kwargs)
             elif (view_only_permission_check is not None
@@ -102,7 +102,7 @@ def require_permission_to_edit_user(view_func):
         go_ahead = False
         if hasattr(request, "couch_user"):
             user = request.couch_user
-            if user.is_superuser or user.user_id == couch_user_id or (hasattr(user, "is_domain_admin") and user.is_domain_admin()):
+            if user.invoke_superuser() or user.user_id == couch_user_id or (hasattr(user, "is_domain_admin") and user.is_domain_admin()):
                 go_ahead = True
             else:
                 couch_user = CouchUser.get_by_user_id(couch_user_id)

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -197,7 +197,7 @@ class UpdateUserPermissionForm(forms.Form):
 
     def update_user_permission(self, couch_user=None, editable_user=None, is_super_user=None):
         is_update_successful = False
-        if editable_user and couch_user.is_superuser:
+        if editable_user and couch_user.is_superuser:  # is_superuser intentional
             editable_user.is_superuser = is_super_user
             editable_user.save()
             is_update_successful = True

--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -58,7 +58,7 @@ class UsersMiddleware(MiddlewareMixin):
 
 class SuperuserMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        if request.user.is_superuser:
+        if request.user.is_superuser:  # is_superuser intentional (of course)
             def invoke_superuser():
                 return True
         else:

--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -66,13 +66,25 @@ class SuperuserMiddleware(MiddlewareMixin):
             def invoke_superuser():
                 return False
 
-        self.invoke_superuser = invoke_superuser
-        if user_exists:
-            request.user.invoke_superuser = invoke_superuser
+        request.invoke_superuser = invoke_superuser
+        self.init_user(request)
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        couch_user_exists = getattr(request, 'couch_user', None)
-        if couch_user_exists:
+        self.init_couch_user(request)
+
+    @staticmethod
+    def init_user(request):
+        if getattr(request, 'user', None):
+            request.user.invoke_superuser = request.invoke_superuser
+
+    @staticmethod
+    def init_couch_user(request):
+        if getattr(request, 'couch_user', None):
             # can't set jsonobject dynamic properties to a function directly
             # so we're setting in this roundabout way through __dict__
-            request.couch_user.__dict__['invoke_superuser'] = self.invoke_superuser
+            request.couch_user.__dict__['invoke_superuser'] = request.invoke_superuser
+
+    @classmethod
+    def reinit_request(cls, request):
+        cls.init_user(request)
+        cls.init_couch_user(request)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -844,7 +844,7 @@ class EulaMixin(DocumentSchema):
         return data
 
     def is_eula_signed(self, version=CURRENT_VERSION):
-        if self.is_superuser:
+        if self.is_superuser:  # is_superuser intentional (not really a permission escalation)
             return True
         for eula in self.eulas:
             if eula.version == version:
@@ -1329,7 +1329,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     def is_previewer(self):
         from django.conf import settings
-        return (self.is_superuser or
+        return (self.invoke_superuser() or
                 bool(re.compile(settings.PREVIEWER_RE).match(self.username)))
 
     def sync_from_django_user(self, django_user):
@@ -2354,7 +2354,7 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
 
     def is_global_admin(self):
         # override this function to pass global admin rights off to django
-        return self.is_superuser
+        return self.invoke_superuser()
 
     @classmethod
     def create(cls, domain, username, password, email=None, uuid='', date='', **kwargs):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1324,6 +1324,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             include_docs=True,
         )
 
+    def invoke_superuser(self):
+        return False
+
     def is_previewer(self):
         from django.conf import settings
         return (self.is_superuser or

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -256,7 +256,7 @@
     </div>
   {% endif %}
 
-  {% if user.is_superuser %}
+  {% if user.invoke_superuser %}
     <div class="panel panel-default">
       <div class="panel-heading"
            role="tab"

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -366,7 +366,7 @@ class EditWebUserView(BaseEditUserView):
     @property
     def form_user_update_permissions(self):
         user = self.editable_user
-        is_super_user = user.is_superuser
+        is_super_user = user.is_superuser  # is_superuser intentional
 
         return UpdateUserPermissionForm(auto_id=False, initial={'super_user': is_super_user})
 
@@ -379,7 +379,7 @@ class EditWebUserView(BaseEditUserView):
     @property
     @memoized
     def can_grant_superuser_access(self):
-        return self.request.couch_user.is_superuser and toggles.SUPPORT.enabled(self.request.couch_user.username)
+        return self.request.couch_user.invoke_superuser() and toggles.SUPPORT.enabled(self.request.couch_user.username)
 
     @property
     def page_context(self):
@@ -765,7 +765,7 @@ class UserInvitationView(object):
             context['current_page'] = {'page_name': _('Project Invitation, Account Required')}
         if request.user.is_authenticated:
             is_invited_user = request.couch_user.username.lower() == invitation.email.lower()
-            if self.is_invited(invitation, request.couch_user) and not request.couch_user.is_superuser:
+            if self.is_invited(invitation, request.couch_user) and not request.couch_user.invoke_superuser():
                 if is_invited_user:
                     # if this invite was actually for this user, just mark it accepted
                     messages.info(request, _("You are already a member of {entity}.").format(

--- a/corehq/ex-submodules/auditcare/views.py
+++ b/corehq/ex-submodules/auditcare/views.py
@@ -60,7 +60,7 @@ def audited_login(request, *args, **kwargs):
 
 
 @login_required
-@user_passes_test(lambda u: u.is_superuser)
+@user_passes_test(lambda u: u.invoke_superuser())
 def audited_views(request, *args, **kwargs):
     db = AccessAudit.get_db()
     views = db.view('auditcare/urlpath_by_user_date', reduce=False).all()
@@ -98,7 +98,7 @@ def audited_logout(request, *args, **kwargs):
 
 
 @login_required()
-@user_passes_test(lambda u: u.is_superuser)
+@user_passes_test(lambda u: u.invoke_superuser())
 def model_instance_history(request, model_name, model_uuid, *args, **kwargs):
     # it's for a particular model
     context = {}
@@ -117,7 +117,7 @@ def model_instance_history(request, model_name, model_uuid, *args, **kwargs):
 
 
 @login_required()
-@user_passes_test(lambda u: u.is_superuser)
+@user_passes_test(lambda u: u.invoke_superuser())
 def single_model_history(request, model_name, *args, **kwargs):
     # it's for a particular model
     context = {}
@@ -130,7 +130,7 @@ def single_model_history(request, model_name, *args, **kwargs):
 
 
 @login_required()
-@user_passes_test(lambda u: u.is_superuser)
+@user_passes_test(lambda u: u.invoke_superuser())
 def model_histories(request, *args, **kwargs):
     """
     Looks at all the audit model histories and shows for a given model

--- a/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
+++ b/corehq/ex-submodules/dimagi/utils/django/profiling_middleware.py
@@ -34,12 +34,12 @@ class ProfileMiddleware(MiddlewareMixin):
     WARNING: It uses hotshot profiler which is not thread safe.
     """
     def process_request(self, request):
-        if (settings.DEBUG or request.user.is_superuser) and 'prof' in request.GET:
+        if (settings.DEBUG or request.user.invoke_superuser()) and 'prof' in request.GET:
             self.tmpfile = tempfile.mktemp()
             self.prof = hotshot.Profile(self.tmpfile)
 
     def process_view(self, request, callback, callback_args, callback_kwargs):
-        if (settings.DEBUG or request.user.is_superuser) and 'prof' in request.GET:
+        if (settings.DEBUG or request.user.invoke_superuser()) and 'prof' in request.GET:
             return self.prof.runcall(callback, request, *callback_args, **callback_kwargs)
 
     def get_group(self, file):
@@ -89,7 +89,7 @@ class ProfileMiddleware(MiddlewareMixin):
                "</pre>"
 
     def process_response(self, request, response):
-        if (settings.DEBUG or request.user.is_superuser) and 'prof' in request.GET:
+        if (settings.DEBUG or request.user.invoke_superuser()) and 'prof' in request.GET:
             self.prof.close()
 
             out = StringIO.StringIO()

--- a/corehq/messaging/scheduling/views.py
+++ b/corehq/messaging/scheduling/views.py
@@ -598,7 +598,7 @@ class ConditionalAlertListView(ConditionalAlertBaseView):
         # can restart a rule run. Also don't limit it if it's an environment
         # that is a standalone environment.
         return not (
-            self.request.couch_user.is_superuser or
+            self.request.couch_user.invoke_superuser() or
             settings.SERVER_ENVIRONMENT in settings.UNLIMITED_RULE_RESTART_ENVS
         )
 

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -107,5 +107,5 @@ def use_phone_entries():
 def show_messaging_dashboard(domain, couch_user):
     return (
         not toggles.HIDE_MESSAGING_DASHBOARD_FROM_NON_SUPERUSERS.enabled(domain) or
-        couch_user.is_superuser
+        couch_user.invoke_superuser()
     )

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -69,7 +69,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
             'repeater_types_info': self.repeater_types_info,
             'pending_record_count': RepeatRecord.count(self.domain),
             'user_can_configure': (
-                self.request.couch_user.is_superuser or
+                self.request.couch_user.invoke_superuser() or
                 self.request.couch_user.can_edit_motech() or
                 toggles.IS_CONTRACTOR.enabled(self.request.couch_user.username)
             )

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -913,7 +913,7 @@ class ApplicationsTab(UITab):
         couch_user = self.couch_user
         return (self.domain and couch_user
                 and (couch_user.is_web_user() or couch_user.can_edit_apps())
-                and (couch_user.is_member_of(self.domain) or couch_user.is_superuser)
+                and (couch_user.is_member_of(self.domain) or couch_user.invoke_superuser())
                 and has_privilege(self._request, privileges.PROJECT_ACCESS))
 
 
@@ -1130,7 +1130,7 @@ class MessagingTab(UITab):
                 ],
             })
 
-        if self.couch_user.is_superuser or self.couch_user.is_domain_admin(self.domain):
+        if self.couch_user.invoke_superuser() or self.couch_user.is_domain_admin(self.domain):
             settings_urls.extend([
                 {'title': ugettext_lazy("General Settings"),
                  'url': reverse('sms_settings', args=[self.domain])},
@@ -1624,7 +1624,7 @@ class ProjectSettingsTab(UITab):
 
         from corehq.apps.users.models import WebUser
         if isinstance(self.couch_user, WebUser):
-            if (user_is_billing_admin or self.couch_user.is_superuser) and not settings.ENTERPRISE_MODE:
+            if (user_is_billing_admin or self.couch_user.invoke_superuser()) and not settings.ENTERPRISE_MODE:
                 from corehq.apps.domain.views.accounting import (
                     DomainSubscriptionView, EditExistingBillingAccountView,
                     DomainBillingStatementsView, ConfirmSubscriptionRenewalView,
@@ -1664,7 +1664,7 @@ class ProjectSettingsTab(UITab):
                                            args=[self.domain]),
                         }
                     )
-                if self.couch_user.is_superuser:
+                if self.couch_user.invoke_superuser():
                     subscription.append({
                         'title': _('Internal Subscription Management (Dimagi Only)'),
                         'url': reverse(
@@ -1674,7 +1674,7 @@ class ProjectSettingsTab(UITab):
                     })
                 items.append((_('Subscription'), subscription))
 
-        if self.couch_user.is_superuser:
+        if self.couch_user.invoke_superuser():
             from corehq.apps.domain.views.internal import (
                 EditInternalDomainInfoView,
                 EditInternalCalculationsView,
@@ -1971,7 +1971,7 @@ class SMSAdminTab(UITab):
 
     @property
     def _is_viewable(self):
-        return self.couch_user and self.couch_user.is_superuser
+        return self.couch_user and self.couch_user.invoke_superuser()
 
 
 class AdminTab(UITab):
@@ -1982,7 +1982,7 @@ class AdminTab(UITab):
 
     @property
     def dropdown_items(self):
-        if (self.couch_user and not self.couch_user.is_superuser
+        if (self.couch_user and not self.couch_user.invoke_superuser()
                 and (toggles.IS_CONTRACTOR.enabled(self.couch_user.username))):
             return [
                 dropdown_dict(_("System Info"), url=reverse("system_info")),
@@ -2015,7 +2015,7 @@ class AdminTab(UITab):
     def sidebar_items(self):
         # todo: convert these to dispatcher-style like other reports
         if (self.couch_user and
-                (not self.couch_user.is_superuser and
+                (not self.couch_user.invoke_superuser() and
                  toggles.IS_CONTRACTOR.enabled(self.couch_user.username))):
             return [
                 (_('System Health'), [
@@ -2123,5 +2123,5 @@ class AdminTab(UITab):
     @property
     def _is_viewable(self):
         return (self.couch_user and
-                (self.couch_user.is_superuser or
+                (self.couch_user.invoke_superuser() or
                  toggles.IS_CONTRACTOR.enabled(self.couch_user.username)))

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -183,7 +183,7 @@ class StaticToggle(object):
                     or (hasattr(request, 'domain') and self.enabled(request.domain, namespace=NAMESPACE_DOMAIN))
                 ):
                     return view_func(request, *args, **kwargs)
-                if request.user.is_superuser:
+                if request.user.invoke_superuser():
                     from corehq.apps.toggle_ui.views import ToggleEditView
                     toggle_url = reverse(ToggleEditView.urlname, args=[self.slug])
                     messages.warning(

--- a/settings.py
+++ b/settings.py
@@ -147,6 +147,7 @@ MIDDLEWARE = [
     'corehq.middleware.OpenRosaMiddleware',
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
+    'corehq.apps.users.middleware.SuperuserMiddleware',
     'corehq.middleware.SentryContextMiddleware',
     'corehq.apps.domain.middleware.DomainMigrationMiddleware',
     'corehq.middleware.TimeoutMiddleware',

--- a/settings.py
+++ b/settings.py
@@ -147,7 +147,6 @@ MIDDLEWARE = [
     'corehq.middleware.OpenRosaMiddleware',
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
-    'corehq.apps.users.middleware.SuperuserMiddleware',
     'corehq.middleware.SentryContextMiddleware',
     'corehq.apps.domain.middleware.DomainMigrationMiddleware',
     'corehq.middleware.TimeoutMiddleware',

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -204,7 +204,7 @@ def celery_failure_handler(task, exc, task_id, args, kwargs, einfo):
 
 def get_allowed_websocket_channels(request, channels):
     from django.core.exceptions import PermissionDenied
-    if request.user and request.user.is_authenticated and request.user.is_superuser:
+    if request.user and request.user.is_authenticated and request.user.invoke_superuser():
         return channels
     else:
         raise PermissionDenied(


### PR DESCRIPTION
Prefactor related to https://dimagi-dev.atlassian.net/browse/SAASP-10245

##### SUMMARY
Route superuser permissions checks through a new method, `request.(user|couch_user).invoke_superuser()`. This lets us distinguish between requests to escalate the logged-in users privileges based on their superuser status from admin operations that check or set the is_superuser flag of a user, list all users with that flag set, etc.

I should say it may not be a _perfect_ prefactor in the sense that it may also change behavior, specifically in that when checking `.invoke_superuser()` on a user object that isn't the logged in user object in the request, it'll always return False even if the `is_superuser` is true. However I've attempted to only call `invoke_superuser` when the user is the logged in user.

In an upcoming PR, we can then modify the conditions under which we allow superuser privileges to be invoked—the one we have in mind in https://dimagi-dev.atlassian.net/browse/SAASP-10245 is to allow it only if they have two factor auth enabled, and perhaps later only if they've reverified their identity with a two factor token recently. It will also let us give the act of invoking superuser privileges some side effects, such as logging it, displaying to the user that an attempt to invoke privileges was rejected (e.g. because they lack two factor auth), etc.

Right now this is just to do a first pass test run, I think I'll have a few more related changes in this PR before I'm ready to merge.