### PR TITLE
Clean up support-related emails

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -512,7 +512,8 @@ class BillingAccount(ValidateModelMixin, models.Model):
             'old_user_name': old_user_name,
             'billing_account_name': self.name,
             'billing_info_url': absolute_reverse(EditExistingBillingAccountView.urlname,
-                                                 args=[domain])
+                                                 args=[domain]),
+            'invoicing_contact_email': settings.INVOICING_CONTACT_EMAIL,
         }
 
         send_html_email_async(
@@ -541,7 +542,8 @@ class BillingAccount(ValidateModelMixin, models.Model):
             'last_4': last_4,
             'billing_account_name': self.name,
             'billing_info_url': absolute_reverse(EditExistingBillingAccountView.urlname,
-                                                 args=[domain])
+                                                 args=[domain]),
+            'invoicing_contact_email': settings.INVOICING_CONTACT_EMAIL,
         }
 
         send_html_email_async(

--- a/corehq/apps/accounting/templates/accounting/email/autopay_card_removed.html
+++ b/corehq/apps/accounting/templates/accounting/email/autopay_card_removed.html
@@ -4,13 +4,14 @@
     Hello {{ old_user_name }},
   </p>
   <p>
-    Your card is no longer being used for autopayment on the account {{billing_account_name}}.
+    Your card is no longer being used for autopayment on the account {{ billing_account_name }}.
   </p>
   <p>
     A card belonging to <strong><a href="mailto:{{ new_user }}">{{new_user}}</a></strong> is being used instead. If this is expected, you do not have to take any further action, and this card will be used to pay monthly invoices and will be charged on the invoice due date. If this change is unexpected, you can view and alter the credit card information at any time by navigating to your <a href="{{ billing_info_url }}">Billing Information</a> page.
   </p>
   <p>
-    Thank you for using CommCare. If you have any questions, please don't hesitate to contact <a href="mailto:accounting@dimagi.com">commcarehq-support@dimagi.com</a>.
+    Thank you for using CommCare. If you have any questions, please don't hesitate to contact
+    <a href="mailto:{{ invoicing_contact_email }}">{{ invoicing_contact_email }}</a>.
   </p>
   <p>
     Best Regards,

--- a/corehq/apps/accounting/templates/accounting/email/invoice_autopay_setup.html
+++ b/corehq/apps/accounting/templates/accounting/email/invoice_autopay_setup.html
@@ -38,7 +38,8 @@
 </p>
 <p>
   {% blocktrans %}
-    Thank you for using CommCare. If you have any questions, please don't hesitate to contact <a href="mailto:commcarehq-support@dimagi.com">commcarehq-support@dimagi.com</a>.
+    Thank you for using CommCare. If you have any questions, please don't hesitate to contact
+    <a href="mailto:{{ invoicing_contact_email }}">{{ invoicing_contact_email }}</a>.
   {% endblocktrans %}
 </p>
 <p>

--- a/corehq/apps/accounting/templates/accounting/email/wire_invoice.html
+++ b/corehq/apps/accounting/templates/accounting/email/wire_invoice.html
@@ -65,7 +65,7 @@
 
 <p>
   {% blocktrans %}
-    Thank you for using CommCare. If you have any questions, please don't hesitate to contact billing-support@dimagi.com.
+    Thank you for using CommCare. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
   {% endblocktrans %}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/email/wire_invoice.txt
+++ b/corehq/apps/accounting/templates/accounting/email/wire_invoice.txt
@@ -17,7 +17,7 @@ Dimagi accepts wire payments via ACH and wire transfer. To complete the Wire Pay
 
 2. Send an email to {{ accounts_email }} after you have made the payment including the date of the payment, the amount, the invoice number and the project space name.
 
-Thank you for using CommCare. If you have any questions, please don't hesitate to contact billing-support@dimagi.com.
+Thank you for using CommCare. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
 
 Best Regards,
 The CommCare HQ Team

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -971,9 +971,11 @@ class TransferDomainRequest(models.Model):
 
     def email_from_request(self):
         context = self.as_dict()
-        context['settings_url'] = "{url_base}{path}".format(
-            url_base=get_url_base(),
-            path=reverse('transfer_domain_view', args=[self.domain]))
+        context.update({
+            'settings_url': "{url_base}{path}".format(url_base=get_url_base(),
+                                                      path=reverse('transfer_domain_view', args=[self.domain])),
+            'support_email': settings.SUPPORT_EMAIL,
+        })
 
         html_content = render_to_string("{template}.html".format(template=self.TRANSFER_FROM_EMAIL), context)
         text_content = render_to_string("{template}.txt".format(template=self.TRANSFER_FROM_EMAIL), context)

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
@@ -8,7 +8,9 @@
 
 <p>
   {% blocktrans %}
-    A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and follow <a href="{{ settings_url }}">this link</a> to deactivate the transfer: {{ settings_url }}
+    A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe
+    this is an error, please contact Dimagi immediately at <a href="mailto:{{ support_email }}">{{ support_email }}</a>
+    and follow <a href="{{ settings_url }}">this link</a> to deactivate the transfer: {{ settings_url }}
   {% endblocktrans %}
 </p>
 

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.txt
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.txt
@@ -5,7 +5,7 @@ Hello,
 {% endblocktrans %}
 
 {% blocktrans %}
-A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and follow this link to deactivate the transfer: {{ settings_url }}
+A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at {{ support_email }} and follow this link to deactivate the transfer: {{ settings_url }}
 {% endblocktrans %}
 
 {% blocktrans %}

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1447,10 +1447,11 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
             messages.error(
                 request, _(
                     "You have already scheduled a downgrade to the %(software_plan_name)s Software Plan on "
-                    "%(downgrade_date)s. If this is a mistake, please reach out to billing-support@dimagi.com."
+                    "%(downgrade_date)s. If this is a mistake, please reach out to %(contact_email)."
                 ) % {
                     'software_plan_name': software_plan_name,
                     'downgrade_date': downgrade_date,
+                    'contact_email': settings.INVOICING_CONTACT_EMAIL,
                 }
             )
 

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -580,14 +580,13 @@ def jserror(request):
 
 @method_decorator([login_required], name='dispatch')
 class BugReportView(View):
-
     @property
     def recipients(self):
         """
             Returns:
                 list
         """
-        return settings.BUG_REPORT_RECIPIENTS
+        return [settings.SUPPORT_EMAIL]
 
     def post(self, req, *args, **kwargs):
         report = dict([(key, req.POST.get(key, '')) for key in (

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -709,7 +709,7 @@ class BugReportView(View):
         if re.search(r'@dimagi\.com$', report['username']) and not is_icds_env:
             email.from_email = report['username']
         else:
-            email.from_email = settings.CCHQ_BUG_REPORT_EMAIL
+            email.from_email = settings.SERVER_EMAIL
 
         email.send(fail_silently=False)
 

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -709,7 +709,7 @@ class BugReportView(View):
         if re.search(r'@dimagi\.com$', report['username']) and not is_icds_env:
             email.from_email = report['username']
         else:
-            email.from_email = settings.SERVER_EMAIL
+            email.from_email = settings.SUPPORT_EMAIL
 
         email.send(fail_silently=False)
 

--- a/custom/icds_reports/templates/icds_reports/dashboard.html
+++ b/custom/icds_reports/templates/icds_reports/dashboard.html
@@ -230,7 +230,7 @@ related to angular not being defined. But if we split it here it works fine.
             <h3 class="modal-title" id="modal-title">Report an Issue<i style="float: right;" ng-click="$dismiss()" class="fa fa-close pointer"></i></h3>
         </div>
         <div class="modal-body" id="modal-body">
-            Please contact icds-support@dimagi.com in order to report an issue with the Dashboard
+            Please contact {{ support_email }} in order to report an issue with the Dashboard
         </div>
         <div class="modal-footer">
            <button ng-click="$dismiss()" class="btn btn-primary">Close</button>

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -371,7 +371,10 @@ class DashboardView(TemplateView):
     def get_context_data(self, **kwargs):
         kwargs.update(self.kwargs)
         kwargs.update(get_dashboard_template_context(self.domain, self.couch_user))
-        kwargs['is_mobile'] = False
+        kwargs.update({
+            'is_mobile': False,
+            'support_email': ICDS_SUPPORT_EMAIL,
+        })
         if self.couch_user.is_commcare_user() and self._has_helpdesk_role():
             build_id = get_latest_issue_tracker_build_id()
             kwargs['report_an_issue_url'] = webapps_module(

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -94,7 +94,6 @@ EMAIL_SMTP_PORT = 587
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ADMINS = (('HQ Dev Team', 'commcarehq-dev+www-notifications@example.com'),)
-BUG_REPORT_RECIPIENTS = ['commcarehq-support@example.com']
 NEW_DOMAIN_RECIPIENTS = ['commcarehq-dev+newdomain@example.com']
 
 SERVER_EMAIL = 'commcarehq-noreply@example.com'  # the physical server emailing - differentiate if needed

--- a/settings.py
+++ b/settings.py
@@ -439,7 +439,6 @@ SERVER_EMAIL = 'commcarehq-noreply@example.com'
 DEFAULT_FROM_EMAIL = 'commcarehq-noreply@example.com'
 SUPPORT_EMAIL = "support@example.com"
 PROBONO_SUPPORT_EMAIL = 'pro-bono@example.com'
-CCHQ_BUG_REPORT_EMAIL = 'commcarehq-bug-reports@example.com'
 ACCOUNTS_EMAIL = 'accounts@example.com'
 DATA_EMAIL = 'datatree@example.com'
 SUBSCRIPTION_CHANGE_EMAIL = 'accounts+subchange@example.com'

--- a/settings.py
+++ b/settings.py
@@ -434,9 +434,6 @@ EMAIL_SMTP_PORT = 587
 # These are the normal Django settings
 EMAIL_USE_TLS = True
 
-# put email addresses here to have them receive bug reports
-BUG_REPORT_RECIPIENTS = ()
-
 # the physical server emailing - differentiate if needed
 SERVER_EMAIL = 'commcarehq-noreply@example.com'
 DEFAULT_FROM_EMAIL = 'commcarehq-noreply@example.com'


### PR DESCRIPTION
Part of https://dimagi-dev.atlassian.net/browse/ICDS-1304 / https://dimagi-dev.atlassian.net/browse/SAAS-10710

I switched `CCHQ_BUG_REPORT_EMAIL` (the from address for bug reports) to the normal noreply email, because it didn't seem worth having a specific email for bug reports. Guessing this existed so that in bygone days people could filter their email. Also deprecated `BUG_REPORT_RECIPIENTS` because all bugs now go through support.

I don't think either of these decisions will be controversial or affect localhosting (doubt anyone doing localhosting currently does much with bug reports), but anyone feel free to push back. FYI @dimagi/product and @esoergel 