### PR TITLE
don't override False with None in user upload

### DIFF
--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -2,7 +2,7 @@ from dimagi.utils.parsing import string_to_boolean
 
 
 def spec_value_to_boolean_or_none(user_spec_dict, key):
-    value = user_spec_dict.get(key) or None
+    value = user_spec_dict.get(key, None)
     if value and isinstance(value, str):
         return string_to_boolean(value)
     return value

--- a/corehq/apps/user_importer/helpers.py
+++ b/corehq/apps/user_importer/helpers.py
@@ -5,4 +5,7 @@ def spec_value_to_boolean_or_none(user_spec_dict, key):
     value = user_spec_dict.get(key, None)
     if value and isinstance(value, str):
         return string_to_boolean(value)
-    return value
+    elif isinstance(value, bool):
+        return value
+    else:
+        return None

--- a/corehq/apps/user_importer/tests/test_validators.py
+++ b/corehq/apps/user_importer/tests/test_validators.py
@@ -82,6 +82,7 @@ TEST_CASES = [
             {'username': factory.user_name(), 'is_account_confirmed': 'False'},
             {'username': factory.user_name(), 'is_account_confirmed': 'True'},
             {'username': factory.user_name(), 'is_account_confirmed': ''},
+            {'username': factory.user_name(), 'is_account_confirmed': False},
         ],
         NewUserPasswordValidator('domain'),
         {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Somewhere in our excel parsing magic, certain values like "0" are automatically converted to `False`, but then `False` was getting converted back to `None` by this code, which then caused [this check](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/user_importer/validation.py#L187) to fail on valid "False" data.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
Enable two-stage user provisioning (users confirm and set their own passwords via email).

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Now certain "falsey" values like "0" also work to set `is_account_confirmed` to false in bulk user upload, and not just "no".
