### PR TITLE
send account confirmation emails to relevant users

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -1,5 +1,4 @@
 import io
-import json
 from datetime import date, timedelta
 
 from django.conf import settings
@@ -10,14 +9,13 @@ from django.template.loader import render_to_string
 
 import attr
 import csv
-import requests
 from celery.schedules import crontab
 from celery.task import task
 from celery.task.base import periodic_task
 
 from dimagi.utils.django.email import send_HTML_email
 from dimagi.utils.logging import notify_error
-from dimagi.utils.web import get_site_domain, get_static_url_prefix
+from dimagi.utils.web import get_static_url_prefix
 from pillowtop.utils import get_couch_pillow_instances
 
 from corehq.apps.es.users import UserES

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -17,7 +17,7 @@ from celery.task.base import periodic_task
 
 from dimagi.utils.django.email import send_HTML_email
 from dimagi.utils.logging import notify_error
-from dimagi.utils.web import get_site_domain
+from dimagi.utils.web import get_site_domain, get_static_url_prefix
 from pillowtop.utils import get_couch_pillow_instances
 
 from corehq.apps.es.users import UserES
@@ -84,7 +84,7 @@ def send_mass_emails(username, real_email, subject, html, text):
     for recipient in recipients:
         context = recipient
         context.update({
-            'url_prefix': '' if settings.STATIC_CDN else 'http://' + get_site_domain(),
+            'url_prefix': get_static_url_prefix()
         })
 
         html_template = Template(html)

--- a/corehq/apps/registration/tasks.py
+++ b/corehq/apps/registration/tasks.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext
 from celery.schedules import crontab
 from celery.task import periodic_task, task
 
