### PR TITLE
Updated location_tree to not look for l__ prefix

### DIFF
--- a/corehq/apps/locations/static/locations/js/location_tree.js
+++ b/corehq/apps/locations/static/locations/js/location_tree.js
@@ -86,7 +86,7 @@ hqDefine('locations/js/location_tree', [
             if (!self.l__selected_location_id()) {
                 return;
             }
-            return (self.l__selected_location_id().split("l__")[1]);
+            return self.l__selected_location_id();
         });
 
         self.selected_location = ko.computed(function () {


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/26682 is going to break the main location search, which is looking for the `l__` prefix.

Product: not worth announcing, as the bug this fixes should not be live for more than the time it takes to deploy.