### PR TITLE
Surface server errors on mobile worker creation

### DIFF
--- a/corehq/apps/users/static/users/js/mobile_workers.js
+++ b/corehq/apps/users/static/users/js/mobile_workers.js
@@ -60,6 +60,7 @@ hqDefine("users/js/mobile_workers",[
         options = options || {};
         options = _.defaults(options, {
             creation_status: STATUS.NONE,
+            creation_error: "",
             username: '',
             first_name: '',
             last_name: '',
@@ -497,6 +498,9 @@ hqDefine("users/js/mobile_workers",[
                     newUser.creation_status(STATUS.SUCCESS);
                 } else {
                     newUser.creation_status(STATUS.ERROR);
+                    if (data.error) {
+                        newUser.creation_error(data.error);
+                    }
                 }
             }).fail(function () {
                 newUser.creation_status(STATUS.ERROR);

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -205,6 +205,7 @@
                   <span class="text-danger">
                     <i class="fa fa-exclamation-triangle"></i>
                     {% trans "ERROR" %}
+                    <!-- ko text: creation_error --><!--/ko-->
                   </span>
               </div>
             </td>


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/27104/files#r406209696

Adds error detail when mobile worker creation fails:

<img width="1165" alt="Screen Shot 2020-04-09 at 2 11 03 PM" src="https://user-images.githubusercontent.com/1486591/78927172-6b17cd00-7a6c-11ea-87db-4f11fa222035.png">
