### PR TITLE
Revert "ICDS Dashboard: Incorrect maps fill"

### DIFF
--- a/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
+++ b/custom/icds_reports/static/js/directives/indie-map/indie-map.directive.js
@@ -191,12 +191,6 @@ function IndieMapController($scope, $compile, $location, $filter, storageService
                         .translate([element.offsetWidth / 2, element.offsetHeight / div]);
                     path = d3.geo.path().projection(projection);
                 }
-                $(function () {
-                    var svg = d3.select('#map svg');
-                    svg.selectAll(".datamaps-subunit").transition().style('fill', vm.map.fills.defaultFill);
-                    vm.addCombinedSelectorClassToMaps(document.getElementsByClassName("datamaps-subunit"));
-                    vm.colorMapBasedOnCombinedSelectorClass(svg);
-                });
                 return {path: path, projection: projection};
             },
         };
@@ -208,23 +202,6 @@ function IndieMapController($scope, $compile, $location, $filter, storageService
             };
         }
 
-        vm.addCombinedSelectorClassToMaps = function (locations) {
-            for (var i = 0; i < locations.length; i++) {
-                var combinedClass = "";
-                for (var j = 0; j < locations[i].classList.length; j++) {
-                    combinedClass += locations[i].classList[j];
-                }
-                locations[i].classList.add(combinedClass);
-            }
-        };
-        vm.colorMapBasedOnCombinedSelectorClass = function (svg) {
-            for (var locationId in vm.map.data) {
-                if (vm.map.data.hasOwnProperty(locationId)) {
-                    svg.selectAll('.datamaps-subunit' + locationId.replace(/\s/g,''))
-                        .transition().style('fill', vm.map.data[locationId].fillKey);
-                }
-            }
-        };
         vm.mapPlugins = {
             bubbles: null,
         };

--- a/custom/icds_reports/templates/icds_reports/icds_app/indie-map.directive.html
+++ b/custom/icds_reports/templates/icds_reports/icds_app/indie-map.directive.html
@@ -1,5 +1,5 @@
 <div class="indie-map-directive">
   <div id="locPopup" class="locPopup"></div>
   <datamap on-click="$ctrl.handleMapClick" map="$ctrl.map" plugins="$ctrl.mapPlugins"
-           plugin-data="$ctrl.mapPluginData" id="map"></datamap>
+           plugin-data="$ctrl.mapPluginData"></datamap>
 </div>


### PR DESCRIPTION
Reverts dimagi/commcare-hq#27092

This is causing issues in national level maps:
`jquery.min.js?version=1055018:2 Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Element': '.datamaps-subunitAndaman&NicobarIslands' is not a valid selector.`