### PR TITLE
ViewModel to cast connection_settings_id as an int

### DIFF
--- a/corehq/motech/dhis2/static/dhis2/js/dhis2_map_settings.js
+++ b/corehq/motech/dhis2/static/dhis2/js/dhis2_map_settings.js
@@ -80,7 +80,7 @@ hqDefine('dhis2/js/dhis2_map_settings', [
         self.toJSON = function () {
             return {
                 "description": self.description(),
-                "connection_settings_id": self.connectionSettingsId(),
+                "connection_settings_id": Number(self.connectionSettingsId()),
                 "ucr_id": self.ucrId(),
                 "frequency": self.frequency(),
                 "day_to_send": Number(self.dayOfMonth()),


### PR DESCRIPTION
Context: [SC-628](https://dimagi-dev.atlassian.net/browse/SC-628)

##### SUMMARY
It seems you can set `DataSetMap.connections_settings_id` to a string when you create a new instance, but you get a TypeError if you try to update an existing value to a string.

It also seems I knew about this already, because the ViewModel casts `day_to_send` as an int. I missed that when I created the `connections_settings_id` property.

##### FEATURE FLAG
DHIS2 Integration
