### PR TITLE
Give us more flexibility in handling projects' acute rate-limiting problems

### DIFF
--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -27,7 +27,7 @@ from corehq.util.timer import TimingContext
 
 submission_rate_limiter = RateLimiter(
     feature_key='submissions',
-    get_rate_limits=PerUserRateDefinition(
+    get_rate_limits=lambda domain: PerUserRateDefinition(
         per_user_rate_definition=get_dynamic_rate_definition(
             'submissions_per_user',
             default=get_standard_ratio_rate_definition(events_per_day=46),
@@ -42,7 +42,7 @@ submission_rate_limiter = RateLimiter(
                 per_second=1,
             ),
         ),
-    ).get_rate_limits
+    ).get_rate_limits(domain)
 )
 
 global_submission_rate_limiter = RateLimiter(

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -25,19 +25,22 @@ from corehq.util.timer import TimingContext
 # If we as a team end up regretting this decision, we'll have to reset expectations
 # with the Dimagi NDoH team.
 
-SUBMISSIONS_PER_DAY = 46
-
 submission_rate_limiter = RateLimiter(
     feature_key='submissions',
     get_rate_limits=PerUserRateDefinition(
-        per_user_rate_definition=get_standard_ratio_rate_definition(
-            events_per_day=SUBMISSIONS_PER_DAY),
-        constant_rate_definition=RateDefinition(
-            per_week=100,
-            per_day=50,
-            per_hour=30,
-            per_minute=10,
-            per_second=1,
+        per_user_rate_definition=get_dynamic_rate_definition(
+            'submissions_per_user',
+            default=get_standard_ratio_rate_definition(events_per_day=46),
+        ),
+        constant_rate_definition=get_dynamic_rate_definition(
+            'baseline_submissions_per_project',
+            default=RateDefinition(
+                per_week=100,
+                per_day=50,
+                per_hour=30,
+                per_minute=10,
+                per_second=1,
+            ),
         ),
     ).get_rate_limits
 )

--- a/corehq/apps/receiverwrapper/rate_limiter.py
+++ b/corehq/apps/receiverwrapper/rate_limiter.py
@@ -25,9 +25,15 @@ from corehq.util.timer import TimingContext
 # If we as a team end up regretting this decision, we'll have to reset expectations
 # with the Dimagi NDoH team.
 
+
 submission_rate_limiter = RateLimiter(
     feature_key='submissions',
-    get_rate_limits=lambda domain: PerUserRateDefinition(
+    get_rate_limits=lambda domain: _get_per_user_submission_rate_definition(domain)
+)
+
+
+def _get_per_user_submission_rate_definition(domain):
+    return PerUserRateDefinition(
         per_user_rate_definition=get_dynamic_rate_definition(
             'submissions_per_user',
             default=get_standard_ratio_rate_definition(events_per_day=46),
@@ -43,7 +49,7 @@ submission_rate_limiter = RateLimiter(
             ),
         ),
     ).get_rate_limits(domain)
-)
+
 
 global_submission_rate_limiter = RateLimiter(
     feature_key='global_submissions',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1731,18 +1731,15 @@ ICDS_GOVERNANCE_DASHABOARD_API = StaticToggle(
     relevant_environments={'icds', 'india'},
 )
 
-RATE_LIMIT_SUBMISSIONS = DynamicallyPredictablyRandomToggle(
-    'rate_limit_submissions',
-    'Rate limit submissions with a 429 TOO MANY REQUESTS response',
+DO_NOT_RATE_LIMIT_SUBMISSIONS = StaticToggle(
+    'do_not_rate_limit_submissions',
+    'Do not rate limit submissions for this project, on a temporary basis.',
     TAG_INTERNAL,
     [NAMESPACE_DOMAIN],
     description="""
-    While we are gaining an understanding of the effects of rate limiting,
-    we want to force rate limiting on certain domains, while also being to
-    toggle on and off global rate limiting quickly in response to issues.
-
-    To turn on global rate limiting, set Randomness Level to 1.
-    To turn it off, set to 0.
+    When an individual project is having problems with rate limiting,
+    use this toggle to lift the restriction for them on a temporary basis,
+    just to unblock them while we sort out the conversation with the client.
     """
 )
 


### PR DESCRIPTION
##### SUMMARY
- Allow us to adjust the coefficients involved in calculating projects' submission limits. Changing the coefficients applies to _all_ projects, so it's not a targeted way of unblocking a single project
- Allow us to turn off rate limiting for a single project using a new `DO_NOT_RATE_LIMIT_SUBMISSIONS` toggle, which should be used on a temporary basis while engaging with the client.
