### PR TITLE
Improve couch to sql migration instructions

### DIFF
--- a/corehq/apps/api/management/commands/populate_apiuser.py
+++ b/corehq/apps/api/management/commands/populate_apiuser.py
@@ -11,6 +11,10 @@ class Command(PopulateSQLCommand):
         from corehq.apps.api.models import ApiUser
         return ApiUser
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "09839af06e924917681371e7a28b295fd15927bb"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             id=doc['_id'],

--- a/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
+++ b/corehq/apps/app_manager/management/commands/populate_sql_global_app_config.py
@@ -17,6 +17,10 @@ class Command(PopulateSQLCommand):
         from corehq.apps.app_manager.models import GlobalAppConfig
         return GlobalAppConfig
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "d1ebf3cfbd2a6f4eac8e2aae0b0ca5fe8cc73a94"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             domain=doc['domain'],

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -44,6 +44,15 @@ class PopulateSQLCommand(BaseCommand):
         return couch_count - sql_count
 
     @classmethod
+    def commit_adding_migration(cls):
+        """
+        This should be the merge commit of the pull request that adds the command to the commcare-hq repository.
+        If this is provided, the failure message in migrate_from_migration will instruct users to deploy this
+        commit before running the command.
+        """
+        return None
+
+    @classmethod
     def migrate_from_migration(cls, apps, schema_editor):
         """
             Should only be called from within a django migration.
@@ -75,6 +84,16 @@ class PopulateSQLCommand(BaseCommand):
                 A migration must be performed before this environment can be upgraded to the latest version
                 of CommCareHQ. This migration is run using the management command {command_name}.
             """)
+            if cls.commit_adding_migration():
+                print(f"""
+                Run the following commands to run the migration and get up to date:
+
+                    commcare-cloud <env> fab deploy commcare --commcare-rev={cls.commit_adding_migration()}
+
+                    commcare-cloud <env> django-manage {command_name}
+
+                    commcare-cloud <env> fab deploy commcare
+                """)
             sys.exit(1)
 
     @classmethod

--- a/corehq/apps/cloudcare/management/commands/populate_application_access.py
+++ b/corehq/apps/cloudcare/management/commands/populate_application_access.py
@@ -12,6 +12,10 @@ class Command(PopulateSQLCommand):
         from corehq.apps.cloudcare.models import ApplicationAccess
         return ApplicationAccess
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "1e099ff2f11cc6c3c7a0d647f1a67f32994ac01b"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             domain=doc['domain'],

--- a/corehq/apps/consumption/management/commands/populate_defaultconsumption.py
+++ b/corehq/apps/consumption/management/commands/populate_defaultconsumption.py
@@ -11,6 +11,10 @@ class Command(PopulateSQLCommand):
         from corehq.apps.consumption.models import SQLDefaultConsumption
         return SQLDefaultConsumption
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "d38d08f8616b908f7d5f803f54bc5f775e49ca95"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             couch_id=doc['_id'],

--- a/corehq/apps/hqadmin/management/commands/populate_sql_hq_deploy.py
+++ b/corehq/apps/hqadmin/management/commands/populate_sql_hq_deploy.py
@@ -11,6 +11,10 @@ class Command(PopulateSQLCommand):
         from corehq.apps.hqadmin.models import HqDeploy
         return HqDeploy
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "9f124faf85eb0880baceaffa7b1bcfb1dfaba6b5"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             couch_id=doc['_id'],

--- a/corehq/apps/registration/management/commands/populate_sql_registration_request.py
+++ b/corehq/apps/registration/management/commands/populate_sql_registration_request.py
@@ -13,6 +13,10 @@ class Command(PopulateSQLCommand):
         from corehq.apps.registration.models import SQLRegistrationRequest
         return SQLRegistrationRequest
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "61dc4670073baf7c51b7ab23cccbf16e3ecedbe9"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             couch_id=doc['_id'],

--- a/corehq/apps/users/management/commands/populate_usersinvitation.py
+++ b/corehq/apps/users/management/commands/populate_usersinvitation.py
@@ -17,6 +17,10 @@ class Command(PopulateSQLCommand):
         from corehq.apps.users.models import SQLInvitation
         return SQLInvitation
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "3c6e3ea5b42834ac78b266b4e340af3d9a10481e"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             couch_id=doc['_id'],

--- a/corehq/motech/dhis2/management/commands/populate_sql_dhis2_connection.py
+++ b/corehq/motech/dhis2/management/commands/populate_sql_dhis2_connection.py
@@ -11,6 +11,10 @@ class Command(PopulateSQLCommand):
         from corehq.motech.dhis2.models import Dhis2Connection
         return Dhis2Connection
 
+    @classmethod
+    def commit_adding_migration(cls):
+        return "d670f19bfda1ab4e842d7d47162c5691b9bef55d"
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             domain=doc['domain'],

--- a/docs/couch_to_sql_models.rst
+++ b/docs/couch_to_sql_models.rst
@@ -74,7 +74,8 @@ This should contain:
   * `Sample command for RegistrationRequest <https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/registration/management/commands/populate_sql_registration_request.py>`_.
   * This command should ideally populate the sql models based on the json from couch alone, not the wrapped document (to avoid introducing another dependency on the couch model). You may need to convert data types that the default ``wrap`` implementation would handle; note that the sample command above uses ``force_to_datetime`` to cast datetimes.
   * Don't know which database your doc type is in? Run ``from corehq.util.couchdb_management import couch_config; couch_config.all_dbs_by_slug`` in a shell to list all of the couch databases and then ``MyModel.get_db()`` to see which one you need.
-  
+  * ``PopulateSQLCommand`` includes the method ``commit_adding_migration`` to let third parties know which commit to deploy if they need to run the migration manually. Note this means you need to update the migration **after** this PR is merged, to add the hash of the commit that merged this PR into master.
+
 * Adds code to keep the couch and sql items in sync.
 
   * The easiest way to do this is to use `SyncCouchToSQLMixin <https://github.com/dimagi/commcare-hq/blob/c2b93b627c830f3db7365172e9be2de0019c6421/corehq/ex-submodules/dimagi/utils/couch/migration.py#L4>`_ and `SyncSQLToCouchMixin <https://github.com/dimagi/commcare-hq/blob/c2b93b627c830f3db7365172e9be2de0019c6421/corehq/ex-submodules/dimagi/utils/couch/migration.py#L115>`_.


### PR DESCRIPTION
Uses https://github.com/dimagi/commcare-cloud/pull/3676/ to add better instructions for [this situation](https://github.com/dimagi/commcare-cloud/pull/3676/#issuecomment-592205021). New instructions look like this:

```
Run the following commands to run the migration and get up to date:

    commcare-cloud <env> fab deploy commcare --commcare-rev=61dc4670073baf7c51b7ab23cccbf16e3ecedbe9

    commcare-cloud <env> django-manage populate_sql_registration_request

    commcare-cloud <env> fab deploy commcare
```