### PR TITLE
ucr user "name" transform

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1785,6 +1785,19 @@ To use this in a mobile ucr, set the ``'mobile_or_web'`` property to
        }
    }
 
+Displaying Readable User  Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+HQ's best guess at the user's display name, using their first and last name, if available,
+then falling back to their username.
+
+.. code:: json
+
+   {
+       "type": "custom",
+       "custom_type": "user_display_including_name"
+   }
+
 Displaying username instead of user ID
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -1785,7 +1785,7 @@ To use this in a mobile ucr, set the ``'mobile_or_web'`` property to
        }
    }
 
-Displaying Readable User  Name
+Displaying Readable User Name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 HQ's best guess at the user's display name, using their first and last name, if available,

--- a/corehq/apps/userreports/transforms/custom/users.py
+++ b/corehq/apps/userreports/transforms/custom/users.py
@@ -1,10 +1,11 @@
 from corehq.apps.users.util import (
     cached_owner_id_to_display,
     cached_user_id_to_username,
-)
+    cached_user_id_to_user_display)
 
 # these are just aliased here to make it clear what is supported
 get_user_display = cached_user_id_to_username
+get_user_display_use_names = cached_user_id_to_user_display
 get_owner_display = cached_owner_id_to_display
 
 

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -18,7 +18,7 @@ from corehq.apps.userreports.transforms.custom.users import (
     get_owner_display,
     get_user_display,
     get_user_without_domain_display,
-)
+    get_user_display_use_names)
 from corehq.apps.userreports.util import localize
 
 
@@ -34,6 +34,7 @@ _CUSTOM_TRANSFORM_MAP = {
     'month_display': get_month_display,
     'days_elapsed_from_date': days_elapsed_from_date,
     'user_display': get_user_display,
+    'user_display_including_name': get_user_display_use_names,
     'owner_display': get_owner_display,
     'user_without_domain_display': get_user_without_domain_display,
     'short_decimal_display': get_short_decimal_display,

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django.test import TestCase
 
 from corehq.apps.users.models import CommCareUser
-from corehq.apps.users.util import username_to_user_id, user_id_to_username
+from corehq.apps.users.util import username_to_user_id, user_id_to_username, cached_user_id_to_user_display
 
 
 class TestUsernameToUserID(TestCase):
@@ -67,3 +67,16 @@ class TestUserIdToUsernameToUserName(TestCase):
                                                       use_name_if_available=True))
         self.assertEqual('Alice Jones', user_id_to_username(self.user_with_full_name.user_id,
                                                             use_name_if_available=True))
+
+    def test_cached_user_id_to_user_display(self):
+        self.assertEqual('Alice', cached_user_id_to_user_display(self.user_with_first_name.user_id))
+        self.assertEqual('Alice Jones', cached_user_id_to_user_display(self.user_with_full_name.user_id))
+        self.user_with_first_name.first_name = 'Betty'
+        self.user_with_first_name.save()
+        self.assertEqual('Betty', user_id_to_username(self.user_with_first_name.user_id,
+                                                      use_name_if_available=True))
+        self.assertEqual('Alice', cached_user_id_to_user_display(self.user_with_first_name.user_id))
+        self.assertEqual('Alice Jones', cached_user_id_to_user_display(self.user_with_full_name.user_id))
+        # set username back because other tests rely on it
+        self.user_with_first_name.first_name = 'Alice'
+        self.user_with_first_name.save()

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django.test import TestCase
 
 from corehq.apps.users.models import CommCareUser
-from corehq.apps.users.util import username_to_user_id
+from corehq.apps.users.util import username_to_user_id, user_id_to_username
 
 
 class TestUsernameToUserID(TestCase):
@@ -26,3 +26,44 @@ class TestUsernameToUserID(TestCase):
     def test_username_to_user_id_wrong_username(self):
         user_id = username_to_user_id('not-here')
         self.assertIsNone(user_id)
