### PR TITLE
Switched User Org recipients search to use standard location search

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -245,6 +245,7 @@ class FilteredLocationDownload(BaseLocationView):
 
 class LocationOptionsController(EmwfOptionsController):
     namespace_locations = False
+    case_sharing_only = False
 
     @property
     def data_sources(self):

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -38,11 +38,13 @@ def paginate_options(data_sources, query, start, size):
 
 class EmwfOptionsController(object):
     namespace_locations = True
+    case_sharing_only = False
 
-    def __init__(self, request, domain, search):
+    def __init__(self, request, domain, search, case_sharing_only=False):
         self.request = request
         self.domain = domain
         self.search = search
+        self.case_sharing_only = case_sharing_only
 
     @property
     @memoized
@@ -91,6 +93,8 @@ class EmwfOptionsController(object):
         else:
             included_objects = SQLLocation.active_objects
         locations = included_objects.filter_by_user_input(self.domain, query)
+        if self.case_sharing_only:
+            locations = locations.filter(location_type__shares_cases=True)
         return locations.accessible_to_user(self.domain, self.request.couch_user)
 
     def get_locations_size(self, query):

--- a/corehq/messaging/scheduling/async_handlers.py
+++ b/corehq/messaging/scheduling/async_handlers.py
@@ -84,23 +84,12 @@ class MessagingRecipientHandler(BaseAsyncHandler):
         return self._get_user_organization_response()
 
     def _get_user_organization_response(self, case_sharing_only=False):
-        domain = self.request.domain
-        query = self.data.get('searchString')
-        result = (
-            SQLLocation
-            .active_objects
-            .filter(domain=domain, name__icontains=query)
-            .order_by('name')
-            .values_list('location_id', 'name')
-        )
-
-        if case_sharing_only:
-            result = result.filter(location_type__shares_cases=True)
-
-        return [
-            {'id': row[0], 'text': row[1]}
-            for row in result[:10]
-        ]
+        from corehq.apps.locations.views import LocationOptionsController
+        controller = LocationOptionsController(self.request, self.request.domain,
+                                               self.data.get('searchString'),
+                                               case_sharing_only=case_sharing_only)
+        (count, results) = controller.get_options()
+        return results[:10]
 
     @property
     def schedule_location_types_response(self):

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -33,6 +33,7 @@ from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.reminders.util import get_form_list, get_combined_id, split_combined_id
+from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.sms.util import get_or_create_translation_doc
 from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.users.models import CommCareUser
@@ -1063,6 +1064,7 @@ class ScheduleForm(Form):
         required=False,
         label=ugettext_lazy("User Organization Recipient(s)"),
         widget=SelectMultiple(choices=[]),
+        help_text=ExpandedMobileWorkerFilter.location_search_help,
     )
     include_descendant_locations = BooleanField(
         required=False,


### PR DESCRIPTION
##### SUMMARY
Same idea as https://github.com/dimagi/commcare-hq/pull/26646

`async_handlers.py` could probably use the EMWF more, but the current problem for ICDS is just that the location search isn't returning proper results, so that's the only part I touched here.

##### PRODUCT DESCRIPTION
See https://github.com/dimagi/commcare-hq/pull/26646 - this PR applies that same location search to the "User Organization Recipient(s)" dropdown in conditional alerts.

<img width="818" alt="Screen Shot 2020-03-09 at 11 52 27 AM" src="https://user-images.githubusercontent.com/1486591/76232047-876de300-61fc-11ea-8abc-b2381e9738e7.png">

