### PR TITLE
force refresh the page on 403 errors after signing the EULA

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -393,9 +393,16 @@ hqDefine('hqwebapp/js/main', [
                             $("#eulaModal").modal('hide');
                             $("body").removeClass("has-eula");
                         },
-                        error: function () {
-                            // do nothing, user will get the popup again on next page load
-                            $("body").removeClass("has-eula");
+                        error: function (xhr) {
+                            // if we got a 403 it may be due to two-factor settings.
+                            // force a page reload
+                            // https://dimagi-dev.atlassian.net/browse/SAAS-10785
+                            if (xhr.status === 403) {
+                                location.reload();
+                            } else {
+                                // do nothing, user will get the popup again on next page load
+                                $("body").removeClass("has-eula");
+                            }
                         },
                     });
                 });


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10785

<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes the popup (by refreshing the page) even if you don't have permission on the page.

Even on success, the [EULA view returns a redirect](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/registration/views.py#L468) which jquery follows, but if you were on the "permission denied" 2FA page, then the redirect 403s again and things just hang.

Manually forcing a refresh triggers another 403, but the EULA has been confirmed so you don't see the popup again.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Not worth announcing.
