### PR TITLE
add stub user account confirmation page and tests for error cases

### DIFF
--- a/corehq/apps/sms/admin.py
+++ b/corehq/apps/sms/admin.py
@@ -6,7 +6,7 @@ from corehq.apps.sms.models import (
     PhoneNumber,
     QueuedSMS,
     SQLMobileBackendMapping,
-)
+    SelfRegistrationInvitation)
 
 
 class SMSAdmin(admin.ModelAdmin):
@@ -104,3 +104,4 @@ admin.site.register(QueuedSMS, QueuedSMSAdmin)
 admin.site.register(PhoneBlacklist, PhoneBlacklistAdmin)
 admin.site.register(PhoneNumber, PhoneNumberAdmin)
 admin.site.register(SQLMobileBackendMapping, SQLMobileBackendMappingAdmin)
+admin.site.register(SelfRegistrationInvitation)

--- a/corehq/apps/users/templates/users/commcare_user_confirm_account.html
+++ b/corehq/apps/users/templates/users/commcare_user_confirm_account.html
@@ -1,0 +1,39 @@
+{% extends "hqwebapp/base_page.html" %}
+{% load hq_shared_tags %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Confirm Account" %}{% endblock %}
+
+{% block header %}
+  <div class="page-header container">
+    <h1>{% blocktrans %}{{ hr_name }} Registration{% endblocktrans %}</h1>
+  </div>
+{% endblock %}
+
+{% block content %}
+  {% if user.is_account_confirmed and user.is_active %}
+    <div>
+      <p>
+        {% blocktrans %}
+          Your account is already confirmed! Go sign in.
+        {% endblocktrans %}
+      </p>
+    </div>
+  {% elif user.is_account_confirmed %}
+    <div class="alert-alert-danger">
+      <p>
+        {% blocktrans %}
+          It looks like your account has been deactivated.
+          Contact your administrator if you think this is a mistake.
+        {% endblocktrans %}
+      </p>
+    </div>
+  {% else %}
+    <div id="confirm-account-form">
+      <p>Confirm your account here!</p>
+      {#  todo    {% crispy form %}#}
+    </div>
+  {% endif %}
+{% endblock %}
+{% block mobile-logout %}{% endblock %}

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -1,0 +1,75 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import CommCareUser
+from corehq.util.test_utils import flag_enabled
+
+
+class TestMobileWorkerConfirmAccountView(TestCase):
+    domain = 'mobile-worker-confirm-account'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project = create_domain(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.delete()
+        from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
+        delete_all_users()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = CommCareUser.create(
+            self.domain,
+            'mw1',
+            's3cr4t',
+            email='mw1@example.com',
+            is_account_confirmed=False,
+        )
+        self.url = reverse('commcare_user_confirm_account', args=[self.domain, self.user.get_id])
+
+    def tearDown(self):
+        self.user.delete()
+
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    def test_expected_workflow(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, 'Confirm your account here')
+
+    def test_feature_flag_not_enabled(self):
+        response = self.client.get(self.url)
+        self.assertEqual(404, response.status_code)
+
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    def test_user_id_not_found(self):
+        response = self.client.get(reverse('commcare_user_confirm_account', args=[self.domain, 'missing-id']))
+        self.assertEqual(404, response.status_code)
+
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    def test_user_domain_mismatch(self):
+        response = self.client.get(reverse('commcare_user_confirm_account',
+                                           args=['wrong-domain', self.user.get_id]))
+        self.assertEqual(404, response.status_code)
+
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    def test_account_active(self):
+        self.user.is_account_confirmed = True
+        self.user.is_active = True
+        self.user.save()
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, 'Your account is already confirmed')
+
+    @flag_enabled('TWO_STAGE_USER_PROVISIONING')
+    def test_account_inactive_but_confirmed(self):
+        self.user.is_account_confirmed = True
+        self.user.is_active = False
+        self.user.save()
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, 'your account has been deactivated')

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -38,7 +38,6 @@ class TestMobileWorkerConfirmAccountView(TestCase):
     def test_expected_workflow(self):
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
-        self.assertEqual(200, response.status_code)
         self.assertContains(response, 'Confirm your account here')
 
     def test_feature_flag_not_enabled(self):

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -62,7 +62,7 @@ from .views.mobile.users import (
     update_user_groups,
     user_download_job_poll,
     user_upload_job_poll,
-)
+    CommCareUserConfirmAccountView)
 
 urlpatterns = [
     url(r'^$', DefaultProjectUserSettingsView.as_view(), name=DefaultProjectUserSettingsView.urlname),
@@ -145,6 +145,8 @@ urlpatterns = [
         name=ConfirmBillingAccountForExtraUsersView.urlname),
     url(r'^commcare/register/(?P<token>[\w-]+)/$', CommCareUserSelfRegistrationView.as_view(),
         name=CommCareUserSelfRegistrationView.urlname),
+    url(r'^commcare/confirm_account/(?P<user_id>[\w-]+)/$', CommCareUserConfirmAccountView.as_view(),
+        name=CommCareUserConfirmAccountView.urlname),
 ] + [
     url(r'^groups/$', GroupsListView.as_view(), name=GroupsListView.urlname),
     url(r'^groups/(?P<group_id>[ \w-]+)/$', EditGroupMembersView.as_view(), name=EditGroupMembersView.urlname),


### PR DESCRIPTION
Related to [ongoing covid signup work](https://docs.google.com/document/d/1gZlOGroRTeUMHXwzCuOVw2EUuJcjOsAaAe1qc2iUEe0/edit)

Didn't get very far on this today due to other distractions, though it's the first time I'm using TDD on view code and overall I'm enjoying the experience... 

(Going to tag these as invisible until the feature is done to avoid confusing the product team)