### PR TITLE
additional permission for uploading data files to dropzone

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -139,6 +139,7 @@ class Permissions(DocumentSchema):
     view_web_apps_list = StringListProperty(default=[])
 
     view_file_dropzone = BooleanProperty(default=False)
+    edit_file_dropzone = BooleanProperty(default=False)
     manage_releases = BooleanProperty(default=True)
     manage_releases_list = StringListProperty(default=[])
 
@@ -234,6 +235,7 @@ class Permissions(DocumentSchema):
             edit_billing=True,
             edit_shared_exports=True,
             view_file_dropzone=True,
+            edit_file_dropzone=True,
         )
 
 

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -273,6 +273,46 @@
             </div>
           </div>{# END data permissions #}
 
+          {# BEGIN dropzone permissions #}
+          {% if request|toggle_enabled:"DATA_FILE_DOWNLOAD" %}
+          <div class="form-group">
+
+            <div class="col-sm-2 controls">
+              <div class="form-check">
+                <input type="checkbox"
+                       id="edit-dropzone-checkbox"
+                       data-bind="checked: permissions.edit_file_dropzone,
+                                                  disable: !$root.allowEdit" />
+                <label for="edit-dropzone-checkbox"><span class="sr-only">{% trans "Edit & Download files from the Dropzone " %}</span></label>
+              </div>
+            </div>
+
+            <div class="col-sm-2 controls">
+
+              {# PLACEHOLDER checkbox when edit_file_dropzone is true #}
+              <div class="form-check" data-bind="visible: permissions.edit_file_dropzone()">
+                <input type="checkbox" checked="checked" disabled="disabled" />
+                <label><span class="sr-only">{% trans "View-Only Dropzone" %}</span></label>
+              </div> {# end PLACEHOLDER #}
+
+              {# REAL checkbox that controls view_file_dropzone permission #}
+              <div class="form-check" data-bind="visible: !permissions.edit_file_dropzone()">
+                <input type="checkbox"
+                       id="view-dropzone-checkbox"
+                       data-bind="checked: permissions.view_file_dropzone,
+                                                  disable: !$root.allowEdit" />
+                <label for="view-dropzone-checkbox"><span class="sr-only">{% trans "Download-Only files from the Dropzone" %}</span></label>
+              </div> {# END REAL checkbox #}
+
+            </div>
+            <div class="col-sm-8 control-label">
+              {% blocktrans %}
+                <strong>Dropzone</strong> &mdash; Upload and download files from the file Dropzone
+              {% endblocktrans %}
+            </div>
+          </div> {# END dropzone permissions #}
+          {% endif %}
+
           {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
             {# BEGIN Shared Export permissions #}
             <div class="form-group">
@@ -590,24 +630,6 @@
               </div>
             </div>
           </div>
-          {% if request|toggle_enabled:"DATA_FILE_DOWNLOAD" %}
-            <div class="form-group">
-              <label class="col-sm-4 control-label">
-                {% trans "View File Dropzone" %}
-              </label>
-              <div class="col-sm-8 controls">
-                <div class="form-check">
-                  <input type="checkbox"
-                         id="view-file-dropzone-checkbox"
-                         data-bind="checked: permissions.view_file_dropzone,
-                                                      disable: !$root.allowEdit" />
-                  <label for="view-file-dropzone-checkbox">
-                    {% trans "Allow role to upload and download files from dropzone." %}
-                  </label>
-                </div>
-              </div>
-            </div>
-          {% endif %}
         </div>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
##### SUMMARY
Add a permission for uploading files to the dropzone

##### FEATURE FLAG
data_file_download

##### PRODUCT DESCRIPTION
Previously only domain admins could upload files to the dropzone. This PR adds a new permission which allows giving other users access to upload files to the dropzone.

This PR changes the way the permission is displayed. It used to be a single permission at the bottom of the role window. The description on this permission was also misleading as it did not give there user access to upload files, only domain admins were able to do that.

See image of current layout on [confluence](https://confluence.dimagi.com/display/ccinternal/Offer+hosting+and+sharing+data+files+for+downloading+from+a+secure+dropzone?preview=/45613475/45613482/image2018-9-10%2014%3A4%3A9.png).

It is now a dual "Edit / View" permission:

![Screenshot from 2020-04-09 16-03-45](https://user-images.githubusercontent.com/249606/78903947-2431d380-7a7c-11ea-938a-4a5fbd4107a9.png)
