### PR TITLE
Updated feature flag category for mobile self reg

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1072,8 +1072,8 @@ ENABLE_INCLUDE_SMS_GATEWAY_CHARGING = StaticToggle(
 
 MOBILE_WORKER_SELF_REGISTRATION = StaticToggle(
     'mobile_worker_self_registration',
-    'UW: Allow mobile workers to self register',
-    TAG_CUSTOM,
+    'UW: Allow mobile workers to self register. Only works in CommCare 2.44 and lower.',
+    TAG_DEPRECATED,
     help_link='https://confluence.dimagi.com/display/commcarepublic/SMS+Self+Registration',
     namespaces=[NAMESPACE_DOMAIN],
 )


### PR DESCRIPTION
##### SUMMARY
Minor. See https://github.com/dimagi/commcare-hq/pull/26864#issuecomment-599592033

##### FEATURE FLAG
UW: Allow mobile workers to self register.

##### PRODUCT DESCRIPTION
Marks this flag deprecated since it doesn't work on current versions of CommCare.  fyi @AndreaMKing5 this would be a fairly large chunk of code to delete sometime. I don't think any real projects are still using it but of course we'd need to verify that.
