### PR TITLE
Upgrade psycopg2

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -137,7 +137,7 @@ prometheus-client==0.7.1
 prompt-toolkit==1.0.18    # via ipython
 psutil==5.7.0
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 ptyprocess==0.6.0         # via pexpect
 py-kissmetrics==1.0.1
 pycco==0.5.1

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -112,7 +112,7 @@ polib==1.1.0
 prometheus-client==0.7.1
 prompt-toolkit==1.0.18    # via ipython
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 ptyprocess==0.6.0         # via pexpect
 py-kissmetrics==1.0.1
 pyasn1==0.4.7

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -103,7 +103,7 @@ ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prometheus-client==0.7.1
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 py-kissmetrics==1.0.1
 pycco==0.5.1
 pycparser==2.19           # via cffi

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -115,7 +115,7 @@ ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prometheus-client==0.7.1
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 py-kissmetrics==1.0.1
 pycco==0.5.1
 pycparser==2.19           # via cffi

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -137,7 +137,7 @@ prometheus-client==0.7.1
 prompt-toolkit==1.0.18    # via ipython
 psutil==5.7.0
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 ptyprocess==0.6.0         # via pexpect
 py-kissmetrics==1.0.1
 pycco==0.5.1

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -112,7 +112,7 @@ polib==1.1.0
 prometheus-client==0.7.1
 prompt-toolkit==1.0.18    # via ipython
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 ptyprocess==0.6.0         # via pexpect
 py-kissmetrics==1.0.1
 pyasn1==0.4.7

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -31,7 +31,7 @@ billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery
 mock==2.0.0
 Pillow>=6.2.2,<7.0.0
 phonenumberslite~=8.8
-psycopg2~=2.7.7
+psycopg2>=2.8.4  # Python 3.8 support
 psycogreen~=1.0
 pycryptodome>=3.6.6  # security update
 py-KISSmetrics==1.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -103,7 +103,7 @@ ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prometheus-client==0.7.1
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 py-kissmetrics==1.0.1
 pycco==0.5.1
 pycparser==2.19           # via cffi

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -115,7 +115,7 @@ ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0
 prometheus-client==0.7.1
 psycogreen==1.0.1
-psycopg2==2.7.7
+psycopg2==2.8.5
 py-kissmetrics==1.0.1
 pycco==0.5.1
 pycparser==2.19           # via cffi


### PR DESCRIPTION
Context: Draft PR #27176 

##### SUMMARY
Upgrading psycopg2 is necessary to allow HQ to run on Python 3.8.

Relevant Psycopg changelog: https://www.psycopg.org/articles/2019/10/20/psycopg-284-released/ (although the change in this PR will install the latest psycopg2, currently 2.8.5).

It also seems to be sufficient to allow HQ to run on Python 3.8, but I will float the idea of taking a thorough look at that past QA, and see what they think.

Based on the conversation on PR #27176, the next step is to investigate the best way to upgrade production environments to Python 3.8. This is not a high priority for me, but I will try to spend some spare lockdown hours on it.

This PR seems pretty safe though, and allows us to move forward at our convenience.
