### PR TITLE
Couch to SQL: missing forms, cases, and ledgers

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -6,6 +6,7 @@ from functools import partial
 import attr
 
 from casexml.apps.case.xform import get_case_ids_from_form
+from casexml.apps.stock.const import TRANSACTION_TYPE_STOCKONHAND
 from casexml.apps.stock.models import StockTransaction
 from dimagi.utils.couch.database import retry_on_couch_error
 
@@ -303,6 +304,8 @@ class StockTransactionLoader:
         for report in get_all_stock_report_helpers_from_form(xform):
             for tx in report.transactions:
                 yield report.report_type, tx
+                if tx.action == TRANSACTION_TYPE_STOCKONHAND:
+                    yield report.report_type, tx
 
 
 def diff_case_forms(couch_json, sql_json):

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -177,6 +177,11 @@ def diff_ledgers(case_ids, dd_count):
             dd_count("commcare.couchsqlmigration.ledger.rebuild")
         if couch_state is None:
             diffs = [stock_tx.diff_missing_ledger(ledger_value)]
+            old_value = diffs[0].old_value
+            if old_value["form_state"] == FORM_PRESENT and "ledger" not in old_value:
+                changes = diffs_to_changes(diffs, "missing couch stock transaction")
+                all_changes.append(("stock state", ref.as_id(), changes))
+                diffs = []
         else:
             diffs = diff(couch_state, ledger_value)
             if diffs and stock_tx.has_duplicate_transactions(ref):

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -187,12 +187,14 @@ def diff_ledgers(case_ids, dd_count):
             if old_value["form_state"] == FORM_PRESENT and "ledger" not in old_value:
                 changes = diffs_to_changes(diffs, "missing couch stock transaction")
                 all_changes.append(("stock state", ref.as_id(), changes))
+                dd_count("commcare.couchsqlmigration.ledger.did_change")
                 diffs = []
         else:
             diffs = diff(couch_state, ledger_value)
             if diffs and stock_tx.has_duplicate_transactions(ref):
                 changes = diffs_to_changes(diffs, "duplicate stock transaction")
                 all_changes.append(("stock state", ref.as_id(), changes))
+                dd_count("commcare.couchsqlmigration.ledger.did_change")
                 diffs = []
         if diffs:
             dd_count("commcare.couchsqlmigration.ledger.has_diff")

--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -324,10 +324,14 @@ def diff_form_state(form_id, *, in_couch=False):
     in_sql = FormAccessorSQL.form_exists(form_id)
     couch_miss = "missing"
     if not in_couch and get_blob_db().metadb.get_for_parent(form_id):
-        couch_miss = "missing, blob present"
-    old = {"form_state": "present" if in_couch else couch_miss}
-    new = {"form_state": "present" if in_sql else "missing"}
+        couch_miss = MISSING_BLOB_PRESENT
+    old = {"form_state": FORM_PRESENT if in_couch else couch_miss}
+    new = {"form_state": FORM_PRESENT if in_sql else "missing"}
     return old, new
+
+
+FORM_PRESENT = "present"
+MISSING_BLOB_PRESENT = "missing, blob present"
 
 
 def add_missing_docs(data, couch_cases, sql_case_ids, dd_count):

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -598,7 +598,8 @@ def patch_XFormInstance_get_xml():
 @contextmanager
 def patch_kafka():
     def drop_change(self, topic, change_meta):
