### PR TITLE
Revert "Resize raw doc editor to show all content"

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/raw_doc.js
@@ -13,8 +13,7 @@ hqDefine('hqadmin/js/raw_doc', [
         $("#doc-form").koApplyBindings(viewModel);
 
         var $element = $("#doc-element"),
-            options = {maxLines: Infinity},
             doc = ($element.length ? JSON.stringify($element.data('doc'), null, 4) : null);
-        baseAce.initAceEditor($element.get(0), 'ace/mode/json', options, doc);
+        baseAce.initAceEditor($element.get(0), 'ace/mode/json', {}, doc);
     });
 });


### PR DESCRIPTION
Reverts dimagi/commcare-hq#26698

This unfortunately interferes with the ace searchbox: it no longer scrolls the document to the current search result, making search basically useless on large documents. I think this is a bigger usability problem than the double scroll bars.

Probably need to fix the double scroll bars using CSS on the raw doc page - it looks like the "extra" scrolling space is about the same height as the top nav plus the "Enter a doc id" section - or maybe there's an ace option that will take care of it.