### PR TITLE
Track lag by kafka partition

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -196,6 +196,7 @@ def change_from_kafka_message(message):
         metadata=change_meta,
         document_store=document_store,
         topic=message.topic,
+        partition=message.partition,
     )
 
 

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -49,11 +49,12 @@ class Change(object):
     }
 
     def __init__(self, id, sequence_id, document=None, deleted=False, metadata=None,
-                 document_store=None, topic=None):
+                 document_store=None, topic=None, partition=None):
         self._dict = {}
         self.id = id
         self.sequence_id = sequence_id
         self.topic = topic
+        self.partition = partition
         self.document = document
         # on couch-based change feeds .deleted represents a hard deletion.
         # on kafka-based feeds, .deleted represents a soft deletion and is equivalent

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -371,7 +371,10 @@ class PillowBase(metaclass=ABCMeta):
             change_lag = (datetime.utcnow() - change.metadata.publish_timestamp).total_seconds()
             datadog_gauge('commcare.change_feed.change_lag', change_lag, tags=[
                 'pillow_name:{}'.format(self.get_name()),
-                _topic_for_ddog(change.partition if change.partition else change.topic),
+                _topic_for_ddog(
+                    TopicPartition(change.topic, change.partition)
+                    if change.partition else change.topic
+                ),
             ])
 
             if processing_time:

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -373,7 +373,7 @@ class PillowBase(metaclass=ABCMeta):
                 'pillow_name:{}'.format(self.get_name()),
                 _topic_for_ddog(
                     TopicPartition(change.topic, change.partition)
-                    if change.partition else change.topic
+                    if change.partition is not None else change.topic
                 ),
             ])
 

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -371,7 +371,7 @@ class PillowBase(metaclass=ABCMeta):
             change_lag = (datetime.utcnow() - change.metadata.publish_timestamp).total_seconds()
             datadog_gauge('commcare.change_feed.change_lag', change_lag, tags=[
                 'pillow_name:{}'.format(self.get_name()),
-                _topic_for_ddog(change.topic),
+                _topic_for_ddog(change.partition if change.partition else change.topic),
             ])
 
             if processing_time:

--- a/corehq/ex-submodules/pillowtop/tests/test_metrics.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_metrics.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.test import SimpleTestCase, override_settings
+from kafka import TopicPartition
 
 from corehq.util.test_utils import patch_datadog
 from pillowtop.feed.interface import Change, ChangeMeta
@@ -35,6 +36,21 @@ class TestPillowMetrics(SimpleTestCase):
             'commcare.change_feed.processing_time.processor:all_processors',
         })
 
+    def test_basic_metrics_with_partition(self):
+        stats = self._get_stats([self._get_change_with_partition()])
+        self.assertEqual(set(stats), {
+            'commcare.change_feed.changes.count.datasource:test_commcarehq',
+            'commcare.change_feed.changes.count.is_deletion:False',
+            'commcare.change_feed.changes.count.pillow_name:fake pillow',
+            'commcare.change_feed.changes.count.processor:all_processors',
+            'commcare.change_feed.change_lag.pillow_name:fake pillow',
+            'commcare.change_feed.change_lag.topic:case-1',
+            'commcare.change_feed.processing_time.datasource:test_commcarehq',
+            'commcare.change_feed.processing_time.is_deletion:False',
+            'commcare.change_feed.processing_time.pillow_name:fake pillow',
+            'commcare.change_feed.processing_time.processor:all_processors',
+        })
+
     @override_settings(ENTERPRISE_MODE=True)
     def test_case_type_metrics(self):
         stats = self._get_stats([self._get_change()])
@@ -61,6 +77,24 @@ class TestPillowMetrics(SimpleTestCase):
             doc_id,
             'seq',
             topic=topic,
+            metadata=ChangeMeta(
+                data_source_type='couch',
+                data_source_name='test_commcarehq',
+                document_id=doc_id,
+                document_type=doc_type,
+                document_subtype=doc_subtype,
+                is_deletion=False,
+
+            )
+        )
+
+    def _get_change_with_partition(self, topic='case', doc_type='CommCareCase', doc_subtype='person'):
+        doc_id = uuid.uuid4().hex
+        return Change(
+            doc_id,
+            'seq',
+            topic=topic,
+            partition=TopicPartition(topic, 1),
             metadata=ChangeMeta(
                 data_source_type='couch',
                 data_source_name='test_commcarehq',

--- a/corehq/ex-submodules/pillowtop/tests/test_metrics.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_metrics.py
@@ -1,7 +1,6 @@
 import uuid
 
 from django.test import SimpleTestCase, override_settings
-from kafka import TopicPartition
 
 from corehq.util.test_utils import patch_datadog
 from pillowtop.feed.interface import Change, ChangeMeta
@@ -94,7 +93,7 @@ class TestPillowMetrics(SimpleTestCase):
             doc_id,
             'seq',
             topic=topic,
-            partition=TopicPartition(topic, 1),
+            partition=1,
             metadata=ChangeMeta(
                 data_source_type='couch',
                 data_source_name='test_commcarehq',


### PR DESCRIPTION
##### SUMMARY
This will let us separately track each topic partition's lag, making each one a fairly continuous line, instead of jumping back and forth between the values of all the partitions. In practice currently, we find that they can be hours apart.

I'm also hoping the next step will be to save the last value for each partition in redis, and use that as part of the control system that gauges whether to rate limit and based on what: when there's case lag, rate limit based on cases changed; when there's form lag rate limit based on forms submitted. Having specific warning signs like this that the system can react to itself allows us to encode how we'd like to trade off different SLAs against one another in times of stress without a dev needing to be present to poke the system.
