### PR TITLE
Revert "Process feeds all the way to the end"

### DIFF
--- a/corehq/apps/change_feed/tests/test_kafka_change_feed.py
+++ b/corehq/apps/change_feed/tests/test_kafka_change_feed.py
@@ -76,7 +76,7 @@ class KafkaCheckpointTest(TestCase):
         publish_stub_change(topics.CASE)
         publish_stub_change(topics.CASE)
         publish_stub_change(topics.CASE_SQL)
-        pillow.process_changes(since=offsets)
+        pillow.process_changes(since=offsets, forever=False)
         self.assertEqual(4, processor.count)
         self.assertEqual(feed.get_current_checkpoint_offsets(), pillow.get_last_checkpoint_sequence())
         publish_stub_change(topics.FORM)
@@ -84,7 +84,7 @@ class KafkaCheckpointTest(TestCase):
         publish_stub_change(topics.CASE)
         publish_stub_change(topics.CASE)
         publish_stub_change(topics.CASE_SQL)
-        pillow.process_changes(pillow.get_last_checkpoint_sequence())
+        pillow.process_changes(pillow.get_last_checkpoint_sequence(), forever=False)
         self.assertEqual(8, processor.count)
         self.assertEqual(feed.get_current_checkpoint_offsets(), pillow.get_last_checkpoint_sequence())
 
@@ -113,7 +113,7 @@ class KafkaCheckpointTest(TestCase):
         publish_stub_change(topics.COMMCARE_USER)
         # the following line causes tests to fail if you have multiple partitions
         current_kafka_offsets[(topics.COMMCARE_USER, 0)] += 1
-        pillow.process_changes(since=original_kafka_offsets)
+        pillow.process_changes(since=original_kafka_offsets, forever=False)
         self.assertEqual(1, processor.count)
         self.assertEqual(feed.get_current_checkpoint_offsets(), current_kafka_offsets)
 

--- a/corehq/apps/userreports/tests/test_location_data_source.py
+++ b/corehq/apps/userreports/tests/test_location_data_source.py
@@ -88,11 +88,11 @@ class TestLocationDataSource(TestCase):
         sweetwater.save()
 
         # Process both changes together and verify that they went through
-        self.pillow.process_changes(since=since)
+        self.pillow.process_changes(since=since, forever=False)
         self.assertDataSourceAccurate(["Westworld", "Pariah", "Las Mudas", "Blood Arroyo"])
 
         # Delete a location
         since = self.pillow.get_change_feed().get_latest_offsets()
         las_mudas.delete()
-        self.pillow.process_changes(since=since)
+        self.pillow.process_changes(since=since, forever=False)
         self.assertDataSourceAccurate(["Westworld", "Pariah", "Blood Arroyo"])

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_synclog_pillow.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_synclog_pillow.py
@@ -73,7 +73,7 @@ class SyncLogPillowTest(TestCase):
 
         # make sure processor updates the user correctly
         pillow = get_user_sync_history_pillow()
-        pillow.process_changes(since=kafka_seq)
+        pillow.process_changes(since=kafka_seq, forever=False)
         ccuser = CommCareUser.get(self.ccuser._id)
         self.assertEqual(len(ccuser.reporting_metadata.last_syncs), 1)
         self.assertEqual(ccuser.reporting_metadata.last_syncs[0].sync_date, synclog.date)
@@ -105,7 +105,7 @@ class SyncLogPillowTest(TestCase):
 
         # make sure processor updates the user correctly
         pillow = get_user_sync_history_pillow()
-        pillow.process_changes(since=kafka_seq)
+        pillow.process_changes(since=kafka_seq, forever=False)
         process_reporting_metadata_staging()
         ccuser = CommCareUser.get(self.ccuser._id)
         self.assertEqual(len(ccuser.reporting_metadata.last_syncs), 1)
@@ -147,7 +147,7 @@ class SyncLogPillowTest(TestCase):
 
         # make sure processor updates the user correctly
         pillow = get_user_sync_history_pillow()
-        pillow.process_changes(since=kafka_seq)
+        pillow.process_changes(since=kafka_seq, forever=False)
         process_reporting_metadata_staging()
         ccuser = CommCareUser.get(self.ccuser._id)
         self.assertEqual(len(ccuser.reporting_metadata.last_syncs), 1)

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -128,15 +128,12 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
         self.checkpoint_callback = checkpoint_callback
 
     def should_update_checkpoint(self, context):
