### PR TITLE
Location Reassignment Phase 2 bug fixes

### DIFF
--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -43,7 +43,7 @@ class Parser(object):
         self.requested_transitions = {}
         self.site_codes_to_be_archived = []
         self.location_type_codes = list(map(lambda lt: lt.code, LocationType.objects.by_domain(self.domain)))
-        self.new_location_details = {location_type_code: [] for location_type_code in self.location_type_codes}
+        self.new_location_details = {location_type_code: {} for location_type_code in self.location_type_codes}
         self.valid_transitions = {location_type_code: {
             MERGE_OPERATION: defaultdict(list),
             SPLIT_OPERATION: defaultdict(list),
@@ -83,12 +83,18 @@ class Parser(object):
         if self._invalid_row(operation, old_site_code, new_site_code):
             return
         self._note_transition(operation, location_type_code, new_site_code, old_site_code)
-        self.new_location_details[location_type_code].append({
-            'name': row.get(NEW_NAME),
-            'site_code': new_site_code,
-            'parent_site_code': row.get(NEW_PARENT_SITE_CODE),
-            'lgd_code': row.get(NEW_LGD_CODE)
-        })
+        if new_site_code in self.new_location_details[location_type_code]:
+            details = self.new_location_details[location_type_code]
+            if (details['name'] != row.get(NEW_NAME)
+                    or details['parent_site_code'] != row.get(NEW_PARENT_SITE_CODE)
+                    or details['lgd_code'] != row.get(NEW_LGD_CODE)):
+                self.errors.append("Creating new location %s with different information" % new_site_code)
+        else:
+            self.new_location_details[location_type_code][new_site_code] = {
+                'name': row.get(NEW_NAME),
+                'parent_site_code': row.get(NEW_PARENT_SITE_CODE),
+                'lgd_code': row.get(NEW_LGD_CODE)
+            }
 
     def _invalid_row(self, operation, old_site_code, new_site_code):
         invalid = False

--- a/custom/icds/location_reassignment/processor.py
+++ b/custom/icds/location_reassignment/processor.py
@@ -36,19 +36,19 @@ class Processor(object):
 
         with transaction.atomic():
             for location_type_code in self.location_types_by_code:
-                new_locations_details = self.new_location_details.get(location_type_code, [])
-                for details in new_locations_details:
+                new_locations_details = self.new_location_details.get(location_type_code, {})
+                for site_code, details in new_locations_details.items():
                     parent_location = None
                     if details['parent_site_code']:
                         parent_location = locations_by_site_code[details['parent_site_code']]
                     location = SQLLocation.objects.create(
-                        domain=self.domain, site_code=details['site_code'], name=details['name'],
+                        domain=self.domain, site_code=site_code, name=details['name'],
                         parent=parent_location,
                         location_type=self.location_types_by_code[location_type_code],
                         metadata={'lgd_code': details['lgd_code']}
                     )
                     # add new location in case its a parent to any other locations getting created
-                    locations_by_site_code[details['site_code']] = location
+                    locations_by_site_code[site_code] = location
 
     def _get_existing_parent_locations(self):
         existing_parent_site_codes = set()
@@ -56,11 +56,11 @@ class Processor(object):
         for location_type_code in list(reversed(list(self.location_types_by_code))):
             new_locations_details = self.new_location_details.get(location_type_code)
             if new_locations_details:
-                for details in new_locations_details:
+                for site_code, details in new_locations_details.items():
                     if details['parent_site_code']:
                         existing_parent_site_codes.add(details['parent_site_code'])
                     # remove it from parent site codes if it itself needs to be created
-                    existing_parent_site_codes.discard(details['site_code'])
+                    existing_parent_site_codes.discard(site_code)
 
         if existing_parent_site_codes:
             return self._get_locations_by_site_codes(existing_parent_site_codes)

--- a/custom/icds/location_reassignment/processor.py
+++ b/custom/icds/location_reassignment/processor.py
@@ -54,13 +54,12 @@ class Processor(object):
         existing_parent_site_codes = set()
 
         for location_type_code in list(reversed(list(self.location_types_by_code))):
-            new_locations_details = self.new_location_details.get(location_type_code)
-            if new_locations_details:
-                for site_code, details in new_locations_details.items():
-                    if details['parent_site_code']:
-                        existing_parent_site_codes.add(details['parent_site_code'])
-                    # remove it from parent site codes if it itself needs to be created
-                    existing_parent_site_codes.discard(site_code)
+            new_locations_details = self.new_location_details.get(location_type_code, {})
+            for site_code, details in new_locations_details.items():
+                if details['parent_site_code']:
+                    existing_parent_site_codes.add(details['parent_site_code'])
+                # remove it from parent site codes if it itself needs to be created
+                existing_parent_site_codes.discard(site_code)
 
         if existing_parent_site_codes:
             return self._get_locations_by_site_codes(existing_parent_site_codes)

--- a/custom/icds/location_reassignment/processor.py
+++ b/custom/icds/location_reassignment/processor.py
@@ -53,12 +53,14 @@ class Processor(object):
     def _get_existing_parent_locations(self):
         existing_parent_site_codes = set()
 
-        for location_type_code, new_locations_details in self.new_location_details.items():
-            for details in new_locations_details:
-                if details['parent_site_code']:
-                    existing_parent_site_codes.add(details['parent_site_code'])
-                # remove it from parent site codes if it itself needs to be created
-                existing_parent_site_codes.discard(details['site_code'])
+        for location_type_code in list(reversed(list(self.location_types_by_code))):
+            new_locations_details = self.new_location_details.get(location_type_code)
+            if new_locations_details:
+                for details in new_locations_details:
+                    if details['parent_site_code']:
+                        existing_parent_site_codes.add(details['parent_site_code'])
+                    # remove it from parent site codes if it itself needs to be created
+                    existing_parent_site_codes.discard(details['site_code'])
 
         if existing_parent_site_codes:
             return self._get_locations_by_site_codes(existing_parent_site_codes)

--- a/custom/icds/location_reassignment/tests/test_processor.py
+++ b/custom/icds/location_reassignment/tests/test_processor.py
@@ -56,20 +56,36 @@ class TestProcessor(TestCase):
     @patch('corehq.apps.locations.models.SQLLocation.objects.create')
     def test_creating_new_locations(self, location_create_mock, locations_mock, *_):
         locations_mock.return_value = self.all_locations
+        location_create_mock.return_value = "A New Location"
         new_location_details = {
-            'supervisor': {'13': {
-                'name': 'Test 13',
-                'parent_site_code': None,
-                'lgd_code': 'LGD 13'
-            }}
+            'supervisor': {
+                '13': {
+                    'name': 'Test 13',
+                    'parent_site_code': None,
+                    'lgd_code': 'LGD 13'
+                }
+            },
+            'awc': {
+                '131': {
+                    'name': 'Test 131',
+                    'parent_site_code': '13',
+                    'lgd_code': 'LGD 131'
+                }
+
+            }
         }
         Processor(self.domain, self.transitions, new_location_details, site_codes).process()
         location_type_supervisor = None
+        location_type_awc = None
         for location_type in location_types:
             if location_type.code == 'supervisor':
                 location_type_supervisor = location_type
-                break
-        location_create_mock.assert_called_with(
-            domain=self.domain, site_code='13', name='Test 13', parent=None,
-            metadata={'lgd_code': 'LGD 13'}, location_type=location_type_supervisor
-        )
+            elif location_type.code == 'awc':
+                location_type_awc = location_type
+        calls = [
+            call(domain=self.domain, site_code='13', name='Test 13', parent=None,
+                 metadata={'lgd_code': 'LGD 13'}, location_type=location_type_supervisor),
+            call(domain=self.domain, site_code='131', name='Test 131', parent="A New Location",
+                 metadata={'lgd_code': 'LGD 131'}, location_type=location_type_awc)
+        ]
+        location_create_mock.assert_has_calls(calls)

--- a/custom/icds/location_reassignment/tests/test_processor.py
+++ b/custom/icds/location_reassignment/tests/test_processor.py
@@ -57,12 +57,11 @@ class TestProcessor(TestCase):
     def test_creating_new_locations(self, location_create_mock, locations_mock, *_):
         locations_mock.return_value = self.all_locations
         new_location_details = {
-            'supervisor': [{
+            'supervisor': {'13': {
                 'name': 'Test 13',
-                'site_code': '13',
                 'parent_site_code': None,
                 'lgd_code': 'LGD 13'
-            }]
+            }}
         }
         Processor(self.domain, self.transitions, new_location_details, site_codes).process()
         location_type_supervisor = None


### PR DESCRIPTION
Introduced in https://github.com/dimagi/commcare-hq/pull/27079/commits/b5ca63f364a5ed88275c759b58324cc2948d75d2#diff-bb1e1b944d92fcccad420f264063f667R60

##### SUMMARY
In order to eliminate new locations getting created within the process but also declared as a parent to another location, its necessary to start with lowest location first. This way when we move up to top, such new location will get discarded from existing location parent locations set after it was added by a child location otherwise it is retained later.

The other fix is also when creating new locations, a new location is noted twice in case of a merge operation.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
