### PR TITLE
Upgrade jsonobject-couchdbkit to 1.0.1 for Django 2 compatability

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -103,7 +103,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -87,7 +87,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -82,7 +82,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -90,7 +90,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -103,7 +103,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -87,7 +87,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,7 @@
 attrs~=18.1
 iso8601==0.1.12
 jsonobject==0.9.9
-jsonobject-couchdbkit~=0.9
+jsonobject-couchdbkit~=1.0.1
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed
 # originally changes were made on nickpell/celery, but this was moved to dimagi/celery

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -82,7 +82,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -90,7 +90,7 @@ jinja2==2.10.3
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0
 jsonfield==1.0.3
-jsonobject-couchdbkit==0.9.17
+jsonobject-couchdbkit==1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7


### PR DESCRIPTION
##### SUMMARY
Tracking here https://docs.google.com/spreadsheets/d/1lWVxPLU2_f7Lobf5z4GcXOue91lWDzSWvGjEe_4o7QA/edit#gid=0

This rolls out the changes Daniel made in https://github.com/dimagi/couchdbkit/pull/76. Thanks @millerdev!