### PR TITLE
Make location path queries more powerful

### DIFF
--- a/corehq/apps/callcenter/views.py
+++ b/corehq/apps/callcenter/views.py
@@ -74,7 +74,7 @@ class CallCenterOptionsController(EmwfOptionsController):
 
     def get_locations_query(self, query):
         return (SQLLocation.objects
-                .filter_path_by_user_input(self.domain, query)
+                .filter_by_user_input(self.domain, query)
                 .filter(location_type__shares_cases=True))
 
     def group_es_query(self, query):

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -293,13 +293,13 @@ class LocationManager(LocationQueriesMixin, AdjListManager):
         except self.model.DoesNotExist:
             return self.get(domain=domain, name__iexact=user_input)
 
-    def filter_path_by_user_input(self, domain, user_input):
+    def filter_by_user_input(self, domain, user_input):
         """
         Returns a queryset based on user input
           - Matching happens by name or site-code
           - Adding a slash to the input string starts a new search node among descendants
           - Matching is partial unless the query node is wrapped in quotes
-        Refer to TestFilterPath for example usages.
+        Refer to TestFilterByUserInput for example usages.
         """
         query = None
         for part in user_input.split('/'):

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -140,7 +140,7 @@ class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
         # they are allowed to see
         middlesex_locs = (
             SQLLocation.objects
-            .filter_path_by_user_input(self.domain, "Massachusetts")
+            .filter_path_by_user_input(self.domain, "Massachusetts/")
             .accessible_to_user(self.domain, self.web_user)
         )
         self.assertItemsEqual(

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -181,21 +181,23 @@ class TestFilterPath(LocationHierarchyTestCase):
 
     def test_path_queries(self):
         for querystring, expected in [
-            ('Suffolk', ['Suffolk', 'Boston', 'Brookline']),
-            ('Suff', ['Suffolk', 'Boston', 'Brookline']),
+            ('Suff', ['Suffolk']),
+            ('Suffolk', ['Suffolk']),
             ('Cambridge', ['Cambridge', 'Cambridge']),
             ('Massachusetts/Cambridge', ['Cambridge']),
             ('"Copycat"/Cambridge', []),
-            ('Middlesex/Cambridge', ['Cambridge', 'Cambridge']),
             ('"Middlesex"/Cambridge', ['Cambridge']),
             ('"Middlesex/Cambridge', ['Cambridge', 'Cambridge']),
             ('"Middlesex"/Somerville', ['Somerville', 'Evil Somerville']),
             ('"Middlesex"/"Somer', ['Somerville', 'Evil Somerville']),
             ('"Middlesex"/"Somerville"', ['Somerville']),
             ('mass/mid/Som', ['Somerville', 'Evil Somerville']),
+            ('Middl', ['Middlesex', 'Evil Middlesex']),
+            ('Middl/', ['Cambridge', 'Somerville', 'Evil Somerville', 'Cambridge', 'Somerville']),
+            ('Middl/camb', ['Cambridge', 'Cambridge']),
         ]:
             actual = list(SQLLocation.objects
                           .filter_path_by_user_input(self.domain, querystring)
                           .values_list('name', flat=True))
-            error_msg =  f"\nExpected '{querystring}' to yield\n{expected}\nbut got\n{actual}"
+            error_msg = f"\nExpected '{querystring}' to yield\n{expected}\nbut got\n{actual}"
             self.assertItemsEqual(actual, expected, error_msg)

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -122,14 +122,14 @@ class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
             SQLLocation.objects.accessible_to_user(self.domain, unassigned_user)
         )
 
