### PR TITLE
Queue selected person cases to asyn queue

### DIFF
--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
     def handle(self, *args,**kwargs):
         person_config = _get_config_by_id('static-icds-cas-static-person_cases_v3')
         table_name = get_table_name('icds-cas', 'static-person_cases_v3')
-        query = """select doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175' order by doc_id""".format(table_name)
+        query = """select supervisor, doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175' order by supervisor, doc_id""".format(table_name)
 
         with connections['icds-ucr-citus'].cursor() as cursor:
             cursor.execute(query)
@@ -23,8 +23,8 @@ class Command(BaseCommand):
         total_doc_ids = len(doc_ids)
         count = 0
         for ids_chunk in chunked(doc_ids, 10000):
-            ids_list = [item[0] for item in ids_chunk]
-            AsyncIndicator.bulk_creation(ids_list, 'case', 'icds-cas', [person_config._id])
+            ids_list = [item for item in ids_chunk]
+            AsyncIndicator.bulk_creation([elem[1] for elem in ids_list], 'case', 'icds-cas', [person_config._id])
             count += 10000
             print("Success till doc_id: {}".format(ids_list[-1]))
             print("progress: {}/{}".format(count, total_doc_ids ))

--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -1,0 +1,25 @@
+
+from django.core.management.base import BaseCommand
+from corehq.apps.userreports.tasks import _get_config_by_id
+from corehq.apps.userreports.util import get_table_name
+from corehq.apps.userreports.models import AsyncIndicator
+from django.db import connections, models, transaction, router
+
+
+class Command(BaseCommand):
+    help = "Rebuild Bihar person cases "
+
+    def handle(self):
+        person_config = _get_config_by_id('static-icds-cas-static-person_cases_v3')
+        table_name = get_table_name('icds-cas', 'static-person_cases_v3')
+        query = """select doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175'""".format(table_name)
+
+        with connections['icds-ucr-citus'].cursor()  as cursor:
+            cursor.execute(query)
+            doc_ids = cursor.fetchall()
+            doc_ids = [doc[0] for doc in doc_ids]
+
+        for doc_id in doc_ids:
+            AsyncIndicator.update_record(
+                doc_id, person_config.referenced_doc_type, person_config.domain, [person_config._id]
+            )

--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -14,16 +14,17 @@ class Command(BaseCommand):
     def handle(self):
         person_config = _get_config_by_id('static-icds-cas-static-person_cases_v3')
         table_name = get_table_name('icds-cas', 'static-person_cases_v3')
-        query = """select doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175' order by supervisor_id, doc_id""".format(table_name)
+        query = """select doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175' order by doc_id""".format(table_name)
 
-        with connections['icds-ucr-citus'].cursor()  as cursor:
+        with connections['icds-ucr-citus'].cursor() as cursor:
             cursor.execute(query)
             doc_ids = cursor.fetchall()
-            doc_ids = [doc[0] for doc in doc_ids]
 
+        total_doc_ids = len(doc_ids)
         count = 0
         for ids_chunk in chunked(doc_ids, 10000):
-            AsyncIndicator.bulk_creation(ids_chunk, 'case', 'icds-cas', [person_config._id])
-            count += len(ids_chunk)
-            print("Success till doc_id: {}".format(ids_chunk))
-            print("progress: {}/{}".format(count, len(doc_ids)))
+            ids_list = [item[0] for item in ids_chunk]
+            AsyncIndicator.bulk_creation(ids_list, 'case', 'icds-cas', [person_config._id])
+            count += 10000
+            print("Success till doc_id: {}".format(ids_list[-1]))
+            print("progress: {}/{}".format(count, total_doc_ids ))

--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -17,9 +17,9 @@ class Command(BaseCommand):
         # sort by supervisor_id and doc_id to improve the performance, sorting is needed to resume the queueing
         # if it fails in between.
         query = """
-            select supervisor, doc_id from "{}"
+            select supervisor_id, doc_id from "{}"
             where state_id='f9b47ea2ee2d8a02acddeeb491d3e175'
-            order by supervisor, doc_id
+            order by supervisor_id, doc_id
         """.format(table_name)
 
         with connections['icds-ucr-citus'].cursor() as cursor:

--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -11,7 +11,7 @@ from dimagi.utils.chunked import chunked
 class Command(BaseCommand):
     help = "Rebuild Bihar person cases "
 