-        if context.should_flush:
-            return True
-        if context.changes_seen >= self.checkpoint_frequency:
-            return True
-        elif self.max_checkpoint_delay:
+        frequency_hit = context.changes_seen >= self.checkpoint_frequency
+        time_hit = False
+        if self.max_checkpoint_delay:
             seconds_since_last_update = (datetime.utcnow() - self.last_update).total_seconds()
-            return seconds_since_last_update >= self.max_checkpoint_delay
-        else:
-            return False
+            time_hit = seconds_since_last_update >= self.max_checkpoint_delay
+        return frequency_hit or time_hit
 
     def get_new_seq(self, change):
         return change['seq']

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -50,7 +50,7 @@ class AppPillowTest(TestCase):
         app = self._create_app(app_name)
 
         app_db_pillow = get_application_db_kafka_pillow('test_app_db_pillow')
-        app_db_pillow.process_changes(couch_seq)
+        app_db_pillow.process_changes(couch_seq, forever=False)
 
         # confirm change made it to kafka
         message = next(consumer)
@@ -60,7 +60,7 @@ class AppPillowTest(TestCase):
 
         # send to elasticsearch
         app_pillow = get_app_to_elasticsearch_pillow()
-        app_pillow.process_changes(since=kafka_seq)
+        app_pillow.process_changes(since=kafka_seq, forever=False)
         self.es.indices.refresh(APP_INDEX_INFO.index)
 
         # confirm change made it to elasticserach
@@ -83,9 +83,9 @@ class AppPillowTest(TestCase):
 
     def refresh_elasticsearch(self, kafka_seq, couch_seq):
         app_db_pillow = get_application_db_kafka_pillow('test_app_db_pillow')
-        app_db_pillow.process_changes(couch_seq)
+        app_db_pillow.process_changes(couch_seq, forever=False)
         app_pillow = get_app_to_elasticsearch_pillow()
-        app_pillow.process_changes(since=kafka_seq)
+        app_pillow.process_changes(since=kafka_seq, forever=False)
         self.es.indices.refresh(APP_INDEX_INFO.index)
 
     @patch.object(Application, 'validate_app', list)
@@ -129,7 +129,7 @@ class AppPillowTest(TestCase):
 
         app = self._create_app('test_hard_deleted_app', cleanup=False)
         app_db_pillow = get_application_db_kafka_pillow('test_app_db_pillow')
-        app_db_pillow.process_changes(couch_seq)
+        app_db_pillow.process_changes(couch_seq, forever=False)
 
         # confirm change made it to kafka
         message = next(consumer)
@@ -139,7 +139,7 @@ class AppPillowTest(TestCase):
 
         # send to elasticsearch
         app_pillow = get_app_to_elasticsearch_pillow()
-        app_pillow.process_changes(since=kafka_seq)
+        app_pillow.process_changes(since=kafka_seq, forever=False)
         self.es.indices.refresh(APP_INDEX_INFO.index)
 
         # confirm change made it to elasticserach
@@ -150,14 +150,14 @@ class AppPillowTest(TestCase):
         kafka_seq = get_topic_offset(topics.APP)
 
         app.delete()
-        app_db_pillow.process_changes(couch_seq)
+        app_db_pillow.process_changes(couch_seq, forever=False)
 
         # confirm change made it to kafka. Would raise StopIteration otherwise
         next(consumer)
 
         # send to elasticsearch
         app_pillow = get_app_to_elasticsearch_pillow()
-        app_pillow.process_changes(since=kafka_seq)
+        app_pillow.process_changes(since=kafka_seq, forever=False)
         self.es.indices.refresh(APP_INDEX_INFO.index)
 
         # confirm deletion made it to elasticserach

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -67,7 +67,7 @@ class CaseSearchPillowTest(TestCase):
         with patch('corehq.pillows.case_search.domain_needs_search_index',
                    new=MagicMock(return_value=True)) as fake_case_search_enabled_for_domain:
             # send to elasticsearch
-            self.pillow.process_changes(since=kafka_seq)
+            self.pillow.process_changes(since=kafka_seq, forever=False)
             fake_case_search_enabled_for_domain.assert_called_with(self.domain)
 
         self._assert_case_in_es(self.domain, case)
@@ -131,7 +131,7 @@ class CaseSearchPillowTest(TestCase):
         with patch('corehq.pillows.case_search.domain_needs_search_index',
                    new=MagicMock(return_value=True)) as fake_case_search_enabled_for_domain:
             # send to elasticsearch
-            self.pillow.process_changes(since=kafka_seq)
+            self.pillow.process_changes(since=kafka_seq, forever=False)
             fake_case_search_enabled_for_domain.assert_called_with(self.domain)
 
         self._assert_case_in_es(self.domain, case)

