### PR TITLE
Don't interpret normal logs as forced logs

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -122,7 +122,7 @@ def _process_form(request, domain, app_id, user_id, authenticated,
             submit_ip=couchforms.get_submit_ip(request),
             last_sync_token=couchforms.get_last_sync_token(request),
             openrosa_headers=couchforms.get_openrosa_headers(request),
-            force_logs=bool(request.GET.get('force_logs', False)),
+            force_logs=request.GET.get('force_logs', 'false') == 'true',
         )
 
         try:


### PR DESCRIPTION
Came across this randomly, and had context on the code:
https://sentry.io/organizations/dimagi/issues/1562473297/

"false" is not True (mobile sets force_logs=false)

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
