### PR TITLE
Nh/omrs/missing values

### DIFF
--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -1,7 +1,13 @@
 from testil import eq
 
-from corehq.motech.openmrs.openmrs_config import OpenmrsConfig, OpenmrsFormConfig
-from corehq.motech.openmrs.workflow_tasks import CreateVisitsEncountersObsTask
+from corehq.motech.openmrs.openmrs_config import (
+    OpenmrsConfig,
+    OpenmrsFormConfig,
+)
+from corehq.motech.openmrs.workflow_tasks import (
+    CreateVisitsEncountersObsTask,
+    get_values_for_concept,
+)
 from corehq.motech.value_source import CaseTriggerInfo
 
 
@@ -24,8 +30,8 @@ def test_concept_directions():
         }
     )
     task = get_task(info, form_json, form_config_dict)
-    values_for_concept = task._get_values_for_concept(form_config, task.info)
-    eq(values_for_concept, {
+    values_for_concepts = get_values_for_concept(form_config, task.info)
+    eq(values_for_concepts, {
         # "direction": "out"
         'e7fdcd25-6d11-4d85-a80a-8979785f0f4b': ['eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0'],
         # "direction": null, or not specified

--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -24,7 +24,7 @@ def test_concept_directions():
         }
     )
     task = get_task(info, form_json, form_config_dict)
-    values_for_concept = task._get_values_for_concept(form_config)
+    values_for_concept = task._get_values_for_concept(form_config, task.info)
     eq(values_for_concept, {
         # "direction": "out"
         'e7fdcd25-6d11-4d85-a80a-8979785f0f4b': ['eea8e4e9-4a91-416c-b0f5-ef0acfbc51c0'],

--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -1,6 +1,9 @@
+from django.test import SimpleTestCase
+
 from testil import eq
 
 from corehq.motech.openmrs.openmrs_config import (
+    ALL_CONCEPTS,
     OpenmrsConfig,
     OpenmrsFormConfig,
 )
@@ -91,6 +94,95 @@ def test_start_stop_datetime_import():
     )
     eq(start_datetime, "2019-12-16T12:36:00.000+0000")
     eq(stop_datetime, "2019-12-17T12:35:59.000+0000")
+
+
+class GetValuesForConceptTests(SimpleTestCase):
+
+    def test_get_values_for_all_concepts(self):
+        form_config = OpenmrsFormConfig.wrap({
+            "openmrs_observations": [{
+                "concept": ALL_CONCEPTS
+            }]
+        })
+        info = CaseTriggerInfo(domain="test-domain", case_id="c0ffee")
+        values_for_concept = get_values_for_concept(form_config, info)
+        self.assertEqual(values_for_concept, {})
+
+    def test_get_values_for_different_concepts(self):
+        form_config = OpenmrsFormConfig.wrap({
+            "openmrs_observations": [
+                {
+                    "concept": "123456",
+                    "value": {"form_question": "/data/symptoms/fever"}
+                },
+                {
+                    "concept": "789abc",
+                    "value": {"form_question": "/data/symptoms/vomiting"}
+                },
+                {
+                    "concept": "def012",
+                    "value": {"form_question": "/data/symptoms/diarrhea"}
+                },
+            ]
+        })
+        info = CaseTriggerInfo(
+            domain="test-domain",
+            case_id="c0ffee",
+            form_question_values={
+                "/data/symptoms/fever": True,
+                "/data/symptoms/vomiting": True,
+                "/data/symptoms/diarrhea": True,
+            }
+        )
+        values_for_concept = get_values_for_concept(form_config, info)
+        self.assertEqual(values_for_concept, {
+            "123456": [True],
+            "789abc": [True],
+            "def012": [True],
+        })
+
+    def test_get_values_for_the_same_concept(self):
+        form_config = OpenmrsFormConfig.wrap({
+            "openmrs_observations": [
+                {
+                    "concept": "123456",
+                    "value": {"form_question": "/data/symptoms/fever"}
+                },
+                {
+                    "concept": "123456",
+                    "value": {"form_question": "/data/symptoms/vomiting"}
+                },
+                {
+                    "concept": "123456",
+                    "value": {"form_question": "/data/symptoms/diarrhea"}
+                },
+            ]
+        })
+        info = CaseTriggerInfo(
+            domain="test-domain",
+            case_id="c0ffee",
+            form_question_values={
+                "/data/symptoms/fever": True,
+                "/data/symptoms/vomiting": True,
+                "/data/symptoms/diarrhea": True,
+            }
+        )
+        values_for_concept = get_values_for_concept(form_config, info)
+        self.assertEqual(values_for_concept, {"123456": [True, True, True]})
+
+    def test_get_values_for_import_concept(self):
+        form_config = OpenmrsFormConfig.wrap({
+            "openmrs_observations": [{
+                "concept": "123456",
+                "value": {
+                    "case_property": "has_fever",
+                    "direction": "in",
+                }
+            }]
+        })
+        info = CaseTriggerInfo(domain="test-domain", case_id="c0ffee")
+        values_for_concept = get_values_for_concept(form_config, info)
+        self.assertEqual(values_for_concept, {})
 
 
 def get_form_config_dict():

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 
 from dimagi.utils.parsing import string_to_utc_datetime
@@ -204,14 +205,14 @@ def get_values_for_concept(form_config, info):
     Returns a dictionary mapping OpenMRS concept UUIDs to lists of
     values. Each value will be exported as a separate Observation.
     """
-    values_for_concept = {}
+    values_for_concept = defaultdict(list)
     for obs in form_config.openmrs_observations:
         if not obs.concept:
             # Skip ObservationMappings for importing all observations.
             continue
         value_source = as_value_source(obs.value)
         if value_source.can_export and not is_blank(value_source.get_value(info)):
-            values_for_concept[obs.concept] = [value_source.get_value(info)]
+            values_for_concept[obs.concept].append(value_source.get_value(info))
     return values_for_concept
 
 

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -10,6 +10,7 @@ from corehq.motech.openmrs.const import (
     PERSON_PROPERTIES,
     PERSON_UUID_IDENTIFIER_TYPE_ID,
 )
+from corehq.motech.openmrs.openmrs_config import ALL_CONCEPTS
 from corehq.motech.openmrs.repeater_helpers import (
     get_ancestor_location_openmrs_uuid,
     get_export_data,
@@ -207,8 +208,9 @@ def get_values_for_concept(form_config, info):
     """
     values_for_concept = defaultdict(list)
     for obs in form_config.openmrs_observations:
-        if not obs.concept:
-            # Skip ObservationMappings for importing all observations.
+        if obs.concept == ALL_CONCEPTS:
+            # ALL_CONCEPTS is a special value for importing all
+            # Observations as extension cases. It's not applicable here.
             continue
         value_source = as_value_source(obs.value)
         if value_source.can_export and not is_blank(value_source.get_value(info)):

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -166,15 +166,15 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
         stop_datetime = to_omrs_datetime(cc_stop_datetime)
         return start_datetime, stop_datetime
 
-    def _get_values_for_concept(self, form_config):
+    def _get_values_for_concept(self, form_config, info):
         values_for_concept = {}
         for obs in form_config.openmrs_observations:
             if not obs.concept:
                 # Skip ObservationMappings for importing all observations.
                 continue
             value_source = as_value_source(obs.value)
-            if value_source.can_export and not is_blank(value_source.get_value(self.info)):
-                values_for_concept[obs.concept] = [value_source.get_value(self.info)]
+            if value_source.can_export and not is_blank(value_source.get_value(info)):
+                values_for_concept[obs.concept] = [value_source.get_value(info)]
         return values_for_concept
 
     def run(self):
@@ -200,7 +200,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
                         provider_uuid=provider_uuid,
                         start_datetime=start_datetime,
                         stop_datetime=stop_datetime,
-                        values_for_concept=self._get_values_for_concept(form_config),
+                        values_for_concept=self._get_values_for_concept(form_config, self.info),
                         encounter_type=form_config.openmrs_encounter_type,
                         openmrs_form=form_config.openmrs_form,
                         visit_type=form_config.openmrs_visit_type,


### PR DESCRIPTION
Context: [SC-487](https://dimagi-dev.atlassian.net/browse/SC-487)

##### SUMMARY
Currently, when OpenMRS integration is configured to send multiple values for the same concept (e.g. OpenMRS has a concept for "symptoms" and a CommCare app allows you to enter/select multiple symptoms), only one of the values is sent.

This change fixes that.

##### FEATURE FLAG
OpenMRS integration
