### PR TITLE
Remove model manager only used in one place

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -341,16 +341,6 @@ class OnlyUnarchivedLocationManager(LocationManager):
         return list(self.accessible_to_user(domain, user).location_ids())
 
 
-class OnlyArchivedLocationManager(LocationManager):
-
-    def get_queryset(self):
-        return (super(OnlyArchivedLocationManager, self).get_queryset()
-                .filter(is_archived=True))
-
-    def accessible_location_ids(self, domain, user):
-        return list(self.accessible_to_user(domain, user).location_ids())
-
-
 class SQLLocation(AdjListModel):
     domain = models.CharField(max_length=255, db_index=True)
     name = models.CharField(max_length=255, null=True)
@@ -381,7 +371,6 @@ class SQLLocation(AdjListModel):
     objects = _tree_manager = LocationManager()
     # This should really be the default location manager
     active_objects = OnlyUnarchivedLocationManager()
-    inactive_objects = OnlyArchivedLocationManager()
 
     def get_ancestor_of_type(self, type_code):
         """

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -87,12 +87,10 @@ class EmwfOptionsController(object):
         return [self.utils.reporting_group_tuple(g) for g in groups_query.run().hits]
 
     def get_locations_query(self, query):
-        show_inactive = json.loads(self.request.GET.get('show_inactive', 'false'))
-        if show_inactive:
-            included_objects = SQLLocation.inactive_objects
-        else:
-            included_objects = SQLLocation.active_objects
-        locations = included_objects.filter_by_user_input(self.domain, query)
+        show_inactive = self.request.GET.get('show_inactive') == 'true'
+        locations = (SQLLocation.objects
+                     .filter_by_user_input(self.domain, query)
+                     .filter(is_archived=show_inactive))
         if self.case_sharing_only:
             locations = locations.filter(location_type__shares_cases=True)
         return locations.accessible_to_user(self.domain, self.request.couch_user)

--- a/corehq/apps/reports/filters/controllers.py
+++ b/corehq/apps/reports/filters/controllers.py
@@ -1,5 +1,3 @@
-import json
-
 from memoized import memoized
 
 from corehq.apps.es import GroupES, UserES, groups


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
Minor bit of cleanup related to a recent discussion
I believe `show_inactive` is only set [here](https://github.com/dimagi/commcare-hq/blob/5e625e67ec2fc41dc3ee2267d1eed01c2613eee5/corehq/apps/locations/static/locations/js/utils.js#L22-L22), when using the location search feature.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
