### PR TITLE
Make the operationalization calculation of ASR same as MPR

### DIFF
--- a/custom/icds_reports/resources/block_asr.json
+++ b/custom/icds_reports/resources/block_asr.json
@@ -2,16 +2,8 @@
   "operationalization": {
     "data_source": [
       {
-        "id": "static-{domain}-static-dashboard_asr_2_3_person_cases",
-        "filter": [
-          {
-            "type": "daterange",
-            "column": "dob",
-            "operator": "between",
-            "end": 1096,
-            "start": 1825
-          }
-        ],
+        "id": "static-{domain}-static-dashboard_asr_4a_6_pse",
+        "date_filter_field": "submitted_on",
         "columns": [
           {
             "column_name": "awc_count",

--- a/custom/icds_reports/ucr/reports/dashboard/asr_4a_6.pse.json
+++ b/custom/icds_reports/ucr/reports/dashboard/asr_4a_6.pse.json
@@ -1,0 +1,152 @@
+{
+  "domains": [
+    "icds-dashboard-qa",
+    "sankalp_cas",
+    "zohaib-sandbox",
+    "akshita-sandbox",
+    "sunaina-sandbox",
+    "laurence-project-1",
+    "jessica-icds-cas",
+    "marissa-test",
+    "derek-icds-sandbox",
+    "priyanka-app",
+    "shrena-dev",
+    "aparatest",
+    "reach-sandbox",
+    "reach-dashboard-qa",
+    "reach-test",
+    "icds-test",
+    "icds-sql",
+    "icds-cas",
+    "cas-lab",
+    "icds-cas-sandbox"
+  ],
+  "server_environment": [
+    "india",
+    "icds"
+  ],
+  "report_id": "static-dashboard_asr_4a_6_pse",
+  "data_source_table": "static-daily_feeding_forms",
+  "config": {
+    "title": "ASR - 4a,6 - PSE (Static)",
+    "description": "",
+    "visible": false,
+    "aggregation_columns": [
+      "owner_id"
+    ],
+    "filters": [
+      {
+        "compare_as_string": false,
+        "datatype": "date",
+        "required": false,
+        "display": "Date Form Submitted",
+        "field": "submitted_on",
+        "type": "date",
+        "slug": "submitted_on"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "awc_id",
+        "field": "awc_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "ancestor_expression": {
+            "field": "supervisor_id",
+            "location_type": "supervisor"
+        },
+        "display": "Filter by AWW"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "supervisor_id",
+        "field": "supervisor_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Supervisor"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "block_id",
+        "field": "block_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by Block"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "district_id",
+        "field": "district_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by District"
+      },
+      {
+        "compare_as_string": false,
+        "show_all": true,
+        "datatype": "string",
+        "type": "dynamic_choice_list",
+        "required": false,
+        "slug": "state_id",
+        "field": "state_id",
+        "choice_provider": {
+          "type": "location"
+        },
+        "display": "Filter by State"
+      }
+    ],
+    "columns": [
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "transform": {
+          "type": "custom",
+          "custom_type": "owner_display"
+        },
+        "column_id": "owner_id",
+        "field": "awc_id",
+        "calculate_total": false,
+        "type": "field",
+        "display": {
+          "en": "Owner",
+          "hin": "Owner"
+        },
+        "aggregation": "simple"
+      },
+      {
+        "sortable": false,
+        "description": null,
+        "format": "default",
+        "aggregation": "count_unique",
+        "column_id": "awc_count",
+        "field": "awc_id",
+        "transform": {},
+        "calculate_total": true,
+        "type": "field",
+        "display": "awc_count"
+      }
+    ],
+    "sort_expression": [],
+    "configured_charts": []
+  }
+}


### PR DESCRIPTION
This code change makes the operationalization section of [ASR report](https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/resources/block_asr.json#L2) same as [MPR report](https://github.com/dimagi/commcare-hq/blob/master/custom/icds_reports/resources/block_mpr.json#L2).

Ticket: https://dimagi-dev.atlassian.net/browse/ICDS-1411
