### PR TITLE
Fix downgrade triggers

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -767,8 +767,7 @@ def get_unpaid_invoices_over_threshold_by_domain(today, domain):
 
 def _get_unpaid_saas_invoices_in_downgrade_daterange(today):
     return _get_all_unpaid_saas_invoices().filter(
-        date_due__lte=today - datetime.timedelta(days=1),
-        date_due__gte=today - datetime.timedelta(days=61)
+        date_due__lte=today - datetime.timedelta(days=1)
     ).order_by('date_due').select_related('subscription__subscriber')
 
 
@@ -846,7 +845,7 @@ def _apply_downgrade_process(oldest_unpaid_invoice, total, today, subscription=N
         })
 
     days_ago = (today - oldest_unpaid_invoice.date_due).days
-    if days_ago == 61:
+    if days_ago >= 61:
         if not oldest_unpaid_invoice.is_customer_invoice:  # We do not automatically downgrade customer invoices
             _downgrade_domain(subscription)
             _send_downgrade_notice(oldest_unpaid_invoice, context)

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -811,8 +811,10 @@ def get_accounts_with_customer_invoices_over_threshold(today):
 
 def is_subscription_eligible_for_downgrade_process(subscription):
     return (
-        subscription.plan_version.plan.edition != SoftwarePlanEdition.COMMUNITY
-        and not subscription.skip_auto_downgrade
+        subscription.plan_version.plan.edition not in [
+            SoftwarePlanEdition.COMMUNITY,
+            SoftwarePlanEdition.PAUSED,
+        ] and not subscription.skip_auto_downgrade
     )
 
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10296

##### SUMMARY
It appears that we cap "eligible overdue invoices" at 61 days and also ONLY apply the downgrade process when an overdue invoice is exactly 61 days old.

This means if a domain's subscription that was once `skip_autodowngrade=True` and is now `skip_autodowngrade=False`, it's older invoices no longer qualify it for the downgrade process. Additionally, if the task FAILS to run for any reason on day 61, then there is never an option the following day to downgrade a domain until the next unpaid invoice reaches 61 days of age.

Anyway, this fixes the shenanigans so that the downgrade script runs as expected. FYI, this issue is nearly 2 years old. 👀 