### PR TITLE
prevent regular checkpoint from rewinding pillow

### DIFF
--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -141,8 +141,10 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
     def get_new_seq(self, change):
         return change['seq']
 
-    def update_checkpoint(self, change, context):
+    def update_checkpoint(self, change, context, prevent_rewind=False):
         if self.should_update_checkpoint(context):
+            if prevent_rewind and self.get_new_seq(change) < self.checkpoint.get_current_sequence_id():
+                return False
             context.reset()
             self.checkpoint.update_to(self.get_new_seq(change))
             self.last_update = datetime.utcnow()

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -120,9 +120,9 @@ class PillowBase(metaclass=ABCMeta):
             self.wait_for_change(since)
             pillow_logging.info("Next message arrived.")
 
-    def _update_checkpoint(self, change, context):
+    def _update_checkpoint(self, change, context, prevent_rewind=False):
         if change and context:
-            updated = self.update_checkpoint(change, context)
+            updated = self.update_checkpoint(change, context, prevent_rewind)
         else:
             updated = self.checkpoint.touch(min_interval=CHECKPOINT_MIN_WAIT)
         if updated:
@@ -166,7 +166,7 @@ class PillowBase(metaclass=ABCMeta):
                 self._batch_process_with_error_handling(chunk)
             # only attempt to update checkpoint if there is a latest change
             if last_change:
-                self._update_checkpoint(last_change, context)
+                self._update_checkpoint(last_change, context, prevent_rewind=True)
 
         # keep track of chunk for batch processors
         changes_chunk = []


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This prevents pillows from saving a checkpoint that is lower than the previously saved one. Danny and I spoke about this a while ago, during the pillow rewind issues. Wanted to open it up for review to see if this seems like the right path forward. I still need to do a bit more testing to make sure this works as expected, but wanted to start review to see if this was even worth pursuing