### PR TITLE
Couch to SQL: patch SQL cases to match couch state

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -34,6 +34,7 @@ from corehq.util.metrics import metrics_counter
 from .diff import filter_case_diffs, filter_ledger_diffs
 from .rebuildcase import rebuild_and_diff_cases
 from .statedb import Change
+from .util import retry_on_sql_error
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +78,7 @@ def diff_cases(couch_cases, log_cases=False):
     assert isinstance(couch_cases, dict), repr(couch_cases)[:100]
     assert "_diff_state" in globals()
     data = DiffData()
-    dd_count = partial(metrics_counter, tags={"domain": _diff_state.domain})
+    dd_count = partial(metrics_counter, tags={"domain": get_domain()})
     case_ids = list(couch_cases)
     sql_case_ids = set()
     for sql_case in CaseAccessorSQL.get_cases(case_ids):
@@ -114,6 +115,8 @@ def diff_case(sql_case, couch_case, dd_count):
         return couch_case, diffs, changes
     diffs = diff(couch_case, sql_json)
     if diffs:
+        if is_case_patched(diffs):
+            return couch_case, [], []
         form_diffs = diff_case_forms(couch_case, sql_json)
         if form_diffs:
             diffs.extend(form_diffs)
@@ -142,14 +145,15 @@ def diff_case(sql_case, couch_case, dd_count):
 
 
 def check_domains(case_id, couch_json, sql_json):
-    if couch_json["domain"] == _diff_state.domain:
-        if sql_json["domain"] == _diff_state.domain:
+    domain = get_domain()
+    if couch_json["domain"] == domain:
+        if sql_json["domain"] == domain:
             return []
         log.warning("sql case %s has wrong domain: %s", case_id, sql_json["domain"])
-        diffs = json_diff({"domain": _diff_state.domain}, {"domain": sql_json["domain"]})
+        diffs = json_diff({"domain": domain}, {"domain": sql_json["domain"]})
     else:
         log.warning("couch case %s has wrong domain: %s", case_id, couch_json["domain"])
-        diffs = json_diff({"domain": couch_json["domain"]}, {"domain": _diff_state.domain})
+        diffs = json_diff({"domain": couch_json["domain"]}, {"domain": domain})
     assert diffs, "expected domain diff"
     return diffs
 
@@ -299,13 +303,24 @@ class StockTransactionLoader:
         return num
 
     def iter_stock_transactions(self, form_id):
-        xform = FormAccessorCouch.get_form(form_id)
-        assert xform.domain == _diff_state.domain, xform
+        xform = get_couch_form(form_id)
+        assert xform.domain == get_domain(), xform
         for report in get_all_stock_report_helpers_from_form(xform):
             for tx in report.transactions:
                 yield report.report_type, tx
                 if tx.action == TRANSACTION_TYPE_STOCKONHAND:
                     yield report.report_type, tx
+
+
+def is_case_patched(diffs):
+    from .casepatch import PatchForm
+    if not (len(diffs) == 1
+            and diffs[0].diff_type == "set_mismatch"
+            and list(diffs[0].path) == ["xform_ids", "[*]"]
+            and diffs[0].new_value):
+        return False
+    form_ids = diffs[0].new_value.split(",")
+    return any(f.xmlns == PatchForm.xmlns for f in get_sql_forms(form_ids))
 
 
 def diff_case_forms(couch_json, sql_json):
@@ -442,7 +457,7 @@ class WorkerState:
 
 def has_only_deleted_forms(couch_case):
     def get_deleted_form_ids(form_ids):
-        forms = FormAccessorSQL.get_forms(form_ids)
+        forms = get_sql_forms(form_ids)
         return {f.form_id for f in forms if f.is_deleted}
     form_ids = couch_case["xform_ids"]
     return set(form_ids) == get_deleted_form_ids(form_ids)
@@ -451,7 +466,7 @@ def has_only_deleted_forms(couch_case):
 def is_orphaned_case(couch_case):
     def references_case(form_id):
         try:
-            form = FormAccessorCouch.get_form(form_id)
+            form = get_couch_form(form_id)
         except XFormNotFound:
             return True  # assume case is referenced if form not found
         try:
@@ -467,6 +482,20 @@ def should_diff(case):
     return _diff_state.should_diff(case)
 
 
+def get_domain():
+    return _diff_state.domain
+
+
 @retry_on_couch_error
 def get_couch_cases(case_ids):
     return CaseAccessorCouch.get_cases(case_ids)
+
+
+@retry_on_couch_error
+def get_couch_form(form_id):
+    return FormAccessorCouch.get_form(form_id)
+
+
+@retry_on_sql_error
+def get_sql_forms(form_id):
+    return FormAccessorSQL.get_forms(form_id)

--- a/corehq/apps/couch_sql_migration/casedifftool.py
+++ b/corehq/apps/couch_sql_migration/casedifftool.py
@@ -117,7 +117,7 @@ class CaseDiffTool:
         log.info(f"patching {count} cases")
         diffs = with_progress_bar(diffs, count, prefix="Case diffs", oneline=False)
         for pending_diffs in self.map_cases(patch_diffs, diffs):
-            statedb.add_cases_to_diff(pending_diffs)
+            statedb.add_patched_cases(pending_diffs)
 
     def iter_case_diff_results(self, cases):
         if cases is None:

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -28,7 +28,6 @@ from corehq.util.metrics import metrics_counter
 from .casediff import get_domain
 from .casedifftool import format_diffs
 from .couchsqlmigration import get_case_and_ledger_updates, save_migrated_models
