### PR TITLE
Fix sync messaging on hard-deleted case

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import date, datetime, time
 
 from django.db.models import Q
@@ -58,6 +59,7 @@ from corehq.messaging.scheduling.tests.util import (
 )
 from corehq.messaging.tasks import (
     run_messaging_rule,
+    sync_case_for_messaging,
     sync_case_for_messaging_rule,
 )
 from corehq.sql_db.util import paginate_query_across_partitioned_databases
@@ -614,9 +616,8 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
             instances = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)
             self.assertEqual(instances.count(), 0)
 
-    @run_with_all_backends
-    @patch('corehq.messaging.scheduling.util.utcnow')
-    def test_timed_schedule_specific_start_date(self, utcnow_patch):
+    @contextmanager
+    def setup_timed_schedule_with_case(self, utcnow_patch):
         schedule = TimedSchedule.create_simple_daily_schedule(
             self.domain,
             TimedEvent(time=time(9, 0)),
@@ -644,6 +645,13 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
         utcnow_patch.return_value = datetime(2018, 2, 28, 7, 0)
         with create_case(self.domain, 'person') as case:
+            yield schedule, rule, definition, case
+
+    @run_with_all_backends
+    @patch('corehq.messaging.scheduling.util.utcnow')
+    def test_timed_schedule_specific_start_date(self, utcnow_patch):
+        setup = self.setup_timed_schedule_with_case(utcnow_patch)
+        with setup as (schedule, rule, definition, case):
             # Rule does not match, no instances created
             instances = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)
             self.assertEqual(instances.count(), 0)
@@ -710,6 +718,20 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
             self.assertEqual(instances[0].schedule_iteration_num, 2)
             self.assertEqual(instances[0].next_event_due, datetime(2018, 2, 2, 14, 0))
             self.assertFalse(instances[0].active)
+
+    @run_with_all_backends
+    @patch('corehq.messaging.scheduling.util.utcnow')
+    def test_sync_messaging_on_hard_deleted_case(self, utcnow_patch):
+        setup = self.setup_timed_schedule_with_case(utcnow_patch)
+        with setup as (schedule, rule, definition, case):
+            utcnow_patch.return_value = datetime(2018, 2, 28, 7, 1)
+            update_case(self.domain, case.case_id, case_properties={'start_sending': 'Y'})
+            instances = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)
+            self.assertEqual(instances.count(), 1)
+
+        sync_case_for_messaging(self.domain, case.case_id)
+        instances = get_case_timed_schedule_instances_for_schedule(case.case_id, schedule)
+        self.assertEqual(instances.count(), 0)
 
     @run_with_all_backends
     @patch('corehq.messaging.scheduling.util.utcnow')

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -54,12 +54,14 @@ def _sync_case_for_messaging(domain, case_id):
 
 def update_messaging_for_case(domain, case_id, case):
     if case is None or case.is_deleted:
-        sms_tasks.delete_phone_numbers_for_owners([case_id])
-        delete_schedule_instances_for_cases(domain, [case_id])
-        return
-
-    if use_phone_entries():
+        clear_messaging_for_case(domain, case_id)
+    elif use_phone_entries():
         sms_tasks._sync_case_phone_number(case)
+
+
+def clear_messaging_for_case(domain, case_id):
+    sms_tasks.delete_phone_numbers_for_owners([case_id])
+    delete_schedule_instances_for_cases(domain, [case_id])
 
 
 def run_auto_update_rules_for_case(case):
@@ -77,7 +79,11 @@ def _get_cached_rule(domain, rule_id):
 
 def _sync_case_for_messaging_rule(domain, case_id, rule_id):
     case_load_counter("messaging_rule_sync", domain)()
-    case = CaseAccessors(domain).get_case(case_id)
+    try:
+        case = CaseAccessors(domain).get_case(case_id)
+    except CaseNotFound:
+        clear_messaging_for_case(domain, case_id)
+        return
     rule = _get_cached_rule(domain, rule_id)
     if rule:
         rule.run_rule(case, utcnow())

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -48,7 +48,8 @@ def _sync_case_for_messaging(domain, case_id):
         case = None
     case_load_counter("messaging_sync", domain)()
     update_messaging_for_case(domain, case_id, case)
-    run_auto_update_rules_for_case(case)
+    if case is not None:
+        run_auto_update_rules_for_case(case)
 
 
 def update_messaging_for_case(domain, case_id, case):


### PR DESCRIPTION
Came across this while testing migration of hard-deleted cases in the Couch to SQL forms and cases migration. Execution follow:

`hard_delete_case_and_forms`
-> `publish_case_saved(case)`
-> `sql_case_post_save` (signal)
-> `messaging_case_changed_receiver(sender, case, ...)`
-> `sync_case_for_messaging.delay(domain, case_id)`
-> `_sync_case_for_messaging(domain, case_id)`
-> `run_auto_update_rules_for_case(case)` (ERROR! `case` is None)

`sync_case_for_messaging` with hard-deleted case id probably worked prior to https://github.com/dimagi/commcare-hq/commit/ed8ecc68e7d48ec51edaa51b4d11450d09a2eb8f, `sync_case_for_messaging_rule` never worked in that scenario.