### PR TITLE
fix tabular report ui bug

### DIFF
--- a/custom/icds_reports/static/js/angular-services/locations.service.js
+++ b/custom/icds_reports/static/js/angular-services/locations.service.js
@@ -305,9 +305,12 @@ window.angular.module('icdsApp').factory('locationsService', ['$http', '$locatio
         },
         
         resetLevelsBelow : function(level, vm) {
-            if (vm.selectedLocationLevel > level &&
-                vm.selectedLocations[level] !== undefined &&
-                vm.selectedLocations[level] !== null) {
+            // for the reports like THR report which does not allow download
+            // below block level. So, if you switch from a report which does
+            // allow download below block level to THR report and does not change
+            // the location and directly click the export. The location_id which is sent
+            // is not the block level but the lower level location selected in previous report
+            if (vm.selectedLocationLevel > level && vm.selectedLocations[level]) {
                 vm.selectedLocationId = vm.selectedLocations[level];
             }
             for (var i = level + 1; i <= vm.maxLevel; i++) {

--- a/custom/icds_reports/static/js/angular-services/locations.service.js
+++ b/custom/icds_reports/static/js/angular-services/locations.service.js
@@ -305,6 +305,11 @@ window.angular.module('icdsApp').factory('locationsService', ['$http', '$locatio
         },
         
         resetLevelsBelow : function(level, vm) {
+            if (vm.selectedLocationLevel > level &&
+                vm.selectedLocations[level] !== undefined &&
+                vm.selectedLocations[level] !== null) {
+                vm.selectedLocationId = vm.selectedLocations[level];
+            }
             for (var i = level + 1; i <= vm.maxLevel; i++) {
                 vm.hierarchy[i].selected = null;
                 vm.selectedLocations[i] = null;

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -393,8 +393,8 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     };
 
     /**
-     * To Adjust selectedLevel for the reports does not have viewBy filters
-     * end up having aggregation_leve set by viewBy filter in the last report selected.
+     * To adjust selectedLevel for the reports that do not have viewBy filter. These
+     * reports end up having selectedLevel set by viewBy filter in the last report selected.
      */
     vm.adjustSelectedLevelForNoViewByFilter = function () {
 

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -104,6 +104,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     vm.selectedPDFFormat = 'many';
     vm.selectedLocationId = userLocationId;
     vm.selectedLevel = 1;
+    vm.selectedLocationLevel = 0;
     vm.now = new Date().getMonth() + 1;
     vm.showWarning = function () {
         return (
@@ -246,6 +247,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     };
 
     vm.onSelectLocation = function ($item, level) {
+        vm.selectedLocationLevel = level + 1;
         locationsService.onSelectLocation($item, level, locationsCache, vm);
     };
 
@@ -385,8 +387,21 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
             vm.onSelectYear({'id': vm.selectedYear});
             vm.selectedFormat = 'xlsx';
         }
+
+        vm.adjustSelectedLevelForNoViewByFilter();
+
     };
 
+    /**
+     * To Adjust selectedLevel for the reports does not have viewBy filters
+     * end up having aggregation_leve set by viewBy filter in the last report selected.
+     */
+    vm.adjustSelectedLevelForNoViewByFilter = function () {
+
+        if (!vm.showViewBy() || vm.isTakeHomeRationReportSelected()) {
+            vm.selectedLevel = vm.selectedLocationLevel;
+        }
+    };
     vm.submitForm = function (csrfToken) {
         $rootScope.report_link = '';
         var awcs = vm.selectedPDFFormat === 'one' ? ['all'] : vm.selectedAWCs;
@@ -430,6 +445,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         vm.selectedLocations = [];
         vm.selectedLocationId = userLocationId;
         vm.selectedLevel = 1;
+        vm.selectedLocationLevel = 0;
         vm.selectedMonth = new Date().getMonth() + 1;
         vm.selectedYear = new Date().getFullYear();
         vm.selectedIndicator = 1;

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -390,7 +390,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
      * reports end up having selectedLevel set by viewBy filter in the last report selected.
      */
     vm.adjustSelectedLevelForNoViewByFilter = function () {
-        if (!vm.showViewBy() || vm.isTakeHomeRationReportSelected()) {
+        if (!vm.showViewBy()) {
             vm.selectedLevel = locationsService.selectedLocationIndex(vm.selectedLocations) + 1;
         }
     };
@@ -525,7 +525,8 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
 
     vm.showViewBy = function () {
         return !(vm.isChildBeneficiaryListSelected() || vm.isIncentiveReportSelected() ||
-            vm.isLadySupervisorSelected() || vm.isDashboardUsageSelected());
+            vm.isLadySupervisorSelected() || vm.isDashboardUsageSelected() ||
+            vm.isTakeHomeRationReportSelected());
     };
 
     vm.showLocationFilter = function () {

--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -104,7 +104,6 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     vm.selectedPDFFormat = 'many';
     vm.selectedLocationId = userLocationId;
     vm.selectedLevel = 1;
-    vm.selectedLocationLevel = 0;
     vm.now = new Date().getMonth() + 1;
     vm.showWarning = function () {
         return (
@@ -223,18 +222,13 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         return locationsService.getLocations(level, locationsCache, vm.selectedLocations, vm.disallowNational());
     };
 
-    var selectedLocationIndex = function () {
-        return _.findLastIndex(vm.selectedLocations, function (locationId) {
-            return locationId && locationId !== ALL_OPTION.location_id;
-        });
-    };
-
     vm.disabled = function (level) {
         return locationsService.isLocationDisabled(level, vm);
     };
 
     vm.onSelectForISSNIP = function ($item, level) {
-        var selectedLocationId = vm.selectedLocations[selectedLocationIndex()];
+        var selectedLocIndex = locationsService.selectedLocationIndex(vm.selectedLocations);
+        var selectedLocationId = vm.selectedLocations[selectedLocIndex];
         vm.locationPromise = locationsService.getAwcLocations(selectedLocationId).then(function (data) {
             if ($item.user_have_access) {
                 vm.awcLocations = [ALL_OPTION].concat(data);
@@ -247,7 +241,6 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
     };
 
     vm.onSelectLocation = function ($item, level) {
-        vm.selectedLocationLevel = level + 1;
         locationsService.onSelectLocation($item, level, locationsCache, vm);
     };
 
@@ -397,9 +390,8 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
      * reports end up having selectedLevel set by viewBy filter in the last report selected.
      */
     vm.adjustSelectedLevelForNoViewByFilter = function () {
-
         if (!vm.showViewBy() || vm.isTakeHomeRationReportSelected()) {
-            vm.selectedLevel = vm.selectedLocationLevel;
+            vm.selectedLevel = locationsService.selectedLocationIndex(vm.selectedLocations) + 1;
         }
     };
     vm.submitForm = function (csrfToken) {
@@ -445,7 +437,6 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
         vm.selectedLocations = [];
         vm.selectedLocationId = userLocationId;
         vm.selectedLevel = 1;
-        vm.selectedLocationLevel = 0;
         vm.selectedMonth = new Date().getMonth() + 1;
         vm.selectedYear = new Date().getFullYear();
         vm.selectedIndicator = 1;


### PR DESCRIPTION
This PR fixes two things:
1. When a report(eg THR report) does not support view-by filter. It ends up having the aggregation_level set up by the view_by filter of last selected report which was causing it to fail([ticket](https://dimagi-dev.atlassian.net/browse/ICDS-1392)).
2. The THR report does not support levels below the block level. So if a level is selected lower than the block in the previously selected Report in THR as well that location_id is considered as selected