### PR TITLE
uniform metric tags + cleanup

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -301,10 +301,7 @@ def send_message_via_backend(msg, backend=None, orig_phone_number=None):
 
         if backend.domain_is_authorized(msg.domain):
             backend.send(msg, orig_phone_number=orig_phone_number)
-            sms_load_counter("outbound", msg.domain, extra_tags={
-                'status': 'ok',
-                'backend': _get_backend_tag(backend),
-            })()
+            sms_load_counter("outbound", msg.domain)()
         else:
             raise BackendAuthorizationException(
                 "Domain '%s' is not authorized to use backend '%s'" % (msg.domain, backend.pk)
@@ -315,10 +312,7 @@ def send_message_via_backend(msg, backend=None, orig_phone_number=None):
         msg.save()
         return True
     except Exception:
-        sms_load_counter("outbound", msg.domain, extra_tags={
-            'status': 'error',
-            'backend': _get_backend_tag(backend),
-        })()
+        sms_load_counter("outbound", msg.domain)()
         should_log_exception = True
 
         if backend:

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -254,7 +254,7 @@ class PillowBase(metaclass=ABCMeta):
                 ))
                 raise
         if is_success:
-            self._record_change_success_in_datadog(change, processor)
+            self._record_change_success_in_datadog(change)
         return timer.duration
 
     @abstractmethod
@@ -347,19 +347,19 @@ class PillowBase(metaclass=ABCMeta):
                 'processor': processor.__class__.__name__ if processor else "all_processors",
             })
 
-    def _record_change_success_in_datadog(self, change, processor):
-        self.__record_change_metric_in_datadog('commcare.change_feed.changes.success', change, processor)
+    def _record_change_success_in_datadog(self, change):
+        self.__record_change_metric_in_datadog('commcare.change_feed.changes.success', change)
 
-    def __record_change_metric_in_datadog(self, metric, change, processor=None, processing_time=None,
+    def __record_change_metric_in_datadog(self, metric, change, processing_time=None,
                                           add_case_type_tag=False):
         if change.metadata is not None:
             metric_tags = {
                 'datasource': change.metadata.data_source_name,
                 'pillow_name': self.get_name(),
-                'case_type': 'NA'
             }
 
             if add_case_type_tag and settings.ENTERPRISE_MODE:
+                metric_tags['case_type'] = 'NA'
                 if change.metadata.document_type == 'CommCareCase':
                     metric_tags['case_type'] = change.metadata.document_subtype
 

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -255,8 +255,6 @@ class PillowBase(metaclass=ABCMeta):
                 raise
         if is_success:
             self._record_change_success_in_datadog(change, processor)
-        else:
-            self._record_change_exception_in_datadog(change, processor)
         return timer.duration
 
     @abstractmethod
@@ -351,9 +349,6 @@ class PillowBase(metaclass=ABCMeta):
 
     def _record_change_success_in_datadog(self, change, processor):
         self.__record_change_metric_in_datadog('commcare.change_feed.changes.success', change, processor)
-
-    def _record_change_exception_in_datadog(self, change, processor):
-        self.__record_change_metric_in_datadog('commcare.change_feed.changes.exceptions', change, processor)
 
     def __record_change_metric_in_datadog(self, metric, change, processor=None, processing_time=None,
                                           add_case_type_tag=False):

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -314,8 +314,6 @@ class PillowBase(metaclass=ABCMeta):
 
         tags = {"pillow_name": self.get_name()}
         max_change_lag = (datetime.utcnow() - changes_chunk[0].metadata.publish_timestamp).total_seconds()
-        min_change_lag = (datetime.utcnow() - changes_chunk[-1].metadata.publish_timestamp).total_seconds()
-        metrics_gauge('commcare.change_feed.chunked.min_change_lag', min_change_lag, tags=tags)
         metrics_gauge('commcare.change_feed.chunked.max_change_lag', max_change_lag, tags=tags)
 
         # processing_time per change

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -356,9 +356,9 @@ class PillowBase(metaclass=ABCMeta):
                 'pillow_name': self.get_name(),
             }
 
