### PR TITLE
Change option label in internal credit adjustment UI

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -2221,7 +2221,7 @@ class AdjustBalanceForm(forms.Form):
 
     method = forms.ChoiceField(
         choices=(
-            (CreditAdjustmentReason.MANUAL, "Update balance directly"),
+            (CreditAdjustmentReason.MANUAL, "Register back office payment"),
             (CreditAdjustmentReason.TRANSFER, "Take from available credit lines"),
         )
     )


### PR DESCRIPTION
to better reflect what the option means.
There are plans to add a third option to the dropdown,
so I wanted to change the text to distinguish this better from the new option.
to better reflect what the option means.
There are plans to add a third option to the dropdown,
so I wanted to change the text to distinguish this better from the new option.

See also https://docs.google.com/document/d/14RYr66tqjpgWDQkOG9M88RvQiZnBpShVugVqk4o1I-k/edit?disco=AAAAGc3QslQ

Thought I'd go ahead and just make the change, but there's certainly no rush to merge