-    def handle(self):
+    def handle(self, *args,**kwargs):
         person_config = _get_config_by_id('static-icds-cas-static-person_cases_v3')
         table_name = get_table_name('icds-cas', 'static-person_cases_v3')
         query = """select doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175' order by doc_id""".format(table_name)

--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -3,8 +3,7 @@ from django.core.management.base import BaseCommand
 from corehq.apps.userreports.tasks import _get_config_by_id
 from corehq.apps.userreports.util import get_table_name
 from corehq.apps.userreports.models import AsyncIndicator
-from django.db import connections, models, transaction, router
-from pillowtop.dao.couch import ID_CHUNK_SIZE
+from django.db import connections
 
 from dimagi.utils.chunked import chunked
 

--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -4,6 +4,9 @@ from corehq.apps.userreports.tasks import _get_config_by_id
 from corehq.apps.userreports.util import get_table_name
 from corehq.apps.userreports.models import AsyncIndicator
 from django.db import connections, models, transaction, router
+from pillowtop.dao.couch import ID_CHUNK_SIZE
+
+from dimagi.utils.chunked import chunked
 
 
 class Command(BaseCommand):
@@ -12,14 +15,16 @@ class Command(BaseCommand):
     def handle(self):
         person_config = _get_config_by_id('static-icds-cas-static-person_cases_v3')
         table_name = get_table_name('icds-cas', 'static-person_cases_v3')
-        query = """select doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175'""".format(table_name)
+        query = """select doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175' order by supervisor_id, doc_id""".format(table_name)
 
         with connections['icds-ucr-citus'].cursor()  as cursor:
             cursor.execute(query)
             doc_ids = cursor.fetchall()
             doc_ids = [doc[0] for doc in doc_ids]
 
-        for doc_id in doc_ids:
-            AsyncIndicator.update_record(
-                doc_id, person_config.referenced_doc_type, person_config.domain, [person_config._id]
-            )
+        count = 0
+        for ids_chunk in chunked(doc_ids, 10000):
+            AsyncIndicator.bulk_creation(ids_chunk, 'case', 'icds-cas', [person_config._id])
+            count += len(ids_chunk)
+            print("Success till doc_id: {}".format(ids_chunk))
+            print("progress: {}/{}".format(count, len(doc_ids)))

--- a/custom/icds_reports/management/commands/queue_person_cases.py
+++ b/custom/icds_reports/management/commands/queue_person_cases.py
@@ -9,12 +9,18 @@ from dimagi.utils.chunked import chunked
 
 
 class Command(BaseCommand):
-    help = "Rebuild Bihar person cases "
+    help = "Rebuild Bihar person cases"
 
-    def handle(self, *args,**kwargs):
+    def handle(self, *args, **kwargs):
         person_config = _get_config_by_id('static-icds-cas-static-person_cases_v3')
         table_name = get_table_name('icds-cas', 'static-person_cases_v3')
-        query = """select supervisor, doc_id from "{}" where state_id='f9b47ea2ee2d8a02acddeeb491d3e175' order by supervisor, doc_id""".format(table_name)
+        # sort by supervisor_id and doc_id to improve the performance, sorting is needed to resume the queueing
+        # if it fails in between.
+        query = """
+            select supervisor, doc_id from "{}"
+            where state_id='f9b47ea2ee2d8a02acddeeb491d3e175'
+            order by supervisor, doc_id
+        """.format(table_name)
 
         with connections['icds-ucr-citus'].cursor() as cursor:
             cursor.execute(query)
@@ -22,9 +28,10 @@ class Command(BaseCommand):
 
         total_doc_ids = len(doc_ids)
         count = 0
-        for ids_chunk in chunked(doc_ids, 10000):
+        chunk_size = 10000
+        for ids_chunk in chunked(doc_ids, chunk_size):
             ids_list = [item for item in ids_chunk]
             AsyncIndicator.bulk_creation([elem[1] for elem in ids_list], 'case', 'icds-cas', [person_config._id])
-            count += 10000
+            count += chunk_size
             print("Success till doc_id: {}".format(ids_list[-1]))
-            print("progress: {}/{}".format(count, total_doc_ids ))
+            print("progress: {}/{}".format(count, total_doc_ids))


### PR DESCRIPTION
queueing person cases to rebuild for the Bihar APi.
I have used this technique to queue Household cases in the weekend. Though completed queueing, But it was very slow.

But I can't do it for person cases because there are about 93M cases. Is there any faster way I can do it? Can I use bulk create?

@calellowitz  @czue @snopoke  