### PR TITLE
re-save blobs when saving error forms

### DIFF
--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -42,7 +42,7 @@ from corehq.form_processor.exceptions import (
     AttachmentNotFound,
     MissingFormXml,
     XFormNotFound,
-)
+    CaseSaveError)
 from corehq.form_processor.interfaces.processor import (
     FormProcessorInterface,
     ProcessedForms,
@@ -328,7 +328,7 @@ class CouchSqlDomainMigrator:
         _migrate_case_attachments(couch_case, sql_case)
         try:
             CaseAccessorSQL.save_case(sql_case)
-        except IntegrityError:
+        except CaseSaveError:
             # case re-created by form processing so just mark the case as deleted
             CaseAccessorSQL.soft_delete_cases(
                 self.domain,

--- a/corehq/apps/hqcase/tests/test_object_cache.py
+++ b/corehq/apps/hqcase/tests/test_object_cache.py
@@ -45,18 +45,17 @@ class CaseObjectCacheTest(BaseCaseMultimediaTest):
     """
 
     def setUp(self):
+        super(CaseObjectCacheTest, self).setUp()
         self.domain = Domain.get_or_create_with_name(TEST_DOMAIN_NAME, is_active=True)
         self.user = WebUser.create(TEST_DOMAIN_NAME, TEST_USER, TEST_PASSWORD)
         self.user.set_role(self.domain.name, 'admin')
         self.user.save()
         self.interface = FormProcessorInterface(TEST_DOMAIN_NAME)
-        delete_all_cases()
-        delete_all_xforms()
-        time.sleep(1)
 
     def tearDown(self):
         self.user.delete()
         self.domain.delete()
+        super(CaseObjectCacheTest, self).tearDown()
 
     def testCreateMultimediaCase(self):
         """

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -99,12 +99,13 @@ class BaseCaseMultimediaTest(TestCase, TestFileMixin):
                 last_sync_token=sync_token,
                 received_on=date
             )
-        attachments = result.xform.attachments
+        xform = result.xform
+        attachments = xform.attachments
         self.assertEqual(set(dict_attachments.keys()),
                          set(attachments.keys()))
         self.assertEqual(result.case.case_id, TEST_CASE_ID)
 
-        return result.response, result.xform, result.cases
+        return result.response, self.formdb.get_form(xform.form_id), result.cases
 
     def _submit_and_verify(self, doc_id, xml_data, dict_attachments,
                            sync_token=None, date=None):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -621,10 +621,11 @@ class FormAccessorSQL(AbstractFormAccessor):
             operation.form_id = form.form_id
 
         try:
-            with form.attachment_writer() as write_attachments, \
+            with form.attachment_writer() as attachment_writer, \
                     transaction.atomic(using=form.db, savepoint=False):
+                transaction.on_commit(attachment_writer.commit, using=form.db)
                 form.save()
-                write_attachments()
+                attachment_writer.write()
                 for operation in operations:
                     operation.save()
         except InternalError as e:

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -11,7 +11,7 @@ from itertools import groupby
 from uuid import UUID
 
 from django.conf import settings
-from django.db import InternalError, transaction, router
+from django.db import InternalError, transaction, router, DatabaseError
 from django.db.models import F, Q
 from django.db.models.expressions import Value
 from django.db.models.functions import Concat, Greatest
@@ -1026,7 +1026,7 @@ class CaseAccessorSQL(AbstractCaseAccessor):
                 CaseAttachmentSQL.objects.using(case.db).filter(id__in=attachment_ids_to_delete).delete()
 
                 case.clear_tracked_models()
-        except InternalError as e:
+        except DatabaseError as e:
             raise CaseSaveError(e)
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -654,12 +654,11 @@ class FormAccessorSQL(AbstractFormAccessor):
         with transaction.atomic(using=db_name):
             if form.form_id_updated():
                 operations = form.original_operations + new_operations
-                with transaction.atomic(db_name):
-                    form.save()
-                    get_blob_db().metadb.reparent(form.orig_id, form.form_id)
-                    for model in operations:
-                        model.form = form
-                        model.save()
+                form.save()
+                get_blob_db().metadb.reparent(form.orig_id, form.form_id)
+                for model in operations:
+                    model.form = form
+                    model.save()
             else:
                 with transaction.atomic(db_name):
                     form.save()

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -104,7 +104,11 @@ class FormProcessorSQL(object):
                 ledger_value.db for ledger_value in stock_result.models_to_save
             }
 