+
+
+class TestUserIdToUsernameToUserName(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestUserIdToUsernameToUserName, cls).setUpClass()
+        cls.user_without_name = CommCareUser.create('test-domain', 'no_name', 'a_secret')
+        cls.user_with_first_name = CommCareUser.create('test-domain', 'first_name', 'a_secret',
+                                                       first_name='Alice')
+        cls.user_with_last_name = CommCareUser.create('test-domain', 'last_name', 'a_secret',
+                                                       last_name='Jones')
+        cls.user_with_full_name = CommCareUser.create('test-domain', 'full_name', 'a_secret',
+                                                       first_name='Alice', last_name='Jones')
+        cls.users = [
+            cls.user_without_name,
+            cls.user_with_first_name,
+            cls.user_with_last_name,
+            cls.user_with_full_name,
+        ]
+        cache.clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        for user in cls.users:
+            user.delete()
+        cache.clear()
+        super(TestUserIdToUsernameToUserName, cls).tearDownClass()
+
+    def test_user_id_to_username_no_names(self):
+        for user in self.users:
+            self.assertEqual(user.username, user_id_to_username(user.user_id))
+
+    def test_user_id_to_username_with_names(self):
+        self.assertEqual('no_name', user_id_to_username(self.user_without_name.user_id,
+                                                        use_name_if_available=True))
+        self.assertEqual('Alice', user_id_to_username(self.user_with_first_name.user_id,
+                                                      use_name_if_available=True))
+        self.assertEqual('Jones', user_id_to_username(self.user_with_last_name.user_id,
+                                                      use_name_if_available=True))
+        self.assertEqual('Alice Jones', user_id_to_username(self.user_with_full_name.user_id,
+                                                            use_name_if_available=True))

--- a/corehq/apps/users/tests/test_util.py
+++ b/corehq/apps/users/tests/test_util.py
@@ -36,9 +36,9 @@ class TestUserIdToUsernameToUserName(TestCase):
         cls.user_with_first_name = CommCareUser.create('test-domain', 'first_name', 'a_secret',
                                                        first_name='Alice')
         cls.user_with_last_name = CommCareUser.create('test-domain', 'last_name', 'a_secret',
-                                                       last_name='Jones')
+                                                      last_name='Jones')
         cls.user_with_full_name = CommCareUser.create('test-domain', 'full_name', 'a_secret',
-                                                       first_name='Alice', last_name='Jones')
+                                                      first_name='Alice', last_name='Jones')
         cls.users = [
             cls.user_without_name,
             cls.user_with_first_name,

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -103,7 +103,7 @@ def username_to_user_id(username):
     return user._id
 
 
-def user_id_to_username(user_id):
+def user_id_to_username(user_id, use_name_if_available=False):
     from corehq.apps.users.models import CouchUser
     if not user_id:
         return None
@@ -116,7 +116,12 @@ def user_id_to_username(user_id):
         user_object = CouchUser.get_db().get(user_id)
     except ResourceNotFound:
         return None
-    return raw_username(user_object['username']) if "username" in user_object else None
+
+    if use_name_if_available and (user_object.get('first_name', '') or user_object.get('last_name', '')):
+        return ' '.join([user_object.get('first_name', ''), user_object.get('last_name', '')]).strip()
+    else:
+        return raw_username(user_object['username']) if "username" in user_object else None
+
 
 def cached_user_id_to_username(user_id):
     if not user_id:

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -137,6 +137,11 @@ def cached_user_id_to_username(user_id):
         return ret
 
 
+@quickcache(['user_id'])
+def cached_user_id_to_user_display(user_id):
+    return user_id_to_username(user_id, use_name_if_available=True)
+
+
 def cached_owner_id_to_display(owner_id):
     from corehq.apps.users.cases import get_wrapped_owner
     from corehq.apps.users.models import CouchUser

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -113,11 +113,10 @@ def user_id_to_username(user_id):
     elif user_id == DEMO_USER_ID:
         return DEMO_USER_ID
     try:
-        login = CouchUser.get_db().get(user_id)
+        user_object = CouchUser.get_db().get(user_id)
     except ResourceNotFound:
         return None
-    return raw_username(login['username']) if "username" in login else None
-
+    return raw_username(user_object['username']) if "username" in user_object else None
 
 def cached_user_id_to_username(user_id):
     if not user_id:


### PR DESCRIPTION
This adds a new transform to UCR to display the user's name (not to be confused with username) if available.

Will be documented [here](https://commcare-hq.readthedocs.io/ucr.html#transforms) post merge.

##### FEATURE FLAG
UCR

##### PRODUCT DESCRIPTION
UCR builders can now use user names wherever they can use transforms