### PR TITLE
skip hitting accessor DB if forms are queried on root case

### DIFF
--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -211,7 +211,10 @@ class FormsInDateExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
             return context.get_cache_value(cache_key)
 
         domain = context.root_doc['domain']
-        xform_ids = CaseAccessors(domain).get_case_xform_ids(case_id)
+        if case_id != context.root_doc['_id'] or 'xform_ids' not in context.root_doc:
+            xform_ids = CaseAccessors(domain).get_case_xform_ids(case_id)
+        else:
+            xform_ids = context.root_doc.get('xform_ids')
         context.set_cache_value(cache_key, xform_ids)
         return xform_ids
 

--- a/custom/icds_reports/ucr/expressions.py
+++ b/custom/icds_reports/ucr/expressions.py
@@ -211,7 +211,7 @@ class FormsInDateExpressionSpec(NoPropertyTypeCoercionMixIn, JsonObject):
             return context.get_cache_value(cache_key)
 
         domain = context.root_doc['domain']
-        if case_id != context.root_doc['_id'] or 'xform_ids' not in context.root_doc:
+        if case_id != context.root_doc.get('_id') or 'xform_ids' not in context.root_doc:
             xform_ids = CaseAccessors(domain).get_case_xform_ids(case_id)
         else:
             xform_ids = context.root_doc.get('xform_ids')


### PR DESCRIPTION
This expression is used in ICDS and all the uses pull forms for the case being processed, so it's not necessary to hit DB for this.

@calellowitz @snopoke 