### PR TITLE
Add web apps button to two factor pages for mobile workers

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
@@ -23,7 +23,7 @@
   <form method="post">{% csrf_token %}{{ form }}
     {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
       <a href="{% url 'homepage'%}"
-       class="pull-right btn btn-link">{% trans "Begin Using CommCare Now" %}</a>
+       class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
     {% endif %}
     <a href="{% url 'two_factor:profile'%}"
        class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
@@ -23,7 +23,7 @@
   <form method="post">{% csrf_token %}{{ form }}
     {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
       <a href="{% url 'homepage'%}"
-       class="pull-right btn btn-link">{% trans "To Webapps" %}</a>
+       class="pull-right btn btn-link">{% trans "Begin Using CommCare Now" %}</a>
     {% endif %}
     <a href="{% url 'two_factor:profile'%}"
        class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
@@ -27,6 +27,6 @@
     {% endif %}
     <a href="{% url 'two_factor:profile'%}"
        class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>
-    <button class="btn btn-primary" type="submit">{% trans "Generate Tokens" %}</button>
+    <button class="btn btn-default" type="submit">{% trans "Generate Tokens" %}</button>
   </form>
 {% endblock %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
@@ -21,6 +21,10 @@
   {% endif %}
 
   <form method="post">{% csrf_token %}{{ form }}
+    {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
+      <a href="{% url 'homepage'%}"
+       class="pull-right btn btn-link">{% trans "To Webapps" %}</a>
+    {% endif %}
     <a href="{% url 'two_factor:profile'%}"
        class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>
     <button class="btn btn-primary" type="submit">{% trans "Generate Tokens" %}</button>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
@@ -1,5 +1,6 @@
 {% extends "hqwebapp/base_section.html" %}
 {% load i18n %}
+{% load hq_shared_tags %}
 
 {% block page_content %}
   <h1>{% block title %}{% trans "Backup Tokens" %}{% endblock %}</h1>
@@ -21,9 +22,11 @@
   {% endif %}
 
   <form method="post">{% csrf_token %}{{ form }}
-    {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
-      <a href="{% url 'homepage'%}"
-       class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
+    {% if request|toggle_enabled:"TWO_STAGE_USER_PROVISIONING" %}
+      {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
+        <a href="{% url 'homepage'%}"
+         class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
+      {% endif %}
     {% endif %}
     <a href="{% url 'two_factor:profile'%}"
        class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/backup_tokens.html
@@ -1,6 +1,5 @@
 {% extends "hqwebapp/base_section.html" %}
 {% load i18n %}
-{% load hq_shared_tags %}
 
 {% block page_content %}
   <h1>{% block title %}{% trans "Backup Tokens" %}{% endblock %}</h1>
@@ -22,11 +21,8 @@
   {% endif %}
 
   <form method="post">{% csrf_token %}{{ form }}
-    {% if request|toggle_enabled:"TWO_STAGE_USER_PROVISIONING" %}
-      {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
-        <a href="{% url 'homepage'%}"
-         class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
-      {% endif %}
+    {% if link_to_webapps %}
+      <a href="{% url 'homepage'%}" class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
     {% endif %}
     <a href="{% url 'two_factor:profile'%}"
        class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -20,8 +20,8 @@
         <a href="{% url 'homepage'%}"
          class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
       {% endif %}
-      <a href="{% url 'two_factor:profile' %}"
-         class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>
+      <p></p><a href="{% url 'two_factor:profile' %}"
+         class="pull-right btn btn-link">{% trans "Back to Profile" %}</a></p>
       <p><a href="{% url 'two_factor:backup_tokens' %}"
             class="btn btn-default">{% trans "Generate Backup Tokens" %}</a></p>
     {% endif %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -23,7 +23,7 @@
       <a href="{% url 'two_factor:profile' %}"
          class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>
       <p><a href="{% url 'two_factor:backup_tokens' %}"
-            class="btn btn-primary">{% trans "Generate Backup Tokens" %}</a></p>
+            class="btn btn-default">{% trans "Generate Backup Tokens" %}</a></p>
     {% endif %}
 
 {% endblock %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -1,6 +1,5 @@
 {% extends "hqwebapp/base_section.html" %}
 {% load i18n %}
-{% load hq_shared_tags %}
 
 {% block page_content %}
   <h1>{% block title %}{% trans "Enable Two-Factor Authentication" %}{% endblock %}</h1>
@@ -9,21 +8,15 @@
     authentication.{% endblocktrans %}
 
     {% if not phone_methods %}
-      {% if request|toggle_enabled:"TWO_STAGE_USER_PROVISIONING" %}
-        {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
-          <a href="{% url 'homepage'%}"
-           class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
-        {% endif %}
+      {% if link_to_webapps %}
+        <a href="{% url 'homepage'%}" class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
       {% endif %}
       <p><a href="{% url 'two_factor:profile' %}"
             class="btn btn-block btn-default">{% trans "Back to Profile" %}</a></p>
     {% else %}
       <p>{% blocktrans %}To enable account recovery, generate backup tokens.{% endblocktrans %}</p>
-      {% if request|toggle_enabled:"TWO_STAGE_USER_PROVISIONING" %}
-        {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
-          <a href="{% url 'homepage'%}"
-           class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
-        {% endif %}
+      {% if link_to_webapps %}
+        <a href="{% url 'homepage'%}" class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
       {% endif %}
       <p></p><a href="{% url 'two_factor:profile' %}"
          class="pull-right btn btn-link">{% trans "Back to Profile" %}</a></p>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -8,11 +8,18 @@
     authentication.{% endblocktrans %}
 
     {% if not phone_methods %}
+      {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
+        <a href="{% url 'homepage'%}"
+         class="pull-right btn btn-link">{% trans "To Webapps" %}</a>
+      {% endif %}
       <p><a href="{% url 'two_factor:profile' %}"
             class="btn btn-block btn-default">{% trans "Back to Profile" %}</a></p>
     {% else %}
       <p>{% blocktrans %}To enable account recovery, generate backup tokens.{% endblocktrans %}</p>
-
+      {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
+        <a href="{% url 'homepage'%}"
+         class="pull-right btn btn-link">{% trans "To Webapps" %}</a>
+      {% endif %}
       <a href="{% url 'two_factor:profile' %}"
          class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>
       <p><a href="{% url 'two_factor:backup_tokens' %}"

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -10,7 +10,7 @@
     {% if not phone_methods %}
       {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
         <a href="{% url 'homepage'%}"
-         class="pull-right btn btn-link">{% trans "Begin Using CommCare Now" %}</a>
+         class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
       {% endif %}
       <p><a href="{% url 'two_factor:profile' %}"
             class="btn btn-block btn-default">{% trans "Back to Profile" %}</a></p>
@@ -18,7 +18,7 @@
       <p>{% blocktrans %}To enable account recovery, generate backup tokens.{% endblocktrans %}</p>
       {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
         <a href="{% url 'homepage'%}"
-         class="pull-right btn btn-link">{% trans "Begin Using CommCare Now" %}</a>
+         class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
       {% endif %}
       <a href="{% url 'two_factor:profile' %}"
          class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -1,5 +1,6 @@
 {% extends "hqwebapp/base_section.html" %}
 {% load i18n %}
+{% load hq_shared_tags %}
 
 {% block page_content %}
   <h1>{% block title %}{% trans "Enable Two-Factor Authentication" %}{% endblock %}</h1>
@@ -8,17 +9,21 @@
     authentication.{% endblocktrans %}
 
     {% if not phone_methods %}
-      {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
-        <a href="{% url 'homepage'%}"
-         class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
+      {% if request|toggle_enabled:"TWO_STAGE_USER_PROVISIONING" %}
+        {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
+          <a href="{% url 'homepage'%}"
+           class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
+        {% endif %}
       {% endif %}
       <p><a href="{% url 'two_factor:profile' %}"
             class="btn btn-block btn-default">{% trans "Back to Profile" %}</a></p>
     {% else %}
       <p>{% blocktrans %}To enable account recovery, generate backup tokens.{% endblocktrans %}</p>
-      {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
-        <a href="{% url 'homepage'%}"
-         class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
+      {% if request|toggle_enabled:"TWO_STAGE_USER_PROVISIONING" %}
+        {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
+          <a href="{% url 'homepage'%}"
+           class="btn btn-primary">{% trans "Begin Using CommCare Now" %}</a>
+        {% endif %}
       {% endif %}
       <p></p><a href="{% url 'two_factor:profile' %}"
          class="pull-right btn btn-link">{% trans "Back to Profile" %}</a></p>

--- a/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/core/setup_complete.html
@@ -10,7 +10,7 @@
     {% if not phone_methods %}
       {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
         <a href="{% url 'homepage'%}"
-         class="pull-right btn btn-link">{% trans "To Webapps" %}</a>
+         class="pull-right btn btn-link">{% trans "Begin Using CommCare Now" %}</a>
       {% endif %}
       <p><a href="{% url 'two_factor:profile' %}"
             class="btn btn-block btn-default">{% trans "Back to Profile" %}</a></p>
@@ -18,7 +18,7 @@
       <p>{% blocktrans %}To enable account recovery, generate backup tokens.{% endblocktrans %}</p>
       {% if request.couch_user.domain_memberships.0.role.default_landing_page == 'webapps' %}
         <a href="{% url 'homepage'%}"
-         class="pull-right btn btn-link">{% trans "To Webapps" %}</a>
+         class="pull-right btn btn-link">{% trans "Begin Using CommCare Now" %}</a>
       {% endif %}
       <a href="{% url 'two_factor:profile' %}"
          class="pull-right btn btn-link">{% trans "Back to Profile" %}</a>

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -360,7 +360,7 @@ class TwoFactorSetupCompleteView(BaseMyAccountView, SetupCompleteView):
     @property
     def page_context(self):
         return {
-            "link_to_webapps": _show_link_to_webapps(self.request.user),
+            "link_to_webapps": _show_link_to_webapps(self.request.couch_user),
         }
 
 
@@ -377,12 +377,12 @@ class TwoFactorBackupTokensView(BaseMyAccountView, BackupTokensView):
     @property
     def page_context(self):
         return {
-            "link_to_webapps": _show_link_to_webapps(self.request.user),
+            "link_to_webapps": _show_link_to_webapps(self.request.couch_user),
         }
 
 
 def _show_link_to_webapps(user):
-    if user.is_commcare_user():
+    if user and user.is_commcare_user():
         if user.domain_memberships:
             membership = user.domain_memberships[0]
             if membership.role and membership.role.default_landing_page == "webapps":

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -39,6 +39,7 @@ from corehq.apps.domain.decorators import (
     require_superuser,
     two_factor_exempt,
 )
+from corehq import toggles
 from corehq.apps.domain.views.base import BaseDomainView
 from corehq.apps.hqwebapp.utils import sign, update_session_language
 from corehq.apps.hqwebapp.views import BaseSectionPageView
@@ -356,6 +357,12 @@ class TwoFactorSetupCompleteView(BaseMyAccountView, SetupCompleteView):
         # this is only here to add the login_required decorator
         return super(TwoFactorSetupCompleteView, self).dispatch(request, *args, **kwargs)
 
+    @property
+    def page_context(self):
+        return {
+            "link_to_webapps": _show_link_to_webapps(self.request.user),
+        }
+
 
 class TwoFactorBackupTokensView(BaseMyAccountView, BackupTokensView):
     urlname = 'two_factor_backup_tokens'
@@ -366,6 +373,22 @@ class TwoFactorBackupTokensView(BaseMyAccountView, BackupTokensView):
     def dispatch(self, request, *args, **kwargs):
         # this is only here to add the login_required decorator
         return super(TwoFactorBackupTokensView, self).dispatch(request, *args, **kwargs)
+
+    @property
+    def page_context(self):
+        return {
+            "link_to_webapps": _show_link_to_webapps(self.request.user),
+        }
+
+
+def _show_link_to_webapps(user):
+    if user.is_commcare_user():
+        if user.domain_memberships:
+            membership = user.domain_memberships[0]
+            if membership.role and membership.role.default_landing_page == "webapps":
+                if toggles.TWO_STAGE_USER_PROVISIONING.enabled(membership.domain):
+                    return True
+    return False
 
 
 class TwoFactorDisableView(BaseMyAccountView, DisableView):


### PR DESCRIPTION
This adds one commit to https://github.com/dimagi/commcare-hq/pull/27080/ which I can't directly edit.

##### SUMMARY
See https://github.com/dimagi/commcare-hq/pull/27080/  This PR just updates the feature flag check, which wasn't working because there's no domain on this page. Instead, it uses the first domain where the user has a membership - which will be its only membership, since this only affects mobile workers.

##### FEATURE FLAG
Enable two-stage user provisioning

##### PRODUCT DESCRIPTION
See screenshots here: https://github.com/dimagi/commcare-hq/pull/27080#issuecomment-611184173
