### PR TITLE
Remove hard request timeout on kafka consumer

### DIFF
--- a/corehq/apps/change_feed/connection.py
+++ b/corehq/apps/change_feed/connection.py
@@ -28,5 +28,4 @@ def get_kafka_consumer():
     return ClosingContextProxy(KafkaConsumer(
         client_id='pillowtop_utils',
         bootstrap_servers=settings.KAFKA_BROKERS,
-        request_timeout_ms=1000
     ))


### PR DESCRIPTION
##### SUMMARY
After increasing partitions on production kafka, we began hitting this limit constantly. Not sure what the value is of having it instead of relying on the much higher default of 30s