### PR TITLE
Move a form to the right UCR in reconciliation mapping

### DIFF
--- a/custom/icds_reports/models/util.py
+++ b/custom/icds_reports/models/util.py
@@ -150,7 +150,6 @@ class UcrReconciliationStatus(models.Model):
                     'http://openrosa.org/formdesigner/0AD845EA-69E8-4479-9140-4072A14AA0E5',
                 ],
                 "static-ls_home_visit_forms_filled": [
-                    'http://openrosa.org/formdesigner/32083FFC-9AD7-46A8-B256-1B9431469262',
                     'http://openrosa.org/formdesigner/327e11f3c04dfc0a7fea9ee57d7bb7be83475309',
                 ],
                 "static-ls_vhnd_form": [

--- a/custom/icds_reports/models/util.py
+++ b/custom/icds_reports/models/util.py
@@ -148,6 +148,7 @@ class UcrReconciliationStatus(models.Model):
                 ],
                 "static-it_report_follow_issue": [
                     'http://openrosa.org/formdesigner/0AD845EA-69E8-4479-9140-4072A14AA0E5',
+                    'http://openrosa.org/formdesigner/32083FFC-9AD7-46A8-B256-1B9431469262'
                 ],
                 "static-ls_home_visit_forms_filled": [
                     'http://openrosa.org/formdesigner/327e11f3c04dfc0a7fea9ee57d7bb7be83475309',


### PR DESCRIPTION
This particular doesn't form doesn't appear in [ls_home_visit_home_visit_forms_filled](https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json#L42) but in [it_report_follow_issue](https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/ucr/data_sources/it_report_follow_issue.json#L44).

Most of the records seem to be these, and they always fail, because it's incorrect mapping.

```
In [25]: u = UcrReconciliationStatus.objects.filter(documents_missing__gt=0)

In [26]: u.filter(table_id='static-ls_home_visit_forms_filled').filter(doc_type_filter='http://openrosa.org/formdesig
    ...: ner/32083FFC-9AD7-46A8-B256-1B9431469262').count()
Out[26]: 3178

In [27]: u.count()
Out[27]: 3714
```

@calellowitz @snopoke 