### PR TITLE
ICDS Dashboard: always set mobile height to available height (even if it's less)

### DIFF
--- a/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
+++ b/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
@@ -71,11 +71,9 @@ function IndieMapController($scope, $compile, $location, $filter, storageService
                 // scale maps based on space available on device.
                 var headerHeight = $('#map-chart-header').height() + $('#page-heading').innerHeight();
                 var legendHeight = 145; // fixed legend height to calculate available space for map
-                // take window height and subtract height of the header plus legend height plus 44px of additional padding / margins
-                var availableHeight = window.innerHeight - headerHeight - legendHeight - 44;
-                if (availableHeight < vm.mapHeight) {
-                    vm.mapHeight = availableHeight;
-                }
+                // always set map height to available height, which is:
+                // widow height - height of the header - legend height - 44px of additional padding / margins
+                vm.mapHeight = window.innerHeight - headerHeight - legendHeight - 44;
             }
         }
     };


### PR DESCRIPTION
this fixes a bug where some geographies weren't taking up the whole screen.

easy