### PR TITLE
Update to add sort block

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -17,6 +17,7 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     Header,
     Locale,
     SessionDatum,
+    Sort,
     Template,
     Text,
     Xpath,
@@ -422,7 +423,9 @@ def _get_data_detail(config, domain, new_mobile_ucr_restore):
     if toggles.ADD_ROW_INDEX_TO_MOBILE_UCRS.enabled(domain):
         fields = [Field(
             header=Header(text=Text(), width=0,),
-            template=Template(text=Text(xpath=get_xpath("row_index"),), width=0,),
+            template=Template(text=Text(), width=0,),
+            sort_node=Sort(type='int', direction='ascending', order='1',
+                           text=Text(xpath=get_xpath("row_index")),)
         )]
     else:
         fields = []

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -329,10 +329,13 @@ class ReportFiltersSuiteTest(TestCase, TestXmlMixin):
                 <text/>
               </header>
               <template width="0">
+                <text/>
+              </template>
+              <sort direction="ascending" order="1" type="int">
                 <text>
                   <xpath function="column[@id='row_index']"/>
                 </text>
-              </template>
+              </sort>
             </field>
             <field>
               <header>
@@ -426,10 +429,13 @@ class ReportFiltersSuiteTest(TestCase, TestXmlMixin):
                 <text/>
               </header>
               <template width="0">
+                <text/>
+              </template>
+              <sort direction="ascending" order="1" type="int">
                 <text>
                   <xpath function="column[@id='row_index']"/>
                 </text>
-              </template>
+              </sort>
             </field>
             <field>
               <header>

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -13,7 +13,9 @@ from casexml.apps.phone.tests.utils import (
 
 from corehq.apps.app_manager.const import MOBILE_UCR_VERSION_2
 from corehq.apps.app_manager.fixtures import report_fixture_generator
-from corehq.apps.app_manager.fixtures.mobile_ucr import ReportFixturesProviderV1
+from corehq.apps.app_manager.fixtures.mobile_ucr import (
+    ReportFixturesProviderV1,
+)
 from corehq.apps.app_manager.models import (
     Application,
     GraphConfiguration,
@@ -52,7 +54,11 @@ from corehq.apps.userreports.tests.utils import (
     mock_datasource_config,
 )
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-from corehq.toggles import MOBILE_UCR, NAMESPACE_DOMAIN, ADD_ROW_INDEX_TO_MOBILE_UCRS
+from corehq.toggles import (
+    ADD_ROW_INDEX_TO_MOBILE_UCRS,
+    MOBILE_UCR,
+    NAMESPACE_DOMAIN,
+)
 from corehq.util.test_utils import flag_enabled
 
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1237

##### SUMMARY
Slight refresh in requirements addressed in https://github.com/dimagi/commcare-hq/pull/26707
We were relying on default ordering done on mobile by the first column but It was found out that 
- the mobile will sort on something only if it has a header displayed 
- it would order by it as a "string". 
So since we were using a hidden field and that it would be sorted as a string which won't work here since we are using numbers, it was suggested to add a sort block to solve both issues.

##### FEATURE FLAG
`ADD_ROW_INDEX_TO_MOBILE_UCRS`

##### PRODUCT DESCRIPTION
None
