### PR TITLE
Added hasattr checks for is_verified

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -136,7 +136,7 @@ def _inactive_domain_response(request, domain_name):
 def _is_missing_two_factor(view_fn, request):
     return (_two_factor_required(view_fn, request.project, request.couch_user)
             and not getattr(request, 'bypass_two_factor', False)
-            and not request.user.is_verified())
+            and not (hasattr(request.user, 'is_verified') and request.user.is_verified()))
 
 
 def _page_is_whitelisted(path, domain):

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -247,7 +247,7 @@ def _two_factor_needed(domain_name, request):
         return (
             domain_obj.two_factor_auth
             and not request.couch_user.two_factor_disabled
-            and not request.user.is_verified()
+            and not (hasattr(request.user, 'is_verified') and request.user.is_verified())
         )
 
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-613

https://sentry.io/organizations/dimagi/issues/1605197406/

I think there's a deeper problem with mobile workers using 2FA but haven't figured it out. Not sure this is going to fix the issue, it might just result in all 2FA-gated calls failing.

Feature flag: Two-stage user provisioning