### PR TITLE
Case Bulk Importer API

### DIFF
--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -11,6 +11,8 @@ class ImporterError(Exception):
     When possible, a more specific subclass should be used
     """
 
+class ImporterRawError(ImporterError):
+    """Stand-in for generic error return codes"""
 
 class ImporterFileNotFound(ImporterError):
     """Raised when a referenced file can't be found"""

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -11,8 +11,10 @@ class ImporterError(Exception):
     When possible, a more specific subclass should be used
     """
 
+
 class ImporterRawError(ImporterError):
     """Stand-in for generic error return codes"""
+
 
 class ImporterFileNotFound(ImporterError):
     """Raised when a referenced file can't be found"""

--- a/corehq/apps/case_importer/urls.py
+++ b/corehq/apps/case_importer/urls.py
@@ -11,12 +11,14 @@ from corehq.apps.case_importer.views import (
     excel_commit,
     excel_config,
     excel_fields,
+    bulk_case_upload_api,
 )
 
 urlpatterns = [
     url(r'^excel/config/$', excel_config, name='excel_config'),
     url(r'^excel/fields/$', excel_fields, name='excel_fields'),
     url(r'^excel/commit/$', excel_commit, name='excel_commit'),
+    url(r'^excel/bulk_upload_api/$', bulk_case_upload_api, name='bulk_case_upload_api'),
     url(r'^history/uploads/$', case_uploads, name='case_importer_uploads'),
     url(r'^history/uploads/(?P<upload_id>[\w-]+)/comment/$', update_case_upload_comment,
         name='case_importer_update_upload_comment'),

--- a/corehq/apps/case_importer/util.py
+++ b/corehq/apps/case_importer/util.py
@@ -10,6 +10,7 @@ from memoized import memoized
 
 from corehq.apps.case_importer.const import LookupErrors
 from corehq.apps.case_importer.exceptions import (
+    ImporterRawError,
     ImporterExcelError,
     ImporterExcelFileEncrypted,
     ImporterFileNotFound,
@@ -207,6 +208,8 @@ def get_importer_error_message(e):
                  'Please choose a file that is not password protected.')
     elif isinstance(e, ImporterExcelError):
         return _("The file uploaded has the following error: {}").format(str(e))
+    elif isinstance(e, ImporterRawError):
+        return str(e)
     else:
         return _("Error: {}").format(str(e))
 

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -251,7 +251,6 @@ def excel_commit(request, domain):
     more information.
     """
     config = importer_util.ImporterConfig.from_request(request)
-    print(config.to_json())
 
     excel_id = request.session.get(EXCEL_SESSION_ID)
 
@@ -333,7 +332,6 @@ def _bulk_case_upload_api(request,domain):
             search_field=search_field,
             create_new_cases=create_new_cases,
             )
-    print(config.to_json())
 
     case_upload.trigger_upload(domain, config)
     return json_response({"msg":"success"})

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -295,7 +295,7 @@ def bulk_case_upload_api(request, domain, **kwargs):
         return json_response({'error_msg': _(error)})
 
 
-def _bulk_case_upload_api(request,domain):
+def _bulk_case_upload_api(request, domain):
     upload_file, case_type, search_field, create_new_cases, search_column =_get_bulk_case_upload_args_from_request(request, domain)
 
     case_upload, context = _process_file_and_get_upload(upload_file, request, domain)

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -23,7 +23,7 @@ from corehq.apps.case_importer.suggested_fields import (
 )
 from corehq.apps.case_importer.tracking.case_upload_tracker import CaseUpload
 from corehq.apps.case_importer.util import get_importer_error_message
-from corehq.apps.domain.decorators import api_auth, login_and_domain_required
+from corehq.apps.domain.decorators import api_auth
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.reports.analytics.esaccessors import (
     get_case_types_for_domain_es,
@@ -91,7 +91,6 @@ def excel_config(request, domain):
     return render(request, "case_importer/excel_config.html", context)
 
 
-
 def _process_file_and_get_upload(uploaded_file_handle, request, domain):
     extension = os.path.splitext(uploaded_file_handle.name)[1][1:].strip().lower()
 
@@ -135,7 +134,7 @@ def _process_file_and_get_upload(uploaded_file_handle, request, domain):
         raise ImporterError(
             'Your spreadsheet has too many columns. '
             'A maximum of %(max_columns)s is supported.'
-         % {'max_columns': MAX_CASE_IMPORTER_COLUMNS})
+            % {'max_columns': MAX_CASE_IMPORTER_COLUMNS})
 
     case_types_from_apps = sorted(get_case_types_from_apps(domain))
     unrecognized_case_types = sorted([t for t in get_case_types_for_domain_es(domain)
@@ -218,7 +217,7 @@ def excel_fields(request, domain):
 
     field_specs = get_suggested_case_fields(
         domain, case_type, exclude=[search_field])
-    
+
     case_field_specs = [field_spec.to_json() for field_spec in field_specs]
 
     context = {
@@ -267,7 +266,6 @@ def excel_commit(request, domain):
     return HttpResponseRedirect(base.ImportCases.get_url(domain))
 
 
-
 def _get_bulk_case_upload_args_from_request(request, domain):
     try:
         upload_file = request.FILES["file"]
@@ -275,11 +273,12 @@ def _get_bulk_case_upload_args_from_request(request, domain):
         search_field = request.POST['search_field']
         create_new_cases = request.POST.get('create_new_cases') == 'on'
         search_column = request.POST['search_column']
-        return upload_file, case_type, search_field, create_new_cases,search_column
+        return upload_file, case_type, search_field, create_new_cases, search_column
     except Exception:
         raise ImporterError(
                 "Invalid post request."
                 "Submit the form with field 'file' and the required params")
+
 
 @csrf_exempt
 @require_POST
@@ -287,7 +286,7 @@ def _get_bulk_case_upload_args_from_request(request, domain):
 @require_can_edit_data
 def bulk_case_upload_api(request, domain, **kwargs):
     try:
-        response = _bulk_case_upload_api(request,domain)
+        response = _bulk_case_upload_api(request, domain)
         return response
     except ImporterError as e:
         error = get_importer_error_message(e)
@@ -295,8 +294,9 @@ def bulk_case_upload_api(request, domain, **kwargs):
         error = "Please upload file with extension .xls or .xlsx"
         return json_response({'error_msg': _(error)})
 
+
 def _bulk_case_upload_api(request,domain):
-    upload_file, case_type, search_field, create_new_cases,search_column = _get_bulk_case_upload_args_from_request(request,domain)
+    upload_file, case_type, search_field, create_new_cases, search_column =_get_bulk_case_upload_args_from_request(request, domain)
 
     case_upload, context = _process_file_and_get_upload(upload_file, request, domain)
 
@@ -330,8 +330,7 @@ def _bulk_case_upload_api(request,domain):
             search_column=search_column,
             case_type=case_type,
             search_field=search_field,
-            create_new_cases=create_new_cases,
-            )
+            create_new_cases=create_new_cases)
 
     case_upload.trigger_upload(domain, config)
-    return json_response({"msg":"success"})
+    return json_response({"msg": "success"})


### PR DESCRIPTION
This provides a basic endpoint for providing a structured excel file for upload and providing the relevant details to automatically trigger the case upload process

##### SUMMARY
I attempted (within reason) to duplicate as little code as possible by reusing the same code from the excel importer. There isn't much error handling, which seems acceptable given that users will generally be doing their uploads with the UI uploader until satisfied then switch to the API endpoint.

##### FEATURE FLAG
Not exactly. The endpoint is invisible for now

##### PRODUCT DESCRIPTION
Creates a [Bulk Upload Case Data API](https://confluence.dimagi.com/display/commcarepublic/Bulk+Upload+Case+Data) endpoint for automating working Excel Upload sheets for bulk case creation.