-from .statedb import Change
 from .util import retry_on_sql_error
 
 log = logging.getLogger(__name__)

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -1,0 +1,171 @@
+import logging
+from datetime import datetime
+from functools import partial
+from uuid import uuid4
+
+from django.template.loader import render_to_string
+
+import attr
+from memoized import memoized
+
+from casexml.apps.phone.xml import get_case_xml
+from dimagi.utils.couch.database import retry_on_couch_error
+from dimagi.utils.parsing import json_format_datetime
+
+from corehq.blobs import get_blob_db
+from corehq.form_processor.backends.couch.dbaccessors import CaseAccessorCouch
+from corehq.form_processor.models import (
+    Attachment,
+    XFormInstanceSQL,
+    XFormOperationSQL,
+)
+from corehq.util.metrics import metrics_counter
+
+from .casediff import get_domain
+from .casedifftool import format_diffs
+from .couchsqlmigration import get_case_and_ledger_updates, save_migrated_models
+from .statedb import Change
+from .util import retry_on_sql_error
+
+log = logging.getLogger(__name__)
+
+
+def patch_diffs(doc_diffs, log_cases=False):
+    """Patch case diffs
+
+    :param doc_diffs: List of three-tuples as returned by
+    `StateDB.iter_doc_diffs()`.
+    :returns: A list of case ids to re-diff.
+    """
+    pending_diffs = []
+    dd_count = partial(metrics_counter, tags={"domain": get_domain()})
+    for kind, case_id, diffs in doc_diffs:
+        assert kind == "CommCareCase", (kind, case_id)
+        dd_count("commcare.couchsqlmigration.case.patch")
+        try:
+            patch_case(case_id, diffs)
+        except CannotPatch as err:
+            error_diffs = [(kind, case_id, err.diffs)]
+            log.warning("cannot patch %s", format_diffs(error_diffs))
+            continue
+        pending_diffs.append(case_id)
+    return pending_diffs
+
+
+def patch_case(case_id, diffs):
+    case_diffs = [d for d in diffs if d.kind != "stock state"]
+    couch_case = get_couch_case(case_id)
+    assert couch_case.domain == get_domain(), (couch_case, get_domain())
+    case = PatchCase(couch_case, case_diffs)
+    form = PatchForm(case)
+    process_patch(form)
+    patch_ledgers([d for d in diffs if d.kind == "stock state"])
+
+
+def patch_ledgers(diffs):
+    if diffs:
+        raise NotImplementedError
+
+
+@attr.s
+class PatchCase:
+    case = attr.ib()
+    diffs = attr.ib()
+    indices = attr.ib(factory=list, init=False)
+    case_attachments = attr.ib(factory=list, init=False)
+    IGNORE_PROPS = {"xform_ids"}
+
+    def __attrs_post_init__(self):
+        self._updates = []
+        if not all(isinstance(d, Change) for d in self.diffs):
+            raise CannotPatch([d.json_diff for d in self.diffs])
+
+    def __getattr__(self, name):
+        return getattr(self.case, name)
+
+    def dynamic_case_properties(self):
+        props = {}
+        ignore = self.IGNORE_PROPS
+        for planning_diff in self.diffs:
+            diff = planning_diff.json_diff
+            path = diff.path
+            if path[0] in ignore:
+                continue
+            raise CannotPatch([diff])
+        return props
+
+
+@attr.s
+class PatchForm:
+    _case = attr.ib()
+    form_id = attr.ib(factory=lambda: uuid4().hex, init=False)
+    received_on = attr.ib(factory=datetime.utcnow, init=False)
+    device_id = "couch-to-sql/patch-case-diff"
+    xmlns = f"http://commcarehq.org/{device_id}"
+    _proxy_attrs = {"domain", "user_id"}
+
+    def __getattr__(self, name):
+        if name in self._proxy_attrs:
+            return getattr(self._case, name)
+        raise AttributeError(name)
+
+    @memoized
+    def get_xml(self):
+        updates = self._case._updates
+        case_block = get_case_xml(self._case, updates, version='2.0')
+        return render_to_string('hqcase/xml/case_block.xml', {
+            'xmlns': self.xmlns,
+            'case_block': case_block.decode('utf-8'),
+            'time': json_format_datetime(self.received_on),
+            'uid': self.form_id,
+            'username': "",
+            'user_id': self.user_id or "",
+            'device_id': self.device_id,
+        })
+
+
+def process_patch(patch_form):
+    sql_form = XFormInstanceSQL(
+        form_id=patch_form.form_id,
+        domain=patch_form.domain,
+        xmlns=patch_form.xmlns,
+        user_id=patch_form.user_id,
+        received_on=patch_form.received_on,
+    )
+    add_form_xml(sql_form, patch_form)
+    add_patch_operation(sql_form)
+    case_stock_result = get_case_and_ledger_updates(patch_form.domain, sql_form)
+    save_sql_form(sql_form, case_stock_result)
+
+
+def add_form_xml(sql_form, patch_form):
+    xml = patch_form.get_xml()
+    att = Attachment("form.xml", xml.encode("utf-8"), content_type="text/xml")
+    xml_meta = att.write(get_blob_db(), sql_form)
+    sql_form.attachments_list = [xml_meta]
+
+
+def add_patch_operation(sql_form):
+    sql_form.track_create(XFormOperationSQL(
+        form=sql_form,
+        user_id=sql_form.user_id,
+        date=datetime.utcnow(),
+        operation="Couch to SQL case patch"
+    ))
+
+
+class CannotPatch(Exception):
+
+    def __init__(self, json_diffs):
+        super().__init__(repr(json_diffs))
+        self.diffs = json_diffs
+
+
+@retry_on_couch_error
+def get_couch_case(case_id):
+    return CaseAccessorCouch.get_case(case_id)
+
+
+@retry_on_sql_error
+def save_sql_form(sql_form, case_stock_result):
+    save_migrated_models(sql_form, case_stock_result)

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -162,8 +162,10 @@ class CouchSqlDomainMigrator:
         self.counter = DocCounter(self.statedb)
         if rebuild_state:
             self.statedb.is_rebuild = True
-        assert case_diff in {"after", "asap", "none"}, case_diff
-        self.diff_cases_after_forms = case_diff == "after"
+        assert case_diff in {"after", "patch", "asap", "none"}, case_diff
+        assert case_diff != "patch" or forms in [None, "missing"], (case_diff, forms)
+        self.should_patch_diffs = case_diff == "patch"
+        self.should_diff_cases = case_diff == "after"
         if case_diff == "asap":
             diff_queue = CaseDiffProcess
         else:
@@ -186,7 +188,9 @@ class CouchSqlDomainMigrator:
                 self._process_main_forms()
                 self._copy_unprocessed_forms()
                 self._copy_unprocessed_cases()
-            if self.diff_cases_after_forms:
+            if self.should_patch_diffs:
+                self._patch_diffs()
+            elif self.should_diff_cases:
                 self._diff_cases()
 
         log.info('migrated domain {}'.format(self.domain))
@@ -253,7 +257,7 @@ class CouchSqlDomainMigrator:
             _migrate_form_operations(sql_form, couch_form)
             case_stock_result = (self._get_case_stock_result(sql_form, couch_form)
                 if form_is_processed else None)
-            _save_migrated_models(sql_form, case_stock_result)
+            save_migrated_models(sql_form, case_stock_result)
         except IntegrityError as err:
             exc_info = sys.exc_info()
             try:
@@ -285,7 +289,7 @@ class CouchSqlDomainMigrator:
     def _get_case_stock_result(self, sql_form, couch_form):
         case_stock_result = None
         if sql_form.initial_processing_complete:
-            case_stock_result = _get_case_and_ledger_updates(self.domain, sql_form)
+            case_stock_result = get_case_and_ledger_updates(self.domain, sql_form)
             if case_stock_result.case_models:
                 has_noop_update = any(
                     len(update.actions) == 1 and isinstance(update.actions[0], CaseNoopAction)
@@ -373,6 +377,16 @@ class CouchSqlDomainMigrator:
             )
         finally:
             self.case_diff_queue.enqueue(couch_case.case_id)
+
+    def _patch_diffs(self):
+        from .casedifftool import CaseDiffTool
+        casediff = CaseDiffTool(self)
+        if not self.forms:
+            casediff.diff_cases()
+            self._process_missing_forms()
+        casediff.diff_cases("pending")
+        casediff.patch_diffs()
+        casediff.diff_cases("pending")
 
     def _diff_cases(self):
         from .casedifftool import CaseDiffTool
@@ -1036,7 +1050,7 @@ def _migrate_case_indices(couch_case, sql_case):
         ))
 
 
-def _get_case_and_ledger_updates(domain, sql_form):
+def get_case_and_ledger_updates(domain, sql_form):
     """
     Get a CaseStockProcessingResult with the appropriate cases and ledgers to
     be saved.
@@ -1077,7 +1091,7 @@ def _get_case_and_ledger_updates(domain, sql_form):
     )
 
 
-def _save_migrated_models(sql_form, case_stock_result):
+def save_migrated_models(sql_form, case_stock_result):
     """
     See SubmissionPost.save_processed_models for ~what this should do.
     However, note that that function does some things that this one shouldn't,

--- a/corehq/apps/couch_sql_migration/couchsqlmigration.py
+++ b/corehq/apps/couch_sql_migration/couchsqlmigration.py
@@ -244,7 +244,7 @@ class CouchSqlDomainMigrator:
                 xmlns = couch_form.xmlns
                 user_id = couch_form.user_id
             if xmlns == SYSTEM_ACTION_XMLNS:
