### PR TITLE
 Get rid of old NEW_*_DB settings for couch db names

### DIFF
--- a/corehq/apps/app_manager/__init__.py
+++ b/corehq/apps/app_manager/__init__.py
@@ -8,9 +8,8 @@ class AppManagerAppConfig(AppConfig):
     name = 'corehq.apps.app_manager'
 
     def ready(self):
-        # Also sync this app's design docs to NEW_APPS_DB
-        ExtraPreindexPlugin.register('app_manager', __file__,
-                                     (settings.APPS_DB, settings.NEW_APPS_DB))
+        # Also sync this app's design docs to APPS_DB
+        ExtraPreindexPlugin.register('app_manager', __file__, settings.APPS_DB)
 
 
 default_app_config = 'corehq.apps.app_manager.AppManagerAppConfig'

--- a/corehq/apps/cleanup/deletable_doc_types.py
+++ b/corehq/apps/cleanup/deletable_doc_types.py
@@ -22,7 +22,7 @@ DELETABLE_COUCH_DOC_TYPES = {
     'ExportMigrationMeta': (META_DB,),
     'ForwardingRule': (MAIN_DB,),
     'ForwardingRule-Deleted': (MAIN_DB,),
-    'GlobalAppConfig': (settings.NEW_APPS_DB,),
+    'GlobalAppConfig': (settings.APPS_DB,),
     'ILSGatewayConfig': (MAIN_DB,),
     'WisePillDeviceEvent': (MAIN_DB,),
 }

--- a/corehq/apps/cleanup/deletable_doc_types.py
+++ b/corehq/apps/cleanup/deletable_doc_types.py
@@ -7,7 +7,6 @@ clean up these docs.
 from django.conf import settings
 
 MAIN_DB = None
-META_DB = None
 
 # Doc types for classes we've removed from our code
 # but may still have docs lying around from
@@ -19,7 +18,7 @@ DELETABLE_COUCH_DOC_TYPES = {
     'CaseReminderHandler': (MAIN_DB,),
     'CaseReminderEvent': (MAIN_DB,),
     'Dhis2Connection': (MAIN_DB,),
-    'ExportMigrationMeta': (META_DB,),
+    'ExportMigrationMeta': (settings.META_DB,),
     'ForwardingRule': (MAIN_DB,),
     'ForwardingRule-Deleted': (MAIN_DB,),
     'GlobalAppConfig': (settings.APPS_DB,),

--- a/corehq/apps/fixtures/__init__.py
+++ b/corehq/apps/fixtures/__init__.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 from corehq.preindex import ExtraPreindexPlugin
 
-ExtraPreindexPlugin.register('fixtures', __file__, settings.NEW_FIXTURES_DB)
+ExtraPreindexPlugin.register('fixtures', __file__, settings.FIXTURES_DB)

--- a/corehq/apps/groups/__init__.py
+++ b/corehq/apps/groups/__init__.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 from corehq.preindex import ExtraPreindexPlugin
 
-ExtraPreindexPlugin.register('groups', __file__, settings.NEW_USERS_GROUPS_DB)
+ExtraPreindexPlugin.register('groups', __file__, settings.USERS_GROUPS_DB)

--- a/corehq/apps/users/__init__.py
+++ b/corehq/apps/users/__init__.py
@@ -11,7 +11,7 @@ class UsersAppConfig(AppConfig):
 
     def ready(self):
         """Code to run with Django starts"""
-        ExtraPreindexPlugin.register('users', __file__, settings.NEW_USERS_GROUPS_DB)
+        ExtraPreindexPlugin.register('users', __file__, settings.USERS_GROUPS_DB)
         connect_user_signals()
 
 

--- a/corehq/couchapps/__init__.py
+++ b/corehq/couchapps/__init__.py
@@ -2,23 +2,23 @@ from corehq.preindex import CouchAppsPreindexPlugin
 from django.conf import settings
 
 CouchAppsPreindexPlugin.register('couchapps', __file__, {
-    'schemas_by_xmlns_or_case_type': 'meta',
-    'export_instances_by_domain': 'meta',
-    'export_instances_by_is_daily_saved': 'meta',
+    'schemas_by_xmlns_or_case_type': settings.META_DB,
+    'export_instances_by_domain': settings.META_DB,
+    'export_instances_by_is_daily_saved': settings.META_DB,
     'receiverwrapper': 'receiverwrapper',
-    'users_extra': (settings.USERS_GROUPS_DB, settings.NEW_USERS_GROUPS_DB),
+    'users_extra': settings.USERS_GROUPS_DB,
     'deleted_users_by_username': settings.USERS_GROUPS_DB,
     'all_docs': (
-        None, settings.NEW_USERS_GROUPS_DB, settings.NEW_FIXTURES_DB, 'meta',
-        settings.NEW_DOMAINS_DB, settings.NEW_APPS_DB),
+        None, settings.USERS_GROUPS_DB, settings.FIXTURES_DB, settings.META_DB,
+        settings.DOMAINS_DB, settings.APPS_DB),
     'by_domain_doc_type_date': (
-        None, settings.NEW_USERS_GROUPS_DB, settings.NEW_FIXTURES_DB, 'meta',
-        settings.NEW_DOMAINS_DB, settings.NEW_APPS_DB),
-    'last_modified': (settings.USERS_GROUPS_DB, settings.DOMAINS_DB, settings.NEW_APPS_DB),
+        None, settings.USERS_GROUPS_DB, settings.FIXTURES_DB, settings.META_DB,
+        settings.DOMAINS_DB, settings.APPS_DB),
+    'last_modified': (settings.USERS_GROUPS_DB, settings.DOMAINS_DB, settings.APPS_DB),
 
-    'app_translations_by_popularity': settings.NEW_APPS_DB,
-    'exports_forms_by_app': settings.NEW_APPS_DB,
-    'forms_by_app_info': settings.NEW_APPS_DB,
-    'apps_with_submissions': settings.NEW_APPS_DB,
-    'saved_apps_auto_generated': settings.NEW_APPS_DB,
+    'app_translations_by_popularity': settings.APPS_DB,
+    'exports_forms_by_app': settings.APPS_DB,
+    'forms_by_app_info': settings.APPS_DB,
+    'apps_with_submissions': settings.APPS_DB,
+    'saved_apps_auto_generated': settings.APPS_DB,
 })

