### PR TITLE
Removed caching logic from SMS chat contacts

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -32,7 +32,6 @@ from couchexport.export import export_raw
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
 from dimagi.utils.couch import CriticalSection
-from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.decorators.view import get_file
 from dimagi.utils.logging import notify_exception
@@ -622,17 +621,6 @@ def get_mobile_worker_contact_info(domain_obj, user_ids):
 
 
 def get_contact_info(domain):
-    # If the data has been cached, just retrieve it from there
-    cache_key = 'sms-chat-contact-list-%s' % domain
-    cache_expiration = 30 * 60
-    try:
-        client = cache_core.get_redis_client()
-        cached_data = client.get(cache_key)
-        if cached_data:
-            return json.loads(cached_data)
-    except:
-        pass
-
     domain_obj = Domain.get_by_name(domain, strict=True)
     case_ids = []
     mobile_worker_ids = []
@@ -672,13 +660,6 @@ def get_contact_info(domain):
     for row in data:
         contact_info = contact_data.get(row[3])
         row[0] = contact_info[0] if contact_info else _('(unknown)')
-
-    # Save the data to the cache for faster lookup next time
-    try:
-        client.set(cache_key, json.dumps(data))
-        client.expire(cache_key, cache_expiration)
-    except:
-        pass
 
     return data
 


### PR DESCRIPTION
##### SUMMARY
This caching logic was added in [2015](https://github.com/dimagi/commcare-hq/commit/c7149b2ae49659718a66801badd60ac5445d29b4), when PhoneNumber was a couch model.

It seems to not be invalidating correctly (or possibly at all). Given that PhoneNumber is now in SQL and has an index on domain, I'm inclined to remove it. Will backtrack if that ends up being a performance issue.