-    def test_filter_path_by_user_input(self):
+    def test_filter_by_user_input(self):
         self.restrict_user_to_assigned_locations(self.web_user)
 
         # User searching for higher in the hierarchy is only given the items
         # they are allowed to see
         middlesex_locs = (
             SQLLocation.objects
-            .filter_path_by_user_input(self.domain, "Massachusetts/")
+            .filter_by_user_input(self.domain, "Massachusetts/")
             .accessible_to_user(self.domain, self.web_user)
         )
         self.assertItemsEqual(
@@ -140,13 +140,13 @@ class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
         # User searching for a branch they don't have access to get nothing
         no_locs = (
             SQLLocation.objects
-            .filter_path_by_user_input(self.domain, "Suffolk")
+            .filter_by_user_input(self.domain, "Suffolk")
             .accessible_to_user(self.domain, self.web_user)
         )
         self.assertItemsEqual([], no_locs)
 
 
-class TestFilterPath(LocationHierarchyTestCase):
+class TestFilterByUserInput(LocationHierarchyTestCase):
     location_type_names = ['state', 'county', 'city']
     location_structure = [
         ('Massachusetts', [
@@ -186,7 +186,7 @@ class TestFilterPath(LocationHierarchyTestCase):
             ('Middl/camb', ['Cambridge', 'Cambridge']),
         ]:
             actual = list(SQLLocation.objects
-                          .filter_path_by_user_input(self.domain, querystring)
+                          .filter_by_user_input(self.domain, querystring)
                           .values_list('name', flat=True))
             error_msg = f"\nExpected '{querystring}' to yield\n{expected}\nbut got\n{actual}"
             self.assertItemsEqual(actual, expected, error_msg)

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -29,26 +29,15 @@ class BaseTestLocationQuerysetMethods(LocationHierarchyTestCase):
 
 class TestLocationQuerysetMethods(BaseTestLocationQuerysetMethods):
 
-    def test_filter_by_user_input(self):
-        middlesex_locs = (SQLLocation.objects
-                          .filter_by_user_input(self.domain, "Middlesex"))
-        self.assertItemsEqual(
-            ['Middlesex'],
-            [loc.name for loc in middlesex_locs]
-        )
-
     def test_ancestors(self):
-        boston_matches = (SQLLocation.objects
-                          .filter_by_user_input(self.domain, "Boston"))
-
+        boston = SQLLocation.objects.get(name="Boston")
         self.assertItemsEqual(
-            [loc.name for loc in boston_matches[0].get_ancestors()],
+            [loc.name for loc in boston.get_ancestors()],
             ['Suffolk', 'Massachusetts']
         )
 
     def test_ancestor_of_type(self):
-        boston = (SQLLocation.objects
-                  .filter_by_user_input(self.domain, "Boston"))[0]
+        boston = SQLLocation.objects.get(name="Boston")
         self.assertEqual(
             boston.get_ancestor_of_type('county').name,
             'Suffolk'

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -90,7 +90,7 @@ class EmwfOptionsController(object):
             included_objects = SQLLocation.inactive_objects
         else:
             included_objects = SQLLocation.active_objects
-        locations = included_objects.filter_path_by_user_input(self.domain, query)
+        locations = included_objects.filter_by_user_input(self.domain, query)
         return locations.accessible_to_user(self.domain, self.request.couch_user)
 
     def get_locations_size(self, query):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -84,45 +84,13 @@ class EmwfOptionsController(object):
                         .sort("name.exact"))
         return [self.utils.reporting_group_tuple(g) for g in groups_query.run().hits]
 
-    @staticmethod
-    def _get_location_specific_custom_filters(query):
-        query_sections = query.split("/")
-        # first section would be u'"parent' or u'"parent_name"', so split with " to get
-        # ['', 'parent'] or ['', 'parent_name', '']
-        parent_name_section_splits = query_sections[0].split('"')
-        parent_name = parent_name_section_splits[1]
-        try:
-            search_query = query_sections[1]
-        except IndexError:
-            # when user has entered u'"parent_name"' without trailing "/"
-            # consider it same as u'"parent_name"/'
-            search_query = "" if len(parent_name_section_splits) == 3 else None
-        return parent_name, search_query
-
     def get_locations_query(self, query):
         show_inactive = json.loads(self.request.GET.get('show_inactive', 'false'))
         if show_inactive:
             included_objects = SQLLocation.inactive_objects
         else:
             included_objects = SQLLocation.active_objects
-        if self.search.startswith('"'):
-            parent_name, search_query = self._get_location_specific_custom_filters(query)
-            if search_query is None:
-                # autocomplete parent names while user is looking for just the parent name
-                # and has not yet entered any child location name
-                locations = included_objects.filter(name__istartswith=parent_name, domain=self.domain)
-            else:
-                # if any parent locations with name entered then
-                #    find locations under them
-                # else just return empty queryset
-                parents = included_objects.filter(name__iexact=parent_name, domain=self.domain)
-                if parent_name and parents.count():
-                    descendants = included_objects.get_queryset_descendants(parents, include_self=True)
-                    locations = descendants.filter_by_user_input(self.domain, search_query)
-                else:
-                    return included_objects.none()
-        else:
-            locations = included_objects.filter_path_by_user_input(self.domain, query)
+        locations = included_objects.filter_path_by_user_input(self.domain, query)
         return locations.accessible_to_user(self.domain, self.request.couch_user)
 
     def get_locations_size(self, query):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -208,9 +208,12 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         group_ids = emwf.selected_group_ids(mobile_user_and_group_slugs)
     """
     location_search_help = ugettext_lazy(mark_safe(
-        '<i class="fa fa-info-circle"></i> To quick search for a '
-        '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations" '
-        'target="_blank">location</a>, write your query as "parent"/descendant.'
+        '<i class="fa fa-info-circle"></i> '
+        '<a href="https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations"'
+        'target="_blank">Advanced Search:</a> '
+        'Put your location name in quotes to show only exact matches. To more '
+        'easily find a location, you may specify multiple levels by separating '
+        'with a "/". For example, "Massachusetts/Suffolk/Boston"'
     ))
 
     slug = "emw"

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -241,7 +241,7 @@ class LocationChoiceProvider(ChainableChoiceProvider):
     def _locations_query(self, query_text, user):
         locations = SQLLocation.active_objects
         if query_text:
-            locations = locations.filter_path_by_user_input(
+            locations = locations.filter_by_user_input(
                 domain=self.domain,
                 user_input=query_text
             )


### PR DESCRIPTION
##### SUMMARY
This is something I've had in my to-do list for a long while, and I figured the wider adoption of the feature brought about by https://github.com/dimagi/commcare-hq/pull/26646 warrants the hour or so of work it took.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
This reworks the filtering logic when searching for a location.  It differs from the current implementation in that:
 - you can use more than one slash
- you don't need to use quotes to use slashes
- you can partial match ancestors (eg, "mass/mid/cam" to get "Massachusetts/Middlesex/Cambridge")
- quotes give you exact name matches, but still return descendant matches

This last decision may be controversial, and I'm open to reconsidering (say, if the last node is quoted, don't show descendants of it).  I don't like how this changes the logic, though, and think the point would be moot with proper ordering, which would show the first exact match at the top.

If accepted as-is, we should probably update https://confluence.dimagi.com/display/commcarepublic/Exact+Search+for+Locations