### PR TITLE
DHIS2 UI: Support DataSet integration for multiple DHIS2 servers

### DIFF
--- a/corehq/motech/dhis2/dbaccessors.py
+++ b/corehq/motech/dhis2/dbaccessors.py
@@ -2,12 +2,6 @@ from corehq.util.quickcache import quickcache
 
 
 @quickcache(['domain_name'])
-def get_dhis2_connection(domain_name):
-    from corehq.motech.dhis2.models import Dhis2Connection
-    return Dhis2Connection.objects.filter(domain=domain_name).first()
-
-
-@quickcache(['domain_name'])
 def get_dataset_maps(domain_name):
     from corehq.motech.dhis2.models import DataSetMap
 

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -17,7 +17,6 @@ from corehq.motech.dhis2.const import (
     SEND_FREQUENCY_MONTHLY,
     SEND_FREQUENCY_QUARTERLY,
 )
-from corehq.motech.dhis2.dbaccessors import get_dhis2_connection
 from corehq.motech.dhis2.models import Dhis2Connection
 
 SEND_FREQUENCY_CHOICES = (
@@ -62,7 +61,7 @@ class Dhis2ConnectionForm(forms.Form):
 
     def save(self, domain_name):
         try:
-            dhis2_conn = get_dhis2_connection(domain_name)
+            dhis2_conn = Dhis2Connection.objects.filter(domain=domain_name).first()
             if dhis2_conn is None:
                 dhis2_conn = Dhis2Connection(domain=domain_name)
             dhis2_conn.server_url = self.cleaned_data['server_url']

--- a/corehq/motech/dhis2/forms.py
+++ b/corehq/motech/dhis2/forms.py
@@ -68,11 +68,8 @@ class Dhis2ConnectionForm(forms.Form):
             dhis2_conn.server_url = self.cleaned_data['server_url']
             dhis2_conn.username = self.cleaned_data['username']
             if self.cleaned_data['password']:
-                # Don't save it if it hasn't been changed. Use simple symmetric encryption. We don't need it to be
-                # strong, considering we'd have to store the algorithm and the key together anyway; it just
-                # shouldn't be plaintext.
-                plaintext = self.cleaned_data['password'].encode('utf8')
-                dhis2_conn.password = b64encode(bz2.compress(plaintext))
+                # Don't save it if it hasn't been changed.
+                dhis2_conn.plaintext_password = self.cleaned_data['password']
             dhis2_conn.skip_cert_verify = self.cleaned_data['skip_cert_verify']
             dhis2_conn.save()
             return True

--- a/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
+++ b/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
@@ -38,7 +38,7 @@ def strip_api(server_url):
 
     """
     if server_url.rstrip('/').endswith('api'):
-        i = server_url.index('api')
+        i = len(server_url.rstrip('/')) - 3
         return server_url[:i]
     return server_url
 

--- a/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
+++ b/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
@@ -1,0 +1,72 @@
+"""
+Migrate Dhis2Connection instances to ConnectionSettings model
+"""
+from django.core.management import BaseCommand
+
+from corehq.motech.dhis2.dbaccessors import get_dataset_maps
+from corehq.motech.dhis2.models import Dhis2Connection
+from corehq.motech.models import ConnectionSettings
+from corehq.motech.repeaters.models import BASIC_AUTH
+
+
+class Command(BaseCommand):
+
+    def handle(self, **options):
+        for dhis2_conn in Dhis2Connection.objects.all():
+            if conn_settings_exists(dhis2_conn):
+                continue
+            conn_settings = create_conn_settings(dhis2_conn)
+            link_data_set_maps(conn_settings)
+
+
+def conn_settings_exists(dhis2_conn: Dhis2Connection) -> bool:
+    """
+    Does a ConnectionSettings instance exist for ``dhis2_conn``.
+    """
+    return ConnectionSettings.objects\
+        .filter(domain=dhis2_conn.domain)\
+        .filter(url=strip_api(dhis2_conn.server_url))\
+        .count()
+
+
+def strip_api(server_url):
+    """
+    Strips "api/" from the end of ``server_url``, if present
+
+    >>> strip_api('https://play.dhis2.org/demo/api/')
+    'https://play.dhis2.org/demo/'
+
+    """
+    if server_url.rstrip('/').endswith('api'):
+        i = server_url.index('api')
+        return server_url[:i]
+    return server_url
+
+
+def create_conn_settings(dhis2_conn: Dhis2Connection) -> ConnectionSettings:
+    """
+    Creates and returns a ConnectionSettings instance for ``dhis2_conn``.
+    """
+    url = strip_api(dhis2_conn.server_url)
+    conn_settings = ConnectionSettings(
+        domain=dhis2_conn.domain,
+        name=url,
+        url=url,
+        auth_type=BASIC_AUTH,
+        username=dhis2_conn.username,
+        skip_cert_verify=dhis2_conn.skip_cert_verify,
+        notify_addresses_str=""
+    )
+    conn_settings.plaintext_password = dhis2_conn.plaintext_password
+    conn_settings.save()
+    return conn_settings
+
+
+def link_data_set_maps(conn_settings: ConnectionSettings):
+    """
+    Links DataSetMap instances to their ConnectionSettings instance.
+    """
+    for data_set_map in get_dataset_maps(conn_settings.domain):
+        data_set_map.connection_settings_id = conn_settings.id
+        data_set_map.save()
+    get_dataset_maps.clear(conn_settings.domain)

--- a/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
+++ b/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
@@ -26,7 +26,7 @@ def conn_settings_exists(dhis2_conn: Dhis2Connection) -> bool:
     return ConnectionSettings.objects\
         .filter(domain=dhis2_conn.domain)\
         .filter(url=strip_api(dhis2_conn.server_url))\
-        .count()
+        .exists()
 
 
 def strip_api(server_url):

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -1,8 +1,8 @@
 import bz2
-from base64 import b64encode
+from base64 import b64decode, b64encode
+from itertools import chain
 
 from django.db import models
-from itertools import chain
 
 from dimagi.ext.couchdbkit import (
     BooleanProperty,
@@ -37,7 +37,8 @@ class Dhis2Connection(models.Model):
 
     @property
     def plaintext_password(self):
-        pass  # TODO: ...
+        plaintext_bytes = bz2.decompress(b64decode(self.password))
+        return plaintext_bytes.decode('utf8')
 
     @plaintext_password.setter
     def plaintext_password(self, plaintext):

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -1,3 +1,6 @@
+import bz2
+from base64 import b64encode
+
 from django.db import models
 from itertools import chain
 
@@ -31,6 +34,19 @@ class Dhis2Connection(models.Model):
     username = models.CharField(max_length=255)
     password = models.CharField(max_length=255, null=True)
     skip_cert_verify = models.BooleanField(default=False)
+
+    @property
+    def plaintext_password(self):
+        pass  # TODO: ...
+
+    @plaintext_password.setter
+    def plaintext_password(self, plaintext):
+        # Use simple symmetric encryption. We don't need it to be
+        # strong, considering we'd have to store the algorithm and the
+        # key together anyway; it just shouldn't be plaintext.
+        # (2020-03-09) Not true. The key is stored separately.
+        plaintext_bytes = plaintext.encode('utf8')
+        self.password = b64encode(bz2.compress(plaintext_bytes))
 
 
 class DataValueMap(DocumentSchema):

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -4,6 +4,7 @@ from itertools import chain
 
 from django.db import models
 
+from corehq.motech.models import ConnectionSettings
 from dimagi.ext.couchdbkit import (
     BooleanProperty,
     Document,
@@ -60,6 +61,7 @@ class DataValueMap(DocumentSchema):
 class DataSetMap(Document):
     # domain and UCR uniquely identify a DataSetMap
     domain = StringProperty()
+    connection_settings_id = IntegerProperty(required=False, default=None)
     ucr_id = StringProperty()  # UCR ReportConfig id
 
     description = StringProperty()
@@ -75,6 +77,11 @@ class DataSetMap(Document):
     complete_date = StringProperty()  # Optional
 
     datavalue_maps = SchemaListProperty(DataValueMap)
+
+    @property
+    def connection_settings(self):
+        if self.connection_settings_id:
+            return ConnectionSettings.objects.get(pk=self.connection_settings_id)
 
     @quickcache(['self.domain', 'self.ucr_id'])
     def get_datavalue_map_dict(self):

--- a/corehq/motech/dhis2/static/dhis2/js/dhis2_map_settings.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dhis2_map_settings.js
@@ -37,6 +37,7 @@ hqDefine('dhis2/js/dhis2_map_settings', [
         var self = {};
 
         self.description = ko.observable(properties["description"]);
+        self.connectionSettingsId = ko.observable(properties["connection_settings_id"]);
         self.ucrId = ko.observable(properties["ucr_id"]);
         self.frequency = ko.observable(properties["frequency"]);
         self.dayOfMonth = ko.observable(properties["day_to_send"]);
@@ -79,6 +80,7 @@ hqDefine('dhis2/js/dhis2_map_settings', [
         self.toJSON = function () {
             return {
                 "description": self.description(),
+                "connection_settings_id": self.connectionSettingsId(),
                 "ucr_id": self.ucrId(),
                 "frequency": self.frequency(),
                 "day_to_send": Number(self.dayOfMonth()),

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -1,5 +1,3 @@
-import bz2
-from base64 import b64decode
 from datetime import datetime
 
 from celery.schedules import crontab
@@ -8,10 +6,8 @@ from celery.task import periodic_task, task
 from toggle.shortcuts import find_domains_with_toggle_enabled
 
 from corehq import toggles
-from corehq.motech.dhis2.dbaccessors import (
-    get_dataset_maps,
-    get_dhis2_connection,
-)
+from corehq.motech.dhis2.dbaccessors import get_dataset_maps
+from corehq.motech.dhis2.models import Dhis2Connection
 from corehq.motech.requests import Requests
 
 
@@ -38,7 +34,7 @@ def send_datasets(domain_name, send_now=False, send_date=None):
     """
     if not send_date:
         send_date = datetime.today()
-    dhis2_conn = get_dhis2_connection(domain_name)
+    dhis2_conn = Dhis2Connection.objects.filter(domain=domain_name).first()
     dataset_maps = get_dataset_maps(domain_name)
     if not dhis2_conn or not dataset_maps:
         return  # Nothing to do

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -46,7 +46,7 @@ def send_datasets(domain_name, send_now=False, send_date=None):
         domain_name,
         dhis2_conn.server_url,
         dhis2_conn.username,
-        bz2.decompress(b64decode(dhis2_conn.password)),
+        dhis2_conn.plaintext_password,
         verify=not dhis2_conn.skip_cert_verify,
     )
     endpoint = 'dataValueSets'

