### PR TITLE
Removed unused consumption code

### DIFF
--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 
 from dimagi.utils.couch.cache import cache_core
 
-from corehq.apps.consumption.const import DAYS_IN_MONTH
 from corehq.apps.consumption.models import (
     TYPE_DOMAIN,
     TYPE_PRODUCT,
@@ -50,15 +49,6 @@ def get_domain_monthly_consumption_data(domain):
         reduce=False,
     )
     return results
-
-
-def get_default_consumption(domain, product_id, location_type, case_id):
-    consumption = get_default_monthly_consumption(domain, product_id, location_type, case_id)
-
-    if consumption:
-        return consumption / Decimal(DAYS_IN_MONTH)
-    else:
-        return None
 
 
 def set_default_monthly_consumption_for_domain(domain, amount):

--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -71,12 +71,6 @@ def set_default_consumption_for_product(domain, product_id, amount):
     return _update_or_create_default(domain, amount, default, TYPE_PRODUCT, product_id=product_id)
 
 
-def set_default_consumption_for_supply_point(domain, product_id, supply_point_id, amount):
-    default = DefaultConsumption.get_supply_point_default(domain, product_id, supply_point_id)
-    return _update_or_create_default(domain, amount, default, TYPE_SUPPLY_POINT,
-                                     product_id=product_id, supply_point_id=supply_point_id)
-
-
 def _update_or_create_default(domain, amount, default, type, **kwargs):
     if default and default.default_consumption == amount:
         return default

--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -129,12 +129,3 @@ def get_loaded_default_monthly_consumption(consumption_dict, domain, product_id,
             return consumption_dict[key]
 
     return None
-
-
-def get_loaded_default_consumption(consumption_dict, domain, product_id, location_type, case_id):
-    consumption = get_loaded_default_monthly_consumption(consumption_dict, domain, product_id, location_type, case_id)
-
-    if consumption:
-        return consumption / Decimal(DAYS_IN_MONTH)
-    else:
-        return None

--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -37,7 +37,7 @@ def get_default_monthly_consumption(domain, product_id, location_type, case_id):
         return None
 
 
-def get_domain_monthly_consumption_data(domain):
+def _get_domain_monthly_consumption_data(domain):
     """
     Get all default consumption rows for this domain.
     """
@@ -74,7 +74,7 @@ def _update_or_create_default(domain, amount, default, type, **kwargs):
         return default
 
 
-def hashable_key(key):
+def _hashable_key(key):
     """
     Convert the key from couch into something hasable.
     Mostly, just need to make it a tuple and remove the special
@@ -88,10 +88,10 @@ def build_consumption_dict(domain):
     Takes raw rows from couch and builds a dict to 
     look up consumption values from.
     """
-    raw_rows = get_domain_monthly_consumption_data(domain)
+    raw_rows = _get_domain_monthly_consumption_data(domain)
 
     return dict(
-        (hashable_key(row['key']), Decimal(row['value']))
+        (_hashable_key(row['key']), Decimal(row['value']))
         for row in raw_rows if row['value']
     )
 

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -4,7 +4,6 @@ from corehq.apps.consumption.const import DAYS_IN_MONTH
 from corehq.apps.consumption.shortcuts import (
     build_consumption_dict,
     get_default_consumption,
-    get_loaded_default_consumption,
     set_default_consumption_for_product,
     set_default_consumption_for_supply_point,
     set_default_monthly_consumption_for_domain,
@@ -114,17 +113,6 @@ class GetDefaultConsumptionTestCase(DefaultConsumptionBase, ConsumptionTestBase)
     def setUp(self):
         super(GetDefaultConsumptionTestCase, self).setUp()
         self.consumption_method = get_default_consumption
-
-
-class GetLoadedDefaultConsumptionTestCase(DefaultConsumptionBase, ConsumptionTestBase):
-
-    def wrapped_consumption_function(self, *args):
-        consumption_dict = build_consumption_dict(domain)
-        return get_loaded_default_consumption(consumption_dict, *args)
-
-    def setUp(self):
-        super(GetLoadedDefaultConsumptionTestCase, self).setUp()
-        self.consumption_method = self.wrapped_consumption_function
 
 
 class ConsumptionShortcutsTestCase(ConsumptionTestBase):

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -1,9 +1,10 @@
+from decimal import Decimal
 from django.test import TestCase
 
 from corehq.apps.consumption.const import DAYS_IN_MONTH
 from corehq.apps.consumption.shortcuts import (
     build_consumption_dict,
-    get_default_consumption,
+    get_default_monthly_consumption,
     set_default_consumption_for_product,
     set_default_monthly_consumption_for_domain,
 )
@@ -33,85 +34,86 @@ class ConsumptionTestBase(TestCase):
         self.assertEqual(0, _count_consumptions())
 
 
-class DefaultConsumptionBase(object):
+class GetDefaultConsumptionTestCase(ConsumptionTestBase):
+
+    def get_default_consumption(self, domain, product_id, location_type, case_id):
+        consumption = get_default_monthly_consumption(domain, product_id, location_type, case_id)
+
+        if consumption:
+            return consumption / Decimal(DAYS_IN_MONTH)
+        else:
+            return None
 
     def testGetNoDefault(self):
-        self.assertEqual(None, self.consumption_method(domain, 'whatever', 'goes', 'here'))
+        self.assertEqual(None, self.get_default_consumption(domain, 'whatever', 'goes', 'here'))
 
     def testGetDomainOnly(self):
         _create_domain_consumption(5)
-        self.assertEqual(5, self.consumption_method(domain, 'whatever', 'goes', 'here'))
-        self.assertEqual(None, self.consumption_method('wrong', 'whatever', 'goes', 'here'))
+        self.assertEqual(5, self.get_default_consumption(domain, 'whatever', 'goes', 'here'))
+        self.assertEqual(None, self.get_default_consumption('wrong', 'whatever', 'goes', 'here'))
 
     def testGetForProduct(self):
         _create_product_consumption(5)
-        self.assertEqual(5, self.consumption_method(domain, product_id, 'doesnt', 'matter'))
-        self.assertEqual(None, self.consumption_method(domain, 'wrong', 'doesnt', 'matter'))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, 'doesnt', 'matter'))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, 'doesnt', 'matter'))
+        self.assertEqual(None, self.get_default_consumption(domain, 'wrong', 'doesnt', 'matter'))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, 'doesnt', 'matter'))
 
         _create_domain_consumption(3)
