### PR TITLE
very basic ability to confirm an unconfirmed user account

### DIFF
--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -17,7 +17,6 @@ from couchexport.models import Format
 from dimagi.utils.django.email import send_HTML_email
 from soil.util import expose_zipped_blob_download
 
-from corehq import toggles
 from corehq.apps.domain.models import Domain
 from corehq.apps.es import DomainES
 from corehq.util.quickcache import quickcache

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -391,8 +391,10 @@ class WebUserInvitationForm(NoAutocompleteMixin, DomainRegistrationForm):
     def clean_eula_confirmed(self):
         data = self.cleaned_data['eula_confirmed']
         if data is not True:
-            raise forms.ValidationError('You must agree to our Terms of Service and Business Agreement '
-                                        'in order to register an account.')
+            raise forms.ValidationError(_(
+                'You must agree to our Terms of Service and Business Agreement '
+                'in order to register an account.'
+            ))
         return data
 
 

--- a/corehq/apps/users/exceptions.py
+++ b/corehq/apps/users/exceptions.py
@@ -9,3 +9,7 @@ class NoAccountException(Exception):
 
 class InvalidMobileWorkerRequest(Exception):
     pass
+
+
+class IllegalAccountConfirmation(Exception):
+    pass

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -2,9 +2,11 @@ import datetime
 import json
 import re
 
+from captcha.fields import CaptchaField
 from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import SetPasswordForm
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator, validate_email
 from django.forms.widgets import PasswordInput
@@ -30,7 +32,7 @@ from corehq import toggles
 from corehq.apps.analytics.tasks import set_analytics_opt_out
 from corehq.apps.app_manager.models import validate_lang
 from corehq.apps.custom_data_fields.edit_entity import CustomDataEditor
-from corehq.apps.domain.forms import EditBillingAccountInfoForm, clean_password
+from corehq.apps.domain.forms import EditBillingAccountInfoForm, clean_password, NoAutocompleteMixin
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.crispy import HQModalFormHelper
@@ -1222,3 +1224,71 @@ class CommCareUserFilterForm(forms.Form):
         if "*" in search_string or "?" in search_string:
             raise forms.ValidationError(_("* and ? are not allowed"))
         return search_string
+
+
+class MobileWorkerAccountConfirmationForm(NoAutocompleteMixin, forms.Form):
+    """
+    For Mobile Workers to confirm their accounts.
+    """
+    # note: this form is heavily inspired by WebUserInvitationForm
+    email = forms.EmailField(label=_('Email Address'),
+                             max_length=User._meta.get_field('email').max_length,
+                             widget=forms.TextInput(attrs={'class': 'form-control'}))
+    full_name = forms.CharField(label=_('Full Name'),
+                                max_length=User._meta.get_field('first_name').max_length +
+                                           User._meta.get_field('last_name').max_length + 1,
+                                widget=forms.TextInput(attrs={'class': 'form-control'}))
+    password = forms.CharField(label=_('Create Password'),
+                               widget=forms.PasswordInput(render_value=False,
+                                                          attrs={
+                                                            'data-bind': "value: password, valueUpdate: 'input'",
+                                                            'class': 'form-control',
+                                                          }),
+                               help_text=mark_safe("""
+                               <span data-bind="text: passwordHelp, css: color">
+                               """))
+    if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
+        captcha = CaptchaField(_("Type the letters in the box"))
+
+    # required must be set to False to have the clean_*() routine called
+    # todo: should this and other duplicate logic be handled a mixin?
+    eula_confirmed = forms.BooleanField(required=False,
+                                        label="",
+                                        help_text=mark_safe_lazy(_(
+                                            """I have read and agree to Dimagi's
+                                                <a href="http://www.dimagi.com/terms/latest/privacy/"
+                                                    target="_blank">Privacy Policy</a>,
+                                                <a href="http://www.dimagi.com/terms/latest/tos/"
+                                                    target="_blank">Terms of Service</a>,
+                                                <a href="http://www.dimagi.com/terms/latest/ba/"
+                                                    target="_blank">Business Agreement</a>, and
+                                                <a href="http://www.dimagi.com/terms/latest/aup/"
+                                                    target="_blank">Acceptable Use Policy</a>.
+                                               """)))
+
+    def clean_full_name(self):
+        data = self.cleaned_data['full_name'].split()
+        return [data.pop(0)] + [' '.join(data)]
+
+    def clean_email(self):
+        data = self.cleaned_data['email'].strip().lower()
+        validate_email(data)
+        return data
+
+    def clean_password(self):
+        return clean_password(self.cleaned_data.get('password'))
+
+    def clean(self):
+        for field in self.cleaned_data:
+            if isinstance(self.cleaned_data[field], str):
+                self.cleaned_data[field] = self.cleaned_data[field].strip()
+        return self.cleaned_data
+
+    def clean_eula_confirmed(self):
+        data = self.cleaned_data['eula_confirmed']
+        if data is not True:
+            raise forms.ValidationError(_(
+                'You must agree to our Terms of Service and Business Agreement '
+                'in order to register an account.'
+            ))
+        return data

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1873,10 +1873,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         assert not self.is_active, 'Active account should not be unconfirmed!'
         self.is_active = True
         self.is_account_confirmed = True
