### PR TITLE
generate blob_id if missing

### DIFF
--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -2092,8 +2092,9 @@ class CasDataExport(View):
                     except InvalidLocationTypeException as e:
                         return JsonResponse({"message": e})
                     with open(export_file, 'r') as csv_file:
-                        icds_file, new = IcdsFile.objects.get_or_create(blob_id=blob_id, data_type=f'mbt_{data_type}')
+                        blob_id = f'{data_type}-{location_id}-{selected_date}'
                         THREE_DAYS = 60 * 60 * 24 * 3
+                        icds_file, new = IcdsFile.objects.get_or_create(blob_id=blob_id, data_type=f'mbt_{data_type}')
                         icds_file.store_file_in_blobdb(csv_file, expired=THREE_DAYS)
             params = dict(
                 indicator=data_type,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
I misunderstood the interface of `get_cas_data_blob_file` and missed that it does not return the `blob_id` if it cannot find the file, even though the id does not depend on the file.