### PR TITLE
Show progress for Show Deleted on edit export page

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -289,7 +289,8 @@ hqDefine('export/js/models', [
                 }
 
                 self.buildSchemaProgress(response.progress.percent || 0);
-                if (response.not_started || response.progress.current !== response.progress.total) {
+                if (response.not_started || response.progress.current === null ||
+                        response.progress.current !== response.progress.total) {
                     window.setTimeout(
                         self.checkBuildSchemaProgress.bind(self, response.download_id, successHandler, errorHandler),
                         2000


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10699

##### SUMMARY
Show progress for Show Deleted on edit export page by fixing the poll condition to start polling under normal circumstances.

I believe this is a long-existing bug. I'm guessing it started at some point when we maybe changed the semantics of `not_started` versus `missing` or something like that, either to fix some other UI or as part of a celery upgrade or something like that. That's all conjecture though