### PR TITLE
Add new USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER option

### DIFF
--- a/corehq/apps/change_feed/partitioners.py
+++ b/corehq/apps/change_feed/partitioners.py
@@ -1,0 +1,60 @@
+from memoized import memoized
+
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.connection import get_kafka_consumer
+from corehq.util.quickcache import quickcache
+from pillowtop import get_pillow_by_name, get_all_pillow_configs
+
+
+TOPIC_TO_PILLOW_NAME_MAP = {
+    topics.CASE: 'case-pillow',
+    topics.CASE_SQL: 'case-pillow',
+    topics.FORM: 'xform-pillow',
+    topics.FORM_SQL: 'xform-pillow',
+}
+
+
+def choose_best_partition_for_topic(topic):
+    if topic not in _get_topic_to_pillow_map():
+        # None means there's no best, use the default
+        return None
+
+    backlog_lengths_by_partition = _get_backlog_lengths_by_partition(topic)
+    _, best_partition = min(
+        (backlog_length, partition)
+        for partition, backlog_length in backlog_lengths_by_partition.items()
+    )
+    return best_partition
+
+
+@quickcache(['topic'], memoize_timeout=10, timeout=10)
+def _get_backlog_lengths_by_partition(topic):
+    assert topic in _get_topic_to_pillow_map(), \
+        f"Allowed topics are {', '.join(_get_topic_to_pillow_map().keys())}"
+
+    pillow = _get_topic_to_pillow_map()[topic]
+    seq_by_topic_partition = {
+        topic_partition: seq
+        for topic_partition, seq in pillow.get_checkpoint().wrapped_sequence.items()
+        if topic_partition.topic == topic
+    }
+    backlog_length_by_partition = {}
+
+    with get_kafka_consumer() as consumer:
+        offset_by_topic_partition = consumer.end_offsets(seq_by_topic_partition.keys())
+
+    for key in set(seq_by_topic_partition) | set(offset_by_topic_partition):
+        topic, partition = key
+        backlog_length_by_partition[partition] = (
+            offset_by_topic_partition[key] - seq_by_topic_partition[key])
+    return backlog_length_by_partition
+
+
+@memoized
+def _get_topic_to_pillow_map():
+    all_pillow_names = {config.name for config in get_all_pillow_configs()}
+    return {
+        topic: get_pillow_by_name(pillow_name)
+        for topic, pillow_name in TOPIC_TO_PILLOW_NAME_MAP.items()
+        if pillow_name in all_pillow_names
+    }

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -40,12 +40,18 @@ class ChangeProducer(object):
         return self._producer
 
     def send_change(self, topic, change_meta):
+        if settings.USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER:
+            from corehq.apps.change_feed.partitioners import choose_best_partition_for_topic
+            partition = choose_best_partition_for_topic(topic)
+        else:
+            partition = None
+
         message = change_meta.to_json()
         message_json_dump = json.dumps(message).encode('utf-8')
         change_meta._transaction_id = uuid.uuid4().hex
         try:
             _audit_log(CHANGE_PRE_SEND, change_meta)
-            future = self.producer.send(topic, message_json_dump, key=change_meta.document_id)
+            future = self.producer.send(topic, message_json_dump, key=change_meta.document_id, partition=partition)
             if self.auto_flush:
                 future.get()
                 _audit_log(CHANGE_SENT, change_meta)

--- a/settings.py
+++ b/settings.py
@@ -948,6 +948,10 @@ RATE_LIMIT_SUBMISSIONS = False
 STALE_EXPORT_THRESHOLD = None
 
 REQUIRE_TWO_FACTOR_FOR_SUPERUSERS = False
+# Use an experimental partitioning algorithm
+# that adds messages to the partition with the fewest unprocessed messages
+USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER = False
+
 
 try:
     # try to see if there's an environmental variable set for local_settings


### PR DESCRIPTION
##### SUMMARY
for using an experimental partitioning algorithm that adds messages to the partition with the fewest unprocessed messages.

This is something I'd like to use to address wildly varying backlog lengths for different partitions of the form/case topics during a period of pillow lag. Depending on what exactly the issue is, just trying to keep the "queue lengths" even across partitions will likely cut the max cue depth at any moment in half or in four, since what was previously the longest queue will now be split up over all partitions. If it works out that way, I'd expect that in turn to significantly affect our peak lag times.

Implementation note: I originally tried to use the kafka-python library's concept of a "partitioner", but `topic` was not one of the things that the partitioner was given to use in the decision, and there wasn't a neat way to wedge it in, so I decided to do the decision-making ahead of time and pass in the answer as the `partition` arg to `KafkaProducer.send`.

##### FEATURE FLAG
All under the `USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER` `settings.py` setting
