### PR TITLE
Improve stale_data_in_es and republish_doc_changes

### DIFF
--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -6,7 +6,7 @@ from django.core.management import BaseCommand, CommandError
 from corehq.apps.change_feed import data_sources, topics
 from corehq.apps.change_feed.producer import producer
 from corehq.apps.hqadmin.management.commands.stale_data_in_es import DataRow, HEADER_ROW
-from corehq.form_processor.backends.sql.dbaccessors import ShardAccessor, doc_type_to_state
+from corehq.form_processor.backends.sql.dbaccessors import ShardAccessor
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.form_processor.utils import should_use_sql_backend
 from dimagi.utils.chunked import chunked
@@ -23,7 +23,7 @@ DocumentRecord = namedtuple('DocumentRecord', ['doc_id', 'doc_type', 'doc_subtyp
 
 
 CASE_DOC_TYPES = {'CommCareCase'}
-FORM_DOC_TYPES = set(doc_type_to_state.keys())
+FORM_DOC_TYPES = {'XFormInstance', 'XFormArchived'}
 
 ALL_DOC_TYPES = set.union(CASE_DOC_TYPES, FORM_DOC_TYPES)
 

--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -30,14 +30,15 @@ class Command(BaseCommand):
     """
     Republish doc changes. Meant to be used in conjunction with stale_data_in_es command
 
-        $ ./manage.py republish_doc_changes changes.csv
+        $ ./manage.py republish_doc_changes changes.tsv
     """
 
     def add_arguments(self, parser):
         parser.add_argument('stale_data_in_es_file')
+        parser.add_argument('--delimiter', default='\t', choices=('\t', ','))
 
-    def handle(self, stale_data_in_es_file, *args, **options):
-        data_rows = _get_data_rows(stale_data_in_es_file)
+    def handle(self, stale_data_in_es_file, delimiter, *args, **options):
+        data_rows = _get_data_rows(stale_data_in_es_file, delimiter=delimiter)
         document_records = _get_document_records(data_rows)
         form_records = []
         case_records = []
@@ -52,10 +53,10 @@ class Command(BaseCommand):
         _publish_forms(form_records)
 
 
-def _get_data_rows(stale_data_in_es_file):
+def _get_data_rows(stale_data_in_es_file, delimiter):
     with open(stale_data_in_es_file, 'r') as f:
         for line in f.readlines():
-            data_row = DataRow(*line.rstrip('\n').split(','))
+            data_row = DataRow(*line.rstrip('\n').split(delimiter))
             # Skip the header row anywhere in the file.
             # The "anywhere in the file" part is useful
             # if you cat multiple stale_data_in_es_file files together.

--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -77,7 +77,7 @@ def _get_document_records(data_rows):
 def _publish_cases(case_records):
     for domain, records in itertools.groupby(case_records, lambda r: r.domain):
         if should_use_sql_backend(domain):
-            _publish_cases_for_sql(domain, records)
+            _publish_cases_for_sql(domain, list(records))
         else:
             _publish_cases_for_couch(domain, [c.doc_id for c in records])
 

--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -1,3 +1,4 @@
+import csv
 import itertools
 from collections import namedtuple
 
@@ -5,7 +6,7 @@ from django.core.management import BaseCommand, CommandError
 
 from corehq.apps.change_feed import data_sources, topics
 from corehq.apps.change_feed.producer import producer
-from corehq.apps.hqadmin.management.commands.stale_data_in_es import DataRow, HEADER_ROW
+from corehq.apps.hqadmin.management.commands.stale_data_in_es import DataRow, HEADER_ROW, get_csv_args
 from corehq.form_processor.backends.sql.dbaccessors import ShardAccessor
 from corehq.form_processor.models import CommCareCaseSQL
 from corehq.form_processor.utils import should_use_sql_backend
@@ -57,8 +58,9 @@ class Command(BaseCommand):
 
 def _get_data_rows(stale_data_in_es_file, delimiter):
     with open(stale_data_in_es_file, 'r') as f:
-        for line in f.readlines():
-            data_row = DataRow(*line.rstrip('\n').split(delimiter))
+        csv_reader = csv.reader(f, **get_csv_args(delimiter))
+        for csv_row in csv_reader:
+            data_row = DataRow(*csv_row)
             # Skip the header row anywhere in the file.
             # The "anywhere in the file" part is useful
             # if you cat multiple stale_data_in_es_file files together.

--- a/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
+++ b/corehq/apps/hqadmin/management/commands/republish_doc_changes.py
@@ -25,6 +25,8 @@ DocumentRecord = namedtuple('DocumentRecord', ['doc_id', 'doc_type', 'doc_subtyp
 CASE_DOC_TYPES = {'CommCareCase'}
 FORM_DOC_TYPES = set(doc_type_to_state.keys())
 
+ALL_DOC_TYPES = set.union(CASE_DOC_TYPES, FORM_DOC_TYPES)
+
 
 class Command(BaseCommand):
     """
@@ -68,7 +70,7 @@ def _get_document_records(data_rows):
     for data_row in data_rows:
         doc_id, doc_type, doc_subtype, domain = \
             data_row.doc_id, data_row.doc_type, data_row.doc_subtype, data_row.domain
-        if doc_type not in set.union(CASE_DOC_TYPES, FORM_DOC_TYPES):
+        if doc_type not in ALL_DOC_TYPES:
             raise CommandError(f"Found bad doc type {doc_type}. "
                                "Did you use the right command to create the data?")
         yield DocumentRecord(doc_id, doc_type, doc_subtype, domain)

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -69,63 +69,86 @@ class Command(BaseCommand):
         run_config = RunConfig(domain, start, end, case_type)
 
         for data_model in data_models:
-            if data_model.lower() == 'case':
-                for case_id, case_type, es_date, primary_date in get_server_modified_on_for_domain(run_config):
-                    print(f"{case_id},CommCareCase,{case_type},{es_date},{primary_date}")
-            elif data_model.lower() == 'form':
-                for form_id, doc_type, xmlns, es_date, primary_date in get_stale_form_data(run_config):
-                    print(f"{form_id},{doc_type},{xmlns},{es_date},{primary_date}")
-            else:
-                raise CommandError('Only valid options for data model are "case" and "form"')
+            try:
+                process_data_model_fn = DATA_MODEL_BACKENDS[data_model.lower()]()
+            except KeyError:
+                raise CommandError('Only valid options for data model are "{}"'.format(
+                    '", "'.join(DATA_MODEL_BACKENDS.keys())
+                ))
+            process_data_model_fn(run_config)
 
 
-def get_server_modified_on_for_domain(run_config):
-    if should_use_sql_backend(run_config.domain):
-        return _get_data_for_sql_backend(run_config)
-    else:
-        return _get_data_for_couch_backend(run_config)
+DATA_MODEL_BACKENDS = {
+    'case': lambda: CaseBackend.run,
+    'form': lambda: FormBackend.run,
+}
 
 
-def _get_data_for_couch_backend(run_config):
-    if run_config.case_type:
-        raise CommandError('Case type argument is not supported for couch domains!')
-    domain = run_config.domain
-    start_time = datetime.utcnow()
-    chunk_size = 1000
-    chunked_iterator = chunked(paginate_view(
-        CommCareCase.get_db(),
-        'cases_by_server_date/by_server_modified_on',
-        chunk_size=chunk_size,
-        startkey=[domain],
-        endkey=[domain, {}],
-        include_docs=False,
-        reduce=False
-    ), chunk_size)
-    for chunk in chunked_iterator:
-        case_ids = [row['id'] for row in chunk]
-        es_modified_on_by_ids = _get_es_modified_dates(domain, case_ids)
-        for row in chunk:
-            case_id, couch_modified_on = row['id'], row['value']
-            if iso_string_to_datetime(couch_modified_on) > start_time:
-                # skip cases modified after the script started
-                continue
-            es_modified_on = es_modified_on_by_ids.get(case_id)
-            if not es_modified_on or (es_modified_on != couch_modified_on):
-                yield (case_id, 'COUCH_TYPE_NOT_SUPPORTED', es_modified_on, couch_modified_on)
+class CaseBackend:
+    @staticmethod
+    def run(run_config):
+        rows = CaseBackend._get_server_modified_on_for_domain(run_config)
+        for case_id, case_type, es_date, primary_date in rows:
+            print(f"{case_id},CommCareCase,{case_type},{es_date},{primary_date}")
 
+    @staticmethod
+    def _get_server_modified_on_for_domain(run_config):
+        if should_use_sql_backend(run_config.domain):
+            return CaseBackend._get_data_for_sql_backend(run_config)
+        else:
+            return CaseBackend._get_data_for_couch_backend(run_config)
 
-def _get_data_for_sql_backend(run_config):
-    for db in get_db_aliases_for_partitioned_query():
-        matching_records_for_db = get_sql_case_data_for_db(db, run_config)
+    @staticmethod
+    def _get_data_for_sql_backend(run_config):
+        for db in get_db_aliases_for_partitioned_query():
+            matching_records_for_db = get_sql_case_data_for_db(db, run_config)
+            chunk_size = 1000
+            for chunk in chunked(matching_records_for_db, chunk_size):
+                case_ids = [val[0] for val in chunk]
+                es_modified_on_by_ids = CaseBackend._get_es_modified_dates(run_config.domain, case_ids)
+                for case_id, case_type, sql_modified_on in chunk:
+                    sql_modified_on_str = f'{sql_modified_on.isoformat()}Z'
+                    es_modified_on = es_modified_on_by_ids.get(case_id)
+                    if not es_modified_on or (es_modified_on < sql_modified_on_str):
+                        yield case_id, case_type, es_modified_on, sql_modified_on_str
+
+    @staticmethod
+    def _get_data_for_couch_backend(run_config):
+        if run_config.case_type:
+            raise CommandError('Case type argument is not supported for couch domains!')
+        domain = run_config.domain
+        start_time = datetime.utcnow()
         chunk_size = 1000
-        for chunk in chunked(matching_records_for_db, chunk_size):
-            case_ids = [val[0] for val in chunk]
-            es_modified_on_by_ids = _get_es_modified_dates(run_config.domain, case_ids)
-            for case_id, case_type, sql_modified_on in chunk:
-                sql_modified_on_str = f'{sql_modified_on.isoformat()}Z'
+        chunked_iterator = chunked(paginate_view(
+            CommCareCase.get_db(),
+            'cases_by_server_date/by_server_modified_on',
+            chunk_size=chunk_size,
+            startkey=[domain],
+            endkey=[domain, {}],
+            include_docs=False,
+            reduce=False
+        ), chunk_size)
+        for chunk in chunked_iterator:
+            case_ids = [row['id'] for row in chunk]
+            es_modified_on_by_ids = CaseBackend._get_es_modified_dates(domain, case_ids)
+            for row in chunk:
+                case_id, couch_modified_on = row['id'], row['value']
+                if iso_string_to_datetime(couch_modified_on) > start_time:
+                    # skip cases modified after the script started
+                    continue
                 es_modified_on = es_modified_on_by_ids.get(case_id)
-                if not es_modified_on or (es_modified_on < sql_modified_on_str):
-                    yield (case_id, case_type, es_modified_on, sql_modified_on_str)
+                if not es_modified_on or (es_modified_on != couch_modified_on):
+                    yield case_id, 'COUCH_TYPE_NOT_SUPPORTED', es_modified_on, couch_modified_on
+
+    @staticmethod
+    def _get_es_modified_dates(domain, case_ids):
+        results = (
+            CaseES(es_instance_alias=ES_EXPORT_INSTANCE)
+            .domain(domain)
+            .case_ids(case_ids)
+            .values_list('_id', 'server_modified_on')
+        )
+        return dict(results)
 
 
 def get_sql_case_data_for_db(db, run_config):
@@ -141,53 +164,52 @@ def get_sql_case_data_for_db(db, run_config):
     return matching_cases.values_list('case_id', 'type', 'server_modified_on')
 
 
-def _get_es_modified_dates(domain, case_ids):
-    results = (CaseES(es_instance_alias=ES_EXPORT_INSTANCE)
+class FormBackend:
+    @staticmethod
+    def run(run_config):
+        for form_id, doc_type, xmlns, es_date, primary_date in FormBackend._get_stale_form_data(run_config):
+            print(f"{form_id},{doc_type},{xmlns},{es_date},{primary_date}")
+
+    @staticmethod
+    def _get_stale_form_data(run_config):
+        if should_use_sql_backend(run_config.domain):
+            return FormBackend._get_stale_form_data_for_sql_backend(run_config)
+        else:
+            raise CommandError('Form data for couch domains is not supported!')
+
+    @staticmethod
+    def _get_stale_form_data_for_sql_backend(run_config):
+        for db in get_db_aliases_for_partitioned_query():
+            matching_records_for_db = FormBackend._get_sql_form_data_for_db(db, run_config)
+            chunk_size = 1000
+            length = len(matching_records_for_db) // chunk_size
+            chunk_iter = chunked(matching_records_for_db, chunk_size)
+            for chunk in with_progress_bar(chunk_iter, prefix=f'Processing DB {db}',
+                                           length=length, stream=sys.stderr):
+                form_ids = [val[0] for val in chunk]
+                es_modified_on_by_ids = FormBackend._get_es_modified_dates_for_forms(run_config.domain, form_ids)
+                for form_id, state, xmlns, sql_modified_on in chunk:
+                    doc_type = state_to_doc_type.get(state, 'XFormInstance')
+                    sql_modified_on_str = f'{sql_modified_on.isoformat()}Z'
+                    es_modified_on = es_modified_on_by_ids.get(form_id)
+                    if not es_modified_on or (es_modified_on < sql_modified_on_str):
+                        yield form_id, doc_type, xmlns, es_modified_on, sql_modified_on_str
+
+    @staticmethod
+    def _get_sql_form_data_for_db(db, run_config):
+        return XFormInstanceSQL.objects.using(db).filter(
+            domain=run_config.domain,
+            received_on__gte=run_config.start_date,
+            received_on__lte=run_config.end_date,
+        ).values_list('form_id', 'state', 'xmlns', 'received_on')
+
+    @staticmethod
+    def _get_es_modified_dates_for_forms(domain, form_ids):
+        results = (
+            FormES(es_instance_alias=ES_EXPORT_INSTANCE)
+            .remove_default_filters()
             .domain(domain)
-            .case_ids(case_ids)
-            .values_list('_id', 'server_modified_on'))
-    return dict(results)
-
-
-def get_stale_form_data(run_config):
-    if should_use_sql_backend(run_config.domain):
-        return _get_stale_form_data_for_sql_backend(run_config)
-    else:
-        raise CommandError('Form data for couch domains is not supported!')
-
-
-def _get_stale_form_data_for_sql_backend(run_config):
-    for db in get_db_aliases_for_partitioned_query():
-        matching_records_for_db = _get_sql_form_data_for_db(db, run_config)
-        chunk_size = 1000
-        length = len(matching_records_for_db) // chunk_size
-        chunk_iter = chunked(matching_records_for_db, chunk_size)
-        for chunk in with_progress_bar(chunk_iter, prefix=f'Processing DB {db}',
-                                       length=length, stream=sys.stderr):
-            form_ids = [val[0] for val in chunk]
-            es_modified_on_by_ids = _get_es_modified_dates_for_forms(run_config.domain, form_ids)
-            for form_id, state, xmlns, sql_modified_on in chunk:
-                doc_type = state_to_doc_type.get(state, 'XFormInstance')
-                sql_modified_on_str = f'{sql_modified_on.isoformat()}Z'
-                es_modified_on = es_modified_on_by_ids.get(form_id)
-                if not es_modified_on or (es_modified_on < sql_modified_on_str):
-                    yield (form_id, doc_type, xmlns, es_modified_on, sql_modified_on_str)
-
-
-def _get_sql_form_data_for_db(db, run_config):
-    return XFormInstanceSQL.objects.using(db).filter(
-        domain=run_config.domain,
-        received_on__gte=run_config.start_date,
-        received_on__lte=run_config.end_date,
-    ).values_list('form_id', 'state', 'xmlns', 'received_on')
-
-
-def _get_es_modified_dates_for_forms(domain, form_ids):
-    results = (
-        FormES(es_instance_alias=ES_EXPORT_INSTANCE)
-        .remove_default_filters()
-        .domain(domain)
-        .form_ids(form_ids)
-        .values_list('_id', 'received_on')
-    )
-    return dict(results)
+            .form_ids(form_ids)
+            .values_list('_id', 'received_on')
+        )
+        return dict(results)

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from django.core.management.base import BaseCommand, CommandError
 
 import dateutil
+from django.db.models import F
 
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.chunked import chunked
@@ -227,8 +228,8 @@ class FormBackend:
         matching_forms = XFormInstanceSQL.objects.using(db).filter(
             received_on__gte=run_config.start_date,
             received_on__lte=run_config.end_date,
-            # Only check for "normal" forms
-            state=XFormInstanceSQL.NORMAL
+            # Only check for "normal" and "archived" forms
+            state=F('state').bitand(XFormInstanceSQL.NORMAL) + F('state').bitand(XFormInstanceSQL.ARCHIVED)
         )
         if run_config.domain is not ALL_SQL_DOMAINS:
             matching_forms = matching_forms.filter(

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -158,6 +158,7 @@ def get_sql_case_data_for_db(db, run_config):
     matching_cases = CommCareCaseSQL.objects.using(db).filter(
         server_modified_on__gte=run_config.start_date,
         server_modified_on__lte=run_config.end_date,
+        deleted=False,
     )
     if run_config.domain is not ALL_SQL_DOMAINS:
         matching_cases = matching_cases.filter(

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from django.core.management.base import BaseCommand, CommandError
 
 import dateutil
-from django.db.models import F
 
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.chunked import chunked
@@ -228,8 +227,8 @@ class FormBackend:
         matching_forms = XFormInstanceSQL.objects.using(db).filter(
             received_on__gte=run_config.start_date,
             received_on__lte=run_config.end_date,
-            # Exclude deleted
-            state=F('state') + F('state').bitand(XFormInstanceSQL.DELETED)
+            # Only check for "normal" forms
+            state=XFormInstanceSQL.NORMAL
         )
         if run_config.domain is not ALL_SQL_DOMAINS:
             matching_forms = matching_forms.filter(

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from django.core.management.base import BaseCommand, CommandError
 
 import dateutil
+from django.db.models import F
 
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.chunked import chunked
@@ -227,6 +228,8 @@ class FormBackend:
         matching_forms = XFormInstanceSQL.objects.using(db).filter(
             received_on__gte=run_config.start_date,
             received_on__lte=run_config.end_date,
+            # Exclude deleted
+            state=F('state') + F('state').bitand(XFormInstanceSQL.DELETED)
         )
         if run_config.domain is not ALL_SQL_DOMAINS:
             matching_forms = matching_forms.filter(

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -92,9 +92,9 @@ class Command(BaseCommand):
         run_config = RunConfig(domain, start, end, case_type)
 
         if run_config.domain is ALL_SQL_DOMAINS:
-            print('Running for all SQL domains (and excluding Couch domains!)', file=sys.stderr)
+            print('Running for all SQL domains (and excluding Couch domains!)', file=self.stderr)
 
-        csv_writer = csv.writer(sys.stdout, **get_csv_args(delimiter))
+        csv_writer = csv.writer(self.stdout, **get_csv_args(delimiter))
 
         def print_data_row(data_row):
             # Casting as str print `None` as 'None'

--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -1,3 +1,4 @@
+import csv
 import inspect
 import sys
 from collections import namedtuple
@@ -35,6 +36,13 @@ HEADER_ROW = DataRow(
     es_date='ES Date',
     primary_date='Correct Date',
 )
+
+
+def get_csv_args(delimiter):
+    return {
+        'delimiter': delimiter,
+        'lineterminator': '\n',
+    }
 
 
 class Command(BaseCommand):
@@ -86,9 +94,11 @@ class Command(BaseCommand):
         if run_config.domain is ALL_SQL_DOMAINS:
             print('Running for all SQL domains (and excluding Couch domains!)', file=sys.stderr)
 
+        csv_writer = csv.writer(sys.stdout, **get_csv_args(delimiter))
+
         def print_data_row(data_row):
-            # Casting as str print `None` as 'None' and datetimes as 'YYYY-MM-DD hh-mm-ss'
-            print(delimiter.join(map(str, data_row)))
+            # Casting as str print `None` as 'None'
+            csv_writer.writerow(map(str, data_row))
 
         print_data_row(HEADER_ROW)
 

--- a/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
+++ b/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
@@ -1,0 +1,178 @@
+import uuid
+from io import StringIO
+from unittest import skip
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils.decorators import method_decorator
+
+from casexml.apps.case.mock import CaseBlock
+from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
+from corehq.apps.domain.models import Domain
+from corehq.apps.receiverwrapper.util import submit_form_locally
+from corehq.elastic import get_es_new, send_to_elasticsearch
+from corehq.form_processor.document_stores import FormDocumentStore, CaseDocumentStore
+from corehq.form_processor.utils.xform import FormSubmissionBuilder
+from corehq.pillows.case import transform_case_for_elasticsearch
+from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
+from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
+from corehq.pillows.xform import transform_xform_for_elasticsearch
+from corehq.util.elastic import reset_es_index
+
+
+class TestStaleDataInESSQL(TestCase):
+
+    use_sql_backend = True
+    case_type = 'patient'
+
+    def test_no_output(self):
+        self._assert_in_sync(self._stale_data_in_es('form'))
+        self._assert_in_sync(self._stale_data_in_es('case'))
+        self._assert_in_sync(self._stale_data_in_es('form', 'case'))
+
+    def test_form_missing_then_not(self):
+        self._test_form_missing_then_not({})
+
+    def test_form_missing_then_not_domain_specific(self):
+        self._test_form_missing_then_not({'domain': self.project.name})
+
+    def test_case_missing_then_not(self):
+        self._test_case_missing_then_not({})
+
+    def test_case_missing_then_not_domain_specific(self):
+        self._test_case_missing_then_not({'domain': self.project.name})
+
+    def _test_form_missing_then_not(self, cmd_kwargs):
+        def call():
+            return self._stale_data_in_es('form', **cmd_kwargs)
+
+        form, cases = self._submit_form(self.project.name)
+        self._assert_not_in_sync(call(), rows=[
+            (form.form_id, 'XFormInstance', form.xmlns, form.domain, None, form.received_on)
+        ])
+
+        self._send_forms_to_es([form])
+        self._assert_in_sync(call())
+
+        form.archive(trigger_signals=False)
+        self._assert_not_in_sync(call(), rows=[
+            (form.form_id, 'XFormArchived', form.xmlns, form.domain, form.received_on, form.received_on)
+        ])
+
+        self._send_forms_to_es([form])
+        self._assert_in_sync(call())
+
+        form.unarchive(trigger_signals=False)
+        self._assert_not_in_sync(call(), rows=[
+            (form.form_id, 'XFormInstance', form.xmlns, form.domain, form.received_on, form.received_on)
+        ])
+
+        self._send_forms_to_es([form])
+        self._assert_in_sync(call())
+
+    def _test_case_missing_then_not(self, cmd_kwargs):
+        def call():
+            return self._stale_data_in_es('case', **cmd_kwargs)
+        form, (case,) = self._submit_form(self.project.name, new_cases=1)
+        self._assert_not_in_sync(call(), rows=[
+            (case.case_id, 'CommCareCase', case.type, case.domain, None, case.server_modified_on)
+        ])
+
+        self._send_cases_to_es([case])
+        self._assert_in_sync(call())
+
+        old_date = case.server_modified_on
+        form, (case,) = self._submit_form(self.project.name, update_cases=[case])
+        self._assert_not_in_sync(call(), rows=[
+            (case.case_id, 'CommCareCase', case.type, case.domain, old_date, case.server_modified_on)
+        ])
+
+        self._send_cases_to_es([case])
+        self._assert_in_sync(call())
+
+    @staticmethod
+    def _stale_data_in_es(*args, **kwargs):
+        f = StringIO()
+        call_command('stale_data_in_es', *args, stdout=f, **kwargs)
+        return f.getvalue()
+
+    def _submit_form(self, domain, new_cases=0, update_cases=()):
+        case_blocks = [
+            CaseBlock(
+                case_id=str(uuid.uuid4()),
+                case_type=self.case_type,
+                create={'name': str(uuid.uuid4())[:5]},
+            )
+            for i in range(new_cases)
+        ]
+        case_blocks += [
+            CaseBlock(
+                case_id=case.case_id,
+                update={}
+            )
+            for case in update_cases
+        ]
+
+        form_xml = FormSubmissionBuilder(form_id=str(uuid.uuid4()), case_blocks=case_blocks).as_xml_string()
+        result = submit_form_locally(form_xml, domain)
+        return result.xform, result.cases
+
+    @classmethod
+    def _send_forms_to_es(cls, forms):
+        for form in forms:
+
+            es_form = transform_xform_for_elasticsearch(
+                FormDocumentStore(form.domain, form.xmlns).get_document(form.form_id)
+            )
+            send_to_elasticsearch('forms', es_form)
+
+        cls.elasticsearch.indices.refresh(XFORM_INDEX_INFO.index)
+
+    @classmethod
+    def _send_cases_to_es(cls, cases):
+        for case in cases:
+            es_case = transform_case_for_elasticsearch(
+                CaseDocumentStore(case.domain, case.type).get_document(case.case_id)
+            )
+            send_to_elasticsearch('cases', es_case)
+
+        cls.elasticsearch.indices.refresh(CASE_INDEX_INFO.index)
+
+    def _assert_in_sync(self, output):
+        self.assertEqual(
+            output,
+            'Doc ID\tDoc Type\tDoc Subtype\tDomain\tES Date\tCorrect Date\n'
+        )
+
+    def _assert_not_in_sync(self, output, rows):
+        content = "".join('{}\n'.format('\t'.join(map(str, row))) for row in rows)
+        self.assertEqual(
+            output,
+            f'Doc ID\tDoc Type\tDoc Subtype\tDomain\tES Date\tCorrect Date\n{content}'
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project = Domain.get_or_create_with_name(
+            'project', is_active=True, use_sql_backend=cls.use_sql_backend)
+        cls.project.save()
+        cls.elasticsearch = get_es_new()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.delete()
+
+    def tearDown(self):
+        delete_all_xforms()
+        delete_all_cases()
+        reset_es_index(XFORM_INDEX_INFO)
+        reset_es_index(CASE_INDEX_INFO)
+
+
+@method_decorator(skip("Not yet implemented"), 'test_form_missing_then_not')
+@method_decorator(skip("Not yet implemented"), 'test_form_missing_then_not_domain_specific')
+@method_decorator(skip("Not yet implemented"), 'test_case_missing_then_not')
+class TestStaleDataInESCouch(TestStaleDataInESSQL):
+
+    use_sql_backend = False
+    case_type = 'COUCH_TYPE_NOT_SUPPORTED'

--- a/custom/icds_reports/management/commands/stale_data_in_ucr.py
+++ b/custom/icds_reports/management/commands/stale_data_in_ucr.py
@@ -95,7 +95,7 @@ def _get_stale_data(run_config):
         for chunk in chunked(matching_records_for_db, chunk_size):
             doc_ids = [val[0] for val in chunk]
             ucr_insertion_dates = _get_ucr_insertion_dates(run_config.domain, run_config.table_id, doc_ids)
-            for doc_id, doc_type, sql_modified_on, _ in chunk:
+            for doc_id, doc_type, sql_modified_on in chunk:
                 ucr_insert_date = ucr_insertion_dates.get(doc_id)
                 if (not ucr_insert_date
                         # Handle small time drift between databases
@@ -130,4 +130,5 @@ def _get_primary_data_for_db(db, run_config):
             matching_xforms = matching_xforms.filter(xmlns=run_config.xmlns)
         return matching_xforms.values_list('form_id', 'xmlns', 'received_on')
     else:
-        return get_sql_case_data_for_db(db, run_config)
+        for case_id, case_type, server_date_modified, _ in get_sql_case_data_for_db(db, run_config):
+            yield case_id, case_type, server_date_modified

--- a/custom/icds_reports/management/commands/stale_data_in_ucr.py
+++ b/custom/icds_reports/management/commands/stale_data_in_ucr.py
@@ -95,7 +95,7 @@ def _get_stale_data(run_config):
         for chunk in chunked(matching_records_for_db, chunk_size):
             doc_ids = [val[0] for val in chunk]
             ucr_insertion_dates = _get_ucr_insertion_dates(run_config.domain, run_config.table_id, doc_ids)
-            for doc_id, doc_type, sql_modified_on in chunk:
+            for doc_id, doc_type, sql_modified_on, _ in chunk:
                 ucr_insert_date = ucr_insertion_dates.get(doc_id)
                 if (not ucr_insert_date
                         # Handle small time drift between databases


### PR DESCRIPTION
##### SUMMARY
These commands were exactly what I was trying to do with https://github.com/dimagi/commcare-hq/pull/26943 (thanks @czue!) so I'm dropping that and investing in these commands instead.

A lot of it is cleanup that hopefully makes the relationships between things clearer, but there are also a few actual changes:
- You can now run on all SQL domains instead of just one domain. (Running on all couch domains or on all domains couch+sql isn't supported.)
- For cases, deleted cases are no longer counted as "missing" in ES, since they're not supposed to be in ES
- `republish_doc_changes` now supports form types other than `XFormInstance`, since all different types are in fact saved to ES (and `stale_data_in_es` was already finding them)
- I made the default tsv so it's easier to paste in to a google sheet. csv is still available with `--delimiter=,`

Not quite done but wanted to put it up
