### PR TITLE
Don't include billing context in ENTERPRISE_MODE

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -461,9 +461,9 @@ class BillingAccount(ValidateModelMixin, models.Model):
             return None
         except cls.MultipleObjectsReturned:
             log_accounting_error(
-                "Multiple billing accounts showed up for the domain '%s'. The "
-                "latest one was served, but you should reconcile very soon."
-                % domain
+                f"Multiple billing accounts showed up for the domain '{domain}'. The "
+                "latest one was served, but you should reconcile very soon.",
+                show_stack_trace=True,
             )
             return cls.objects.filter(created_by_domain=domain).latest('date_created')
         return None

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -78,7 +78,9 @@ def domain(request):
 def domain_billing_context(request):
     is_domain_billing_admin = False
     restrict_domain_creation = settings.RESTRICT_DOMAIN_CREATION
-    if getattr(request, 'couch_user', None) and getattr(request, 'domain', None):
+    if (getattr(request, 'couch_user', None)
+            and getattr(request, 'domain', None)
+            and not settings.ENTERPRISE_MODE):
         account = BillingAccount.get_account_by_domain(request.domain)
         if account:
             if has_privilege(request, privileges.ACCOUNTING_ADMIN):


### PR DESCRIPTION
https://forum.dimagi.com/t/email-alert-multiple-billing-accounts-showed-up-for-the-domain-fmoh-echis/7260

##### SUMMARY
There's a global context processor which inserts a couple flags based on billing information into every request.  In `ENTERPRISE_MODE`, billing information isn't available anyways, so this removes it.  A bunch of domains have two billing accounts (not sure why - this predates my recent changes), this will silence the error when not relevant.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
