### PR TITLE
user provisioning polish

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -532,7 +532,8 @@ class NewMobileWorkerForm(forms.Form):
     force_account_confirmation = forms.BooleanField(
         label=ugettext_noop("Require Account Confirmation?"),
         help_text=ugettext_noop(
-            "If checked, the user will be sent a confirmation email and asked to set their password."
+            "The user's account will not be active until "
+            "they have confirmed their email and set a password."
         ),
         required=False,
     )
@@ -546,6 +547,14 @@ class NewMobileWorkerForm(forms.Form):
                 <!-- ko text: $root.emailStatusMessage --><!-- /ko -->
             </span>
         """
+    )
+    send_account_confirmation_email = forms.BooleanField(
+        label=ugettext_noop("Send Account Confirmation Email Now?"),
+        help_text=ugettext_noop(
+            "The user will be sent their account confirmation email now. "
+            "Otherwise it must be sent manually at a later time."
+        ),
+        required=False,
     )
     new_password = forms.CharField(
         widget=forms.PasswordInput(),
@@ -608,6 +617,10 @@ class NewMobileWorkerForm(forms.Form):
                     },
                 '''
             )
+            send_email_field = crispy.Field(
+                'send_account_confirmation_email',
+                data_bind='checked: send_account_confirmation_email, enable: sendConfirmationEmailEnabled',
+            )
         else:
             confirm_account_field = crispy.Hidden(
                 'force_account_confirmation',
@@ -619,6 +632,12 @@ class NewMobileWorkerForm(forms.Form):
                 '',
                 data_bind='value: email',
             )
+            send_email_field = crispy.Hidden(
+                'send_account_confirmation_email',
+                '',
+                data_bind='value: send_account_confirmation_email',
+            )
+
 
         self.helper = HQModalFormHelper()
         self.helper.form_tag = False
@@ -651,6 +670,7 @@ class NewMobileWorkerForm(forms.Form):
                 location_field,
                 confirm_account_field,
                 email_field,
+                send_email_field,
                 crispy.Div(
                     hqcrispy.B3MultiField(
                         _("Password"),

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -67,6 +67,7 @@ hqDefine("users/js/mobile_workers",[
             user_id: '',
             force_account_confirmation: false,
             email: '',
+            send_account_confirmation_email: false,
             is_active: true,
             custom_fields: {},
         });
@@ -80,6 +81,7 @@ hqDefine("users/js/mobile_workers",[
         // used by two-stage provisioning
         self.emailRequired = ko.observable(self.force_account_confirmation());
         self.passwordEnabled = ko.observable(!self.force_account_confirmation());
+        self.sendConfirmationEmailEnabled = ko.observable(self.force_account_confirmation());
 
         self.action_error = ko.observable('');  // error when activating/deactivating a user
 
@@ -370,11 +372,13 @@ hqDefine("users/js/mobile_workers",[
                     // clear and disable password input
                     user.password('');
                     user.passwordEnabled(false);
+                    user.sendConfirmationEmailEnabled(true);
                 } else {
                     // make email optional
                     user.emailRequired(false);
                     // enable password input
                     user.passwordEnabled(true);
+                    user.sendConfirmationEmailEnabled(false);
                 }
             });
         });

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -379,6 +379,8 @@ hqDefine("users/js/mobile_workers",[
                     // enable password input
                     user.passwordEnabled(true);
                     user.sendConfirmationEmailEnabled(false);
+                    // uncheck email confirmation box if it was checked
+                    user.send_account_confirmation_email(false);
                 }
             });
         });

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -644,10 +644,6 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         return NewMobileWorkerForm(self.request.project, self.couch_user)
 
     @property
-    def _mobile_worker_form(self):
-        return self.new_mobile_worker_form
-
-    @property
     @memoized
     def custom_data(self):
         return CustomDataEditor(
@@ -739,7 +735,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
 
         self.request.POST = form_data
 
-        is_valid = lambda: self._mobile_worker_form.is_valid() and self.custom_data.is_valid()
+        is_valid = lambda: self.new_mobile_worker_form.is_valid() and self.custom_data.is_valid()
         if not is_valid():
             return {'error': _("Forms did not validate")}
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -740,8 +740,8 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
             return {'error': _("Forms did not validate")}
 
         couch_user = self._build_commcare_user()
-        send_account_confirmation_if_necessary(couch_user)
-
+        if self.new_mobile_worker_form.cleaned_data['send_account_confirmation_email']:
+            send_account_confirmation_if_necessary(couch_user)
         return {
             'success': True,
             'user_id': couch_user.userID,
@@ -789,6 +789,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
                 'location_id': user_data.get('location_id'),
                 'email': user_data.get('email'),
                 'force_account_confirmation': user_data.get('force_account_confirmation'),
+                'send_account_confirmation_email': user_data.get('send_account_confirmation_email'),
                 'domain': self.domain,
             }
             for k, v in user_data.get('custom_fields', {}).items():

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1824,5 +1824,6 @@ TWO_STAGE_USER_PROVISIONING = StaticToggle(
     'two_stage_user_provisioning',
     'Enable two-stage user provisioning (users confirm and set their own passwords via email).',
     TAG_SOLUTIONS_LIMITED,
-    [NAMESPACE_DOMAIN]
+    [NAMESPACE_DOMAIN],
+    help_link='https://confluence.dimagi.com/display/ccinternal/Two-Stage+Mobile+Worker+Account+Creation',
 )


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://docs.google.com/document/d/1gZlOGroRTeUMHXwzCuOVw2EUuJcjOsAaAe1qc2iUEe0/edit#

review by commit, adds a documentation link and a checkbox to send account confirmation emails immediately (versus later which isn't implemented yet but should be soon :man_shrugging: )

Didn't get to [this feedback yet](https://github.com/dimagi/commcare-hq/pull/26920#discussion_r397146704) since I understood it late in the game, but will look into it tomorrow.
 
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