--- a/corehq/ex-submodules/fluff/management/commands/ptop_reindexer_fluff.py
+++ b/corehq/ex-submodules/fluff/management/commands/ptop_reindexer_fluff.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         if pillow.kafka_topic in (topics.CASE, topics.FORM):
             couch_db = couch_config.get_db(None)
         elif pillow.kafka_topic == topics.COMMCARE_USER:
-            couch_db = couch_config.get_db(settings.NEW_USERS_GROUPS_DB)
+            couch_db = couch_config.get_db(settings.USERS_GROUPS_DB)
         else:
             raise CommandError('Reindexer not configured for topic: {}'.format(pillow.kafka_topic))
 

--- a/settings.py
+++ b/settings.py
@@ -1302,19 +1302,11 @@ INDICATOR_CONFIG = {
 
 COMPRESS_URL = STATIC_CDN + STATIC_URL
 
-####### Couch Forms & Couch DB Kit Settings #######
-NEW_USERS_GROUPS_DB = 'users'
-USERS_GROUPS_DB = NEW_USERS_GROUPS_DB
-
-NEW_FIXTURES_DB = 'fixtures'
-FIXTURES_DB = NEW_FIXTURES_DB
-
-NEW_DOMAINS_DB = 'domains'
-DOMAINS_DB = NEW_DOMAINS_DB
-
-NEW_APPS_DB = 'apps'
-APPS_DB = NEW_APPS_DB
-
+# Couch database name suffixes
+USERS_GROUPS_DB = 'users'
+FIXTURES_DB = 'fixtures'
+DOMAINS_DB = 'domains'
+APPS_DB = 'apps'
 META_DB = 'meta'
 
 _serializer = 'corehq.util.python_compatibility.Py3PickleSerializer'
@@ -1412,7 +1404,7 @@ COUCHDB_APPS = [
 COUCH_SETTINGS_HELPER = helper.CouchSettingsHelper(
     COUCH_DATABASES,
     COUCHDB_APPS,
-    [NEW_USERS_GROUPS_DB, NEW_FIXTURES_DB, NEW_DOMAINS_DB, NEW_APPS_DB],
+    [USERS_GROUPS_DB, FIXTURES_DB, DOMAINS_DB, APPS_DB],
     UNIT_TESTING
 )
 COUCH_DATABASE = COUCH_SETTINGS_HELPER.main_db_url


### PR DESCRIPTION
##### SUMMARY
Some straightforward cleanup of some old redundant vars that annoy me a little bit whenever I see them. They're left over from a migration we did probably 4 years ago.


##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
