### PR TITLE
Correct month and optimisation

### DIFF
--- a/custom/icds_reports/tests/agg_tests/reports/test_bihar_api_vaccines.py
+++ b/custom/icds_reports/tests/agg_tests/reports/test_bihar_api_vaccines.py
@@ -42,4 +42,4 @@ class VaccinesAPITest(TestCase):
             ,
             first_person_case
         )
-        self.assertEqual(44, count)
+        self.assertEqual(48, count)

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/bihar_api_demographics.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/bihar_api_demographics.py
@@ -155,7 +155,8 @@ class BiharApiDemographicsHelper(BaseICDSAggregationDistributedHelper):
         WHERE
             demographics_details.household_id = person_list.household_case_id AND
             demographics_details.husband_name = person_list.name AND
-            demographics_details.supervisor_id = person_list.supervisor_id
+            demographics_details.supervisor_id = person_list.supervisor_id AND
+            person_list.state_id='{self.bihar_state_id}'
         """
 
         yield f"""
@@ -165,7 +166,8 @@ class BiharApiDemographicsHelper(BaseICDSAggregationDistributedHelper):
                     WHERE
                         bihar_demographics.household_id = person_list.household_case_id AND
                         bihar_demographics.father_name = person_list.name AND 
-                        bihar_demographics.supervisor_id = person_list.supervisor_id
+                        bihar_demographics.supervisor_id = person_list.supervisor_id AND
+                        person_list.state_id='{self.bihar_state_id}'
             """
 
     def add_partition_table__query(self):

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/bihar_api_demographics.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/bihar_api_demographics.py
@@ -57,7 +57,7 @@ class BiharApiDemographicsHelper(BaseICDSAggregationDistributedHelper):
 
     def aggregation_query(self):
         month_start_string = month_formatter(self.month)
-        month_end_string = month_formatter(self.month + relativedelta(months=1, seconds=-1))
+        month_end_string = self.month + relativedelta(months=1, seconds=-1)
 
         columns = (
             ('state_id', 'person_list.state_id'),

--- a/custom/icds_reports/utils/aggregation_helpers/distributed/bihar_api_demographics.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/bihar_api_demographics.py
@@ -13,7 +13,7 @@ class BiharApiDemographicsHelper(BaseICDSAggregationDistributedHelper):
 
     def __init__(self, month):
         self.month = transform_day_to_month(month)
-        self.end_date = transform_day_to_month(month + relativedelta(months=1, seconds=-1))
+        self.next_month_start = month + relativedelta(months=1)
         self.person_case_ucr = get_table_name(self.domain, 'static-person_cases_v3')
         self.household_ucr = get_table_name(self.domain, 'static-household_cases')
 
@@ -57,7 +57,6 @@ class BiharApiDemographicsHelper(BaseICDSAggregationDistributedHelper):
 
     def aggregation_query(self):
         month_start_string = month_formatter(self.month)
-        month_end_string = self.month + relativedelta(months=1, seconds=-1)
 
         columns = (
             ('state_id', 'person_list.state_id'),
@@ -134,7 +133,7 @@ class BiharApiDemographicsHelper(BaseICDSAggregationDistributedHelper):
                 )
                 WHERE 
                 (
-                    person_list.opened_on <= '{month_end_string}' AND
+                    person_list.opened_on < '{self.next_month_start}' AND
                     (person_list.closed_on IS NULL OR person_list.closed_on >= '{month_start_string}' )
                 ) AND
                 (


### PR DESCRIPTION
This PR does two things in two commits:
1. remove the month_formatter from the month_end date as month_formatter makes it first of the month.
2. add the state filter while updating father and husband Id. It reduces the  complexity from :
```
Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
   Task Count: 64
   Tasks Shown: One of 64
   ->  Task
         Node: host=100.71.184.232 port=6432 dbname=icds_ucr
         ->  Update on "bihar_api_demographics_2020-03-01_583484" demographics_details  (cost=792440.74..1574353.62 rows=2 width=609)
               ->  Hash Join  (cost=792440.74..1574353.62 rows=2 width=609)
                     Hash Cond: ((demographics_details.household_id = person_list.household_case_id) AND (demographics_details.husband_name = person_list.name) AND (demographics_details.supervisor_id = person_list.supervisor_id))
                     ->  Seq Scan on "bihar_api_demographics_2020-03-01_583484" demographics_details  (cost=0.00..123914.14 rows=1413614 width=566)
                     ->  Hash  (cost=462488.54..462488.54 rows=8681154 width=142)
                           ->  Seq Scan on "ucr_icds-cas_static-person_cases_v3_2ae0879a_103866" person_list  (cost=0.00..462488.54 rows=8681154 width=142)
(11 rows)
```

To: 
```
Custom Scan (Citus Router)  (cost=0.00..0.00 rows=0 width=0)
   Task Count: 64
   Tasks Shown: One of 64
   ->  Task
         Node: host=100.71.184.232 port=6432 dbname=icds_ucr
         ->  Update on "bihar_api_demographics_2020-03-01_583484" demographics_details  (cost=544240.89..1180522.77 rows=1 width=609)
               ->  Hash Join  (cost=544240.89..1180522.77 rows=1 width=609)
                     Hash Cond: ((demographics_details.household_id = person_list.household_case_id) AND (demographics_details.husband_name = person_list.name) AND (demographics_details.supervisor_id = person_list.supervisor_id))
                     ->  Seq Scan on "bihar_api_demographics_2020-03-01_583484" demographics_details  (cost=0.00..123914.14 rows=1413614 width=566)
                     ->  Hash  (cost=484191.42..484191.42 rows=1579912 width=142)
                           ->  Seq Scan on "ucr_icds-cas_static-person_cases_v3_2ae0879a_103866" person_list  (cost=0.00..484191.42 rows=1579912 width=142)
                                 Filter: (state_id = 'f9b47ea2ee2d8a02acddeeb491d3e175'::text)
(12 rows)

```
