### PR TITLE
Added support for linked app visit schedulers to conditional alerts

### DIFF
--- a/corehq/messaging/scheduling/async_handlers.py
+++ b/corehq/messaging/scheduling/async_handlers.py
@@ -22,7 +22,7 @@ def get_visit_scheduler_forms(domain, timestamp):
     result = []
     for app_id in get_app_ids_in_domain(domain):
         app = get_latest_released_app(domain, app_id)
-        if app and app.doc_type == 'Application':
+        if app and not app.is_deleted() and not app.is_remote_app():
             for module in app.get_modules():
                 for form in module.get_forms():
                     if isinstance(form, AdvancedForm) and form.schedule and form.schedule.enabled:

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2696,8 +2696,8 @@ class ConditionalAlertScheduleForm(ScheduleForm):
         required=False,
         choices=(
             (START_DATE_RULE_TRIGGER, ugettext_lazy("The first available time after the rule is satisfied")),
-            (START_DATE_CASE_PROPERTY, ugettext_lazy("The date from case property:")),
-            (START_DATE_SPECIFIC_DATE, ugettext_lazy("A specific date:")),
+            (START_DATE_CASE_PROPERTY, ugettext_lazy("The date from case property")),
+            (START_DATE_SPECIFIC_DATE, ugettext_lazy("A specific date")),
         )
     )
 


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1294

Linked apps were deliberately excluded from this - see https://github.com/dimagi/commcare-hq/commit/bcec3c7107a0913bd01c3a547f50fe2a749780b2 - but I'm fairly certain that they should work fine. https://github.com/dimagi/commcare-hq/pull/24945 is another example of where linked apps had been excluded from SMS functionality but were later added in without ill effects.

##### FEATURE FLAG
Linked project spaces + Visit scheduler

##### PRODUCT DESCRIPTION
This makes forms from linked apps available in the visit scheduler dropdowns in conditional alert scheduling:

<img width="787" alt="Screen Shot 2020-03-11 at 2 02 05 PM" src="https://user-images.githubusercontent.com/1486591/76448565-ed936b00-63a0-11ea-84b1-8912dea270e6.png">

