### PR TITLE
Add "Bearer Token" as Repeater Auth option

### DIFF
--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -25,7 +25,7 @@ class HTTPBearerAuth(requests.auth.AuthBase):
             "password": self.password
                     }
 
-        token_response = requests.get(token_request_url, data=post_data)
+        token_response = requests.post(token_request_url, data=post_data)
         try:
             return token_response.json()['access_token']
         except Exception:

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -23,13 +23,13 @@ class HTTPBearerAuth(requests.auth.AuthBase):
         post_data = {"grant_type": "password",
             "username": self.username,
             "password": self.password
-            }
+                    }
 
         token_response = requests.get(token_request_url, data=post_data)
         try:
             return token_response.json()['access_token']
         except Exception:
-            raise RequestException(None, r, 
+            raise RequestException(None, r,
                     "Unable to retrieve access token for request: %s" % token_response.content)
 
     def __call__(self, r):

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -1,0 +1,36 @@
+import requests
+import re
+from urllib.parse import urljoin
+from requests.exceptions import RequestException
+
+class HTTPBearerAuth(requests.auth.AuthBase):
+    def __init__(self, username, plaintext_password):
+        self.username = username
+        self.password = plaintext_password
+
+    def _find_bearer_base(self, r):
+        m = re.compile('https.*/api/v[0-9]+/').match(r.url)
+        if m:
+            return m.group(0)
+        else:
+            raise RequestException(None, r, "HTTP endpoint is not not valid for bearer auth")
+
+    def _get_auth_token(self, r):
+        token_base = self._find_bearer_base(r)
+        token_request_url = urljoin(token_base, "token")
+
+        post_data = {"grant_type": "password", 
+            "username": self.username, 
+            "password": self.password
+        }
+
+        token_response = requests.get(token_request_url, data=post_data)
+        try: 
+            return token_response.json()['access_token']
+        except:
+            raise RequestException(None, r, "Unable to retrieve access token for request: %s" % token_response.content)
+
+    def __call__(self, r):
+        token = self._get_auth_token(r)
+        r.headers["Authorization"] = "Bearer %s" % token
+        return r

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -3,6 +3,7 @@ import re
 from urllib.parse import urljoin
 from requests.exceptions import RequestException
 
+
 class HTTPBearerAuth(requests.auth.AuthBase):
     def __init__(self, username, plaintext_password):
         self.username = username
@@ -19,16 +20,17 @@ class HTTPBearerAuth(requests.auth.AuthBase):
         token_base = self._find_bearer_base(r)
         token_request_url = urljoin(token_base, "token")
 
-        post_data = {"grant_type": "password", 
-            "username": self.username, 
+        post_data = {"grant_type": "password",
+            "username": self.username,
             "password": self.password
-        }
+            }
 
         token_response = requests.get(token_request_url, data=post_data)
-        try: 
+        try:
             return token_response.json()['access_token']
-        except:
-            raise RequestException(None, r, "Unable to retrieve access token for request: %s" % token_response.content)
+        except e:
+            raise RequestException(None, r, 
+                    "Unable to retrieve access token for request: %s" % token_response.content)
 
     def __call__(self, r):
         token = self._get_auth_token(r)

--- a/corehq/motech/auth.py
+++ b/corehq/motech/auth.py
@@ -28,7 +28,7 @@ class HTTPBearerAuth(requests.auth.AuthBase):
         token_response = requests.get(token_request_url, data=post_data)
         try:
             return token_response.json()['access_token']
-        except e:
+        except Exception:
             raise RequestException(None, r, 
                     "Unable to retrieve access token for request: %s" % token_response.content)
 

--- a/corehq/motech/const.py
+++ b/corehq/motech/const.py
@@ -1,6 +1,7 @@
 BASIC_AUTH = "basic"
 DIGEST_AUTH = "digest"
 OAUTH1 = "oauth1"
+BEARER_AUTH = "bearer"
 
 PASSWORD_PLACEHOLDER = '*' * 16
 

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -10,6 +10,7 @@ from corehq.motech.const import (
     BASIC_AUTH,
     DIGEST_AUTH,
     OAUTH1,
+    BEARER_AUTH,
     PASSWORD_PLACEHOLDER,
 )
 from corehq.motech.utils import b64_aes_decrypt, b64_aes_encrypt
@@ -32,6 +33,7 @@ class ConnectionSettings(models.Model):
             (BASIC_AUTH, "Basic"),
             (DIGEST_AUTH, "Digest"),
             (OAUTH1, "OAuth1"),
+            (BEARER_AUTH, "Bearer"),
         )
     )
     username = models.CharField(max_length=255)

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -100,7 +100,7 @@ from corehq.form_processor.interfaces.dbaccessors import (
     CaseAccessors,
     FormAccessors,
 )
-from corehq.motech.const import ALGO_AES, BASIC_AUTH, DIGEST_AUTH, OAUTH1
+from corehq.motech.const import ALGO_AES, BASIC_AUTH, DIGEST_AUTH, OAUTH1, BEARER_AUTH
 from corehq.motech.repeaters.repeater_generators import (
     AppStructureGenerator,
     CaseRepeaterJsonPayloadGenerator,
@@ -168,7 +168,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
     url = StringProperty()
     format = StringProperty()
 
-    auth_type = StringProperty(choices=(BASIC_AUTH, DIGEST_AUTH, OAUTH1), required=False)
+    auth_type = StringProperty(choices=(BASIC_AUTH, DIGEST_AUTH, OAUTH1, BEARER_AUTH), required=False)
     username = StringProperty()
     password = StringProperty()  # See also plaintext_password()
     skip_cert_verify = BooleanProperty(default=False)  # See also verify()

--- a/corehq/motech/repeaters/views/repeaters.py
+++ b/corehq/motech/repeaters/views/repeaters.py
@@ -26,10 +26,12 @@ from corehq.apps.users.decorators import (
     require_permission,
 )
 from corehq.apps.users.models import Permissions
+from corehq.motech.auth import HTTPBearerAuth
 from corehq.motech.const import (
     ALGO_AES,
     BASIC_AUTH,
     DIGEST_AUTH,
+    BEARER_AUTH,
     PASSWORD_PLACEHOLDER,
 )
 from corehq.motech.repeaters.forms import (
@@ -395,6 +397,8 @@ def test_repeater(request, domain):
             auth = HTTPBasicAuth(username, password)
         elif auth_type == DIGEST_AUTH:
             auth = HTTPDigestAuth(username, password)
+        elif auth_type == BEARER_AUTH:
+            auth = HTTPBearerAuth(username, password)
         else:
             auth = None
 


### PR DESCRIPTION
One of the external teams we are working with has a "swagger" API which uses ["Bearer Token"](https://docs.ipswitch.com/MOVEit/Automation2018/API/REST-API/index.html) authentication. This implements that option into the repeater requests framework.

##### SUMMARY
Uses the python requests library preferred method for extending authentication options. 

This approach just attempts to extract the api paths for the token endpoints, since they seem consistent in swagger API's (the only place I found that used this auth type). I think that's a good design tradeoff with low risk.

##### FEATURE FLAG
DHIS2/Motech

##### PRODUCT DESCRIPTION
Adds "Bearer Token" as an authentication option for MOTECH repeaters