-from dimagi.utils.web import get_site_domain
+from dimagi.utils.web import get_site_domain, get_static_url_prefix
 
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.registration.models import RegistrationRequest
@@ -25,18 +25,16 @@ def activation_24hr_reminder_email():
     """
     request_reminders = RegistrationRequest.get_requests_24hrs_ago()
 
-    DNS_name = get_site_domain()
-
     for request in request_reminders:
         user = WebUser.get_by_username(request.new_user_username)
-        registration_link = 'http://' + DNS_name + reverse(
+        registration_link = 'http://' + get_site_domain() + reverse(
             'registration_confirm_domain') + request.activation_guid + '/'
         email_context = {
             "domain": request.domain,
             "registration_link": registration_link,
             "full_name": user.full_name,
             "first_name": user.first_name,
-            'url_prefix': '' if settings.STATIC_CDN else 'http://' + DNS_name,
+            'url_prefix': get_static_url_prefix(),
         }
 
         message_plaintext = render_to_string(
@@ -59,7 +57,6 @@ PRICING_LINK = 'https://www.commcarehq.org/pricing'
 
 @task(serializer='pickle', queue="email_queue")
 def send_domain_registration_email(recipient, domain_name, guid, full_name, first_name):
-    DNS_name = get_site_domain()
     registration_link = 'http://' + DNS_name + reverse('registration_confirm_domain') + guid + '/'
     params = {
         "domain": domain_name,
@@ -69,7 +66,7 @@ def send_domain_registration_email(recipient, domain_name, guid, full_name, firs
         "first_name": first_name,
         "forum_link": FORUM_LINK,
         "wiki_link": WIKI_LINK,
-        'url_prefix': '' if settings.STATIC_CDN else 'http://' + DNS_name,
+        'url_prefix': get_static_url_prefix(),
     }
     message_plaintext = render_to_string('registration/email/confirm_account.txt', params)
     message_html = render_to_string('registration/email/confirm_account.html', params)

--- a/corehq/apps/registration/templates/registration/email/mobile_worker_confirm_account.html
+++ b/corehq/apps/registration/templates/registration/email/mobile_worker_confirm_account.html
@@ -1,0 +1,38 @@
+{% extends "registration/email/confirm_account.html" %}
+{% load i18n %}
+
+{% block preview_text %}
+  {% blocktrans %}
+    You have been added to the {{ domain }} project on CommCare HQ.
+  {% endblocktrans %}
+{% endblock %}
+
+{% block cta_headline %}
+  {% blocktrans %}
+    You've been added to {{ domain }}.
+  {% endblocktrans %}
+{% endblock %}
+
+{% block cta_url %}{{ url }}{% endblock %}
+
+{% block cta_text %}
+  {% blocktrans %}
+    Confirm Account
+  {% endblocktrans %}
+{% endblock %}
+
+{% block lead_text %}
+  {% blocktrans %}
+    Once you confirm your account you will be able to
+    access and submit data in the {{ domain }} project on CommCare HQ.
+  {% endblocktrans %}
+{% endblock %}
+
+{% block secondary_text %}{% endblock %}
+
+{% block reason_for_email %}
+  {% blocktrans %}
+    You received this message because we received an invitation request from
+    an administrator of the project "{{ domain }}".
+  {% endblocktrans %}
+{% endblock %}

--- a/corehq/apps/registration/templates/registration/email/mobile_worker_confirm_account.txt
+++ b/corehq/apps/registration/templates/registration/email/mobile_worker_confirm_account.txt
@@ -1,0 +1,18 @@
+{% load i18n %}
+{% blocktrans %}Hey there,{% endblocktrans %}
+
+{% blocktrans %}
+You have been added to the "{{ domain }}" project on CommCare HQ.
+{% endblocktrans %}
+
+{% blocktrans %}
+To confirm your account, please open the following link in your browser: {{ url}}
+{% endblocktrans %}
+
+{% blocktrans %}
+Once you confirm your account you will be able to access and submit data in the "{{ domain }}" project on CommCare HQ.
+{% endblocktrans %}
+
+{% blocktrans %}Thanks,{% endblocktrans %}
+
+{% blocktrans %}-The CommCare HQ team{% endblocktrans %}

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -13,7 +13,7 @@ from corehq.util.soft_assert import soft_assert
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.database import get_safe_write_kwargs
 from dimagi.utils.name_to_url import name_to_url
-from dimagi.utils.web import get_ip, get_site_domain, get_url_base
+from dimagi.utils.web import get_ip, get_url_base, get_static_url_prefix
 
 from corehq.apps.accounting.models import (
     DEFAULT_ACCOUNT_FORMAT,
@@ -223,7 +223,7 @@ def send_mobile_experience_reminder(recipient, full_name):
     params = {
         "full_name": full_name,
         "url": url,
-        'url_prefix': '' if settings.STATIC_CDN else 'http://' + get_site_domain(),
+        'url_prefix': get_static_url_prefix(),
     }
     message_plaintext = render_to_string(
         'registration/email/mobile_signup_reminder.txt', params)

--- a/corehq/apps/users/account_confirmation.py
+++ b/corehq/apps/users/account_confirmation.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.utils.translation import override, ugettext_lazy as _
+
+from corehq.apps.domain.utils import guess_domain_language
+from corehq.util.view_utils import absolute_reverse
+from dimagi.utils.web import get_static_url_prefix
+
+
+def send_account_confirmation_if_necessary(couch_user):
+    """
+    Sends an account confirmation email if necessary (user has just signed up
+    and is in an unconfirmed state).
+
+    Returns whether an email was sent or not.
+    :param couch_user:
+    :return:
+    """
+    if should_send_account_confirmation(couch_user):
+        send_account_confirmation(couch_user)
+        return True
+    else:
+        return False
+
+
+def should_send_account_confirmation(couch_user):
+    from corehq.apps.users.models import CommCareUser
+    if not isinstance(couch_user, CommCareUser):
+        return False
+    # todo: this might want to get more complex, e.g. maintain state of whether it has been
+    # sent already, etc.
+    return not couch_user.is_account_confirmed
+
+
+def send_account_confirmation(commcare_user):
+    from corehq.apps.hqwebapp.tasks import send_html_email_async
+    from corehq.apps.users.views.mobile import CommCareUserConfirmAccountView
+    url = absolute_reverse(CommCareUserConfirmAccountView.urlname,
+                           args=[commcare_user.domain, commcare_user.get_id])
+    template_params = {
+        'domain': commcare_user.domain,
+        'url': url,
+        'url_prefix': get_static_url_prefix(),
+    }
+
+    lang = guess_domain_language(commcare_user.domain)
+    with override(lang):
+        text_content = render_to_string("registration/email/mobile_worker_confirm_account.txt",
+                                        template_params)
+        html_content = render_to_string("registration/email/mobile_worker_confirm_account.html",
+                                        template_params)
+        subject = _(f'Confirm your CommCare account for {commcare_user.domain}')
+    send_html_email_async.delay(subject, commcare_user.email, html_content,
+                                text_content=text_content,
+                                email_from=settings.DEFAULT_FROM_EMAIL)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -45,7 +45,7 @@ from dimagi.utils.couch.undo import DELETED_SUFFIX, DeleteRecord
 from dimagi.utils.dates import force_to_datetime
 from dimagi.utils.logging import log_signal_errors, notify_exception
 from dimagi.utils.modules import to_function
-from dimagi.utils.web import get_site_domain
+from dimagi.utils.web import get_static_url_prefix
 
 from corehq import toggles
 from corehq.apps.app_manager.const import USERCASE_TYPE
@@ -2666,7 +2666,7 @@ class SQLInvitation(SyncSQLToCouchMixin, models.Model):
             "url": url,
             'days': remaining_days,
             "inviter": inviter.formatted_name,
-            'url_prefix': '' if settings.STATIC_CDN else 'http://' + get_site_domain(),
+            'url_prefix': get_static_url_prefix(),
         }
 
         domain_request = DomainRequest.by_email(self.domain, self.email, is_approved=True)

--- a/corehq/apps/users/tests/test_confirm_account.py
+++ b/corehq/apps/users/tests/test_confirm_account.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.account_confirmation import should_send_account_confirmation
 from corehq.apps.users.exceptions import IllegalAccountConfirmation
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.util.test_utils import generate_cases
 
 
 class TestAccountConfirmation(TestCase):
@@ -53,3 +55,12 @@ class TestAccountConfirmation(TestCase):
         self.user.confirm_account('abc')
         with self.assertRaises(IllegalAccountConfirmation):
             self.user.confirm_account('def')
+
+
+@generate_cases([
+    (CommCareUser(username='normal', is_account_confirmed=False), True),
+    (CommCareUser(username='already_confirmed', is_account_confirmed=True), False),
+    (WebUser(is_account_confirmed=False), False),
+])
+def test_should_send_account_confirmation(self, user, result):
+    self.assertEqual(result, should_send_account_confirmation(user))

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -8,6 +8,7 @@ from braces.views import JsonRequestResponseMixin
 from couchdbkit import ResourceNotFound
 
 from corehq.apps.registration.forms import MobileWorkerAccountConfirmationForm
+from corehq.apps.users.account_confirmation import send_account_confirmation_if_necessary
 from corehq.util import get_document_or_404
 from couchexport.models import Format
 from couchexport.writers import Excel2007ExportWriter
@@ -744,6 +745,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
             return {'error': _("Forms did not validate")}
 
         couch_user = self._build_commcare_user()
+        send_account_confirmation_if_necessary(couch_user)
 
         return {
             'success': True,

--- a/corehq/ex-submodules/dimagi/utils/web.py
+++ b/corehq/ex-submodules/dimagi/utils/web.py
@@ -27,6 +27,10 @@ def get_site_domain():
     return settings.BASE_ADDRESS
 
 
+def get_static_url_prefix():
+    return '' if settings.STATIC_CDN else 'http://' + get_site_domain(),
+
+
 def render_to_response(req, template_name, dictionary=None, **kwargs):
     """Proxies calls to django.shortcuts.render_to_response, to avoid having
        to include the global variables in every request. This is a giant hack,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

https://docs.google.com/document/d/1gZlOGroRTeUMHXwzCuOVw2EUuJcjOsAaAe1qc2iUEe0/edit#

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Hooks up the actual email invitation part of the user confirmation workflow. This should make the whole thing "feature complete" for a V1. Planning on running through the flow and adding some docs tomorrow (as well as responding to other PR feedback and remaining todos).

Review by commit - first one is just some cleanup. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
