### PR TITLE
remove mail_admins from accounting errors

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1229,7 +1229,7 @@ LOGGING = {
             'propagate': False,
         },
         'accounting': {
-            'handlers': ['accountinglog', 'console', 'mail_admins'],
+            'handlers': ['accountinglog', 'console'],
             'level': 'INFO',
             'propagate': False,
         },


### PR DESCRIPTION
stops the massive email spam to commcarehq-ops+admins@dimagi.com