### PR TITLE
Fix verify phone number workflow

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -660,6 +660,10 @@ def process_incoming(msg):
         is_two_way = v is not None and v.is_two_way
 
         if msg.domain and domain_has_privilege(msg.domain, privileges.INBOUND_SMS):
+            if v and v.pending_verification:
+                from . import verify
+                handled = verify.process_verification(v, msg, create_subevent_for_inbound=not has_domain_two_way_scope)
+
             if (
                 (is_two_way or has_domain_two_way_scope)
                 and is_contact_active(v.domain, v.owner_doc_type, v.owner_id)


### PR DESCRIPTION
##### SUMMARY
I feel a little nuts saying this but it seems like the verify user phone number workflow is broken and has been since around Feb 17 when 2adfd8e2b3b195a348cc24c404b5aeaab1256603 was deployed. My data points are that it's broken now, and that my reading of the code says the only reference of the function that completes the verification process (`process_verification`) was removed in that commit, so that seems like the logical conclusion, but perhaps there's some explanation for the phenomena.

Going to test this out on staging.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
