### PR TITLE
Force fresh data to fix error creating new domain

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -39,14 +39,14 @@ class BaseModifySubscriptionHandler(object):
     def __init__(self, domain, new_plan_version, changed_privs, date_start=None):
 
         def get_domain(domain):
-            obj = Domain.get_by_name(domain)
+            obj = Domain.get_by_name(domain, strict=True)
             if obj:
                 return obj
             else:
                 # This could happen in when there is an issue with couch cluster
                 #   that makes the obj not available
                 time.sleep(5)
-                return Domain.get_by_name(domain)
+                return Domain.get_by_name(domain, strict=True)
 
         self.domain = domain if isinstance(domain, Domain) else get_domain(domain)
         if self.domain is None:


### PR DESCRIPTION
##### SUMMARY
https://sentry.io/organizations/dimagi/issues/1507146357/events/79eee128200a433e885fc5f714cc8fb8/?project=136860

I think this is the right fix, but it seems like the brittleness in this area only turned into this bug on Feb 10, possibly due to the rollout of https://github.com/dimagi/commcare-hq/pull/26348. There are other possible readings of sentry on this, but that's my current best guess.