### PR TITLE
don't auto create ES indices

### DIFF
--- a/corehq/apps/domain/tests/test_domain_calculated_properties.py
+++ b/corehq/apps/domain/tests/test_domain_calculated_properties.py
@@ -14,6 +14,7 @@ from corehq.elastic import get_es_new, refresh_elasticsearch_index
 from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
+from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
 from pillowtop.processors.elastic import send_to_elasticsearch
 
@@ -26,7 +27,7 @@ class DomainCalculatedPropertiesTest(TestCase):
         cls.es = [{
             'info': i,
             'instance': get_es_new(),
-        } for i in [CASE_INDEX_INFO, SMS_INDEX_INFO, XFORM_INDEX_INFO]]
+        } for i in [CASE_INDEX_INFO, SMS_INDEX_INFO, XFORM_INDEX_INFO, USER_INDEX_INFO]]
 
     def setUp(self):
         self.domain = Domain(name='test-b9289e19d819')

--- a/corehq/apps/users/tests/test_analytics.py
+++ b/corehq/apps/users/tests/test_analytics.py
@@ -10,6 +10,7 @@ from corehq.apps.users.analytics import (
 )
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.util.elastic import reset_es_index
 
 

--- a/corehq/apps/users/tests/test_analytics.py
+++ b/corehq/apps/users/tests/test_analytics.py
@@ -10,6 +10,7 @@ from corehq.apps.users.analytics import (
 )
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.util.elastic import reset_es_index
 
 
 class UserAnalyticsTest(TestCase):
@@ -42,6 +43,7 @@ class UserAnalyticsTest(TestCase):
             username='web',
             password='secret',
         )
+        reset_es_index(USER_INDEX_INFO)
         update_analytics_indexes()
 
     @classmethod

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -170,8 +170,9 @@ class TestSendToElasticsearch(SimpleTestCase):
 
     def test_auto_index_creation_fails(self):
         es = get_es_new()
+        ensure_index_deleted(self.index)
         with self.assertRaises(NotFoundError):
-            es.create("test_hqusers", "user", {"username": "test"}, id="1")
+            es.create(self.index, TEST_INDEX_INFO.type, {"username": "test"}, id="1")
 
     def _send_to_es_and_check(self, doc, update=False, es_merge_update=False,
                               delete=False, esgetter=None):

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.conf import settings
 from django.test import SimpleTestCase
-from corehq.util.es.elasticsearch import ConnectionError
+from corehq.util.es.elasticsearch import ConnectionError, NotFoundError
 
 from corehq.elastic import get_es_new
 from corehq.util.elastic import ensure_index_deleted
@@ -167,6 +167,11 @@ class TestSendToElasticsearch(SimpleTestCase):
     def test_create_doc(self):
         doc = {'_id': uuid.uuid4().hex, 'doc_type': 'MyCoolDoc', 'property': 'foo'}
         self._send_to_es_and_check(doc)
+
+    def test_auto_index_creation_fails(self):
+        es = get_es_new()
+        with self.assertRaises(NotFoundError):
+            es.create("test_hqusers", "user", {"username": "test"}, id="1")
 
     def _send_to_es_and_check(self, doc, update=False, es_merge_update=False,
                               delete=False, esgetter=None):

--- a/docker/files/elasticsearch.yml
+++ b/docker/files/elasticsearch.yml
@@ -2,6 +2,7 @@
 #     $ ./scripts/docker rebuild elasticsearch
 #     $ ./scripts/docker up -d elasticsearch
 
+network.host: 0.0.0.0
 http.port: 9200
 
 # dev-only setting to allow client-side ES front-ends

--- a/docker/files/elasticsearch.yml
+++ b/docker/files/elasticsearch.yml
@@ -8,3 +8,5 @@ http.port: 9200
 http.cors.allow-origin: "*"
 http.cors.enabled: true
 index.max_result_window: 1000000
+
+action.auto_create_index: false

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -46,7 +46,6 @@ services:
     environment:
       ES_CLUSTER_NAME: ES_CLUSTER_NAME
       ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
-      action.auto_create_index: 0
     ports:
       - "9200:9200"
 

--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -46,6 +46,7 @@ services:
     environment:
       ES_CLUSTER_NAME: ES_CLUSTER_NAME
       ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
+      action.auto_create_index: 0
     ports:
       - "9200:9200"
 

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -74,13 +74,11 @@ services:
     image: elasticsearch:2.4.6
     environment:
       ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
-      action.auto_create_index: "false"
-      TAKE_FILE_OWNERSHIP: "true"
     expose:
       - "9200"
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-elasticsearch:}/usr/share/elasticsearch/data
-      - ./files/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      - ./files/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
 
   zookeeper:
     image: wurstmeister/zookeeper

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -74,10 +74,13 @@ services:
     image: elasticsearch:2.4.6
     environment:
       ES_JAVA_OPTS: "-Des.script.engine.groovy.inline.aggs=true -Des.script.engine.groovy.inline.search=true"
+      action.auto_create_index: "false"
+      TAKE_FILE_OWNERSHIP: "true"
     expose:
       - "9200"
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-elasticsearch:}/usr/share/elasticsearch/data
+      - ./files/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 
   zookeeper:
     image: wurstmeister/zookeeper


### PR DESCRIPTION
Two main changes.
1. HQ manages all index creation and doesn't depend on the fact that ES autocreates an index if one doesn't exist. So, we can turn off `action.auto_create_index` which prevents auto index creation. 
2. Make docker setup use the elasticsearch.yml file