### PR TITLE
Check base_doc, not is_deleted

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -62,11 +62,11 @@
         {
           "expression": {
             "type": "property_name",
-            "property_name": "is_deleted",
+            "property_name": "base_doc",
             "datatype": null
           },
-          "operator": "eq",
-          "property_value": false,
+          "operator": "not_eq",
+          "property_value": "CouchUser-Deleted",
           "type": "boolean_expression",
           "comment": null
         }


### PR DESCRIPTION
Like #26785 but more likely to work. :unamused: 

##### SUMMARY
is_deleted() is a property function, not an attribute, so it isn't present in the JSON representation of a CommCareUser. We have to check the value of base_doc to determine whether the user is deleted.
