### PR TITLE
Disable project info email on non-Dimagi environments

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -121,7 +121,7 @@ def cached_property(method):
 
 
 def icds_conditional_session_key():
-    if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+    if settings.IS_ICDS_ENV:
         # memoize for process lifecycle
         return None
     else:

--- a/corehq/apps/domain/tasks.py
+++ b/corehq/apps/domain/tasks.py
@@ -11,6 +11,7 @@ from corehq.apps.domain.views.internal import EditInternalDomainInfoView
 from corehq.apps.es.domains import DomainES
 from corehq.apps.es.forms import FormES
 from corehq.apps.users.models import WebUser
+from corehq.util.celery_utils import periodic_task_when_true
 from corehq.util.log import send_HTML_email
 
 
@@ -58,7 +59,8 @@ def incomplete_domains_to_email():
     return email_domains
 
 
-@periodic_task(
+@periodic_task_when_true(
+    settings.IS_DIMAGI_ENVIRONMENT,
     run_every=crontab(minute=0, hour=0, day_of_week="monday", day_of_month="15-21"),
     queue='background_queue'
 )

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -400,7 +400,7 @@ def _login(req, domain_name, custom_login_page, extra_context=None):
         context.update({
             'current_page': {'page_name': _('Welcome back to %s!') % commcare_hq_name},
         })
-    if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+    if settings.IS_ICDS_ENV:
         auth_view = CloudCareLoginView
     else:
         auth_view = HQLoginView if not domain_name else CloudCareLoginView
@@ -423,7 +423,7 @@ def _login(req, domain_name, custom_login_page, extra_context=None):
 def login(req):
     # This is a wrapper around the _login view
 
-    if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+    if settings.IS_ICDS_ENV:
         login_url = reverse('domain_login', kwargs={'domain': 'icds-cas'})
         return HttpResponseRedirect(login_url)
 
@@ -713,8 +713,7 @@ class BugReportView(View):
             email.attach(filename=filename, content=content)
 
         # only fake the from email if it's an @dimagi.com account
-        is_icds_env = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
-        if re.search(r'@dimagi\.com$', report['username']) and not is_icds_env:
+        if re.search(r'@dimagi\.com$', report['username']) and not settings.IS_ICDS_ENV:
             email.from_email = report['username']
         else:
             email.from_email = settings.SUPPORT_EMAIL

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -205,7 +205,7 @@ def from_demo_user(form_json):
 # Form-submissions with request.GET['submit_mode'] as 'demo' are ignored, if not from demo-user
 DEMO_SUBMIT_MODE = 'demo'
 
-IGNORE_ALL_DEMO_USER_SUBMISSIONS = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
+IGNORE_ALL_DEMO_USER_SUBMISSIONS = settings.IS_ICDS_ENV
 
 
 def _submitted_by_demo_user(form_meta, domain):

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -308,7 +308,7 @@ class MessageLogReport(BaseCommConnectLogReport):
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
-        return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
+        return not settings.IS_ICDS_ENV
 
     def get_message_type_filter(self):
         filtered_types = MessageTypeFilter.get_value(self.request, self.domain)
@@ -636,7 +636,7 @@ class MessagingEventsReport(BaseMessagingEventReport):
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
-        return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
+        return not settings.IS_ICDS_ENV
 
     @property
     def headers(self):

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -200,7 +200,7 @@ class SumoLogicLog(object):
         https://docs.google.com/document/d/18sSwv2GRGepOIHthC6lxQAh_aUYgDcTou6w9jL2976o/edit#bookmark=id.ao4j7x5tjvt7
         """
         environment = 'test-env'
-        if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+        if settings.IS_ICDS_ENV:
             environment = 'cas'
         if settings.SERVER_ENVIRONMENT == 'india':
             environment = 'india'

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -177,9 +177,8 @@ def _handle_duplicate(new_doc):
         XFormInstance.get_db().delete_doc(conflict_id)
         return new_doc, None
 
-    is_icds = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
     try:
-        if is_icds and new_doc.metadata.deviceID == existing_doc.metadata.deviceID:
+        if settings.IS_ICDS_ENV and new_doc.metadata.deviceID == existing_doc.metadata.deviceID:
             # ICDS does not use 'edit form' functionality via the web and form editing is not possible
             # on mobile devices so it's safe to assume this is a duplicate without checking md5 etc.
             duplicate = interface.deduplicate_xform(new_doc)

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -101,7 +101,7 @@ def use_phone_entries():
     Phone entries are not used in ICDS because they're not needed and
     it helps performance to avoid keeping them up to date.
     """
-    return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
+    return not settings.IS_ICDS_ENV
 
 
 def show_messaging_dashboard(domain, couch_user):

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -209,8 +209,8 @@ def deserialize_run_every_setting(run_every_setting):
         raise generic_value_error
 
 
-def periodic_task_on_envs(envs, *args, **kwargs):
-    if settings.SERVER_ENVIRONMENT in envs:
+def periodic_task_when_true(boolean, *args, **kwargs):
+    if boolean:
         return periodic_task(*args, **kwargs)
     else:
         return lambda fn: fn

--- a/custom/icds/tasks/__init__.py
+++ b/custom/icds/tasks/__init__.py
@@ -8,7 +8,7 @@ from iso8601 import parse_date
 from corehq.blobs import CODES, get_blob_db
 from corehq.blobs.models import BlobMeta
 from corehq.sql_db.util import get_db_aliases_for_partitioned_query, estimate_row_count
-from corehq.util.celery_utils import periodic_task_on_envs
+from corehq.util.celery_utils import periodic_task_when_true
 from corehq.util.metrics import metrics_counter, metrics_gauge
 from custom.icds.tasks.sms import send_monthly_sms_report  # noqa imported for celery
 from custom.icds.tasks.hosted_ccz import setup_ccz_file_for_hosting  # noqa imported for celery
@@ -16,7 +16,7 @@ from custom.icds.tasks.hosted_ccz import setup_ccz_file_for_hosting  # noqa impo
 MAX_RUNTIME = 6 * 3600
 
 
-@periodic_task_on_envs(settings.ICDS_ENVS, run_every=crontab(minute=30, hour=18))
+@periodic_task_when_true(settings.IS_ICDS_ENV, run_every=crontab(minute=30, hour=18))
 def delete_old_images():
     for db_name in get_db_aliases_for_partitioned_query():
         delete_old_images_on_db.delay(db_name, datetime.utcnow())

--- a/custom/icds/tasks/sms.py
+++ b/custom/icds/tasks/sms.py
@@ -14,11 +14,11 @@ from soil.util import expose_cached_download
 
 from celery.schedules import crontab
 from corehq.apps.hqwebapp.tasks import send_html_email_async
-from corehq.util.celery_utils import periodic_task_on_envs
+from corehq.util.celery_utils import periodic_task_when_true
 from corehq.util.files import file_extention_from_filename
 
 
-@periodic_task_on_envs(settings.ICDS_ENVS, run_every=crontab(day_of_month='2', minute=0, hour=0), queue='sms_queue')
+@periodic_task_when_true(settings.IS_ICDS_ENV, run_every=crontab(day_of_month='2', minute=0, hour=0), queue='sms_queue')
 def send_monthly_sms_report():
     subject = _('Monthly SMS report')
     recipients = ['ayogi@dimagi.com', 'akaul@dimagi-associate.com', 'smazumdar@dimagi.com',

--- a/custom/icds/views/hosted_ccz.py
+++ b/custom/icds/views/hosted_ccz.py
@@ -219,7 +219,7 @@ class HostedCCZView(DomainViewMixin, TemplateView):
             'page_title': self._page_title,
             'hosted_cczs': [h.to_json() for h in HostedCCZ.objects.filter(link=self.hosted_ccz_link)
                             if h.utility.file_exists()],
-            'icds_env': settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS,
+            'icds_env': settings.IS_ICDS_ENV,
             'supporting_files': self._get_supporting_files(),
             'footer_files': self._get_files_for(DISPLAY_CHOICE_FOOTER),
         }

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -1834,7 +1834,7 @@ class AggregationScriptPage(BaseDomainView):
 
     @use_daterangepicker
     def dispatch(self, *args, **kwargs):
-        if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+        if settings.IS_ICDS_ENV:
             return HttpResponse("This page is only available for QA and not available for production instances.")
 
         couch_user = self.request.couch_user

--- a/settings.py
+++ b/settings.py
@@ -1002,6 +1002,7 @@ for database in DATABASES.values():
 _location = lambda x: os.path.join(FILEPATH, x)
 
 IS_SAAS_ENVIRONMENT = SERVER_ENVIRONMENT in ('production', 'staging')
+IS_ICDS_ENV = SERVER_ENVIRONMENT in ICDS_ENVS
 
 if 'KAFKA_URL' in globals():
     import warnings


### PR DESCRIPTION
##### SUMMARY
The third commit is the one that matters - it disables that "please update your project settings" email on non-Dimagi environments.  To do so, I reused an ICDS decorator.  Each commit should be logical.  Lemme know if you've got a suggestion for a more concise name.

@orangejenny pinging you as a potentially interested ICDS party.
@dannyroberts reworking your relatively recent `periodic_task_on_envs` decorator to use more generally.  Feel free to weigh in if you have feelings.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
