### PR TITLE
make sure subscriptions scheduled to end are also paused

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -143,10 +143,14 @@ def _deactivate_subscription(subscription):
             account = subscription.account
         else:
             account = BillingAccount.create_account_for_domain(
-                domain, created_by='default_community_after_customer_level'
+                domain, created_by='deactivation_after_customer_level'
             )
         next_subscription = assign_explicit_unpaid_subscription(
-            domain, subscription.date_end, SubscriptionAdjustmentMethod.DEFAULT_COMMUNITY, account=account
+            domain,
+            subscription.date_end,
+            SubscriptionAdjustmentMethod.AUTOMATIC_DOWNGRADE,
+            account=account,
+            is_paused=True
         )
         new_plan_version = next_subscription.plan_version
     _, downgraded_privs, upgraded_privs = get_change_status(subscription.plan_version, new_plan_version)


### PR DESCRIPTION
instead of being downgraded to community

Fixes the issue here:
https://dimagi-dev.atlassian.net/browse/SAAS-10668

##### SUMMARY
The downgrading process for unpaid invoices correctly makes sure that all domains triggering a downgrade are paused. However, if a domain's subscription is scheduled to end with no paid subscription to follow, this logic happens in a separate area, and `is_paused` was not explicitly set to `True`. This fixes that