-        self.assertEqual(5, self.consumption_method(domain, product_id, 'doesnt', 'matter'))
-        self.assertEqual(3, self.consumption_method(domain, 'wrong', 'doesnt', 'matter'))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, 'doesnt', 'matter'))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, 'doesnt', 'matter'))
+        self.assertEqual(3, self.get_default_consumption(domain, 'wrong', 'doesnt', 'matter'))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, 'doesnt', 'matter'))
 
     def testGetForType(self):
         _create_type_consumption(5)
-        self.assertEqual(5, self.consumption_method(domain, product_id, type_id, 'useless'))
-        self.assertEqual(None, self.consumption_method(domain, product_id, 'wrong', 'useless'))
-        self.assertEqual(None, self.consumption_method(domain, 'wrong', type_id, 'useless'))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, type_id, 'useless'))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, type_id, 'useless'))
+        self.assertEqual(None, self.get_default_consumption(domain, product_id, 'wrong', 'useless'))
+        self.assertEqual(None, self.get_default_consumption(domain, 'wrong', type_id, 'useless'))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, type_id, 'useless'))
 
         _create_product_consumption(3)
-        self.assertEqual(5, self.consumption_method(domain, product_id, type_id, 'useless'))
-        self.assertEqual(3, self.consumption_method(domain, product_id, 'wrong', 'useless'))
-        self.assertEqual(None, self.consumption_method(domain, 'wrong', type_id, 'useless'))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, type_id, 'useless'))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, type_id, 'useless'))
+        self.assertEqual(3, self.get_default_consumption(domain, product_id, 'wrong', 'useless'))
+        self.assertEqual(None, self.get_default_consumption(domain, 'wrong', type_id, 'useless'))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, type_id, 'useless'))
 
         _create_domain_consumption(2)
-        self.assertEqual(5, self.consumption_method(domain, product_id, type_id, 'useless'))
-        self.assertEqual(3, self.consumption_method(domain, product_id, 'wrong', 'useless'))
-        self.assertEqual(2, self.consumption_method(domain, 'wrong', type_id, 'useless'))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, type_id, 'useless'))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, type_id, 'useless'))
+        self.assertEqual(3, self.get_default_consumption(domain, product_id, 'wrong', 'useless'))
+        self.assertEqual(2, self.get_default_consumption(domain, 'wrong', type_id, 'useless'))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, type_id, 'useless'))
 
     def testGetForId(self):
         _create_id_consumption(5)
-        self.assertEqual(5, self.consumption_method(domain, product_id, type_id, supply_point_id))
-        self.assertEqual(5, self.consumption_method(domain, product_id, 'useless', supply_point_id))
-        self.assertEqual(None, self.consumption_method(domain, product_id, type_id, 'wrong'))
-        self.assertEqual(None, self.consumption_method(domain, product_id, 'wrong', 'wrong'))
-        self.assertEqual(None, self.consumption_method(domain, 'wrong', type_id, supply_point_id))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, type_id, supply_point_id))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, type_id, supply_point_id))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, 'useless', supply_point_id))
+        self.assertEqual(None, self.get_default_consumption(domain, product_id, type_id, 'wrong'))
+        self.assertEqual(None, self.get_default_consumption(domain, product_id, 'wrong', 'wrong'))
+        self.assertEqual(None, self.get_default_consumption(domain, 'wrong', type_id, supply_point_id))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, type_id, supply_point_id))
 
         _create_type_consumption(4)
