### PR TITLE
Make Sure Accounting Errors Go to Sentry

### DIFF
--- a/corehq/apps/accounting/exceptions.py
+++ b/corehq/apps/accounting/exceptions.py
@@ -60,3 +60,27 @@ class ProductPlanNotFoundError(Exception):
 
 class EnterpriseReportError(Exception):
     pass
+
+
+class NoActiveSubscriptionError(Exception):
+    pass
+
+
+class MultipleActiveSubscriptionsError(Exception):
+    pass
+
+
+class ActiveSubscriptionWithoutDomain(Exception):
+    pass
+
+
+class CreditLineBalanceMismatchError(Exception):
+    pass
+
+
+class AccountingCommunicationError(Exception):
+    pass
+
+
+class SubscriptionTaskError(Exception):
+    pass

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -368,14 +368,6 @@ class CreditStripePaymentHandler(BaseStripePaymentHandler):
                     subscription=self.subscription,
                     payment_record=payment_record,
                 ))
-            else:
-                log_accounting_error(
-                    "{account} tried to make a payment for Credits for less than $0.5."
-                    "You should follow up with them."
-                    .format(
-                        account=self.account,
-                    )
-                )
 
 
 class AutoPayInvoicePaymentHandler(object):

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -33,6 +33,7 @@ from corehq.apps.accounting.exceptions import (
     NewSubscriptionError,
     PaymentRequestError,
     SubscriptionAdjustmentError,
+    SubscriptionRenewalError,
 )
 from corehq.apps.accounting.forms import (
     AnnualPlanContactForm,
@@ -1560,13 +1561,15 @@ class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin
     def next_plan_version(self):
         plan_version = DefaultProductPlan.get_default_plan_version(self.new_edition)
         if plan_version is None:
-            log_accounting_error(
-                "Could not find a matching renewable plan "
-                "for %(domain)s, subscription number %(sub_pk)s." % {
-                    'domain': self.domain,
-                    'sub_pk': self.subscription.pk
-                }
-            )
+            try:
+                # needed for sending to sentry
+                raise SubscriptionRenewalError()
+            except SubscriptionRenewalError:
+                log_accounting_error(
+                    f"Could not find a matching renewable plan "
+                    f"for {self.domain}, "
+                    f"subscription number {self.subscription.pk}."
+                )
             raise Http404
         return plan_version
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10763

##### SUMMARY
This is a followup to https://github.com/dimagi/commcare-hq/pull/27031 where I removed `mail_admins` from the `accounting` `Logger`. For Accounting errors that we care about (ideally we care about ALL accounting errors), we need to make sure they go to Sentry. If an exception is not raised before calling `log_accounting_error`, HQ will swallow it and not send it to Sentry. This is generally ok for most things, but I think accounting issues are probably the most critical to have records for.