### PR TITLE
Upgrade django-partial-index to 0.6.0 for Django 2.2 compatibility

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -51,7 +51,7 @@ django-extensions==2.2.5
 django-formtools==2.1
 git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -42,7 +42,7 @@ django-crispy-forms==1.7.0
 django-cte==1.1.4
 django-formtools==2.1
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -41,7 +41,7 @@ django-crispy-forms==1.7.0
 django-cte==1.1.4
 django-formtools==2.1
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -46,7 +46,7 @@ django-cte==1.1.4
 django-formtools==2.1
 git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -51,7 +51,7 @@ django-extensions==2.2.5
 django-formtools==2.1
 git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -42,7 +42,7 @@ django-crispy-forms==1.7.0
 django-cte==1.1.4
 django-formtools==2.1
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -70,7 +70,7 @@ django-compressor==2.1
 django-angular==0.7.16
 Pycco==0.5.1
 django-cte==1.1.4
-django-partial-index~=0.5.0
+django-partial-index~=0.6.0
 jsonpath-rw==1.4.0
 django-transfer==0.4
 Pygments~=2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,7 +41,7 @@ django-crispy-forms==1.7.0
 django-cte==1.1.4
 django-formtools==2.1
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -46,7 +46,7 @@ django-cte==1.1.4
 django-formtools==2.1
 git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 django-otp==0.3.13
-django-partial-index==0.5.2
+django-partial-index==0.6.0
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.7
 django-ranged-response==0.2.0  # via django-simple-captcha


### PR DESCRIPTION
##### SUMMARY
Tracking in https://docs.google.com/spreadsheets/d/1lWVxPLU2_f7Lobf5z4GcXOue91lWDzSWvGjEe_4o7QA/edit#gid=0

The diff is quite small https://github.com/mattiaslinnap/django-partial-index/compare/0.5.2...0.6.0 so I think this upgrade doesn't require much fuss beyond just tests passing. (We could [get away without this upgrade](https://github.com/mattiaslinnap/django-partial-index/tree/master#060-latest) if we were targeting Django 2.0 or 2.1, but Django 2.2 is the LTS release and the one we've chosen to target.)