-                for form_id, case_ids in do_system_action(couch_form):
+                for form_id, case_ids in do_system_action(couch_form, self.statedb):
                     self.case_diff_queue.update(case_ids, form_id)
             sql_form = XFormInstanceSQL(
                 form_id=couch_form.form_id,

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -88,8 +88,10 @@ load_ignore_rules = memoized(lambda: add_duplicate_rules({
         Ignore('diff', 'owner_id', old=''),
         Ignore('type', 'owner_id', old=None),
         Ignore('type', 'user_id', old=None),
+        Ignore('diff', 'user_id', old='', check=is_user_owner_mapping_case),
         Ignore('type', 'opened_on', old=None),
         Ignore('type', 'opened_by', old=MISSING),
+        Ignore('diff', 'opened_by', old='', check=is_user_owner_mapping_case),
         # The form that created the case was archived, but the opened_by
         # field was not updated as part of the subsequent rebuild.
         # `CouchCaseUpdateStrategy.reset_case_state()` does not reset
@@ -440,3 +442,7 @@ def is_case_without_create_action(old_obj, new_obj, rule, diff):
 
 def is_truncated_255(old_obj, new_obj, rule, diff):
     return len(diff.old_value) > 255 and diff.old_value[:255] == diff.new_value
+
+
+def is_user_owner_mapping_case(old_obj, new_obj, rule, diff):
+    return new_obj.get("case_id", "").startswith("user-owner-mapping-")

--- a/corehq/apps/couch_sql_migration/diff.py
+++ b/corehq/apps/couch_sql_migration/diff.py
@@ -156,6 +156,7 @@ load_ignore_rules = memoized(lambda: add_duplicate_rules({
     'LedgerValue': [
         Ignore(path='_id'),  # couch != SQL
         Ignore("missing", "location_id", old=MISSING, new=None),
+        Ignore("type", "location_id", old=None),
         Ignore("diff", "last_modified", check=has_close_dates),
         Ignore("type", "last_modified_form_id", old=None),
     ],

--- a/corehq/apps/couch_sql_migration/rebuildcase.py
+++ b/corehq/apps/couch_sql_migration/rebuildcase.py
@@ -34,10 +34,9 @@ def rebuild_and_diff_cases(sql_case, couch_case, original_couch_case, diff, dd_c
         sql_json = new_case.to_json()
         diffs = diff(couch_case, sql_json)
         if diffs and couch_case != original_couch_case:
-            original_diffs = diff(original_couch_case, sql_json)
-            if not original_diffs:
+            diffs = diff(original_couch_case, sql_json)
+            if not diffs:
                 log.info("original Couch case matches rebuilt SQL case: %s", sql_case.case_id)
-                diffs = original_diffs
         if not diffs:
             # save case only if rebuild resolves diffs
             CaseAccessorSQL.save_case(new_case)

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -524,6 +524,7 @@ class StateDB(DiffDB):
         - DocChanges - casediff w (case and stock kinds), main r/w
         - MissingDoc - casediff w, main r
         - NoActionCaseForm - main r/w
+        - PatchedCase - main r/w
         - ProblemForm - main r/w
         """
         def quote(value):

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -416,9 +416,9 @@ class StateDB(DiffDB):
         They are grouped with diffs of the corresponding case
         (kind="CommCareCase", doc_id=<case_id>).
 
-        :yeilds: two-tuples `(doc_id, diffs)`. The diffs yielded here are
-        `PlanningDiff` objects, which should not be confused with json
-        diffs (`<PlanningDiff>.json_diff`).
+        :yeilds: three-tuples `(kind, doc_id, diffs)`. The diffs yielded
+        here are `PlanningDiff` objects, which should not be confused
+        with json diffs (`<PlanningDiff>.json_diff`).
         """
         if _model is None:
             _model = DocDiffs

--- a/corehq/apps/couch_sql_migration/statedb.py
+++ b/corehq/apps/couch_sql_migration/statedb.py
@@ -484,7 +484,7 @@ class StateDB(DiffDB):
             diffs=diffs.get(kind, 0),
             missing=missing.get(kind, 0),
             changes=changes.get(kind, 0),
-        ) for kind in set(totals) | set(missing) | set(diffs)}
+        ) for kind in set(totals) | set(diffs) | set(missing) | set(changes)}
 
     def iter_missing_doc_ids(self, kind):
         with self.session() as session:

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -644,3 +644,44 @@ class DiffTestCases(SimpleTestCase):
         diffs = json_diff(couch_case, sql_case, track_list_indices=False)
         filtered = filter_case_diffs(couch_case, sql_case, diffs)
         self.assertEqual(filtered, [])
+
+    def test_user_owner_mapping_case_with_opened_and_user_diffs(self):
+        couch_case = {
+            "case_id": "user-owner-mapping-eca7a8",
+            "actions": [{"action_type": "create", "user_id": "somebody"}],
+            "doc_type": "CommCareCase",
+            "opened_by": "",
+            "user_id": "",
+        }
+        sql_case = {
+            "case_id": "user-owner-mapping-eca7a8",
+            "actions": [{"action_type": "create", "user_id": "somebody"}],
+            "doc_type": "CommCareCase",
+            "opened_by": "somebody",
+            "user_id": "somebody",
+        }
+        diffs = json_diff(couch_case, sql_case, track_list_indices=False)
+        filtered = filter_case_diffs(couch_case, sql_case, diffs)
+        self.assertEqual(filtered, [])
+
+    def test_non_user_owner_mapping_case_with_opened_and_user_diffs(self):
+        couch_case = {
+            "case_id": "eca7a8",
+            "actions": [{"action_type": "create", "user_id": "somebody"}],
+            "doc_type": "CommCareCase",
+            "opened_by": "",
+            "user_id": "",
+        }
+        sql_case = {
+            "case_id": "eca7a8",
+            "actions": [{"action_type": "create", "user_id": "somebody"}],
+            "doc_type": "CommCareCase",
+            "opened_by": "somebody",
+            "user_id": "somebody",
+        }
+        diffs = json_diff(couch_case, sql_case, track_list_indices=False)
+        filtered = filter_case_diffs(couch_case, sql_case, diffs)
+        self.assertEqual(filtered, [
+            FormJsonDiff(diff_type='diff', path=('opened_by',), old_value='', new_value='somebody'),
+            FormJsonDiff(diff_type='diff', path=('user_id',), old_value='', new_value='somebody'),
+        ])

--- a/corehq/apps/couch_sql_migration/tests/test_diffs.py
+++ b/corehq/apps/couch_sql_migration/tests/test_diffs.py
@@ -308,7 +308,17 @@ class DiffTestCases(SimpleTestCase):
         ])
 
     def test_filter_ledger_diffs(self):
-        ignored_diffs = _make_ignored_diffs('LedgerValue')
+        ignored_diffs = _make_ignored_diffs('LedgerValue') + [
+            FormJsonDiff(
+                diff_type='diff', path=('last_modified',),
+                old_value='2016-04-01T00:00:00.000000Z',
+                new_value='2016-04-01T15:39:19.711333Z',
+            ),
+            FormJsonDiff(
+                diff_type='type', path=('last_modified_form_id',),
+                old_value=None, new_value='7ab03ccc-e5b7-4c8f-b88f-43ee3b0543a5',
+            ),
+        ]
         filtered = filter_ledger_diffs(ignored_diffs + REAL_DIFFS)
         self.assertEqual(filtered, REAL_DIFFS)
 

--- a/corehq/apps/couch_sql_migration/tests/test_migration.py
+++ b/corehq/apps/couch_sql_migration/tests/test_migration.py
@@ -140,13 +140,15 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
         FormProcessorTestUtils.delete_all_cases_forms_ledgers()
         self.domain.delete()
 
-    def _do_migration(self, domain=None, action=MIGRATE, chunk_size=0, **options):
+    def do_migration(self, action=MIGRATE, domain=None, chunk_size=0, **options):
         if domain is None:
             domain = self.domain_name
         if chunk_size:
             patch_chunk_size = self.patch_migration_chunk_size(chunk_size)
         else:
             patch_chunk_size = suppress()  # until nullcontext with py3.7
+        diffs = options.pop("diffs", None)
+        ignore_fail = options.pop("ignore_fail", False)
         if "missing_docs" not in options:
             patch_find_missing_docs = mock.patch(
                 "corehq.apps.couch_sql_migration.management.commands"
@@ -171,13 +173,12 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
                 raise
             except SystemExit:
                 success = False
+        self.assert_backend(("couch" if action == RESET else "sql"), domain)
         self.migration_success = success
+        if action == MIGRATE and diffs is not IGNORE:
+            self.compare_diffs(diffs=diffs, ignore_fail=ignore_fail)
 
-    def _do_migration_and_assert_flags(self, domain, **options):
-        self._do_migration(domain, finish=True, **options)
-        self.assert_backend("sql", domain)
-
-    def _compare_diffs(self, diffs=None, changes=None, missing=None, ignore_fail=False):
+    def compare_diffs(self, diffs=None, changes=None, missing=None, ignore_fail=False):
         statedb = open_state_db(self.domain_name, self.state_dir)
         self.assertEqual(Diff.getlist(statedb.iter_diffs()), diffs or [])
         self.assertEqual(Diff.getlist(statedb.iter_changes()), changes or [])
@@ -186,8 +187,18 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
             for kind, counts in statedb.get_doc_counts().items()
             if counts.missing
         }, missing or {})
-        if not (diffs or changes or self.migration_success or ignore_fail):
-            self.fail("migration failed")
+        if not (diffs or changes or ignore_fail):
+            if not self.migration_success:
+                self.fail("migration failed")
+            assert not self.is_live_migration(), "live migration not finished"
+
+    def is_live_migration(self):
+        from corehq.apps.couch_sql_migration.progress import (
+            MigrationStatus,
+            get_couch_sql_migration_status,
+        )
+        status = get_couch_sql_migration_status(self.domain_name)
+        return status == MigrationStatus.DRY_RUN
 
     def _get_form_ids(self, doc_type='XFormInstance'):
         domain = self.domain_name
@@ -304,6 +315,9 @@ class BaseMigrationTestCase(TestCase, TestFileMixin):
             yield
 
 
+IGNORE = object()
+
+
 @contextmanager
 def null_context():
     yield
@@ -330,20 +344,19 @@ class MigrationTestCase(BaseMigrationTestCase):
     def test_migration_blacklist(self):
         COUCH_SQL_MIGRATION_BLACKLIST.set(self.domain_name, True, NAMESPACE_DOMAIN)
         with self.assertRaises(mod.MigrationRestricted):
-            self._do_migration(self.domain_name)
+            self.do_migration()
         COUCH_SQL_MIGRATION_BLACKLIST.set(self.domain_name, False, NAMESPACE_DOMAIN)
 
     def test_migration_custom_report(self):
         with get_report_domain() as domain:
             with self.assertRaises(mod.MigrationRestricted):
-                self._do_migration(domain.name)
+                self.do_migration(domain=domain.name)
 
     def test_basic_form_migration(self):
         create_and_save_a_form(self.domain_name)
         self.assertEqual(1, len(self._get_form_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_form_ids()))
-        self._compare_diffs([])
 
     def test_basic_form_migration_with_timezones(self):
         form_xml = self.get_xml('tz_form')
@@ -352,19 +365,17 @@ class MigrationTestCase(BaseMigrationTestCase):
             submit_form_locally(form_xml, self.domain_name)
         self.assertEqual(1, len(self._get_form_ids()))
         self.assertEqual(1, len(self._get_case_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_case_ids()))
         self.assertEqual(1, len(self._get_form_ids()))
-        self._compare_diffs([])
 
     def test_form_with_not_meta_migration(self):
         submit_form_locally(SIMPLE_FORM_XML, self.domain_name)
         couch_form_ids = self._get_form_ids()
         self.assertEqual(1, len(couch_form_ids))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         sql_form_ids = self._get_form_ids()
         self.assertEqual(couch_form_ids, sql_form_ids)
-        self._compare_diffs([])
 
     def test_form_with_missing_xmlns(self):
         form_id = uuid.uuid4().hex
@@ -394,32 +405,28 @@ class MigrationTestCase(BaseMigrationTestCase):
         form.delete_attachment('form.xml')
         form.put_attachment(xml_no_xmlns, 'form.xml')
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_form_ids()))
-        self._compare_diffs([])
 
     def test_archived_form_migration(self):
         form = create_and_save_a_form(self.domain_name)
         form.archive('user1')
         self.assertEqual(self._get_form_ids('XFormArchived'), {form.form_id})
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(self._get_form_ids('XFormArchived'), {form.form_id})
-        self._compare_diffs([])
 
     def test_archived_form_with_case_migration(self):
         self.submit_form(make_test_form("archived")).archive()
         self.assertEqual(self._get_form_ids('XFormArchived'), {'archived'})
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(self._get_form_ids('XFormArchived'), {'archived'})
         self.assertEqual(self._get_case_ids('CommCareCase-Deleted'), {'test-case'})
