### PR TITLE
add an owner location column to report builder reports for location-safety

### DIFF
--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -300,7 +300,7 @@ class UsernameComputedCasePropertyOption(ColumnOption):
         return column_dicts
 
 
-class OwnernameComputedCasePropertyOption(ColumnOption):
+class OwnerIdComputedCasePropertyOption(ColumnOption):
     def _get_indicator(self, ui_aggregation, is_multiselect_chart_report=False):
         column_id = get_column_name(self._property)
         expression = {
@@ -317,8 +317,10 @@ class OwnernameComputedCasePropertyOption(ColumnOption):
             'expression': expression
         }
 
+
+class OwnernameComputedCasePropertyOption(OwnerIdComputedCasePropertyOption):
     def to_column_dicts(self, index, display_text, ui_aggregation, is_aggregated_on=False):
-        column_dicts = super(OwnernameComputedCasePropertyOption, self).to_column_dicts(
+        column_dicts = super().to_column_dicts(
             index, display_text, ui_aggregation
         )
         column_dicts[0]['transform'] = {

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -300,7 +300,7 @@ class UsernameComputedCasePropertyOption(ColumnOption):
         return column_dicts
 
 
-class OwnerIdComputedCasePropertyOption(ColumnOption):
+class OwnernameComputedCasePropertyOption(ColumnOption):
     def _get_indicator(self, ui_aggregation, is_multiselect_chart_report=False):
         column_id = get_column_name(self._property)
         expression = {
@@ -317,8 +317,6 @@ class OwnerIdComputedCasePropertyOption(ColumnOption):
             'expression': expression
         }
 
-
-class OwnernameComputedCasePropertyOption(OwnerIdComputedCasePropertyOption):
     def to_column_dicts(self, index, display_text, ui_aggregation, is_aggregated_on=False):
         column_dicts = super().to_column_dicts(
             index, display_text, ui_aggregation

--- a/corehq/apps/userreports/reports/builder/const.py
+++ b/corehq/apps/userreports/reports/builder/const.py
@@ -1,5 +1,6 @@
 COMPUTED_USER_NAME_PROPERTY_ID = "computed/user_name"
 COMPUTED_OWNER_NAME_PROPERTY_ID = "computed/owner_name"
+COMPUTED_OWNER_LOCATION_PROPERTY_ID = "computed/owner_location"
 
 UI_AGG_AVERAGE = "Average"
 UI_AGG_COUNT_PER_CHOICE = "Count per Choice"

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -48,12 +48,14 @@ from corehq.apps.userreports.reports.builder.columns import (
     CountColumn,
     FormMetaColumnOption,
     MultiselectQuestionColumnOption,
+    OwnerIdComputedCasePropertyOption,
     OwnernameComputedCasePropertyOption,
     QuestionColumnOption,
     RawPropertyColumnOption,
     UsernameComputedCasePropertyOption,
 )
 from corehq.apps.userreports.reports.builder.const import (
+    COMPUTED_OWNER_LOCATION_PROPERTY_ID,
     COMPUTED_OWNER_NAME_PROPERTY_ID,
     COMPUTED_USER_NAME_PROPERTY_ID,
     PROPERTY_TYPE_CASE_PROP,
@@ -75,7 +77,7 @@ from corehq.apps.userreports.reports.builder.sources import (
 from corehq.apps.userreports.sql import get_column_name
 from corehq.apps.userreports.ui.fields import JsonField
 from corehq.apps.userreports.util import has_report_builder_access
-from corehq.toggles import SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER
+from corehq.toggles import SHOW_RAW_DATA_SOURCES_IN_REPORT_BUILDER, SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER
 
 # This dict maps filter types from the report builder frontend to UCR filter types
 REPORT_BUILDER_FILTER_TYPE_MAP = {
@@ -172,6 +174,8 @@ class DataSourceProperty(object):
         elif self._type == PROPERTY_TYPE_CASE_PROP:
             if self._id == COMPUTED_OWNER_NAME_PROPERTY_ID:
                 return OwnernameComputedCasePropertyOption(self._id, self._data_types, self._text)
+            elif self._id == COMPUTED_OWNER_LOCATION_PROPERTY_ID:
+                return OwnerIdComputedCasePropertyOption(self._id, self._data_types, self._text)
             elif self._id == COMPUTED_USER_NAME_PROPERTY_ID:
                 return UsernameComputedCasePropertyOption(self._id, self._data_types, self._text)
             else:
@@ -229,6 +233,8 @@ class DataSourceProperty(object):
             filter.update({"choice_provider": {"type": "owner"}})
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_USER_NAME_PROPERTY_ID:
             filter.update({"choice_provider": {"type": "user"}})
+        if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_LOCATION_PROPERTY_ID:
+            filter.update({"choice_provider": {"type": "location"}})
         if configuration.get('pre_value') or configuration.get('pre_operator'):
             filter.update({
                 'type': 'pre',  # type could have been "date"
@@ -527,8 +533,7 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
         if self.source_type == 'form':
             return self._get_data_source_properties_from_form(self.source_form, self.source_xform)
 
-    @classmethod
-    def _get_data_source_properties_from_case(cls, case_properties):
+    def _get_data_source_properties_from_case(self, case_properties):
         property_map = {
             'closed': _('Case Closed'),
             'user_id': _('User ID Last Updating Case'),
@@ -550,8 +555,11 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
                 source=property,
                 data_types=data_types,
             )
-        properties[COMPUTED_OWNER_NAME_PROPERTY_ID] = cls._get_owner_name_pseudo_property()
-        properties[COMPUTED_USER_NAME_PROPERTY_ID] = cls._get_user_name_pseudo_property()
+        properties[COMPUTED_OWNER_NAME_PROPERTY_ID] = self._get_owner_name_pseudo_property()
+        properties[COMPUTED_USER_NAME_PROPERTY_ID] = self._get_user_name_pseudo_property()
+
+        if SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER.enabled(self.domain):
+            properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID] = self._get_owner_location_pseudo_property()
         return properties
 
     @staticmethod
@@ -564,6 +572,18 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
             id=COMPUTED_OWNER_NAME_PROPERTY_ID,
             text=_('Case Owner'),
             source=COMPUTED_OWNER_NAME_PROPERTY_ID,
+            data_types=["string"],
+        )
+
+    @classmethod
+    def _get_owner_location_pseudo_property(cls):
+        # owner_location is a special pseudo-case property for which
+        # the report builder reference the owner_id, but treat it as a location
+        return DataSourceProperty(
+            type=PROPERTY_TYPE_CASE_PROP,
+            id=COMPUTED_OWNER_LOCATION_PROPERTY_ID,
+            text=_('Case Owner (Location)'),
+            source=COMPUTED_OWNER_LOCATION_PROPERTY_ID,
             data_types=["string"],
         )
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -48,7 +48,6 @@ from corehq.apps.userreports.reports.builder.columns import (
     CountColumn,
     FormMetaColumnOption,
     MultiselectQuestionColumnOption,
-    OwnerIdComputedCasePropertyOption,
     OwnernameComputedCasePropertyOption,
     QuestionColumnOption,
     RawPropertyColumnOption,
@@ -172,10 +171,8 @@ class DataSourceProperty(object):
         elif self._type == PROPERTY_TYPE_META:
             return FormMetaColumnOption(self._id, self._data_types, self._text, self._source)
         elif self._type == PROPERTY_TYPE_CASE_PROP:
-            if self._id == COMPUTED_OWNER_NAME_PROPERTY_ID:
+            if self._id == COMPUTED_OWNER_NAME_PROPERTY_ID or self._id == COMPUTED_OWNER_LOCATION_PROPERTY_ID:
                 return OwnernameComputedCasePropertyOption(self._id, self._data_types, self._text)
-            elif self._id == COMPUTED_OWNER_LOCATION_PROPERTY_ID:
-                return OwnerIdComputedCasePropertyOption(self._id, self._data_types, self._text)
             elif self._id == COMPUTED_USER_NAME_PROPERTY_ID:
                 return UsernameComputedCasePropertyOption(self._id, self._data_types, self._text)
             else:

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -21,6 +21,7 @@ from corehq.apps.userreports.models import (
 from corehq.apps.userreports.reports.builder.columns import (
     MultiselectQuestionColumnOption,
 )
+from corehq.apps.userreports.reports.builder.const import COMPUTED_OWNER_LOCATION_PROPERTY_ID
 from corehq.apps.userreports.reports.builder.forms import (
     ConfigureListReportForm,
     ConfigureTableReportForm,
@@ -28,6 +29,7 @@ from corehq.apps.userreports.reports.builder.forms import (
     ReportBuilderDataSourceReference,
 )
 from corehq.apps.userreports.tests.utils import get_simple_xform
+from corehq.util.test_utils import flag_enabled
 
 
 class ReportBuilderDBTest(TestCase):
@@ -126,6 +128,14 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         first_name_prop = builder.data_source_properties['first_name']
         self.assertEqual('first_name', first_name_prop.get_id())
         self.assertEqual('first name', first_name_prop.get_text())
+
+    @flag_enabled('SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER')
+    def test_owner_as_location(self):
+        builder = DataSourceBuilder(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
+        self.assertTrue(COMPUTED_OWNER_LOCATION_PROPERTY_ID in builder.data_source_properties)
+        owner_location_prop = builder.data_source_properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID]
+        self.assertEqual(COMPUTED_OWNER_LOCATION_PROPERTY_ID, owner_location_prop.get_id())
+        self.assertEqual('Case Owner (Location)', owner_location_prop.get_text())
 
 
 class DataSourceReferenceTest(ReportBuilderDBTest):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1162,6 +1162,14 @@ UNLIMITED_REPORT_BUILDER_REPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER = StaticToggle(
+    'show_owner_location_property_in_report_builder',
+    'Show an additional "Owner (Location)" property in report builder reports. '
+    'This can be used to create report builder reports that are location-safe.',
+    TAG_SOLUTIONS_LIMITED,
+    [NAMESPACE_DOMAIN]
+)
+
 MOBILE_USER_DEMO_MODE = StaticToggle(
     'mobile_user_demo_mode',
     'Ability to make a mobile worker into Demo only mobile worker',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10793

Sorry I didn't break this up much - I was just scoping out what changed would be needed, but then I got close enough to finishing it that I decided to go for it. Can review all at once.

- [x] Do more local testing
- [x] See if easy to add automated tests, and add if so

<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This adds an additional column in report builder reports - primarily to be used in filters - that creates a "dynamic_choice_list" filter with a choice provider of "location" off the "owner_id" column so that you can use report builder to create location safe reports.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

Show an additional "Owner (Location)" property in report builder reports. This can be used to create report builder reports that are location-safe.

(flag is added in this PR)

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Just adds a new choice called "Case Owner (Location)" to the dropdowns in report builder:

![image](https://user-images.githubusercontent.com/66555/79309283-56b75280-7efa-11ea-9e2d-cf816cf3725d.png)
