### PR TITLE
enable order for custom data source

### DIFF
--- a/custom/icds_reports/reports/ucr.py
+++ b/custom/icds_reports/reports/ucr.py
@@ -60,8 +60,7 @@ class TwoStageAggregateCustomQueryProvider(ConfigurableReportCustomQueryProvider
             self.table.name,
             filters=split_filters['inner'],
             group_by=self.report_data_source.group_by,
-            # note: is this necessary to add?
-            # order_by=self.order_by,
+            order_by=self.report_data_source.order_by,
         )
         for c in self.report_data_source.columns:
             query_context.append_column(c.view)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1237

##### SUMMARY
We added a custom report for ICDS but didn't allow it to include order clause, this adds that.

##### PRODUCT DESCRIPTION
Report should be sorted with the column configured

Query being run now
```
In [2]: data_source.data_source.get_query_strings()
Out[2]: 'SELECT sum(CASE WHEN female_death_type IS NOT NULL AND female_death_type != \'\' AND age_at_death_yrs >= :p5ee5e5109b7
64a59a6d5ecf6a7343d4c THEN :param_1 ELSE :param_2 END) AS dead_preg_count, name AS name, age_at_death_yrs AS age_at_death_yrs,
female_death_type AS female_death_type, resident AS resident, date_death AS date_death, doc_id AS doc_id, supervisor_id AS supe
rvisor_id \nFROM "ucr_icds-cas_static-person_cases_v3_2ae0879a" GROUP BY doc_id, supervisor_id ORDER BY date_death DESC'
```
