### PR TITLE
Turn.io SMS fallback

### DIFF
--- a/corehq/messaging/smsbackends/turn/forms.py
+++ b/corehq/messaging/smsbackends/turn/forms.py
@@ -1,10 +1,12 @@
 from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms import layout as crispy
+from django.forms import ChoiceField
 
 from dimagi.utils.django.fields import TrimmedCharField
 
 from corehq.apps.sms.forms import BackendForm
+from corehq.apps.sms.models import SQLMobileBackend
 
 
 class TurnBackendForm(BackendForm):
@@ -12,13 +14,25 @@ class TurnBackendForm(BackendForm):
     business_id = TrimmedCharField(label=_("Business ID"))
     template_namespace = TrimmedCharField(label=_("Template Namespace"))
     business_auth_token = TrimmedCharField(label=_("Business Auth Token"))
+    fallback_backend_id = ChoiceField(label=_("Fallback Backend"))
 
     @property
     def gateway_specific_fields(self):
+        domain_backends = SQLMobileBackend.get_domain_backends(
+            SQLMobileBackend.SMS,
+            self.domain,
+        )
+        backend_choices = [('', _("No Fallback Backend"))]
+        backend_choices.extend([
+            (backend.id, backend.name) for backend in domain_backends
+            if backend.id != self.backend_id
+        ])
+        self.fields['fallback_backend_id'].choices = backend_choices
         return crispy.Fieldset(
             _("Turn Settings"),
             "client_auth_token",
             "business_id",
             "template_namespace",
             "business_auth_token",
+            "fallback_backend_id",
         )

--- a/corehq/messaging/smsbackends/turn/forms.py
+++ b/corehq/messaging/smsbackends/turn/forms.py
@@ -14,7 +14,7 @@ class TurnBackendForm(BackendForm):
     business_id = TrimmedCharField(label=_("Business ID"))
     template_namespace = TrimmedCharField(label=_("Template Namespace"))
     business_auth_token = TrimmedCharField(label=_("Business Auth Token"))
-    fallback_backend_id = ChoiceField(label=_("Fallback Backend"))
+    fallback_backend_id = ChoiceField(label=_("Fallback Backend"), required=False)
 
     @property
     def gateway_specific_fields(self):
@@ -24,7 +24,7 @@ class TurnBackendForm(BackendForm):
         )
         backend_choices = [('', _("No Fallback Backend"))]
         backend_choices.extend([
-            (backend.id, backend.name) for backend in domain_backends
+            (backend.couch_id, backend.name) for backend in domain_backends
             if backend.id != self.backend_id
         ])
         self.fields['fallback_backend_id'].choices = backend_choices

--- a/corehq/messaging/smsbackends/turn/models.py
+++ b/corehq/messaging/smsbackends/turn/models.py
@@ -1,11 +1,10 @@
 import re
 from collections import namedtuple
 
-from corehq.apps.sms.models import SMS, SQLSMSBackend
+from corehq.apps.sms.api import send_sms_with_backend, MessageMetadata
+from corehq.apps.sms.models import SMS, SQLSMSBackend, MessagingEvent, PhoneNumber
 from corehq.apps.sms.util import clean_phone_number
-from corehq.messaging.smsbackends.turn.exceptions import (
-    WhatsAppTemplateStringException,
-)
+from corehq.messaging.smsbackends.turn.exceptions import WhatsAppTemplateStringException
 from corehq.messaging.smsbackends.turn.forms import TurnBackendForm
 from turn import TurnBusinessManagementClient, TurnClient
 from turn.exceptions import WhatsAppContactNotFound
@@ -44,7 +43,6 @@ class SQLTurnWhatsAppBackend(SQLSMSBackend):
         config = self.config
         client = TurnClient(config.client_auth_token)
         to = clean_phone_number(msg.phone_number)
-
         try:
             wa_id = client.contacts.get_whatsapp_id(to)
 
@@ -52,36 +50,44 @@ class SQLTurnWhatsAppBackend(SQLSMSBackend):
                 return self._send_template_message(client, wa_id, msg)
             else:
                 return self._send_text_message(client, wa_id, msg)
