### PR TITLE
[de-id text change] always format [sensitive] as *sensitive*

### DIFF
--- a/corehq/apps/api/odata/serializers.py
+++ b/corehq/apps/api/odata/serializers.py
@@ -86,7 +86,6 @@ class ODataBaseSerializer(Serializer):
                 split_columns=config.split_multiselects,
                 transform_dates=config.transform_dates,
                 as_json=True,
-                is_odata=True,
             )
             data.extend(rows)
         return data

--- a/corehq/apps/api/odata/utils.py
+++ b/corehq/apps/api/odata/utils.py
@@ -44,7 +44,7 @@ def _get_odata_fields_from_columns(export_config, special_types, table_id):
 
     metadata = []
     for column in table.selected_columns:
-        for header in column.get_headers(split_column=export_config.split_multiselects, is_odata=True):
+        for header in column.get_headers(split_column=export_config.split_multiselects):
             metadata.append(FieldMetadata(
                 header,
                 special_types.get(_get_dot_path(column), 'Edm.String')

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -405,12 +405,9 @@ class ExportColumn(DocumentSchema):
     def is_deidentifed(self):
         return bool(self.deid_transform)
 
-    def get_headers(self, split_column=False, is_odata=False):
+    def get_headers(self, split_column=False):
         if self.is_deidentifed:
-            return ["{} {}".format(
-                self.label,
-                "*sensitive*" if is_odata else "[sensitive]"
-            )]
+            return [f"{self.label} *sensitive*"]
         else:
             return [self.label]
 
@@ -487,7 +484,7 @@ class TableConfiguration(DocumentSchema):
         return headers
 
     def get_rows(self, document, row_number, split_columns=False,
-                 transform_dates=False, as_json=False, is_odata=False):
+                 transform_dates=False, as_json=False):
         """
         Return a list of ExportRows generated for the given document.
         :param document: dictionary representation of a form submission or case
@@ -523,7 +520,7 @@ class TableConfiguration(DocumentSchema):
                     transform_dates=transform_dates,
                 )
                 if as_json:
-                    for index, header in enumerate(col.get_headers(split_column=split_columns, is_odata=is_odata)):
+                    for index, header in enumerate(col.get_headers(split_column=split_columns)):
                         if isinstance(val, list):
                             row_data[header] = "{}".format(val[index])
                         else:

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -829,7 +829,7 @@ class ExportTest(SimpleTestCase):
             {
                 'My table': {
                     'headers': [
-                        'DEID Date Transform column [sensitive]',
+                        'DEID Date Transform column *sensitive*',
                     ],
                     'rows': [
                         [MISSING_VALUE],
@@ -946,4 +946,4 @@ class TableHeaderTest(SimpleTestCase):
             label="my column",
             deid_transform="deid_id",
         )
-        self.assertEqual(col.get_headers(), ["my column [sensitive]"])
+        self.assertEqual(col.get_headers(), ["my column *sensitive*"])


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1041

##### SUMMARY
There's some very strange caching behavior on prod that I'm not able to replicate on staging or locally. Since De-Id is such a sparsely used feature and since this is only going to be a text change `[sensitive]` to `*sensitive*`, we've decided it is not worth the cost/effort to have `sensitive` be marked with `*` vs brackets only for OData feeds...