### PR TITLE
UCR Transforms to display a doc_id column as View Form/Case link

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1837,6 +1837,51 @@ Rounds decimal and floating point numbers to two decimal places.
        "custom_type": "short_decimal_display"
    }
 
+
+Prefix a string
+~~~~~~~~~~~~~~~
+
+Prefixes the column value with another string
+
+.. code:: json
+	{
+        "type": "prefix_string",
+        "prefix": "hello "
+    }
+
+Convert into a link
+~~~~~~~~~~~~~~~~~~~
+
+Display a text as a hyperlink
+
+.. code:: json
+
+   {
+       "type": "hyperlink",
+       "link_text": "View Form",
+   }
+
+
+Nesting Transforms
+~~~~~~~~~~~~~~~~~~
+
+Any of above transforms can be nested like below. For example to convert a doc_id
+column into a 'View Form' hyperlink
+
+.. code:: json
+	{
+        "type": "nested",
+        "inner_expression": {
+            "type": "prefix_string",
+            "prefix": "http://my_hq_link/"
+        },
+        "outer_expression": {
+            "type": "hyperlink",
+            "link_text": "View Form"
+        },
+    }
+
+
 Generic number formatting
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/corehq/apps/userreports/tests/test_transforms.py
+++ b/corehq/apps/userreports/tests/test_transforms.py
@@ -221,3 +221,43 @@ class MultiValueStringTranslationTransform(SimpleTestCase):
         self.assertEqual(transform('#800080 #123456'), 'Purple #123456')
         self.assertEqual(transform('#123 #123456'), '#123 #123456')
         self.assertEqual(transform("#0000FF"), "Blue")
+
+
+class TestPrefixStringTransform(SimpleTestCase):
+
+    def test_basic(self):
+        transform = TransformFactory.get_transform({
+            "type": "prefix_string",
+            "prefix": "hello "
+        }).get_transform_function()
+
+        self.assertEqual(transform("world"), 'hello world')
+
+
+class TestHyperlinkTransform(SimpleTestCase):
+
+    def test_basic(self):
+        transform = TransformFactory.get_transform({
+            "type": "hyperlink",
+            "link_text": "View Form",
+        }).get_transform_function()
+
+        self.assertEqual(transform("http://my_hq_link"), "<a href='http://my_hq_link'>View Form</a>")
+
+
+class NestedTransform(SimpleTestCase):
+
+    def test_basic(self):
+        transform = TransformFactory.get_transform({
+            "type": "nested",
+            "inner_expression": {
+                "type": "prefix_string",
+                "prefix": "http://my_hq_link/"
+            },
+            "outer_expression": {
+                "type": "hyperlink",
+                "link_text": "View Form"
+            },
+        }).get_transform_function()
+
+        self.assertEqual(transform('my_doc_id'), "<a href='http://my_hq_link/my_doc_id'>View Form</a>")

--- a/corehq/apps/userreports/transforms/factory.py
+++ b/corehq/apps/userreports/transforms/factory.py
@@ -5,32 +5,18 @@ from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
 
 from corehq.apps.userreports.exceptions import BadSpecError
-from corehq.apps.userreports.transforms.specs import (
-    CustomTransform,
-    DateFormatTransform,
-    MultipleValueStringTranslationTransform,
-    NumberFormatTransform,
-    TranslationTransform,
-)
+from corehq.apps.userreports.transforms.specs import TRANSFORM_SPEC_MAP
 
 
 class TransformFactory(object):
-    spec_map = {
-        'custom': CustomTransform,
-        'date_format': DateFormatTransform,
-        'number_format': NumberFormatTransform,
-        'translation': TranslationTransform,
-        'multiple_value_string_translation': MultipleValueStringTranslationTransform
-    }
-
     @classmethod
     def get_transform(cls, spec):
         try:
-            return cls.spec_map[spec['type']].wrap(spec)
+            return TRANSFORM_SPEC_MAP[spec['type']].wrap(spec)
         except KeyError:
             raise BadSpecError(_('Invalid or missing transform type: {}. Valid options are: {}').format(
                 spec.get('type', None),
-                ', '.join(cls.spec_map),
+                ', '.join(TRANSFORM_SPEC_MAP),
             ))
         except BadValueError as e:
             raise BadSpecError(_('Problem creating transform: {}. Message is: {}').format(


### PR DESCRIPTION
This adds ability to turn any UCR into a sort of Submit History/Case-List report. Needed on ICDS as UCR reports are much faster than the ES ones and as a fallback.