-        self._compare_diffs([])
 
     def test_error_form_migration(self):
         submit_form_locally(ERROR_FORM, self.domain_name)
         self.assertEqual(self._get_form_ids('XFormError'), {"im-a-bad-form"})
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(self._get_form_ids('XFormError'), {"im-a-bad-form"})
-        self._compare_diffs([])
 
     def test_error_with_normal_doc_type_migration(self):
         submit_form_locally(ERROR_FORM, self.domain_name)
@@ -427,9 +434,8 @@ class MigrationTestCase(BaseMigrationTestCase):
         form_json = form.to_json()
         form_json['doc_type'] = 'XFormInstance'
         XFormInstance.wrap(form_json).save()
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(self._get_form_ids('XFormError'), {'im-a-bad-form'})
-        self._compare_diffs([])
 
     def test_duplicate_form_migration(self):
         with open('corehq/ex-submodules/couchforms/tests/data/posts/duplicate.xml', encoding='utf-8') as f:
@@ -440,10 +446,9 @@ class MigrationTestCase(BaseMigrationTestCase):
 
         self.assertEqual(1, len(self._get_form_ids()))
         self.assertEqual(1, len(self._get_form_ids('XFormDuplicate')))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_form_ids()))
         self.assertEqual(1, len(self._get_form_ids('XFormDuplicate')))
-        self._compare_diffs([])
 
     @softer_assert()
     def test_deprecated_form_migration(self):
@@ -480,9 +485,8 @@ class MigrationTestCase(BaseMigrationTestCase):
             self.assertEqual(self._get_case_ids(), {case_id})
 
         assertState()
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         assertState()
-        self._compare_diffs([])
 
     def test_old_form_metadata_migration(self):
         form_with_old_meta = """<?xml version="1.0" ?>
@@ -502,9 +506,8 @@ class MigrationTestCase(BaseMigrationTestCase):
         """
         submit_form_locally(form_with_old_meta, self.domain_name)
         self.assertEqual(1, len(self._get_form_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_form_ids()))
-        self._compare_diffs([])
 
     def test_deleted_form_migration(self):
         form = create_and_save_a_form(self.domain_name)
@@ -513,9 +516,8 @@ class MigrationTestCase(BaseMigrationTestCase):
         )
 
         self.assertEqual(1, len(self._get_form_ids("XFormInstance-Deleted")))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain_name)))
-        self._compare_diffs([])
 
     def test_edited_deleted_form(self):
         form = create_and_save_a_form(self.domain_name)
@@ -525,12 +527,11 @@ class MigrationTestCase(BaseMigrationTestCase):
             [form.form_id], datetime.utcnow(), 'test-deletion'
         )
         self.assertEqual(self._get_form_ids("XFormInstance-Deleted"), {form.form_id})
-        self._do_migration_and_assert_flags(form.domain)
+        self.do_migration()
         self.assertEqual(
             FormAccessorSQL.get_deleted_form_ids_in_domain(form.domain),
             [form.form_id],
         )
-        self._compare_diffs([])
 
     def test_submission_error_log_migration(self):
         try:
@@ -539,9 +540,8 @@ class MigrationTestCase(BaseMigrationTestCase):
             pass
 
         self.assertEqual(1, len(self._get_form_ids(doc_type='SubmissionErrorLog')))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_form_ids(doc_type='SubmissionErrorLog')))
-        self._compare_diffs([])
 
     def test_hqsubmission_migration(self):
         form = create_and_save_a_form(self.domain_name)
@@ -549,9 +549,8 @@ class MigrationTestCase(BaseMigrationTestCase):
         form.save()
 
         self.assertEqual(self._get_form_ids("HQSubmission"), {form.form_id})
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(self._get_form_ids(), {form.form_id})
-        self._compare_diffs([])
 
     @flag_enabled('MM_CASE_PROPERTIES')
     def test_migrate_attachments(self):
@@ -595,17 +594,15 @@ class MigrationTestCase(BaseMigrationTestCase):
 
         self.assertEqual(1, len(self._get_form_ids()))
         self.assertEqual(1, len(self._get_case_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_form_ids()))
         self.assertEqual(1, len(self._get_case_ids()))
-        self._compare_diffs([])
 
     def test_basic_case_migration(self):
         create_and_save_a_case(self.domain_name, case_id=uuid.uuid4().hex, case_name='test case')
         self.assertEqual(1, len(self._get_case_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_case_ids()))
-        self._compare_diffs([])
 
     def test_basic_case_migration_case_name(self):
         case_id = uuid.uuid4().hex
