### PR TITLE
ICDS Dashboard: add mobile dashboard auditing

### DIFF
--- a/custom/icds_reports/middleware.py
+++ b/custom/icds_reports/middleware.py
@@ -16,6 +16,7 @@ exclude_urls = (
 AUDIT_URLS = frozenset(
     [url.name for url in DASHBOARD_URL_GROUPS if hasattr(url, 'name') and url.name not in exclude_urls] + [
         'icds_dashboard',
+        'icds_dashboard_mobile',
     ]
 )
 

--- a/custom/icds_reports/tests/test_audit_data.py
+++ b/custom/icds_reports/tests/test_audit_data.py
@@ -59,6 +59,9 @@ class TestICDSAuditData(TestCase):
 
 @generate_cases([
     (DASHBOARD_DOMAIN, '/a/{domain}/login/', 200, True),
+    (DASHBOARD_DOMAIN, '/a/{domain}/icds_dashboard/', 200, True),
+    (DASHBOARD_DOMAIN, '/a/{domain}/icds_dashboard_mobile/', 200, True),
+    (DASHBOARD_DOMAIN, '/a/{domain}/icds_dashboard_mobile/login/', 200, True),
     (DASHBOARD_DOMAIN, '/a/{domain}/icds_download_pdf/', 401, True),
     ('other', '/a/{domain}/icds_download_pdf/', 200, False),
 ], TestICDSAuditData)


### PR DESCRIPTION
this will include mobile dashboard hits in the dashboard activity report (currently indistinguishable from normal dashboard views)