### PR TITLE
Support new user provisioning flow in the main mobile worker UI

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -588,22 +588,22 @@ class NewMobileWorkerForm(forms.Form):
         if self.two_stage_provisioning_enabled:
             confirm_account_field = crispy.Field(
                 'force_account_confirmation',
-                # data_bind='value: force_account_confirmation',
+                data_bind='value: force_account_confirmation',
             )
             email_field = crispy.Field(
                 'email',
-                # data_bind='value: email',
+                data_bind='value: email',
             )
         else:
             confirm_account_field = crispy.Hidden(
                 'force_account_confirmation',
                 '',
-                # data_bind='value: force_account_confirmation',
+                data_bind='value: force_account_confirmation',
             )
             email_field = crispy.Hidden(
                 'email',
                 '',
-                # data_bind='value: email',
+                data_bind='value: email',
             )
 
         self.helper = HQModalFormHelper()

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -539,6 +539,13 @@ class NewMobileWorkerForm(forms.Form):
     email = forms.EmailField(
         label=ugettext_noop("Email"),
         required=False,
+        help_text="""
+            <span data-bind="visible: $root.emailStatus() !== $root.STATUS.NONE">
+                <i class="fa fa-exclamation-triangle"
+                   data-bind="visible: $root.emailStatus() === $root.STATUS.ERROR"></i>
+                <!-- ko text: $root.emailStatusMessage --><!-- /ko -->
+            </span>
+        """
     )
     new_password = forms.CharField(
         widget=forms.PasswordInput(),
@@ -590,9 +597,16 @@ class NewMobileWorkerForm(forms.Form):
                 'force_account_confirmation',
                 data_bind='checked: force_account_confirmation',
             )
