### PR TITLE
OData De-ID Updates

### DIFF
--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -86,6 +86,7 @@ class ODataBaseSerializer(Serializer):
                 split_columns=config.split_multiselects,
                 transform_dates=config.transform_dates,
                 as_json=True,
+                is_odata=True,
             )
             data.extend(rows)
         return data

--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -44,7 +44,7 @@ def _get_odata_fields_from_columns(export_config, special_types, table_id):
 
     metadata = []
     for column in table.selected_columns:
-        for header in column.get_headers(split_column=export_config.split_multiselects):
+        for header in column.get_headers(split_column=export_config.split_multiselects, is_odata=True):
             metadata.append(FieldMetadata(
                 header,
                 special_types.get(_get_dot_path(column), 'Edm.String')

--- a/corehq/apps/api/odata/views.py
+++ b/corehq/apps/api/odata/views.py
@@ -65,9 +65,16 @@ class ODataCaseMetadataView(BaseODataView):
     def get(self, request, domain, config_id, **kwargs):
         table_id = int(kwargs.get('table_id', 0))
         config = get_document_or_404(CaseExportInstance, domain, config_id)
+        case_fields = get_case_odata_fields_from_config(config, table_id)
+
+        field_names = [f.name for f in case_fields]
+        primary_key = 'caseid' if table_id == 0 else 'number'
+        if f'{primary_key} *sensitive*' in field_names:
+            primary_key = f'{primary_key} *sensitive*'
+
         metadata = render_to_string('api/odata_metadata.xml', {
-            'fields': get_case_odata_fields_from_config(config, table_id),
-            'primary_key': 'caseid' if table_id == 0 else 'number',
+            'fields': case_fields,
+            'primary_key': primary_key,
         })
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))
 
@@ -105,9 +112,16 @@ class ODataFormMetadataView(BaseODataView):
     def get(self, request, domain, config_id, **kwargs):
         table_id = int(kwargs.get('table_id', 0))
         config = get_document_or_404(FormExportInstance, domain, config_id)
+        form_fields = get_form_odata_fields_from_config(config, table_id)
+
+        field_names = [f.name for f in form_fields]
+        primary_key = 'formid' if table_id == 0 else 'number'
+        if f'{primary_key} *sensitive*' in field_names:
+            primary_key = f'{primary_key} *sensitive*'
+
         metadata = render_to_string('api/odata_metadata.xml', {
-            'fields': get_form_odata_fields_from_config(config, table_id),
-            'primary_key': 'formid' if table_id == 0 else 'number',
+            'fields': form_fields,
+            'primary_key': primary_key,
         })
         return add_odata_headers(HttpResponse(metadata, content_type='application/xml'))
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -405,9 +405,12 @@ class ExportColumn(DocumentSchema):
     def is_deidentifed(self):
         return bool(self.deid_transform)
 
-    def get_headers(self, split_column=False):
+    def get_headers(self, split_column=False, is_odata=False):
         if self.is_deidentifed:
-            return ["{} {}".format(self.label, "[sensitive]")]
+            return ["{} {}".format(
+                self.label,
+                "*sensitive*" if is_odata else "[sensitive]"
+            )]
         else:
             return [self.label]
 
@@ -484,7 +487,7 @@ class TableConfiguration(DocumentSchema):
         return headers
 
     def get_rows(self, document, row_number, split_columns=False,
-                 transform_dates=False, as_json=False):
+                 transform_dates=False, as_json=False, is_odata=False):
         """
         Return a list of ExportRows generated for the given document.
         :param document: dictionary representation of a form submission or case
@@ -520,7 +523,7 @@ class TableConfiguration(DocumentSchema):
                     transform_dates=transform_dates,
                 )
                 if as_json:
-                    for index, header in enumerate(col.get_headers(split_column=split_columns)):
+                    for index, header in enumerate(col.get_headers(split_column=split_columns, is_odata=is_odata)):
                         if isinstance(val, list):
                             row_data[header] = "{}".format(val[index])
                         else:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1041
(addresses the two linked open tickets in this ticket)

##### SUMMARY
Sensitive fields are now marked as `*sensitive*` instead of `[sensitive]` because it breaks in Tableau due to `[` and `]`. This ONLY applies to OData feeds, not exports.

This also allows primary keys (`formid`, `caseid`) to also get marked as sensitive, without erroring out in Tableau and PowerBI.

cc @marshalldaly looks like it was potentially an easier fix than expected. will see how QA does once this is merged

Feature flag is `Allow De-Identification in OData feeds`