-
         except WhatsAppContactNotFound:
             msg.set_system_error(SMS.ERROR_INVALID_DESTINATION_NUMBER)
-            return
+            if self.config.fallback_backend_id:
+                self._send_fallback_message(msg)
+            return False
+        # TODO: Add other exceptions here
 
     def _send_template_message(self, client, wa_id, msg):
         try:
             parts = get_template_hsm_parts(msg.text)
         except WhatsAppTemplateStringException:
             msg.set_system_error(SMS.ERROR_MESSAGE_FORMAT_INVALID)
-        try:
-            return client.messages.send_templated_message(
-                wa_id,
-                self.config.template_namespace,
-                parts.template_name,
-                parts.lang_code,
-                parts.params,
-            )
-        except:  # TODO: Add messaging exceptions to package
-            raise
-        else:
-            raise
+
+        return client.messages.send_templated_message(
+            wa_id,
+            self.config.template_namespace,
+            parts.template_name,
+            parts.lang_code,
+            parts.params,
+        )
 
     def _send_text_message(self, client, wa_id, msg):
-        try:
-            return client.messages.send_text(wa_id, msg.text)
-        except:  # TODO: Add message exceptions to package
-            raise
+        return client.messages.send_text(wa_id, msg.text)
+
+    def _send_fallback_message(self, msg):
+        logged_event = MessagingEvent.create_event_for_adhoc_sms(self.domain, recipient=msg.recipient)
+        logged_subevent = logged_event.create_subevent_for_single_sms(recipient_doc_type=msg.recipient.doc_type, recipient_id=msg.recipient.get_id)
+        metadata = MessageMetadata(
+            messaging_subevent_id=logged_subevent.pk,
+            custom_metadata={"fallback": "WhatsApp Contact Not Found"}
+        )
+        if send_sms_with_backend(
+            self.domain, msg.phone_number, msg.text, self.config.fallback_backend_id, metadata
+        ):
+            logged_subevent.completed()
+            logged_event.completed()
         else:
-            raise
+            logged_subevent.error(MessagingEvent.ERROR_INTERNAL_SERVER_ERROR)
 
     def get_all_templates(self):
         config = self.config
@@ -100,7 +106,7 @@ def get_template_hsm_parts(message_text):
     parts = message_text.split(":")
 
     try:
-        params = re.findall('{(.+?)}+', parts[3])
+        params = re.findall("{(.+?)}+", parts[3])
     except IndexError:
         params = []
 
@@ -115,10 +121,10 @@ def generate_template_string(template):
     """
 
     template_text = ""
-    for component in template.get('components', []):
+    for component in template.get("components", []):
         if component.get("type") == "BODY":
             template_text = component.get("text", "")
             break
-    num_params = template_text.count('{') // 2  # each parameter is bracketed by {{}}
-    parameters = ",".join([f'{{var{i}}}' for i in range(1, num_params + 1)])
+    num_params = template_text.count("{") // 2  # each parameter is bracketed by {{}}
+    parameters = ",".join([f"{{var{i}}}" for i in range(1, num_params + 1)])
     return f"{WA_TEMPLATE_STRING}:{template['name']}:{template['language']}:{parameters}"

--- a/corehq/messaging/smsbackends/turn/models.py
+++ b/corehq/messaging/smsbackends/turn/models.py
@@ -33,6 +33,7 @@ class SQLTurnWhatsAppBackend(SQLSMSBackend):
             "client_auth_token",
             "business_id",
             "business_auth_token",
+            "fallback_backend_id",
         ]
 
     @classmethod


### PR DESCRIPTION
https://docs.google.com/document/d/1wDwMpYnZJVXGu4KDpX3iMWMTuteme82DujbnSly3hQ0/edit#

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds the ability to select a fallback SMS backend when sending messages via the Turn Backend. The use case is if a recipient doesn't have WhatsApp, they will still receive messages via SMS. 

Once we handle more Turn exceptions, I will add them in here with specific error messages. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
