### PR TITLE
Late PMT report: Do not show deleted users

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -58,6 +58,17 @@
           "property_value": true,
           "type": "boolean_expression",
           "comment": null
+        },
+        {
+          "expression": {
+            "type": "property_name",
+            "property_name": "is_deleted",
+            "datatype": null
+          },
+          "operator": "eq",
+          "property_value": false,
+          "type": "boolean_expression",
+          "comment": null
         }
       ]
     },


### PR DESCRIPTION
##### SUMMARY
The (original) Late PMT report is showing rows for deleted users.

(This report is a static report for AIRS and VectorLink project spaces.)
