### PR TITLE
Resumable ES reindex command using scan/bulk insert

### DIFF
--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from django.core.management.base import BaseCommand
 
 from corehq.elastic import get_es_new
-from corehq.util.dates import iso_string_to_datetime
 from elasticsearch.helpers import reindex
 
 

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -1,0 +1,56 @@
+from django.core.management.base import BaseCommand
+
+from corehq.elastic import get_es_new
+from corehq.util.dates import iso_string_to_datetime
+from elasticsearch.helpers import reindex
+
+
+class Command(BaseCommand):
+    help = ("Adhoc command for ICDS xforms reindex using scan and bulk insert API")
+
+    def add_arguments(self, parser):
+        parser.add_argument('index_name')
+        parser.add_argument('start_date', type=int)
+        parser.add_argument('end_date', type=int)
+
+    def handle(self, index_name, start_date, end_date, **options):
+        es = get_es_new()
+        start_date = self._get_last_start_date(es, start_date, end_date)
+        query = {
+            "sort": {"server_modified_on": {"order": "asc"}},
+            "query": {
+                "range": {
+                    "server_modified_on": {
+                        "gte": start_date,
+                        "lte": end_date,
+                        "format": "yyyy-MM-dd"
+                    }
+                }
+            }
+        }
+        old_index = "xforms"  # alias
+        reindex(es, old_index, index_name, query=query, chunk_size=100, scroll='100m',
+            bulk_kwargs={"_source_excludes": ["_id"]})
+
+    def _get_last_start_date(self, es, start_date, end_date):
+        query = {
+            "sort": {"server_modified_on": {"order": "asc"}},
+            "query": {
+                "range": {
+                    "server_modified_on": {
+                        "gte": start_date,
+                        "lte": end_date,
+                        "format": "yyyy-MM-dd"
+                    }
+                }
+            },
+            "_source": ["server_modified_on"],
+            "from": 0,
+            "size": 1
+        }
+        result = es.search('xforms', body=query)
+        hits = result['hits']
+        if not hits:
+            return start_date
+        else:
+            return str(iso_string_to_datetime(hits[0]['_source']['server_modified_on']))

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -10,8 +10,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('index_name')
-        parser.add_argument('start_date', type=int)
-        parser.add_argument('end_date', type=int)
+        parser.add_argument('start_date', help='in yyyy-MM-dd format')
+        parser.add_argument('end_date', help='in yyyy-MM-dd format')
 
     def handle(self, index_name, start_date, end_date, **options):
         es = get_es_new()

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
 
     def handle(self, index_name, start_date, end_date, **options):
         es = get_es_new()
