### PR TITLE
Dump usernames followup

### DIFF
--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -177,8 +177,8 @@ def dump_usernames(domain, download_id, user_filters, task):
     if location_id:
         location = SQLLocation.active_objects.get_or_None(location_id=location_id)
         location_name = location.name if location else ""
-    filename_suffix = "_".join([a for a in [domain, location_name] if bool(a)])
-    filename = "{}_users.xlsx".format(filename_suffix)
+    filename_prefix = "_".join([a for a in [domain, location_name] if bool(a)])
+    filename = "{}_users.xlsx".format(filename_prefix)
     _dump_xlsx_and_expose_download(filename, headers, rows, download_id, task, users_count)
 
 

--- a/corehq/apps/users/bulk_download.py
+++ b/corehq/apps/users/bulk_download.py
@@ -172,7 +172,13 @@ def dump_usernames(domain, download_id, user_filters, task):
 
     headers = [('users', [['username']])]
     rows = [('users', [[username] for username in usernames])]
-    filename = "{}_users.xlsx".format(domain)
+    location_id = user_filters.get('location_id')
+    location_name = ""
+    if location_id:
+        location = SQLLocation.active_objects.get_or_None(location_id=location_id)
+        location_name = location.name if location else ""
+    filename_suffix = "_".join([a for a in [domain, location_name] if bool(a)])
+    filename = "{}_users.xlsx".format(filename_suffix)
     _dump_xlsx_and_expose_download(filename, headers, rows, download_id, task, users_count)
 
 

--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -19,7 +19,7 @@ def get_all_commcare_users_by_domain(domain):
 
 def get_mobile_usernames_by_filters(domain, user_filters):
     query = _get_es_query(domain, user_filters)
-    return query.values_list('username', flat=True)
+    return query.values_list('base_username', flat=True)
 
 
 def _get_es_query(domain, user_filters):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1201

User suggestion on https://github.com/dimagi/commcare-hq/pull/26630/files

1. update filename to include state name used for filtering when downloading mobile workers
2. download just raw usernames instead of the normalise complete username

Feature Flag:
`FILTERED_BULK_USER_DOWNLOAD`