### PR TITLE
Location Reassignment Phase 2 bug fixes fix

### DIFF
--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -84,7 +84,7 @@ class Parser(object):
             return
         self._note_transition(operation, location_type_code, new_site_code, old_site_code)
         if new_site_code in self.new_location_details[location_type_code]:
-            details = self.new_location_details[location_type_code]
+            details = self.new_location_details[location_type_code][new_site_code]
             if (details['name'] != row.get(NEW_NAME)
                     or details['parent_site_code'] != row.get(NEW_PARENT_SITE_CODE)
                     or details['lgd_code'] != row.get(NEW_LGD_CODE)):

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -88,7 +88,7 @@ class Parser(object):
             if (details['name'] != row.get(NEW_NAME)
                     or details['parent_site_code'] != row.get(NEW_PARENT_SITE_CODE)
                     or details['lgd_code'] != row.get(NEW_LGD_CODE)):
-                self.errors.append("Creating new location %s with different information" % new_site_code)
+                self.errors.append("New location %s reused with different information" % new_site_code)
         else:
             self.new_location_details[location_type_code][new_site_code] = {
                 'name': row.get(NEW_NAME),

--- a/custom/icds/location_reassignment/processor.py
+++ b/custom/icds/location_reassignment/processor.py
@@ -42,6 +42,9 @@ class Processor(object):
             for location_type_code in self.location_types_by_code:
                 new_locations_details = self.new_location_details.get(location_type_code, {})
                 for site_code, details in new_locations_details.items():
+                    # if location already present don't try creating it
+                    if site_code in self.transiting_locations_by_site_code:
+                        continue
                     parent_location = None
                     if details['parent_site_code']:
                         parent_location = locations_by_site_code[details['parent_site_code']]

--- a/custom/icds/location_reassignment/processor.py
+++ b/custom/icds/location_reassignment/processor.py
@@ -36,7 +36,7 @@ class Processor(object):
                 self._perform_transitions(operation, transitions)
 
     def _create_new_locations(self):
-        locations_by_site_code = self._get_existing_parent_locations()
+        parent_locations_by_site_code = self._get_existing_parent_locations()
 
         with transaction.atomic():
             for location_type_code in self.location_types_by_code:
@@ -47,7 +47,7 @@ class Processor(object):
                         continue
                     parent_location = None
                     if details['parent_site_code']:
-                        parent_location = locations_by_site_code[details['parent_site_code']]
+                        parent_location = parent_locations_by_site_code[details['parent_site_code']]
                     location = SQLLocation.objects.create(
                         domain=self.domain, site_code=site_code, name=details['name'],
                         parent=parent_location,
@@ -55,7 +55,7 @@ class Processor(object):
                         metadata={'lgd_code': details['lgd_code']}
                     )
                     # add new location in case its a parent to any other locations getting created
-                    locations_by_site_code[site_code] = location
+                    parent_locations_by_site_code[site_code] = location
                     # update transiting locations mapping
                     self.transiting_locations_by_site_code[site_code] = location
 

--- a/custom/icds/location_reassignment/tests/test_parser.py
+++ b/custom/icds/location_reassignment/tests/test_parser.py
@@ -51,7 +51,15 @@ class TestParser(TestCase):
             # valid operation to move 112 -> 131
             ('AWC 2', 'AWC 3', '112', '131', 'AWC-112',
              'AWC-131', 'Supervisor 2', '11', '13',
-             'username2', 'username3', 'Move'))),
+             'username2', 'username3', 'Move'),
+            # valid operation to merge 113 114 -> 132 but
+            # with different lgd code for new location in 114
+            ('AWC 4', 'AWC 6', '113', '132', 'AWC-113',
+             'AWC-132', 'Supervisor 1', '11', '13',
+             'username4', 'username5', 'Merge'),
+            ('AWC 5', 'AWC 6', '114', '132', 'AWC-114',
+             'AWC-133', 'Supervisor 1', '11', '13',
+             'username6', 'username7', 'Merge'))),
         ('supervisor', (
             # invalid row with missing new site code
             ('Supervisor 1', 'Supervisor 1', '11', '', 'Sup-11',
@@ -78,9 +86,11 @@ class TestParser(TestCase):
             workbook = get_workbook(file)
             valid_transitions, errors = Parser(self.domain, workbook).parse()
             self.assertEqual(valid_transitions['awc']['Move'], {'131': '112'})
+            self.assertEqual(valid_transitions['awc']['Merge'], {'132': ['113', '114']})
             self.assertEqual(valid_transitions['supervisor']['Move'], {'13': '12'})
             self.assertEqual(errors, [
                 "No change in location code for Extract, got old: '111' and new: '111'",
+                "New location 132 reused with different information",
                 "Missing location code for Split, got old: '11' and new: ''",
                 "Invalid Operation Unknown"
             ])

--- a/custom/icds/location_reassignment/tests/test_parser.py
+++ b/custom/icds/location_reassignment/tests/test_parser.py
@@ -9,9 +9,18 @@ from couchexport.models import Format
 
 from corehq.util.workbook_json.excel import get_workbook
 from custom.icds.location_reassignment.const import (
+    CURRENT_LGD_CODE,
+    CURRENT_NAME,
+    CURRENT_PARENT_NAME,
+    CURRENT_PARENT_SITE_CODE,
     CURRENT_SITE_CODE_COLUMN,
+    NEW_LGD_CODE,
+    NEW_NAME,
+    NEW_PARENT_SITE_CODE,
     NEW_SITE_CODE_COLUMN,
+    NEW_USERNAME_COLUMN,
     OPERATION_COLUMN,
+    USERNAME_COLUMN,
 )
 from custom.icds.location_reassignment.parser import Parser
 
@@ -22,16 +31,16 @@ class TestParser(TestCase):
     domain = 'test'
     headers = (
         ('awc',
-         ('name', 'new_name', CURRENT_SITE_CODE_COLUMN, NEW_SITE_CODE_COLUMN, 'lgd_code',
-          'new_lgd_code', 'parent_name', 'parent_site_code', 'new_parent_site_code',
-          'username', 'new_username', OPERATION_COLUMN)),
+         (CURRENT_NAME, NEW_NAME, CURRENT_SITE_CODE_COLUMN, NEW_SITE_CODE_COLUMN, CURRENT_LGD_CODE,
+          NEW_LGD_CODE, CURRENT_PARENT_NAME, CURRENT_PARENT_SITE_CODE, NEW_PARENT_SITE_CODE,
+          USERNAME_COLUMN, NEW_USERNAME_COLUMN, OPERATION_COLUMN)),
         ('supervisor',
-         ('name', 'new_name', CURRENT_SITE_CODE_COLUMN, NEW_SITE_CODE_COLUMN, 'lgd_code',
-          'new_lgd_code', 'parent_name', 'parent_site_code', 'new_parent_site_code',
-          'username', 'new_username', OPERATION_COLUMN)),
+         (CURRENT_NAME, NEW_NAME, CURRENT_SITE_CODE_COLUMN, NEW_SITE_CODE_COLUMN, CURRENT_LGD_CODE,
+          NEW_LGD_CODE, CURRENT_PARENT_NAME, CURRENT_PARENT_SITE_CODE, NEW_PARENT_SITE_CODE,
+          USERNAME_COLUMN, NEW_USERNAME_COLUMN, OPERATION_COLUMN)),
         ('state',
-         ('name', 'new_name', CURRENT_SITE_CODE_COLUMN, NEW_SITE_CODE_COLUMN, 'lgd_code',
-          'new_lgd_code', 'username', 'new_username', OPERATION_COLUMN)),
+         (CURRENT_NAME, NEW_NAME, CURRENT_SITE_CODE_COLUMN, NEW_SITE_CODE_COLUMN, CURRENT_LGD_CODE,
+          NEW_LGD_CODE, USERNAME_COLUMN, NEW_USERNAME_COLUMN, OPERATION_COLUMN)),
     )
     rows = (
         ('awc', (

--- a/custom/icds/location_reassignment/tests/test_processor.py
+++ b/custom/icds/location_reassignment/tests/test_processor.py
@@ -55,7 +55,7 @@ class TestProcessor(TestCase):
 
     @patch('corehq.apps.locations.models.SQLLocation.objects.create')
     def test_creating_new_locations(self, location_create_mock, locations_mock, *_):
-        locations_mock.return_value = self.all_locations
+        locations_mock.return_value = [self.location_112, self.location_12]
         location_create_mock.return_value = "A New Location"
         new_location_details = {
             'supervisor': {


### PR DESCRIPTION
A example of poor management of changes across different branches
At certain point i changed column names in https://github.com/dimagi/commcare-hq/pull/27056/commits/db47314290219248275a0a11401e357bc0148aee but didn't update tests and then added https://github.com/dimagi/commcare-hq/pull/27121/commits/1b290a2086ea6b2425980d2f7e4c9c6f655c579e which should have caused tests to fail but did not because they were using wrong columns.

Also addresses a bug when creating new locations. Currently we were trying to create all new/target locations even when they were already present. Something that could have been avoided by following a better naming like target locations or final locations instead of new locations, which i will take in the follow up to avoid creating conflicts with branches in progress.

##### SUMMARY
Fixes bug to catch different information passed for the same new location

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
