### PR TITLE
add soft assert for no group by

### DIFF
--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -280,7 +280,10 @@ class SqlData(ReportDataSource):
             raise SqlReportException('Keys supplied without group_by.')
 
         if not self.group_by:
-            queries = self.get_sql_queries()
+            try:
+                queries = self.get_sql_queries()
+            except NotImplementedError:
+                queries = "Not implemented"
             soft_assert('mkangia@{}'.format('dimagi.com'))(
                 self.group_by, f'SqlAgg has no group by: {self.__class__.__name__}', queries
             )

--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -17,6 +17,7 @@ from corehq.apps.reports.datatables import (
 )
 from corehq.apps.reports.util import format_datatables_data
 from corehq.sql_db.connections import DEFAULT_ENGINE_ID, connection_manager
+from corehq.util.soft_assert import soft_assert
 
 
 class SqlReportException(Exception):
@@ -277,6 +278,12 @@ class SqlData(ReportDataSource):
     def _get_data(self, start=None, limit=None):
         if self.keys is not None and not self.group_by:
             raise SqlReportException('Keys supplied without group_by.')
+
+        if not self.group_by:
+            queries = self.get_sql_queries()
+            soft_assert('mkangia@{}'.format('dimagi.com'))(
+                self.group_by, f'SqlAgg has no group by: {self.__class__.__name__}', queries
+            )
 
         qc = self.query_context(start=start, limit=limit)
         session_helper = connection_manager.get_session_helper(self.engine_id, readonly=True)

--- a/corehq/apps/reports/tests/test_sql_reports.py
+++ b/corehq/apps/reports/tests/test_sql_reports.py
@@ -2,7 +2,6 @@ from datetime import datetime, time
 
 from django import test as unittest
 from django.test.client import RequestFactory
-from unittest2 import skip
 
 from dimagi.utils.dates import DateSpan
 
@@ -10,6 +9,7 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
 from corehq.sql_db.connections import Session
 from corehq.util.dates import iso_string_to_date
+from corehq.util.test_utils import softer_assert
 
 from .sql_fixture import load_data
 from .sql_reports import RegionTestReport, UserTestReport, test_report
@@ -67,13 +67,13 @@ class BaseReportTest(unittest.TestCase):
 
 class SimpleReportTest(BaseReportTest):
 
-    @skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
+    @softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
     def test_no_group_no_filter(self):
         html_data, sort_data = self._get_report_data(test_report(UserTestReport), "2013-01-01", "2013-02-01")
         self.assertEqual(len(sort_data), 1)
         self.assertEqual(sort_data[0], [2, 2, 66])
 
-    @skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
+    @softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
     def test_no_group_with_filter(self):
         filters = ["date > :startdate"]
         report = test_report(UserTestReport, filters=filters)

--- a/corehq/apps/reports/tests/test_sql_reports.py
+++ b/corehq/apps/reports/tests/test_sql_reports.py
@@ -2,6 +2,7 @@ from datetime import datetime, time
 
 from django import test as unittest
 from django.test.client import RequestFactory
+from unittest2 import skip
 
 from dimagi.utils.dates import DateSpan
 
@@ -66,11 +67,13 @@ class BaseReportTest(unittest.TestCase):
 
 class SimpleReportTest(BaseReportTest):
 
+    @skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
     def test_no_group_no_filter(self):
         html_data, sort_data = self._get_report_data(test_report(UserTestReport), "2013-01-01", "2013-02-01")
         self.assertEqual(len(sort_data), 1)
         self.assertEqual(sort_data[0], [2, 2, 66])
 
+    @skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
     def test_no_group_with_filter(self):
         filters = ["date > :startdate"]
         report = test_report(UserTestReport, filters=filters)

--- a/custom/champ/sqldata.py
+++ b/custom/champ/sqldata.py
@@ -180,6 +180,7 @@ class TargetsDataSource(ChampSqlData):
 
     @property
     def group_by(self):
+        # ToDo: add a group by clause here or test before release
         return []
 
     @property

--- a/custom/champ/tests/test_pva_chart.py
+++ b/custom/champ/tests/test_pva_chart.py
@@ -1,15 +1,14 @@
 import json
 import mock
 
-from unittest2 import skip
-
+from corehq.util.test_utils import softer_assert
 from custom.champ.tests.utils import ChampTestCase
 from custom.champ.views import PrevisionVsAchievementsView
 
 from django.urls import reverse
 
 
