### PR TITLE
Hard delete archived forms

### DIFF
--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -917,12 +917,15 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
 
     def tearDown(self):
         self.domain2.delete()
+        call_command('hard_delete_forms_and_cases_in_domain', self.domain2.name, noinput=True)
+        call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
         super(TestHardDeleteSQLFormsAndCases, self).tearDown()
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_hard_delete_forms(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             create_form_for_test(domain_name)
+            create_form_for_test(domain_name, state=XFormInstanceSQL.ARCHIVED)
             self.assertEqual(len(FormAccessors(domain_name).get_all_form_ids_in_domain()), 1)
 
         self.domain.delete()
@@ -930,7 +933,7 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(FormAccessors(self.domain.name).get_all_form_ids_in_domain()), 0)
         self.assertEqual(len(FormAccessors(self.domain2.name).get_all_form_ids_in_domain()), 1)
 
-        self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 1)
+        self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 2)
         self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain2.name)), 0)
 
         call_command('hard_delete_forms_and_cases_in_domain', self.domain.name, noinput=True)
@@ -945,6 +948,7 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
     def test_hard_delete_forms_none_to_delete(self):
         for domain_name in [self.domain.name, self.domain2.name]:
             create_form_for_test(domain_name)
+            create_form_for_test(domain_name, state=XFormInstanceSQL.ARCHIVED)
             self.assertEqual(len(FormAccessors(domain_name).get_all_form_ids_in_domain()), 1)
 
         self.domain.delete()
@@ -952,7 +956,7 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(FormAccessors(self.domain.name).get_all_form_ids_in_domain()), 0)
         self.assertEqual(len(FormAccessors(self.domain2.name).get_all_form_ids_in_domain()), 1)
 
-        self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 1)
+        self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 2)
         self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain2.name)), 0)
 
         call_command('hard_delete_forms_and_cases_in_domain', self.domain2.name, noinput=True)
@@ -960,7 +964,7 @@ class TestHardDeleteSQLFormsAndCases(TestCase):
         self.assertEqual(len(FormAccessors(self.domain.name).get_all_form_ids_in_domain()), 0)
         self.assertEqual(len(FormAccessors(self.domain2.name).get_all_form_ids_in_domain()), 1)
 
-        self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 1)
+        self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain.name)), 2)
         self.assertEqual(len(FormAccessorSQL.get_deleted_form_ids_in_domain(self.domain2.name)), 0)
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -699,8 +699,14 @@ class FormAccessorSQL(AbstractFormAccessor):
 
     @staticmethod
     def get_deleted_form_ids_in_domain(domain):
-        deleted_state = XFormInstanceSQL.NORMAL | XFormInstanceSQL.DELETED
-        return FormAccessorSQL.get_form_ids_in_domain_by_state(domain, deleted_state)
+        result = []
+        for db_name in get_db_aliases_for_partitioned_query():
+            result.extend(
+                XFormInstanceSQL.objects.using(db_name)
+                .annotate(state_deleted=F('state').bitand(XFormInstanceSQL.DELETED))
+                .filter(domain=domain, state_deleted=XFormInstanceSQL.DELETED).values_list('form_id', flat=True)
+            )
+        return result
 
     @staticmethod
     def get_form_ids_in_domain_by_state(domain, state):


### PR DESCRIPTION
I stumbled onto this when looking at https://dimagi-dev.atlassian.net/browse/SAAS-10106

##### SUMMARY
Before: `hard_delete_forms_and_cases_in_domain` management command only hard deletes SQL forms that are in the `NORMAL | DELETED` state.
After: `hard_delete_forms_and_cases_in_domain` management command deletes all forms in a DELETED state (i.e. `state & DELETED == DELETED`)
