### PR TITLE
Make celery monitoring heartbeat tasks use ignore_result=True

### DIFF
--- a/corehq/celery_monitoring/heartbeat.py
+++ b/corehq/celery_monitoring/heartbeat.py
@@ -97,5 +97,5 @@ class Heartbeat(object):
 
         heartbeat.__name__ = str(self.periodic_task_name)
 
-        heartbeat = periodic_task(run_every=HEARTBEAT_FREQUENCY, queue=self.queue)(heartbeat)
+        heartbeat = periodic_task(run_every=HEARTBEAT_FREQUENCY, queue=self.queue, ignore_result=True)(heartbeat)
         return heartbeat


### PR DESCRIPTION
##### SUMMARY
Adding `ignore_result=True` makes celery not need to write to postgres at all for a task, since postgres is just needed to store and fetch progress and results. (The actual task is queued in RabbitMQ.)

I think these add up to maybe 5-8% of all celery tasks, which is neither overwhelming nor totally insignificant. DB queries to (1) fetch and (2) update individual celery tasks by task id are each individually the top 2 queries by total time spent on pgmain0-production (RDS instance). I expect this change will by itself have little visible effect to the instances high CPU usage, but this back of the envelope calculation says it's worth a shot, and I think it can't hurt.