### PR TITLE
Have case upload set task result synchronously on success

### DIFF
--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -33,13 +33,13 @@ def bulk_import_async(config, domain, excel_id):
         return exit_celery_with_error_message(bulk_import_async, get_importer_error_message(e))
     finally:
         if not result_stored:
-            store_task_result.delay(excel_id)
+            store_task_result_if_failed.delay(excel_id)
 
 
 @task(serializer='pickle', queue='case_import_queue')
-def store_task_result(upload_id):
+def store_task_result_if_failed(upload_id):
     case_upload = CaseUpload.get(upload_id)
-    case_upload.store_task_result()
+    case_upload.store_task_result_if_failed()
 
 
 def _alert_on_result(result, domain):

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -11,7 +11,7 @@ from .do_import import do_import
 from .exceptions import ImporterError
 from .tracking.analytics import get_case_upload_files_total_bytes
 from .tracking.case_upload_tracker import CaseUpload
-from .tracking.task_status import normalize_task_status_result, make_task_status_success
+from .tracking.task_status import make_task_status_success
 from .util import get_importer_error_message, exit_celery_with_error_message
 
 

--- a/corehq/apps/case_importer/tasks.py
+++ b/corehq/apps/case_importer/tasks.py
@@ -11,32 +11,29 @@ from .do_import import do_import
 from .exceptions import ImporterError
 from .tracking.analytics import get_case_upload_files_total_bytes
 from .tracking.case_upload_tracker import CaseUpload
+from .tracking.task_status import normalize_task_status_result, make_task_status_success
 from .util import get_importer_error_message, exit_celery_with_error_message
 
 
 @task(serializer='pickle', queue='case_import_queue')
 def bulk_import_async(config, domain, excel_id):
     case_upload = CaseUpload.get(excel_id)
+    result_stored = False
     try:
         case_upload.check_file()
-    except ImporterError as e:
-        return exit_celery_with_error_message(bulk_import_async, get_importer_error_message(e))
-
-    try:
         with case_upload.get_spreadsheet() as spreadsheet:
             result = do_import(spreadsheet, config, domain, task=bulk_import_async,
                                record_form_callback=case_upload.record_form)
 
         _alert_on_result(result, domain)
-
-        # return compatible with soil
-        return {
-            'messages': result
-        }
+        # save the success result into the CaseUploadRecord
+        case_upload.store_task_result(make_task_status_success(result))
+        result_stored = True
     except ImporterError as e:
         return exit_celery_with_error_message(bulk_import_async, get_importer_error_message(e))
     finally:
-        store_task_result.delay(excel_id)
+        if not result_stored:
+            store_task_result.delay(excel_id)
 
 
 @task(serializer='pickle', queue='case_import_queue')

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -26,9 +26,8 @@
       <span class="label label-warning">{% trans "Success with warnings" %}</span>
       <!--/ko-->
       <!--/ko-->
-      {# The following failed state is necessary to handle legacy errors #}
       <!--ko if: task_status().state == $root.states.SUCCESS && !task_status().result-->
-      <span class="label label-danger">{% trans "Failed" %}</span>
+      <span class="label label-success">{% trans "Success" %}</span>
       <!--/ko-->
       <!--ko if: task_status().state == $root.states.MISSING && isExpiredUpload() || task_status().state == $root.states.FAILED-->
       <span class="label label-danger">{% trans "Failed" %}</span>

--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_status.html
@@ -50,6 +50,11 @@
 </div>
 <!--/ko-->
 <!--/ko-->
+<!--ko if: state == $root.states.SUCCESS && !result-->
+<div class="alert alert-warning">
+  <p>{% trans "Unable to retrieve details" %}</p>
+</div>
+<!--/ko-->
 <!--ko if: state === $root.states.FAILED && result && !_.isEmpty(result.errors)-->
 <div class="alert alert-warning">
   <ul class="list-unstyled">

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -70,9 +70,13 @@ class CaseUpload(object):
             upload_file_meta=case_upload_file_meta,
         ).save()
 
-    def store_task_result(self):
-        if self._case_upload_record.set_task_status_json_if_finished():
+    def store_task_result(self, task_status=None):
+        if task_status:
+            self._case_upload_record.set_task_status_json(task_status)
             self._case_upload_record.save()
+        else:
+            if self._case_upload_record.set_task_status_json_if_finished():
+                self._case_upload_record.save()
 
     def record_form(self, form_id):
         case_upload_record = self._case_upload_record

