### PR TITLE
Unauthenticated link for mini-exchange

### DIFF
--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -155,7 +155,7 @@ urlpatterns = [
     url(r'^browse/(?P<app_id>[\w-]+)/(?P<form_unique_id>[\w-]+)/source/$',
         get_xform_source, name='get_xform_source'),
     url(r'^source/(?P<app_id>[\w-]+)/$', app_source, name='app_source'),
-    url(r'^app_exchange/$', app_exchange, name='app_exchange'),     # TODO: make external-facing link
+    url(r'^app_exchange/$', app_exchange, name='app_exchange'),
     url(r'^import_app/$', import_app, name='import_app'),
     url(r'^app_from_template/(?P<slug>[\w-]+)/$', app_from_template, name='app_from_template'),
     url(r'^copy_app/$', copy_app, name='copy_app'),

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -54,8 +54,6 @@ from django_digest.decorators import httpdigest
 
 logger = logging.getLogger(__name__)
 
-REDIRECT_FIELD_NAME = 'next'
-
 OTP_AUTH_FAIL_RESPONSE = {"error": "must send X-COMMCAREHQ-OTP header or 'otp' URL parameter"}
 
 

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -10,7 +10,7 @@
       <h2>{% trans "My Projects" %}</h2>
       <ul class="nav nav-pills nav-stacked">
         {% for domain in domains_for_user %}
-          <li><a href="{% url "domain_homepage" domain.name %}">{{ domain.display_name }}</a></li>
+          <li><a href="{% url next_view domain.name %}">{{ domain.display_name }}</a></li>
         {% endfor %}
       </ul>
       {% if open_invitations %}

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -31,10 +31,12 @@
     </div>
     <div class="col-sm-4">
       {% if not restrict_domain_creation or request.user.is_superuser %}
-        <aside class="well">
-          <h3>{% trans "Have a new idea?" %}</h3>
-          <a class="btn btn-primary" href="{% url "registration_domain" %}">{% trans "Create a Blank Project" %}</a>
-        </aside>
+        {% if not hide_create_new_project %}
+          <aside class="well">
+            <h3>{% trans "Have a new idea?" %}</h3>
+            <a class="btn btn-primary" href="{% url "registration_domain" %}">{% trans "Create a Blank Project" %}</a>
+          </aside>
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -20,7 +20,7 @@ from corehq.apps.users.models import SQLInvitation
 # Domain not required here - we could be selecting it for the first time. See notes domain.decorators
 # about why we need this custom login_required decorator
 @login_required
-def select(request, domain_select_template='domain/select.html', do_not_redirect=False):
+def select(request, do_not_redirect=False):
     domains_for_user = Domain.active_for_user(request.user)
     if not domains_for_user:
         return redirect('registration_domain')
@@ -34,6 +34,7 @@ def select(request, domain_select_template='domain/select.html', do_not_redirect
         'current_page': {'page_name': _('Select A Project')},
     }
 
+    domain_select_template = "domain/select.html"
     last_visited_domain = request.session.get('last_visited_domain')
     if open_invitations \
        or do_not_redirect \

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -57,7 +57,8 @@ def select(request, do_not_redirect=False, next_view=None):
                 or domain_obj.is_snapshot
             ):
                 try:
-                    return HttpResponseRedirect(reverse(next_view or 'dashboard_default', args=[last_visited_domain]))
+                    return HttpResponseRedirect(reverse(next_view or 'dashboard_default',
+                                                args=[last_visited_domain]))
                 except Http404:
                     pass
 

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -17,10 +17,13 @@ from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.users.models import SQLInvitation
 
 
+def covid19(request):
+    return select(request, next_view="app_exchange")
+
 # Domain not required here - we could be selecting it for the first time. See notes domain.decorators
 # about why we need this custom login_required decorator
 @login_required
-def select(request, do_not_redirect=False):
+def select(request, do_not_redirect=False, next_view=None):
     domains_for_user = Domain.active_for_user(request.user)
     if not domains_for_user:
         return redirect('registration_domain')
