### PR TITLE
Couch to SQL: connection resets and log clean up

### DIFF
--- a/corehq/apps/couch_sql_migration/casedifftool.py
+++ b/corehq/apps/couch_sql_migration/casedifftool.py
@@ -249,6 +249,7 @@ def init_worker(domain, *args):
     clean_break = False
     reset_django_db_connections()
     reset_couchdb_connections()
+    reset_blobdb_connections()
     signal.signal(signal.SIGINT, on_break)
     set_local_domain_sql_backend_override(domain)
     return global_diff_state(domain, *args)
@@ -276,6 +277,15 @@ def reset_couchdb_connections():
         server = db[0] if isinstance(db, tuple) else db.server
         with safe_socket_close():
             server.cloudant_client.r_session.close()
+
+
+def reset_blobdb_connections():
+    from corehq.blobs import _db, get_blob_db
+    if _db:
+        assert len(_db) == 1, _db
+        old_blob_db = get_blob_db()
+        _db.pop()
+        assert get_blob_db() is not old_blob_db
 
 
 @contextmanager

--- a/corehq/apps/couch_sql_migration/casedifftool.py
+++ b/corehq/apps/couch_sql_migration/casedifftool.py
@@ -250,6 +250,7 @@ def init_worker(domain, *args):
     reset_django_db_connections()
     reset_couchdb_connections()
     reset_blobdb_connections()
+    reset_redis_connections()
     signal.signal(signal.SIGINT, on_break)
     set_local_domain_sql_backend_override(domain)
     return global_diff_state(domain, *args)
@@ -286,6 +287,12 @@ def reset_blobdb_connections():
         old_blob_db = get_blob_db()
         _db.pop()
         assert get_blob_db() is not old_blob_db
+
+
+def reset_redis_connections():
+    from django_redis.pool import ConnectionFactory
+    for pool in ConnectionFactory._pools.values():
+        pool.reset()
 
 
 @contextmanager

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -1150,10 +1150,6 @@ def _iter_docs(domain, doc_type, resume_key, stopper):
         for row in rows:
             yield row[row_key]
     finally:
-        if row is not None:
-            row_copy = dict(row)
-            row_copy.pop("doc", None)
-            log.info("last item: %r", row_copy)
         final_state = rows.state.to_json().get("kwargs")
         if final_state:
             log.info("final iteration state: %r", final_state)

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -302,13 +302,13 @@ class Command(BaseCommand):
                 short,
                 diffs_only,
             )
-
+        if any(x.missing for x in doc_counts.values()):
+            print("\nRun again with --forms=missing to migrate missing docs")
         pending = statedb.count_undiffed_cases()
         if pending:
             print(shell_red(f"\nThere are {pending} case diffs pending."))
             print(f"Resolution: couch_sql_diff {domain} cases --select=pending")
             return True
-
         if diffs_only and not has_diffs:
             print(shell_green("No differences found between old and new docs!"))
         return has_diffs

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -267,7 +267,7 @@ class Command(BaseCommand):
         self.print_stats(domain, short=not self.verbose)
 
     def do_diff(self, domain):
-        print(f"replaced by: couch_sql_diff show {domain} [--select=DOC_TYPE]")
+        print(f"replaced by: couch_sql_diff {domain} show [--select=DOC_TYPE]")
 
     def do_rewind(self, domain):
         db = open_state_db(domain, self.state_dir)
@@ -306,7 +306,7 @@ class Command(BaseCommand):
         pending = statedb.count_undiffed_cases()
         if pending:
             print(shell_red(f"\nThere are {pending} case diffs pending."))
-            print(f"Resolution: couch_sql_diff cases {domain} --select=pending")
+            print(f"Resolution: couch_sql_diff {domain} cases --select=pending")
             return True
 
         if diffs_only and not has_diffs:

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -222,7 +222,7 @@ class Command(BaseCommand):
             if status == MigrationStatus.DRY_RUN:
                 log.info("Continuing live migration. Use --finish to complete.")
                 self.live_migrate = True
-        if self.missing_docs == CACHED and (self.finish or not self.live_migrate):
+        if self.missing_docs == CACHED:
             self.missing_docs = RESUME
         set_couch_sql_migration_started(domain, self.live_migrate)
         do_couch_to_sql_migration(
@@ -236,17 +236,12 @@ class Command(BaseCommand):
             forms=self.forms,
         )
 
-        return_code = 0
+        has_diffs = self.print_stats(domain, short=True, diffs_only=True)
         if self.live_migrate:
             print("Live migration completed.")
-            has_diffs = True
-        else:
-            has_diffs = self.print_stats(domain, short=True, diffs_only=True)
-            return_code = int(has_diffs)
         if has_diffs:
             print("\nRun `diff` or `stats [--verbose]` for more details.\n")
-        if return_code:
-            sys.exit(return_code)
+            sys.exit(1)
 
     def do_reset(self, domain):
         if not self.no_input:

--- a/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_multiple_domains_from_couch_to_sql.py
@@ -72,11 +72,11 @@ class Command(BaseCommand):
 
     def migrate_domain(self, domain, state_dir):
         if should_use_sql_backend(domain):
-            log.error("{} already on the SQL backend\n".format(domain))
+            log.info("{} already on the SQL backend\n".format(domain))
             return True, None
 
         if couch_sql_migration_in_progress(domain, include_dry_runs=True):
-            log.error("{} migration is already in progress\n".format(domain))
+            log.error("{} migration is in progress\n".format(domain))
             return False, "in progress"
 
         set_couch_sql_migration_started(domain)


### PR DESCRIPTION
More connections need to be reset in subprocesses since case diffs are initiated immediately after migrating forms, and subprocesses cannot use the same connections as the parent process (this was causing errors that prevented some case diffs from being resolved, although they were not lost). Previously the main/parent process for case diffs did not create connections to the blob db or redis before spawning workers.

Review by commit 🐡 or all at once 🏢 