### PR TITLE
No repeat saved exports

### DIFF
--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -123,7 +123,7 @@ def rebuild_saved_export(export_instance_id, manual=False):
     download_data = _get_saved_export_download_data(export_instance_id)
     status = get_task_status(download_data.task)
     if manual and status.missing() and download_data.task:
-        download_data.task.revoke()
+        download_data.task.revoke(terminate=True)
     if status.not_started() or status.started():
         return
 

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -173,7 +173,7 @@ def _is_real_task(task):
         #   - task_id: <task_id>
         # If ANYTHING else is set, we give it the benefit of the doubt and call it real
         return any(
-            value
+            value is not None
             for key, value in task._get_task_meta().items()
             if not (
                 (key == 'status' and value == 'PENDING')

--- a/corehq/ex-submodules/soil/progress.py
+++ b/corehq/ex-submodules/soil/progress.py
@@ -167,7 +167,21 @@ def get_task_status(task, is_multiple_download_task=False):
 def _is_real_task(task):
     # You can look up a task with a made-up ID and it'll give you a meaningless task object
     # Make sure the task object you have corresponds to an actual celery task
-    return task and task._get_task_meta().get('task_name') is not None
+    if task:
+        # Non-real "tasks" will have all null values except for
+        #   - status: "PENDING"
+        #   - task_id: <task_id>
+        # If ANYTHING else is set, we give it the benefit of the doubt and call it real
+        return any(
+            value
+            for key, value in task._get_task_meta().items()
+            if not (
+                (key == 'status' and value == 'PENDING')
+                or key == 'task_id'
+            )
+        )
+    else:
+        return False
 
 
 def _is_task_pending(task):

--- a/corehq/ex-submodules/soil/tests/test_get_task_status.py
+++ b/corehq/ex-submodules/soil/tests/test_get_task_status.py
@@ -1,0 +1,86 @@
+import datetime
+
+from django.test import SimpleTestCase, override_settings
+
+from soil.progress import get_task_status, TaskStatus, TaskProgress, STATES
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+class GetTaskStatusTest(SimpleTestCase):
+    def test_missing(self):
+        self.assertEqual(get_task_status(self.MockTask(
+            task_meta={
+                'date_done': None,
+                'result': None,
+                'status': 'PENDING',
+                'task_args': None,
+                'task_id': 'obviously fake!',
+                'task_kwargs': None,
+                'task_name': None,
+                'traceback': None
+            }
+        )), TaskStatus(
+            result=None,
+            error=None,
+            state=STATES.missing,
+            progress=TaskProgress(
+                current=None,
+                total=None,
+                percent=None,
+                error=False,
+                error_message=''
+            )
+        ))
+
+    def test_not_missing(self):
+        self.assertEqual(get_task_status(self.MockTask(
+            task_meta={
+                'children': [],
+                'date_done': datetime.datetime(2020, 4, 7, 14, 37, 1, 926615),
+                'result': {'current': 17076, 'total': 10565489},
+                'status': 'PROGRESS',
+                'task_args': None,
+                'task_id': '2243626c-f725-442e-b257-b018a0860d1b',
+                'task_kwargs': None,
+                'task_name': None,
+                'traceback': None
+            }
+        )), TaskStatus(
+            result=None,
+            error=None,
+            state=STATES.started,
+            progress=TaskProgress(
+                current=17076,
+                total=10565489,
+                percent=100 * 17076 // 10565489,
+                error=False,
+                error_message=''
+            )
+        ))
+
+    class MockTask(object):
+        def __init__(self, task_meta, failed=False, successful=False):
+            self.__task_meta = task_meta
+            self.__failed = failed
+            self.__successful = successful
+
+        def _get_task_meta(self):
+            return self.__task_meta
+
+        def failed(self):
+            return self.__failed
+
+        def successful(self):
+            return self.__successful
+
+        @property
+        def status(self):
+            return self.__task_meta.get('status')
+
+        state = status
+
+        @property
+        def result(self):
+            return self.__task_meta.get('result')
+
+        info = result


### PR DESCRIPTION
##### SUMMARY
We previously were calling tasks "missing" when they weren't, and also we weren't terminating saved export tasks when we revoked them, so together those were making it so that when someone rage clicks the Update Data button on saved exports, it floods the queue with duplicate tasks for their (probably super huge) saved export.

This plugs both of those holes (either of which would have been enough to fix the immediate issue) and adds a test for the change in the "missing" determination.

This originated in https://github.com/dimagi/commcare-hq/pull/26494 which was fixing a real problem (people couldn't force restart a data upload because the "existing" task was actually missing from the backend), but apparently way over-corrected (it was calling many tasks—possibly every task—missing when it wasn't).