### PR TITLE
add email address validation to mobile worker user signup

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -740,6 +740,12 @@ class NewMobileWorkerForm(forms.Form):
             )
         )
 
+    def clean_email(self):
+        clean_email = self.cleaned_data['email'].strip().lower()
+        if clean_email:
+            validate_email(clean_email)
+        return clean_email
+
     def clean_location_id(self):
         location_id = self.cleaned_data['location_id']
         if not user_can_access_location_id(self.domain, self.request_user, location_id):

--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -30,6 +30,7 @@ hqDefine("users/js/mobile_workers",[
     'zxcvbn/dist/zxcvbn',
     'locations/js/widgets',
     'hqwebapp/js/components.ko', // for pagination
+    'hqwebapp/js/validators.ko', // email address validation
 ], function (
     $,
     ko,
@@ -78,6 +79,10 @@ hqDefine("users/js/mobile_workers",[
             return ko.observable(value);
         });
         var self = ko.mapping.fromJS(options);
+
+        self.email.extend({
+            emailRFC2822: true,
+        });
 
         // used by two-stage provisioning
         self.emailRequired = ko.observable(self.force_account_confirmation());
@@ -287,22 +292,31 @@ hqDefine("users/js/mobile_workers",[
             return self.STATUS.WARNING;
         });
 
+        self.requiredEmailMissing = ko.computed(function () {
+            return self.stagedUser() && self.stagedUser().emailRequired() && !self.stagedUser().email();
+        });
+
+        self.emailIsInvalid = ko.computed(function () {
+            return self.stagedUser() && !self.stagedUser().email.isValid();
+        });
+
         self.emailStatus = ko.computed(function () {
 
             if (!self.stagedUser()) {
                 return self.STATUS.NONE;
             }
 
-            // todo: add email validation eventually
-            if (self.stagedUser().emailRequired() && !self.stagedUser().email()) {
+            if (self.requiredEmailMissing() || self.emailIsInvalid()) {
                 return self.STATUS.ERROR;
             }
         });
 
         self.emailStatusMessage = ko.computed(function () {
-            // todo: add email validation eventually
-            if (self.emailStatus() === self.STATUS.ERROR) {
+
+            if (self.requiredEmailMissing()) {
                 return gettext('Email address is required when users confirm their own accounts.');
+            } else if (self.emailIsInvalid()) {
+                return gettext('Please enter a valid email address.');
             }
             return "";
         });
@@ -445,7 +459,7 @@ hqDefine("users/js/mobile_workers",[
                     }
                 }
             }
-            if (self.stagedUser().emailRequired() && !self.stagedUser().email()) {
+            if (self.requiredEmailMissing() || self.emailIsInvalid()) {
                 return false;
             }
             if (options.require_location_id && !self.stagedUser().location_id()) {

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -737,7 +737,11 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
 
         is_valid = lambda: self.new_mobile_worker_form.is_valid() and self.custom_data.is_valid()
         if not is_valid():
-            return {'error': _("Forms did not validate")}
+            all_errors = [e for errors in self.new_mobile_worker_form.errors.values() for e in errors]
+            all_errors += [e for errors in self.custom_data.errors.values() for e in errors]
+            return {'error': _("Forms did not validate: {errors}").format(
+                errors=', '.join(all_errors)
+            )}
 
         couch_user = self._build_commcare_user()
         if self.new_mobile_worker_form.cleaned_data['send_account_confirmation_email']:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-10784

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This adds front and backend email address validation to the mobile worker creation page.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
Enable two-stage user provisioning (users confirm and set their own passwords via email).

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
![image](https://user-images.githubusercontent.com/66555/78873599-6858b000-7a4b-11ea-9b02-4c1dd9ace300.png)
