### PR TITLE
Added initial linked app pull when linking a remote app

### DIFF
--- a/corehq/apps/linked_domain/management/commands/link_app_to_remote.py
+++ b/corehq/apps/linked_domain/management/commands/link_app_to_remote.py
@@ -1,6 +1,7 @@
 from django.core.management import BaseCommand
 
 from corehq.apps.app_manager.models import LinkedApplication
+from corehq.apps.app_manager.views.utils import update_linked_app
 from corehq.apps.linked_domain.applications import link_app
 from corehq.apps.linked_domain.models import RemoteLinkDetails
 
@@ -34,3 +35,4 @@ class Command(BaseCommand):
 
         linked_app = LinkedApplication.get(linked_id)
         link_app(linked_app, domain, master_id, remote_details)
+        update_linked_app(linked_app, master_id, 'system')


### PR DESCRIPTION
##### SUMMARY
Make `link_app_to_remote` match its non-remote counterpart, `link_apps`: https://github.com/dimagi/commcare-hq/blob/764a0c2757b56be627322f7f50d5a576c01940f0/corehq/apps/linked_domain/management/commands/link_apps.py#L31-L32

@ctsims this fixes the issue where you can't pull a new remote app because `upstream_app_id` isn't set.

##### FEATURE FLAG
Linked project spaces
