### PR TITLE
Added explicit ordering for conditional alerts translations

### DIFF
--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -1879,14 +1879,15 @@ class ScheduleForm(Form):
     @cached_property
     def language_list(self):
         sms_translations = get_or_create_sms_translations(self.domain)
-        result = set(sms_translations.langs)
+        result = sms_translations.langs     # maintain order set on languages config page
 
+        # add any languages present in alert but deleted from languages config page
         if self.initial_schedule:
-            result |= self.initial_schedule.memoized_language_set
+            initial_langs = self.initial_schedule.memoized_language_set
+            initial_langs.discard('*')
+            result += list(self.initial_schedule.memoized_language_set - set(result))
 
-        result.discard('*')
-
-        return list(result)
+        return result
 
     @property
     def use_case(self):


### PR DESCRIPTION
##### PRODUCT DESCRIPTION
Guarantees that conditional alert translations will display in the same order used on the SMS languages page.

<img width="777" alt="Screen Shot 2020-04-23 at 11 46 19 AM" src="https://user-images.githubusercontent.com/1486591/80119814-2efa6700-8558-11ea-8226-a020ef991fb3.png">
