### PR TITLE
remove redundant check

### DIFF
--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -234,10 +234,4 @@ class HouseholdReassignmentParser(object):
                     'old_site_code': location_site_code,
                     'new_site_code': new_awc_code
                 }
-        locations = SQLLocation.active_objects.filter(domain=self.domain, site_code__in=site_codes)
-        if len(locations) != len(site_codes):
-            site_codes_found = set([l.site_code for l in locations])
-            errors.append(
-                "Missing site codes %s" % ",".join(site_codes - site_codes_found)
-            )
         return errors

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -216,10 +216,8 @@ class HouseholdReassignmentParser(object):
 
     def parse(self):
         errors = []
-        site_codes = set()
         for worksheet in self.workbook.worksheets:
             location_site_code = worksheet.title
-            site_codes.add(location_site_code)
             for row in worksheet:
                 household_id = row.get(HOUSEHOLD_ID_COLUMN)
                 new_awc_code = row.get(AWC_CODE_COLUMN)
@@ -229,7 +227,6 @@ class HouseholdReassignmentParser(object):
                 if not new_awc_code:
                     errors.append("Missing New AWC Code for household ID %s" % household_id)
                     continue
-                site_codes.add(new_awc_code)
                 self.reassignments[household_id] = {
                     'old_site_code': location_site_code,
                     'new_site_code': new_awc_code


### PR DESCRIPTION
Follow up on https://github.com/dimagi/commcare-hq/pull/27296. Same check was blocking while parsing but since it was already done on view, it was fine to remove it completely.



##### FEATURE FLAG
`LOCATION_REASSIGNMENT`