@@ -628,9 +625,8 @@ class MigrationTestCase(BaseMigrationTestCase):
         )
 
         self.assertEqual(1, len(self._get_case_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(1, len(self._get_case_ids()))
-        self._compare_diffs([])
 
     def test_case_with_indices_migration(self):
         parent_case_id = uuid.uuid4().hex
@@ -640,9 +636,8 @@ class MigrationTestCase(BaseMigrationTestCase):
         set_parent_case(self.domain_name, child_case, parent_case)
 
         self.assertEqual(2, len(self._get_case_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(2, len(self._get_case_ids()))
-        self._compare_diffs([])
 
         indices = CaseAccessorSQL.get_indices(self.domain_name, child_case_id)
         self.assertEqual(1, len(indices))
@@ -664,9 +659,8 @@ class MigrationTestCase(BaseMigrationTestCase):
             [parent_case_id, child_case_id], datetime.utcnow(), 'test-deletion-with-cases'
         )
         self.assertEqual(2, len(self._get_case_ids("CommCareCase-Deleted")))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(2, len(CaseAccessorSQL.get_deleted_case_ids_in_domain(self.domain_name)))
-        self._compare_diffs([])
         parent_transactions = CaseAccessorSQL.get_transactions(parent_case_id)
         self.assertEqual(2, len(parent_transactions))
         self.assertTrue(parent_transactions[0].is_case_create)
@@ -715,14 +709,13 @@ class MigrationTestCase(BaseMigrationTestCase):
 
         self.assertEqual(2, len(self._get_form_ids()))
         self.assertEqual(2, len(self._get_case_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(2, len(self._get_form_ids()))
         self.assertEqual(2, len(self._get_case_ids()))
-        self._compare_diffs([])
 
     def test_commit(self):
-        self._do_migration_and_assert_flags(self.domain_name)
-        self._do_migration(action=COMMIT)
+        self.do_migration()
+        self.do_migration(COMMIT)
         self.assert_backend("sql")
 
     def test_v1_case(self):
@@ -779,14 +772,13 @@ class MigrationTestCase(BaseMigrationTestCase):
 
         self.assertEqual(2, len(self._get_form_ids()))
         self.assertEqual(1, len(self._get_case_ids()))
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
         self.assertEqual(2, len(self._get_form_ids()))
         self.assertEqual(1, len(self._get_case_ids()))
-        self._compare_diffs([])
 
     def test_timings(self):
         with capture_metrics() as received_stats:
-            self._do_migration_and_assert_flags(self.domain_name)
+            self.do_migration()
         tracked_stats = [
             'commcare.couch_sql_migration.unprocessed_cases.count',
             'commcare.couch_sql_migration.main_forms.count',
@@ -804,18 +796,18 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assert_backend("couch")
 
         with self.patch_migration_chunk_size(2):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
 
         with self.assertRaises(CommandError):
-            self._do_migration(action=COMMIT)
+            self.do_migration(COMMIT)
 
         self.submit_form(make_test_form("test-5"))
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2", "test-3", "test-4", "test-5"})
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True)
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2", "test-3", "test-4", "test-5"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
 
@@ -838,11 +830,11 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.submit_form(make_test_form("form-2"), timedelta(minutes=-90))
 
         with interrupted_migration():
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"form-1"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs(ignore_fail=True)
+        self.compare_diffs(ignore_fail=True)
 
         clear_local_domain_sql_backend_override(self.domain_name)
         # change couch form, which has already been migrated, to create a diff
@@ -851,24 +843,23 @@ class MigrationTestCase(BaseMigrationTestCase):
         form.save()
 
         # migration should re-diff previously migrated form-1
-        self._do_migration_and_assert_flags(self.domain_name)
-        self.assertEqual(self._get_form_ids(), {"form-1", "form-2"})
-        self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs([
+        self.do_migration(finish=True, diffs=[
             Diff('form-1', 'diff', ['form', 'first_name'], old="Zeena", new="Xeenax"),
         ])
+        self.assertEqual(self._get_form_ids(), {"form-1", "form-2"})
+        self.assertEqual(self._get_case_ids(), {"test-case"})
 
     def test_migrate_unprocessed_form_twice(self):
         self.submit_form(make_test_form("form-1"), timedelta(minutes=-95)).archive()
         self.submit_form(make_test_form("form-2"), timedelta(minutes=-90)).archive()
 
         with self.stop_on_doc("XFormArchived", "form-2"):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids("XFormArchived"), {"form-1"})
         self.assertEqual(self._get_case_ids(), set())
         self.assertEqual(self._get_case_ids("CommCareCase-Deleted"), set())
-        self._compare_diffs(ignore_fail=True)
+        self.compare_diffs(ignore_fail=True)
 
         clear_local_domain_sql_backend_override(self.domain_name)
         # change couch form, which has already been migrated, to create a diff
@@ -877,12 +868,11 @@ class MigrationTestCase(BaseMigrationTestCase):
         form.save()
 
         # migration should re-diff previously migrated form-1
-        self._do_migration_and_assert_flags(self.domain_name)
-        self.assertEqual(self._get_form_ids("XFormArchived"), {"form-1", "form-2"})
-        self.assertEqual(self._get_case_ids("CommCareCase-Deleted"), {"test-case"})
-        self._compare_diffs([
+        self.do_migration(finish=True, diffs=[
             Diff('form-1', 'diff', ['form', 'first_name'], old="Zeena", new="Xeenax"),
         ])
+        self.assertEqual(self._get_form_ids("XFormArchived"), {"form-1", "form-2"})
+        self.assertEqual(self._get_case_ids("CommCareCase-Deleted"), {"test-case"})
 
     def test_migrate_deleted_case_twice(self):
         form1 = make_test_form("form-1", case_id="case-1")
@@ -893,12 +883,12 @@ class MigrationTestCase(BaseMigrationTestCase):
         CaseAccessors(self.domain.name).soft_delete_cases(["case-1", "case-2"], now)
 
         with self.stop_on_doc("CommCareCase-Deleted", "case-2"):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"form-1", "form-2"})
         self.assertEqual(self._get_case_ids("CommCareCase-Deleted"), {"case-1"})
         self.assertEqual(self._get_case_ids(), {"case-2"})
-        self._compare_diffs(ignore_fail=True)
+        self.compare_diffs(ignore_fail=True)
 
         clear_local_domain_sql_backend_override(self.domain_name)
         # change couch case, which has already been migrated, to create a diff
@@ -908,11 +898,10 @@ class MigrationTestCase(BaseMigrationTestCase):
 
         # migration should re-diff previously migrated form-1
         with self.diff_without_rebuild():
-            self._do_migration_and_assert_flags(self.domain_name)
+            self.do_migration(finish=True, diffs=[
+                Diff("case-1", 'diff', ['age'], old='35', new='27', kind="CommCareCase-Deleted"),
+            ])
         self.assertEqual(self._get_case_ids("CommCareCase-Deleted"), {"case-1", "case-2"})
-        self._compare_diffs([
-            Diff("case-1", 'diff', ['age'], old='35', new='27', kind="CommCareCase-Deleted"),
-        ])
 
     def test_migrate_archived_form_after_live_migration_of_error_forms(self):
         # The theory of this test is that XFormArchived comes earlier in
@@ -920,7 +909,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         # that an archived form added after an error form that was not
         # processed by the previous live migration will be migrated.
         self.submit_form(ERROR_FORM)
-        self._do_migration(live=True)
+        self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids('XFormError'), set())
 
@@ -928,20 +917,16 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assert_backend("couch")
         self.submit_form(make_test_form("archived")).archive()
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True)
         self.assertEqual(self._get_form_ids("XFormError"), {"im-a-bad-form"})
         self.assertEqual(
             {self._describe(f) for f in self._iter_forms("XFormArchived")},
             {"archived", "archive_form archived"}
         )
-        self._compare_diffs([])
 
     def test_edit_form_after_live_migration(self):
-        self.assert_backend("couch")
         self.submit_form(make_test_form("test-1"), timedelta(minutes=-90))
-
-        self._do_migration(live=True)
-        self.assert_backend("sql")
+        self.do_migration(live=True, diffs=IGNORE)
         self.assertEqual(self._get_form_ids(), {"test-1"})
 
         clear_local_domain_sql_backend_override(self.domain_name)
@@ -949,8 +934,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         with self.assertRaises(NotAllowed):
             self.submit_form(make_test_form("test-1", age=30))
 
-        self._do_migration_and_assert_flags(self.domain_name)
-        self._compare_diffs([])
+        self.do_migration(finish=True)
         self.assertEqual(self._get_form_ids(), {"test-1"})
         self.assertEqual(self._get_form_ids("XFormDeprecated"), set())
         form = FormAccessorSQL.get_form("test-1")
@@ -963,7 +947,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.submit_form(make_test_form("arch-1"), timedelta(minutes=-95))
         self.submit_form(make_test_form("arch-2"), timedelta(minutes=-90)).archive()
         with self.patch_migration_chunk_size(1):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"arch-1"})
         self.assertEqual(self._get_form_ids("XFormArchived"), {"arch-2"})
@@ -973,21 +957,19 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assert_backend("couch")
         self._get_form("arch-1").archive()
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True)
         self.assertFalse(self._get_form_ids())
         self.assertEqual(
             {self._describe(f) for f in self._iter_forms("XFormArchived")},
             {"arch-1", "arch-2", "archive_form arch-1"}
         )
         self.assertEqual(self._get_case_ids("CommCareCase-Deleted"), {"test-case"})
-        self._compare_diffs([])
 
     def test_migrate_unarchived_form_after_live_migration(self):
         self.submit_form(make_test_form("form"), timedelta(minutes=-90))
         self.submit_form(make_test_form("arch"), timedelta(minutes=-95)).archive()
         with self.patch_migration_chunk_size(1):
-            self._do_migration(live=True)
-        self.assert_backend("sql")
+            self.do_migration(live=True, diffs=IGNORE)
         self.assertEqual(self._get_form_ids("XFormArchived"), {"arch"})
         self.assertEqual(self._get_form_ids(), {"form"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
@@ -996,7 +978,10 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assert_backend("couch")
         self._get_form("arch").unarchive()
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True, diffs=[
+            # diff because "arch" was originally migrated as an "unprocessed_form"
+            Diff('test-case', 'set_mismatch', ['xform_ids', '[*]'], old='arch', new=''),
+        ])
         self.assertEqual(
             {self._describe(f) for f in self._iter_forms()},
             {"form", "arch"},
@@ -1006,13 +991,8 @@ class MigrationTestCase(BaseMigrationTestCase):
             {"archive_form arch"}
         )
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        # diff because "arch" was originally migrated as an "unprocessed_form"
-        self._compare_diffs([
-            Diff('test-case', 'set_mismatch', ['xform_ids', '[*]'], old='arch', new=''),
-        ])
 
-        self._do_migration(forms="missing", case_diff="patch")
-        self._compare_diffs()
+        self.do_migration(forms="missing", case_diff="patch")
 
     @staticmethod
     def _describe(form):
@@ -1026,16 +1006,15 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.submit_form(make_test_form("form-1"), timedelta(minutes=-95))
         self.submit_form(make_test_form("form-2"), timedelta(minutes=-90)).soft_delete()
         with self.patch_migration_chunk_size(1):
-            self._do_migration(live=True)
-        self._compare_diffs(changes=[
+            self.do_migration(live=True, diffs=IGNORE)
+        self.compare_diffs(changes=[
             Diff("test-case", path=["xform_ids", "[*]"], old="form-2", new="", reason='rebuild case'),
         ])
 
         clear_local_domain_sql_backend_override(self.domain_name)
         safe_hard_delete(self._get_case("test-case"))
 
-        self._do_migration_and_assert_flags(self.domain_name)
-        self._compare_diffs()
+        self.do_migration(finish=True)
         deleted = FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain_name)
         self.assertEqual(set(deleted), {"form-2"})
         self.assertEqual(self._get_form_ids(), set())
@@ -1049,7 +1028,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.submit_form(make_test_form("form-1"), timedelta(minutes=-95))
         self.submit_form(make_test_form("form-2"), timedelta(minutes=-90)).soft_delete()
         with self.patch_migration_chunk_size(1):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         with self.assertRaises(NotAllowed):
             self._get_form("form-1").soft_delete()
@@ -1067,17 +1046,16 @@ class MigrationTestCase(BaseMigrationTestCase):
         with self.assertRaises(NotAllowed):
             FormAccessors(self.domain_name).soft_undelete_forms(["form-2"])
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True, diffs=IGNORE)
         deleted = FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain_name)
         self.assertEqual(set(deleted), {"form-2"})
         self.assertEqual(self._get_form_ids(), {"form-1"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs(changes=[
+        self.compare_diffs(changes=[
             Diff("test-case", path=["xform_ids", "[*]"], old="form-2", new="", reason="rebuild case")
         ])
 
-        self._do_migration(forms="missing", case_diff="patch")
-        self._compare_diffs()
+        self.do_migration(forms="missing", case_diff="patch")
         self.assertEqual(self._get_case("test-case").xform_ids, ["form-1", ANY])
 
     def test_delete_user_during_migration(self):
@@ -1085,7 +1063,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         user = CommCareUser.create(self.domain_name, "mobile-user", "123")
         # NOTE user is deleted when domain is deleted in tearDown
         with self.patch_migration_chunk_size(1):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         with self.assertRaises(NotAllowed):
             user.retire()
@@ -1099,9 +1077,8 @@ class MigrationTestCase(BaseMigrationTestCase):
         with self.assertRaises(NotAllowed):
             user.unretire()
 
-        self._do_migration_and_assert_flags(self.domain_name)
-        self._compare_diffs([])
-        self._do_migration(action=COMMIT)
+        self.do_migration(finish=True)
+        self.do_migration(COMMIT)
         user.retire()
         user.unretire()
 
@@ -1109,7 +1086,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         from corehq.apps.hqcase.tasks import delete_exploded_cases
         self.submit_form(make_test_form("form-1"), timedelta(minutes=-95))
         with self.patch_migration_chunk_size(1):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         with self.assertRaises(NotAllowed):
             CaseAccessors(self.domain_name).soft_undelete_cases(["test-case"])
@@ -1127,8 +1104,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         with self.assertRaises(NotAllowed):
             CaseAccessors(self.domain_name).soft_undelete_cases(["test-case"])
 
-        self._do_migration_and_assert_flags(self.domain_name)
-        self._compare_diffs([])
+        self.do_migration(finish=True)
 
     def test_migrate_skipped_forms(self):
         def skip_forms(form_ids):
@@ -1152,24 +1128,23 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assert_backend("couch")
 
         with self.patch_migration_chunk_size(1), skip_forms({"test-1", "test-2"}):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"test-3"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
 
         with self.patch_migration_chunk_size(1), skip_forms({"test-2"}):
-            self._do_migration(action=STATS, missing_docs=REBUILD)
-            self._do_migration(live=True, forms="missing")
+            self.do_migration(STATS, missing_docs=REBUILD, diffs=IGNORE)
+            self.do_migration(live=True, forms="missing", diffs=IGNORE)
         self.assertEqual(self._get_form_ids(), {"test-1", "test-3"})
 
         with self.patch_migration_chunk_size(1):
-            self._do_migration(action=STATS, missing_docs=REBUILD)
-        self._do_migration(forms="missing")
+            self.do_migration(STATS, missing_docs=REBUILD, diffs=IGNORE)
+        self.do_migration(forms="missing", diffs=IGNORE)
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2", "test-3"})
 
-        self._do_migration(finish=True)
+        self.do_migration(finish=True)
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2", "test-3", "test-4"})
-        self._compare_diffs([])
 
     def test_migrate_partially_migrated_form_with_case(self):
         # form      age     min     max
@@ -1179,24 +1154,22 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.submit_form(make_test_form("test-2", age=31, max=9), timedelta(days=-1))
         self.assert_backend("couch")
         with self.skip_case_and_ledger_updates("test-1"):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=[
+                Diff("test-case", 'missing', ['min'], old='0', new=MISSING),
+                Diff("test-case", 'set_mismatch', ['xform_ids', '[*]'], old='test-1', new=''),
+            ])
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs([
-            Diff("test-case", 'missing', ['min'], old='0', new=MISSING),
-            Diff("test-case", 'set_mismatch', ['xform_ids', '[*]'], old='test-1', new=''),
-        ])
-        self._do_migration(forms="missing")
+        self.do_migration(forms="missing", ignore_fail=True)
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs([])
 
     def test_migrate_should_not_update_case_when_not_missing(self):
         self.submit_form(make_test_form("test-1", age=30, min=0), timedelta(days=-90))
         self.submit_form(make_test_form("test-2", age=31, max=9), timedelta(days=-1))
         self.assert_backend("couch")
-        self._do_migration(live=True)
+        self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"test-1", "test-2"})
         self.assertEqual(self._get_case_ids(), {"test-case"})
@@ -1205,18 +1178,18 @@ class MigrationTestCase(BaseMigrationTestCase):
         statedb.replace_case_diffs([("CommCareCase", "test-case", [diff])])
         with mock.patch.object(CaseAccessorSQL, "save_case") as save_case:
             save_case.side_effect = BaseException("unexpected save")
-            self._do_migration(forms="missing")
+            self.do_migration(forms="missing", diffs=IGNORE)
 
     def test_reset_migration(self):
         now = datetime.utcnow()
         self.submit_form(make_test_form("test-1"), now - timedelta(minutes=95))
         self.assert_backend("couch")
 
-        self._do_migration(live=True)
+        self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {"test-1"})
 
-        self._do_migration(action=RESET)
+        self.do_migration(RESET)
         self.assert_backend("couch")
         self.assertEqual(self._get_form_ids(), {"test-1"})
         form_ids = FormAccessorSQL \
@@ -1246,8 +1219,7 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.submit_form(make_test_form("arch"), timedelta(minutes=-93)).archive()
         with self.patch_migration_chunk_size(1), \
                 self.on_doc("XFormInstance", "one", interrupt, **kw):
-            self._do_migration(live=True, case_diff="asap")
-        self.assert_backend("sql")
+            self.do_migration(live=True, case_diff="asap", diffs=IGNORE)
         self.assertFalse(self._get_form_ids("XFormArchived"))
 
     def get_resume_state(self, key, default=object()):
@@ -1258,10 +1230,9 @@ class MigrationTestCase(BaseMigrationTestCase):
         return value
 
     def resume_after_interruption(self):
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True)
         self.assertEqual(self._get_form_ids(), {"one", "two"})
         self.assertEqual(self._get_form_ids("XFormArchived"), {"arch"})
