### PR TITLE
Fixed alignment of billing modals

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2243,20 +2243,18 @@ class AdjustBalanceForm(forms.Form):
                 'adjust',
                 css_class='modal-body ko-adjust-balance-form',
             ),
-            hqcrispy.FormActions(
-                crispy.ButtonHolder(
-                    crispy.Submit(
-                        'adjust_balance',
-                        'Apply',
-                        css_class='disable-on-submit',
-                        data_loading_text='Submitting...',
-                    ),
-                    crispy.Button(
-                        'close',
-                        'Close',
-                        css_class='disable-on-submit btn-default',
-                        data_dismiss='modal',
-                    ),
+            crispy.Div(
+                crispy.Submit(
+                    'adjust_balance',
+                    'Apply',
+                    css_class='disable-on-submit',
+                    data_loading_text='Submitting...',
+                ),
+                crispy.Button(
+                    'close',
+                    'Close',
+                    css_class='disable-on-submit btn-default',
+                    data_dismiss='modal',
                 ),
                 css_class='modal-footer',
             ),
@@ -2441,20 +2439,18 @@ class ResendEmailForm(forms.Form):
                 'resend',
                 css_class='modal-body',
             ),
-            hqcrispy.FormActions(
-                crispy.ButtonHolder(
-                    crispy.Submit(
-                        'resend_email',
-                        'Send Email',
-                        css_class='disable-on-submit',
-                        data_loading_text='Submitting...',
-                    ),
-                    crispy.Button(
-                        'close',
-                        'Close',
-                        css_class='disable-on-submit',
-                        data_dismiss='modal',
-                    ),
+            crispy.Div(
+                crispy.Submit(
+                    'resend_email',
+                    'Send Email',
+                    css_class='disable-on-submit',
+                    data_loading_text='Submitting...',
+                ),
+                crispy.Button(
+                    'close',
+                    'Close',
+                    css_class='disable-on-submit btn-default',
+                    data_dismiss='modal',
                 ),
                 css_class='modal-footer',
             ),


### PR DESCRIPTION
Tiny. Ignore whitespace.

Before
<img width="635" alt="Screen Shot 2020-03-09 at 10 11 39 PM" src="https://user-images.githubusercontent.com/1486591/76273097-6389bc00-6253-11ea-993b-9fa6b03b7bf8.png">

After
<img width="646" alt="Screen Shot 2020-03-09 at 10 10 08 PM" src="https://user-images.githubusercontent.com/1486591/76273106-68e70680-6253-11ea-9dc2-0b62f767eec1.png">
