### PR TITLE
Make the Case List Explorer location-safe

### DIFF
--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -11,6 +11,7 @@ from corehq.apps.case_search.const import (
 )
 from corehq.apps.case_search.filter_dsl import CaseFilterError
 from corehq.apps.es.case_search import CaseSearchES, flatten_result
+from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq.apps.reports.filters.case_list import CaseListFilter
@@ -29,6 +30,7 @@ from corehq.util.metrics import metrics_histogram_timer
 from corehq.util.soft_assert import soft_assert
 
 
+@location_safe
 class CaseListExplorer(CaseListReport):
     name = _('Case List Explorer')
     slug = 'case_list_explorer'


### PR DESCRIPTION
The CLE is already location safe.  It extends the regular case list report, which is location safe.

<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
CASE_LIST_EXPLORER: "Show the case list explorer report"

##### PRODUCT DESCRIPTION
This makes the Case List Explorer report accessible to location-restricted users (when already enabled for that project)