-        self._compare_diffs([])
 
     def test_rebuild_state(self):
         def interrupt():
@@ -1271,15 +1242,14 @@ class MigrationTestCase(BaseMigrationTestCase):
             self.submit_form(make_test_form(form_id), timedelta(minutes=-90))
         with self.patch_migration_chunk_size(2), \
                 self.on_doc("XFormInstance", "form-3", interrupt, raises=None):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), set(form_ids[:4]))
         statedb = init_state_db(self.domain_name, self.state_dir)
         with statedb.pop_resume_state("CaseDiffQueue", None):
             pass  # simulate failed exit
-        self._do_migration(live=True, rebuild_state=True)
+        self.do_migration(live=True, rebuild_state=True, ignore_fail=True)
         self.assertEqual(self._get_form_ids(), set(form_ids))
-        self._compare_diffs([])
 
     def test_case_forms_list_order(self):
         SERVER_DATES = [
@@ -1297,11 +1267,10 @@ class MigrationTestCase(BaseMigrationTestCase):
         case = self._get_case("89da")
         self.assertEqual(case.xform_ids, ["f1-9017", "f2-b1ce", "f3-7c38", "f4-3226"])
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration()
 
         case = self._get_case("89da")
         self.assertEqual(set(case.xform_ids), {"f1-9017", "f2-b1ce", "f3-7c38", "f4-3226"})
-        self._compare_diffs([])
 
     def test_normal_form_with_problem_and_case_updates(self):
         bad_form = submit_form_locally(TEST_FORM, self.domain_name).xform
@@ -1326,19 +1295,18 @@ class MigrationTestCase(BaseMigrationTestCase):
         case = self._get_case("test-case")
         self.assertEqual(case.xform_ids, ["test-form"])
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True, diffs=IGNORE)
 
         case = self._get_case("test-case")
         self.assertEqual(case.xform_ids, ["new-form"])