-            email_field = crispy.Field(
-                'email',
-                data_bind='value: email',
+            email_field = crispy.Div(
+                crispy.Field(
+                    'email',
+                    data_bind="value: email, valueUpdate: 'keyup'",
+                ),
+                data_bind='''
+                    css: {
+                        'has-error': $root.emailStatus() === $root.STATUS.ERROR,
+                    },
+                '''
             )
         else:
             confirm_account_field = crispy.Hidden(

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -588,7 +588,7 @@ class NewMobileWorkerForm(forms.Form):
         if self.two_stage_provisioning_enabled:
             confirm_account_field = crispy.Field(
                 'force_account_confirmation',
-                data_bind='value: force_account_confirmation',
+                data_bind='checked: force_account_confirmation',
             )
             email_field = crispy.Field(
                 'email',
@@ -642,7 +642,7 @@ class NewMobileWorkerForm(forms.Form):
                         _("Password"),
                         InlineField(
                             'new_password',
-                            data_bind="value: password, valueUpdate: 'input'",
+                            data_bind="value: password, valueUpdate: 'input', enable: passwordEnabled",
                         ),
                         crispy.HTML('''
                             <p class="help-block" data-bind="if: $root.isSuggestedPassword">
@@ -666,6 +666,9 @@ class NewMobileWorkerForm(forms.Form):
                                         <i class="fa fa-warning"></i> {rules}
                                     <!-- /ko -->
                                 <!-- /ko -->
+                                <!-- ko if: $root.passwordStatus() === $root.STATUS.DISABLED -->
+                                    <i class="fa fa-warning"></i> {disabled}
+                                <!-- /ko -->
                             </p>
                         '''.format(
                             suggested=_("This password is automatically generated. Please copy it or create "
@@ -675,6 +678,8 @@ class NewMobileWorkerForm(forms.Form):
                             weak=_("Your password is too weak! Try adding numbers or symbols!"),
                             rules=_("Password Requirements: 1 special character, 1 number, 1 capital letter, "
                                 "minimum length of 8 characters."),
+                            disabled=_("Setting a password is disabled. "
+                                       "The user will set their own password on confirming their account email."),
                         )),
                         required=True,
                     ),

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -539,7 +539,7 @@ class NewMobileWorkerForm(forms.Form):
 
     def __init__(self, project, request_user, *args, **kwargs):
         super(NewMobileWorkerForm, self).__init__(*args, **kwargs)
-        email_string = "@{}.commcarehq.org".format(project.name)
+        email_string = "@{}.{}".format(project.name, settings.HQ_ACCOUNT_ROOT)
         max_chars_username = 80 - len(email_string)
         self.project = project
         self.domain = self.project.name

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -2,11 +2,9 @@ import datetime
 import json
 import re
 
-from captcha.fields import CaptchaField
 from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import SetPasswordForm
-from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator, validate_email
 from django.forms.widgets import PasswordInput
@@ -32,7 +30,7 @@ from corehq import toggles
 from corehq.apps.analytics.tasks import set_analytics_opt_out
 from corehq.apps.app_manager.models import validate_lang
 from corehq.apps.custom_data_fields.edit_entity import CustomDataEditor
-from corehq.apps.domain.forms import EditBillingAccountInfoForm, clean_password, NoAutocompleteMixin
+from corehq.apps.domain.forms import EditBillingAccountInfoForm, clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.crispy import HQModalFormHelper

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -279,7 +279,7 @@ hqDefine("users/js/mobile_workers",[
         self.emailStatusMessage = ko.computed(function () {
             // todo: add email validation eventually
             if (self.emailStatus() === self.STATUS.ERROR) {
-                return gettext('Email address is required when users confirm their own accounts.')
+                return gettext('Email address is required when users confirm their own accounts.');
             }
             return "";
         });

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -78,6 +78,7 @@ hqDefine("users/js/mobile_workers",[
         var self = ko.mapping.fromJS(options);
 
         // used by two-stage provisioning
+        self.emailRequired = ko.observable(false);
         self.passwordEnabled = ko.observable(true);
 
         self.action_error = ko.observable('');  // error when activating/deactivating a user
@@ -264,6 +265,26 @@ hqDefine("users/js/mobile_workers",[
             return self.STATUS.WARNING;
         });
 
+        self.emailStatus = ko.computed(function () {
+
+            if (!self.stagedUser()) {
+                return self.STATUS.NONE;
+            }
+
+            // todo: add email validation eventually
+            if (self.stagedUser().emailRequired() && !self.stagedUser().email()) {
+                return self.STATUS.ERROR;
+            }
+        });
+
+        self.emailStatusMessage = ko.computed(function () {
+            // todo: add email validation eventually
+            if (self.emailStatus() === self.STATUS.ERROR) {
+                return gettext('Email address is required when users confirm their own accounts.')
+            }
+            return "";
+        });
+
         self.generateStrongPassword = function () {
             function pick(possible, min, max) {
                 var n, chars = '';
@@ -350,13 +371,16 @@ hqDefine("users/js/mobile_workers",[
             user.force_account_confirmation.subscribe(function (enabled) {
                 console.log('account confirmation', enabled);
                 if (enabled) {
-                    // todo: make email required
+                    // make email required
+                    user.emailRequired(true);
                     // clear and disable password input
                     user.password('');
                     user.passwordEnabled(false);
 
                 } else {
-                    // todo: make email optional
+                    // make email optional
+                    user.emailRequired(false);
+
                     // enable password input
                     user.passwordEnabled(true);
                 }

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -208,6 +208,7 @@ hqDefine("users/js/mobile_workers",[
         self.useStrongPasswords = ko.observable(options.strong_mobile_passwords);
         self.useDraconianSecurity = ko.observable(options.draconian_security);
         self.implementPasswordObfuscation = ko.observable(options.implement_password_obfuscation);
+        self.twoStageProvisioningEnabled = ko.observable(options.two_stage_provisioning_enabled);
 
         self.passwordStatus = ko.computed(function () {
             if (!self.useStrongPasswords()) {

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -64,6 +64,8 @@ hqDefine("users/js/mobile_workers",[
             location_id: '',
             password: '',
             user_id: '',
+            force_account_confirmation: '',
+            email: '',
             is_active: true,
             custom_fields: {},
         });

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -213,12 +213,11 @@ hqDefine("users/js/mobile_workers",[
         self.twoStageProvisioningEnabled = ko.observable(options.two_stage_provisioning_enabled);
 
         self.passwordStatus = ko.computed(function () {
-            if (!self.useStrongPasswords()) {
-                // No validation
+            if (!self.stagedUser()) {
                 return self.STATUS.NONE;
             }
-
-            if (!self.stagedUser()) {
+            if (!self.useStrongPasswords()) {
+                // No validation
                 return self.STATUS.NONE;
             }
 

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -421,6 +421,7 @@ hqDefine("users/js/mobile_workers",[
             location_url: initialPageData.reverse('location_search'),
             require_location_id: !initialPageData.get('can_access_all_locations'),
             strong_mobile_passwords: initialPageData.get('strong_mobile_passwords'),
+            two_stage_provisioning_enabled: initialPageData.get('two_stage_provisioning_enabled'),
         });
         $("#new-user-modal-trigger").koApplyBindings(newUserCreation);
         $("#new-user-modal").koApplyBindings(newUserCreation);

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -13,6 +13,7 @@
   {% initial_page_data 'implement_password_obfuscation' implement_password_obfuscation %}
   {% initial_page_data 'pagination_limit_cookie_name' pagination_limit_cookie_name %}
   {% initial_page_data 'strong_mobile_passwords' strong_mobile_passwords %}
+  {% initial_page_data 'two_stage_provisioning_enabled' two_stage_provisioning_enabled %}
   {% registerurl 'location_search' domain %}
   {% registerurl 'mobile_workers' domain %}
   {% registerurl 'edit_commcare_user' domain '---' %}

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -195,7 +195,6 @@ def doc_value_wrapper(doc_cls, value_cls):
 
 def can_add_extra_mobile_workers(request):
     from corehq.apps.users.models import CommCareUser
-    from corehq.apps.accounting.models import Subscription
     num_web_users = CommCareUser.total_by_domain(request.domain)
     user_limit = request.plan.user_limit
     if user_limit == -1 or num_web_users < user_limit:

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -676,7 +676,8 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
             'can_edit_billing_info': self.request.couch_user.is_domain_admin(self.domain),
             'strong_mobile_passwords': self.request.project.strong_mobile_passwords,
             'implement_password_obfuscation': settings.OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE,
-            'bulk_download_url': bulk_download_url
+            'bulk_download_url': bulk_download_url,
+            'two_stage_provisioning_enabled': TWO_STAGE_USER_PROVISIONING.enabled(self.domain),
         }
 
     @property

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1439,9 +1439,14 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
         return context
 
     def post(self, request, *args, **kwargs):
-        if self.form.is_valid():
-            # todo set email and name too
-            self.user.confirm_account(password=self.form.cleaned_data['password'])
+        form = self.form
+        if form.is_valid():
+            user = self.user
+            user.email = form.cleaned_data['email']
+            full_name = form.cleaned_data['full_name']
+            user.first_name = full_name[0]
+            user.last_name = full_name[1]
+            user.confirm_account(password=self.form.cleaned_data['password'])
             messages.success(request, _(
                 f'You have successfully confirmed the {self.user.raw_username} account. '
                 'You can now login'

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1425,6 +1425,7 @@ class CommCareUserConfirmAccountView(TemplateView, DomainViewMixin):
         else:
             return MobileWorkerAccountConfirmationForm(initial={
                 'username': self.user.raw_username,
+                'full_name': self.user.full_name,
                 'email': self.user.email,
             })
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -754,17 +754,21 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         username = self.new_mobile_worker_form.cleaned_data['username']
         password = self.new_mobile_worker_form.cleaned_data['new_password']
         first_name = self.new_mobile_worker_form.cleaned_data['first_name']
+        email = self.new_mobile_worker_form.cleaned_data['email']
         last_name = self.new_mobile_worker_form.cleaned_data['last_name']
         location_id = self.new_mobile_worker_form.cleaned_data['location_id']
+        is_account_confirmed = not self.new_mobile_worker_form.cleaned_data['force_account_confirmation']
 
         return CommCareUser.create(
             self.domain,
             username,
             password,
+            email=email,
             device_id="Generated from HQ",
             first_name=first_name,
             last_name=last_name,
             user_data=self.custom_data.get_data_to_save(),
+            is_account_confirmed=is_account_confirmed,
             location=SQLLocation.objects.get(location_id=location_id) if location_id else None,
         )
 
@@ -786,6 +790,8 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
                 'first_name': user_data.get('first_name'),
                 'last_name': user_data.get('last_name'),
                 'location_id': user_data.get('location_id'),
+                'email': user_data.get('email'),
+                'force_account_confirmation': user_data.get('force_account_confirmation'),
                 'domain': self.domain,
             }
             for k, v in user_data.get('custom_fields', {}).items():


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://docs.google.com/document/d/1gZlOGroRTeUMHXwzCuOVw2EUuJcjOsAaAe1qc2iUEe0/edit#

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
![image](https://user-images.githubusercontent.com/66555/77174801-4f9f4f00-6aca-11ea-9eb8-9d04868595e5.png)

This adds two new fields (behind a feature flag) to the mobile worker creation page - one for enabling the "self-confirmation" workflow, and an email address (note: should this be added for all domains?).

I think this is non-breaking and feature-complete, but I'm putting a "don't merge" on until I have a chance to do better regression testing (I was mostly looking at the flag-enabled case).

Side note: I really don't understand the value of crispy forms for something this JS heavy. It seems like this would be much simpler if we just used the form for the field/validaiton logic and rendered the whole thing in HTML / JS. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
