### PR TITLE
Initial two-stage user provisioning modeling, tests, and import flow

### DIFF
--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -1,0 +1,8 @@
+from dimagi.utils.parsing import string_to_boolean
+
+
+def spec_value_to_boolean_or_none(user_spec_dict, key):
+    value = user_spec_dict.get(key) or None
+    if value and isinstance(value, str):
+        return string_to_boolean(value)
+    return value

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -337,7 +337,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
 
                     # note: explicitly not including "None" here because that's the default value if not set.
                     # False means it was set explicitly to that value
-                    if is_account_confirmed is not False:
+                    if is_account_confirmed is False:
                         raise UserUploadError(_(
                             f"You can only set 'Is Account Confirmed' to 'False' on a new User."
                         ))

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -337,7 +337,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
 
                     # note: explicitly not including "None" here because that's the default value if not set.
                     # False means it was set explicitly to that value
-                    if is_account_confirmed == False:
+                    if is_account_confirmed is not False:
                         raise UserUploadError(_(
                             f"You can only set 'Is Account Confirmed' to 'False' on a new User."
                         ))

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -10,6 +10,7 @@ from couchdbkit.exceptions import (
     ResourceNotFound,
 )
 
+from corehq.apps.user_importer.helpers import spec_value_to_boolean_or_none
 from dimagi.utils.parsing import string_to_boolean
 
 from corehq import privileges
@@ -319,13 +320,8 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                 username = normalize_username(str(username), domain) if username else None
                 password = str(password) if password else None
 
-                is_active = row.get('is_active') or None
-                if is_active and isinstance(is_active, str):
-                    is_active = string_to_boolean(is_active)
-
-                is_account_confirmed = row.get('is_account_confirmed') or None
-                if is_account_confirmed and isinstance(is_account_confirmed, str):
-                    is_account_confirmed = string_to_boolean(is_account_confirmed)
+                is_active = spec_value_to_boolean_or_none(row, 'is_active')
+                is_account_confirmed = spec_value_to_boolean_or_none(row, 'is_account_confirmed')
 
                 if user_id:
                     user = CommCareUser.get_by_user_id(user_id, domain)

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -30,7 +30,7 @@ from corehq.apps.users.util import normalize_username
 required_headers = set(['username'])
 allowed_headers = set([
     'data', 'email', 'group', 'language', 'name', 'password', 'phone-number',
-    'uncategorized_data', 'user_id', 'is_active', 'location_code', 'role',
+    'uncategorized_data', 'user_id', 'is_active', 'is_account_confirmed', 'location_code', 'role',
     'User IMEIs (read only)', 'registered_on (read only)', 'last_submission (read only)',
     'last_sync (read only)'
 ]) | required_headers
@@ -339,7 +339,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                     # False means it was set explicitly to that value
                     if is_account_confirmed == False:
                         raise UserUploadError(_(
-                            f"You can only set 'Is Account Confirmed' on a new User (user '{user.username}'"
+                            f"You can only set 'Is Account Confirmed' to 'False' on a new User."
                         ))
 
                     if is_password(password):

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -41,7 +41,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             'hello',
             self.domain.name))
 
-    def _get_spec(self, **kwargs):
+    def _get_spec(self, delete_keys=None, **kwargs):
         spec = {
             'username': 'hello',
             'name': 'Another One',
@@ -51,6 +51,9 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             'password': 123,
             'email': None
         }
+        if delete_keys:
+            for key in delete_keys:
+                spec.pop(key)
         spec.update(kwargs)
         return spec
 
@@ -254,6 +257,17 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertIsNotNone(
             CommCareUser.get_by_username('{}@{}.commcarehq.org'.format('123', self.domain.name))
         )
+
+    def test_upload_with_unconfirmed_account(self):
+        import_users_and_groups(
+            self.domain.name,
+            [self._get_spec(delete_keys=['is_active'], is_account_confirmed='False')],
+            [],
+        )
+        user = self.user
+        self.assertIsNotNone(user)
+        self.assertEqual(False, user.is_active)
+        self.assertEqual(False, user.is_account_confirmed)
 
 
 class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -78,10 +78,15 @@ TEST_CASES = [
             {'username': factory.user_name()},
             {'username': factory.user_name(), 'user_id': factory.uuid4()},
             {'username': factory.user_name(), 'password': factory.password()},
-            {'username': factory.user_name(), 'password': 123}
+            {'username': factory.user_name(), 'password': 123},
+            {'username': factory.user_name(), 'is_account_confirmed': 'False'},
+            {'username': factory.user_name(), 'is_account_confirmed': 'True'},
         ],
         NewUserPasswordValidator('domain'),