-            if add_case_type_tag and settings.ENTERPRISE_MODE:
+            if add_case_type_tag:
                 metric_tags['case_type'] = 'NA'
-                if change.metadata.document_type == 'CommCareCase':
+                if settings.ENTERPRISE_MODE and change.metadata.document_type == 'CommCareCase':
                     metric_tags['case_type'] = change.metadata.document_subtype
 
             metrics_counter(metric, tags=metric_tags)

--- a/corehq/ex-submodules/pillowtop/pillow/interface.py
+++ b/corehq/ex-submodules/pillowtop/pillow/interface.py
@@ -373,7 +373,7 @@ class PillowBase(metaclass=ABCMeta):
             })
 
             if processing_time:
-                tags = {'pillow_name': self.get_name(),}
+                tags = {'pillow_name': self.get_name()}
                 metrics_counter('commcare.change_feed.processing_time.total', processing_time, tags=tags)
                 metrics_counter('commcare.change_feed.processing_time.count', tags=tags)
 

--- a/corehq/ex-submodules/pillowtop/tests/test_metrics.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_metrics.py
@@ -24,38 +24,24 @@ class TestPillowMetrics(SimpleTestCase):
         metrics = self._get_metrics([self._get_change()])
         self.assertEqual(set(metrics.to_flattened_dict()), {
             'commcare.change_feed.changes.count.datasource:test_commcarehq',
-            'commcare.change_feed.changes.count.is_deletion:False',
             'commcare.change_feed.changes.count.pillow_name:fake pillow',
-            'commcare.change_feed.changes.count.processor:all_processors',
+            'commcare.change_feed.changes.count.case_type:NA',
             'commcare.change_feed.change_lag.pillow_name:fake pillow',
             'commcare.change_feed.change_lag.topic:case',
-            'commcare.change_feed.processing_time.total.datasource:test_commcarehq',
-            'commcare.change_feed.processing_time.total.is_deletion:False',
             'commcare.change_feed.processing_time.total.pillow_name:fake pillow',
-            'commcare.change_feed.processing_time.total.processor:all_processors',
-            'commcare.change_feed.processing_time.count.datasource:test_commcarehq',
-            'commcare.change_feed.processing_time.count.is_deletion:False',
             'commcare.change_feed.processing_time.count.pillow_name:fake pillow',
-            'commcare.change_feed.processing_time.count.processor:all_processors',
         })
 
     def test_basic_metrics_with_partition(self):
         metrics = self._get_metrics([self._get_change_with_partition()])
         self.assertEqual(set(metrics.to_flattened_dict()), {
             'commcare.change_feed.changes.count.datasource:test_commcarehq',
-            'commcare.change_feed.changes.count.is_deletion:False',
             'commcare.change_feed.changes.count.pillow_name:fake pillow',
-            'commcare.change_feed.changes.count.processor:all_processors',
+            'commcare.change_feed.changes.count.case_type:NA',
             'commcare.change_feed.change_lag.pillow_name:fake pillow',
             'commcare.change_feed.change_lag.topic:case-1',
-            'commcare.change_feed.processing_time.total.datasource:test_commcarehq',
-            'commcare.change_feed.processing_time.total.is_deletion:False',
             'commcare.change_feed.processing_time.total.pillow_name:fake pillow',
-            'commcare.change_feed.processing_time.total.processor:all_processors',
-            'commcare.change_feed.processing_time.count.datasource:test_commcarehq',
-            'commcare.change_feed.processing_time.count.is_deletion:False',
             'commcare.change_feed.processing_time.count.pillow_name:fake pillow',
-            'commcare.change_feed.processing_time.count.processor:all_processors',
         })
 
     @override_settings(ENTERPRISE_MODE=True)

