### PR TITLE
Make to_omrs_boolean() available to DHIS2

### DIFF
--- a/corehq/motech/dhis2/serializers.py
+++ b/corehq/motech/dhis2/serializers.py
@@ -1,4 +1,5 @@
 from corehq.motech.dhis2.const import (
+    DHIS2_DATA_TYPE_BOOLEAN,
     DHIS2_DATA_TYPE_DATE,
     DHIS2_DATA_TYPE_INTEGER,
     DHIS2_DATA_TYPE_NUMBER,
@@ -6,6 +7,7 @@ from corehq.motech.dhis2.const import (
 )
 from corehq.motech.serializers import (
     serializers,
+    to_boolean,
     to_date_str,
     to_decimal,
     to_integer,
@@ -14,6 +16,7 @@ from corehq.motech.serializers import (
 
 serializers.update({
     # (from_data_type, to_data_type): function
+    (None, DHIS2_DATA_TYPE_BOOLEAN): to_boolean,
     (None, DHIS2_DATA_TYPE_DATE): to_date_str,
     (None, DHIS2_DATA_TYPE_INTEGER): to_integer,
     (None, DHIS2_DATA_TYPE_NUMBER): to_decimal,

--- a/corehq/motech/openmrs/serializers.py
+++ b/corehq/motech/openmrs/serializers.py
@@ -14,7 +14,7 @@ from corehq.motech.openmrs.const import (
     OPENMRS_DATA_TYPE_DATETIME,
     OPENMRS_DATA_TYPE_MILLISECONDS,
 )
-from corehq.motech.serializers import serializers, to_date_str
+from corehq.motech.serializers import serializers, to_boolean, to_date_str
 
 
 def to_omrs_date(value):
@@ -49,12 +49,6 @@ def to_omrs_datetime(value):
         micros = value.strftime('%f')[:3]  # Only 3 digits for OpenMRS
         tz = value.strftime('%z') or '+0000'  # If we don't know, lie
         return value.strftime('%Y-%m-%dT%H:%M:%S.{f}{z}'.format(f=micros, z=tz))
-
-
-def to_omrs_boolean(value):
-    if isinstance(value, str) and value.lower() in ('false', '0'):
-        return False
-    return bool(value)
 
 
 def omrs_datetime_to_date(value):
@@ -117,7 +111,7 @@ serializers.update({
     # (from_data_type, to_data_type): function
     (None, OPENMRS_DATA_TYPE_DATE): to_date_str,
     (None, OPENMRS_DATA_TYPE_DATETIME): to_omrs_datetime,
-    (None, OPENMRS_DATA_TYPE_BOOLEAN): to_omrs_boolean,
+    (None, OPENMRS_DATA_TYPE_BOOLEAN): to_boolean,
     (OPENMRS_DATA_TYPE_DATETIME, COMMCARE_DATA_TYPE_DATE): omrs_datetime_to_date,
     (OPENMRS_DATA_TYPE_BOOLEAN, COMMCARE_DATA_TYPE_TEXT): omrs_boolean_to_text,
     (OPENMRS_DATA_TYPE_MILLISECONDS, None): omrs_timestamp_to_datetime,

--- a/corehq/motech/serializers.py
+++ b/corehq/motech/serializers.py
@@ -19,14 +19,14 @@ from typing import Any
 
 from dateutil import parser as dateutil_parser
 
+from dimagi.utils.parsing import FALSE_STRINGS
+
 from corehq.motech.const import (
     COMMCARE_DATA_TYPE_BOOLEAN,
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_INTEGER,
     COMMCARE_DATA_TYPE_TEXT,
 )
-
-FALSEY_STRINGS = ('0', 'false', 'no')
 
 
 def to_boolean(value: Any) -> bool:
@@ -40,7 +40,7 @@ def to_boolean(value: Any) -> bool:
     False
 
     """
-    if isinstance(value, str) and value.lower() in FALSEY_STRINGS:
+    if isinstance(value, str) and value.lower() in FALSE_STRINGS:
         return False
     return bool(value)
 

--- a/corehq/motech/serializers.py
+++ b/corehq/motech/serializers.py
@@ -15,14 +15,34 @@ value in `to_data_type`.
 """
 import datetime
 import re
+from typing import Any
 
 from dateutil import parser as dateutil_parser
 
 from corehq.motech.const import (
+    COMMCARE_DATA_TYPE_BOOLEAN,
     COMMCARE_DATA_TYPE_DECIMAL,
     COMMCARE_DATA_TYPE_INTEGER,
     COMMCARE_DATA_TYPE_TEXT,
 )
+
+FALSEY_STRINGS = ('0', 'false', 'no')
+
+
+def to_boolean(value: Any) -> bool:
+    """
+    Converts truthy and falsey values, including falsey strings, to
+    boolean.
+
+    >>> to_boolean(1)
+    True
+    >>> to_boolean('No')
+    False
+
+    """
+    if isinstance(value, str) and value.lower() in FALSEY_STRINGS:
+        return False
+    return bool(value)
 
 
 def to_decimal(value):
@@ -65,6 +85,7 @@ def to_date_str(value):
 
 serializers = {
     # (from_data_type, to_data_type): function
+    (None, COMMCARE_DATA_TYPE_BOOLEAN): to_boolean,
     (None, COMMCARE_DATA_TYPE_DECIMAL): to_decimal,
     (None, COMMCARE_DATA_TYPE_INTEGER): to_integer,
     (None, COMMCARE_DATA_TYPE_TEXT): to_text,


### PR DESCRIPTION
Requirement discovered during QA.

##### SUMMARY
This change renames/moves `to_omrs_boolean()`, which converts "false" and "0" to `False` and other truthy and falsey values to booleans for OpenMRS, to `to_boolean()` and makes it available for converting values for DHIS2, and also for importing values to CommCare.

##### FEATURE FLAG
DHIS2 Integration

##### PRODUCT DESCRIPTION
A simpler way to convert "yes"/"no" values for DHIS2.
