### PR TITLE
fix renamed param in password CBV

### DIFF
--- a/custom/icds_reports/mobile_views.py
+++ b/custom/icds_reports/mobile_views.py
@@ -45,7 +45,7 @@ def password_reset(request, domain):
     kwargs['extra_context']['form_submit_url'] = reverse('cas_mobile_dashboard_password_reset', args=[domain])
     kwargs['extra_context']['login_url'] = reverse('cas_mobile_dashboard_login', args=[domain])
     # so that we can redirect to a custom "done" page
-    kwargs['post_reset_redirect'] = reverse('cas_mobile_dashboard_password_reset_done', args=[domain])
+    kwargs['success_url'] = reverse('cas_mobile_dashboard_password_reset_done', args=[domain])
     return auth_views.PasswordResetView.as_view(**kwargs)(request)
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://github.com/dimagi/commcare-hq/pull/26857#discussion_r400660168

From https://df.readthedocs.io/en/latest/topics/auth/default.html
> The optional arguments of this view are similar to the class-based PasswordResetView attributes, except the post_reset_redirect and password_reset_form arguments which map to the success_url and form_class attributes of the class-based view.

