### PR TITLE
Use the `other` field

### DIFF
--- a/custom/abt/reports/filters_2020.py
+++ b/custom/abt/reports/filters_2020.py
@@ -16,7 +16,7 @@ class VectorLinkLocFilter(BaseSingleOptionFilter):
             self.domain,
             data_types_by_tag["level_2_dcv"]._id,
             filter_in={'level_1_dcv': level_1_ids},
-            filter_out={'name': 'Other'},
+            filter_out={'other': '1'},
         )
 
     def get_level_3s(self, level_2_ids):
@@ -25,7 +25,7 @@ class VectorLinkLocFilter(BaseSingleOptionFilter):
             self.domain,
             data_types_by_tag["level_3_dcv"]._id,
             filter_in={'level_2_dcv': level_2_ids},
-            filter_out={'name': 'Other'},
+            filter_out={'other': '1'},
         )
 
 
@@ -39,7 +39,7 @@ class LevelOneFilter(VectorLinkLocFilter):
         level_1s = get_fixture_dicts(
             self.domain,
             data_types_by_tag["level_1_dcv"]._id,
-            filter_out={'name': 'Other'},
+            filter_out={'other': '1'},
         )
         return [(loc['id'], loc['name']) for loc in level_1s]
 
@@ -98,6 +98,6 @@ class LevelFourFilter(VectorLinkLocFilter):
             self.domain,
             data_types_by_tag["level_4_dcv"]._id,
             filter_in={'level_3_dcv': l3_ids},
-            filter_out={'name': 'Other'},
+            filter_out={'other': '1'},
         )
         return [(loc['id'], loc['name']) for loc in level_4s]

--- a/custom/abt/reports/fixture_utils.py
+++ b/custom/abt/reports/fixture_utils.py
@@ -37,7 +37,7 @@ def get_locations(domain, filters) -> List[LocationTuple]:
         filter_in={
             'id': [filters['level_1']] if filters['level_1'] else None
         },
-        filter_out={'name': 'Other'},
+        filter_out={'other': '1'},
     )
     l2s_by_l1 = get_fixture_dicts_by_key(
         domain,
@@ -47,7 +47,7 @@ def get_locations(domain, filters) -> List[LocationTuple]:
             'level_1_dcv': [l['id'] for l in level_1s],
             'id': [filters['level_2']] if filters['level_2'] else None
         },
-        filter_out={'name': 'Other'},
+        filter_out={'other': '1'},
     )
     l3s_by_l2 = get_fixture_dicts_by_key(
         domain,
@@ -57,7 +57,7 @@ def get_locations(domain, filters) -> List[LocationTuple]:
             'level_2_dcv': [l2['id'] for l2s in l2s_by_l1.values() for l2 in l2s],
             'id': [filters['level_3']] if filters['level_3'] else None
         },
-        filter_out={'name': 'Other'},
+        filter_out={'other': '1'},
     )
     l4_data_items = get_fixture_items_for_data_type(domain, data_types_by_tag["level_4_dcv"]._id)
     country_has_level_4 = len(l4_data_items) > 1
@@ -70,7 +70,7 @@ def get_locations(domain, filters) -> List[LocationTuple]:
                 'level_3_dcv': [l3['id'] for l3s in l3s_by_l2.values() for l3 in l3s],
                 'id': [filters['level_4']] if filters['level_4'] else None
             },
-            filter_out={'name': 'Other'},
+            filter_out={'other': '1'},
         )
     else:
         l4s_by_l3 = {}


### PR DESCRIPTION
Follows on from PR #26825 

##### SUMMARY
All the lookup tables that Vectorlink uses for storing information about locations have a field named "other". If its value is `'1'`, it should not appear in the Late PMT report. These locations are only named "Other" in countries where the official language is English.

cc @esoergel 
