### PR TITLE
[Icds Dashboard] fix agg errors

### DIFF
--- a/custom/icds_reports/management/commands/update_location_tables.py
+++ b/custom/icds_reports/management/commands/update_location_tables.py
@@ -12,4 +12,4 @@ class Command(BaseCommand):
         agg_record = AggregationRecord.objects.get(agg_uuid=agg_uuid)
         if not agg_record.run_aggregation_queries:
             return
-        update_aggregate_locations_tables(agg_record.agg_date)
+        update_aggregate_locations_tables()

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -385,7 +385,7 @@ def _create_aggregate_functions(cursor):
         raise
 
 
-def update_aggregate_locations_tables(agg_date):
+def update_aggregate_locations_tables():
     try:
         celery_task_logger.info("Starting icds reports update_location_tables")
         with transaction.atomic(using=router.db_for_write(AwcLocation)):

--- a/custom/icds_reports/tasks.py
+++ b/custom/icds_reports/tasks.py
@@ -606,7 +606,7 @@ def _child_health_monthly_data(state_ids, day):
 
     # https://github.com/celery/celery/issues/4274
     sub_aggregations = [
-        _child_health_helper.delay(queries)
+        _child_health_helper.delay(list(queries))
         for queries in helper.pre_aggregation_queries()
     ]
     for sub_aggregation in sub_aggregations:


### PR DESCRIPTION
Fixes:
1) Removed unused argument which was causing agg failure on India
2) Resolved 'EncodeError: can't pickle generator objects' Error coming on India when QA runs the agg.

@czue @snopoke  adding you as Cal is offline today and this is blocking QA 