### PR TITLE
Bulk lookup for mobile users

### DIFF
--- a/corehq/apps/users/static/users/js/bulk_lookup.js
+++ b/corehq/apps/users/static/users/js/bulk_lookup.js
@@ -1,0 +1,15 @@
+hqDefine("users/js/bulk_lookup", [
+    "jquery",
+    "hqwebapp/js/bulk_upload_file",
+], function (
+    $,
+    ko
+) {
+    // Most bulk upload pages use .disable-on-submit and reload the page on submit.
+    // This one downloads an excel file, so the page doesn't get reloaded.
+    $(function () {
+        $(".disable-on-submit").removeClass("disable-on-submit");
+    });
+
+    return 1;
+});

--- a/corehq/apps/users/static/users/js/bulk_lookup.js
+++ b/corehq/apps/users/static/users/js/bulk_lookup.js
@@ -2,8 +2,7 @@ hqDefine("users/js/bulk_lookup", [
     "jquery",
     "hqwebapp/js/bulk_upload_file",
 ], function (
-    $,
-    ko
+    $
 ) {
     // Most bulk upload pages use .disable-on-submit and reload the page on submit.
     // This one downloads an excel file, so the page doesn't get reloaded.

--- a/corehq/apps/users/templates/users/bulk_lookup.html
+++ b/corehq/apps/users/templates/users/bulk_lookup.html
@@ -1,0 +1,21 @@
+{% extends 'hqwebapp/base_section.html' %}
+
+{% load crispy_forms_tags %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% requirejs_main 'hqwebapp/js/bulk_upload_file' %}
+
+{% block page_content %}
+  {% blocktrans %}
+    <h2>
+      Mobile Workers Bulk Lookup
+    </h2>
+
+    <p class="help-block">
+      Please upload an Excel file with a single <strong>username</strong> column.
+    </p>
+
+  {% endblocktrans %}
+  {% crispy bulk_upload_form %}
+{% endblock page_content %}

--- a/corehq/apps/users/templates/users/bulk_lookup.html
+++ b/corehq/apps/users/templates/users/bulk_lookup.html
@@ -4,7 +4,7 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% requirejs_main 'hqwebapp/js/bulk_upload_file' %}
+{% requirejs_main 'users/js/bulk_lookup' %}
 
 {% block page_content %}
   {% blocktrans %}

--- a/corehq/apps/users/templates/users/bulk_lookup.html
+++ b/corehq/apps/users/templates/users/bulk_lookup.html
@@ -14,6 +14,7 @@
 
     <p class="help-block">
       Please upload an Excel file with a single <strong>username</strong> column.
+      This page will then generate an Excel download noting which of the uploaded users already exist.
     </p>
 
   {% endblocktrans %}

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -60,13 +60,11 @@
                 {% trans "Edit User Fields" %}
               </a>
             {% endif %}
-            {% if request|toggle_enabled:"BULK_USER_DELETE" %}
+            {% if request|toggle_enabled:"FILTERED_BULK_USER_DOWNLOAD" %}
               <a class="btn btn-danger" href="{% url "delete_commcare_users" domain %}">
                 <i class="fa fa-trash"></i>
                 {% trans "Bulk Delete Users" %}
               </a>
-            {% endif %}
-            {% if request|toggle_enabled:"BULK_USER_LOOKUP" %}
               <a class="btn btn-default" href="{% url "commcare_users_lookup" domain %}">
                 <i class="fa fa-search"></i>
                 {% trans "Bulk Lookup of Users" %}

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -66,6 +66,12 @@
                 {% trans "Bulk Delete Users" %}
               </a>
             {% endif %}
+            {% if request|toggle_enabled:"BULK_USER_LOOKUP" %}
+              <a class="btn btn-default" href="{% url "commcare_users_lookup" domain %}">
+                <i class="fa fa-search"></i>
+                {% trans "Bulk Lookup of Users" %}
+              </a>
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -34,6 +34,7 @@ from .views.mobile.groups import (
     GroupsListView,
 )
 from .views.mobile.users import (
+    CommCareUsersLookup,
     CommCareUserSelfRegistrationView,
     ConfirmBillingAccountForExtraUsersView,
     ConfirmTurnOffDemoModeView,
@@ -115,6 +116,7 @@ urlpatterns = [
     url(r'^commcare/confirm_turn_off_demo_mode/(?P<couch_user_id>[ \w-]+)/$', ConfirmTurnOffDemoModeView.as_view(),
         name=ConfirmTurnOffDemoModeView.urlname),
     url(r'^commcare/delete/$', DeleteCommCareUsers.as_view(), name=DeleteCommCareUsers.urlname),
+    url(r'^commcare/lookup/$', CommCareUsersLookup.as_view(), name=CommCareUsersLookup.urlname),
     url(r'^commcare/reset_demo_user_restore/(?P<user_id>[ \w-]+)/$', reset_demo_user_restore,
         name='reset_demo_user_restore'),
     url(r'^commcare/demo_restore/status/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/(?P<user_id>[ \w-]+)/$',

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1142,16 +1142,8 @@ class UsernameUploadMixin(object):
             Get username list from Excel supplied in request.FILES.
             Adds any errors to request.messages.
         """
-        try:
-            workbook = get_workbook(request.FILES.get('bulk_upload_file'))
-        except WorkbookJSONError as e:
-            messages.error(request, str(e))
-            return None
-
-        try:
-            sheet = workbook.get_worksheet()
-        except WorksheetNotFound:
-            messages.error(request, _("Workbook has no worksheets"))
+        sheet = self._get_sheet(request)
+        if not sheet:
             return None
 
         try:
@@ -1165,6 +1157,21 @@ class UsernameUploadMixin(object):
             return None
 
         return usernames
+
+    def _get_sheet(self, request):
+        try:
+            workbook = get_workbook(request.FILES.get('bulk_upload_file'))
+        except WorkbookJSONError as e:
+            messages.error(request, str(e))
+            return None
+
+        try:
+            sheet = workbook.get_worksheet()
+        except WorksheetNotFound:
+            messages.error(request, _("Workbook has no worksheets"))
+            return None
+
+        return sheet
 
 
 class DeleteCommCareUsers(BaseManageCommCareUserView, UsernameUploadMixin):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1255,11 +1255,6 @@ class CommCareUsersLookup(BaseManageCommCareUserView, UsernameUploadMixin):
         return context
 
     def post(self, request, *args, **kwargs):
-        outfile = io.BytesIO()
-        writer = Excel2007ExportWriter()
-        tab_name = "users"
-        header_table = [(tab_name, [(_("username"), _("exists"))])]
-        writer.open(header_table=header_table, file=outfile)
         usernames = self._get_usernames(request)
         if not usernames:
             return self.get(request, *args, **kwargs)
@@ -1270,6 +1265,12 @@ class CommCareUsersLookup(BaseManageCommCareUserView, UsernameUploadMixin):
         rows = []
         for username in usernames:
             rows.append([raw_username(username), _("no") if username in usernames_not_found else _("yes")])
+
+        outfile = io.BytesIO()
+        tab_name = "users"
+        header_table = [(tab_name, [(_("username"), _("exists"))])]
+        writer = Excel2007ExportWriter()
+        writer.open(header_table=header_table, file=outfile)
         writer.write([(tab_name, rows)])
         writer.close()
         response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1,3 +1,4 @@
+import io
 import json
 import re
 from collections import defaultdict
@@ -5,12 +6,14 @@ from datetime import datetime
 
 from braces.views import JsonRequestResponseMixin
 from couchdbkit import ResourceNotFound
+from couchexport.models import Format
+from couchexport.writers import Excel2007ExportWriter
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.http.response import HttpResponseServerError
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
@@ -1129,7 +1132,55 @@ class FilteredUserDownload(BaseManageCommCareUserView):
         )
 
 
-class DeleteCommCareUsers(BaseManageCommCareUserView):
+class UsernameUploadMixin(object):
+    """
+    Contains helper functions for working with a file that consists of a single column of usernames.
+    """
+
+    def _get_usernames(self, request):
+        """
+            Get username list from Excel supplied in request.FILES.
+            Adds any errors to request.messages.
+        """
+        try:
+            workbook = get_workbook(request.FILES.get('bulk_upload_file'))
+        except WorkbookJSONError as e:
+            messages.error(request, str(e))
+            return None
+
+        try:
+            sheet = workbook.get_worksheet()
+        except WorksheetNotFound:
+            messages.error(request, _("Workbook has no worksheets"))
+            return None
+
+        try:
+            usernames = [format_username(row['username'], request.domain) for row in sheet]
+        except KeyError:
+            messages.error(request, _("No users found. Please check your file contains a 'username' column."))
+            return None
+
+        if not len(usernames):
+            messages.error(request, _("No users found. Please check file is not empty."))
+            return None
+
+        return usernames
+
+    def _get_usernames_not_found(self, request, user_docs_by_id, usernames, strict=True):
+        """
+            The only side effect of this is to possibly add to request.messages.
+
+            If strict is True, add errors to request.messages for users not found.
+        """
+        usernames_not_found = set(usernames) - {doc['username'] for doc in user_docs_by_id.values()}
+        if strict and usernames_not_found:
+            message = _("The following users were not found: {}.").format(
+                ", ".join(map(raw_username, usernames_not_found)))
+            messages.error(request, message)
+        return usernames_not_found
+
+
+class DeleteCommCareUsers(BaseManageCommCareUserView, UsernameUploadMixin):
     urlname = 'delete_commcare_users'
     page_title = ugettext_noop('Bulk Delete')
     template_name = 'users/bulk_delete.html'
@@ -1160,31 +1211,6 @@ class DeleteCommCareUsers(BaseManageCommCareUserView):
 
         return self.get(request, *args, **kwargs)
 
-    def _get_usernames(self, request):
-        """
-            Get username list from Excel supplied in request.FILES.
-            Adds any errors to request.messages.
-        """
-        try:
-            workbook = get_workbook(request.FILES.get('bulk_upload_file'))
-        except WorkbookJSONError as e:
-            messages.error(request, str(e))
-            return None
-
-        try:
-            sheet = workbook.get_worksheet()
-        except WorksheetNotFound:
-            messages.error(request, _("Workbook has no worksheets"))
-            return None
-
-        try:
-            usernames = {format_username(row['username'], request.domain) for row in sheet}
-        except KeyError:
-            messages.error(request, _("No users found. Please check your file contains a 'username' column."))
-            return None
-
-        return usernames
-
     def _get_user_ids_with_forms(self, request, user_docs_by_id):
         """
             Find users who have ever submitted a form, and add to request.messages if so.
@@ -1205,17 +1231,6 @@ class DeleteCommCareUsers(BaseManageCommCareUserView):
 
         return user_ids_with_forms
 
-    def _get_usernames_not_found(self, request, user_docs_by_id, usernames):
-        """
-            The only side effect of this is to possibly add to request.messages.
-        """
-        usernames_not_found = usernames - {doc['username'] for doc in user_docs_by_id.values()}
-        if usernames_not_found:
-            message = _("The following users were not found: {}.").format(
-                ", ".join(map(raw_username, usernames_not_found)))
-            messages.error(request, message)
-        return usernames_not_found
-
     def _delete_users(self, request, user_docs_by_id, user_ids_with_forms):
         deleted_count = 0
         for user_id, doc in user_docs_by_id.items():
@@ -1226,7 +1241,7 @@ class DeleteCommCareUsers(BaseManageCommCareUserView):
             messages.success(request, f"{deleted_count} user(s) deleted.")
 
 
-class CommCareUsersLookup(BaseManageCommCareUserView):
+class CommCareUsersLookup(BaseManageCommCareUserView, UsernameUploadMixin):
     urlname = 'commcare_users_lookup'
     page_title = ugettext_noop('Mobile Workers Bulk Lookup')
     template_name = 'users/bulk_lookup.html'
@@ -1240,8 +1255,27 @@ class CommCareUsersLookup(BaseManageCommCareUserView):
         return context
 
     def post(self, request, *args, **kwargs):
-        # TODO: download
-        return
+        outfile = io.BytesIO()
+        writer = Excel2007ExportWriter()
+        tab_name = "users"
+        header_table = [(tab_name, [(_("username"), _("exists"))])]
+        writer.open(header_table=header_table, file=outfile)
+        usernames = self._get_usernames(request)
+        if not usernames:
+            return self.get(request, *args, **kwargs)
+
+        user_docs_by_id = {doc['_id']: doc for doc in get_user_docs_by_username(usernames)}
+        usernames_not_found = self._get_usernames_not_found(request, user_docs_by_id, usernames, strict=False)
+
+        rows = []
+        for username in usernames:
+            rows.append([raw_username(username), _("no") if username in usernames_not_found else _("yes")])
+        writer.write([(tab_name, rows)])
+        writer.close()
+        response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)
+        response['Content-Disposition'] = f'attachment; filename="{self.domain} users.xlsx"'
+        response.write(outfile.getvalue())
+        return response
 
 
 @require_can_edit_commcare_users

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1226,6 +1226,24 @@ class DeleteCommCareUsers(BaseManageCommCareUserView):
             messages.success(request, f"{deleted_count} user(s) deleted.")
 
 
+class CommCareUsersLookup(BaseManageCommCareUserView):
+    urlname = 'commcare_users_lookup'
+    page_title = ugettext_noop('Mobile Workers Bulk Lookup')
+    template_name = 'users/bulk_lookup.html'
+
+    @property
+    def page_context(self):
+        context = self.main_context
+        context.update({
+            'bulk_upload_form': get_bulk_upload_form(),
+        })
+        return context
+
+    def post(self, request, *args, **kwargs):
+        # TODO: download
+        return
+
+
 @require_can_edit_commcare_users
 def count_users(request, domain):
     from corehq.apps.users.dbaccessors.all_commcare_users import get_commcare_users_by_filters

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1262,6 +1262,12 @@ class CommCareUsersLookup(BaseManageCommCareUserView, UsernameUploadMixin):
         for username in usernames:
             rows.append([raw_username(username), _("yes") if username in known_usernames else _("no")])
 
+        response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)
+        response['Content-Disposition'] = f'attachment; filename="{self.domain} users.xlsx"'
+        response.write(self._excel_data(rows))
+        return response
+
+    def _excel_data(self, rows):
         outfile = io.BytesIO()
         tab_name = "users"
         header_table = [(tab_name, [(_("username"), _("exists"))])]
@@ -1269,10 +1275,7 @@ class CommCareUsersLookup(BaseManageCommCareUserView, UsernameUploadMixin):
         writer.open(header_table=header_table, file=outfile)
         writer.write([(tab_name, rows)])
         writer.close()
-        response = HttpResponse(content_type=Format.from_format('xlsx').mimetype)
-        response['Content-Disposition'] = f'attachment; filename="{self.domain} users.xlsx"'
-        response.write(outfile.getvalue())
-        return response
+        return outfile.getvalue()
 
 
 @require_can_edit_commcare_users

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1271,6 +1271,8 @@ class ProjectUsersTab(UITab):
                      'urlname': 'upload_commcare_users'},
                     {'title': _('Bulk Delete'),
                      'urlname': 'delete_commcare_users'},
+                    {'title': _('Bulk Lookup'),
+                     'urlname': 'commcare_users_lookup'},
                     {'title': _('Edit User Fields'),
                      'urlname': 'user_fields_view'},
                     {'title': _('Filter and Download Users'),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1360,7 +1360,7 @@ BULK_USER_LOOKUP = StaticToggle(
     "a download noting which ones exist in the system.",
     TAG_SOLUTIONS_LIMITED,
     [NAMESPACE_DOMAIN],
-    help_link='TODO',
+    help_link='https://confluence.dimagi.com/display/ccinternal/Bulk+Lookup+Users',
 )
 
 FILTERED_LOCATION_DOWNLOAD = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1354,6 +1354,15 @@ BULK_USER_DELETE = StaticToggle(
     help_link='https://confluence.dimagi.com/display/ccinternal/Bulk+Delete+Users',
 )
 
+BULK_USER_LOOKUP = StaticToggle(
+    'bulk_user_lookup',
+    "Bulk mobile worker lookup: upload a set of usernames and receive "
+    "a download noting which ones exist in the system.",
+    TAG_SOLUTIONS_LIMITED,
+    [NAMESPACE_DOMAIN],
+    help_link='TODO',
+)
+
 FILTERED_LOCATION_DOWNLOAD = StaticToggle(
     'filtered_location_download',
     "Ability to filter location download to include only a specified location and its descendants.",

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1340,27 +1340,10 @@ ENABLE_ALL_ADD_ONS = StaticToggle(
 
 FILTERED_BULK_USER_DOWNLOAD = StaticToggle(
     'filtered_bulk_user_download',
-    "Ability to filter mobile workers based on role, location, and username when doing bulk download",
+    "Bulk mobile worker management features: filtered download, bulk delete, and bulk lookup users.",
     TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/ccinternal/Filter+Mobile+Workers+Download',
-)
-
-BULK_USER_DELETE = StaticToggle(
-    'bulk_user_delete',
-    "Allow bulk deletion of users based on a username upload.",
-    TAG_SOLUTIONS_LIMITED,
-    [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/ccinternal/Bulk+Delete+Users',
-)
-
-BULK_USER_LOOKUP = StaticToggle(
-    'bulk_user_lookup',
-    "Bulk mobile worker lookup: upload a set of usernames and receive "
-    "a download noting which ones exist in the system.",
-    TAG_SOLUTIONS_LIMITED,
-    [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/ccinternal/Bulk+Lookup+Users',
+    help_link='https://confluence.dimagi.com/display/ccinternal/Bulk+Mobile+Workers+Management',
 )
 
 FILTERED_LOCATION_DOWNLOAD = StaticToggle(


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1199

##### FEATURE FLAG
"Bulk mobile worker management features: filtered download, bulk delete, and bulk lookup users."

This PR renames this flag, which used to be called "Ability to filter mobile workers based on role, location, and username when doing bulk download." It also deletes the "Allow bulk deletion of users based on a username upload." and moves that functionality under the same feature flag.

##### PRODUCT DESCRIPTION
Adds a "Bulk Lookup of Users" button to mobile workers page. @dimagi/product and @biyeun  I'm not proud of adding a sixth button to this row of buttons and am open to feedback. I considered putting tabs or panels on this page (one for users, one for "actions"?) but wasn't convinced it would be better.
<img width="1389" alt="Screen Shot 2020-03-09 at 7 11 38 PM" src="https://user-images.githubusercontent.com/1486591/76265210-4eecfa00-623a-11ea-952f-f2937ec446d1.png">

The upload page accepts a spreadsheet of usernames and then creates a download indicating which of those users are already present in the system.
<img width="892" alt="Screen Shot 2020-03-09 at 7 12 08 PM" src="https://user-images.githubusercontent.com/1486591/76265225-544a4480-623a-11ea-9c15-4786b2a7d362.png">

@AndreaMKing5 The feature flag is marked solutions limited, let me know if you would prefer something else. There's no harm or risk to this feature, I just don't imagine many projects having a use for it.