### PR TITLE
metric event api

### DIFF
--- a/corehq/apps/hqadmin/management/commands/record_deploy_success.py
+++ b/corehq/apps/hqadmin/management/commands/record_deploy_success.py
@@ -6,8 +6,8 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
 import requests
-from datadog import api as datadog_api
 
+from corehq.util.metrics import create_metrics_event
 from dimagi.utils.parsing import json_format_datetime
 from pillow_retry.models import PillowError
 
@@ -96,7 +96,7 @@ class Command(BaseCommand):
         if settings.DATADOG_API_KEY:
             tags = ['environment:{}'.format(options['environment'])]
             link = diff_link(compare_url)
-            datadog_api.Event.create(
+            create_metrics_event(
                 title="Deploy Success",
                 text=deploy_notification_text.format(
                     dashboard_link=dashboard_link(DASHBOARD_URL),

--- a/corehq/apps/hqadmin/signals.py
+++ b/corehq/apps/hqadmin/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import receiver
 
-from corehq.util.datadog.utils import create_datadog_event
+from corehq.util.metrics import create_metrics_event
 from corehq.util.signals import post_command
 
 
@@ -10,6 +10,6 @@ def record_command_event(sender, args, kwargs, outcome, **extra):
         outcome = f'{outcome.__class__}: {outcome}'
     text = f'args: {args}\noptions: {kwargs}\noutcome: {outcome}'
     event = '{}'.format(sender.__name__)
-    create_datadog_event(
+    create_metrics_event(
         event, text, aggregation_key=sender.__name__
     )

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -49,6 +49,7 @@ from sentry_sdk import last_event_id
 from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 from two_factor.views import LoginView
 
+from corehq.util.metrics import create_metrics_event
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.django.request import mutable_querydict
@@ -110,7 +111,7 @@ from corehq.util.context_processors import commcare_hq_names
 from corehq.util.datadog.const import DATADOG_UNKNOWN
 from corehq.util.datadog.gauges import datadog_counter, datadog_gauge
 from corehq.util.datadog.metrics import JSERROR_COUNT
-from corehq.util.datadog.utils import create_datadog_event, sanitize_url
+from corehq.util.datadog.utils import sanitize_url
 from corehq.util.view_utils import reverse
 from no_exceptions.exceptions import Http403
 
@@ -314,7 +315,7 @@ def server_up(req):
             html.linebreaks('<strong>{}</strong>: {}'.format(check, html.escape(status.msg)).strip())
             for check, status in failed_checks
         ]
-        create_datadog_event(
+        create_metrics_event(
             'Serverup check failed', '\n'.join(status_messages),
             alert_type='error', aggregation_key='serverup',
         )

--- a/corehq/util/datadog/const.py
+++ b/corehq/util/datadog/const.py
@@ -1,6 +1,1 @@
-ALERT_ERROR = 'error'
-ALERT_WARNING = 'warning'
-ALERT_INFO = 'info'
-ALERT_SUCCESS = 'success'
-
 DATADOG_UNKNOWN = '<unknown>'

--- a/corehq/util/datadog/utils.py
+++ b/corehq/util/datadog/utils.py
@@ -1,12 +1,10 @@
 import re
 from datetime import timedelta
-from functools import wraps, partial
+from functools import partial, wraps
 
-from datadog import api
 from django.conf import settings
 
-from corehq.util.datadog import statsd, COMMON_TAGS, datadog_logger
-from corehq.util.datadog.const import ALERT_INFO
+from corehq.util.datadog import datadog_logger, statsd
 
 WILDCARD = '*'
 DATADOG_WEB_USERS_GAUGE = 'commcare.hubspot.web_users_processed'
@@ -35,24 +33,6 @@ def count_by_response_code(metric_name):
         return _inner
 
     return _wrapper
-
-
-def datadog_initialized():
-    return api._api_key and api._application_key
-
-
-def create_datadog_event(title, text, alert_type=ALERT_INFO, tags=None, aggregation_key=None):
-    tags = COMMON_TAGS + (tags or [])
-    if datadog_initialized():
-        try:
-            api.Event.create(
-                title=title, text=text, tags=tags,
-                alert_type=alert_type, aggregation_key=aggregation_key,
-            )
-        except Exception as e:
-            datadog_logger.exception('Error creating Datadog event', e)
-    else:
-        datadog_logger.debug('Datadog event: (%s) %s\n%s', alert_type, title, text)
 
 
 def sanitize_url(url):

--- a/corehq/util/metrics/const.py
+++ b/corehq/util/metrics/const.py
@@ -1,0 +1,8 @@
+import settings
+
+ALERT_ERROR = 'error'
+ALERT_WARNING = 'warning'
+ALERT_INFO = 'info'
+ALERT_SUCCESS = 'success'
+
+COMMON_TAGS = {'environment': settings.SERVER_ENVIRONMENT}

--- a/corehq/util/metrics/datadog.py
+++ b/corehq/util/metrics/datadog.py
@@ -105,10 +105,13 @@ class DatadogMetrics(HqMetrics):
 
     def _create_event(self, title: str, text: str, alert_type: str = ALERT_INFO,
                       tags: dict = None, aggregation_key: str = None):
-        api.Event.create(
-            title=title, text=text, tags=tags,
-            alert_type=alert_type, aggregation_key=aggregation_key,
-        )
+        if datadog_initialized():
+            api.Event.create(
+                title=title, text=text, tags=tags,
+                alert_type=alert_type, aggregation_key=aggregation_key,
+            )
+        else:
+            datadog_logger.debug('Metrics event: (%s) %s\n%s\n%s', alert_type, title, text, tags)
 
 
 def _datadog_record(fn, name, value, tags=None):
@@ -116,3 +119,7 @@ def _datadog_record(fn, name, value, tags=None):
         fn(name, value, tags=tags)
     except Exception:
         datadog_logger.exception('Unable to record Datadog stats')
+
+
+def datadog_initialized():
+    return api._api_key and api._application_key

--- a/corehq/util/metrics/metrics.py
+++ b/corehq/util/metrics/metrics.py
@@ -4,6 +4,7 @@ import re
 from abc import abstractmethod
 from typing import List
 
+from corehq.util.metrics.const import ALERT_INFO
 from corehq.util.soft_assert import soft_assert
 from prometheus_client.utils import INF
 
@@ -13,7 +14,7 @@ RESERVED_METRIC_TAG_NAME_RE = re.compile(r'^__.*$')
 RESERVED_METRIC_TAG_NAMES = ['quantile', 'le']
 
 
-logger = logging.getLogger('commcare.metrics')
+metrics_logger = logging.getLogger('commcare.metrics')
 
 
 def _enforce_prefix(name, prefix):
@@ -61,6 +62,11 @@ class HqMetrics(metaclass=abc.ABCMeta):
         _validate_tag_names(tags)
         self._histogram(name, value, bucket_tag, buckets, bucket_unit, tags, documentation)
 
+    def create_event(self, title: str, text: str, alert_type: str = ALERT_INFO,
+                     tags: dict = None, aggregation_key: str = None):
+        _validate_tag_names(tags)
+        self._create_event(title, text, alert_type, tags, aggregation_key)
+
     @abstractmethod
     def _counter(self, name, value, tags, documentation):
         raise NotImplementedError
@@ -73,6 +79,11 @@ class HqMetrics(metaclass=abc.ABCMeta):
     def _histogram(self, name, value, bucket_tag, buckets, bucket_unit, tags, documentation):
         raise NotImplementedError
 
+    def _create_event(self, title: str, text: str, alert_type: str = ALERT_INFO,
+                     tags: dict = None, aggregation_key: str = None):
+        """Optional API to implement"""
+        pass
+
 
 class DebugMetrics:
     def __getattr__(self, item):
@@ -81,9 +92,14 @@ class DebugMetrics:
                 tags = kwargs.get('tags', {})
                 _enforce_prefix(name, 'commcare')
                 _validate_tag_names(tags)
-                logger.debug("[%s] %s %s %s", item, name, tags, value)
+                metrics_logger.debug("[%s] %s %s %s", item, name, tags, value)
             return _check
         raise AttributeError(item)
+
+    def create_event(self, title: str, text: str, alert_type: str = ALERT_INFO,
+                     tags: dict = None, aggregation_key: str = None):
+        _validate_tag_names(tags)
+        metrics_logger.debug('Metrics event: (%s) %s\n%s\n%s', alert_type, title, text, tags)
 
 
 class DelegatedMetrics:
@@ -91,7 +107,7 @@ class DelegatedMetrics:
         self.delegates = delegates
 
     def __getattr__(self, item):
-        if item in ('counter', 'gauge', 'histogram'):
+        if item in ('counter', 'gauge', 'histogram', 'create_event'):
             def _record_metric(*args, **kwargs):
                 for delegate in self.delegates:
                     getattr(delegate, item)(*args, **kwargs)

--- a/custom/icds_reports/utils/data_accessor.py
+++ b/custom/icds_reports/utils/data_accessor.py
@@ -2,7 +2,8 @@ from copy import deepcopy
 
 from time import sleep
 from datetime import datetime, timedelta
-from corehq.util.datadog.utils import create_datadog_event
+
+from corehq.util.metrics import create_metrics_event
 from custom.icds_reports.cache import icds_quickcache
 from custom.icds_reports.const import LocationTypes
 from custom.icds_reports.reports.awc_infrastracture import get_awc_infrastructure_data
@@ -26,7 +27,7 @@ def _all_zeros(data, agg_level):
     else:
         retry = all(values)
     if retry:
-        create_datadog_event('ICDS 0s', 'All indicators in program summary equals 0', aggregation_key='icds_0')
+        create_metrics_event('ICDS 0s', 'All indicators in program summary equals 0', aggregation_key='icds_0')
     return retry
 
 
@@ -116,7 +117,7 @@ def _all_zeros_graph(step, data, agg_level):
 
     retry = all(values)
     if retry:
-        create_datadog_event('ICDS 0s', 'All indicators in awc_covered equals 0', aggregation_key='icds_0')
+        create_metrics_event('ICDS 0s', 'All indicators in awc_covered equals 0', aggregation_key='icds_0')
     return retry
 
 


### PR DESCRIPTION
##### SUMMARY
Consistent interface for creating metrics events. Currently only supported by Datadog.

This should also fix deploy which fails on `record_deploy_success`