+        self.set_password(password)
         self.save()
-        django_user = self.get_django_user()
-        django_user.set_password(password)
-        django_user.save()
 
     def get_case_sharing_groups(self):
         from corehq.apps.groups.models import Group

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -22,6 +22,7 @@ from memoized import memoized
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.phone.models import OTARestoreCommCareUser, OTARestoreWebUser
 from casexml.apps.phone.restore_caching import get_loadtest_factor_for_user
+from corehq.apps.users.exceptions import IllegalAccountConfirmation
 from dimagi.ext.couchdbkit import (
     BooleanProperty,
     DateProperty,
@@ -1865,6 +1866,17 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         else:
             django_user.delete()
         self.save()
+
+    def confirm_account(self, password):
+        if self.is_account_confirmed:
+            raise IllegalAccountConfirmation('Account is already confirmed')
+        assert not self.is_active, 'Active account should not be unconfirmed!'
+        self.is_active = True
+        self.is_account_confirmed = True
+        self.save()
+        django_user = self.get_django_user()
+        django_user.set_password(password)
+        django_user.save()
 
     def get_case_sharing_groups(self):
         from corehq.apps.groups.models import Group

--- a/corehq/apps/users/templates/users/commcare_user_confirm_account.html
+++ b/corehq/apps/users/templates/users/commcare_user_confirm_account.html
@@ -1,38 +1,106 @@
-{% extends "hqwebapp/base_page.html" %}
-{% load hq_shared_tags %}
-{% load crispy_forms_tags %}
+{% extends login_template %}
 {% load i18n %}
+{% load field_tags %}
+{% load hq_shared_tags %}
 
-{% block title %}{% trans "Confirm Account" %}{% endblock %}
+{% requirejs_main 'users/js/accept_invite' %}
 
-{% block header %}
-  <div class="page-header container">
-    <h1>{% blocktrans %}{{ hr_name }} Registration{% endblocktrans %}</h1>
+{% block title %}{% blocktrans %}Confirm your account to join the {{ domain_name }} project{% endblocktrans %}{% endblock title %}
+{% block tabs %}{% endblock %}
+
+{% block login-content %}
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-12">
+        <div class="reg-form-container sign-in-container">
+          <div class="form-bubble form-bubble-lg">
+            {% if request.user.is_authenticated %}
+              <h3>
+                {% trans "You are already signed in." %}
+              </h3>
+              <h4>
+                {% url 'logout' as sign_out_url %}
+                {% blocktrans %}
+                  To accept this invitation, you must first <a href="{{ sign_out_url }}">sign out</a>.
+                {% endblocktrans %}
+              </h4>
+            {% elif user.is_account_confirmed and user.is_active %}
+              <h3>
+                {% trans "Your account is already confirmed!" %}
+              </h3>
+              <h4>
+                {% url 'login' as login_url %}
+                {% blocktrans %}
+                  <a href="{{ login_url }}">Login</a> to access your account.
+                {% endblocktrans %}
+              </h4>
+            {% elif user.is_account_confirmed %}
+              <h3>
+                {% blocktrans %}
+                  It looks like your account has been deactivated.
+                  Contact your administrator if you think this is a mistake.
+                {% endblocktrans %}
+              </h3>
+            {% else %}
+              <h2>
+                {% blocktrans %}Confirm Your Account{% endblocktrans %}
+              </h2>
+              <div class="help-block">
+                {% blocktrans %}
+                  Fill in the details below to confirm your account.
+                {% endblocktrans %}
+              </div>
+              <form name="form" method="post" action="">
+                <h4>
+                  {% with user.raw_username as username %}
+                  {% blocktrans %}
+                    Your username <strong>{{ username }}</strong> was chosen by your project administrator.
+                  {% endblocktrans %}
+                  {% endwith %}
+                </h4>
+                {% csrf_token %}
+                {% for global_error in form.non_field_errors %}
+                  <div class="alert alert-danger">
+                    {{ global_error }}
+                  </div>
+                {% endfor %}
+                <fieldset class="check-password">
+                  {% for field in form.visible_fields %}
+                    <div class="form-group has-feedback{% if field.errors %} has-error{% endif %}">
+                      <label class="control-label" for="{{ field.id }}">{{ field.label }}</label>
+                      <div id="div_id_{{ field.name }}">
+                        {{ field }}
+                        {% for error in field.errors %}
+                          <p class="help-block">{{ error }}</p>
+                        {% endfor %}
+                        {% if field.help_text %}
+                          <p class="help-block">
+                            {{ field.help_text }}
+                          </p>
+                        {% endif %}
+                      </div>
+                    </div>
+                  {% endfor %}
+                  {% for hidden in form.hidden_fields %}
+                    {{ hidden }}
+                  {% endfor %}
+                  <div class="hide">
+                    {{ form.errors }}
+                  </div>
+
+                  <div class="form-bubble-actions">
+                    <button type="submit"
+                            class="btn btn-lg btn-primary"
+                            data-bind="enable: passwordSufficient">
+                      {% trans "Confirm Account" %}
+                    </button>
+                  </div>
+                </fieldset>
+              </form>
+          {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-{% endblock %}
-
-{% block content %}
-  {% if user.is_account_confirmed and user.is_active %}
-    <div>
-      <p>
-        {% blocktrans %}
-          Your account is already confirmed! Go sign in.
-        {% endblocktrans %}
-      </p>
-    </div>
-  {% elif user.is_account_confirmed %}
-    <div class="alert alert-danger">
-      <p>
-        {% blocktrans %}
-          It looks like your account has been deactivated.
-          Contact your administrator if you think this is a mistake.
-        {% endblocktrans %}
-      </p>
-    </div>
-  {% else %}
-    <div id="confirm-account-form">
-      <p>Confirm your account here!</p>
-      {#  todo    {% crispy form %}#}
-    </div>
-  {% endif %}
 {% endblock %}

--- a/corehq/apps/users/templates/users/commcare_user_confirm_account.html
+++ b/corehq/apps/users/templates/users/commcare_user_confirm_account.html
@@ -21,7 +21,7 @@
       </p>
     </div>
   {% elif user.is_account_confirmed %}
-    <div class="alert-alert-danger">
+    <div class="alert alert-danger">
       <p>
         {% blocktrans %}
           It looks like your account has been deactivated.
@@ -36,4 +36,3 @@
     </div>
   {% endif %}
 {% endblock %}
-{% block mobile-logout %}{% endblock %}

--- a/corehq/apps/users/templates/users/mobile/commcare_user_self_register.html
+++ b/corehq/apps/users/templates/users/mobile/commcare_user_self_register.html
@@ -23,7 +23,7 @@
       </p>
     </div>
   {% elif invitation.expired %}
-    <div class="alert-alert-danger">
+    <div class="alert alert-danger">
       <p>
         {% blocktrans %}
           Your registration invitation has expired. Please contact your administrator.

--- a/corehq/apps/users/tests/test_confirm_account.py
+++ b/corehq/apps/users/tests/test_confirm_account.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.exceptions import IllegalAccountConfirmation
 from corehq.apps.users.models import CommCareUser
 
 
@@ -48,3 +49,8 @@ class TestAccountConfirmation(TestCase):
         self.assertEqual(False, self.client.login(username=self.username, password=self.password))
         # but can with new password
         self.assertEqual(True, self.client.login(username=self.username, password=new_password))
+
+    def test_cant_confirm_twice(self):
+        self.user.confirm_account('abc')
+        with self.assertRaises(IllegalAccountConfirmation):
+            self.user.confirm_account('def')

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -36,7 +36,7 @@ class TestMobileWorkerConfirmAccountView(TestCase):
     def test_expected_workflow(self):
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
-        self.assertContains(response, 'Confirm your account here')
+        self.assertContains(response, 'Confirm your account')
 
     def test_feature_flag_not_enabled(self):
         response = self.client.get(self.url)

--- a/corehq/apps/users/tests/test_confirm_account_view.py
+++ b/corehq/apps/users/tests/test_confirm_account_view.py
@@ -17,8 +17,6 @@ class TestMobileWorkerConfirmAccountView(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.project.delete()
-        from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
-        delete_all_users()
         super().tearDownClass()
 
     def setUp(self):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -712,7 +712,6 @@ class UserInvitationView(object):
     template = "users/accept_invite.html"
 
     def __call__(self, request, invitation_id, **kwargs):
-        logging.info("Don't use this view in more apps until it gets cleaned up.")
         # add the correct parameters to this instance
         self.request = request
         self.inv_id = invitation_id


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

[more of this](https://docs.google.com/document/d/1gZlOGroRTeUMHXwzCuOVw2EUuJcjOsAaAe1qc2iUEe0/edit#heading=h.8h4o0ztcd51n)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This adds basic account confirmation. Putting it up for review though it's not 100% done.

![image](https://user-images.githubusercontent.com/66555/77080937-9b86c100-6a02-11ea-96a9-80c3fe1f4816.png)

Review by commit. I'll do a quick review pointing out a few things I'm mulling over.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