-        start_date = self._get_last_start_date(es, start_date, end_date)
+        start_date = self._get_last_start_date(es, index_name, start_date, end_date)
         query = {
             "sort": {"server_modified_on": {"order": "asc"}},
             "query": {
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         reindex(es, old_index, index_name, query=query, chunk_size=100, scroll='100m',
             bulk_kwargs={"_source_excludes": ["_id"]})
 
-    def _get_last_start_date(self, es, start_date, end_date):
+    def _get_last_start_date(self, es, index_name, start_date, end_date):
         query = {
             "sort": {"server_modified_on": {"order": "asc"}},
             "query": {
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             "from": 0,
             "size": 1
         }
-        result = es.search('xforms', body=query)
+        result = es.search(index_name, body=query)
         hits = result['hits']
         if not hits:
             return start_date

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -40,7 +40,6 @@ class Command(BaseCommand):
 
         print("Total number of docs in this date range in old index",
             old_docs_count)
-        start_date = self._get_last_start_date(es, index_name, start_date, end_date)
         query = self._base_query(start_date, end_date)
         query.update({
             "_source": {"exclude": ["_id"]}
@@ -54,12 +53,11 @@ class Command(BaseCommand):
 
     def _base_query(self, start_date, end_date):
         return copy.deepcopy({
-            "sort": {"received_on": {"order": "asc"}},
             "query": {
                 "range": {
                     "received_on": {
                         "gte": start_date,
-                        "lte": end_date,
+                        "lt": end_date,
                         "format": "yyyy-MM-dd"
                     }
                 }
@@ -70,30 +68,3 @@ class Command(BaseCommand):
         query = self._base_query(start_date, end_date)
         ret = es.count(index, body=query)
         return ret['count']
-
-    def _get_last_start_date(self, es, index_name, start_date, end_date):
-        query = self._base_query(start_date, end_date)
-        query.update({
-            "sort": {"received_on": {"order": "desc"}},
-            "_source": ["received_on"],
-            "from": 0,
-            "size": 1
-        })
-        result = es.search(index_name, body=query)
-        hits = result['hits']['hits']
-        if not hits:
-            print("Starting fresh! No docs in new index in this date range")
-            return start_date
-        else:
-            new_start_date = str(iso_string_to_datetime(hits[0]['_source']['received_on']).date() - timedelta(1))
-            print("Trying to resume from ", new_start_date)
-            already_index_count = self._get_doc_count(es, index_name, start_date, new_start_date)
-            expected_count = self._get_doc_count(es, 'xforms', start_date, new_start_date)
-            print(already_index_count, " docs already reindexed. ", "Expected count ", expected_count)
-            if already_index_count == expected_count:
-                print(already_index_count, " docs are already indexed ")
-                print("Resuming from date ", new_start_date)
-                return new_start_date
-            else:
-                print("Doc counts don't match, starting for all range")
-                return start_date

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -199,7 +199,6 @@ class Command(BaseCommand):
                 print("This could mean task finished succesfully")
             time.sleep(20)
 
-
     def _get_doc_count(self, index, start_date, end_date):
         query = self._base_query(start_date, end_date)
         ret = self.es.count(index, body=query)

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
                 "by_hour": {
                     "date_histogram": {
                         "field": "received_on",
-                        "interval": "minute"
+                        "interval": "hour"
                     }
                 }
             }

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -15,9 +15,13 @@ class Command(BaseCommand):
         parser.add_argument('index_name')
         parser.add_argument('start_date', help='in yyyy-MM-dd format')
         parser.add_argument('end_date', help='in yyyy-MM-dd format')
-        parser.add_argument('scroll_timeout', help='Elasticsearch scroll timeout such as 5m, 10m or 100m etc')
+        parser.add_argument('--scroll_timeout', default='100m',
+            help='Elasticsearch scroll timeout such as 5m, 10m or 100m etc')
+        parser.add_argument('--chunk_size', default=100, type=int)
 
-    def handle(self, index_name, start_date, end_date, scroll_timeout, **options):
+    def handle(self, index_name, start_date, end_date, **options):
+        scroll_timeout = options.get('scroll_timeout')
+        chunk_size = options.get('chunk_size')
         es = get_es_new()
         print("Total number of docs in this date range in old index",
             self._get_doc_count(es, 'xforms', start_date, end_date))
@@ -30,7 +34,7 @@ class Command(BaseCommand):
         print("Number of remaining docs to be reindexed to new index ",
             self._get_doc_count(es, 'xforms', start_date, end_date))
         print("Starting reindex ", datetime.now())
-        reindex(es, old_index, index_name, query=query, chunk_size=100, scroll=scroll_timeout)
+        reindex(es, old_index, index_name, query=query, chunk_size=chunk_size, scroll=scroll_timeout)
         print("Reindex finished ", datetime.now())
 
     def _base_query(self, start_date, end_date):

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -1,3 +1,6 @@
+import copy
+from datetime import datetime
+
 from django.core.management.base import BaseCommand
 
 from corehq.elastic import get_es_new
@@ -12,45 +15,62 @@ class Command(BaseCommand):
         parser.add_argument('index_name')
         parser.add_argument('start_date', help='in yyyy-MM-dd format')
         parser.add_argument('end_date', help='in yyyy-MM-dd format')
+        parser.add_argument('scroll_timeout', help='Elasticsearch scroll timeout such as 5m, 10m or 100m etc')
 
-    def handle(self, index_name, start_date, end_date, **options):
+    def handle(self, index_name, start_date, end_date, scroll_timeout, **options):
         es = get_es_new()
+        print("Total number of docs in this date range in old index",
+            self._get_doc_count(es, 'xforms', start_date, end_date))
         start_date = self._get_last_start_date(es, index_name, start_date, end_date)
-        query = {
-            "sort": {"server_modified_on": {"order": "asc"}},
-            "query": {
-                "range": {
-                    "server_modified_on": {
-                        "gte": start_date,
-                        "lte": end_date,
-                        "format": "yyyy-MM-dd"
-                    }
-                }
-            }
-        }
+        query = self._base_query(start_date, end_date)
+        query.update({
+            "_source": {"exclude": ["_id"]}
+        })
         old_index = "xforms"  # alias
-        reindex(es, old_index, index_name, query=query, chunk_size=100, scroll='100m',
-            bulk_kwargs={"_source_excludes": ["_id"]})
+        print("Number of remaining docs to be reindexed to new index ",
+            self._get_doc_count(es, 'xforms', start_date, end_date))
+        print("Starting reindex ", datetime.now())
+        reindex(es, old_index, index_name, query=query, chunk_size=100, scroll=scroll_timeout)
+        print("Reindex finished ", datetime.now())
 
-    def _get_last_start_date(self, es, index_name, start_date, end_date):
-        query = {
-            "sort": {"server_modified_on": {"order": "asc"}},
+    def _base_query(self, start_date, end_date):
+        return copy.deepcopy({
+            "sort": {"received_on": {"order": "asc"}},
             "query": {
                 "range": {
-                    "server_modified_on": {
+                    "received_on": {
                         "gte": start_date,
                         "lte": end_date,
                         "format": "yyyy-MM-dd"
                     }
                 }
             },
-            "_source": ["server_modified_on"],
+        })
+
+    def _get_doc_count(self, es, index, start_date, end_date):
+        query = self._base_query(start_date, end_date)
+        ret = es.count(index, body=query)
+        return ret['count']
+
+    def _get_last_start_date(self, es, index_name, start_date, end_date):
+        query = self._base_query(start_date, end_date)
+        query.update({
+            "sort": {"received_on": {"order": "desc"}},
+            "_source": ["received_on"],
             "from": 0,
             "size": 1
-        }
+        })
         result = es.search(index_name, body=query)
-        hits = result['hits']
+        hits = result['hits']['hits']
         if not hits:
             return start_date
         else:
-            return str(iso_string_to_datetime(hits[0]['_source']['server_modified_on']))
+            new_start_date = str(iso_string_to_datetime(hits[0]['_source']['received_on']).date())
+            already_index_count = self._get_doc_count(es, index_name, start_date, new_start_date)
+            expected_count = self._get_doc_count(es, 'xforms', start_date, new_start_date)
+            if already_index_count == expected_count:
+                print(already_index_count, " docs are already indexed ")
+                print("Resuming from date ", new_start_date)
+                return new_start_date
+            else:
+                return start_date

--- a/corehq/apps/es/management/commands/reindex_icds_xforms.py
+++ b/corehq/apps/es/management/commands/reindex_icds_xforms.py
@@ -15,7 +15,14 @@ class Command(BaseCommand):
         parser.add_argument('index_name')
         parser.add_argument('start_date', help='in yyyy-MM-dd format')
         parser.add_argument('end_date', help='in yyyy-MM-dd format')
-        parser.add_argument('--scroll_timeout', default='100m',
+        parser.add_argument(
+            '--native',
+            action='store_true',
+            default=False,
+            help="""By default reindex is done via scan/bulk-insert helper. Use this
+                 option to reindex using ES reindex api instead"""
+        )
+        parser.add_argument('--scroll_timeout', default='10m',
             help='Elasticsearch scroll timeout such as 5m, 10m or 100m etc')
         parser.add_argument('--chunk_size', default=100, type=int)
         parser.add_argument(
@@ -26,45 +33,99 @@ class Command(BaseCommand):
         )
 
     def handle(self, index_name, start_date, end_date, **options):
-        es = get_es_new()
+        self.es = get_es_new()
+        self.new_index = index_name
+        self.old_index = "xforms"  # alias
         scroll_timeout = options.get('scroll_timeout')
         chunk_size = options.get('chunk_size')
         print_counts = options.get('print_counts')
-        old_docs_count = self._get_doc_count(es, 'xforms', start_date, end_date)
+        use_native_api = options.get('native')
+        old_docs_count = self._get_doc_count(self.old_index, start_date, end_date)
+        print("Number of docs in old index",
+            old_docs_count)
+        print("Number of docs in new index",
+            self._get_doc_count(self.new_index, start_date, end_date))
         if print_counts:
-            print("Number of docs in old index",
-                old_docs_count)
-            print("Number of docs in new index",
-                self._get_doc_count(es, index_name, start_date, end_date))
             return
 
-        print("Total number of docs in this date range in old index",
-            old_docs_count)
+        for query in self._breakup_by_hours(start_date, end_date):
+            query.update({
+                "_source": {"exclude": ["_id"]}
+            })
+            print("Starting reindex at ", datetime.now())
+            print("Query issued is ", query)
+            if use_native_api:
+                print("Using native reindex")
+                self.reindex_using_es_api(query)
+            else:
+                reindex(self.es, self.old_index, self.new_index,
+                    query=query, chunk_size=chunk_size, scroll=scroll_timeout)
+            print("Reindex finished ", datetime.now())
+
+    def _breakup_by_hours(self, start_date, end_date):
         query = self._base_query(start_date, end_date)
         query.update({
-            "_source": {"exclude": ["_id"]}
+            "aggs": {
+                "by_hour": {
+                    "date_histogram": {
+                        "field": "received_on",
+                        "interval": "minute"
+                    }
+                }
+            }
         })
-        old_index = "xforms"  # alias
-        print("Number of remaining docs to be reindexed to new index ",
-            self._get_doc_count(es, 'xforms', start_date, end_date))
-        print("Starting reindex ", datetime.now())
-        reindex(es, old_index, index_name, query=query, chunk_size=chunk_size, scroll=scroll_timeout)
-        print("Reindex finished ", datetime.now())
 
-    def _base_query(self, start_date, end_date):
+        def get_counts_by_hour(index):
+            print("Getting doc counts by hourly from index", index)
+            counts_by_hour = {}
+            results = self.es.search(index, body=query)['aggregations']['by_hour']['buckets']
+            for result in results:
+                hour_epoch = result['key']
+                from_hour = datetime.utcfromtimestamp(hour_epoch / 1000)
+                count = result['doc_count']
+                counts_by_hour[from_hour] = count
+            return counts_by_hour
+
+        counts_by_hour_old_index = get_counts_by_hour(self.old_index)
+        counts_by_hour_new_index = get_counts_by_hour(self.new_index)
+
+        for hour, count in counts_by_hour_old_index.items():
+            start_time = hour.strftime('%Y-%m-%d %H:%M:%S')
+            end_time = (hour + timedelta(hours=1)).strftime('%Y-%m-%d %H:%M:%S')
+            if counts_by_hour_new_index[hour] != count:
+                yield self._base_query(
+                    start_time, end_time, 'yyyy-MM-dd HH:mm:ss'
+                )
+            else:
+                print("Already reindexed. Skipping the hour of ", start_time)
+
+    def _base_query(self, start_date, end_date, format="yyyy-MM-dd"):
         return copy.deepcopy({
             "query": {
                 "range": {
                     "received_on": {
                         "gte": start_date,
                         "lt": end_date,
-                        "format": "yyyy-MM-dd"
+                        "format": format
                     }
                 }
             },
         })
 
-    def _get_doc_count(self, es, index, start_date, end_date):
+    def reindex_using_es_api(self, query):
+        reindex_query = {
+            "source": {
+                "index": self.old_index,
+                "_source": {"exclude": ["_id"]}
+            },
+            "dest": {"index": self.new_index},
+            "conflicts": "proceed"
+        }
+        reindex_query['source'].update(query)
+        result = self.es.reindex(reindex_query, wait_for_completion=True, request_timeout=300)
+        print("Result task is ", result)
+
+    def _get_doc_count(self, index, start_date, end_date):
         query = self._base_query(start_date, end_date)
-        ret = es.count(index, body=query)
+        ret = self.es.count(index, body=query)
         return ret['count']


### PR DESCRIPTION
@snopoke 

This is baed on https://elasticsearch-py.readthedocs.io/en/master/helpers.html#reindex

I think we have to do something like this to get a robust reindex of ICDS xforms. I will test this on staging to see how it performs. Just wanted to get feedback on this.

This also allows parallel reindices based on the date.

Per docs, this should not incur any fielddata related memory spikes. I tested the basic query (like a date histogram) and didn't see any spikes. Though the official docs themselves mention that all these docs will be loaded in memeory.