### PR TITLE
Use SQL backend by default

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -332,7 +332,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     location_restriction_for_users = BooleanProperty(default=False)
     usercase_enabled = BooleanProperty(default=False)
     hipaa_compliant = BooleanProperty(default=False)
-    use_sql_backend = BooleanProperty(default=False)
+    use_sql_backend = BooleanProperty(default=True)
     first_domain_for_user = BooleanProperty(default=False)
 
     case_display = SchemaProperty(CaseDisplaySettings)
@@ -619,7 +619,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
         return domain
 
     @classmethod
-    def get_or_create_with_name(cls, name, is_active=False, secure_submissions=True, use_sql_backend=False):
+    def get_or_create_with_name(cls, name, is_active=False, secure_submissions=True):
         result = cls.view("domain/domains", key=name, reduce=False, include_docs=True).first()
         if result:
             return result
@@ -629,7 +629,6 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
                 is_active=is_active,
                 date_created=datetime.utcnow(),
                 secure_submissions=secure_submissions,
-                use_sql_backend=use_sql_backend,
             )
             new_domain.save(**get_safe_write_kwargs())
             return new_domain

--- a/corehq/apps/domain/views/tombstone.py
+++ b/corehq/apps/domain/views/tombstone.py
@@ -63,7 +63,6 @@ def create_tombstone(request):
             date_created=datetime.utcnow(),
             creating_user=request.couch_user.username,
             secure_submissions=True,
-            use_sql_backend=True,
             first_domain_for_user=False,
         )
         project.save()

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -101,7 +101,6 @@ def request_new_domain(request, form, is_new_user=True):
             date_created=datetime.utcnow(),
             creating_user=current_user.username,
             secure_submissions=True,
-            use_sql_backend=True,
             first_domain_for_user=is_new_user
         )
 


### PR DESCRIPTION
I reviewed possible places where domains could have been created with `use_sql_backend=False`, but didn't find any smoking guns. This PR tightens things up a big and moves the default deeper so it is harder to accidentally create a Couch domain.

Changed: the `populate_inddex_test_domain` management command previously created Couch domains. It will now create SQL domains.

I didn't run tests yet (will see what Travis says). Maybe this won't be so easy?