### PR TITLE
upgrade kafka client

### DIFF
--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -1,19 +1,9 @@
 from django.conf import settings
-
-from kafka.client import KafkaClient, SimpleClient
+from kafka import KafkaConsumer, KafkaAdminClient, KafkaClient
 
 from corehq.util.io import ClosingContextProxy
 
 GENERIC_KAFKA_CLIENT_ID = 'cchq-kafka-client'
-
-
-def get_simple_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
-    # this uses the old SimpleClient because we are using the old SimpleProducer interface
-    return ClosingContextProxy(SimpleClient(
-        hosts=settings.KAFKA_BROKERS,
-        client_id=client_id,
-        timeout=30,  # seconds
-    ))
 
 
 def get_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
@@ -22,3 +12,19 @@ def get_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
         client_id=client_id,
         api_version=settings.KAFKA_API_VERSION
     )
+
+
+def get_kafka_admin_client(client_id=GENERIC_KAFKA_CLIENT_ID) -> KafkaAdminClient:
+    return ClosingContextProxy(KafkaAdminClient(
+        bootstrap_servers=settings.KAFKA_BROKERS,
+        client_id=client_id,
+        api_version=settings.KAFKA_API_VERSION
+    ))
+
+
+def get_kafka_consumer() -> KafkaConsumer:
+    return ClosingContextProxy(KafkaConsumer(
+        client_id='pillowtop_utils',
+        bootstrap_servers=settings.KAFKA_BROKERS,
+        request_timeout_ms=1000
+    ))

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -4,7 +4,7 @@ from copy import copy
 from django.conf import settings
 
 from kafka import KafkaConsumer
-from kafka.common import TopicPartition
+from kafka.structs import TopicPartition
 
 from dimagi.utils.logging import notify_error
 from pillowtop.checkpoints.manager import PillowCheckpointEventHandler

--- a/corehq/apps/change_feed/management/commands/create_kafka_topics.py
+++ b/corehq/apps/change_feed/management/commands/create_kafka_topics.py
@@ -1,7 +1,7 @@
 from django.core.management import BaseCommand
 
 from corehq.apps.change_feed import topics
-from corehq.apps.change_feed.connection import get_simple_kafka_client
+from corehq.apps.change_feed.connection import get_kafka_admin_client
 
 
 class Command(BaseCommand):
@@ -11,11 +11,12 @@ class Command(BaseCommand):
 
 
 def create_kafka_topics():
-    with get_simple_kafka_client() as client:
-        for topic in topics.ALL:
-            if client.has_metadata_for_topic(topic):
-                status = "already exists"
-            else:
-                client.ensure_topic_exists(topic, timeout=10)
-                status = "created"
-            print("topic {}: {}".format(status, topic))
+    with get_kafka_admin_client() as client:
+        existing_topics = set(client.list_topics())
+        new_topics = set(topics.ALL) - existing_topics
+        if not new_topics:
+            print('All topics exists')
+            return
+
+        client.create_topics(list(new_topics), timeout_ms=10 * 1000)
+        print(f"Topics created: {','.join(new_topics)}")

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -5,7 +5,6 @@ from django.test import SimpleTestCase, TestCase
 
 from fakecouch import FakeCouchDb
 from kafka import KafkaConsumer
-from kafka.common import KafkaUnavailableError
 from mock import patch
 
 from pillowtop.dao.exceptions import DocumentMismatchError

--- a/corehq/apps/change_feed/tests/utils.py
+++ b/corehq/apps/change_feed/tests/utils.py
@@ -3,7 +3,7 @@ import uuid
 from django.conf import settings
 
 from kafka import KafkaConsumer
-from kafka.common import KafkaUnavailableError
+from kafka.errors import KafkaUnavailableError
 from nose.tools import nottest
 
 from corehq.util.test_utils import trap_extra_setup

--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -24,7 +24,7 @@ from celery import Celery
 from soil import heartbeat
 
 from corehq.apps.app_manager.models import Application
-from corehq.apps.change_feed.connection import get_kafka_client
+from corehq.apps.change_feed.connection import get_kafka_client, get_kafka_consumer
 from corehq.apps.es import GroupES
 from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.apps.hqadmin.escheck import check_es_cluster_health
@@ -105,12 +105,13 @@ def check_rabbitmq(broker_url):
 def check_kafka():
     try:
         client = get_kafka_client()
