### PR TITLE
Add "add_hours" UCR expression

### DIFF
--- a/corehq/apps/userreports/README.rst
+++ b/corehq/apps/userreports/README.rst
@@ -388,6 +388,12 @@ Dict expressions
 .. autoclass:: corehq.apps.userreports.expressions.date_specs.AddDaysExpressionSpec
 
 
+"Add Hours" expressions
+''''''''''''''''''''''
+
+.. autoclass:: corehq.apps.userreports.expressions.date_specs.AddHoursExpressionSpec
+
+
 "Add Months" expressions
 ''''''''''''''''''''''''
 

--- a/corehq/apps/userreports/expressions/date_specs.py
+++ b/corehq/apps/userreports/expressions/date_specs.py
@@ -9,7 +9,7 @@ from dimagi.ext.jsonobject import JsonObject
 from corehq.apps.userreports.expressions.getters import (
     transform_date,
     transform_int,
-)
+    transform_datetime)
 from corehq.apps.userreports.specs import TypeProperty
 
 
@@ -44,6 +44,45 @@ class AddDaysExpressionSpec(JsonObject):
         int_val = transform_int(self._count_expression(item, context))
         if date_val is not None and int_val is not None:
             return date_val + datetime.timedelta(days=int_val)
+        return None
+
+    def __str__(self):
+        return "add_day({date}, {count})".format(
+            date=self._date_expression,
+            count=self._count_expression)
+
+
+class AddHoursExpressionSpec(JsonObject):
+    """
+    Below is a simple example that demonstrates the structure. The
+    expression below will add 12 hours to a property called "visit_date".
+    The date_expression and count_expression can be any valid expressions, or
+    simply constants.
+
+    .. code:: json
+
+       {
+           "type": "add_hours",
+           "date_expression": {
+               "type": "property_name",
+               "property_name": "visit_date",
+           },
+           "count_expression": 12
+       }
+    """
+    type = TypeProperty('add_hours')
+    date_expression = DefaultProperty(required=True)
+    count_expression = DefaultProperty(required=True)
+
+    def configure(self, date_expression, count_expression):
+        self._date_expression = date_expression
+        self._count_expression = count_expression
+
+    def __call__(self, item, context=None):
+        date_val = transform_datetime(self._date_expression(item, context))
+        int_val = transform_int(self._count_expression(item, context))
+        if date_val is not None and int_val is not None:
+            return date_val + datetime.timedelta(hours=int_val)
         return None
 
     def __str__(self):

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -16,7 +16,7 @@ from corehq.apps.userreports.expressions.date_specs import (
     DiffDaysExpressionSpec,
     MonthEndDateExpressionSpec,
     MonthStartDateExpressionSpec,
-)
+    AddHoursExpressionSpec)
 from corehq.apps.userreports.expressions.list_specs import (
     FilterItemsExpressionSpec,
     FlattenExpressionSpec,
@@ -154,6 +154,15 @@ def _dict_expression(spec, context):
 
 def _add_days_expression(spec, context):
     wrapped = AddDaysExpressionSpec.wrap(spec)
+    wrapped.configure(
+        date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
+        count_expression=ExpressionFactory.from_spec(wrapped.count_expression, context),
+    )
+    return wrapped
+
+
+def _add_hours_expression(spec, context):
+    wrapped = AddHoursExpressionSpec.wrap(spec)
     wrapped.configure(
         date_expression=ExpressionFactory.from_spec(wrapped.date_expression, context),
         count_expression=ExpressionFactory.from_spec(wrapped.count_expression, context),
@@ -314,6 +323,7 @@ class ExpressionFactory(object):
         'nested': _nested_expression,
         'dict': _dict_expression,
         'add_days': _add_days_expression,
+        'add_hours': _add_hours_expression,
         'add_months': _add_months_expression,
         'month_start_date': _month_start_date_expression,
         'month_end_date': _month_end_date_expression,

--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -117,14 +117,7 @@ def transform_date(item):
 def transform_datetime(item):
     if item:
         if isinstance(item, str):
-            try:
-                return iso_string_to_datetime(item, strict=True)
-            except ValueError:
-                try:
-                    parsed_item = iso_string_to_date(item)
-                    return datetime.combine(parsed_item, time(0, 0, 0))
-                except ValueError:
-                    pass
+            return iso_string_to_datetime(item, strict=False)
         elif isinstance(item, datetime):
             return item
         elif isinstance(item, date):

--- a/corehq/apps/userreports/tests/test_date_expressions.py
+++ b/corehq/apps/userreports/tests/test_date_expressions.py
@@ -126,3 +126,28 @@ def test_add_days_to_date_expression(self, source_doc, count_expression, expecte
         'count_expression': count_expression
     })
     self.assertEqual(expected_value, expression(source_doc))
+
+
+@generate_cases([
+    ({'visit_date': '2020-03-12T20:33:49Z'}, 2, datetime(2020, 3, 12, 22, 33, 49)),
+    # 3 hours in UTC due to time zone change
+    ({'visit_date': '2020-03-12T20:33:49.134+02'}, 5, datetime(2020, 3, 12, 23, 33, 49, 134000)),
+    # 7 hours in UTC due to time zone change
+    ({'visit_date': '2020-03-12T20:33:49.134-02'}, 5, datetime(2020, 3, 13, 3, 33, 49, 134000)),
+    ({'visit_date': '2020-03-12T20:33:49.134000Z'}, 2, datetime(2020, 3, 12, 22, 33, 49, 134000)),
+    ({'visit_date': datetime(2020, 3, 12, 20, 33, 49)}, 2, datetime(2020, 3, 12, 22, 33, 49)),
+    (
+        {'visit_date': datetime(2020, 3, 12, 20, 33, 49), 'hours': '3'},
+        {'type': 'property_name', 'property_name': 'hours'},
+        datetime(2020, 3, 12, 23, 33, 49)),
+])
+def test_add_hours_to_datetime_expression(self, source_doc, count_expression, expected_value):
+    expression = ExpressionFactory.from_spec({
+        'type': 'add_hours',
+        'date_expression': {
+            'type': 'property_name',
+            'property_name': 'visit_date',
+        },
+        'count_expression': count_expression
+    })
+    self.assertEqual(expected_value, expression(source_doc))

--- a/corehq/apps/userreports/tests/test_date_expressions.py
+++ b/corehq/apps/userreports/tests/test_date_expressions.py
@@ -101,3 +101,28 @@ def test_diff_days_expression(self, source_doc, to_date_expression, expected_val
         'to_date_expression': to_date_expression
     }, context)
     self.assertEqual(expected_value, named_expression(source_doc))
+
+
+@generate_cases([
+    ({'dob': '2015-01-20'}, 3, date(2015, 1, 23)),
+    ({'dob': '2015-01-20'}, 5, date(2015, 1, 25)),
+    ({'dob': date(2015, 1, 20)}, 3, date(2015, 1, 23)),
+    ({'dob': datetime(2015, 1, 20)}, 3, date(2015, 1, 23)),
+    ({'dob': datetime(2015, 1, 20)}, 3.0, date(2015, 1, 23)),
+    ({'dob': datetime(2015, 1, 20)}, '3.0', date(2015, 1, 23)),
+    (
+        {'dob': datetime(2015, 1, 20), 'days': '3'},
+        {'type': 'property_name', 'property_name': 'days'},
+        date(2015, 1, 23)
+    ),
+])
+def test_add_days_to_date_expression(self, source_doc, count_expression, expected_value):
+    expression = ExpressionFactory.from_spec({
+        'type': 'add_days',
+        'date_expression': {
+            'type': 'property_name',
+            'property_name': 'dob',
+        },
+        'count_expression': count_expression
+    })
+    self.assertEqual(expected_value, expression(source_doc))

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -135,7 +135,7 @@ class PropertyExpressionTest(SimpleTestCase):
             (None, "date", "09/30/2015"),
             (datetime(2015, 9, 30, 19, 4, 27), "datetime", "2015-09-30T19:04:27Z"),
             (datetime(2015, 9, 30, 19, 4, 27, 113609), "datetime", "2015-09-30T19:04:27.113609Z"),
-            (None, "datetime", "2015-09-30 19:04:27Z"),
+            (datetime(2015, 9, 30, 19, 4, 27), "datetime", "2015-09-30 19:04:27Z"),
             (date(2015, 9, 30), "date", "2015-09-30T19:04:27Z"),
             (date(2015, 9, 30), "date", datetime(2015, 9, 30)),
             ('2015-09-30', "string", date(2015, 9, 30)),

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -976,31 +976,6 @@ class RelatedDocExpressionDbTest(TestCase):
 
 
 @generate_cases([
-    ({'dob': '2015-01-20'}, 3, date(2015, 1, 23)),
-    ({'dob': '2015-01-20'}, 5, date(2015, 1, 25)),
-    ({'dob': date(2015, 1, 20)}, 3, date(2015, 1, 23)),
-    ({'dob': datetime(2015, 1, 20)}, 3, date(2015, 1, 23)),
-    ({'dob': datetime(2015, 1, 20)}, 3.0, date(2015, 1, 23)),
-    ({'dob': datetime(2015, 1, 20)}, '3.0', date(2015, 1, 23)),
-    (
-        {'dob': datetime(2015, 1, 20), 'days': '3'},
-        {'type': 'property_name', 'property_name': 'days'},
-        date(2015, 1, 23)
-    ),
-])
-def test_add_days_to_date_expression(self, source_doc, count_expression, expected_value):
-    expression = ExpressionFactory.from_spec({
-        'type': 'add_days',
-        'date_expression': {
-            'type': 'property_name',
-            'property_name': 'dob',
-        },
-        'count_expression': count_expression
-    })
-    self.assertEqual(expected_value, expression(source_doc))
-
-
-@generate_cases([
     ({}, "a + b", {"a": 2, "b": 3}, 2 + 3),
     (
         {},

--- a/custom/icds_reports/ucr/tests/test_adolescent_girl_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_adolescent_girl_ucr.py
@@ -1,3 +1,4 @@
+import datetime
 from mock import patch
 
 from custom.icds_reports.ucr.tests.test_base_form_ucr import BaseFormsTest
@@ -16,7 +17,7 @@ class TestAdolescent(BaseFormsTest):
             [{
                 'admitted_in_school': None,
                 "doc_id": None,
-                "timeend": None,
+                "timeend": datetime.datetime(2019, 12, 9, 8, 23, 52, 511000),
                 'out_of_school': 'yes',
                 'person_case_id': 'dda684cc-f260-4a0e-b608-f22aca3bf467',
                 're_out_of_school': None,
@@ -28,7 +29,7 @@ class TestAdolescent(BaseFormsTest):
             'adolescent_girl_oos_again',
             [{'admitted_in_school': None,
               "doc_id": None,
-              "timeend": None,
+              "timeend": datetime.datetime(2019, 10, 1, 11, 47, 51, 267000),
               'out_of_school': None,
               'person_case_id': 'b957eacc-03a4-40a4-a4c2-4b1e1e12f931',
               're_out_of_school': 'yes',
@@ -40,7 +41,7 @@ class TestAdolescent(BaseFormsTest):
             'adolescent_girl_school_admit',
             [{'admitted_in_school': 'yes',
               "doc_id": None,
-              "timeend": None,
+              "timeend": datetime.datetime(2019, 8, 2, 10, 46, 30, 806000),
               'out_of_school': None,
               'person_case_id': '62861fb8-ba76-4505-b90e-b225b8bf02fe',
               're_out_of_school': None,

--- a/custom/icds_reports/ucr/tests/test_cbe_form_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_cbe_form_ucr.py
@@ -15,7 +15,7 @@ class TestcbeForms(BaseFormsTest):
     def test_cbe_form_date(self):
         self._test_data_source_results(
             'cbe_form', [{
-                'submitted_on': None,
+                'submitted_on': datetime.datetime(2018, 12, 10, 14, 38, 53, 603000),
                 'doc_id': None,
                 'date_cbe_organise': datetime.date(2018, 12, 10),
                 'count_other_beneficiaries': 25,
@@ -27,7 +27,7 @@ class TestcbeForms(BaseFormsTest):
     def test_cbe_coming_of_age(self):
         self._test_data_source_results(
             'cbe_form_coming_of_age', [{
-                'submitted_on': None,
+                'submitted_on': datetime.datetime(2019, 11, 21, 10, 7, 44, 951000),
                 'doc_id': None,
                 'date_cbe_organise': datetime.date(2019, 11, 21),
                 'count_other_beneficiaries': 93,
@@ -39,7 +39,7 @@ class TestcbeForms(BaseFormsTest):
     def test_cbe_suposhan_diwas(self):
         self._test_data_source_results(
             'cbe_form_suposhan_diwas', [{
-                'submitted_on': None,
+                'submitted_on': datetime.datetime(2019, 10, 11, 12, 5, 27, 795000),
                 'doc_id': None,
                 'date_cbe_organise': datetime.date(2019, 10, 11),
                 'count_targeted_beneficiaries': 8,
@@ -51,7 +51,7 @@ class TestcbeForms(BaseFormsTest):
     def test_cbe_annaprasan_diwas(self):
         self._test_data_source_results(
             'cbe_form_annaprasan_diwas', [{
-                'submitted_on': None,
+                'submitted_on': datetime.datetime(2019, 10, 11, 9, 8, 10, 547000),
                 'doc_id': None,
                 'date_cbe_organise': datetime.date(2019, 10, 11),
                 'count_other_beneficiaries': 9,
@@ -59,10 +59,11 @@ class TestcbeForms(BaseFormsTest):
                 'theme_cbe': 'annaprasan_diwas'
             }
             ])
+
     def test_cbe_public_health_message(self):
         self._test_data_source_results(
             'cbe_form_public_health_message', [{
-                'submitted_on': None,
+                'submitted_on': datetime.datetime(2019, 8, 13, 8, 23, 4, 886000),
                 'doc_id': None,
                 'date_cbe_organise': datetime.date(2018, 8, 13),
                 'count_other_beneficiaries': 4,

--- a/custom/icds_reports/ucr/tests/test_gm_form_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_gm_form_ucr.py
@@ -1,3 +1,4 @@
+import datetime
 from mock import patch
 
 from custom.icds_reports.ucr.tests.test_base_form_ucr import BaseFormsTest
@@ -16,7 +17,7 @@ class TestGMForms(BaseFormsTest):
             [{
                 "doc_id": None,
                 "repeat_iteration": 0,
-                "timeend": None,
+                "timeend": datetime.datetime(2017, 12, 2, 11, 52, 42, 11000),
                 "child_health_case_id": "3fb53b1f-605c-4cfd-89c6-f0e72988f9bc",
                 "weight_child": 6,
                 "height_child": 120.0,
@@ -32,7 +33,7 @@ class TestGMForms(BaseFormsTest):
             [{
                 "doc_id": None,
                 "repeat_iteration": 0,
-                "timeend": None,
+                "timeend": datetime.datetime(2018, 1, 16, 10, 24, 49, 881000),
                 "child_health_case_id": "a4f7beff-5995-4155-be9c-ab2f7ec2c91c",
                 "weight_child": 3,
                 "height_child": None,
@@ -48,7 +49,7 @@ class TestGMForms(BaseFormsTest):
             [{
                 "doc_id": None,
                 "repeat_iteration": 0,
-                "timeend": None,
+                "timeend": datetime.datetime(2018, 1, 7, 7, 13, 19, 820000),
                 "child_health_case_id": "00cabe2c-df9e-4520-a943-837ec5b4559b",
                 "weight_child": 3,
                 "height_child": None,

--- a/custom/icds_reports/ucr/tests/test_ls_usage_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_ls_usage_ucr.py
@@ -1,3 +1,4 @@
+import datetime
 from mock import patch
 
 from custom.icds_reports.ucr.tests.test_base_form_ucr import BaseFormsTest
@@ -13,7 +14,7 @@ class TestLsUsage(BaseFormsTest):
     def test_vhnd_form_inclusion(self):
         self._test_data_source_results(
             'ls_vhnd_observation_form', [{
-                'timeend': None,
+                'timeend': datetime.datetime(2018, 8, 24, 8, 6, 40, 712000),
                 'doc_id': None
             }
             ])
@@ -21,7 +22,7 @@ class TestLsUsage(BaseFormsTest):
     def test_awc_mngt_form_inclusion(self):
         self._test_data_source_results(
             'awc_visit_form_with_location', [{
-                'timeend': None,
+                'timeend': datetime.datetime(2018, 11, 6, 15, 24, 34, 784000),
                 'doc_id': None
             }
             ])
@@ -29,7 +30,7 @@ class TestLsUsage(BaseFormsTest):
     def test_ls_home_visit_form_inclusion(self):
         self._test_data_source_results(
             'ls_home_visits', [{
-                'timeend': None,
+                'timeend': datetime.datetime(2019, 3, 27, 7, 15, 37, 183000),
                 'doc_id': None
             }
             ])

--- a/custom/icds_reports/ucr/tests/test_ls_vhnd_form_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_ls_vhnd_form_ucr.py
@@ -14,7 +14,7 @@ class TestLsVhndForms(BaseFormsTest):
     def test_vhnd_form_with_vhnd_date(self):
         self._test_data_source_results(
             'ls_vhnd_observation_form', [{
-                'submitted_on': None,
+                'submitted_on': datetime.datetime(2018, 8, 24, 8, 6, 40, 712000),
                 'doc_id': None,
                 'location_id': 'qwe56poiuytr4xcvbnmkjfghwerffdaa',
                 'vhnd_date': datetime.date(2018, 8, 24)

--- a/custom/icds_reports/ucr/tests/test_migration_form.py
+++ b/custom/icds_reports/ucr/tests/test_migration_form.py
@@ -18,7 +18,7 @@ class TestMigrationForms(BaseFormsTest):
             [{
                 "date_left": None,
                 "doc_id": None,
-                "timeend": None,
+                "timeend": datetime.datetime(2019, 12, 9, 8, 19, 4, 820000),
                 "is_migrated": 1,
                 "person_case_id": "b08669b9-f8d5-4dfb-891f-8727a4486682"
             }])
@@ -29,7 +29,7 @@ class TestMigrationForms(BaseFormsTest):
             [{
                 "date_left": datetime.datetime(2020, 1, 29, 0, 0),
                 "doc_id": None,
-                "timeend": None,
+                "timeend": datetime.datetime(2020, 1, 29, 7, 37, 50, 957000),
                 "is_migrated": 1,
                 "person_case_id": "0b402471-c2e7-4cc5-b8c8-8cb0c4cdc4b1"
             }])

--- a/custom/icds_reports/ucr/tests/test_pnc_form_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_pnc_form_ucr.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 from mock import patch
 
@@ -18,7 +18,7 @@ class TestPNCForms(BaseFormsTest):
             [{
                 "doc_id": None,
                 "repeat_iteration": 0,
-                "timeend": None,
+                "timeend": datetime(2017, 7, 15, 14, 55, 30, 315000),
                 "ccs_record_case_id": "d53c940c-3bf3-44f7-97a1-f43fcbe74359",
                 "child_health_case_id": "03f39da4-8ea3-4108-b8a8-1b58fdb4a698",
                 "counsel_adequate_bf": None,
@@ -45,7 +45,7 @@ class TestPNCForms(BaseFormsTest):
             [{
                 "doc_id": None,
                 "repeat_iteration": 0,
-                "timeend": None,
+                "timeend": datetime(2017, 8, 23, 10, 1, 20, 135000),
                 "ccs_record_case_id": "081cc405-5598-430f-ac8f-39cc4a1fdb30",
                 "child_health_case_id": "252d8e20-c698-4c94-a5a9-53bbf8972b64",
                 "counsel_adequate_bf": None,

--- a/custom/icds_reports/ucr/tests/test_private_school_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_private_school_ucr.py
@@ -20,7 +20,7 @@ class TestPrivateSchoolUcr(BaseFormsTest):
                 'person_case_id': '8076f5f1-f77c-444b-a956-e5dd1d01b678',
                 'date_return_private_school': None,
                 'returned_private_school': None,
-                'timeend': None,
+                'timeend': datetime.datetime(2019, 11, 21, 6, 47, 12, 148000),
                 'doc_id': None
             }
             ])
@@ -35,7 +35,7 @@ class TestPrivateSchoolUcr(BaseFormsTest):
                 'person_case_id': 'df2aa0ce-f6f8-4850-a0af-2be87b0717ca',
                 'date_return_private_school': datetime.date(2019, 10, 18),
                 'returned_private_school': 'yes',
-                'timeend': None,
+                'timeend': datetime.datetime(2019, 10, 18, 11, 20, 10, 718000),
                 'doc_id': None
             }
             ])

--- a/custom/icds_reports/ucr/tests/test_thr_form_ucr.py
+++ b/custom/icds_reports/ucr/tests/test_thr_form_ucr.py
@@ -1,3 +1,4 @@
+import datetime
 from mock import patch
 
 from custom.icds_reports.ucr.tests.test_base_form_ucr import BaseFormsTest
@@ -16,7 +17,7 @@ class TestTHRForms(BaseFormsTest):
             [{
                 "doc_id": None,
                 "repeat_iteration": 0,
-                "timeend": None,
+                "timeend": datetime.datetime(2017, 11, 2, 13, 41, 11, 523000),
                 "ccs_record_case_id": "ef8a946d-3f6a-4715-b743-68d55b86a230",
                 "child_health_case_id": "cccd8d00-851c-4524-ab12-811ac98d1fe9",
                 "days_ration_given_child": 22,
@@ -29,7 +30,7 @@ class TestTHRForms(BaseFormsTest):
             [{
                 "doc_id": None,
                 "repeat_iteration": 0,
-                "timeend": None,
+                "timeend": datetime.datetime(2017, 11, 2, 13, 35, 33, 704000),
                 "ccs_record_case_id": "ecf7d5cc-123d-41d2-a0d7-edf722895d13",
                 "child_health_case_id": None,
                 "days_ration_given_child": None,


### PR DESCRIPTION
This came up on the UCR skype and was easy enough to add.

Review by commit. The only broader-reaching change is https://github.com/dimagi/commcare-hq/commit/81b56ab56e7ea7bf86b919376ca60550cc9d14f9 which makes our datetime parsing better handle time zones. I saw these in my form submissions on prod, so I thought it would be good for UCRs to support them - and mostly seems to be the original intention of the code that was changed anyways (see https://github.com/dimagi/commcare-hq/pull/11706)

Should be documented here once merged: https://commcare-hq.readthedocs.io/ucr.html#add-hours-expressions

##### FEATURE FLAG

UCRs

##### PRODUCT DESCRIPTION

You can now add hours to datetimes