### PR TITLE
Make kafka producer shuffle-shard on the domain

### DIFF
--- a/corehq/apps/change_feed/partitioners.py
+++ b/corehq/apps/change_feed/partitioners.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from kafka import KafkaConsumer
+from kafka.partitioner.hashed import murmur2
 from memoized import memoized
 
 from corehq.apps.change_feed import topics
@@ -16,28 +17,53 @@ TOPIC_TO_PILLOW_NAME_MAP = {
 }
 
 
-def choose_best_partition_for_topic(topic):
+def choose_best_partition_for_topic(topic, key, shuffle_shards_per_key=5):
+    """
+    Choose the best partition for topic through shuffle-sharding
+
+    - Map each key onto :shuffle_shards_per_key: partitions using consistent hashing
+    - Within those, pick the partition with the shortest backlog
+
+    Shuffle-sharding (as proponents put it) has the almost magical effect of simulating
+    one queue per key, isolating customers to a large extent from each others' workloads.
+
+    A :key: value of None is assigned to all partitions, and is thus a way of disabling
+    shuffle-sharding and going for the shortest of all partitions.
+
+    If :shuffle_shards_per_key: or is greater than the number of partitions
+    then the key is irrelevant and all keys are assigned to all partitions;
+    this has the same effect as using key=None.
+
+    For more on shuffle-sharding see:
+    https://aws.amazon.com/blogs/architecture/shuffle-sharding-massive-and-magical-fault-isolation/
+    """
     if topic not in _get_topic_to_pillow_map():
         # None means there's no best, use the default
         return None
 
-    try:
-        backlog_lengths_by_partition = _get_backlog_lengths_by_partition(topic)
-    except Exception:
-        # if there's any issue whatsoever fetching offsets
-        # fall back to the default partitioning algorithm
-        notify_exception(None, "Error measuring kafka partition backlog lengths")
-        return None
+    backlog_lengths_by_partition = _get_backlog_lengths_by_partition(topic)
+    all_partitions = set(backlog_lengths_by_partition.keys())
+    if not key:
+        whitelist = all_partitions
     else:
-        _, best_partition = min(
-            (backlog_length, partition)
-            for partition, backlog_length in backlog_lengths_by_partition.items()
-        )
-        return best_partition
+        # map key to the partitions it's assigned to
+        whitelist = _n_choose_k_hash(
+            key=key,
+            n=max(all_partitions) + 1,
+            k=shuffle_shards_per_key,
+        ) & all_partitions
+
+    _, best_partition = min(
+        (backlog_length, partition)
+        for partition, backlog_length in backlog_lengths_by_partition.items()
+        if partition in whitelist
+    )
+    return best_partition
 
 
 @quickcache(['topic'], memoize_timeout=10, timeout=10)
 def _get_backlog_lengths_by_partition(topic):
+    """Return partition => backlog_length map where partition and backlog length are ints"""
     assert topic in _get_topic_to_pillow_map(), \
         f"Allowed topics are {', '.join(_get_topic_to_pillow_map().keys())}"
 
@@ -75,3 +101,18 @@ def get_kafka_consumer_for_partitioning():
         client_id='change_feed_partitioners',
         bootstrap_servers=settings.KAFKA_BROKERS,
     )
+
+
+def _n_choose_k_hash(key, n, k):
+    """
+    Hash key to a set of k unique numbers from 0 to n-1 inclusive and return the set
+
+    Given the same arguments the function will return the same thing every time,
+    but for any given key it return a random-looking set of k unique numbers in range(n).
+    """
+    choices = set()
+    seed = key
+    while len(choices) < n and len(choices) < k:
+        seed = murmur2(f'{key}{seed}'.encode('utf-8'))
+        choices.add(seed % n)
+    return choices

--- a/corehq/apps/change_feed/partitioners.py
+++ b/corehq/apps/change_feed/partitioners.py
@@ -30,7 +30,7 @@ def choose_best_partition_for_topic(topic, key, shuffle_shards_per_key=5):
     A :key: value of None is assigned to all partitions, and is thus a way of disabling
     shuffle-sharding and going for the shortest of all partitions.
 
-    If :shuffle_shards_per_key: or is greater than the number of partitions
+    If :shuffle_shards_per_key: is greater than the number of partitions
     then the key is irrelevant and all keys are assigned to all partitions;
     this has the same effect as using key=None.
 

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -42,7 +42,13 @@ class ChangeProducer(object):
     def send_change(self, topic, change_meta):
         if settings.USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER:
             from corehq.apps.change_feed.partitioners import choose_best_partition_for_topic
-            partition = choose_best_partition_for_topic(topic)
+            try:
+                partition = choose_best_partition_for_topic(topic, change_meta.domain)
+            except Exception:
+                # if there's any issue whatsoever fetching offsets
+                # fall back to the default partitioning algorithm
+                notify_exception(None, "Error choosing best partition for topic")
+                partition = None
         else:
             partition = None
 

--- a/corehq/apps/change_feed/tests/test_partitioners.py
+++ b/corehq/apps/change_feed/tests/test_partitioners.py
@@ -1,0 +1,58 @@
+from collections import defaultdict
+
+from testil import eq
+
+from corehq.apps.change_feed.partitioners import _n_choose_k_hash
+
+
+def _test_eq(key, n, k, expected_result):
+    eq(_n_choose_k_hash(key, n, k), expected_result)
+
+
+def test_n_choose_k_hash_consistency():
+    yield _test_eq, 'maple', 32, 5, {7, 10, 22, 26, 28}
+    yield _test_eq, 'oak', 32, 5, {2, 3, 5, 15, 23}
+    yield _test_eq, 'palm', 32, 5, {7, 12, 16, 25, 26}
+
+
+def test_n_choose_k_hash_edge_cases():
+    yield _test_eq, 'zero', 0, 0, set()
+    yield _test_eq, 'one', 10, 0, set()
+    yield _test_eq, 'two', 0, 10, set()
+    yield _test_eq, 'three', 10, 10, set(range(10))
+    yield _test_eq, 'four', 5, 10, set(range(5))
+    yield _test_eq, None, 5, 10, set(range(5))
+
+
+def test_n_choose_k_hash_distribution():
+    example_keys = set((
+        "We hold these truths to be self-evident, that all [people] are created equal, "
+        "that they are endowed by their Creator with certain unalienable Rights, "
+        "that among these are Life, Liberty and the pursuit of Happiness."
+    ).split())
+
+    print(len(example_keys))
+    shards_to_keys = defaultdict(list)
+    for i in range(5):
+        for key in example_keys:
+            key_i = f'{key}-{i}'
+            shards_to_keys[tuple(sorted(_n_choose_k_hash(key_i, n=32, k=5)))].append(key_i)
+
+    print(shards_to_keys)
+    clashes = []
+    for shard, keys in shards_to_keys.items():
+        if len(keys) > 1:
+            clashes.append((keys, shard))
+
+    # (32 choose 5) = 201,376
+    # so it is unlikely that there will be any overlap in the chosen set
+    # for a small number of different keys
+    # There's a 1 in 10 chance that 200 keys will have a clash,
+    # which seems high, but if one project is causing trouble at once,
+    # the chance that any other project clashes with _that_ one is really low
+    assert not clashes, "Clashing outputs: {}".format(
+        '; '.join(
+            f"{', '.join(keys)} => {shard}"
+            for keys, shard in clashes
+        )
+    )


### PR DESCRIPTION
##### SUMMARY

Use ?w=1 to look at the diff.

This should have the effect of limiting the effect of any one domain's submissions on everyone else's report lag times.

##### FEATURE FLAG
Only affects environments with `USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER` set to true