-        all_models = filter(None, list(processed_forms) + cases + (stock_result.models_to_save if stock_result else []))
+        all_models = filter(None, (
+            list(processed_forms) +
+            (cases if cases else []) +
+            (stock_result.models_to_save if stock_result else [])
+        ))
         try:
             with ExitStack() as stack:
                 for db_name in db_names:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -137,9 +137,9 @@ class FormProcessorSQL(object):
                             CaseAccessorSQL.save_case(case)
         except DatabaseError:
             for model in all_models:
-                model.pk = None
+                setattr(model, model._meta.pk.attname, None)
                 for tracked in model.create_models:
-                    tracked.pk = None
+                    setattr(tracked, tracked._meta.pk.attname, None)
             raise
 
         if publish_to_kafka:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import uuid
+from itertools import chain
 
 import redis
 from contextlib2 import ExitStack
@@ -104,10 +105,10 @@ class FormProcessorSQL(object):
                 ledger_value.db for ledger_value in stock_result.models_to_save
             }
 
-        all_models = filter(None, (
-            list(processed_forms)
-            + (cases if cases else [])
-            + (stock_result.models_to_save if stock_result else [])
+        all_models = filter(None, chain(
+            processed_forms,
+            cases or [],
+            stock_result.models_to_save if stock_result else [],
         ))
         try:
             with ExitStack() as stack:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -4,7 +4,7 @@ import uuid
 
 import redis
 from contextlib2 import ExitStack
-from django.db import transaction
+from django.db import transaction, DatabaseError
 from lxml import etree
 
 from casexml.apps.case import const
@@ -104,30 +104,38 @@ class FormProcessorSQL(object):
                 ledger_value.db for ledger_value in stock_result.models_to_save
             }
 
-        with ExitStack() as stack:
-            for db_name in db_names:
-                stack.enter_context(transaction.atomic(db_name))
+        all_models = filter(None, list(processed_forms) + cases + (stock_result.models_to_save if stock_result else []))
+        try:
+            with ExitStack() as stack:
+                for db_name in db_names:
+                    stack.enter_context(transaction.atomic(db_name))
 
-            # Save deprecated form first to avoid ID conflicts
-            if processed_forms.deprecated:
-                FormAccessorSQL.update_form(processed_forms.deprecated, publish_changes=False)
+                # Save deprecated form first to avoid ID conflicts
+                if processed_forms.deprecated:
+                    FormAccessorSQL.update_form(processed_forms.deprecated, publish_changes=False)
 
-            FormAccessorSQL.save_new_form(processed_forms.submitted)
-            if cases:
-                for case in cases:
-                    CaseAccessorSQL.save_case(case)
-
-            if stock_result:
-                ledgers_to_save = stock_result.models_to_save
-                LedgerAccessorSQL.save_ledger_values(ledgers_to_save, stock_result)
-
-        if cases:
-            sort_submissions = toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL.enabled(
-                processed_forms.submitted.domain, toggles.NAMESPACE_DOMAIN)
-            if sort_submissions:
-                for case in cases:
-                    if SqlCaseUpdateStrategy(case).reconcile_transactions_if_necessary():
+                FormAccessorSQL.save_new_form(processed_forms.submitted)
+                if cases:
+                    for case in cases:
                         CaseAccessorSQL.save_case(case)
+
+                if stock_result:
+                    ledgers_to_save = stock_result.models_to_save
+                    LedgerAccessorSQL.save_ledger_values(ledgers_to_save, stock_result)
+
+            if cases:
+                sort_submissions = toggles.SORT_OUT_OF_ORDER_FORM_SUBMISSIONS_SQL.enabled(
+                    processed_forms.submitted.domain, toggles.NAMESPACE_DOMAIN)
+                if sort_submissions:
+                    for case in cases:
+                        if SqlCaseUpdateStrategy(case).reconcile_transactions_if_necessary():
+                            CaseAccessorSQL.save_case(case)
+        except DatabaseError:
+            for model in all_models:
+                model.pk = None
+                for tracked in model.create_models:
+                    tracked.pk = None
+            raise
 
         if publish_to_kafka:
             try:

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -105,9 +105,9 @@ class FormProcessorSQL(object):
             }
 
         all_models = filter(None, (
-            list(processed_forms) +
-            (cases if cases else []) +
-            (stock_result.models_to_save if stock_result else [])
+            list(processed_forms)
+            + (cases if cases else [])
+            + (stock_result.models_to_save if stock_result else [])
         ))
         try:
             with ExitStack() as stack:

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -245,9 +245,16 @@ class AttachmentMixin(SaveStateMixin):
         """
         if all(isinstance(a, BlobMeta) for a in self.attachments_list):
             # do nothing if all attachments have already been written
+            class NoopWriter():
+                def write(self):
+                    pass
+
+                def commit(self):
+                    pass
+
             @contextmanager
             def noop_context():
-                yield lambda: None
+                yield NoopWriter()
 
             return noop_context()
 

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -277,8 +277,7 @@ class AttachmentMixin(SaveStateMixin):
             unsaved = self.attachments_list
             assert all(isinstance(a, Attachment) for a in unsaved), unsaved
             with AtomicBlobs(get_blob_db()) as blob_db:
-                writer = Writer(self, blob_db)
-                yield writer
+                yield Writer(self, blob_db)
 
         return atomic_attachments()
 

--- a/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
+++ b/corehq/form_processor/tests/test_gdpr_scrub_user_from_forms.py
@@ -69,6 +69,7 @@ class GDPRScrubUserFromFormsCouchTests(TestCase):
         FormAccessors(DOMAIN).modify_attachment_xml_and_metadata(form, new_form_xml, NEW_USERNAME)
 
         # Test that the metadata changed in the database
+        form = FormAccessors(DOMAIN).get_form(form.form_id)
         actual_form_xml = form.get_attachment("form.xml").decode('utf-8')
         self.assertXMLEqual(EXPECTED_FORM_XML, actual_form_xml)
 

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -474,6 +474,10 @@ class TestReprocessDuringSubmissionSQL(TestReprocessDuringSubmission):
 class TestTransactionErrors(TransactionTestCase):
     domain = uuid.uuid4().hex
 
+    def tearDown(self):
+        FormProcessorTestUtils.delete_all_cases_forms_ledgers(self.domain)
+        super().tearDown()
+
     def test_error_saving_case(self):
         form_id = uuid.uuid4().hex
         case_id = uuid.uuid4().hex

--- a/corehq/form_processor/tests/test_reprocess_errors.py
+++ b/corehq/form_processor/tests/test_reprocess_errors.py
@@ -1,26 +1,37 @@
 import contextlib
 import uuid
 
-from django.db.utils import InternalError
-from django.test import TestCase
-from mock import patch
+from django.db.utils import IntegrityError, InternalError
+from django.test import TestCase, TransactionTestCase
 
-from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.mock import CaseFactory
-from casexml.apps.case.mock import CaseStructure
+from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure
 from casexml.apps.case.signals import case_post_save
 from casexml.apps.case.util import post_case_blocks
+from couchforms.models import UnfinishedSubmissionStub
+from couchforms.signals import successful_form_received
+
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL
 from corehq.form_processor.exceptions import CaseNotFound
-from corehq.form_processor.interfaces.dbaccessors import FormAccessors, CaseAccessors, LedgerAccessors
-from corehq.form_processor.reprocess import reprocess_xform_error, reprocess_unfinished_stub, reprocess_form
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, use_sql_backend
+from corehq.form_processor.interfaces.dbaccessors import (
+    CaseAccessors,
+    FormAccessors,
+    LedgerAccessors,
+)
+from corehq.form_processor.reprocess import (
+    reprocess_form,
+    reprocess_unfinished_stub,
+    reprocess_xform_error,
+)
+from corehq.form_processor.tests.utils import (
+    FormProcessorTestUtils,
+    use_sql_backend,
+)
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.util.context_managers import catch_signal
-from couchforms.models import UnfinishedSubmissionStub
-from couchforms.signals import successful_form_received
+from mock import patch
 
 
 class ReprocessXFormErrorsTest(TestCase):
@@ -457,6 +468,30 @@ class TestReprocessDuringSubmission(TestCase):
 @use_sql_backend
 class TestReprocessDuringSubmissionSQL(TestReprocessDuringSubmission):
     pass
+
+
+@use_sql_backend
+class TestTransactionErrors(TransactionTestCase):
+    domain = uuid.uuid4().hex
+
+    def test_error_saving_case(self):
+        form_id = uuid.uuid4().hex
+        case_id = uuid.uuid4().hex
+
+        with patch(
+            'corehq.form_processor.backends.sql.dbaccessors.CaseAccessorSQL.save_case',
+            side_effect=IntegrityError
+        ), self.assertRaises(IntegrityError):
+            submit_case_blocks(
+                [CaseBlock(case_id=case_id, update={'a': "2"}).as_text()],
+                self.domain,
+                form_id=form_id
+            )
+
+        form = FormAccessorSQL.get_form(form_id)
+        self.assertTrue(form.is_error)
+        self.assertIsNotNone(form.get_xml())
+
 
 
 @contextlib.contextmanager

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -16,7 +16,7 @@ from corehq.blobs import CODES
 from corehq.blobs.models import BlobMeta
 from corehq.form_processor.backends.sql.dbaccessors import (
     CaseAccessorSQL, LedgerAccessorSQL, LedgerReindexAccessor,
-    iter_all_rows)
+    iter_all_rows, FormAccessorSQL)
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.interfaces.processor import ProcessedForms
 from corehq.form_processor.models import XFormInstanceSQL, CommCareCaseSQL, CaseTransaction, Attachment
@@ -261,6 +261,8 @@ def create_form_for_test(
 
     if save:
         FormProcessorSQL.save_processed_models(ProcessedForms(form, None), cases)
+        form = FormAccessorSQL.get_form(form.form_id)
+
     return form
 
 

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -110,6 +110,7 @@ def get_simple_form_xml(form_id, case_id=None, metadata=None, simple_form=SIMPLE
 
 def get_simple_wrapped_form(form_id, metadata=None, save=True, simple_form=SIMPLE_FORM):
     from corehq.form_processor.interfaces.processor import FormProcessorInterface
+    from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 
     metadata = metadata or TestFormMetadata()
     xml = get_simple_form_xml(form_id=form_id, metadata=metadata, simple_form=simple_form)
@@ -121,7 +122,7 @@ def get_simple_wrapped_form(form_id, metadata=None, save=True, simple_form=SIMPL
     interface.store_attachments(wrapped_form, [Attachment('form.xml', xml, 'text/xml')])
     if save:
         interface.save_processed_models([wrapped_form])
-
+        wrapped_form = FormAccessors(metadata.domain).get_form(wrapped_form.form_id)
     return wrapped_form
 
 


### PR DESCRIPTION
New PR from https://github.com/dimagi/commcare-hq/pull/26655

##### SUMMARY
When an error happens after the form is saved the transaction is rolled back. This has some effects:
* form is not saved to db but `form.pk` is not cleared
* form attachments are written to the blob db but the blobdb meta is not saved
* although the blob meta isn't saved their 'saved' state is kept on the form object so when saving the error form the blobs are not re-saved

This PR addresses those by:
1. clear `model.pk` if there is a DB error
2. Separate committing of saved attachment state from the actual saving and only commit if the transactions was successful (using `transaction.on_commit`
