### PR TITLE
Allow dynamic ucrs in app copy management command

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -5601,7 +5601,7 @@ class LinkedApplication(Application):
             self.create_mapping(mm, ref['path'], save=False)
 
 
-def import_app(app_id_or_source, domain, source_properties=None, request=None):
+def import_app(app_id_or_source, domain, source_properties=None, request=None, check_all_reports=True):
     if isinstance(app_id_or_source, str):
         source_app = get_app(None, app_id_or_source)
     else:
@@ -5635,9 +5635,10 @@ def import_app(app_id_or_source, domain, source_properties=None, request=None):
                 try:
                     config.report_id = report_map[config.report_id]
                 except KeyError:
-                    raise AppEditingError(
-                        "Report {} not found in {}".format(config.report_id, domain)
-                    )
+                    if check_all_reports or config.report(source_domain).is_static:
+                        raise AppEditingError(
+                            "Report {} not found in {}".format(config.report_id, domain)
+                        )
 
     app.save_attachments(attachments)
 


### PR DESCRIPTION
##### SUMMARY
https://sentry.io/organizations/dimagi/issues/1496719280/

ICDS already has a management command to copy apps in a way compatible with multimaster. Extend this to also allow limiting the check that both the to and from domains have the same reports, so that it only checks static reports.

Based on https://github.com/dimagi/commcare-hq/pull/23991, I think the UI should be allowing this copy and just showing a warning. I'm going to keep looking into that, but for now this PR is to unblock ICDS.