### PR TITLE
remove caching of Bihar data

### DIFF
--- a/custom/icds_reports/reports/bihar_api.py
+++ b/custom/icds_reports/reports/bihar_api.py
@@ -14,7 +14,6 @@ def get_total_records_count(month, state_id):
     ).count()
 
 
-@icds_quickcache(['month', 'state_id', 'last_person_case_id'], timeout=30 * 60)
 def get_api_demographics_data(month, state_id, last_person_case_id):
     demographics_data_query = BiharDemographicsView.objects.filter(
         month=month,


### PR DESCRIPTION
This code change removes the caching of Bihar demographics data because of the LARGE size of the data. Another reason is that. Since this will be accessed via some code so its very rare that same filter is used again. Because of both of the above reason, I think it is better not to cache the result