### PR TITLE
Fix race condition that results in CaseUploadRecord.DoesNotExist

### DIFF
--- a/corehq/apps/case_importer/tracking/exceptions.py
+++ b/corehq/apps/case_importer/tracking/exceptions.py
@@ -1,0 +1,2 @@
+class TimedOutWaitingForCaseUploadRecord(Exception):
+    pass


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SUPPORT-1152

##### SUMMARY
Looks like my change https://github.com/dimagi/commcare-hq/pull/27244, reverted in https://github.com/dimagi/commcare-hq/pull/27273, exposed this existing race condition by shortening the amount of time between the start of `bulk_import_async` and when the `CaseUploadRecord` needs to exist. (Based on the history of sentry errors, we already sometimes hit this race condition in a different place, but my change made it more common.)

I'm PRing this separately first and then I'll make sure that this (1) doesn't break anything and (2) fixes the error from my original PR on staging

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
