### PR TITLE
Revert "Never checkpoint later than the latest offset"

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -100,13 +100,7 @@ class KafkaChangeFeed(ChangeFeed):
         latest_offsets = self.get_latest_offsets()
         ret = {}
         for topic_partition, sequence in self.get_processed_offsets().items():
-            if sequence >= latest_offsets[topic_partition]:
-                # I'm not quite sure this analysis is correct,
-                # it mostly appears to be doing the right thing.
-                # I don't think we double process the last message,
-                # contrary to the comment below, because
-                # last_offsets appears to be the offset of the latest change + 1.
-                # > Previous comment from Emord in 2017:
+            if sequence == latest_offsets[topic_partition]:
                 # this topic and partition is totally up to date and if we add 1
                 # then kafka will give us an offset out of range error.
                 # not adding 1 to the partition means that we may process this


### PR DESCRIPTION
This reverts commit de7b89a39ef6f68e593a6ca3ffc1218210c83b27.

<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We have seen multiple checkpoint rewinds over the past 2 days, since this change was rolled out to ICDS. Danny and I went through his original PR and believe the most likely explanation is that latest_offset was somehow returning 0 and we were setting the current offset back to that.

Working on part two, to catch the error in case it is not this, but wanted to get the part the fixed the bug out first.