### PR TITLE
Fixed link text on hosted CCZ page

### DIFF
--- a/custom/icds/static/icds/js/manage_hosted_ccz.js
+++ b/custom/icds/static/icds/js/manage_hosted_ccz.js
@@ -21,7 +21,6 @@ hqDefine('icds/js/manage_hosted_ccz', [
                 'app_name',
                 'app_version_tag',
                 'file_name',
-                'link',
                 'link_name',
                 'note',
                 'profile_name',
@@ -33,7 +32,6 @@ hqDefine('icds/js/manage_hosted_ccz', [
                 appName: options.app_name,
                 appVersionTag: options.app_version_tag,
                 fileName: options.file_name,
-                link: options.link,
                 link_name: options.link_name,
                 profileName: options.profile_name,
                 note: options.note,
@@ -42,7 +40,7 @@ hqDefine('icds/js/manage_hosted_ccz', [
             };
             self.removeUrl = initialPageData.reverse("remove_hosted_ccz", self.id);
             self.recreateUrl = initialPageData.reverse("recreate_hosted_ccz", self.id);
-            self.viewUrl = initialPageData.reverse("hosted_ccz", self.link);
+            self.viewUrl = initialPageData.reverse("hosted_ccz", self.link_name);
             return self;
         };
         var hostedCCZsView = function (options) {

--- a/custom/icds/static/icds/js/manage_hosted_ccz.js
+++ b/custom/icds/static/icds/js/manage_hosted_ccz.js
@@ -18,25 +18,27 @@ hqDefine('icds/js/manage_hosted_ccz', [
         var hostedCCZ = function (options) {
             assertProperties.assertRequired(options, [
                 'id',
-                'link',
                 'app_name',
-                'version',
                 'app_version_tag',
-                'profile_name',
                 'file_name',
+                'link',
+                'link_name',
                 'note',
+                'profile_name',
                 'status',
+                'version',
             ]);
             var self = {
                 id: options.id,
-                link: options.link,
                 appName: options.app_name,
-                version: options.version,
                 appVersionTag: options.app_version_tag,
-                profileName: options.profile_name,
                 fileName: options.file_name,
+                link: options.link,
+                link_name: options.link_name,
+                profileName: options.profile_name,
                 note: options.note,
                 status: options.status,
+                version: options.version,
             };
             self.removeUrl = initialPageData.reverse("remove_hosted_ccz", self.id);
             self.recreateUrl = initialPageData.reverse("recreate_hosted_ccz", self.id);

--- a/custom/icds/templates/icds/manage_hosted_ccz.html
+++ b/custom/icds/templates/icds/manage_hosted_ccz.html
@@ -62,7 +62,7 @@
         <tr data-bind="css: {'success': status === 'completed', 'info': status === 'pending',
                              'danger': status === 'failed', 'warning': status === 'building'}">
           <td>
-            <a data-bind="attr: { href: viewUrl}, text: link" target="_blank">
+            <a data-bind="attr: { href: viewUrl}, text: link_name" target="_blank">
             </a>
           </td>
           <td data-bind="text: status">


### PR DESCRIPTION
##### SUMMARY
Introduced in https://github.com/dimagi/commcare-hq/pull/26939

##### FEATURE FLAG
Allow project to manage ccz hosting

##### PRODUCT DESCRIPTION
Fixes the "link" column to again display the name of the link, instead of its id.
![Screen Shot 2020-04-16 at 9 19 05 AM](https://user-images.githubusercontent.com/1486591/79460932-7f574f00-7fc3-11ea-9bef-eb33af946149.png)

