### PR TITLE
Fix name of toggle used in URL to be lowercase

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1736,7 +1736,7 @@ DO_NOT_RATE_LIMIT_SUBMISSIONS = StaticToggle(
 )
 
 TEST_FORM_SUBMISSION_RATE_LIMIT_RESPONSE = StaticToggle(
-    'TEST_FORM_SUBMISSION_RATE_LIMIT_RESPONSE',
+    'test_form_submission_rate_limit_response',
     ("Respond to all form submissions with a 429 response. For use on test domains only. "
      "Without this, there's no sane way to test the UI for being rate limited on "
      "Mobile and Web Apps. Never use this on a real domain."),


### PR DESCRIPTION
##### SUMMARY
Changing the name of this to be lowercase like other toggles. Will have the annoying but basically harmless effect of wiping the current value

##### FEATURE FLAG
TEST_FORM_SUBMISSION_RATE_LIMIT_RESPONSE
