### PR TITLE
Fix Column Sorting in Application Status report

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -155,6 +155,7 @@ class ApplicationStatusReport(GetParamsMixin, PaginatedReportMixin, DeploymentsR
                     sort_dict = {
                         sort_prop: {
                             "order": sort_dir,
+                            "nested_path": "reporting_metadata.last_submissions",
                             "nested_filter": {
                                 "term": {
                                     self.sort_filter: self.selected_app_id


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10717

##### SUMMARY
Apparently `nested_path` needs to be specified in the sorting block of an es query as of elasticsearch 2.4. In 1.7, this field was automatically determined based on the closest inherited nested field.