### PR TITLE
dump mm docs

### DIFF
--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -23,6 +23,7 @@ DOC_PROVIDERS = {
     DocTypeIDProvider(['Application']),
     DocTypeIDProvider(['CommtrackConfig']),
     DocTypeIDProvider(['DefaultConsumption']),
+    ViewIDProvider('CommCareMultimedia', 'hqmedia/by_domain', DomainKeyGenerator()),
     DocTypeIDProvider(['MobileAuthKeyRecord']),
     DocTypeIDProvider(['Product']),
     DocTypeIDProvider(['Program']),

--- a/corehq/apps/dump_reload/management/commands/print_domain_stats.py
+++ b/corehq/apps/dump_reload/management/commands/print_domain_stats.py
@@ -16,6 +16,7 @@ from corehq.apps.dump_reload.sql.dump import (
     get_model_iterator_builders_to_dump,
 )
 from corehq.apps.dump_reload.util import get_model_label
+from corehq.apps.hqmedia.models import CommCareMultimedia
 from corehq.apps.users.dbaccessors.all_commcare_users import (
     get_mobile_user_count,
     get_web_user_count,
@@ -84,6 +85,9 @@ def _get_couchdb_counts(domain):
                 doc_class = get_document_class_by_doc_type(doc_type)
                 count = get_doc_count_in_domain_by_class(domain, doc_class)
                 couch_db_counts.update({doc_type: count})
+
+    for _ in CommCareMultimedia.get_db().view('hqmedia/by_domain', key=domain, include_docs=False):
+        couch_db_counts.update(['CommCareMultimedia'])
 
     mobile_user_count = get_mobile_user_count(domain)
     couch_db_counts.update({

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -141,6 +141,38 @@ class CouchDumpLoadTest(TestCase):
 
         self._dump_and_load(expected_docs, not_expected_docs)
 
+    def test_multimedia(self):
+        from corehq.apps.hqmedia.models import CommCareAudio, CommCareImage, CommCareVideo
+        image_path = os.path.join('corehq', 'apps', 'hqwebapp', 'static', 'hqwebapp', 'images', 'commcare-hq-logo.png')
+        with open(image_path, 'rb') as f:
+            image_data = f.read()
+
+        image = CommCareImage.get_by_data(image_data)
+        image.attach_data(image_data, original_filename='logo.png')
+        image.add_domain(self.domain_name)
+        self.assertEqual(image_data, image.get_display_file(False))
+
+        audio_data = b'fake audio data'
+        audio = CommCareAudio.get_by_data(audio_data)
+        audio.attach_data(audio_data, original_filename='tr-la-la.mp3')
+        audio.add_domain(self.domain_name)
+        self.assertEqual(audio_data, audio.get_display_file(False))
+
+        video_data = b'fake video data'
+        video = CommCareVideo.get_by_data(video_data)
+        video.attach_data(video_data, 'kittens.mp4')
+        video.add_domain(self.domain_name)
+        self.assertEqual(video_data, video.get_display_file(False))
+
+        fakedb = self._dump_and_load([image, audio, video])
+
+        copied_image = CommCareImage.wrap(fakedb.get(image._id))
+        copied_audio = CommCareAudio.wrap(fakedb.get(audio._id))
+        copied_video = CommCareVideo.wrap(fakedb.get(video._id))
+        self.assertEqual(image_data, copied_image.get_display_file(False))
+        self.assertEqual(audio_data, copied_audio.get_display_file(False))
+        self.assertEqual(video_data, copied_video.get_display_file(False))
+
     def test_web_user(self):
         from corehq.apps.users.models import WebUser
         other_domain = Domain(name='other-domain')

--- a/corehq/apps/hqmedia/_design/views/by_domain/map.js
+++ b/corehq/apps/hqmedia/_design/views/by_domain/map.js
@@ -1,0 +1,10 @@
+function(doc){
+    if(doc.doc_type === 'CommCareMultimedia' ||
+        doc.doc_type === 'CommCareImage' ||
+        doc.doc_type === 'CommCareAudio' ||
+        doc.doc_type === 'CommCareVideo') {
+        doc.valid_domains.forEach(function (domain) {
+            emit(domain, null);
+        });
+    }
+}


### PR DESCRIPTION
##### SUMMARY
Add back couch view and code required to dump MM docs for a domain.

Still need to export blob data. Will submit a separate PR for that.