### PR TITLE
Require two factor for superusers

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -364,6 +364,14 @@ def _two_factor_required(view_func, domain, couch_user):
     if exempt:
         return False
     return (
+        # If a user is a superuser, then there is no two_factor_disabled loophole allowed.
+        # If you lose your phone, you have to give up superuser privileges
+        # until you have two factor set up again.
+        settings.REQUIRE_TWO_FACTOR_FOR_SUPERUSERS and couch_user.is_superuser
+    ) or (
+        # For other policies requiring two factor auth,
+        # allow the two_factor_disabled loophole for people who have lost their phones
+        # and need time to set up two factor auth again.
         (domain.two_factor_auth or TWO_FACTOR_SUPERUSER_ROLLOUT.enabled(couch_user.username))
         and not couch_user.two_factor_disabled
     )

--- a/settings.py
+++ b/settings.py
@@ -946,6 +946,8 @@ RATE_LIMIT_SUBMISSIONS = False
 # This is useful for load-shedding in times of crisis.
 STALE_EXPORT_THRESHOLD = None
 
+REQUIRE_TWO_FACTOR_FOR_SUPERUSERS = False
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-10245. All superusers will now face the same two factor restrictions as users in domains that require two factor. That is, all pages will direct them to enable two factor until they've enabled it, and thereafter they'll have to provide provide a two factor token as part of login.

Additionally, the loophole for people who have lost their phone is not open to superusers. If they need to use the loophole, they'll have to first give up their superuser privileges, which can be added back once they've set up two factor again.

(There's also a thematically related but otherwise not related change in this PR having to do with how we calculate two_factor_enabled on a page where we show the two factor status of all supeusers.)

##### FEATURE FLAG 
This requirement only takes effect when
```
REQUIRE_TWO_FACTOR_FOR_SUPERUSERS = True
```
in `settings.py`.