--- a/testapps/test_pillowtop/tests/test_changes.py
+++ b/testapps/test_pillowtop/tests/test_changes.py
@@ -17,7 +17,7 @@ class ChangeFeedDbTest(TestCase):
         pillow = _make_couch_pillow(self.couch_db)
         doc_id = uuid.uuid4().hex
         self.couch_db.save_doc({'_id': doc_id, 'property': 'property_value'})
-        pillow.process_changes(since=self.update_seq)
+        pillow.process_changes(since=self.update_seq, forever=False)
 
         changes = self._extract_changes_from_call_args(pillow.process_change.call_args_list)
         change_ids = {change['id'] for change in changes}
@@ -34,7 +34,7 @@ class ChangeFeedDbTest(TestCase):
         self.couch_db.save_doc({'_id': uuid.uuid4().hex, 'property': 'property_value'})
         form = XFormInstance(domain='test-domain')
         form.save()
-        pillow.process_changes(since=self.update_seq)
+        pillow.process_changes(since=self.update_seq, forever=False)
 
         changes = self._extract_changes_from_call_args(pillow.process_change.call_args_list)
         change_ids = {change['id'] for change in changes}

--- a/testapps/test_pillowtop/tests/test_chunk_pillow.py
+++ b/testapps/test_pillowtop/tests/test_chunk_pillow.py
@@ -47,19 +47,19 @@ class ChunkedPorcessingTest(TestCase):
         self._produce_changes(2)
         # pillow should use process_changes_chunk (make process_change raise an exception for test)
         processor.process_change = MagicMock(side_effect=Exception('_'))
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
         self.assertEqual(processor.count, 2)
 
         self._produce_changes(2)
         # if process_changes_chunk raises exception, pillow should use process_change
         processor.process_change = original_process_change
         processor.process_changes_chunk = MagicMock(side_effect=Exception('_'))
-        pillow.process_changes(since=pillow.get_last_checkpoint_sequence())
+        pillow.process_changes(since=pillow.get_last_checkpoint_sequence(), forever=False)
         self.assertEqual(processor.count, 4)
 
         self._produce_changes(1)
         # offsets after full chunk should still be processed
         processor.process_change = MagicMock(side_effect=Exception('_'))
         processor.process_changes_chunk = original_process_changes_chunk
-        pillow.process_changes(since=pillow.get_last_checkpoint_sequence())
+        pillow.process_changes(since=pillow.get_last_checkpoint_sequence(), forever=False)
         self.assertEqual(processor.count, 5)

--- a/testapps/test_pillowtop/tests/test_domain_pillow.py
+++ b/testapps/test_pillowtop/tests/test_domain_pillow.py
@@ -41,7 +41,7 @@ class DomainPillowTest(TestCase):
 
         # send to elasticsearch
         pillow = get_domain_kafka_to_elasticsearch_pillow()
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
         self.elasticsearch.indices.refresh(self.index_info.index)
 
         # verify there
@@ -59,7 +59,7 @@ class DomainPillowTest(TestCase):
 
         # send to elasticsearch
         pillow = get_domain_kafka_to_elasticsearch_pillow()
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
         self.elasticsearch.indices.refresh(self.index_info.index)
 
         # ensure removed from ES

--- a/testapps/test_pillowtop/tests/test_form_pillow.py
+++ b/testapps/test_pillowtop/tests/test_form_pillow.py
@@ -37,7 +37,7 @@ class FormPillowTest(TestCase):
         producer.send_change(topics.FORM, doc_to_change(form.to_json()).metadata)
         self.assertFalse(self.app.has_submissions)
 
-        self.pillow.process_changes(since=kafka_seq)
+        self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertTrue(Application.get(self.app._id).has_submissions)
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
@@ -54,7 +54,7 @@ class FormPillowTest(TestCase):
         self.assertEqual(self.domain, change_meta.domain)
         self.assertFalse(self.app.has_submissions)
 
-        self.pillow.process_changes(since=kafka_seq)
+        self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertTrue(Application.get(self.app._id).has_submissions)
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
@@ -71,7 +71,7 @@ class FormPillowTest(TestCase):
         self.assertEqual(self.domain, change_meta.domain)
         self.assertFalse(self.app.has_submissions)
 
-        self.pillow.process_changes(since=kafka_seq)
+        self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertFalse(Application.get(self.app._id).has_submissions)
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
@@ -90,7 +90,7 @@ class FormPillowTest(TestCase):
         self.assertEqual(self.domain, change_meta.domain)
         self.assertFalse(self.app.has_submissions)
 