-        self.assertEqual(5, self.consumption_method(domain, product_id, type_id, supply_point_id))
-        self.assertEqual(5, self.consumption_method(domain, product_id, 'useless', supply_point_id))
-        self.assertEqual(4, self.consumption_method(domain, product_id, type_id, 'wrong'))
-        self.assertEqual(None, self.consumption_method(domain, product_id, 'wrong', 'wrong'))
-        self.assertEqual(None, self.consumption_method(domain, 'wrong', type_id, supply_point_id))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, type_id, supply_point_id))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, type_id, supply_point_id))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, 'useless', supply_point_id))
+        self.assertEqual(4, self.get_default_consumption(domain, product_id, type_id, 'wrong'))
+        self.assertEqual(None, self.get_default_consumption(domain, product_id, 'wrong', 'wrong'))
+        self.assertEqual(None, self.get_default_consumption(domain, 'wrong', type_id, supply_point_id))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, type_id, supply_point_id))
 
         _create_product_consumption(3)
-        self.assertEqual(5, self.consumption_method(domain, product_id, type_id, supply_point_id))
-        self.assertEqual(5, self.consumption_method(domain, product_id, 'useless', supply_point_id))
-        self.assertEqual(4, self.consumption_method(domain, product_id, type_id, 'wrong'))
-        self.assertEqual(3, self.consumption_method(domain, product_id, 'wrong', 'wrong'))
-        self.assertEqual(None, self.consumption_method(domain, 'wrong', type_id, supply_point_id))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, type_id, supply_point_id))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, type_id, supply_point_id))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, 'useless', supply_point_id))
+        self.assertEqual(4, self.get_default_consumption(domain, product_id, type_id, 'wrong'))
+        self.assertEqual(3, self.get_default_consumption(domain, product_id, 'wrong', 'wrong'))
+        self.assertEqual(None, self.get_default_consumption(domain, 'wrong', type_id, supply_point_id))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, type_id, supply_point_id))
 
         _create_domain_consumption(2)
-        self.assertEqual(5, self.consumption_method(domain, product_id, type_id, supply_point_id))
-        self.assertEqual(5, self.consumption_method(domain, product_id, 'useless', supply_point_id))
-        self.assertEqual(4, self.consumption_method(domain, product_id, type_id, 'wrong'))
-        self.assertEqual(3, self.consumption_method(domain, product_id, 'wrong', 'wrong'))
-        self.assertEqual(2, self.consumption_method(domain, 'wrong', type_id, supply_point_id))
-        self.assertEqual(None, self.consumption_method('wrong', product_id, type_id, supply_point_id))
-
-
-class GetDefaultConsumptionTestCase(DefaultConsumptionBase, ConsumptionTestBase):
-
-    def setUp(self):
-        super(GetDefaultConsumptionTestCase, self).setUp()
-        self.consumption_method = get_default_consumption
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, type_id, supply_point_id))
+        self.assertEqual(5, self.get_default_consumption(domain, product_id, 'useless', supply_point_id))
+        self.assertEqual(4, self.get_default_consumption(domain, product_id, type_id, 'wrong'))
+        self.assertEqual(3, self.get_default_consumption(domain, product_id, 'wrong', 'wrong'))
+        self.assertEqual(2, self.get_default_consumption(domain, 'wrong', type_id, supply_point_id))
+        self.assertEqual(None, self.get_default_consumption('wrong', product_id, type_id, supply_point_id))
 
 
 class ConsumptionShortcutsTestCase(ConsumptionTestBase):

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 
 from corehq.apps.consumption.const import DAYS_IN_MONTH
 from corehq.apps.consumption.shortcuts import (
-    build_consumption_dict,
     get_default_monthly_consumption,
     set_default_consumption_for_product,
     set_default_monthly_consumption_for_domain,

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -5,7 +5,6 @@ from corehq.apps.consumption.shortcuts import (
     build_consumption_dict,
     get_default_consumption,
     set_default_consumption_for_product,
-    set_default_consumption_for_supply_point,
     set_default_monthly_consumption_for_domain,
 )
 
@@ -135,16 +134,6 @@ class ConsumptionShortcutsTestCase(ConsumptionTestBase):
         updated = set_default_consumption_for_product(domain, product_id, 40)
         self.assertEqual(default._id, updated._id)
         self.assertEqual(40, DefaultConsumption.get_product_default(domain, product_id).default_consumption)
-        self.assertEqual(1, _count_consumptions())
-
-    def testSetForSupplyPoint(self):
-        self.assertEqual(None, DefaultConsumption.get_supply_point_default(domain, product_id, supply_point_id))
-        default = set_default_consumption_for_supply_point(domain, product_id, supply_point_id, 50)
-        self.assertEqual(50, DefaultConsumption.get_supply_point_default(domain, product_id, supply_point_id).default_consumption)
-        self.assertEqual(1, _count_consumptions())
-        updated = set_default_consumption_for_supply_point(domain, product_id, supply_point_id, 40)
-        self.assertEqual(default._id, updated._id)
-        self.assertEqual(40, DefaultConsumption.get_supply_point_default(domain, product_id, supply_point_id).default_consumption)
         self.assertEqual(1, _count_consumptions())
 
 


### PR DESCRIPTION
While migrating `DefaultConsumption`, noticed some of the related code is only used in tests.

Review by commit.