### PR TITLE
Added cache to the count fetching question as it is same always

### DIFF
--- a/custom/icds_reports/middleware.py
+++ b/custom/icds_reports/middleware.py
@@ -10,7 +10,8 @@ exclude_urls = (
     'icds-ng-template',
     'locations',
     'mwcd_indicators',
-    'data_export_api'
+    'data_export_api',
+    'household_members_data'
 )
 
 AUDIT_URLS = frozenset(

--- a/custom/icds_reports/reports/bihar_api.py
+++ b/custom/icds_reports/reports/bihar_api.py
@@ -1,7 +1,18 @@
 from custom.icds_reports.models.views import BiharDemographicsView
 from custom.icds_reports.const import CAS_API_PAGE_SIZE
+from custom.icds_reports.cache import icds_quickcache
 
 
+# cache for 2 hours because it wont change atleast for 24 hours
+@icds_quickcache(['month', 'state_id'], timeout=60 * 60 * 2)
+def get_total_records_count(month, state_id):
+    return BiharDemographicsView.objects.filter(
+        month=month,
+        state_id=state_id
+    ).count()
+
+
+@icds_quickcache(['month', 'state_id', 'last_person_case_id'], timeout=30 * 60)
 def get_api_demographics_data(month, state_id, last_person_case_id):
     demographics_data_query = BiharDemographicsView.objects.filter(
         month=month,
@@ -55,4 +66,4 @@ def get_api_demographics_data(month, state_id, last_person_case_id):
 
     # To apply pagination on database query with data size length
     limited_demographics_data = list(demographics_data_query[:CAS_API_PAGE_SIZE])
-    return limited_demographics_data,  demographics_data_query.count()
+    return limited_demographics_data,  get_total_records_count(month, state_id)

--- a/custom/icds_reports/reports/bihar_api.py
+++ b/custom/icds_reports/reports/bihar_api.py
@@ -3,7 +3,9 @@ from custom.icds_reports.const import CAS_API_PAGE_SIZE
 from custom.icds_reports.cache import icds_quickcache
 
 
-# cache for 2 hours because it wont change atleast for 24 hours
+# cache for 2 hours because it wont change atleast for 24 hours.
+# This API will be hit in a loop of something and they should be able to scrape all
+# the records in 2 hours.
 @icds_quickcache(['month', 'state_id'], timeout=60 * 60 * 2)
 def get_total_records_count(month, state_id):
     return BiharDemographicsView.objects.filter(

--- a/custom/icds_reports/tests/agg_tests/reports/test_bihar_api_demographics.py
+++ b/custom/icds_reports/tests/agg_tests/reports/test_bihar_api_demographics.py
@@ -13,7 +13,7 @@ class DemographicsAPITest(TestCase):
     def test_file_content(self):
         BiharAPIDemographics.aggregate(date(2017, 5, 1))
         data,count = get_api_demographics_data(
-            month=date(2017, 5, 1),
+            month=date(2017, 5, 1).strftime("%Y-%m-%d"),
             state_id='st1',
             last_person_case_id=''
         )

--- a/custom/icds_reports/tests/agg_tests/reports/test_bihar_api_demographics.py
+++ b/custom/icds_reports/tests/agg_tests/reports/test_bihar_api_demographics.py
@@ -12,7 +12,7 @@ class DemographicsAPITest(TestCase):
 
     def test_file_content(self):
         BiharAPIDemographics.aggregate(date(2017, 5, 1))
-        data,count = get_api_demographics_data(
+        data, count = get_api_demographics_data(
             month=date(2017, 5, 1).strftime("%Y-%m-%d"),
             state_id='st1',
             last_person_case_id=''

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -2455,7 +2455,7 @@ class BiharDemographicsAPI(BaseCasAPIView):
         if error_message:
             return JsonResponse({"message": error_message}, status=400)
 
-        if not self.query_month_in_range(valid_query_month, start_month=date(2017, 1, 1)):
+        if not self.query_month_in_range(valid_query_month, start_month=date(2020, 1, 1)):
             return JsonResponse(self.message('invalid_month'), status=400)
 
         if not self.has_access(self.bihar_state_id, request.couch_user):

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -2474,8 +2474,7 @@ class BiharDemographicsAPI(BaseCasAPIView):
             }
         }
 
-        return JsonResponse(data=response_json,
-                            json_dumps_params={'ensure_ascii':False})  # This is to let non-english names to be sent as it is
+        return JsonResponse(data=response_json)
 
     @property
     def bihar_state_id(self):

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -2461,7 +2461,7 @@ class BiharDemographicsAPI(BaseCasAPIView):
         if not self.has_access(self.bihar_state_id, request.couch_user):
             return JsonResponse(self.message('access_denied'), status=403)
 
-        demographics_data, total_count = get_api_demographics_data(valid_query_month,
+        demographics_data, total_count = get_api_demographics_data(valid_query_month.strftime("%Y-%m-%d"),
                                                                    self.bihar_state_id,
                                                                    last_person_case_id)
         response_json = {

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -2474,7 +2474,8 @@ class BiharDemographicsAPI(BaseCasAPIView):
             }
         }
 
-        return JsonResponse(data=response_json)
+        return JsonResponse(data=response_json,
+                            json_dumps_params={'ensure_ascii':False})  # This is to let non-english names to be sent as it is
 
     @property
     def bihar_state_id(self):


### PR DESCRIPTION
Added cache while finding the count because this total count will always be the same.
Keeping the count cached for 2 hours as this API will likely be hit by a loop or something like that, not a browser and this is for only one state So I think in 2 hours they should be able to scrape all the data. That's why keeping it cached for 2 hours and the frequency will also be monthly not even daily.  