+        consumer = get_kafka_consumer()
     except Exception as e:
         return ServiceStatus(False, "Could not connect to Kafka: %s" % e)
 
     if len(client.cluster.brokers()) == 0:
         return ServiceStatus(False, "No Kafka brokers found")
-    elif len(client.cluster.topics()) == 0:
+    elif len(consumer.topics()) == 0:
         return ServiceStatus(False, "No Kafka topics found")
     else:
         return ServiceStatus(True, "Kafka seems to be in order")

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.db import transaction
-from kafka.common import TopicPartition
+from kafka.structs import TopicPartition
 
 from pillowtop.exceptions import PillowtopCheckpointReset
 from pillowtop.logger import pillow_logging

--- a/corehq/ex-submodules/pillowtop/models.py
+++ b/corehq/ex-submodules/pillowtop/models.py
@@ -1,6 +1,6 @@
 import json
 from django.db import models
-from kafka.common import TopicPartition
+from kafka.structs import TopicPartition
 
 SEQUENCE_FORMATS = (
     ('text', 'text'),

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -12,7 +12,7 @@ from sentry_sdk import configure_scope
 from corehq.util.datadog.gauges import datadog_counter, datadog_gauge, datadog_histogram
 from corehq.util.timer import TimingContext
 from dimagi.utils.logging import notify_exception
-from kafka.common import TopicPartition
+from kafka.structs import TopicPartition
 from pillowtop.const import CHECKPOINT_MIN_WAIT
 from pillowtop.dao.exceptions import DocumentMissingError
 from pillowtop.utils import force_seq_int

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -17,6 +17,7 @@ services:
       - redis
       - elasticsearch
       - kafka
+      - zookeeper
       - minio
     expose:
       - 8000

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -61,6 +61,11 @@ services:
       file: hq-compose-services.yml
       service: elasticsearch
 
+  zookeeper:
+    extends:
+      file: hq-compose-services.yml
+      service: zookeeper
+
   kafka:
     extends:
       file: hq-compose-services.yml

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -54,10 +54,16 @@ services:
       file: hq-compose.yml
       service: kafka
     environment:
-      ADVERTISED_HOST: ${KAFKA_ADVERTISED_HOST_NAME}
+      KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
+    ports:
+      - "9092:9092"
+
+  zookeeper:
+    extends:
+      file: hq-compose.yml
+      service: zookeeper
     ports:
       - "2181:2181"
-      - "9092:9092"
 
   minio:
     extends:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -79,16 +79,23 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-elasticsearch:}/usr/share/elasticsearch/data
 
-  kafka:
-    image: spotify/kafka
-    environment:
-      ADVERTISED_PORT: 9092
-    expose:
-      - "2181"
-      - "9092"
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
     volumes:
-      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/tmp/kafka-logs
-      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/var/lib/zookeeper
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.4.13/data
+
+  kafka:
+      image: wurstmeister/kafka:0.8.2.2
+      ports:
+        - "9092:9092"
+      environment:
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_BROKER_ID: 1
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/kafka/kafka-logs-1
 
   minio:
     image: minio/minio

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -24,6 +24,7 @@ services:
       - redis
       - elasticsearch
       - kafka
+      - zookeeper
       - minio
     volumes:
       - ..:/mnt/commcare-hq-ro${RO}

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -106,7 +106,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -90,7 +90,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -85,7 +85,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -93,7 +93,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -106,7 +106,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -90,7 +90,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -25,7 +25,7 @@ eulxml==1.1.3
 ghdiff==0.4
 gunicorn
 lxml~=4.3.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 mock==2.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,7 +85,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -93,7 +93,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==2.0.1
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2

--- a/testapps/test_pillowtop/tests/test_chunk_pillow.py
+++ b/testapps/test_pillowtop/tests/test_chunk_pillow.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.test import TestCase
-from kafka.common import KafkaUnavailableError
+from kafka.errors import KafkaUnavailableError
 from mock import MagicMock
 
 from corehq.apps.change_feed import topics


### PR DESCRIPTION
##### SUMMARY
We're seeing a number of errors publishing to Kafka on ICDS and hoping that this upgrade will help.

The library claims compatibility with the version of Kafka we are using in production (0.8.2.2) but to make sure I have also updated the Docker images to use the same version (previously they were 0.10.1.0).