### PR TITLE
do not reuse variable

### DIFF
--- a/custom/icds_reports/static/js/angular-services/locations.service.js
+++ b/custom/icds_reports/static/js/angular-services/locations.service.js
@@ -241,7 +241,7 @@ window.angular.module('icdsApp').factory('locationsService', ['$http', '$locatio
                         locationsCache[item.location_id] = [ALL_OPTION].concat(data.locations);
                         vm.selectedLocations[level + 1] = ALL_OPTION.location_id;
                     } else {
-                        locationsCache[$item.location_id] = data.locations;
+                        locationsCache[item.location_id] = data.locations;
                         vm.selectedLocations[level + 1] = data.locations[0].location_id;
                         vm.onSelect(data.locations[0], level + 1);
                     }

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -2085,8 +2085,8 @@ class CasDataExport(View):
         else:
             if state != location:
                 # check for cached version
-                sync, blob_id = get_cas_data_blob_file(data_type, location_id, selected_date)
-                if not sync:
+                cached_sync, blob_id = get_cas_data_blob_file(data_type, location_id, selected_date)
+                if not cached_sync:
                     try:
                         export_file = filter_cas_data_export(sync, location)
                     except InvalidLocationTypeException as e:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://sentry.io/organizations/dimagi/issues/1581868185/?project=136860&query=is%3Aunresolved

I was incorrectly reusing a variable name. This makes sure i don't clear out the original file when looking for the cached version