### PR TITLE
Late PMT: Filter out locations named "Other"

### DIFF
--- a/custom/abt/reports/filters_2020.py
+++ b/custom/abt/reports/filters_2020.py
@@ -15,7 +15,8 @@ class VectorLinkLocFilter(BaseSingleOptionFilter):
         return get_fixture_dicts(
             self.domain,
             data_types_by_tag["level_2_dcv"]._id,
-            filter_in={'level_1_dcv': level_1_ids}
+            filter_in={'level_1_dcv': level_1_ids},
+            filter_out={'name': 'Other'},
         )
 
     def get_level_3s(self, level_2_ids):
@@ -23,7 +24,8 @@ class VectorLinkLocFilter(BaseSingleOptionFilter):
         return get_fixture_dicts(
             self.domain,
             data_types_by_tag["level_3_dcv"]._id,
-            filter_in={'level_2_dcv': level_2_ids}
+            filter_in={'level_2_dcv': level_2_ids},
+            filter_out={'name': 'Other'},
         )
 
 
@@ -37,6 +39,7 @@ class LevelOneFilter(VectorLinkLocFilter):
         level_1s = get_fixture_dicts(
             self.domain,
             data_types_by_tag["level_1_dcv"]._id,
+            filter_out={'name': 'Other'},
         )
         return [(loc['id'], loc['name']) for loc in level_1s]
 
@@ -94,6 +97,7 @@ class LevelFourFilter(VectorLinkLocFilter):
         level_4s = get_fixture_dicts(
             self.domain,
             data_types_by_tag["level_4_dcv"]._id,
-            filter_in={'level_3_dcv': l3_ids}
+            filter_in={'level_3_dcv': l3_ids},
+            filter_out={'name': 'Other'},
         )
         return [(loc['id'], loc['name']) for loc in level_4s]

--- a/custom/abt/reports/fixture_utils.py
+++ b/custom/abt/reports/fixture_utils.py
@@ -123,8 +123,6 @@ def get_fixture_dicts(
     key that is in ``filter_in``, then the value of ``item[key]`` must
     be in the (set/tuple/list) value of ``filter_in[key]``.
     """
-    if filter_in is None:
-        filter_in = {}
     data_items = get_fixture_items_for_data_type(domain, data_type_id)
     dicts = (fixture_data_item_to_dict(di) for di in data_items)
     return [d for d in dicts if dict_values_in(d, filter_in)]

--- a/custom/abt/reports/tests/test_fixture_utils.py
+++ b/custom/abt/reports/tests/test_fixture_utils.py
@@ -20,6 +20,12 @@ def test_dict_values_in_param_none():
     assert_true(result)
 
 
+def test_dict_values_in_param_empty():
+    swallow = {'permutation': 'unladen'}
+    result = dict_values_in(swallow, {})
+    assert_true(result)
+
+
 def test_dict_values_in_value_none():
     swallow = {'permutation': 'unladen'}
     result = dict_values_in(swallow, {'permutation': None})


### PR DESCRIPTION
Context: [SC-512](https://dimagi-dev.atlassian.net/browse/SC-512)

##### SUMMARY
Locations named "Other" should not appear in the "Late PMT 2020" report because they have already been excluded in the "Auto PMT" application.

cc @sravfeyn 