--- a/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
+++ b/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
@@ -85,6 +85,23 @@
 
         <div class="form-group">
             <label class="control-label col-sm-3 col-md-2 requiredField">
+                {% trans "DHIS2 Connection" %}<span class="asteriskField">*</span>
+            </label>
+            <div class="controls col-sm-9 col-md-8 col-lg-6">
+                <select class="textinput textInput form-control"
+                        required=""
+                        data-bind="value: connectionSettingsId">
+                  {% for connx in connection_settings %}
+                    <option value="{{ connx.id }}">{{ connx.name }}</option>
+                  {% empty %}
+                    <option value="">No connections defined</option>
+                  {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="control-label col-sm-3 col-md-2 requiredField">
                 {% trans "UCR Report ID" %}<span class="asteriskField">*</span>
             </label>
             <div class="controls col-sm-9 col-md-8 col-lg-6">

--- a/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
+++ b/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
@@ -102,13 +102,18 @@
 
         <div class="form-group">
             <label class="control-label col-sm-3 col-md-2 requiredField">
-                {% trans "UCR Report ID" %}<span class="asteriskField">*</span>
+                {% trans "User Configurable Report" %}<span class="asteriskField">*</span>
             </label>
             <div class="controls col-sm-9 col-md-8 col-lg-6">
-                <input class="textinput textInput form-control"
-                       required=""
-                       type="text"
-                       data-bind="value: ucrId" />
+                <select class="textinput textInput form-control"
+                        required=""
+                        data-bind="value: ucrId">
+                  {% for ucr in ucrs %}
+                    <option value="{{ ucr.get_id }}">{{ ucr.title }}</option>
+                  {% empty %}
+                    <option value="">No UCRs defined</option>
+                  {% endfor %}
+                </select>
             </div>
         </div>
 

--- a/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
+++ b/corehq/motech/dhis2/templates/dhis2/partials/dhis2_dataset_map_templates.html
@@ -105,15 +105,24 @@
                 {% trans "User Configurable Report" %}<span class="asteriskField">*</span>
             </label>
             <div class="controls col-sm-9 col-md-8 col-lg-6">
+              {% if ucrs %}
                 <select class="textinput textInput form-control"
                         required=""
                         data-bind="value: ucrId">
                   {% for ucr in ucrs %}
                     <option value="{{ ucr.get_id }}">{{ ucr.title }}</option>
-                  {% empty %}
-                    <option value="">No UCRs defined</option>
                   {% endfor %}
                 </select>
+              {% else %}
+              <div class="alert alert-warning">
+                DataSet Maps map UCRs in CommCare to DataSets in DHIS2.
+                <a href="https://github.com/dimagi/commcare-hq/blob/master/corehq/motech/dhis2/README.md#datasets"
+                   target="_new">You can find documentation on integrating with
+                  DataSets here</a>.
+                Go to <a href="{% url 'configurable_reports_home' domain %}">Configurable
+                  Reports</a> to define a UCR.
+              </div>
+              {% endif %}
             </div>
         </div>
 

--- a/corehq/motech/dhis2/urls.py
+++ b/corehq/motech/dhis2/urls.py
@@ -1,13 +1,10 @@
 from django.conf.urls import url
 
-from corehq.motech.dhis2.views import (
-    DataSetMapView,
-    Dhis2ConnectionView,
-    send_dhis2_data,
-)
+from corehq.motech.dhis2.views import DataSetMapView, send_dhis2_data
+from corehq.motech.views import ConnectionSettingsView
 
 urlpatterns = [
-    url(r'^conn/$', Dhis2ConnectionView.as_view(), name=Dhis2ConnectionView.urlname),
+    url(r'^conn/$', ConnectionSettingsView.as_view(), name=ConnectionSettingsView.urlname),
     url(r'^map/$', DataSetMapView.as_view(), name=DataSetMapView.urlname),
     url(r'^send/$', send_dhis2_data, name='send_dhis2_data'),
 ]

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -1,6 +1,6 @@
 import json
 
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -9,8 +9,6 @@ from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_http_methods, require_POST
 
 from memoized import memoized
-
-from dimagi.utils.web import json_response
 
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
@@ -99,9 +97,9 @@ class DataSetMapView(BaseProjectSettingsView):
                     update_dataset_map(dataset_map, new_dataset_maps[j])
                     dataset_map.save()
             get_dataset_maps.clear(request.domain)
-            return json_response({'success': _('DHIS2 DataSet Maps saved')})
+            return JsonResponse({'success': _('DHIS2 DataSet Maps saved')})
         except Exception as err:
-            return json_response({'error': str(err)}, status_code=500)
+            return JsonResponse({'error': str(err)}, status=500)
 
     @property
     def page_context(self):
@@ -129,7 +127,7 @@ class DataSetMapView(BaseProjectSettingsView):
 @require_permission(Permissions.edit_motech)
 def send_dhis2_data(request, domain):
     send_datasets.delay(domain, send_now=True)
-    return json_response({'success': _('Data is being sent to DHIS2.')}, status_code=202)
+    return JsonResponse({'success': _('Data is being sent to DHIS2.')}, status=202)
 
 
 @login_and_domain_required

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -27,6 +27,7 @@ from corehq.motech.dhis2.models import (
 )
 from corehq.motech.dhis2.repeaters import Dhis2Repeater
 from corehq.motech.dhis2.tasks import send_datasets
+from corehq.motech.models import ConnectionSettings
 
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
@@ -118,6 +119,7 @@ class DataSetMapView(BaseProjectSettingsView):
         dataset_maps = [to_json(d) for d in get_dataset_maps(self.request.domain)]
         return {
             'dataset_maps': dataset_maps,
+            'connection_settings': ConnectionSettings.objects.filter(domain=self.domain).all(),
             'send_data_url': reverse('send_dhis2_data', kwargs={'domain': self.domain}),
             'is_json_ui': int(self.request.GET.get('json', 0)),
         }

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -1,14 +1,12 @@
 import json
 
-from django.http import HttpResponseRedirect, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_http_methods, require_POST
-
-from memoized import memoized
 
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
@@ -18,49 +16,11 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.dhis2.dbaccessors import get_dataset_maps
 from corehq.motech.dhis2.dhis2_config import Dhis2FormConfig
-from corehq.motech.dhis2.forms import Dhis2ConfigForm, Dhis2ConnectionForm
-from corehq.motech.dhis2.models import (
-    DataSetMap,
-    DataValueMap,
-    Dhis2Connection,
-)
+from corehq.motech.dhis2.forms import Dhis2ConfigForm
+from corehq.motech.dhis2.models import DataSetMap, DataValueMap
 from corehq.motech.dhis2.repeaters import Dhis2Repeater
 from corehq.motech.dhis2.tasks import send_datasets
 from corehq.motech.models import ConnectionSettings
-
-
-@method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
-@method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
-class Dhis2ConnectionView(BaseProjectSettingsView):
-    urlname = 'dhis2_connection_view'
-    page_title = ugettext_lazy("DHIS2 Connection Settings")
-    template_name = 'dhis2/connection_settings.html'
-
-    def post(self, request, *args, **kwargs):
-        form = self.dhis2_connection_form
-        if form.is_valid():
-            form.save(self.domain)
-            return HttpResponseRedirect(self.page_url)
-        context = self.get_context_data(**kwargs)
-        return self.render_to_response(context)
-
-    @property
-    @memoized
-    def dhis2_connection_form(self):
-        dhis2_conn = Dhis2Connection.objects.filter(domain=self.request.domain).first()
-        initial = {
-            'server_url': dhis2_conn.server_url,
-            'username': dhis2_conn.username,
-            'password': dhis2_conn.password,
-            'skip_cert_verify': dhis2_conn.skip_cert_verify,
-        } if dhis2_conn else {}
-        if self.request.method == 'POST':
-            return Dhis2ConnectionForm(self.request.POST, initial=initial)
-        return Dhis2ConnectionForm(initial=initial)
-
-    @property
-    def page_context(self):
-        return {'dhis2_connection_form': self.dhis2_connection_form}
 
 
 @method_decorator(require_permission(Permissions.edit_motech), name='dispatch')

--- a/corehq/motech/dhis2/views.py
+++ b/corehq/motech/dhis2/views.py
@@ -13,6 +13,7 @@ from memoized import memoized
 from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
+from corehq.apps.userreports.dbaccessors import get_report_configs_for_domain
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.motech.dhis2.dbaccessors import get_dataset_maps
@@ -118,6 +119,7 @@ class DataSetMapView(BaseProjectSettingsView):
         return {
             'dataset_maps': dataset_maps,
             'connection_settings': ConnectionSettings.objects.filter(domain=self.domain).all(),
+            'ucrs': get_report_configs_for_domain(self.domain),
             'send_data_url': reverse('send_dhis2_data', kwargs={'domain': self.domain}),
             'is_json_ui': int(self.request.GET.get('json', 0)),
         }

--- a/corehq/motech/forms.py
+++ b/corehq/motech/forms.py
@@ -1,0 +1,94 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
+from crispy_forms.helper import FormHelper
+
+from corehq.motech.models import ConnectionSettings
+
+
+class ConnectionSettingsForm(forms.ModelForm):
+    url = forms.CharField(
+        label=_('URL'),
+        help_text=_('e.g. "http://play.dhis2.org/demo/"')
+    )
+    username = forms.CharField(required=False)
+    plaintext_password = forms.CharField(
+        label=_('Password'),
+        required=False,
+        widget=forms.PasswordInput,
+    )
+    skip_cert_verify = forms.BooleanField(
+        label=_('Skip certificate verification'),
+        help_text=_('Do not use in a production environment'),
+        required=False,
+    )
+    notify_addresses_str = forms.CharField(
+        label=_('Addresses to send notifications'),
+        help_text=_('A comma-separated list of email addresses to send error '
+                    'notifications'),
+        required=False,
+    )
+
+    class Meta:
+        model = ConnectionSettings
+        fields = [
+            'name',
+            'url',
+            'auth_type',
+            'username',
+            'plaintext_password',
+            'skip_cert_verify',
+            'notify_addresses_str',
+        ]
+
+    def __init__(self, *args, domain, **kwargs):
+        self.domain = domain  # Passed by ``FormSet.form_kwargs``
+        super().__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        self.instance.domain = self.domain
+        return super().save(commit)
+
+
+class BaseConnectionSettingsFormSet(forms.BaseModelFormSet):
+
+    def __init__(self, *args, domain, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.form_kwargs['domain'] = domain  # Passed by ``FormView.get_form_kwargs()``
+
+
+ConnectionSettingsFormSet = forms.modelformset_factory(
+    model=ConnectionSettings,
+    form=ConnectionSettingsForm,
+    formset=BaseConnectionSettingsFormSet,
+    extra=1,
+    can_delete=True,  # TODO: Use a function to check it's unused
+)
+
+
+class ConnectionSettingsFormSetHelper(FormHelper):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.form_class = 'form-horizontal'
+        self.label_class = 'col-sm-3 col-md-2'
+        self.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.layout = crispy.Layout(
+            crispy.Fieldset(
+                _('Remote Connection'),
+                twbscrispy.PrependedText('DELETE', ''),
+                crispy.Field('name'),
+                crispy.Field('url'),
+                crispy.Field('auth_type'),
+                crispy.Field('username'),
+                crispy.Field('plaintext_password'),
+                twbscrispy.PrependedText('skip_cert_verify', ''),
+                crispy.Field('notify_addresses_str'),
+            ),
+        )
+        self.add_input(
+            crispy.Submit('submit', _('Save Connections'))
+        )
+        self.render_required_fields = True

--- a/corehq/motech/forms.py
+++ b/corehq/motech/forms.py
@@ -108,7 +108,6 @@ class ConnectionSettingsFormSetHelper(FormHelper):
         self.layout = crispy.Layout(
             crispy.Fieldset(
                 _('Remote Connection'),
-                twbscrispy.PrependedText('DELETE', ''),
                 crispy.Field('name'),
                 crispy.Field('url'),
                 crispy.Field('auth_type'),
@@ -116,6 +115,10 @@ class ConnectionSettingsFormSetHelper(FormHelper):
                 crispy.Field('plaintext_password'),
                 twbscrispy.PrependedText('skip_cert_verify', ''),
                 crispy.Field('notify_addresses_str'),
+                twbscrispy.PrependedText(
+                    'DELETE', '',
+                    wrapper_class='alert alert-warning'
+                ),
             ),
         )
         self.add_input(

--- a/corehq/motech/migrations/0004_connectionsettings.py
+++ b/corehq/motech/migrations/0004_connectionsettings.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('motech', '0003_auto_20200102_1006'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ConnectionSettings',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('domain', models.CharField(db_index=True, max_length=126)),
+                ('name', models.CharField(max_length=255)),
+                ('url', models.CharField(max_length=255)),
+                ('auth_type', models.CharField(blank=True, choices=[
+                    (None, 'None'), ('basic', 'Basic'), ('digest', 'Digest'), ('oauth1', 'OAuth1')
+                ], max_length=7, null=True)),
+                ('username', models.CharField(max_length=255)),
+                ('password', models.CharField(max_length=255)),
+                ('skip_cert_verify', models.BooleanField(default=False)),
+                ('notify_addresses_str', models.CharField(default='', max_length=255)),
+            ],
+        ),
+    ]

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -34,6 +34,9 @@ class ConnectionSettings(models.Model):
     skip_cert_verify = models.BooleanField(default=False)
     notify_addresses_str = models.CharField(max_length=255, default="")
 
+    def __str__(self):
+        return self.name
+
     @property
     def plaintext_password(self):
         if self.password.startswith('${algo}$'.format(algo=ALGO_AES)):

--- a/corehq/motech/openmrs/models.py
+++ b/corehq/motech/openmrs/models.py
@@ -74,11 +74,13 @@ class OpenmrsImporter(Document):
     Import cases from an OpenMRS instance using a report
     """
     domain = StringProperty()
+
+    # TODO: (2020-03-06) Migrate to ConnectionSettings
     server_url = StringProperty()  # e.g. "http://www.example.com/openmrs"
     username = StringProperty()
     password = StringProperty()
 
-    notify_addresses_str = StringProperty(default="")
+    notify_addresses_str = StringProperty(default="")  # See also notify_addresses()
 
     # If a domain has multiple OpenmrsImporter instances, for which CommCare location is this one authoritative?
     location_id = StringProperty()

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -170,14 +170,16 @@ class Repeater(QuickCachedDocumentMixin, Document):
     base_doc = 'Repeater'
 
     domain = StringProperty()
+
+    # TODO: (2020-03-06) Migrate to ConnectionSettings
     url = StringProperty()
     format = StringProperty()
 
     auth_type = StringProperty(choices=(BASIC_AUTH, DIGEST_AUTH, OAUTH1), required=False)
     username = StringProperty()
-    password = StringProperty()
-    skip_cert_verify = BooleanProperty(default=False)
-    notify_addresses_str = StringProperty(default="")
+    password = StringProperty()  # See also plaintext_password()
+    skip_cert_verify = BooleanProperty(default=False)  # See also verify()
+    notify_addresses_str = StringProperty(default="")  # See also notify_addresses()
 
     friendly_name = _("Data")
     paused = BooleanProperty(default=False)

--- a/corehq/motech/templates/motech/connection_settings.html
+++ b/corehq/motech/templates/motech/connection_settings.html
@@ -2,5 +2,5 @@
 {% load crispy_forms_tags %}
 
 {% block page_content %}
-    {% crispy dhis2_connection_form %}
+  {% crispy form helper %}
 {% endblock %}

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -3,13 +3,18 @@ import re
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy
-from django.views.generic import DetailView, ListView
+from django.views.generic import DetailView, FormView, ListView
 
 from memoized import memoized
 
+from corehq import toggles
 from corehq.apps.domain.views.settings import BaseProjectSettingsView
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.motech.forms import (
+    ConnectionSettingsFormSet,
+    ConnectionSettingsFormSetHelper,
+)
 from corehq.motech.models import RequestLog
 
 
@@ -93,3 +98,33 @@ class MotechLogDetailView(BaseProjectSettingsView, DetailView):
     def page_url(self):
         pk = self.kwargs['pk']
         return reverse(self.urlname, args=[self.domain, pk])
+
+
+@method_decorator(require_permission(Permissions.edit_motech), name='dispatch')
+@method_decorator(toggles.DHIS2_INTEGRATION.required_decorator(), name='dispatch')
+class ConnectionSettingsView(BaseProjectSettingsView, FormView):
+    urlname = 'connection_settings_view'
+    page_title = ugettext_lazy('Connection Settings')
+    template_name = 'motech/connection_settings.html'
+    form_class = ConnectionSettingsFormSet  # NOTE: form_class is a formset
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        # BaseConnectionSettingsFormSet needs domain param to add to its
+        # form_kwargs. ConnectionSettingsForm needs it to set
+        # ConnectionSettings.domain when model instance is saved.
+        kwargs['domain'] = self.domain
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['helper'] = ConnectionSettingsFormSetHelper()
+        return context
+
+    def get_success_url(self):
+        # On save, stay on the same page
+        return reverse(self.urlname, kwargs={'domain': self.domain})
+
+    def form_valid(self, form):
+        self.object = form.save()  # Saves the forms in the formset
+        return super().form_valid(form)

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -84,9 +84,9 @@ from corehq.messaging.scheduling.views import (
     UploadConditionalAlertView,
 )
 from corehq.messaging.util import show_messaging_dashboard
-from corehq.motech.dhis2.views import DataSetMapView, Dhis2ConnectionView
+from corehq.motech.dhis2.views import DataSetMapView
 from corehq.motech.openmrs.views import OpenmrsImporterView
-from corehq.motech.views import MotechLogListView
+from corehq.motech.views import ConnectionSettingsView, MotechLogListView
 from corehq.privileges import DAILY_SAVED_EXPORT, EXCEL_DASHBOARD
 from corehq.tabs.uitab import UITab
 from corehq.tabs.utils import (
@@ -1794,8 +1794,8 @@ def _get_integration_section(domain):
 
     if toggles.DHIS2_INTEGRATION.enabled(domain):
         integration.extend([{
-            'title': _(Dhis2ConnectionView.page_title),
-            'url': reverse(Dhis2ConnectionView.urlname, args=[domain])
+            'title': _(ConnectionSettingsView.page_title),
+            'url': reverse(ConnectionSettingsView.urlname, args=[domain])
         }, {
             'title': _(DataSetMapView.page_title),
             'url': reverse(DataSetMapView.urlname, args=[domain])


### PR DESCRIPTION
Context:
* [Jira ticket](https://dimagi-dev.atlassian.net/browse/SC-546)
* [Spec](https://docs.google.com/document/d/1JHaU3pqiGkQCLBNjT02L2YmsTGTuRJRxLz95-vb5S6Y/edit#heading=h.edj98mvudgka)

##### SUMMARY

Aggregated data integration was the first DHIS2 integration CommCare HQ supported because it was not possible with the original MOTECH. Since then, this feature has become well overdue a refactor.

The primary objective of this change is to allow a project space to integrate aggregated data with more than one DHIS2 server.

This PR is also to lay the ground work for further refactors. CommCare supports at least three different ways to connect to remote services: 
* Repeaters
* DHIS2 aggregated data (DataSet) integration
* OpenMRS Importers (which import data from OpenMRS via its Reporting API)

Each stores its connection settings differently. This PR is the first step in unifying these;
* one form to manage remote API connection settings
* one way to manage password encryption
* one way to notifying administrators of errors

That is why the menu item is now called "Connection Settings". Soon these connections can be used for DHIS2, OpenMRS, and other Repeaters.

**Connection Settings formset**:
![image](https://user-images.githubusercontent.com/708421/77362509-b38b7700-6d59-11ea-9866-eb277233514b.png)

**Connection Settings in use**:
![image](https://user-images.githubusercontent.com/708421/77362687-07965b80-6d5a-11ea-8642-7807ca236ac5.png)


##### WHAT IS MISSING?

The Connection Settings page uses a Django FormSet to manage multiple instances.

I took this approach for its simplicity. But because of this, the feature is missing a few things:

* The "Remove" button in the spec is a "Delete" checkbox in the form. I am not happy with this. I am looking for a way to make the purpose of the "Delete" checkbox more obvious. (Red coloring? Right-aligned? I'm open to suggestions.)

* A "Test Connection" button is missing from both the form, and the spec. Each form in the formset ought to have its own "Test Connection" button that asynchronously calls the server URL using the given authentication settings, and shows the user the server's response. I would like to add it in a follow-up PR. It will require a relatively small amount JavaScript.

* I think the separation of the forms is not obvious enough. Perhaps just a spacing issue. I am not sure of the best way to do this.

* Password fields should not be blank if they have been set. They need a placeholder value that looks something like "****************".


##### FEATURE FLAG

DHIS2 integration


##### PRODUCT DESCRIPTION

Support for aggregated data integration for multiple DHIS2 servers

---

**cc**: code buddy @millerdev 

:tropical_fish: Review by commit

Once this PR is merged, and Dhis2Connection instances have been migrated to ConnectionSettings instances, the Dhis2Connection model, its references, and its instances will be removed in a follow-up PR.

