### PR TITLE
[Icds dashboard] mark not null when not toilet

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -406,7 +406,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
             type_toilet = ut.type_toilet,
             preschool_kit_available = ut.preschool_kit_available,
             preschool_kit_usable = ut.preschool_kit_usable,
-            infra_functional_toilet = ut.infra_functional_toilet,
+            infra_functional_toilet = CASE WHEN ut.toilet_facility=1 THEN ut.infra_functional_toilet ELSE 0 END,
             infra_baby_weighing_scale = ut.infra_baby_weighing_scale,
             infra_adult_weighing_scale = ut.infra_adult_weighing_scale,
             infra_infant_weighing_scale = ut.infra_infant_weighing_scale,

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
@@ -256,7 +256,7 @@
             type_toilet = ut.type_toilet,
             preschool_kit_available = ut.preschool_kit_available,
             preschool_kit_usable = ut.preschool_kit_usable,
-            infra_functional_toilet = ut.infra_functional_toilet,
+            infra_functional_toilet = CASE WHEN ut.toilet_facility=1 THEN ut.infra_functional_toilet ELSE 0 END,
             infra_baby_weighing_scale = ut.infra_baby_weighing_scale,
             infra_adult_weighing_scale = ut.infra_adult_weighing_scale,
             infra_infant_weighing_scale = ut.infra_infant_weighing_scale,


### PR DESCRIPTION
toilet_function question is only displayed on the app when toilet_facility is answered as yes. Else, its not displayed. Currently it shows as "data not entered" on the dashboard. We want to handle as if toilet_facility is answered as no then 'not available' should be displayed.

ticket: https://dimagi-dev.atlassian.net/browse/ICDS-1292
