### PR TITLE
Added tracking for apps imported from COVID library

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
@@ -31,7 +31,11 @@ hqDefine("app_manager/js/app_exchange", [
         $("#hq-content").koApplyBindings(AppExchangeModel());
 
         $('.import-button').on('click', function () {
-            kissmetrics.track.event("COVID App Library: Imported application");
+            var $tile = $(this).closest(".well");
+            kissmetrics.track.event("COVID App Library: Imported application", {
+                app_id: $tile.find("[name='from_app_id']").val(),
+                app_name: $tile.find(".app-name").text(),
+            });
         });
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_exchange.js
@@ -1,10 +1,12 @@
 hqDefine("app_manager/js/app_exchange", [
     "jquery",
     "knockout",
+    'analytix/js/kissmetrix',
     "hqwebapp/js/widgets",  // hqwebapp-select2 for versions
 ], function (
     $,
-    ko
+    ko,
+    kissmetrics
 ) {
     var AppExchangeModel = function () {
         var self = {};
@@ -27,5 +29,9 @@ hqDefine("app_manager/js/app_exchange", [
 
     $(function () {
         $("#hq-content").koApplyBindings(AppExchangeModel());
+
+        $('.import-button').on('click', function () {
+            kissmetrics.track.event("COVID App Library: Imported application");
+        });
     });
 });

--- a/corehq/apps/app_manager/templates/app_manager/app_exchange.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_exchange.html
@@ -51,7 +51,7 @@
           {% csrf_token %}
           <div class="col-sm-3">
             <div class="well well-lg text-center">
-              <h3>{{ app.name }}</h3>
+              <h3 class="app-name">{{ app.name }}</h3>
               {% if app.help_link %}
                 <p>
                   <a target="_blank" href="{{ app.help_link }}">{% trans "Application Info" %}</a>

--- a/corehq/apps/app_manager/templates/app_manager/app_exchange.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_exchange.html
@@ -83,7 +83,7 @@
                   <input type="hidden" name="from_app_id" value="{{ version.id }}" />
                 {% endfor %}
               {% endif %}
-              <button type="submit" class="btn btn-primary">
+              <button type="submit" class="btn btn-primary import-button">
                 <i class="fa fa-cloud-download"></i>
                 {% trans "Import" %}
               </button>

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -585,7 +585,9 @@ def app_exchange(request, domain):
     if request.method == "POST":
         clear_app_cache(request, domain)
         from_app_id = request.POST.get('from_app_id')
-        app_copy = import_app_util(from_app_id, domain)
+        app_copy = import_app_util(from_app_id, domain, {
+            'created_from_template': from_app_id,
+        })
         return back_to_main(request, domain, app_id=app_copy._id)
 
     return render(request, template, context)


### PR DESCRIPTION
##### SUMMARY
Adds a kissmetrics event when an app is imported, and stores the id of the app that was imported.

Tagged SaaS devs for review. I'd like to deploy this later today.