--- a/corehq/apps/case_importer/tracking/case_upload_tracker.py
+++ b/corehq/apps/case_importer/tracking/case_upload_tracker.py
@@ -70,13 +70,13 @@ class CaseUpload(object):
             upload_file_meta=case_upload_file_meta,
         ).save()
 
-    def store_task_result(self, task_status=None):
-        if task_status:
-            self._case_upload_record.set_task_status_json(task_status)
+    def store_task_result(self, task_status):
+        self._case_upload_record.set_task_status_json(task_status)
+        self._case_upload_record.save()
+
+    def store_task_result_if_failed(self):
+        if self._case_upload_record.set_task_status_json_if_failed():
             self._case_upload_record.save()
-        else:
-            if self._case_upload_record.set_task_status_json_if_finished():
-                self._case_upload_record.save()
 
     def record_form(self, form_id):
         case_upload_record = self._case_upload_record

--- a/corehq/apps/case_importer/tracking/models.py
+++ b/corehq/apps/case_importer/tracking/models.py
@@ -4,6 +4,7 @@ from jsonfield import JSONField
 from memoized import memoized
 
 from dimagi.utils.logging import notify_exception
+from soil.progress import STATES
 from soil.util import get_task
 
 from corehq.apps.case_importer.tracking.task_status import (
@@ -55,7 +56,7 @@ class CaseUploadRecord(models.Model):
             })
         self.task_status_json = task_status_json
 
-    def set_task_status_json_if_finished(self):
+    def set_task_status_json_if_failed(self):
         """
         set task_status_json based on self.task_id
 
@@ -65,7 +66,7 @@ class CaseUploadRecord(models.Model):
         if self.task_status_json is None:
             # intentionally routing through method to prime local cache
             task_status_json = self.get_task_status_json()
-            if task_status_json.is_finished():
+            if task_status_json.state == STATES.failed:
                 self.task_status_json = task_status_json
                 return True
 

--- a/corehq/apps/case_importer/tracking/models.py
+++ b/corehq/apps/case_importer/tracking/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from jsonfield import JSONField
 from memoized import memoized
 
+from dimagi.utils.logging import notify_exception
 from soil.util import get_task
 
 from corehq.apps.case_importer.tracking.task_status import (
@@ -44,6 +45,15 @@ class CaseUploadRecord(models.Model):
             return TaskStatus.wrap(self.task_status_json)
         else:
             return get_task_status_json(str(self.task_id))
+
+    def set_task_status_json(self, task_status_json):
+        if self.task_status_json is not None:
+            notify_exception(None, "CaseUploadRecord task_status_json already set", {
+                'new_task_status_json': task_status_json,
+                'existing_task_status_json': self.task_status_json,
+                'upload_id': self.upload_id,
+            })
+        self.task_status_json = task_status_json
 
     def set_task_status_json_if_finished(self):
         """

--- a/corehq/apps/case_importer/tracking/task_status.py
+++ b/corehq/apps/case_importer/tracking/task_status.py
@@ -103,3 +103,13 @@ def get_task_status_json(task_id):
             ),
             result=normalize_task_status_result(task_status.result),
         )
+
+
+def make_task_status_success(result):
+    return TaskStatus(
+        state=STATES.success,
+        progress=TaskStatusProgress(
+            percent=0,
+        ),
+        result=normalize_task_status_result(result),
+    )

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -49,12 +49,11 @@ def case_uploads(request, domain):
 
     with transaction.atomic():
         for case_upload_record in case_upload_records:
-            if case_upload_record.set_task_status_json_if_finished():
+            if case_upload_record.set_task_status_json_if_failed():
                 case_upload_record.save()
 
     case_uploads_json = [case_upload_to_user_json(case_upload_record, request)
                          for case_upload_record in case_upload_records]
-
 
     return json_response(case_uploads_json)
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-54

##### SUMMARY
Sometimes we get a case upload record that has state success but no result, which isn't supposed to be possible. Since we're storing results asynchronously, my running hypothesis is that there's a race condition between the `store_task_result` task that's kicked off and celery setting the result of the original task, very occasionally causing `store_task_result` to catch the celery result row in a state where success was recorded but the results of that success have not yet been.

Since we have the desired result in hand, we might as well set it synchronously, directly in the `CaseUploadRecord` rather than relying on a roundabout and potentially flaky series of steps to get it there.