### PR TITLE
PEP-0479: Change StopIteration handling inside generators

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -1,3 +1,4 @@
+from __future__ import generator_stop
 from collections import defaultdict, namedtuple
 import uuid
 
@@ -225,7 +226,6 @@ def get_paged_changes_to_case_property(case, case_property_name, start=0, per_pa
             )
             if property_changed_info:
                 yield property_changed_info, i + start
-        raise StopIteration
 
     num_actions = len(case.actions)
     if start > num_actions:


### PR DESCRIPTION
#### SUMMARY
Python 3.7 introduces a breaking change in how StopIteration exceptions are handled in generators: https://www.python.org/dev/peps/pep-0479/

As far as I can tell this is the only place in our code that is impacted.

I came across this while running tests locally on 3.7.
