### PR TITLE
Upgrade to celery 4.4.x

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -12,12 +12,12 @@ argparse==1.4.0           # via unittest2
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field, sphinx
 beautifulsoup4==4.8.1
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -93,6 +93,7 @@ html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8                 # via email-validator, requests
 imagesize==1.1.0          # via sphinx
+importlib-metadata==1.5.0  # via kombu
 ipdb==0.11
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.2.2
@@ -107,7 +108,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2
 lxml==4.3.5
@@ -209,7 +210,7 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client
 user-agents==2.0          # via django-user-agents
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
@@ -218,6 +219,7 @@ wheel==0.29.0
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, ipdb, ipython, python-levenshtein, python-termstyle, sphinx, tinycss2

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -9,12 +9,12 @@ amqp==2.5.2               # via kombu
 architect==0.5.6
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field, flower
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11
 cffi==1.13.2              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -79,6 +79,7 @@ hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8
+importlib-metadata==1.5.0  # via kombu
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.2.2
 iso8601==0.1.12
@@ -91,7 +92,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 lxml==4.3.5
 mako==1.1.0               # via alembic
@@ -170,7 +171,7 @@ unidecode==0.04.20
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 uwsgi==2.0.18
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
@@ -178,6 +179,7 @@ werkzeug==0.11.15
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==19.3.1

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -9,12 +9,12 @@ amqp==2.5.2               # via kombu
 architect==0.5.6
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -76,6 +76,7 @@ hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8                 # via email-validator, requests
+importlib-metadata==1.5.0  # via kombu
 iso8601==0.1.12
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3
@@ -86,7 +87,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 lxml==4.3.5
 mako==1.1.0               # via alembic
@@ -153,13 +154,14 @@ ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
 werkzeug==0.11.15
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -11,12 +11,12 @@ argparse==1.4.0           # via unittest2
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field
 beautifulsoup4==4.8.1
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -84,6 +84,7 @@ hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8                 # via email-validator, requests
+importlib-metadata==1.5.0  # via kombu
 iso8601==0.1.12
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3
@@ -94,7 +95,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2
 lxml==4.3.5
@@ -171,13 +172,14 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
 werkzeug==0.11.15
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -12,12 +12,12 @@ argparse==1.4.0           # via unittest2
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field, sphinx
 beautifulsoup4==4.8.1
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -93,6 +93,7 @@ html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8                 # via email-validator, requests
 imagesize==1.1.0          # via sphinx
+importlib-metadata==1.5.0  # via kombu
 ipdb==0.11
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.2.2
@@ -107,7 +108,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2
 lxml==4.3.5
@@ -209,7 +210,7 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client
 user-agents==2.0          # via django-user-agents
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
@@ -218,6 +219,7 @@ wheel==0.29.0
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, ipdb, ipython, python-levenshtein, python-termstyle, sphinx, tinycss2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -9,12 +9,12 @@ amqp==2.5.2               # via kombu
 architect==0.5.6
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field, flower
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11
 cffi==1.13.2              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -79,6 +79,7 @@ hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8
+importlib-metadata==1.5.0  # via kombu
 ipython-genutils==0.2.0   # via traitlets
 ipython==5.2.2
 iso8601==0.1.12
@@ -91,7 +92,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 lxml==4.3.5
 mako==1.1.0               # via alembic
@@ -170,7 +171,7 @@ unidecode==0.04.20
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 uwsgi==2.0.18
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
@@ -178,6 +179,7 @@ werkzeug==0.11.15
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==19.3.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,10 +2,7 @@ attrs~=18.1
 iso8601==0.1.12
 jsonobject==0.9.9
 jsonobject-couchdbkit~=0.9
-# celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737
-# upgrade when https://github.com/celery/celery/issues/4980 is fixed
-# originally changes were made on nickpell/celery, but this was moved to dimagi/celery
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery~=4.4.0
 # required by django-digest
 decorator==4.0.11
 django>=1.11.28,<2  # https://github.com/advisories/GHSA-hmr4-m2h5-33qx
@@ -26,8 +23,6 @@ ghdiff==0.4
 gunicorn
 lxml~=4.3.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
-billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 mock==2.0.0
 Pillow>=6.2.0,<7.0.0
 phonenumberslite~=8.8

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,12 +9,12 @@ amqp==2.5.2               # via kombu
 architect==0.5.6
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -76,6 +76,7 @@ hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8                 # via email-validator, requests
+importlib-metadata==1.5.0  # via kombu
 iso8601==0.1.12
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3
@@ -86,7 +87,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 lxml==4.3.5
 mako==1.1.0               # via alembic
@@ -153,13 +154,14 @@ ua-parser==0.8.0          # via user-agents
 unidecode==0.04.20
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
 werkzeug==0.11.15
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -11,12 +11,12 @@ argparse==1.4.0           # via unittest2
 attrs==18.2.0
 babel==2.7.0              # via django-phonenumber-field
 beautifulsoup4==4.8.1
-billiard==3.5.0.4
+billiard==3.6.3.0         # via celery
 boto3==1.10.14
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery==4.4.1
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -84,6 +84,7 @@ hiredis==0.2.0
 html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0
 idna==2.8                 # via email-validator, requests
+importlib-metadata==1.5.0  # via kombu
 iso8601==0.1.12
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3
@@ -94,7 +95,7 @@ jsonobject-couchdbkit==0.9.17
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
-kombu==4.2.2.post1
+kombu==4.6.8              # via celery
 laboratory==0.2.0
 linecache2==1.0.0         # via traceback2
 lxml==4.3.5
@@ -171,13 +172,14 @@ unidecode==0.04.20
 unittest2==1.1.0
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery
 weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
 werkzeug==0.11.15
 wrapt==1.11.2             # via ddtrace
 xlrd==1.0.0
 xlwt==1.3.0
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2


### PR DESCRIPTION
##### SUMMARY
Reopening https://github.com/dimagi/commcare-hq/pull/26779 (which was merged inadvertently and reverted)

Just want to see what the tests look like. I recall this possibly being necessary for the upgrade to Django 2, but regardless it's been on my radar to get on a standard version of celery for a while.
