### PR TITLE
Resize raw doc editor to show all content

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
@@ -13,7 +13,8 @@ hqDefine('hqadmin/js/raw_doc', [
         $("#doc-form").koApplyBindings(viewModel);
 
         var $element = $("#doc-element"),
+            options = {maxLines: Infinity},
             doc = ($element.length ? JSON.stringify($element.data('doc'), null, 4) : null);
-        baseAce.initAceEditor($element.get(0), 'ace/mode/json', {}, doc);
+        baseAce.initAceEditor($element.get(0), 'ace/mode/json', options, doc);
     });
 });


### PR DESCRIPTION
Avoid scrollable editor region embedded in scrollable page by removing editor height limit.

![image](https://user-images.githubusercontent.com/464726/74957885-2f4e7880-53d6-11ea-827a-8550d1ab120f.png)
