### PR TITLE
[Django 2] Add PLPROXY_HOST to check_plproxy_config allowed keys

### DIFF
--- a/corehq/sql_db/__init__.py
+++ b/corehq/sql_db/__init__.py
@@ -26,7 +26,7 @@ def custom_db_checks(app_configs, **kwargs):
 
 @checks.register('settings')
 def check_plproxy_config(app_configs, **kwargs):
-    allowed_keys = {'PROXY_FOR_STANDBYS', 'PROXY', 'SHARDS'}
+    allowed_keys = {'PROXY_FOR_STANDBYS', 'PROXY', 'SHARDS', 'PLPROXY_HOST'}
     messages = []
     for db, config in settings.DATABASES.items():
         if 'PLPROXY' in config:


### PR DESCRIPTION
##### SUMMARY
This failure currently shows (in Django 1.11) when you run `./manage.py check`, but in Django 2.2 it appears to also break our build.

Error message:
```
?: Unrecognised PLPROXY settings: {'PLPROXY_HOST'}
```