-@skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
+@softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
 class TestPVAChart(ChampTestCase):
 
     def setUp(self):

--- a/custom/champ/tests/test_pva_chart.py
+++ b/custom/champ/tests/test_pva_chart.py
@@ -1,12 +1,15 @@
 import json
 import mock
 
+from unittest2 import skip
+
 from custom.champ.tests.utils import ChampTestCase
 from custom.champ.views import PrevisionVsAchievementsView
 
 from django.urls import reverse
 
 
+@skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
 class TestPVAChart(ChampTestCase):
 
     def setUp(self):

--- a/custom/champ/tests/test_pva_table.py
+++ b/custom/champ/tests/test_pva_table.py
@@ -1,7 +1,6 @@
+from corehq.util.test_utils import softer_assert
 from custom.champ.tests.utils import ChampTestCase
 from custom.champ.views import PrevisionVsAchievementsTableView
-
-from unittest2 import skip
 
 import json
 import mock
@@ -9,7 +8,7 @@ import mock
 from django.urls import reverse
 
 
-@skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
+@softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
 class TestPVATable(ChampTestCase):
 
     def setUp(self):

--- a/custom/champ/tests/test_pva_table.py
+++ b/custom/champ/tests/test_pva_table.py
@@ -1,12 +1,15 @@
 from custom.champ.tests.utils import ChampTestCase
 from custom.champ.views import PrevisionVsAchievementsTableView
 
+from unittest2 import skip
+
 import json
 import mock
 
 from django.urls import reverse
 
 
+@skip("to add back post https://github.com/dimagi/sql-agg/pull/56")
 class TestPVATable(ChampTestCase):
 
     def setUp(self):

--- a/custom/up_nrhm/tests/reports/test_asha_reports.py
+++ b/custom/up_nrhm/tests/reports/test_asha_reports.py
@@ -1,12 +1,21 @@
-from mock.mock import MagicMock
 import mock
+from mock.mock import MagicMock
 
+from corehq.util.test_utils import softer_assert
+from custom.up_nrhm.reports.asha_facilitators_report import (
+    ASHAFacilitatorsReport,
+)
+from custom.up_nrhm.reports.asha_functionality_checklist_report import (
+    ASHAFunctionalityChecklistReport,
+)
 from custom.up_nrhm.reports.block_level_af_report import BlockLevelAFReport
-from custom.up_nrhm.reports.block_level_month_report import BlockLevelMonthReport
-from custom.up_nrhm.reports.district_functionality_report import DistrictFunctionalityReport
+from custom.up_nrhm.reports.block_level_month_report import (
+    BlockLevelMonthReport,
+)
+from custom.up_nrhm.reports.district_functionality_report import (
+    DistrictFunctionalityReport,
+)
 from custom.up_nrhm.tests.utils import UpNrhmTestCase
-from custom.up_nrhm.reports.asha_functionality_checklist_report import ASHAFunctionalityChecklistReport
-from custom.up_nrhm.reports.asha_facilitators_report import ASHAFacilitatorsReport
 
 RUN_QUERY_VALUE = {
     'hits': {
@@ -66,6 +75,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             ]
         )
 
+    @softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
     @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_asha_facilitators_report(self, mock_run_query):
         mock = MagicMock()
@@ -135,6 +145,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             for record in expected[0][i]:
                 self.assertIn(record, rows[0][i])
 
+    @softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
     @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_block_level_month_report(self, mock_run_query):
         mock = MagicMock()
@@ -213,6 +224,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             for record in expected[0][i]:
                 self.assertIn(record, rows[0][i])
 
+    @softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
     @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_block_level_af_report(self, mock_run_query):
         mock = MagicMock()
@@ -352,6 +364,7 @@ class TestASHAFunctionalityChecklistReport(UpNrhmTestCase):
             for record in expected[0][i]:
                 self.assertIn(record, rows[0][i])
 
+    @softer_assert("to add back post https://github.com/dimagi/sql-agg/pull/56")
     @mock.patch('corehq.apps.es.es_query.run_query', return_value=RUN_QUERY_VALUE)
     def test_district_functionality_report(self, mock_run_query):
         mock = MagicMock()


### PR DESCRIPTION
In order to bring https://github.com/dimagi/sql-agg/pull/56/files into action, an effort to find out reports that are currently configured without `group by` clause so that they can be updated to use a list of records returned instead of just one.