### PR TITLE
move password dependency

### DIFF
--- a/corehq/apps/registration/static/registration/js/password.js
+++ b/corehq/apps/registration/static/registration/js/password.js
@@ -3,6 +3,7 @@ hqDefine('registration/js/password', [
     'knockout',
     'zxcvbn/dist/zxcvbn',
     'hqwebapp/js/initial_page_data',
+    'hqwebapp/js/knockout_bindings.ko', // password initializeValue binding
 ], function (
     $,
     ko,

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -11,7 +11,6 @@ hqDefine('users/js/edit_commcare_user', [
     'registration/js/password',
     'nic_compliance/js/encoder',
     'select2/dist/js/select2.full.min',
-    'hqwebapp/js/knockout_bindings.ko', // password initializeValue binding
 ], function (
     $,
     ko,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Follow up to https://github.com/dimagi/commcare-hq/pull/26930/ (https://dimagi-dev.atlassian.net/browse/SAAS-10737)

I think when I tested this I had a `debugger;` statement somewhere that was causing everything to get loaded. I removed that before submitting the PR, but then when I tested today it was only working like 5% of the time.

Moving it here is more correct and seems to work 100% of the time without any debugger or console statements.

(I obviously don't have a good mental model of how these dependencies work)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
