### PR TITLE
fix kafka service check

### DIFF
--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -17,11 +17,11 @@ def get_simple_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
 
 
 def get_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
-    return KafkaClient(
+    return ClosingContextProxy(KafkaClient(
         bootstrap_servers=settings.KAFKA_BROKERS,
         client_id=client_id,
         api_version=settings.KAFKA_API_VERSION
-    )
+    ))
 
 
 def get_kafka_consumer():

--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 
-from kafka.client import KafkaClient, SimpleClient
-
 from corehq.util.io import ClosingContextProxy
+from kafka import KafkaConsumer
+from kafka.client import KafkaClient, SimpleClient
 
 GENERIC_KAFKA_CLIENT_ID = 'cchq-kafka-client'
 
@@ -22,3 +22,11 @@ def get_kafka_client(client_id=GENERIC_KAFKA_CLIENT_ID):
         client_id=client_id,
         api_version=settings.KAFKA_API_VERSION
     )
+
+
+def get_kafka_consumer():
+    return ClosingContextProxy(KafkaConsumer(
+        client_id='pillowtop_utils',
+        bootstrap_servers=settings.KAFKA_BROKERS,
+        request_timeout_ms=1000
+    ))

--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -112,12 +112,15 @@ def check_kafka():
     except Exception as e:
         return ServiceStatus(False, "Could not connect to Kafka: %s" % e)
 
-    if len(client.cluster.brokers()) == 0:
-        return ServiceStatus(False, "No Kafka brokers found")
-    elif len(consumer.topics()) == 0:
-        return ServiceStatus(False, "No Kafka topics found")
-    else:
-        return ServiceStatus(True, "Kafka seems to be in order")
+    with client:
+        if len(client.cluster.brokers()) == 0:
+            return ServiceStatus(False, "No Kafka brokers found")
+
+    with consumer:
+        if len(consumer.topics()) == 0:
+            return ServiceStatus(False, "No Kafka topics found")
+
+    return ServiceStatus(True, "Kafka seems to be in order")
 
 
 @change_log_level('urllib3.connectionpool', logging.WARNING)

--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -7,7 +7,6 @@ import logging
 import re
 import time
 import uuid
-import urllib3
 from io import BytesIO
 
 from django.conf import settings
@@ -16,15 +15,19 @@ from django.core import cache
 from django.db import connections
 from django.db.utils import OperationalError
 
-import attr
-import gevent
 import requests
-from celery import Celery
+import urllib3
 
 from soil import heartbeat
 
+import attr
+import gevent
+from celery import Celery
 from corehq.apps.app_manager.models import Application
-from corehq.apps.change_feed.connection import get_kafka_client
+from corehq.apps.change_feed.connection import (
+    get_kafka_client,
+    get_kafka_consumer,
+)
 from corehq.apps.es import GroupES
 from corehq.apps.formplayer_api.utils import get_formplayer_url
 from corehq.apps.hqadmin.escheck import check_es_cluster_health
@@ -105,12 +108,13 @@ def check_rabbitmq(broker_url):
 def check_kafka():
     try:
         client = get_kafka_client()
+        consumer = get_kafka_consumer()
     except Exception as e:
         return ServiceStatus(False, "Could not connect to Kafka: %s" % e)
 
     if len(client.cluster.brokers()) == 0:
         return ServiceStatus(False, "No Kafka brokers found")
-    elif len(client.cluster.topics()) == 0:
+    elif len(consumer.topics()) == 0:
         return ServiceStatus(False, "No Kafka topics found")
     else:
         return ServiceStatus(True, "Kafka seems to be in order")

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -6,8 +6,6 @@ from operator import methodcaller
 
 from django.conf import settings
 
-from kafka import KafkaConsumer
-
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.modules import to_function
 from pillowtop.dao.exceptions import (
@@ -17,7 +15,7 @@ from pillowtop.dao.exceptions import (
 from pillowtop.exceptions import PillowNotFoundError
 from pillowtop.logger import pillow_logging
 
-from corehq.util.io import ClosingContextProxy
+from corehq.apps.change_feed.connection import get_kafka_consumer
 
 
 def _get_pillow_instance(full_class_str):
@@ -145,21 +143,13 @@ def safe_force_seq_int(seq, default=None):
         return default
 
 
-def _get_consumer():
-    return ClosingContextProxy(KafkaConsumer(
-        client_id='pillowtop_utils',
-        bootstrap_servers=settings.KAFKA_BROKERS,
-        request_timeout_ms=1000
-    ))
-
-
 def get_all_pillows_json(active_only=True):
     pillow_configs = get_all_pillow_configs()
     active_pillows = getattr(settings, 'ACTIVE_PILLOW_NAMES', None)
     if active_only and active_pillows:
         pillow_configs = [config for config in pillow_configs if config.name in active_pillows]
 
-    consumer = _get_consumer()
+    consumer = get_kafka_consumer()
     with consumer:
         return [get_pillow_json(pillow_config, consumer) for pillow_config in pillow_configs]
 
@@ -172,7 +162,7 @@ def get_pillow_json(pillow_config, consumer=None):
 
     pillow = pillow_config.get_instance()
     if consumer is None:
-        consumer = _get_consumer()
+        consumer = get_kafka_consumer()
 
     checkpoint = pillow.get_checkpoint()
     timestamp = checkpoint.timestamp


### PR DESCRIPTION
##### SUMMARY
The library changed how some of the API works which resulted in `client.cluster.topics()` not being populated during init. The code to populate it is a bit complex so making use of the consumer to get the topics instead.

I noticed this issue when upgrading to 2.0.1 but didn't test it with the upgrade from 1.4.4 to 1.4.7 (naively assuming it would be the same).