### PR TITLE
add back knockout dependency for strong passwords

### DIFF
--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -11,6 +11,7 @@ hqDefine('users/js/edit_commcare_user', [
     'registration/js/password',
     'nic_compliance/js/encoder',
     'select2/dist/js/select2.full.min',
+    'hqwebapp/js/knockout_bindings.ko', // password initializeValue binding
 ], function (
     $,
     ko,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

https://dimagi-dev.atlassian.net/browse/SAAS-10737

(ran into this while testing https://github.com/dimagi/commcare-hq/pull/26920 and figured I might as well fix it)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The password form [relies](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/forms.py#L409) on [this binding](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/knockout_bindings.ko.js#L622) which wasn't being imported on the page

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
