### PR TITLE
Add command to delete all couch databases

### DIFF
--- a/corehq/apps/cleanup/management/commands/delete_couch_dbs.py
+++ b/corehq/apps/cleanup/management/commands/delete_couch_dbs.py
@@ -1,0 +1,38 @@
+from django.core.management.base import BaseCommand
+
+from corehq.util.couchdb_management import couch_config
+
+from corehq.apps.cleanup.utils import confirm_destructive_operation, abort
+
+
+class Command(BaseCommand):
+    help = "Delete all couch databases. Used to reset an environment."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--commit',
+            action='store_true',
+            dest='commit',
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        confirm_destructive_operation()
+
+        print("This operation will delete the following DBs")
+
+        for name, db in couch_config.all_dbs_by_db_name.items():
+            print(" ", name.ljust(40), db.info()['doc_count'], "docs")
+
+        if input("Still want to proceed? Type 'delete' (Last chance to back out)") != 'delete':
+            abort()
+
+        for name, db in couch_config.all_dbs_by_db_name.items():
+            if options['commit']:
+                db.server.delete_db(db.dbname)
+            print(f"deleted {name}")
+
+        if not options['commit']:
+            print("You need to run it with --commit for the deletion to happen")
+
+        print("deletion done")

--- a/corehq/apps/cleanup/utils.py
+++ b/corehq/apps/cleanup/utils.py
@@ -1,0 +1,28 @@
+import sys
+
+from django.conf import settings
+from django.core.management import color_style
+
+
+def abort():
+    print("Aborting")
+    sys.exit(1)
+
+
+def confirm_destructive_operation():
+    style = color_style()
+    print(style.ERROR("\nHEY! This is wicked dangerous, pay attention."))
+    print(style.WARNING("\nThis operation irreversibly deletes a lot of stuff."))
+    print(f"\nSERVER_ENVIRONMENT = {settings.SERVER_ENVIRONMENT}")
+
+    if settings.IS_SAAS_ENVIRONMENT:
+        print("This command isn't meant to be run on a SAAS environment")
+        abort()
+
+    confirm("Are you SURE you want to proceed?")
+
+
+def confirm(msg):
+    print(msg)
+    if input("(y/N)") != 'y':
+        abort()


### PR DESCRIPTION
##### SUMMARY
Add a command to delete all couch databases to prep a new environment for copying data.  I made it pretty paranoid, and welcome a discussion about the appropriate level of confirmation for this sort of operation.  Any other reasonable hard blocks I should put in there?

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

```
WARNINGS:
?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default TEMPLATES dict: TEMPLATE_DEBUG.

HEY! This is wicked dangerous, pay attention.

This operation irreversibly deletes a lot of stuff.

SERVER_ENVIRONMENT = localdev
Are you SURE you want to proceed?
(y/N)y
This operation will delete the following DBs
  commcarehq__auditcare                    10123 docs
  commcarehq__receiverwrapper              245 docs
  commcarehq__meta                         187 docs
  commcarehq__fluff-bihar                  2 docs
  commcarehq__fluff-mc                     1 docs
  commcarehq__m4change                     4 docs
  commcarehq__users                        295 docs
  commcarehq__fixtures                     5579 docs
  commcarehq__domains                      41 docs
  commcarehq__apps                         192 docs
  commcarehq                               583 docs
Still want to proceed? Type 'delete' (Last chance to back out)
delete
deleted commcarehq__auditcare
deleted commcarehq__receiverwrapper
deleted commcarehq__meta
deleted commcarehq__fluff-bihar
deleted commcarehq__fluff-mc
deleted commcarehq__m4change
deleted commcarehq__users
deleted commcarehq__fixtures
deleted commcarehq__domains
deleted commcarehq__apps
deleted commcarehq
You need to run it with --commit for the deletion to happen
deletion done
```