### PR TITLE
use supervisor first in group by

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/agg_awc.py
@@ -247,7 +247,7 @@ class AggAwcDistributedHelper(BaseICDSAggregationDistributedHelper):
         WHERE (opened_on <= %(end_date)s AND
               (closed_on IS NULL OR closed_on >= %(start_date)s ))
 
-        GROUP BY ucr.awc_id, ucr.supervisor_id) ut
+        GROUP BY ucr.supervisor_id, ucr.awc_id) ut
         WHERE ut.awc_id = agg_awc.awc_id and ut.supervisor_id=agg_awc.supervisor_id;
         """.format(
             tablename=self.temporary_tablename,

--- a/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
+++ b/custom/icds_reports/utils/aggregation_helpers/tests/sql_output/agg-awc.distributed.txt
@@ -139,7 +139,7 @@
         WHERE (opened_on <= %(end_date)s AND
               (closed_on IS NULL OR closed_on >= %(start_date)s ))
 
-        GROUP BY ucr.awc_id, ucr.supervisor_id) ut
+        GROUP BY ucr.supervisor_id, ucr.awc_id) ut
         WHERE ut.awc_id = agg_awc.awc_id and ut.supervisor_id=agg_awc.supervisor_id;
         
 {"end_date": "2019-01-31T23:59:59", "month_end_11yr": "2008-01-31T23:59:59", "month_end_15yr": "2004-01-31T23:59:59", "month_start_14yr": "2005-01-01T00:00:00", "month_start_15yr": "2004-01-01T00:00:00", "month_start_18yr": "2001-01-01T00:00:00", "start_date": "2019-01-01T00:00:00"}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Found this doing unrelated work, but based on the indices we have, this group order should be much quicker on what is one of the slower parts of agg awc.

I did not benchmark this but did run explains on simpler queries with the same kind of grouping

Old order:
`explain select awc_id, sum(registered_status), supervisor_id from "ucr_icds-cas_static-person_cases_v3_2ae0879a" group by awc_id, supervisor_id;`

```
 QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=0.00..0.00 rows=0 width=0)
   Group Key: remote_scan.awc_id, remote_scan.supervisor_id
   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
         Task Count: 64
         Tasks Shown: One of 64
         ->  Task
               Node: host=100.71.184.232 port=6432 dbname=icds_ucr
               ->  Finalize GroupAggregate  (cost=594984.05..1259506.21 rows=819500 width=74)
                     Group Key: awc_id, supervisor_id
                     ->  Gather Merge  (cost=594984.05..1214433.71 rows=4917000 width=74)
                           Workers Planned: 6
                           ->  Partial GroupAggregate  (cost=593983.95..615837.29 rows=819500 width=74)
                                 Group Key: awc_id, supervisor_id
                                 ->  Sort  (cost=593983.95..597398.53 rows=1365834 width=68)
                                       Sort Key: awc_id, supervisor_id
                                       ->  Parallel Seq Scan on "ucr_icds-cas_static-person_cases_v3_2ae0879a_103866" "ucr_icds-cas_static-person_cases_v3_2ae0879a"  (cost=0.00..356359.34 rows=1365834 width=68)
(16 rows)
```

new order:
`explain select awc_id, sum(registered_status), supervisor_id from "ucr_icds-cas_static-person_cases_v3_2ae0879a" group by supervisor_id, awc_id;`

```
   QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=0.00..0.00 rows=0 width=0)
   Group Key: remote_scan.supervisor_id, remote_scan.awc_id
   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
         Task Count: 64
         Tasks Shown: One of 64
         ->  Task
               Node: host=100.71.184.232 port=6432 dbname=icds_ucr
               ->  GroupAggregate  (cost=0.56..682472.14 rows=819500 width=74)
                     Group Key: supervisor_id, awc_id
                     ->  Index Scan using "ix_ucr_icds-cas_static-person_cases_v3_2ae0879a_sup_awc_103866" on "ucr_icds-cas_static-person_cases_v3_2ae0879a_103866" "ucr_icds-cas_static-person_cases_v3_2ae0879a"  (cost=0.56..612814.61 rows=8195004 width=68)
(10 rows)
```