### PR TITLE
fix location drilldown filter in UCRs

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/filters/location_async.html
+++ b/corehq/apps/reports_core/templates/reports_core/filters/location_async.html
@@ -6,7 +6,7 @@
   <span class="form-group report-filter-location-async"
         id="group_{{ filter.css_id }}"
         data-bind="visible: show_location_filter_bool()"
-        data-loc-url='{{ context_.loc_url }}'
+        data-location-url='{{ context_.loc_url }}'
         data-locs='{{ context_.locations|JSON }}'
         data-selected='{{ context_.loc_id|default_if_none:"" }}'
         data-hierarchy='{{ context_.hierarchy|JSON }}'


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-291

This came up on Skype today and I decided to take a look at it.

Basically this needs to match with [this property](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/static/reports/js/filters/main.js#L203) so it was always `undefined` which causes the ajax requests to go to the wrong URL.

##### FEATURE FLAG

UCR

##### PRODUCT DESCRIPTION

Fixes location drilldown filter in UCRs