-        {0: NewUserPasswordValidator.error_message}
+        {
+            0: NewUserPasswordValidator.error_message,
+            5: NewUserPasswordValidator.error_message,
+        }
     ),
     (
         [

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -8,17 +8,19 @@ from corehq.apps.user_importer.validation import (
     EmailValidator,
     ExistingUserValidator,
     GroupValidator,
-    IsActiveValidator,
     UsernameLengthValidator,
     NewUserPasswordValidator,
     RoleValidator,
     UsernameTypeValidator,
     RequiredFieldsValidator,
     UsernameValidator,
-)
+    BooleanColumnValidator)
 
 factory = Faker()
 factory.seed(1571040848)
+
+IsActiveValidator = BooleanColumnValidator('domain', 'is_active')
+IsAccountConfirmedValidator = BooleanColumnValidator('domain', 'is_account_confirmed')
 
 # tuple(specs, validator class, errors dict(row_index: message)
 TEST_CASES = [
@@ -40,8 +42,19 @@ TEST_CASES = [
             {'is_active': ''},
             {},
         ],
-        IsActiveValidator('domain'),
+        IsActiveValidator,
         {2: IsActiveValidator.error_message}
+    ),
+    (
+        [
+            {'is_account_confirmed': 'true'},
+            {'is_account_confirmed': 'false'},
+            {'is_account_confirmed': 'confirmed'},
+            {'is_account_confirmed': ''},
+            {},
+        ],
+        IsAccountConfirmedValidator,
+        {2: IsAccountConfirmedValidator.error_message}
     ),
     (
         [

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.translation import ugettext as _
 
+from corehq.apps.user_importer.helpers import spec_value_to_boolean_or_none
 from corehq.apps.users.dbaccessors.all_commcare_users import get_existing_usernames
 from dimagi.utils.chunked import chunked
 from dimagi.utils.parsing import string_to_boolean
@@ -180,7 +181,10 @@ class NewUserPasswordValidator(ImportValidator):
     def validate_spec(self, spec):
         user_id = spec.get('user_id')
         password = spec.get('password')
-        if not user_id and not is_password(password):
+        is_account_confirmed = spec_value_to_boolean_or_none(spec, 'is_account_confirmed')
+
+        # explicitly check is_account_confirmed against False because None is the default
+        if not user_id and not is_password(password) and is_account_confirmed != False:
             return self.error_message
 
 

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -184,7 +184,7 @@ class NewUserPasswordValidator(ImportValidator):
         is_account_confirmed = spec_value_to_boolean_or_none(spec, 'is_account_confirmed')
 
         # explicitly check is_account_confirmed against False because None is the default
-        if not user_id and not is_password(password) and is_account_confirmed != False:
+        if not user_id and not is_password(password) and is_account_confirmed is not False:
             return self.error_message
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1741,10 +1741,12 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         """
         uuid = uuid or uuid4().hex
         # if the user is not provisioned, also set is_active false so they can't login
-        # unless it was explicitly overridden in the method call
-        is_active = kwargs.pop('is_active', is_provisioned)
-        commcare_user = super(CommCareUser, cls).create(domain, username, password, email, uuid, date,
-                                                        is_active=is_active, **kwargs)
+        if 'is_active' not in kwargs:
+            kwargs['is_active'] = is_provisioned
+        elif not is_provisioned:
+            assert not kwargs['is_active'], \
+                "it's illegal to create a user with is_active=True and is_provisioned=False"
+        commcare_user = super(CommCareUser, cls).create(domain, username, password, email, uuid, date, **kwargs)
         if phone_number is not None:
             commcare_user.add_phone_number(phone_number)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1645,7 +1645,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
     demo_restore_id = IntegerProperty()
     # used by user provisioning workflow. defaults to true unless explicitly overridden during
     # user creation
-    is_provisioned = BooleanProperty(default=True)
+    is_account_confirmed = BooleanProperty(default=True)
 
     # This means that this user represents a location, and has a 1-1 relationship
     # with a location where location.location_type.has_user == True
@@ -1734,18 +1734,18 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                phone_number=None,
                location=None,
                commit=True,
-               is_provisioned=True,
+               is_account_confirmed=True,
                **kwargs):
         """
         Main entry point into creating a CommCareUser (mobile worker).
         """
         uuid = uuid or uuid4().hex
-        # if the user is not provisioned, also set is_active false so they can't login
+        # if the account is not confirmed, also set is_active false so they can't login
         if 'is_active' not in kwargs:
-            kwargs['is_active'] = is_provisioned
-        elif not is_provisioned:
+            kwargs['is_active'] = is_account_confirmed
+        elif not is_account_confirmed:
             assert not kwargs['is_active'], \
-                "it's illegal to create a user with is_active=True and is_provisioned=False"
+                "it's illegal to create a user with is_active=True and is_account_confirmed=False"
         commcare_user = super(CommCareUser, cls).create(domain, username, password, email, uuid, date, **kwargs)
         if phone_number is not None:
             commcare_user.add_phone_number(phone_number)
@@ -1755,7 +1755,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         commcare_user.domain = domain
         commcare_user.device_ids = [device_id]
         commcare_user.registering_device_id = device_id
-        commcare_user.is_provisioned = is_provisioned
+        commcare_user.is_account_confirmed = is_account_confirmed
         commcare_user.domain_membership = DomainMembership(domain=domain, **kwargs)
 
         if location:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1740,7 +1740,11 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         Main entry point into creating a CommCareUser (mobile worker).
         """
         uuid = uuid or uuid4().hex
-        commcare_user = super(CommCareUser, cls).create(domain, username, password, email, uuid, date, **kwargs)
+        # if the user is not provisioned, also set is_active false so they can't login
+        # unless it was explicitly overridden in the method call
+        is_active = kwargs.pop('is_active', is_provisioned)
+        commcare_user = super(CommCareUser, cls).create(domain, username, password, email, uuid, date,
+                                                        is_active=is_active, **kwargs)
         if phone_number is not None:
             commcare_user.add_phone_number(phone_number)
 
@@ -1750,10 +1754,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         commcare_user.device_ids = [device_id]
         commcare_user.registering_device_id = device_id
         commcare_user.is_provisioned = is_provisioned
-        if not is_provisioned:
-            # if the user is not provisioned, also set is_active false so they can't login
-            commcare_user.is_active = False
-
         commcare_user.domain_membership = DomainMembership(domain=domain, **kwargs)
 
         if location:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1734,6 +1734,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                phone_number=None,
                location=None,
                commit=True,
+               is_provisioned=True,
                **kwargs):
         """
         Main entry point into creating a CommCareUser (mobile worker).
@@ -1748,6 +1749,10 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         commcare_user.domain = domain
         commcare_user.device_ids = [device_id]
         commcare_user.registering_device_id = device_id
+        commcare_user.is_provisioned = is_provisioned
+        if not is_provisioned:
+            # if the user is not provisioned, also set is_active false so they can't login
+            commcare_user.is_active = False
 
         commcare_user.domain_membership = DomainMembership(domain=domain, **kwargs)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1736,8 +1736,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                commit=True,
                **kwargs):
         """
-        used to be a function called `create_hq_user_from_commcare_registration_info`
-
+        Main entry point into creating a CommCareUser (mobile worker).
         """
         uuid = uuid or uuid4().hex
         commcare_user = super(CommCareUser, cls).create(domain, username, password, email, uuid, date, **kwargs)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1643,6 +1643,9 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
     loadtest_factor = IntegerProperty()
     is_demo_user = BooleanProperty(default=False)
     demo_restore_id = IntegerProperty()
+    # used by user provisioning workflow. defaults to true unless explicitly overridden during
+    # user creation
+    is_provisioned = BooleanProperty(default=True)
 
     # This means that this user represents a location, and has a 1-1 relationship
     # with a location where location.location_type.has_user == True

--- a/corehq/apps/users/tests/test_create_mobile_workers.py
+++ b/corehq/apps/users/tests/test_create_mobile_workers.py
@@ -35,7 +35,7 @@ class TestCreateMobileWorkers(TestCase):
         self.assertEqual(['my-pixel'], user.device_ids)
         self.assertEqual('Mobile', user.first_name)
         self.assertEqual(True, user.is_active)
-        self.assertEqual(True, user.is_provisioned)
+        self.assertEqual(True, user.is_account_confirmed)
 
         # confirm user was created / can be accessed
         self.assertIsNotNone(CommCareUser.get_by_username('mw1'))
@@ -44,24 +44,24 @@ class TestCreateMobileWorkers(TestCase):
         # confirm user can login
         self.assertEqual(True, self.client.login(username='mw1', password='s3cr4t'))
 
-    def test_create_unprovisioned(self):
+    def test_create_unconfirmed(self):
         user = CommCareUser.create(
             self.domain,
             'mw1',
             's3cr4t',
             email='mw1@example.com',
-            is_provisioned=False,
+            is_account_confirmed=False,
         )
         self.addCleanup(user.delete)
         self.assertEqual(False, user.is_active)
-        self.assertEqual(False, user.is_provisioned)
+        self.assertEqual(False, user.is_account_confirmed)
         # confirm user can't login
 
         django_user = user.get_django_user()
         self.assertEqual(False, django_user.is_active)
         self.assertEqual(False, self.client.login(username='mw1', password='s3cr4t'))
 
-    def test_is_active_overrides_is_provisioned(self):
+    def test_is_active_overrides_is_account_confirmed(self):
         with self.assertRaises(AssertionError):
             CommCareUser.create(
                 self.domain,
@@ -69,7 +69,7 @@ class TestCreateMobileWorkers(TestCase):
                 's3cr4t',
                 email='mw1@example.com',
                 is_active=True,
-                is_provisioned=False,
+                is_account_confirmed=False,
             )
         # confirm no users were created
         self.assertIsNone(CommCareUser.get_by_username('mw1'))

--- a/corehq/apps/users/tests/test_create_mobile_workers.py
+++ b/corehq/apps/users/tests/test_create_mobile_workers.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import CommCareUser
+
+
+class TestCreateMobileWorkers(TestCase):
+    domain = 'test_create_mobile_workers'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project = create_domain(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.delete()
+        super().tearDownClass()
+
+    def test_create_basic(self):
+        user = CommCareUser.create(
+            self.domain,
+            'mw1',
+            's3cr4t',
+            email='mw1@example.com',
+            device_id='my-pixel',
+            first_name='Mobile',
+            last_name='Worker',
+        )
+        self.assertEqual(self.domain, user.domain)
+        self.assertEqual('mw1', user.username)
+        self.assertEqual('mw1@example.com', user.email)
+        self.assertEqual(['my-pixel'], user.device_ids)
+        self.assertEqual('Mobile', user.first_name)
+        self.assertEqual(True, user.is_active)
+        self.addCleanup(user.delete)
+

--- a/corehq/apps/users/tests/test_create_mobile_workers.py
+++ b/corehq/apps/users/tests/test_create_mobile_workers.py
@@ -27,11 +27,24 @@ class TestCreateMobileWorkers(TestCase):
             first_name='Mobile',
             last_name='Worker',
         )
+        self.addCleanup(user.delete)
         self.assertEqual(self.domain, user.domain)
         self.assertEqual('mw1', user.username)
         self.assertEqual('mw1@example.com', user.email)
         self.assertEqual(['my-pixel'], user.device_ids)
         self.assertEqual('Mobile', user.first_name)
         self.assertEqual(True, user.is_active)
-        self.addCleanup(user.delete)
+        self.assertEqual(True, user.is_provisioned)
 
+    def test_create_unprovisioned(self):
+        user = CommCareUser.create(
+            self.domain,
+            'mw1',
+            's3cr4t',
+            email='mw1@example.com',
+            is_provisioned=False,
+        )
+        self.addCleanup(user.delete)
+        self.assertEqual(self.domain, user.domain)
+        self.assertEqual(False, user.is_active)
+        self.assertEqual(False, user.is_provisioned)

--- a/corehq/apps/users/tests/test_create_mobile_workers.py
+++ b/corehq/apps/users/tests/test_create_mobile_workers.py
@@ -47,7 +47,6 @@ class TestCreateMobileWorkers(TestCase):
             is_provisioned=False,
         )
         self.addCleanup(user.delete)
-        self.assertEqual(self.domain, user.domain)
         self.assertEqual(False, user.is_active)
         self.assertEqual(False, user.is_provisioned)
         # confirm user can't login
@@ -55,3 +54,20 @@ class TestCreateMobileWorkers(TestCase):
         django_user = user.get_django_user()
         self.assertEqual(False, django_user.is_active)
         self.assertEqual(False, self.client.login(username='mw1', password='s3cr4t'))
+
+    def test_is_active_overrides_is_provisioned(self):
+        user = CommCareUser.create(
+            self.domain,
+            'mw1',
+            's3cr4t',
+            email='mw1@example.com',
+            is_active=True,
+            is_provisioned=False,
+        )
+        self.addCleanup(user.delete)
+        self.assertEqual(True, user.is_active)
+        self.assertEqual(False, user.is_provisioned)
+        # confirm user can login
+        django_user = user.get_django_user()
+        self.assertEqual(True, django_user.is_active)
+        self.assertEqual(True, self.client.login(username='mw1', password='s3cr4t'))

--- a/corehq/apps/users/tests/test_create_mobile_workers.py
+++ b/corehq/apps/users/tests/test_create_mobile_workers.py
@@ -35,6 +35,8 @@ class TestCreateMobileWorkers(TestCase):
         self.assertEqual('Mobile', user.first_name)
         self.assertEqual(True, user.is_active)
         self.assertEqual(True, user.is_provisioned)
+        # confirm user can login
+        self.assertEqual(True, self.client.login(username='mw1', password='s3cr4t'))
 
     def test_create_unprovisioned(self):
         user = CommCareUser.create(
@@ -48,3 +50,8 @@ class TestCreateMobileWorkers(TestCase):
         self.assertEqual(self.domain, user.domain)
         self.assertEqual(False, user.is_active)
         self.assertEqual(False, user.is_provisioned)
+        # confirm user can't login
+
+        django_user = user.get_django_user()
+        self.assertEqual(False, django_user.is_active)
+        self.assertEqual(False, self.client.login(username='mw1', password='s3cr4t'))

--- a/corehq/apps/users/tests/test_create_mobile_workers.py
+++ b/corehq/apps/users/tests/test_create_mobile_workers.py
@@ -61,7 +61,7 @@ class TestCreateMobileWorkers(TestCase):
         self.assertEqual(False, django_user.is_active)
         self.assertEqual(False, self.client.login(username='mw1', password='s3cr4t'))
 
-    def test_is_active_overrides_is_account_confirmed(self):
+    def test_disallow_unconfirmed_active(self):
         with self.assertRaises(AssertionError):
             CommCareUser.create(
                 self.domain,

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1808,3 +1808,11 @@ ADD_ROW_INDEX_TO_MOBILE_UCRS = StaticToggle(
     TAG_CUSTOM,
     [NAMESPACE_DOMAIN]
 )
+
+
+TWO_STAGE_USER_PROVISIONING = StaticToggle(
+    'two_stage_user_provisioning',
+    'Enable two-stage user provisioning (users confirm and set their own passwords via email).',
+    TAG_SOLUTIONS_LIMITED,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
Review by commit.

##### SUMMARY

For some COVID projects coming up we will likely need a more "sensible" mobile worker provisioning model than "the admin chooses your password". This is a first pass at modeling how that might work.

Much more context in [the working spec doc](https://docs.google.com/document/d/1gZlOGroRTeUMHXwzCuOVw2EUuJcjOsAaAe1qc2iUEe0/edit)

Basically the idea is to add a way to create "non-provisioned" mobile workers who are default deactivated upon creation, but then have a way to set a password and activate their account via email. There's a fair amount of justification for using *this* model in the Google doc - to minimize surface area of the change and maximize re-use of existing paradigms.

Putting this up for review now because:

1. Due to the nature/timelines of the work it's quite time sensitive
2. I want to get any feedback on the modeling/planning side as early as possible to minimize the need to rework things later

cc-ing a hastily and arbitrarily chosen list of potentially interested parties: @orangejenny @dannyroberts @ctsims @snopoke @AndreaMKing5 @esoergel @kaapstorm @biyeun 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

This will initially be rolled out under a new Solutions "limited use" flag until we better understand the product requirements, though has the potential to be a valuable core feature down the line.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

See spec for some thoughts on this, though not 100% finalized.