--- a/corehq/ex-submodules/pillowtop/tests/test_metrics.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_metrics.py
@@ -25,6 +25,7 @@ class TestPillowMetrics(SimpleTestCase):
         self.assertEqual(set(metrics.to_flattened_dict()), {
             'commcare.change_feed.changes.count.datasource:test_commcarehq',
             'commcare.change_feed.changes.count.pillow_name:fake pillow',
+            'commcare.change_feed.changes.count.case_type:NA',
             'commcare.change_feed.change_lag.pillow_name:fake pillow',
             'commcare.change_feed.change_lag.topic:case',
             'commcare.change_feed.processing_time.total.pillow_name:fake pillow',
@@ -36,6 +37,7 @@ class TestPillowMetrics(SimpleTestCase):
         self.assertEqual(set(metrics.to_flattened_dict()), {
             'commcare.change_feed.changes.count.datasource:test_commcarehq',
             'commcare.change_feed.changes.count.pillow_name:fake pillow',
+            'commcare.change_feed.changes.count.case_type:NA',
             'commcare.change_feed.change_lag.pillow_name:fake pillow',
             'commcare.change_feed.change_lag.topic:case-1',
             'commcare.change_feed.processing_time.total.pillow_name:fake pillow',

--- a/corehq/ex-submodules/pillowtop/tests/test_metrics.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_metrics.py
@@ -25,7 +25,6 @@ class TestPillowMetrics(SimpleTestCase):
         self.assertEqual(set(metrics.to_flattened_dict()), {
             'commcare.change_feed.changes.count.datasource:test_commcarehq',
             'commcare.change_feed.changes.count.pillow_name:fake pillow',
-            'commcare.change_feed.changes.count.case_type:NA',
             'commcare.change_feed.change_lag.pillow_name:fake pillow',
             'commcare.change_feed.change_lag.topic:case',
             'commcare.change_feed.processing_time.total.pillow_name:fake pillow',
@@ -37,7 +36,6 @@ class TestPillowMetrics(SimpleTestCase):
         self.assertEqual(set(metrics.to_flattened_dict()), {
             'commcare.change_feed.changes.count.datasource:test_commcarehq',
             'commcare.change_feed.changes.count.pillow_name:fake pillow',
-            'commcare.change_feed.changes.count.case_type:NA',
             'commcare.change_feed.change_lag.pillow_name:fake pillow',
             'commcare.change_feed.change_lag.topic:case-1',
             'commcare.change_feed.processing_time.total.pillow_name:fake pillow',

--- a/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/dbaccessors.py
@@ -171,7 +171,7 @@ def _paginate_query_across_partitioned_databases(model_class, q_expression, load
 
 
 def _paginate_query(db_name, model_class, q_expression, load_source, query_size=5000):
-    track_load = load_counter_for_model(model_class)(load_source, None, extra_tags={'db': db_name})
+    track_load = load_counter_for_model(model_class)(load_source, None)
     sort_cols = ('active', 'next_event_due')
 
     # active is always set to true in the queryset's q_expression so we

--- a/corehq/sql_db/util.py
+++ b/corehq/sql_db/util.py
@@ -89,7 +89,7 @@ def paginate_query(db_name, model_class, q_expression, annotate=None, query_size
     :return: A generator with the results
     """
 
-    track_load = load_counter_for_model(model_class)(load_source, None, extra_tags={'db': db_name})
+    track_load = load_counter_for_model(model_class)(load_source, None)
     sort_col = 'pk'
 
     return_values = None

--- a/corehq/util/metrics/__init__.py
+++ b/corehq/util/metrics/__init__.py
@@ -115,7 +115,7 @@ from typing import Iterable, Callable, Dict
 
 from celery.task import periodic_task
 
-import settings
+from django.conf import settings
 from corehq.util.timer import TimingContext
 from dimagi.utils.modules import to_function
 from .const import COMMON_TAGS, ALERT_INFO

--- a/corehq/util/metrics/prometheus.py
+++ b/corehq/util/metrics/prometheus.py
@@ -65,4 +65,8 @@ class PrometheusMetrics(HqMetrics):
             self._metrics[name] = metric
         else:
             assert metric.__class__ == metric_type
-        return metric.labels(**tags) if tags else metric
+        try:
+            return metric.labels(**tags) if tags else metric
+        except ValueError:
+            print(name, tags, metric._labelnames)
+            raise

--- a/corehq/util/metrics/tests/utils.py
+++ b/corehq/util/metrics/tests/utils.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 import mock
 
-from corehq.util.metrics import DebugMetrics
+from corehq.util.metrics import DebugMetrics, DelegatedMetrics
 
 
 @contextmanager
@@ -50,9 +50,9 @@ class CapturedMetrics:
 def capture_metrics():
     from corehq.util.metrics import _metrics
     capture = DebugMetrics(capture=True)
-    _metrics.append(capture)
+    _metrics.append(DelegatedMetrics([capture] + _metrics))
     try:
         yield CapturedMetrics(capture.metrics)
     finally:
-        assert _metrics[-1] is capture, _metrics
+        assert _metrics[-1].delegates[0] is capture, _metrics
         _metrics.pop()

--- a/corehq/util/metrics/tests/utils.py
+++ b/corehq/util/metrics/tests/utils.py
@@ -48,8 +48,9 @@ class CapturedMetrics:
 
 @contextmanager
 def capture_metrics():
-    from corehq.util.metrics import _metrics
+    from corehq.util.metrics import _get_metrics_provider, _metrics  # noqa
     capture = DebugMetrics(capture=True)
+    _get_metrics_provider()  # ensure _metrics is populated
     _metrics.append(DelegatedMetrics([capture] + _metrics))
     try:
         yield CapturedMetrics(capture.metrics)

--- a/corehq/util/soft_assert/core.py
+++ b/corehq/util/soft_assert/core.py
@@ -44,7 +44,7 @@ class SoftAssert(object):
         """
         if not assertion:
             if self.debug or is_hard_mode():
-                raise AssertionError(msg)
+                raise AssertionError(msg, obj)
             short_tb = get_traceback(skip=self.tb_skip, limit=self.key_limit)
             full_tb = get_traceback(skip=self.tb_skip)
             line = short_tb.strip().split('\n')[-1].strip()

--- a/settings.py
+++ b/settings.py
@@ -837,7 +837,7 @@ SUBSCRIPTION_PASSWORD = None
 # List of metrics providers to use. Available providers:
 # * 'corehq.util.metrics.datadog.DatadogMetrics'
 # * 'corehq.util.metrics.prometheus.PrometheusMetrics'
-METRICS_PROVIDERS = ['corehq.util.metrics.prometheus.PrometheusMetrics']
+METRICS_PROVIDERS = []
 
 DATADOG_API_KEY = None
 DATADOG_APP_KEY = None

--- a/settings.py
+++ b/settings.py
@@ -837,7 +837,7 @@ SUBSCRIPTION_PASSWORD = None
 # List of metrics providers to use. Available providers:
 # * 'corehq.util.metrics.datadog.DatadogMetrics'
 # * 'corehq.util.metrics.prometheus.PrometheusMetrics'
-METRICS_PROVIDERS = []
+METRICS_PROVIDERS = ['corehq.util.metrics.prometheus.PrometheusMetrics']
 
 DATADOG_API_KEY = None
 DATADOG_APP_KEY = None

--- a/testsettings.py
+++ b/testsettings.py
@@ -136,3 +136,9 @@ REPORTING_DATABASES = {
 
 # See comment under settings.SMS_QUEUE_ENABLED
 SMS_QUEUE_ENABLED = False
+
+# use all providers in tests
+METRICS_PROVIDERS = [
+    'corehq.util.metrics.datadog.DatadogMetrics',
+    'corehq.util.metrics.prometheus.PrometheusMetrics',
+]


### PR DESCRIPTION
##### SUMMARY
Prometheus requires that metrics always have the same set of tags.

Once the build passes on this PR the settings change will be reverted.
