### PR TITLE
Whatsapp domain setting

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -391,6 +391,9 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     # If this is None, then the default is applied. See get_daily_outbound_sms_limit()
     custom_daily_outbound_sms_limit = IntegerProperty()
 
+    # Twilio Whatsapp-enabled phone number
+    twilio_whatsapp_phone_number = StringProperty()
+
     # Allowed number of case updates or closes from automatic update rules in the daily rule run.
     # If this value is None, the value in settings.MAX_RULE_UPDATES_IN_ONE_RUN is used.
     auto_case_update_limit = IntegerProperty()

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -20,6 +20,7 @@ from crispy_forms.layout import Div
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.django.fields import TrimmedCharField
 
+from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_built_app_ids
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import DayTimeWindow
@@ -267,6 +268,9 @@ class SettingsForm(Form):
         choices=LANGUAGE_FALLBACK_CHOICES,
         label=ugettext_lazy("Backup behavior for missing translations"),
     )
+    twilio_whatsapp_phone_number = CharField(
+        required=False,
+    )
 
     # Internal settings
     override_daily_outbound_sms_limit = ChoiceField(
@@ -397,6 +401,14 @@ class SettingsForm(Form):
                 """),
             ),
         ]
+
+        if toggles.WHATSAPP_MESSAGING.enabled(self.domain):
+            fields.append(hqcrispy.FieldWithHelpBubble(
+                'twilio_whatsapp_phone_number',
+                help_bubble_text=_("""
+                    Whatsapp-enabled phone number for use with Twilio.
+                """),
+            ))
 
         return crispy.Fieldset(
             _("Registration Settings"),

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1820,6 +1820,8 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
                     ENABLED if domain_obj.custom_daily_outbound_sms_limit else DISABLED,
                 "custom_daily_outbound_sms_limit":
                     domain_obj.custom_daily_outbound_sms_limit,
+                "twilio_whatsapp_phone_number":
+                    domain_obj.twilio_whatsapp_phone_number,
             }
             form = SettingsForm(
                 initial=initial,
@@ -1872,6 +1874,12 @@ class SMSSettingsView(BaseMessagingSectionView, AsyncHandlerMixin):
                     ("custom_daily_outbound_sms_limit",
                      "custom_daily_outbound_sms_limit"),
                 ])
+            if toggles.WHATSAPP_MESSAGING.enabled(self.domain):
+                field_map.extend([
+                    ("twilio_whatsapp_phone_number",
+                     "twilio_whatsapp_phone_number"),
+                ])
+
             for (model_field_name, form_field_name) in field_map:
                 setattr(domain_obj, model_field_name,
                     form.cleaned_data[form_field_name])


### PR DESCRIPTION
##### SUMMARY
To follow on https://github.com/dimagi/commcare-hq/pull/27067 this should allow us to send messages from an actual account, instead of just to and from the sandbox.

This is for demo purposes. It's possible that for real projects this should be stored somewhere else, maybe an environment setting or a flag on the Twilio backend.

##### FEATURE FLAG
Default SMS to send messages via Whatsapp, where available

##### PRODUCT DESCRIPTION
Prototype code, not worth announcing.
