### PR TITLE
Django 2: update djangorestframework to 3.11.0

### DIFF
--- a/corehq/form_processor/serializers.py
+++ b/corehq/form_processor/serializers.py
@@ -235,7 +235,7 @@ class LedgerValueSerializer(serializers.ModelSerializer):
 class StockStateSerializer(serializers.ModelSerializer):
     _id = serializers.IntegerField(source='id')
     entry_id = serializers.CharField(source='product_id')
-    location_id = serializers.CharField(source='sql_location.location_id')
+    location_id = serializers.CharField(source='sql_location.location_id', default=None)
     balance = serializers.IntegerField(source='stock_on_hand')
     last_modified = serializers.DateTimeField(source='last_modified_date')
     domain = serializers.CharField()

--- a/corehq/form_processor/serializers.py
+++ b/corehq/form_processor/serializers.py
@@ -178,7 +178,7 @@ class CommCareCaseSQLSerializer(DeletableModelSerializer):
 
     class Meta(object):
         model = CommCareCaseSQL
-        exclude = ('id', 'case_json',)
+        exclude = ('id',)
 
 
 class CommCareCaseSQLAPISerializer(serializers.ModelSerializer):

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -65,7 +65,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2
 dropbox==9.3.0

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -56,7 +56,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2          # via botocore
 dropbox==9.3.0

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -55,7 +55,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2          # via botocore
 dropbox==9.3.0

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -60,7 +60,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2          # via botocore
 dropbox==9.3.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -65,7 +65,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2
 dropbox==9.3.0

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -56,7 +56,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2          # via botocore
 dropbox==9.3.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -18,7 +18,7 @@ defusedxml==0.5.0
 diff-match-patch==20120106
 dimagi-memoized==1.1.3
 django-tastypie==0.14.2
-djangorestframework==3.5.4
+djangorestframework~=3.11.0
 elasticsearch==1.9.0
 elasticsearch2>=2.0.0,<3.0.0
 eulxml==1.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -55,7 +55,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2          # via botocore
 dropbox==9.3.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -60,7 +60,7 @@ django-two-factor-auth==1.6.2
 django-user-agents==0.3.2
 django-websocket-redis==0.5.2
 django==1.11.28
-djangorestframework==3.5.4
+djangorestframework==3.11.0
 dnspython==1.15.0
 docutils==0.15.2          # via botocore
 dropbox==9.3.0


### PR DESCRIPTION
##### SUMMARY
Required for Django 2 upgrade, tracked in https://docs.google.com/spreadsheets/d/1lWVxPLU2_f7Lobf5z4GcXOue91lWDzSWvGjEe_4o7QA/edit#gid=0.

Opening for tests, will do a more thorough pass afterwards