### PR TITLE
Support mobile worker password reset

### DIFF
--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -2,7 +2,7 @@ import base64
 import re
 from functools import wraps
 
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.views.decorators.debug import sensitive_variables
@@ -209,3 +209,8 @@ class ApiKeyFallbackBackend(object):
         else:
             request.skip_two_factor_check = True
             return user
+
+
+def get_active_users_by_email(email):
+    UserModel = get_user_model()
+    return UserModel._default_manager.filter(username__iexact=email, is_active=True)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -97,6 +97,7 @@ from corehq.apps.callcenter.views import (
     CallCenterOwnerOptionsView,
 )
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
+from corehq.apps.domain.auth import get_active_users_by_email
 from corehq.apps.domain.models import (
     AREA_CHOICES,
     BUSINESS_UNITS,
@@ -1183,15 +1184,13 @@ class HQPasswordResetForm(NoAutocompleteMixin, forms.Form):
             subject_template_name = 'registration/email/password_reset_subject_hq.txt'
             email_template_name = 'registration/email/password_reset_email_hq.html'
 
-        UserModel = get_user_model()
         email = self.cleaned_data["email"]
 
         # this is the line that we couldn't easily override in PasswordForm where
         # we specifically filter for the username, not the email, so that
         # mobile workers who have the same email set as a web worker don't
         # get a password reset email.
-        active_users = UserModel._default_manager.filter(
-            username__iexact=email, is_active=True)
+        active_users = get_active_users_by_email(email)
 
         # the code below is copied from default PasswordForm
         for user in active_users:

--- a/corehq/apps/domain/tests/test_password_reset.py
+++ b/corehq/apps/domain/tests/test_password_reset.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from corehq.apps.domain.auth import get_active_users_by_email
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.users.models import WebUser, CommCareUser
+
+
+class PasswordResetTest(TestCase):
+    domain = 'password-reset-test'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project = create_domain(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.delete()
+        super().tearDownClass()
+
+    def test_missing(self):
+        self.assertEqual(0, get_active_users_by_email('missing@example.com').count())
+
+    def test_web_user_lookup(self):
+        email = 'web-user@example.com'
+        web_user = WebUser.create(self.domain, email, 's3cr3t')
+        self.addCleanup(web_user.delete)
+        results = get_active_users_by_email(email)
+        self.assertEqual(1, results.count())
+        self.assertEqual(web_user.username, results[0].username)
+
+    def test_mobile_worker_excluded(self):
+        email = 'mw-excluded@example.com'
+        mobile_worker = CommCareUser.create(self.domain, 'mw-excluded', 's3cr3t', email=email)
+        self.addCleanup(mobile_worker.delete)
+        results = get_active_users_by_email(email)
+        self.assertEqual(0, results.count())

--- a/corehq/apps/domain/tests/test_password_reset.py
+++ b/corehq/apps/domain/tests/test_password_reset.py
@@ -20,28 +20,34 @@ class PasswordResetTest(TestCase):
         super().tearDownClass()
 
     def test_missing(self):
-        self.assertEqual(0, get_active_users_by_email('missing@example.com').count())
+        self.assertEqual(0, len(list(get_active_users_by_email('missing@example.com'))))
 
     def test_web_user_lookup(self):
         email = 'web-user@example.com'
         web_user = WebUser.create(self.domain, email, 's3cr3t')
         self.addCleanup(web_user.delete)
-        results = get_active_users_by_email(email)
-        self.assertEqual(1, results.count())
+        results = list(get_active_users_by_email(email))
+        self.assertEqual(1, len(results))
         self.assertEqual(web_user.username, results[0].username)
+
+    def test_web_user_by_email(self):
+        email = 'web-user-email@example.com'
+        web_user = WebUser.create(self.domain, 'web-user2@example.com', 's3cr3t', email=email)
+        self.addCleanup(web_user.delete)
+        self.assertEqual(0, len(list(get_active_users_by_email(email))))
 
     def test_mobile_worker_excluded(self):
         email = 'mw-excluded@example.com'
         mobile_worker = CommCareUser.create(self.domain, 'mw-excluded', 's3cr3t', email=email)
         self.addCleanup(mobile_worker.delete)
-        results = get_active_users_by_email(email)
-        self.assertEqual(0, results.count())
+        results = list(get_active_users_by_email(email))
+        self.assertEqual(0, len(results))
 
     @flag_enabled('TWO_STAGE_USER_PROVISIONING')
     def test_mobile_worker_included_with_flag(self):
         email = 'mw-included@example.com'
         mobile_worker = CommCareUser.create(self.domain, 'mw-included', 's3cr3t', email=email)
         self.addCleanup(mobile_worker.delete)
-        results = get_active_users_by_email(email)
-        self.assertEqual(1, results.count())
+        results = list(get_active_users_by_email(email))
+        self.assertEqual(1, len(results))
         self.assertEqual(mobile_worker.username, results[0].username)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://docs.google.com/document/d/1rH7YvSh-uFy9aFdOmjXCP2VDMqP_PG2XnoVfBQX_08s/edit#

We ended up with a variant of option 2 "Multi-Account Reset".

This was much simpler than I expected. Can review how you like.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adds ability for Mobile Workers to reset their passwords if they are a member of a feature-flagged domain.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
Enable two-stage user provisioning (users confirm and set their own passwords via email).

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Now when you request a password reset, you will get _one email per each HQ account_ that matches the following criteria:

- It is a Web User (normal HQ account) with a login matching the email (previous behavior).
- It is a Mobile Worker account with an email address matching the email _in a feature flagged domain_ (new behavior)

Note 1: I thought about also adding Web User accounts who have changed their email to the new email address but didn't yet. This would be a trivial change to implement though.

Note 2: I chose multiple reset emails to multiple links in a single email because the implementation was far easier, and the UX seems relatively comparable.

cc @dimagi/product 