### PR TITLE
Added dropdown to UCR home

### DIFF
--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -2,7 +2,7 @@ hqDefine("userreports/js/configurable_reports_home", [
     'jquery',
     'underscore',
     'DOMPurify/dist/purify.min',
-    'select2/dist/js/select2.full.min'
+    'select2/dist/js/select2.full.min',
 ], function (
     $,
     _,
@@ -10,7 +10,7 @@ hqDefine("userreports/js/configurable_reports_home", [
 ) {
     var $select = $("#select2-navigation");
 
-    $select.on('select2:select', function (e) {
+    $select.on('select2:select', function () {
         document.location = $select.val();
     });
 
@@ -29,6 +29,8 @@ hqDefine("userreports/js/configurable_reports_home", [
                 text: text,
             });
         },
-        escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
+        escapeMarkup: function (m) {
+            return DOMPurify.sanitize(m);
+        },
     });
 });

--- a/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
+++ b/corehq/apps/userreports/static/userreports/js/configurable_reports_home.js
@@ -1,0 +1,34 @@
+hqDefine("userreports/js/configurable_reports_home", [
+    'jquery',
+    'underscore',
+    'DOMPurify/dist/purify.min',
+    'select2/dist/js/select2.full.min'
+], function (
+    $,
+    _,
+    DOMPurify
+) {
+    var $select = $("#select2-navigation");
+
+    $select.on('select2:select', function (e) {
+        document.location = $select.val();
+    });
+
+    $select.select2({
+        placeholder: gettext("Edit a report or data source"),
+        templateResult: function (item) {
+            var text = item.text.trim();
+            if (!item.element) {
+                return text;
+            }
+            var options = $(item.element).data();
+            return _.template("<%= static_label %> <%= deactivated_label %> <i class='<%= icon %>'></i> <%= text %> <script>alert('stuff')</script>")({
+                icon: options.label === "report" ? "fcc fcc-reports" : "fa fa-database",
+                static_label: options.isStatic ? "<span class='label label-default'>" + gettext("static") + "</span>" : "",
+                deactivated_label: options.isDeactivated ? "<span class='label label-default'>" + gettext("deactivated") + "</span>" : "",
+                text: text,
+            });
+        },
+        escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
+    });
+});

--- a/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_reports_home.html
@@ -1,8 +1,46 @@
 {% extends "userreports/userreports_base.html" %}
+{% load hq_shared_tags %}
 {% load i18n %}
+
+{% requirejs_main 'userreports/js/configurable_reports_home' %}
+
 {% block page_content %}
   <h1>{% trans "Configurable Reports" %}</h1>
-  <a href="{% url 'create_configurable_data_source' domain %}" class="btn btn-primary">{% trans 'Add data source' %}</a>
-  <a href="{% url 'create_configurable_report' domain %}" class="btn btn-default">{% trans 'Add report' %}</a>
-  <a href="{% url 'import_configurable_report' domain %}" class="btn btn-default">{% trans 'Import report' %}</a>
+  <a href="{% url 'create_configurable_report' domain %}" class="btn btn-default">
+    <i class="fa fa-plus"></i>
+    {% trans 'Add Report' %}
+  </a>
+  <a href="{% url 'import_configurable_report' domain %}" class="btn btn-default">
+    <i class="fa fa-cloud-upload"></i>
+    {% trans 'Import Report' %}
+  </a>
+  <a href="{% url 'create_configurable_data_source' domain %}" class="btn btn-default">
+    <i class="fa fa-plus"></i>
+    {% trans 'Add Data Source' %}
+  </a>
+
+  <br><br><br>
+
+  <div class="row">
+    <div class="col-sm-6">
+      <select id="select2-navigation" class="form-control">
+        <option></option>
+        {% for report in reports %}
+          <option data-label="report"
+                  data-is-static="{{ report.is_static|yesno:"true,false" }}"
+                  value="{% url 'edit_configurable_report' domain report.get_id %}">
+            {{ report.title }}
+          </option>
+        {% endfor %}
+        {% for data_source in data_sources %}
+          <option data-label="data_source"
+                  data-is-static="{{ data_source.is_static|yesno:"true,false" }}"
+                  data-is-deactivated="{{ data_source.is_deactivated|yesno:"true,false" }}"
+                  value="{% url 'edit_configurable_data_source' domain data_source.get_id %}">
+            {{ data_source.display_name }}
+          </option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
 {% endblock %}

--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -16,6 +16,52 @@
 {% endblock %}
 
 {% block page_navigation %}
+  <h2 class="text-hq-nav-header">{% trans "Tools" %}</h2>
+  <ul class="nav nav-hq-sidebar">
+    <li>
+      <a href="{% url 'configurable_reports_home' domain %}">
+        <i class="fa fa-wrench"></i>
+        {% trans "Configurable Reports" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'create_configurable_report' domain %}">
+        <i class="fa fa-plus"></i>
+        {% trans "Add report" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'import_configurable_report' domain %}">
+        <i class="fa fa-cloud-upload"></i>
+        {% trans "Import report" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'create_configurable_data_source' domain %}">
+        <i class="fa fa-plus"></i>
+        {% trans "Add data source" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'create_configurable_data_source_from_app' domain %}">
+        <i class="fa fa-copy"></i>
+        {% trans "Data source from application" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'expression_debugger' domain %}">
+        <i class="fa fa-search"></i>
+        {% trans "Expression Debugger" %}
+      </a>
+    </li>
+    <li>
+      <a href="{% url 'data_source_debugger' domain %}">
+        <i class="fa fa-search"></i>
+        {% trans "Data Source Debugger" %}
+      </a>
+    </li>
+  </ul>
+
   <h2 class="text-hq-nav-header">{% trans "Edit Reports" %}</h2>
   <ul class="nav nav-hq-sidebar">
     {% with report as selected_report %}
@@ -30,16 +76,6 @@
         </li>
       {% endfor %}
     {% endwith %}
-    <li>
-      <a href="{% url 'create_configurable_report' domain %}">
-        <i class="fa fa-plus"></i>
-        <span class="text-muted">{% trans "Add report" %}</span>
-      </a>
-      <a href="{% url 'import_configurable_report' domain %}">
-        <i class="fa fa-cloud-upload"></i>
-        <span class="text-muted">{% trans "Import report" %}</span>
-      </a>
-    </li>
   </ul>
 
   <h2 class="text-hq-nav-header">{% trans "Edit Data Sources" %}</h2>
@@ -59,30 +95,6 @@
         </li>
       {% endfor %}
     {% endwith %}
-    <li>
-      <a href="{% url 'create_configurable_data_source' domain %}">
-        <i class="fa fa-plus"></i>
-        <span class="text-muted">{% trans "Add data source" %}</span>
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'create_configurable_data_source_from_app' domain %}">
-        <i class="fa fa-copy"></i>
-        <span class="text-muted">{% trans "Data source from application" %}</span>
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'expression_debugger' domain %}">
-        <i class="fa fa-search"></i>
-        <span class="text-muted">{% trans "Expression Debugger" %}</span>
-      </a>
-    </li>
-    <li>
-      <a href="{% url 'data_source_debugger' domain %}">
-        <i class="fa fa-search"></i>
-        <span class="text-muted">{% trans "Data Source Debugger" %}</span>
-      </a>
-    </li>
   </ul>
   {% if request|toggle_enabled:"AGGREGATE_UCRS" %}
     <h2 class="text-hq-nav-header">{% trans "Aggregate Data Sources" %}</h2>


### PR DESCRIPTION
##### SUMMARY
The UCR nav is already unwieldy at ICDS's scale, and [it's about to get 40 new reports](https://github.com/dimagi/commcare-hq/pull/27169). This PR adds a searchable dropdown from the UCR home page to jump directly to a report or data source. It also pulls all of the action links up to the top of the navigation rather than the bottom of the reports and data sources sections.

![Screen Shot 2020-04-21 at 11 10 02 AM](https://user-images.githubusercontent.com/1486591/79882484-aeedc900-83c0-11ea-872e-9afde0d13a2e.png)

##### FEATURE FLAG
UCR