### PR TITLE
Remove tech details from error page

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -382,7 +382,6 @@ def resend_confirmation(request):
             context.update({
                 'current_page': {'page_name': _('Oops!')},
                 'error_msg': _('There was a problem with your request'),
-                'error_details': sys.exc_info(),
                 'show_homepage_link': 1,
             })
             return render(request, 'error.html', context)


### PR DESCRIPTION
##### SUMMARY
Noticed while working on https://github.com/dimagi/commcare-hq/pull/26958 that the error page displayed specifics of the python error. This doesn't help users and isn't ideal from a security perspective.
![image (1)](https://user-images.githubusercontent.com/1486591/77475709-986b4680-6def-11ea-916a-3286a0729cd1.png)

##### PRODUCT DESCRIPTION
Not worth announcing but technically user visible. Errors encountered during user registration will just show a generic message, whereas they used to show specific code detail of what went wrong.