### PR TITLE
Rework family_id handling in backfill_created_from_template.py

### DIFF
--- a/corehq/apps/app_manager/management/commands/backfill_created_from_template.py
+++ b/corehq/apps/app_manager/management/commands/backfill_created_from_template.py
@@ -13,7 +13,8 @@ logger = logging.getLogger('created_from_template_migration')
 APP_V1 = "828f651b0508423783d541240965c73a"
 APP_V2 = "46b1b6e5e3f04a1e9ca12d05150ad948"
 APP_V3 = "fe922d12718b4f2f9b4f9b36205ee860"
-APP_IDS = [APP_V1, APP_V2, APP_V3]
+OLD_APP = "a55dad9d483643d6abca13b16f5a7331"
+KNOWN_FAMILY_IDS = [APP_V1, APP_V2, APP_V3, OLD_APP]
 
 
 def _get_app_id(date_created):
@@ -30,7 +31,7 @@ class Command(BaseCommand):
     help = '''
         Populates created_from_template on apps docs that were likely imported from the COVID app library,
         prior to analytics being added.
-        
+
         This will only do anything on production, sicne it contains hard-coded app ids.
     '''
 
@@ -56,7 +57,7 @@ class Command(BaseCommand):
             h for h in hits
             if 'FFX' in h['name']
             and len(h['modules']) == 9
-            and (not h['family_id'] or h['family_id'] in APP_IDS)
+            and (not h['family_id'] or h['family_id'] in KNOWN_FAMILY_IDS)
         ]
         logger.info(f"Filtered to {len(hits)} apps likely imported from app library")
 

--- a/corehq/apps/app_manager/management/commands/backfill_created_from_template.py
+++ b/corehq/apps/app_manager/management/commands/backfill_created_from_template.py
@@ -10,21 +10,28 @@ from dimagi.utils.parsing import ISO_DATETIME_FORMAT
 
 logger = logging.getLogger('created_from_template_migration')
 
+APP_V1 = "828f651b0508423783d541240965c73a"
+APP_V2 = "46b1b6e5e3f04a1e9ca12d05150ad948"
+APP_V3 = "fe922d12718b4f2f9b4f9b36205ee860"
+APP_IDS = [APP_V1, APP_V2, APP_V3]
+
 
 def _get_app_id(date_created):
     # Guess at version based on date downloaded, assuming most people would have downloaded whatever was latest
     date_created = datetime.strptime(date_created, ISO_DATETIME_FORMAT)
     if date_created > datetime(2020, 4, 1):
-        return "fe922d12718b4f2f9b4f9b36205ee860"
+        return APP_V3
     if date_created > datetime(2020, 3, 27):
-        return "46b1b6e5e3f04a1e9ca12d05150ad948"
-    return "828f651b0508423783d541240965c73a"
+        return APP_V2
+    return APP_V1
 
 
 class Command(BaseCommand):
     help = '''
         Populates created_from_template on apps docs that were likely imported from the COVID app library,
         prior to analytics being added.
+        
+        This will only do anything on production, sicne it contains hard-coded app ids.
     '''
 
     def add_arguments(self, parser):
@@ -41,12 +48,16 @@ class Command(BaseCommand):
         end_date = datetime(2020, 4, 4)     # Release of analytics
         app_query = AppES().term('doc_type', 'Application') \
                            .missing('created_from_template') \
-                           .missing('family_id') \
                            .date_range('date_created', gt=start_date, lt=end_date)
         hits = app_query.run().hits
         logger.info(f"Pulled {len(hits)} apps from ES")
 
-        hits = [h for h in hits if 'FFX' in h['name'] and len(h['modules']) == 9]
+        hits = [
+            h for h in hits
+            if 'FFX' in h['name']
+            and len(h['modules']) == 9
+            and (not h['family_id'] or h['family_id'] in APP_IDS)
+        ]
         logger.info(f"Filtered to {len(hits)} apps likely imported from app library")
 
         for hit in hits:


### PR DESCRIPTION
##### SUMMARY
Updates to https://github.com/dimagi/commcare-hq/pull/27131

I added the family_id limitation last-minute without testing (tsk, tsk) and it turns out to be not quite right. It is possible to have family_id set, because it's set on the FFX template itself, which was copied from another app within the same domain.

Updated to allow family id that matches any of the released versions of the FFX app or the app it was originally copied from.