### PR TITLE
OData - fix 500 issue on edge case feed

### DIFF
--- a/corehq/apps/export/views/new.py
+++ b/corehq/apps/export/views/new.py
@@ -167,6 +167,11 @@ class BaseExportView(BaseProjectDataView):
                          and PROPERTY_TAG_INFO in column.tags)
                             or is_reserved_number):
                         column.selected = True
+                    elif (column.label in ['formid', 'caseid']
+                          and PROPERTY_TAG_INFO not in column.tags):
+                        # make sure hidden (eg deleted) labels that are
+                        # formid/caseid are never selected
+                        column.selected = False
 
                     if column.label not in labels and column.selected:
                         labels.append(column.label)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10264

##### SUMMARY
This makes sure that "formid" or "caseid" columns that are tagged as deleted (or anything not INFO) are NEVER selected in OData feeds.