### PR TITLE
Security upgrade to psutil==5.7.0

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -135,7 +135,7 @@ ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prometheus-client==0.7.1
 prompt-toolkit==1.0.18    # via ipython
-psutil==5.1.3
+psutil==5.7.0
 psycogreen==1.0.1
 psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -4,7 +4,7 @@ django-debug-toolbar
 jenkinsapi==0.2.28
 fixture==1.5.11
 sniffer==0.4.0
-psutil==5.1.3  # for memory profiling
+psutil>5.1.3  # for memory profiling
 django-extensions
 ipython==5.2.2
 ipdb==0.11

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -135,7 +135,7 @@ ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prometheus-client==0.7.1
 prompt-toolkit==1.0.18    # via ipython
-psutil==5.1.3
+psutil==5.7.0
 psycogreen==1.0.1
 psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect


### PR DESCRIPTION
##### SUMMARY

This is only used in custom memory profiling middleware
but no reason to be on an insecure version.
