### PR TITLE
add ability to exclude archive relations

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -435,14 +435,17 @@ class SQLLocation(AdjListModel):
 
     full_delete = delete
 
-    def get_descendants(self, include_self=False, **kwargs):
+    def get_descendants(self, include_self=False, include_archived=True, **kwargs):
         if include_self:
             where = Q(domain=self.domain, id=self.id)
         else:
             where = Q(domain=self.domain, parent_id=self.id)
-        return SQLLocation.objects.get_descendants(
+        queryset = SQLLocation.objects.get_descendants(
             where, **kwargs
         )
+        if not include_archived:
+            queryset = queryset.filter(is_archived=False)
+        return queryset
 
     def get_ancestors(self, include_self=False, **kwargs):
         where = Q(domain=self.domain, id=self.id if include_self else self.parent_id)

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -158,8 +158,7 @@ class SimplifiedInventoryDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 locations = []
 
             locations += list(
-                self.active_location.get_descendants().filter(
-                    is_archived=False,
+                self.active_location.get_descendants(include_archived=False).filter(
                     supply_point_id__isnull=False
                 )
             )

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -213,7 +213,7 @@ class ScheduleInstance(PartitionedModel):
                 # for locations the user selected in the UI, and not for
                 # locations that happen to get here because they are a case
                 # owner, for example.
-                qs = location.get_descendants(include_self=True).filter(is_archived=False)
+                qs = location.get_descendants(include_self=True, include_archived=False)
 
                 # We also only apply the location_type_filter when the recipient_type
                 # is RECIPIENT_TYPE_LOCATION for the same reason.

--- a/custom/intrahealth/report_calcs.py
+++ b/custom/intrahealth/report_calcs.py
@@ -57,8 +57,8 @@ def get_product_id(product_name, domain):
 
 
 def _locations_per_type(domain, loc_type, location):
-    return (location.get_descendants(include_self=True)
-            .filter(domain=domain, location_type__name=loc_type, is_archived=False).count())
+    return (location.get_descendants(include_self=True, include_archived=False)
+            .filter(domain=domain, location_type__name=loc_type).count())
 
 
 def get_product_name(product_id):


### PR DESCRIPTION
Does not change anything across HQ but just makes it possible to look up only active relations for SQLLocation. 
I am not confident to change the usages of these methods but setting it up so that it was be used further when creating new calls (adding one soon) or updating the old ones if possible.
