### PR TITLE
[Django 2] Fix mock import

### DIFF
--- a/corehq/messaging/smsbackends/vertex/tests/test_response.py
+++ b/corehq/messaging/smsbackends/vertex/tests/test_response.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.test import mock
+import mock
 
 from corehq.apps.sms.models import QueuedSMS
 from corehq.messaging.smsbackends.vertex.exceptions import VertexBackendException


### PR DESCRIPTION
##### SUMMARY
Was (likely by mistake) using a since replaced internal Django shim
for trying to import mock form a couple different places,
explictly never meant for external use:
https://github.com/django/django/commit/7aba69145dcb436539a7798086748b73a39121e5#diff-b2989817cedaaadae124d051691f802aL21-L29


Pulled out from #26900