### PR TITLE
Fix py2 to py3 error in ApiUser.set_password

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -44,7 +44,7 @@ class ApiUser(models.Model):
             raise Exception("ApiUser _id has to be 'ApiUser-' + username")
 
     def set_password(self, raw_password):
-        salt = os.urandom(5).encode('hex')
+        salt = os.urandom(5).hex()
         self.password = make_password(raw_password, salt=salt)
 
     def check_password(self, raw_password):


### PR DESCRIPTION
For @ShivamPokhriyal on https://dimagi-dev.atlassian.net/browse/SAAS-10797

##### SUMMARY
This lets us change the buildserver ApiUser's password