### PR TITLE
[exports] catch date-like strings incorrectly handled as dates by the date parser

### DIFF
--- a/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
+++ b/corehq/ex-submodules/couchexport/tests/test_excel_format_value.py
@@ -142,3 +142,7 @@ def test_text():
     yield check, '1241234eeeesffsfs', '1241234eeeesffsfs', numbers.FORMAT_TEXT, str
     yield check, {'en': 'Thanks', 'de': 'Danke'}, "{'en': 'Thanks', 'de': 'Danke'}", \
           numbers.FORMAT_TEXT, str
+
+
+def test_bad_date_string():
+    yield check, '112020-02-2609', '112020-02-2609', numbers.FORMAT_TEXT, str

--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -225,7 +225,12 @@ def get_excel_format_value(value):
     if re.search(r"^\d+(/|-|\.)\d+(/|-|\.)\d+$", value):
         try:
             # always use standard yyy-mm-dd format for excel
-            return ExcelFormatValue(numbers.FORMAT_DATE_YYYYMMDD2, dateutil.parser.parse(value))
+            date_val = dateutil.parser.parse(value)
+            # Last chance at catching an errored date. If the date is invalid,
+            # yet somehow passed the regex, it will fail at this line with a
+            # ValueError:
+            date_val.isoformat()
+            return ExcelFormatValue(numbers.FORMAT_DATE_YYYYMMDD2, date_val)
         except (ValueError, OverflowError):
             pass
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10681

##### SUMMARY
Our date reg-ex is pretty loose on dates so that the `dateutil.parser` does most of the work. However, it sometimes does treat a string incorrectly as a date. In this case it was the value `112020-02-2609`. As soon as `isoformat()` is called on the parsed date, it fails with a `ValueError`...so as long as that happens inside the `try, catch` instead of further down the line, we can avoid errors.