@@ -29,7 +32,7 @@ def select(request, do_not_redirect=False):
     open_invitations = [e for e in SQLInvitation.by_email(email) if not e.is_expired]
 
     # next_view must be a url that expects exactly one parameter, a domain name
-    next_view = request.GET.get('next_view')
+    next_view = next_view or request.GET.get('next_view')
     additional_context = {
         'domains_for_user': domains_for_user,
         'open_invitations': open_invitations,

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -35,7 +35,7 @@ def select(request, do_not_redirect=False, next_view=None):
     next_view = next_view or request.GET.get('next_view')
     additional_context = {
         'domains_for_user': domains_for_user,
-        'open_invitations': [] if bool(next_view) else open_invitations,
+        'open_invitations': [] if next_view else open_invitations,
         'current_page': {'page_name': _('Select A Project')},
         'next_view': next_view or 'domain_homepage',
         'hide_create_new_project': bool(next_view),

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -35,9 +35,10 @@ def select(request, do_not_redirect=False, next_view=None):
     next_view = next_view or request.GET.get('next_view')
     additional_context = {
         'domains_for_user': domains_for_user,
-        'open_invitations': open_invitations,
+        'open_invitations': [] if bool(next_view) else open_invitations,
         'current_page': {'page_name': _('Select A Project')},
         'next_view': next_view or 'domain_homepage',
+        'hide_create_new_project': bool(next_view),
     }
 
     domain_select_template = "domain/select.html"

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -212,7 +212,6 @@ def redirect_to_default(req, domain=None):
         if 0 == len(domains) and not req.user.is_superuser:
             return redirect('registration_domain')
         elif 1 == len(domains):
-            from corehq.apps.dashboard.views import dashboard_default
             from corehq.apps.users.models import DomainMembershipError
             if domains[0]:
                 domain = domains[0].name
@@ -227,14 +226,14 @@ def redirect_to_default(req, domain=None):
                         # web users without roles are redirected to the dashboard default
                         # view since some domains allow web users to request access if they
                         # don't have it
-                        return dashboard_default(req, domain)
+                        url = reverse("dashboard_default", args=[domain])
                 else:
                     if role and role.default_landing_page:
                         url = get_redirect_url(role.default_landing_page, domain)
                     elif couch_user.is_commcare_user():
                         url = reverse(get_cloudcare_urlname(domain), args=[domain])
                     else:
-                        return dashboard_default(req, domain)
+                        url = reverse("dashboard_default", args=[domain])
             else:
                 raise Http404()
         else:

--- a/urls.py
+++ b/urls.py
@@ -10,6 +10,7 @@ from corehq.apps.app_manager.views.formdesigner import ping
 from corehq.apps.app_manager.views.phone import list_apps
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.utils import legacy_domain_re
+from corehq.apps.domain.views.base import covid19
 from corehq.apps.domain.views.feedback import submit_feedback
 from corehq.apps.domain.views.pro_bono import ProBonoStaticView
 from corehq.apps.domain.views.settings import logo
@@ -134,6 +135,7 @@ urlpatterns = [
     url(r'^apache_license/$', apache_license, name='apache_license'),
     url(r'^bsd_license_basic/$', TemplateView.as_view(template_name='bsd_license.html'), name='bsd_license_basic'),
     url(r'^bsd_license/$', bsd_license, name='bsd_license'),
+    url(r'^covid19/$', covid19, name='covid19'),
     url(r'^pro_bono/$', ProBonoStaticView.as_view(), name=ProBonoStaticView.urlname),
     url(r'^ping/$', ping, name='ping'),
     url(r'^robots.txt$', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),


### PR DESCRIPTION
##### SUMMARY
Followup for https://github.com/dimagi/commcare-hq/pull/26850/

This adds support for URLs of the format `http://localhost:8000/domain/select/?next_view=SOME_DOMAIN_VIEW_NAME` that will lead an unauthenticated user through the login flow and domain selection and ultimately redirect them to the view in the original URL.

Included most (all?) of the US-based devs for review, as the plan is to deploy this today.