### PR TITLE
Removed troublesome options binding from autocompleteSelect2 usages

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -23,7 +23,7 @@ class CopyApplicationForm(forms.Form):
     domain = forms.CharField(
         label=ugettext_lazy("Copy this app to project"),
         widget=forms.Select(choices=[], attrs={
-            "data-bind": "autocompleteSelect2: domain_names, options: domain_names",
+            "data-bind": "autocompleteSelect2: domain_names",
         }))
     name = forms.CharField(required=True, label=ugettext_lazy('Name'))
     linked = forms.BooleanField(

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/graph_configuration_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/graph_configuration_modal.html
@@ -252,8 +252,7 @@
       <div class="col-sm-3 ui-front">
         <select class="form-control" placeholder="property"
                 data-bind="autocompleteSelect2: $parent.configPropertyOptions,
-                                   options: $parent.configPropertyOptions,
-                                   value: property,
+                           value: property,
                 "></select>
       </div>
       <div class="col-sm-1 text-center">


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SC-339

Our custom `autocompleteSelect2` binding already sets the dropdown's options, so there's no need to also use knockout's built-in `options` binding. On the graphing page, using `options` was causing this bug, though I don't know exactly how. I think it's something about the dropdown appearing in a modal that has its bindings applied when the modal is opened, rather than on page load.

##### FEATURE FLAG
Mobile graphing

##### PRODUCT DESCRIPTION
Fixes bug where custom graphing properties weren't showing in their dropdown:
<img width="1350" alt="Screen Shot 2020-04-10 at 3 38 49 PM" src="https://user-images.githubusercontent.com/1486591/79018271-68d37280-7b41-11ea-857b-053465569fa8.png">

