### PR TITLE
Add available metadata to docs

### DIFF
--- a/corehq/motech/value_source.py
+++ b/corehq/motech/value_source.py
@@ -220,6 +220,20 @@ class FormQuestion(ValueSource):
               metadata, like "received_on" and "userID", are prefixed
               with "/metadata".
 
+    The following metadata is available:
+
+    ===========   ================================================
+    Name          Description
+    ===========   ================================================
+    deviceID      An integer that identifies the user's device
+    timeStart     The device time when the user opened the form
+    timeEnd       The device time when the user completed the form
+    received_on   The server time when the submission was received
+    username      The user's username without domain suffix
+    userID        A large unique number expressed in hexadecimal
+    instanceID    A UUID identifying this form submission
+    ===========   ================================================
+
     """
     form_question: str
 


### PR DESCRIPTION
##### SUMMARY

An integration partner recently asked what form metadata is available when configuring integrations, and I realised this info was missing from MOTECH documentation.

This change adds it. The docstrings in the value_source module are included in MOTECH documentation.

cc @Rohit25negi 


##### FEATURE FLAG

"OpenMRS integration" or "DHIS2 integration"
