### PR TITLE
Added months required to adolescent girls

### DIFF
--- a/custom/icds_reports/utils/aggregation_helpers/distributed/adolescent_girls_registration.py
+++ b/custom/icds_reports/utils/aggregation_helpers/distributed/adolescent_girls_registration.py
@@ -10,6 +10,7 @@ class AggAdolescentGirlsRegistrationAggregate(StateBasedAggregationDistributedHe
     helper_key = 'adolescent-girls'
     ucr_data_source_id = 'static-adolescent_girls_reg_form'
     aggregate_parent_table = AGG_ADOLESCENT_GIRLS_REGISTRATION_TABLE
+    months_required = 3
 
     def data_from_ucr_query(self):
         month = self.month.replace(day=1)


### PR DESCRIPTION
I have recently added only AG table who helper inherits `StateBasedAggregationDistributedHelper` so adding the months_required to it. 
I also found that [daily_feeding_Agg](https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/utils/aggregation_helpers/distributed/daily_feeding_forms_child_health.py) does not have this parameter. Does it have to be added there as well?
