### PR TITLE
maintain parent_case_ids as list

### DIFF
--- a/custom/icds/location_reassignment/utils.py
+++ b/custom/icds/location_reassignment/utils.py
@@ -67,7 +67,7 @@ def get_household_child_cases_by_owner(domain, household_case_id, owner_id, case
     while parent_case_ids:
         child_cases = get_child_cases(parent_case_ids, iterated_case_ids)
         if child_cases:
-            child_case_ids = set([case.case_id for case in child_cases])
+            child_case_ids = [case.case_id for case in child_cases]
             iterated_case_ids.update(child_case_ids)
             if case_types:
                 cases.extend([case for case in child_cases


### PR DESCRIPTION
Introduced in https://github.com/dimagi/commcare-hq/commit/028a034d835513d4595dd3f0c63ad3a172f3dd88#diff-1acd7eb475e5e2a4ba2528ebaa0f4179

https://sentry.io/organizations/dimagi/issues/1622723651/?environment=india&project=136860&query=is%3Aunresolved&statsPeriod=14d

##### SUMMARY
`get_reverse_indexed_cases` expects ids to be a list always, so pass a list instead of set

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`

