### PR TITLE
update location tables in separate command

### DIFF
--- a/custom/icds_reports/management/commands/run_aggregation_query.py
+++ b/custom/icds_reports/management/commands/run_aggregation_query.py
@@ -41,9 +41,7 @@ from custom.icds_reports.tasks import (
     drop_df_indices,
     drop_gm_indices,
     update_governance_dashboard,
-    update_service_delivery_report,
-    update_aggregate_locations_tables
-
+    update_service_delivery_report
 )
 
 
@@ -87,7 +85,6 @@ NORMAL_TASKS = {
     'update_agg_child_health': (None, update_agg_child_health, None),
     'update_governance_dashboard': (None, update_governance_dashboard, None),
     'update_service_delivery_report': (None, update_service_delivery_report, None),
-    'update_aggregate_locations_tables': (None, update_aggregate_locations_tables, None),
 }
 
 

--- a/custom/icds_reports/management/commands/update_location_tables.py
+++ b/custom/icds_reports/management/commands/update_location_tables.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+
+from custom.icds_reports.models.util import AggregationRecord
+from custom.icds_reports.tasks import update_aggregate_locations_tables
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('agg_uuid')
+
+    def handle(self, agg_uuid, **options):
+        agg_record = AggregationRecord.objects.get(agg_uuid=agg_uuid)
+        if not agg_record.run_aggregation_queries:
+            return
+        update_aggregate_locations_tables(agg_record.agg_date)

--- a/custom/icds_reports/management/commands/update_location_tables.py
+++ b/custom/icds_reports/management/commands/update_location_tables.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from custom.icds_reports.models.util import AggregationRecord
 from custom.icds_reports.tasks import update_aggregate_locations_tables
 
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('agg_uuid')


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The update location function was incompatible with gevent. This moves it to a new management command that does not use gevent.