### PR TITLE
Bulk Upload API Cleanups + Status

### DIFF
--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -53,7 +53,7 @@ class CaseUpload(object):
     def get_spreadsheet(self):
         return get_spreadsheet(self.get_tempfile())
 
-    def trigger_upload(self, domain, config):
+    def trigger_upload(self, domain, config, comment=None):
         from corehq.apps.case_importer.tasks import bulk_import_async
         task = bulk_import_async.delay(config, domain, self.upload_id)
         original_filename = transient_file_store.get_filename(self.upload_id)
@@ -62,6 +62,7 @@ class CaseUpload(object):
 
         CaseUploadRecord(
             domain=domain,
+            comment=comment,
             upload_id=self.upload_id,
             task_id=task.task_id,
             couch_user_id=config.couch_user_id,

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -58,6 +58,7 @@ def case_uploads(request, domain):
 
     return json_response(case_uploads_json)
 
+
 @api_auth
 @require_GET
 @require_can_edit_data

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -31,6 +31,7 @@ from corehq.apps.domain.decorators import api_auth
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.util.view_utils import set_file_download
 
+
 @require_can_edit_data
 @conditionally_location_safe(location_safe_case_imports_enabled)
 def case_uploads(request, domain):

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -7,6 +7,7 @@ from django.http import (
 )
 
 from dimagi.utils.web import json_response
+from django.views.decorators.http import require_GET
 
 from corehq.apps.case_importer.base import location_safe_case_imports_enabled
 from corehq.apps.case_importer.tracking.dbaccessors import (
@@ -26,9 +27,9 @@ from corehq.apps.case_importer.tracking.permissions import (
     user_may_view_file_upload,
 )
 from corehq.apps.case_importer.views import require_can_edit_data
+from corehq.apps.domain.decorators import api_auth
 from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.util.view_utils import set_file_download
-
 
 @require_can_edit_data
 @conditionally_location_safe(location_safe_case_imports_enabled)
@@ -53,7 +54,20 @@ def case_uploads(request, domain):
     case_uploads_json = [case_upload_to_user_json(case_upload_record, request)
                          for case_upload_record in case_upload_records]
 
+
     return json_response(case_uploads_json)
+
+@api_auth
+@require_GET
+@require_can_edit_data
+@conditionally_location_safe(location_safe_case_imports_enabled)
+def case_upload_status(request, domain, upload_id):
+    try:
+        case_upload = _get_case_upload_record(domain, upload_id, request.couch_user)
+    except CaseUploadRecord.DoesNotExist:
+        return HttpResponseNotFound()
+
+    return json_response(case_upload.get_task_status_json())
 
 
 @require_can_edit_data

--- a/corehq/apps/case_importer/urls.py
+++ b/corehq/apps/case_importer/urls.py
@@ -4,6 +4,7 @@ from corehq.apps.case_importer.tracking.views import (
     case_upload_case_ids,
     case_upload_file,
     case_upload_form_ids,
+    case_upload_status,
     case_uploads,
     update_case_upload_comment,
 )
@@ -22,6 +23,8 @@ urlpatterns = [
     url(r'^history/uploads/$', case_uploads, name='case_importer_uploads'),
     url(r'^history/uploads/(?P<upload_id>[\w-]+)/comment/$', update_case_upload_comment,
         name='case_importer_update_upload_comment'),
+    url(r'^history/uploads/(?P<upload_id>[\w-]+)/status$', case_upload_status,
+        name='case_importer_upload_status'),
     url(r'^history/uploads/(?P<upload_id>[\w-]+)/$', case_upload_file,
         name='case_importer_upload_file_download'),
     url(r'^history/uploads/(?P<upload_id>[\w-]+)/form_ids.txt$', case_upload_form_ids,

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -3,14 +3,13 @@ import os.path
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
-from django.urls import reverse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from dimagi.utils.web import get_url_base, json_response
+from dimagi.utils.web import json_response
 
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.app_manager.helpers.validators import validate_property

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -279,7 +279,7 @@ def bulk_case_upload_api(request, domain, **kwargs):
         error = get_importer_error_message(e)
     except SpreadsheetFileExtError:
         error = "Please upload file with extension .xls or .xlsx"
-    return json_response({'code': 500,'message': _(error)}, status_code=500)
+    return json_response({'code': 500, 'message': _(error)}, status_code=500)
 
 
 def _bulk_case_upload_api(request, domain):
@@ -292,7 +292,7 @@ def _bulk_case_upload_api(request, domain):
         raise ImporterError("Invalid POST request. "
         "Both 'file' and 'case_type' are required")
 
-    search_field = request.POST.get('search_field','case_id')
+    search_field = request.POST.get('search_field', 'case_id')
     create_new_cases = request.POST.get('create_new_cases') == 'on'
 
     if search_field == 'case_id':
@@ -303,7 +303,7 @@ def _bulk_case_upload_api(request, domain):
         raise ImporterError("Illegal value for search_field: %s" % search_field)
 
     search_column = request.POST.get('search_column', default_search_column)
-    name_column = request.POST.get('name_column','name')
+    name_column = request.POST.get('name_column', 'name')
 
     upload_comment = request.POST.get('comment')
 
@@ -351,4 +351,4 @@ def _bulk_case_upload_api(request, domain):
             reverse('case_importer_upload_status', args=(domain, upload_id))
             )
 
-    return json_response({"code":200,"message": "success", "status_url":status_url})
+    return json_response({"code": 200, "message": "success", "status_url": status_url})

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -347,8 +347,8 @@ def _bulk_case_upload_api(request, domain):
     upload_id = case_upload.upload_id
 
     status_url = "{}{}".format(
-            get_url_base(),
-            reverse('case_importer_upload_status', args=(domain, upload_id))
-            )
+        get_url_base(),
+        reverse('case_importer_upload_status', args=(domain, upload_id))
+    )
 
     return json_response({"code": 200, "message": "success", "status_url": status_url})

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -282,13 +282,13 @@ def bulk_case_upload_api(request, domain, **kwargs):
 
 
 def _bulk_case_upload_api(request, domain):
-
     try:
         upload_file = request.FILES["file"]
         case_type = request.POST["case_type"]
         search_field = request.POST['search_field']
         create_new_cases = request.POST.get('create_new_cases') == 'on'
         search_column = request.POST['search_column']
+        name_column = request.POST.get('name_column','name')
     except Exception:
         raise ImporterError(
                 "Invalid post request. "
@@ -314,9 +314,9 @@ def _bulk_case_upload_api(request, domain):
     #Create the field arrays for the importer in the same format
     #as the "Step 2" Web UI from the manual process
     for f in excel_fields:
-        if f == "name":
+        if f == name_column:
             custom_fields.append("")
-            case_fields.append(f)
+            case_fields.append("name")
         else:
             custom_fields.append(f)
             case_fields.append("")

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -266,20 +266,6 @@ def excel_commit(request, domain):
     return HttpResponseRedirect(base.ImportCases.get_url(domain))
 
 
-def _get_bulk_case_upload_args_from_request(request, domain):
-    try:
-        upload_file = request.FILES["file"]
-        case_type = request.POST["case_type"]
-        search_field = request.POST['search_field']
-        create_new_cases = request.POST.get('create_new_cases') == 'on'
-        search_column = request.POST['search_column']
-        return upload_file, case_type, search_field, create_new_cases, search_column
-    except Exception:
-        raise ImporterError(
-                "Invalid post request."
-                "Submit the form with field 'file' and the required params")
-
-
 @csrf_exempt
 @require_POST
 @api_auth
@@ -296,7 +282,19 @@ def bulk_case_upload_api(request, domain, **kwargs):
 
 
 def _bulk_case_upload_api(request, domain):
-    upload_file, case_type, search_field, create_new_cases, search_column =_get_bulk_case_upload_args_from_request(request, domain)
+
+    try:
+        upload_file = request.FILES["file"]
+        case_type = request.POST["case_type"]
+        search_field = request.POST['search_field']
+        create_new_cases = request.POST.get('create_new_cases') == 'on'
+        search_column = request.POST['search_column']
+    except Exception:
+        raise ImporterError(
+                "Invalid post request. "
+                "Submit the form with field 'file' and the required params: "
+                "case_type,search_field,search_column")
+
 
     case_upload, context = _process_file_and_get_upload(upload_file, request, domain)
 
@@ -313,7 +311,8 @@ def _bulk_case_upload_api(request, domain):
     custom_fields = []
     case_fields = []
 
-    #populate field arrays
+    #Create the field arrays for the importer in the same format
+    #as the "Step 2" Web UI from the manual process
     for f in excel_fields:
         if f == "name":
             custom_fields.append("")

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -31,6 +31,7 @@ from corehq.apps.reports.analytics.esaccessors import (
 )
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from corehq.util.view_utils import absolute_reverse
 from corehq.util.workbook_reading import SpreadsheetFileExtError
 
 require_can_edit_data = require_permission(Permissions.edit_data)
@@ -345,10 +346,6 @@ def _bulk_case_upload_api(request, domain):
     case_upload.trigger_upload(domain, config, comment=upload_comment)
 
     upload_id = case_upload.upload_id
-
-    status_url = "{}{}".format(
-        get_url_base(),
-        reverse('case_importer_upload_status', args=(domain, upload_id))
-    )
+    status_url = absolute_reverse('case_importer_upload_status', args=(domain, upload_id))
 
     return json_response({"code": 200, "message": "success", "status_url": status_url})

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -353,7 +353,7 @@ def two_factor_check(view_func, api_key):
                 request.user.is_verified = lambda: True
                 return fn(request, domain, *args, **kwargs)
             if api_key:
-                request.bypass_two_factor=True
+                request.bypass_two_factor = True
             return fn(request, domain, *args, **kwargs)
         return _inner
     return _outer

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -352,7 +352,7 @@ def two_factor_check(view_func, api_key):
                 request.user.otp_device = otp_device
                 request.user.is_verified = lambda: True
                 return fn(request, domain, *args, **kwargs)
-            if(api_key):
+            if api_key:
                 request.bypass_two_factor=True
             return fn(request, domain, *args, **kwargs)
         return _inner

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -136,7 +136,6 @@ def _inactive_domain_response(request, domain_name):
 def _is_missing_two_factor(view_fn, request):
     return (_two_factor_required(view_fn, request.project, request.couch_user)
             and not getattr(request, 'bypass_two_factor', False)
-            and not getattr(request.user, 'is_api_request', False)
             and not request.user.is_verified())
 
 
@@ -354,7 +353,7 @@ def two_factor_check(view_func, api_key):
                 request.user.is_verified = lambda: True
                 return fn(request, domain, *args, **kwargs)
             if(api_key):
-                request.user.is_api_request = True
+                request.bypass_two_factor=True
             return fn(request, domain, *args, **kwargs)
         return _inner
     return _outer


### PR DESCRIPTION
Improved error handling and resiliency for the bulk upload API feature, and code cleanup.

Also integrates optional code review feedback from: https://github.com/dimagi/commcare-hq/pull/27151 and https://github.com/dimagi/commcare-hq/pull/27150 which I didn't have time to do before the first push.

(Spread out Code review based on git suggestions from people who reviewed last time, not quite sure how to ask for reviews for non-division resourced work)

##### SUMMARY
This change allows the upload API to have default parameters that match the default behavior that you would see on HQ if you uploaded, and improves parity with the UI.

It also adds new parameters which allow setting the name column (which the HQ UI supports), and allows the uploader to set a comment ahead of time, to note for instance the details of the upload from their side.

Finally it provides a task URL to use to track upload status and the output result, similar to the fixture upload API.

##### PRODUCT DESCRIPTION
Improved error handling for Bulk Case Upload API