### PR TITLE
Drop Dhis2Connection

### DIFF
--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -112,7 +112,6 @@ from corehq.form_processor.interfaces.dbaccessors import (
 from corehq.form_processor.models import XFormInstanceSQL
 from corehq.form_processor.tests.utils import create_form_for_test
 from corehq.motech.models import RequestLog
-from corehq.motech.dhis2.models import Dhis2Connection
 
 
 class TestDeleteDomain(TestCase):
@@ -866,13 +865,11 @@ class TestDeleteDomain(TestCase):
     def _assert_motech_count(self, domain_name, count):
         self._assert_queryset_count([
             RequestLog.objects.filter(domain=domain_name),
-            Dhis2Connection.objects.filter(domain=domain_name),
         ], count)
 
     def test_motech_delete(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             RequestLog.objects.create(domain=domain_name)
-            Dhis2Connection.objects.create(domain=domain_name)
             self._assert_motech_count(domain_name, 1)
 
         self.domain.delete()

--- a/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
+++ b/corehq/motech/dhis2/management/commands/dhis2_conn_to_conn_settings.py
@@ -67,6 +67,7 @@ def link_data_set_maps(conn_settings: ConnectionSettings):
     Links DataSetMap instances to their ConnectionSettings instance.
     """
     for data_set_map in get_dataset_maps(conn_settings.domain):
-        data_set_map.connection_settings_id = conn_settings.id
-        data_set_map.save()
+        if not data_set_map.connection_settings_id:
+            data_set_map.connection_settings_id = conn_settings.id
+            data_set_map.save()
     get_dataset_maps.clear(conn_settings.domain)

--- a/corehq/motech/dhis2/models.py
+++ b/corehq/motech/dhis2/models.py
@@ -2,11 +2,11 @@ import bz2
 from base64 import b64decode, b64encode
 from itertools import chain
 
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from corehq.motech.models import ConnectionSettings
 from dimagi.ext.couchdbkit import (
-    BooleanProperty,
     Document,
     DocumentSchema,
     IntegerProperty,
@@ -29,6 +29,7 @@ from corehq.motech.dhis2.utils import (
 from corehq.util.quickcache import quickcache
 
 
+# UNUSED
 class Dhis2Connection(models.Model):
     domain = models.CharField(max_length=255, unique=True)
     server_url = models.CharField(max_length=255, null=True)
@@ -49,6 +50,11 @@ class Dhis2Connection(models.Model):
         # (2020-03-09) Not true. The key is stored separately.
         plaintext_bytes = plaintext.encode('utf8')
         self.password = b64encode(bz2.compress(plaintext_bytes))
+
+    def save(self, *args, **kwargs):
+        raise ValidationError(
+            'Dhis2Connection is unused. Use ConnectionSettings instead.'
+        )
 
 
 class DataValueMap(DocumentSchema):

--- a/corehq/motech/dhis2/tasks.py
+++ b/corehq/motech/dhis2/tasks.py
@@ -7,7 +7,6 @@ from toggle.shortcuts import find_domains_with_toggle_enabled
 
 from corehq import toggles
 from corehq.motech.dhis2.dbaccessors import get_dataset_maps
-from corehq.motech.dhis2.models import Dhis2Connection
 from corehq.motech.requests import Requests
 
 
@@ -34,33 +33,22 @@ def send_datasets(domain_name, send_now=False, send_date=None):
     """
     if not send_date:
         send_date = datetime.today()
-    dhis2_conn = Dhis2Connection.objects.filter(domain=domain_name).first()
     dataset_maps = get_dataset_maps(domain_name)
     if not dataset_maps:
         return  # Nothing to do
     for dataset_map in dataset_maps:
         if send_now or dataset_map.should_send_on_date(send_date):
-            if dataset_map.connection_settings:
-                conn = dataset_map.connection_settings
-                url = conn.url
-                endpoint = '/api/dataValueSets'
-            else:
-                conn = dhis2_conn
-                url = conn.server_url
-                endpoint = 'dataValueSets'
-            if not conn:
-                continue
-
+            conn = dataset_map.connection_settings
             dataset = dataset_map.get_dataset(send_date)
             requests = Requests(
                 domain_name,
-                url,
+                conn.url,
                 conn.username,
                 conn.plaintext_password,
                 verify=not conn.skip_cert_verify,
                 notify_addresses=conn.notify_addresses if hasattr(conn, 'notify_addresses') else None
             )
-            requests.post(endpoint, json=dataset)
+            requests.post('/api/dataValueSets', json=dataset)
 
 
 @periodic_task(


### PR DESCRIPTION
##### SUMMARY
All instances of Dhis2Connection on prod and staging have been migrated to ConnectionSettings.

This change stops using Dhis2Connection, and raises a ValidationError if someone tries to save a new instance.

I have not dropped the model completely, in case there is a self-hosted HQ out there that is using this, although that is very, very unlikely.

(If they do exist, they can use

    $ commcare-cloud <env> django-manage dhis2_conn_to_conn_settings

to migrate to ConnectionSettings.)

##### FEATURE FLAG
DHIS2 Integration
