### PR TITLE
[ci skip] UCR doc tweaks

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -358,68 +358,68 @@ Iterator Expression
 .. autoclass:: corehq.apps.userreports.expressions.specs.IteratorExpressionSpec
 
 Base iteration number expressions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+'''''''''''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.IterationNumberExpressionSpec
 
 Related document expressions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.RelatedDocExpressionSpec
 
 Ancestor location expression
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.locations.ucr_expressions.AncestorLocationExpression
 
 Nested expressions
-^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.NestedExpressionSpec
 
 Dict expressions
-^^^^^^^^^^^^^^^^
+''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.DictExpressionSpec
 
 "Add Days" expressions
-^^^^^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.date_specs.AddDaysExpressionSpec
 
 
 "Add Months" expressions
-^^^^^^^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.date_specs.AddMonthsExpressionSpec
 
 "Diff Days" expressions
-^^^^^^^^^^^^^^^^^^^^^^^
+'''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.date_specs.DiffDaysExpressionSpec
 
 "Month Start Date" and "Month End Date" expressions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+'''''''''''''''''''''''''''''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.date_specs.MonthStartDateExpressionSpec
 
 "Evaluator" expression
-^^^^^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.EvalExpressionSpec
 
 ‘Get Case Sharing Groups' expression
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.CaseSharingGroupsExpressionSpec
 
 ‘Get Reporting Groups' expression
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+'''''''''''''''''''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.ReportingGroupsExpressionSpec
 
 Filter, Sort, Map and Reduce Expressions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+''''''''''''''''''''''''''''''''''''''''
 
 We have following expressions that act on a list of objects or list of
 lists. The list to operate on is specified by ``items_expression``. This
@@ -428,32 +428,32 @@ can be any valid expression that returns a list. If the
 fail or return one of empty list or ``None`` value.
 
 map_items Expression
-''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: corehq.apps.userreports.expressions.list_specs.MapItemsExpressionSpec
 
 filter_items Expression
-'''''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: corehq.apps.userreports.expressions.list_specs.FilterItemsExpressionSpec
 
 sort_items Expression
-'''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: corehq.apps.userreports.expressions.list_specs.SortItemsExpressionSpec
 
 reduce_items Expression
-'''''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: corehq.apps.userreports.expressions.list_specs.ReduceItemsExpressionSpec
 
 flatten expression
-''''''''''''''''''
+^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: corehq.apps.userreports.expressions.list_specs.FlattenExpressionSpec
 
 Named Expressions
-^^^^^^^^^^^^^^^^^
+'''''''''''''''''
 
 .. autoclass:: corehq.apps.userreports.expressions.specs.NamedExpressionSpec
 

--- a/docs/ucr/examples.md
+++ b/docs/ucr/examples.md
@@ -259,6 +259,35 @@ In the example below, the indicator is inside a form group question called "impa
 }
 ```
 
+### Get a case property form a form that modifies the case
+
+The following expression looks up a case name from a form that references that case.
+
+To lookup a different property, or for more complex form/case relationships and advanced
+modules just adjust the property paths.
+
+```json
+{
+    "type":"related_doc",
+    "related_doc_type":"CommCareCase",
+    "doc_id_expression":{
+        "type": "property_path",
+        "property_path": [
+            "form",
+            "case",
+            "@case_id"
+        ]
+    },
+    "value_expression":{
+        "type":"property_path",
+        "property_path": [
+            "name"
+        ]
+    }
+}
+```
+
+Note: this is an example *expression*. To use it in a data source just wrap it in a column.
 
 ### Get a custom user data property from a form submission
 


### PR DESCRIPTION
This somewhat fixes the table of contents nesting for Expressions and adds a new example for form --> case property lookup