-        log.debug("not publishing doc_id=%s to %s", change_meta.document_id, topic)
+        doc_id = change_meta.document_id
+        log.debug("kafka not publishing doc_id=%s to %s", doc_id, topic)
 
     from corehq.apps.change_feed.producer import ChangeProducer
     send_change = ChangeProducer.send_change

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -320,7 +320,7 @@ def sql_number_has_leading_zero(old_obj, new_obj, rule, diff):
     processor stripped off the leading zero(s), but the SQL form
     processor does not do that.
     """
-    if diff.new_value.startswith("0"):
+    if isinstance(diff.new_value, str) and diff.new_value.startswith("0"):
         try:
             return float(diff.old_value) == float(diff.new_value)
         except (TypeError, ValueError):

--- a/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
+++ b/corehq/apps/couch_sql_migration/management/commands/couch_sql_diff.py
@@ -9,22 +9,30 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from dimagi.utils.chunked import chunked
+from dimagi.utils.couch.database import retry_on_couch_error
 
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.backends.couch.dbaccessors import FormAccessorCouch
+from corehq.form_processor.backends.sql.dbaccessors import (
+    CaseAccessorSQL,
+    FormAccessorSQL,
+)
 from corehq.form_processor.utils import should_use_sql_backend
 from corehq.util.log import with_progress_bar
 
 from ...casediff import get_couch_cases
 from ...casedifftool import do_case_diffs, format_diffs, get_migrator
 from ...couchsqlmigration import setup_logging
+from ...diff import filter_case_diffs, filter_form_diffs
+from ...missingdocs import MissingIds
 from ...rewind import IterationState
-from ...statedb import StateDB, open_state_db
+from ...statedb import Counts, StateDB, open_state_db
 
 log = logging.getLogger(__name__)
 
 CASES = "cases"
 SHOW = "show"
+FILTER = "filter"
 
 PREPARE = "prepare"
 DELETE = "delete"
@@ -35,7 +43,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
-        parser.add_argument('action', choices=[CASES, SHOW])
+        parser.add_argument('action', choices=[CASES, SHOW, FILTER], help="""
+            "cases": diff cases.
+            "show": print diffs.
+            "filter": filter diffs, removing ones that would normally be
+            filtered out. This is useful when new diff ignore rules have
+            been added that apply to existing diff records.
+        """)
         parser.add_argument('--no-input', action='store_true', default=False)
         parser.add_argument('--debug', action='store_true', default=False)
         parser.add_argument('--state-dir', dest='state_path',
@@ -55,8 +69,9 @@ class Command(BaseCommand):
                 containing a case id on each line. The path must begin
                 with / or ./
 
-                With the "show" action, this option should be a doc type.
-                All form and case doc types are supported.
+                With the "show" or "filter" actions, this option should
+                be a doc type. All form and case doc types are
+                supported.
             ''')
         parser.add_argument('--changes',
             dest="changes", action='store_true', default=False,
@@ -69,7 +84,8 @@ class Command(BaseCommand):
             help='''
                 Stop and drop into debugger on first diff. A
                 non-parallel iteration algorithm is used when this
-                option is set.
+                option is set. For "filter --dry-run" propmt to stop
+                after each batch.
             ''')
         parser.add_argument('-b', '--batch-size',
             dest="batch_size", default=100, type=int,
@@ -82,9 +98,12 @@ class Command(BaseCommand):
                 --reset=delete to permanently delete diffs, changes, and
                 progress information from the statedb.
             ''')
+        parser.add_argument('-n', '--dry-run',
+            dest="dry_run", action='store_true', default=False,
+            help="show what would happen, but do not commit changes")
 
     def handle(self, domain, action, **options):
-        if should_use_sql_backend(domain):
+        if action == CASES and should_use_sql_backend(domain):
             raise CommandError(f'It looks like {domain} has already been migrated.')
 
         for opt in [
@@ -97,23 +116,26 @@ class Command(BaseCommand):
             "csv",
             "batch_size",
             "reset",
+            "dry_run",
         ]:
             setattr(self, opt, options[opt])
 
         if self.no_input and not settings.UNIT_TESTING:
             raise CommandError('--no-input only allowed for unit testing')
         if self.changes and action != SHOW:
-            raise CommandError('--changes only allowed with "show" action')
+            raise CommandError(f'{action} --changes not allowed')
         if self.csv and action != SHOW:
-            raise CommandError('--csv only allowed with "show" action')
+            raise CommandError(f'{action} --csv not allowed')
+        if self.dry_run and action != FILTER:
+            raise CommandError(f'{action} --dry-run not allowed')
 
         if self.reset:
-            if action == SHOW:
-                raise CommandError(f'invalid action for --reset: {action}')
+            if action != CASES:
+                raise CommandError(f'{action} --reset not allowed')
             self.do_reset(action, domain)
             return
 
-        if action != SHOW:
+        if action not in [SHOW, FILTER]:
             assert Domain.get_by_name(domain), f'Unknown domain "{domain}"'
         do_action = getattr(self, "do_" + action)
         msg = do_action(domain)
@@ -136,14 +158,7 @@ class Command(BaseCommand):
             items = statedb.iter_doc_diffs(self.select)
         prompt = not self.csv
         if self.csv:
-            counts = statedb.get_doc_counts()
-            if self.select:
-                count = counts.get(self.select, 0)
-            else:
-                count = sum(c.changes if self.changes else c.diffs
-                            for c in counts.values())
-            items = with_progress_bar(
-                items, count, "Docs", oneline=False, stream=sys.stderr)
+            items = self.with_progress(items, statedb)
             print(CSV_HEADERS, file=sys.stdout)
         try:
             for doc_diffs in chunked(items, self.batch_size, list):
@@ -154,6 +169,70 @@ class Command(BaseCommand):
                     break
         except (KeyboardInterrupt, BrokenPipeError):
             pass
+
+    def do_filter(self, domain):
+        def update_doc_diffs(doc_diffs):
+            ids = [d[1] for d in doc_diffs]
+            sql_docs = get_sql_docs(ids)
+            couch_docs = get_couch_docs(ids)
+            new_diffs = []
+            for kind, doc_id, diffs in doc_diffs:
+                couch_json = get_json(kind, doc_id, couch_docs)
+                sql_json = get_json(kind, doc_id, sql_docs)
+                json_diffs = [json_diff(d) for d in diffs]
+                new_diffs = filter_diffs(couch_json, sql_json, json_diffs)
+                if self.dry_run:
+                    print(f"{kind} {doc_id}: {len(diffs)} -> {len(new_diffs)} diffs")
+                else:
+                    statedb.add_diffs(kind, doc_id, new_diffs)
+
+        def get_json(kind, doc_id, docs):
+            doc = docs.get(doc_id)
+            return doc.to_json() if doc is not None else {"doc_type": kind}
+
+        def json_diff(diff):
+            jd = diff.json_diff
+            return jd._replace(path=tuple(jd.path))
+
+        statedb = self.open_state_db(domain, readonly=self.dry_run)
+        if self.changes:
+            raise NotImplementedError("filter --changes")
+        if self.select in MissingIds.form_types:
+            def get_sql_docs(ids):
+                return {f.form_id: f for f in FormAccessorSQL.get_forms(ids)}
+
+            def get_couch_docs(ids):
+                return {f.form_id: f for f in get_couch_forms(ids)}
+
+            filter_diffs = filter_form_diffs
+        elif self.select in MissingIds.case_types:
+            def get_sql_docs(ids):
+                return {c.case_id: c for c in CaseAccessorSQL.get_cases(ids)}
+
+            def get_couch_docs(ids):
+                return {c.case_id: c for c in get_couch_cases(ids)}
+
+            filter_diffs = filter_case_diffs
+        else:
+            raise NotImplementedError(f"--select={self.select}")
+        prompt = self.dry_run and self.stop
+        doc_diffs = statedb.iter_doc_diffs(self.select)
+        doc_diffs = self.with_progress(doc_diffs, statedb)
+        for batch in chunked(doc_diffs, self.batch_size, list):
+            update_doc_diffs(batch)
+            if prompt and not confirm("show more?"):
+                break
+
+    def with_progress(self, doc_diffs, statedb):
+        counts = statedb.get_doc_counts()
+        if self.select:
+            count = counts.get(self.select, Counts())
+            count = count.changes if self.changes else count.diffs
+        else:
+            count = sum(c.changes if self.changes else c.diffs
+                        for c in counts.values())
+        return with_progress_bar(
+            doc_diffs, count, "Docs", oneline=False, stream=sys.stderr)
 
     def do_reset(self, action, domain):
         itr_doc_type = {"cases": "CommCareCase.id"}[action]
@@ -362,8 +441,13 @@ def get_case_related(case_ids):
 def get_form_related(form_ids):
     return {
         form.form_id: (form.user_id, form.received_on)
-        for form in FormAccessorCouch.get_forms(form_ids)
+        for form in get_couch_forms(form_ids)
     }
+
+
+@retry_on_couch_error
+def get_couch_forms(form_ids):
+    return FormAccessorCouch.get_forms(form_ids)
 
 
 def confirm(msg):

--- a/corehq/apps/couch_sql_migration/missingdocs.py
+++ b/corehq/apps/couch_sql_migration/missingdocs.py
@@ -80,8 +80,12 @@ class MissingIds:
     """Iterator of document ids found in Couch but not SQL"""
 
     @classmethod
-    def forms(cls, *args, **kw):
-        return cls(cls.FORM, *args, **kw)
+    def forms(cls, statedb):
+        return cls(cls.FORM, statedb, None)
+
+    @classmethod
+    def cases(cls, statedb):
+        return cls(cls.CASE, statedb, None)
 
     entity = attr.ib()
     statedb = attr.ib()

--- a/corehq/apps/couch_sql_migration/missingdocs.py
+++ b/corehq/apps/couch_sql_migration/missingdocs.py
@@ -110,9 +110,10 @@ class MissingIds:
     }
 
     form_types = list(form_doc_types()) + ["HQSubmission", "XFormInstance-Deleted"]
+    case_types = ['CommCareCase', 'CommCareCase-Deleted']
     _doc_types = {
         FORM: form_types,
-        CASE: ['CommCareCase', 'CommCareCase-Deleted'],
+        CASE: case_types,
     }
 
     def __attrs_post_init__(self):

--- a/corehq/apps/couch_sql_migration/rebuildcase.py
+++ b/corehq/apps/couch_sql_migration/rebuildcase.py
@@ -6,7 +6,6 @@ from dimagi.utils.couch import acquire_lock, release_lock
 from dimagi.ext.jsonobject import DictProperty, StringProperty
 
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.form_processor.change_publishers import publish_case_saved
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.form_processor.backends.sql.processor import FormProcessorSQL
 from corehq.form_processor.models import RebuildWithReason
@@ -42,7 +41,6 @@ def rebuild_and_diff_cases(sql_case, couch_case, original_couch_case, diff, dd_c
         if not diffs:
             # save case only if rebuild resolves diffs
             CaseAccessorSQL.save_case(new_case)
-            publish_case_saved(new_case)
     finally:
         release_lock(lock, degrade_gracefully=True)
     return sql_json, diffs

--- a/corehq/apps/couch_sql_migration/tests/test_casediff.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casediff.py
@@ -123,7 +123,7 @@ class TestDiffCases(SimpleTestCase):
             Diff(
                 doc_id="a",
                 path=["?"],
-                old={"forms": {"b": "missing, blob present"}},
+                old={"forms": {"b": mod.MISSING_BLOB_PRESENT}},
                 new={"forms": {"b": "missing"}},
             ),
         ])
@@ -147,7 +147,7 @@ class TestDiffCases(SimpleTestCase):
         self.assert_diffs([
             Diff(
                 "a/stock/a", "stock state", "missing", ["*"],
-                old={'form_state': 'missing, blob present'},
+                old={'form_state': mod.MISSING_BLOB_PRESENT},
                 new={'form_state': 'missing', 'ledger': self.sql_ledgers["a"].to_json()},
             ),
         ])
@@ -179,7 +179,7 @@ class TestDiffCases(SimpleTestCase):
         self.assert_diffs([
             Diff(
                 "a/stock/a", "stock state", "missing", ["*"],
-                old={'form_state': 'missing, blob present', 'ledger': stock.to_json()},
+                old={'form_state': mod.MISSING_BLOB_PRESENT, 'ledger': stock.to_json()},
                 new={'form_state': 'missing'},
             ),
         ])

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -92,7 +92,7 @@ class FormProcessorSQL(object):
         return (existing_form, new_form)
 
     @classmethod
-    def save_processed_models(cls, processed_forms, cases=None, stock_result=None, publish_to_kafka=True):
+    def save_processed_models(cls, processed_forms, cases=None, stock_result=None):
         db_names = {processed_forms.submitted.db}
         if processed_forms.deprecated:
             db_names |= {processed_forms.deprecated.db}
@@ -142,11 +142,10 @@ class FormProcessorSQL(object):
                     setattr(tracked, tracked._meta.pk.attname, None)
             raise
 
-        if publish_to_kafka:
-            try:
-                cls.publish_changes_to_kafka(processed_forms, cases, stock_result)
-            except Exception as e:
-                raise KafkaPublishingError(e)
+        try:
+            cls.publish_changes_to_kafka(processed_forms, cases, stock_result)
+        except Exception as e:
+            raise KafkaPublishingError(e)
 
     @staticmethod
     def publish_changes_to_kafka(processed_forms, cases, stock_result):

--- a/corehq/form_processor/tests/test_sql_update_strategy.py
+++ b/corehq/form_processor/tests/test_sql_update_strategy.py
@@ -194,14 +194,11 @@ class SqlUpdateStrategyTest(TestCase):
         return CaseAccessorSQL.get_case(case_id)
 
     def _save(self, form, case, transaction):
-        case.track_create(transaction)
-        FormProcessorSQL.save_processed_models(
-            ProcessedForms(form, []),
-            [case],
-            # disable publish to Kafka to avoid intermittent errors caused by
-            # the nexus of kafka's consumer thread and freeze_time
-            publish_to_kafka=False,
-        )
+        # disable publish to Kafka to avoid intermittent errors caused by
+        # the nexus of kafka's consumer thread and freeze_time
+        with patch.object(FormProcessorSQL, "publish_changes_to_kafka"):
+            case.track_create(transaction)
+            FormProcessorSQL.save_processed_models(ProcessedForms(form, []), [case])
 
     def _check_for_reconciliation_error_soft_assert(self, soft_assert_mock):
         for call in soft_assert_mock.call_args_list:


### PR DESCRIPTION
Review by commit 🐡 

The most important change is https://github.com/dimagi/commcare-hq/pull/26768/commits/ca2b56c4e71ade51b6208602c9836dbb1390c4e5, which adds a feature to the `--forms=missing` option that attempts to migrate missing forms referenced by cases and case updates and ledger transactions that are referenced by couch but missing in SQL.