### PR TITLE
kafka client upgrade

### DIFF
--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -17,6 +17,7 @@ services:
       - redis
       - elasticsearch
       - kafka
+      - zookeeper
       - minio
     expose:
       - 8000

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: "${DOCKERFILE}"
     environment:
       COMMCAREHQ_BOOTSTRAP: "yes"
-      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 kafka:9092 elasticsearch:9200 minio:9980"
+      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 elasticsearch:9200 minio:9980 kafka:9092"
       DOCKER_HQ_OVERLAY: "${DOCKER_HQ_OVERLAY}"
     privileged: true  # allows mount inside container
     command: [runserver]

--- a/docker/hq-compose-runserver.yml
+++ b/docker/hq-compose-runserver.yml
@@ -61,6 +61,11 @@ services:
       file: hq-compose-services.yml
       service: elasticsearch
 
+  zookeeper:
+    extends:
+      file: hq-compose-services.yml
+      service: zookeeper
+
   kafka:
     extends:
       file: hq-compose-services.yml

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -54,10 +54,16 @@ services:
       file: hq-compose.yml
       service: kafka
     environment:
-      ADVERTISED_HOST: ${KAFKA_ADVERTISED_HOST_NAME}
+      KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
+    ports:
+      - "9092:9092"
+
+  zookeeper:
+    extends:
+      file: hq-compose.yml
+      service: zookeeper
     ports:
       - "2181:2181"
-      - "9092:9092"
 
   minio:
     extends:

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: "${DOCKERFILE}"
     environment:
-      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 kafka:9092 elasticsearch:9200 minio:9980"
+      DEPENDENT_SERVICES: "couch:5984 postgres:5432 redis:6379 elasticsearch:9200 minio:9980 kafka:9092"
       DOCKER_HQ_OVERLAY: "${DOCKER_HQ_OVERLAY}"
       JS_SETUP: "${JS_SETUP}"
       PYTHON_VERSION: "${PYTHON_VERSION}"

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -79,16 +79,23 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-elasticsearch:}/usr/share/elasticsearch/data
 
-  kafka:
-    image: spotify/kafka
-    environment:
-      ADVERTISED_PORT: 9092
-    expose:
-      - "2181"
-      - "9092"
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
     volumes:
-      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/tmp/kafka-logs
-      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/var/lib/zookeeper
+      - ${VOLUME_PREFIX}${BLANK_IF_TESTS-zookeeper:}/opt/zookeeper-3.4.13/data
+
+  kafka:
+      image: wurstmeister/kafka:0.8.2.2
+      ports:
+        - "9092:9092"
+      environment:
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_BROKER_ID: 1
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - ${VOLUME_PREFIX}${BLANK_IF_TESTS-kafka:}/kafka/kafka-logs-1
 
   minio:
     image: minio/minio

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -24,6 +24,7 @@ services:
       - redis
       - elasticsearch
       - kafka
+      - zookeeper
       - minio
     volumes:
       - ..:/mnt/commcare-hq-ro${RO}

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -106,7 +106,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -90,7 +90,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -85,7 +85,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -93,7 +93,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -106,7 +106,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -90,7 +90,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -25,7 +25,7 @@ eulxml==1.1.3
 ghdiff==0.4
 gunicorn
 lxml~=4.3.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 mock==2.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,7 +85,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 lxml==4.3.5

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -93,7 +93,7 @@ jsonfield==1.0.3
 jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
-kafka-python==1.4.4
+kafka-python==1.4.7
 kombu==4.2.2.post1
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2


### PR DESCRIPTION
#### SUMMARY
We're seeing a number of errors publishing to Kafka on ICDS and hoping that this upgrade will help.

The library claims compatibility with the version of Kafka we are using in production (0.8.2.2) but to make sure I have also updated the Docker images to use the same version (previously they were 
0.10.1.0).

Changelog: https://kafka-python.readthedocs.io/en/1.4.7/changelog.html

(reworking https://github.com/dimagi/commcare-hq/pull/26718)