### PR TITLE
 Disable project info email on non-Dimagi environments (take 2)

### DIFF
--- a/corehq/apps/domain/tasks.py
+++ b/corehq/apps/domain/tasks.py
@@ -11,6 +11,7 @@ from corehq.apps.domain.views.internal import EditInternalDomainInfoView
 from corehq.apps.es.domains import DomainES
 from corehq.apps.es.forms import FormES
 from corehq.apps.users.models import WebUser
+from corehq.util.celery_utils import periodic_task_when_true
 from corehq.util.log import send_HTML_email
 
 
@@ -58,7 +59,8 @@ def incomplete_domains_to_email():
     return email_domains
 
 
-@periodic_task(
+@periodic_task_when_true(
+    settings.IS_DIMAGI_ENVIRONMENT,
     run_every=crontab(minute=0, hour=0, day_of_week="monday", day_of_month="15-21"),
     queue='background_queue'
 )

--- a/corehq/util/celery_utils.py
+++ b/corehq/util/celery_utils.py
@@ -209,11 +209,15 @@ def deserialize_run_every_setting(run_every_setting):
         raise generic_value_error
 
 
-def periodic_task_on_envs(envs, *args, **kwargs):
-    if settings.SERVER_ENVIRONMENT in envs:
+def periodic_task_when_true(boolean, *args, **kwargs):
+    if boolean:
         return periodic_task(*args, **kwargs)
     else:
         return lambda fn: fn
+
+
+def periodic_task_on_envs(envs, *args, **kwargs):
+    return periodic_task_when_true(settings.SERVER_ENVIRONMENT in envs, *args, **kwargs)
 
 
 def run_periodic_task_again(run_every, last_run_start: datetime, last_duration: timedelta) -> bool:


### PR DESCRIPTION
Different approach to https://github.com/dimagi/commcare-hq/pull/27240

Tests regularly override SERVER_ENVIRONMENT to make it an ICDS env, but that change isn't reflected in the value of `IS_ICDS_ENV`.  I didn't want to go down the rabbit hole of reworking that, so instead I'm leaving those be and only adding my special-case.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
