### PR TITLE
Improvements to populate sql script

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -35,6 +35,11 @@ class PopulateSQLCommand(BaseCommand):
         raise NotImplementedError()
 
     def update_or_create_sql_object(self, doc):
+        """
+        This should find and update the sql object that corresponds to the given doc,
+        or create it if it doesn't yet exist. This method is responsible for saving
+        the sql object.
+        """
         raise NotImplementedError()
 
     @classmethod
@@ -123,4 +128,3 @@ class PopulateSQLCommand(BaseCommand):
             with transaction.atomic():
                 logger.info("{} model for doc with id {}".format("Creating" if created else "Updated", doc["_id"]))
                 model, created = self.update_or_create_sql_object(doc)
-                model.save()

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -126,5 +126,5 @@ class PopulateSQLCommand(BaseCommand):
                 doc["_id"]
             ))
             with transaction.atomic():
-                logger.info("{} model for doc with id {}".format("Creating" if created else "Updated", doc["_id"]))
                 model, created = self.update_or_create_sql_object(doc)
+                logger.info("{} model for doc with id {}".format("Creating" if created else "Updated", doc["_id"]))

--- a/corehq/apps/cloudcare/management/commands/populate_application_access.py
+++ b/corehq/apps/cloudcare/management/commands/populate_application_access.py
@@ -28,4 +28,5 @@ class Command(PopulateSQLCommand):
             SQLAppGroup(app_id=group['app_id'], group_id=group['group_id'])
             for group in doc['app_groups']
         ], bulk=False)
+        model.save()
         return (model, created)


### PR DESCRIPTION
As discussed in slack.

The main difference here is that the script has been saving objects explicitly in `migrate_from_migration` even though virtually every subclass uses django's `update_or_create` which already saves the object. This PR removes the explicit save and updates the one subclass that does something more complicated than just calling `update_or_create`.

There's also potentially work to do here to not save objects that were already migrated, but I'm going to investigate some more before doing that. I'm surprised that today's deploy found any Invitation docs to migrate. Once https://github.com/dimagi/commcare-hq/pull/26685 was merged, HQ should have started adding/updating an SQL object every time an Invitation doc was saved, and then I ran the population script, which should have created SQL objects for all pre-merge Invitation docs, so by the time of today's deploy, there shouldn't have been any "missing" SQL objects. Going to look into that further.