### PR TITLE
Change OpenMRS visit duration from 24 hours to 12 hours

### DIFF
--- a/corehq/motech/openmrs/const.py
+++ b/corehq/motech/openmrs/const.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from itertools import chain
 
 from django.utils.translation import ugettext_lazy as _
@@ -8,6 +9,8 @@ LOG_LEVEL_CHOICES = (
     (logging.ERROR, 'Error'),
     (logging.INFO, 'Info'),
 )
+
+VISIT_DURATION = timedelta(hours=12)
 
 IMPORT_FREQUENCY_DAILY = 'daily'
 IMPORT_FREQUENCY_WEEKLY = 'weekly'

--- a/corehq/motech/openmrs/tests/test_workflow_tasks.py
+++ b/corehq/motech/openmrs/tests/test_workflow_tasks.py
@@ -69,7 +69,7 @@ def test_start_stop_datetime_export():
         OpenmrsFormConfig.wrap(form_config_dict)
     )
     eq(start_datetime, "2018-01-01T12:00:00.000+0000")
-    eq(stop_datetime, "2018-01-02T11:59:59.000+0000")
+    eq(stop_datetime, "2018-01-02T00:00:00.000+0000")
 
 
 def test_start_stop_datetime_import():
@@ -93,7 +93,7 @@ def test_start_stop_datetime_import():
         OpenmrsFormConfig.wrap(form_config_dict)
     )
     eq(start_datetime, "2019-12-16T12:36:00.000+0000")
-    eq(stop_datetime, "2019-12-17T12:35:59.000+0000")
+    eq(stop_datetime, "2019-12-17T00:36:00.000+0000")
 
 
 class GetValuesForConceptTests(SimpleTestCase):

--- a/corehq/motech/openmrs/workflow_tasks.py
+++ b/corehq/motech/openmrs/workflow_tasks.py
@@ -9,6 +9,7 @@ from corehq.motech.openmrs.const import (
     NAME_PROPERTIES,
     PERSON_PROPERTIES,
     PERSON_UUID_IDENTIFIER_TYPE_ID,
+    VISIT_DURATION,
 )
 from corehq.motech.openmrs.openmrs_config import ALL_CONCEPTS
 from corehq.motech.openmrs.repeater_helpers import (
@@ -154,7 +155,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
                         'A form config for form XMLNS "{}" uses "openmrs_start_datetime" to get the start of '
                         'the visit but an invalid value was found in the form.'.format(form_config.xmlns)
                     )
-                cc_stop_datetime = cc_start_datetime + timedelta(days=1) - timedelta(seconds=1)
+                cc_stop_datetime = cc_start_datetime + VISIT_DURATION
                 # We need to serialize both values with the data type of
                 # openmrs_start_datetime because they could be either
                 # OpenMRS datetimes or OpenMRS dates, and their data
@@ -163,7 +164,7 @@ class CreateVisitsEncountersObsTask(WorkflowTask):
                 stop_datetime = value_source.serialize(cc_stop_datetime)
                 return start_datetime, stop_datetime
         cc_start_datetime = string_to_utc_datetime(self.form_json['form']['meta']['timeEnd'])
-        cc_stop_datetime = cc_start_datetime + timedelta(days=1) - timedelta(seconds=1)
+        cc_stop_datetime = cc_start_datetime + VISIT_DURATION
         start_datetime = to_omrs_datetime(cc_start_datetime)
         stop_datetime = to_omrs_datetime(cc_stop_datetime)
         return start_datetime, stop_datetime


### PR DESCRIPTION
##### SUMMARY
This issue was raised by Partners In Health, who have a deep understanding about how OpenMRS Visit instances ought to be managed.

This change is a halfway improvement, and is a crude reproduction of how their Visit management works.

The next change will be to set the visit duration from the `timeStart` to the `timeEnd` of the first form submitted for an individual on a day, and then to extend that visit to the `timeEnd` of each subsequent form submission for that individual on that day. That change will be done in a future sprint.

##### FEATURE FLAG
OpenMRS integration