-        self.pillow.process_changes(since=kafka_seq)
+        self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertFalse(Application.get(self.app._id).has_submissions)
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
@@ -103,14 +103,14 @@ class FormPillowTest(TestCase):
         # confirm change made it to kafka
         self.assertFalse(self.app.has_submissions)
 
-        self.pillow.process_changes(since=kafka_seq)
+        self.pillow.process_changes(since=kafka_seq, forever=False)
         newly_saved_app = Application.get(self.app._id)
         self.assertTrue(newly_saved_app.has_submissions)
         # Ensure that the app has been saved
         self.assertNotEqual(self.app._rev, newly_saved_app._rev)
 
         self._make_form()
-        self.pillow.process_changes(since=kafka_seq)
+        self.pillow.process_changes(since=kafka_seq, forever=False)
         self.assertTrue(Application.get(self.app._id).has_submissions)
         # Ensure that the app has not been saved twice
         self.assertEqual(Application.get(self.app._id)._rev, newly_saved_app._rev)

--- a/testapps/test_pillowtop/tests/test_group_pillow.py
+++ b/testapps/test_pillowtop/tests/test_group_pillow.py
@@ -47,7 +47,7 @@ class GroupPillowTest(TestCase):
 
         # send to elasticsearch
         pillow = get_group_pillow()
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
         self.elasticsearch.indices.refresh(GROUP_INDEX_INFO.index)
 
         # verify there

--- a/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
+++ b/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
@@ -164,7 +164,7 @@ class GroupToUserPillowDbTest(TestCase):
 
         # process using pillow
         pillow = get_group_pillow()
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
 
         # confirm updated in elasticsearch
         self.es_client.indices.refresh(USER_INDEX)
@@ -180,7 +180,7 @@ class GroupToUserPillowDbTest(TestCase):
         producer.send_change(topics.GROUP, _group_to_change_meta(group.to_json()))
 
         pillow = get_group_pillow()
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
 
         # confirm removed in elasticsearch
         self.es_client.indices.refresh(USER_INDEX)

--- a/testapps/test_pillowtop/tests/test_sms_pillow.py
+++ b/testapps/test_pillowtop/tests/test_sms_pillow.py
@@ -136,7 +136,7 @@ class SqlSMSPillowTest(TestCase):
 
         # send to elasticsearch
         sms_pillow = get_sql_sms_pillow('SqlSMSPillow')
-        sms_pillow.process_changes(since=kafka_seq)
+        sms_pillow.process_changes(since=kafka_seq, forever=False)
         self.elasticsearch.indices.refresh(SMS_INDEX_INFO.index)
 
         # confirm change made it to elasticserach

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -62,7 +62,7 @@ class UserPillowTest(UserPillowTestBase):
 
         # send to elasticsearch
         pillow = get_user_pillow_old(skip_ucr=True)
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
         self.elasticsearch.indices.refresh(self.index_info.index)
         self.assertEqual(0, UserES().run().total)
 
@@ -76,7 +76,7 @@ class UserPillowTest(UserPillowTestBase):
 
         # send to elasticsearch
         pillow = get_user_pillow_old()
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
         self.elasticsearch.indices.refresh(self.index_info.index)
         self._verify_user_in_es(username)
         return user
@@ -105,7 +105,7 @@ class UnknownUserPillowTest(UserPillowTestBase):
 
         # send to elasticsearch
         pillow = get_xform_pillow()
-        pillow.process_changes(since=since)
+        pillow.process_changes(since=since, forever=False)
         self.elasticsearch.indices.refresh(self.index_info.index)
 
         # the default query doesn't include unknown users so should have no results

--- a/testapps/test_pillowtop/utils.py
+++ b/testapps/test_pillowtop/utils.py
@@ -45,7 +45,7 @@ class process_pillow_changes(ContextDecorator):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         for offsets, pillow in zip(self.offsets, self._pillows):
-            pillow.process_changes(since=offsets)
+            pillow.process_changes(since=offsets, forever=False)
 
 
 class real_pillow_settings(ContextDecorator):


### PR DESCRIPTION
Reverts dimagi/commcare-hq#26842

Starting right after we deployed this, we're seeing about 1500 SQL forms not making it to ES each day, and I've spot-checked those to show that they do appear in kafka, but don't appear in ES, which indicates that the issue is that pillows are missing a small percentage of changes and updating the checkpoint past them without actually processing them.

I haven't figured out what in this PR is wrong, but it pretty much has to be this PR.