-        self._compare_diffs(changes=[
+        self.compare_diffs(changes=[
             Diff("test-case", path=["xform_ids", "[*]"], old="test-form", new="new-form", reason='rebuild case')
         ])
         form = self._get_form('new-form')
         self.assertEqual(form.deprecated_form_id, "test-form")
         self.assertIsNone(form.problem)
 
-        self._do_migration(forms="missing", case_diff="patch")
-        self._compare_diffs()
+        self.do_migration(forms="missing", case_diff="patch")
         self.assertEqual(self._get_case("test-case").xform_ids, ["new-form", ANY])
 
     def test_case_with_problem_form(self):
@@ -1348,20 +1316,17 @@ class MigrationTestCase(BaseMigrationTestCase):
         two = self.submit_form(make_test_form("two", age=30))
         two.problem = "Bad thing that happened"
         two.save()
-        self._do_migration()
-        self._compare_diffs([
+        self.do_migration(diffs=[
             Diff('test-case', 'diff', ['age'], old='30', new='27'),
             Diff('test-case', 'set_mismatch', ['xform_ids', '[*]'], old='two', new=''),
         ])
         Mig = mod.CouchSqlDomainMigrator
         with mock.patch.object(Mig, "_apply_form_to_case", Mig._get_case_stock_result):
-            self._do_migration(forms="missing")
-        self._compare_diffs([
-            Diff('test-case', 'diff', ['age'], old='30', new='27'),
-            Diff('test-case', 'set_mismatch', ['xform_ids', '[*]'], old='two', new=''),
-        ])
-        self._do_migration(forms="missing")
-        self._compare_diffs()
+            self.do_migration(forms="missing", diffs=[
+                Diff('test-case', 'diff', ['age'], old='30', new='27'),
+                Diff('test-case', 'set_mismatch', ['xform_ids', '[*]'], old='two', new=''),
+            ])
+        self.do_migration(forms="missing")
 
     def test_case_with_unprocessed_form(self):
         # form state=normal, initial_processing_complete=false
@@ -1369,13 +1334,11 @@ class MigrationTestCase(BaseMigrationTestCase):
         two = self.submit_form(make_test_form("two", age=30))
         two.initial_processing_complete = False
         two.save()
-        self._do_migration()
-        self._compare_diffs([
+        self.do_migration(diffs=[
             Diff('test-case', 'diff', ['age'], old='30', new='27'),
             Diff('test-case', 'set_mismatch', ['xform_ids', '[*]'], old='two', new=''),
         ])
-        self._do_migration(forms="missing")
-        self._compare_diffs()
+        self.do_migration(forms="missing")
 
     def test_missing_case(self):
         # This can happen when a form is edited, removing the last
@@ -1391,17 +1354,16 @@ class MigrationTestCase(BaseMigrationTestCase):
         self.assertEqual(couch_case.xform_ids, ["test-form"])
         self.assertEqual(self._get_case("other-case").xform_ids, ["test-form"])
 
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True, diffs=IGNORE)
 
         self.assertEqual(self._get_case("other-case").xform_ids, ["test-form"])
         with self.assertRaises(CaseNotFound):
             self._get_case("test-case")
-        self._compare_diffs(changes=[
+        self.compare_diffs(changes=[
             Diff('test-case', 'missing', ['*'], old='*', new=MISSING, reason="orphaned case"),
         ])
 
-        self._do_migration(forms="missing", case_diff="patch")
-        self._compare_diffs()
+        self.do_migration(forms="missing", case_diff="patch")
         sql_case = self._get_case("test-case")
         self.assertNotEqual(type(couch_case), type(sql_case))
         self.assertEqual(sql_case.dynamic_case_properties()["age"], '27')
@@ -1409,25 +1371,23 @@ class MigrationTestCase(BaseMigrationTestCase):
 
     def test_missing_docs(self):
         self.submit_form(TEST_FORM, timedelta(minutes=-90))
-        self._do_migration(self.domain_name, live=True)
+        self.do_migration(live=True, diffs=IGNORE)
         FormAccessorSQL.hard_delete_forms(self.domain_name, ["test-form"])
         CaseAccessorSQL.hard_delete_cases(self.domain_name, ["test-case"])
-        self._do_migration(self.domain_name, missing_docs=REBUILD, finish=True)
-        self._compare_diffs(
+        self.do_migration(missing_docs=REBUILD, finish=True, diffs=IGNORE)
+        self.compare_diffs(
             missing={"XFormInstance": 1, "CommCareCase": 1},
             ignore_fail=True,
         )
 
     def test_form_with_missing_xml(self):
         create_form_with_missing_xml(self.domain_name)
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True)
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs([])
 
     def test_form_with_extra_xml_blob_metadata(self):
         form = create_form_with_extra_xml_blob_metadata(self.domain_name)
-        self._do_migration_and_assert_flags(self.domain_name)
-        self._compare_diffs([])
+        self.do_migration(finish=True)
         self.assertEqual(
             [m.name for m in get_blob_db().metadb.get_for_parent(form.form_id)],
             ["form.xml"],
@@ -1438,26 +1398,24 @@ class MigrationTestCase(BaseMigrationTestCase):
             raise Exception(f"refusing to wrap {doc}")
         form_id = submit_form_locally(SIMPLE_FORM_XML, self.domain_name).xform.form_id
         with mock.patch.object(XFormInstance, "wrap", bad_wrap):
-            self._do_migration_and_assert_flags(self.domain_name)
-        self._compare_diffs([
-            Diff(form_id, 'missing', ['_id'], new=MISSING),
-            Diff(form_id, 'missing', ['auth_context'], new=MISSING),
-            Diff(form_id, 'missing', ['doc_type'], new=MISSING),
-            Diff(form_id, 'missing', ['domain'], new=MISSING),
-            Diff(form_id, 'missing', ['form'], new=MISSING),
-            Diff(form_id, 'missing', ['history'], new=MISSING),
-            Diff(form_id, 'missing', ['initial_processing_complete'], new=MISSING),
-            Diff(form_id, 'missing', ['openrosa_headers'], new=MISSING),
-            Diff(form_id, 'missing', ['partial_submission'], new=MISSING),
-            Diff(form_id, 'missing', ['received_on'], new=MISSING),
-            Diff(form_id, 'missing', ['server_modified_on'], new=MISSING),
-            Diff(form_id, 'missing', ['xmlns'], new=MISSING),
-        ])
+            self.do_migration(finish=True, diffs=[
+                Diff(form_id, 'missing', ['_id'], new=MISSING),
+                Diff(form_id, 'missing', ['auth_context'], new=MISSING),
+                Diff(form_id, 'missing', ['doc_type'], new=MISSING),
+                Diff(form_id, 'missing', ['domain'], new=MISSING),
+                Diff(form_id, 'missing', ['form'], new=MISSING),
+                Diff(form_id, 'missing', ['history'], new=MISSING),
+                Diff(form_id, 'missing', ['initial_processing_complete'], new=MISSING),
+                Diff(form_id, 'missing', ['openrosa_headers'], new=MISSING),
+                Diff(form_id, 'missing', ['partial_submission'], new=MISSING),
+                Diff(form_id, 'missing', ['received_on'], new=MISSING),
+                Diff(form_id, 'missing', ['server_modified_on'], new=MISSING),
+                Diff(form_id, 'missing', ['xmlns'], new=MISSING),
+            ])
 
     def test_case_with_very_long_name(self):
         self.submit_form(make_test_form("naaaame", case_name="ha" * 128))
-        self._do_migration_and_assert_flags(self.domain_name)
-        self._compare_diffs([])
+        self.do_migration(finish=True)
 
 
 class LedgerMigrationTests(BaseMigrationTestCase):
@@ -1498,13 +1456,11 @@ class LedgerMigrationTests(BaseMigrationTestCase):
             self.jelly_babies._id: 175
         }}
         self._validate_ledger_data(self._get_ledger_state(case_id), expected_stock_state)
-        self._do_migration_and_assert_flags(self.domain_name)
+        self.do_migration(finish=True)
         self._validate_ledger_data(self._get_ledger_state(case_id), expected_stock_state)
 
         transactions = LedgerAccessorSQL.get_ledger_transactions_for_case(case_id)
         self.assertEqual(3, len(transactions))
-
-        self._compare_diffs([])
 
     def test_migrate_partially_migrated_form1_with_ledger(self):
         self.submit_form(TEST_FORM, timedelta(days=-5))  # create test-case
@@ -1515,7 +1471,7 @@ class LedgerMigrationTests(BaseMigrationTestCase):
         form2 = self._set_balance("test-case", {self.liquorice: 75}, timedelta(days=-1))
         print("ledger forms:", form1, form2)
         with self.skip_case_and_ledger_updates(form1):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.fix_missing_ledger_diffs(form1, form2, [
             Diff("test-case", "set_mismatch", ["xform_ids", "[*]"], old=form1, new=""),
             Diff(
@@ -1548,7 +1504,7 @@ class LedgerMigrationTests(BaseMigrationTestCase):
         form2 = self._set_balance("test-case", {self.liquorice: 75}, timedelta(days=-1))
         print("ledger forms:", form1, form2)
         with self.skip_case_and_ledger_updates(form2):
-            self._do_migration(live=True)
+            self.do_migration(live=True, diffs=IGNORE)
         self.fix_missing_ledger_diffs(form1, form2, [
             Diff("test-case", "set_mismatch", ["xform_ids", "[*]"], old=form2, new=""),
             Diff(kind="stock state", path=["balance"], old=75, new=50),
@@ -1560,11 +1516,10 @@ class LedgerMigrationTests(BaseMigrationTestCase):
         self.assert_backend("sql")
         self.assertEqual(self._get_form_ids(), {'test-form', form1, form2})
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs(diffs)
-        self._do_migration(forms="missing")
+        self.compare_diffs(diffs)
+        self.do_migration(forms="missing", ignore_fail=True)
         self.assertEqual(self._get_form_ids(), {'test-form', form1, form2})
         self.assertEqual(self._get_case_ids(), {"test-case"})
-        self._compare_diffs([])
 
     def _validate_ledger_data(self, state_dict, expected):
         for section, products in state_dict.items():

--- a/corehq/apps/couch_sql_migration/tests/test_statedb.py
+++ b/corehq/apps/couch_sql_migration/tests/test_statedb.py
@@ -361,6 +361,7 @@ def test_clone_casediff_data_from_tables():
         mod.DocChanges,
         mod.MissingDoc,
         mod.NoActionCaseForm,
+        mod.PatchedCase,
         mod.ProblemForm,
         # models not used by couch-to-sql migration
         PlanningForm,

--- a/corehq/apps/couch_sql_migration/util.py
+++ b/corehq/apps/couch_sql_migration/util.py
@@ -7,7 +7,11 @@ import gevent
 from gevent.pool import Pool
 from greenlet import GreenletExit
 
+from django.db import close_old_connections
+from django.db.utils import DatabaseError, InterfaceError
+
 from dimagi.utils.parsing import ISO_DATETIME_FORMAT
+from dimagi.utils.retry import retry_on
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +30,18 @@ def str_to_datetime(value):
     except ValueError:
         sans_micros = ISO_DATETIME_FORMAT.replace(".%f", "")
         return datetime.strptime(value, sans_micros)
+
+
+def retry_on_sql_error(func):
+    retry = retry_on(DatabaseError, InterfaceError, should_retry=_close_connections)
+    return retry(func)
+
+
+def _close_connections(err):
+    """Close old db connections, then return true to retry"""
+    log.warning("retry diff cases on %s: %s", type(err).__name__, err)
+    close_old_connections()
+    return True
 
 
 @contextmanager


### PR DESCRIPTION
New feature to patch SQL cases by submitting a form for each case with diffs. This makes unstable cases that would change if they were rebuilt in Couch have a stable state once migrated to SQL. Ledger patching is not yet implemented. Preliminary testing has shown that there are a few more case properties where diffs should probably be ignored since they cannot be patched (`opened_by`, `user_id`).

Review by commit 🐡 