### PR TITLE
Add toggle to show form and case id download on case importer page

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
+++ b/corehq/apps/case_importer/templates/case_importer/partials/ko_import_history.html
@@ -9,7 +9,7 @@
     <th class="col-md-4">{% trans "Details" %}</th>
     <th class="col-md-3">{% trans "Comment" %}</th>
     <th class="col-md-2">{% trans "File" %}</th>
-    {% if request|toggle_enabled:"SUPPORT" %}
+    {% if request|toggle_enabled:"FORM_CASE_IDS_CASE_IMPORTER" %}
       <th>Form IDs</th>
       <th>Case IDs</th>
     {% endif %}
@@ -88,7 +88,7 @@
       <!--/ko-->
       <!--/ko-->
     </td>
-    {% if request|toggle_enabled:"SUPPORT" %}
+    {% if request|toggle_enabled:"FORM_CASE_IDS_CASE_IMPORTER" %}
       <td>
         <a data-bind="attr: {href: formIdsUrl()}" target="_blank">
           <i class="fa fa-download"></i>

--- a/corehq/apps/case_importer/tracking/views.py
+++ b/corehq/apps/case_importer/tracking/views.py
@@ -121,8 +121,9 @@ def case_upload_form_ids(request, domain, upload_id):
 
     ids_stream = ('{}\n'.format(form_id)
                   for form_id in get_form_ids_for_case_upload(case_upload))
-
-    return StreamingHttpResponse(ids_stream, content_type='text/plain')
+    response = StreamingHttpResponse(ids_stream, content_type='text/plain')
+    set_file_download(response, f"{domain}-case_upload-form_ids.txt")
+    return response
 
 
 @require_can_edit_data
@@ -136,7 +137,9 @@ def case_upload_case_ids(request, domain, upload_id):
     ids_stream = ('{}\n'.format(case_id)
                   for case_id in get_case_ids_for_case_upload(case_upload))
 
-    return StreamingHttpResponse(ids_stream, content_type='text/plain')
+    response = StreamingHttpResponse(ids_stream, content_type='text/plain')
+    set_file_download(response, f"{domain}-case_upload-case_ids.txt")
+    return response
 
 
 def _get_case_upload_record(domain, upload_id, user):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1639,6 +1639,12 @@ LOCATION_SAFE_CASE_IMPORTS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+FORM_CASE_IDS_CASE_IMPORTER = StaticToggle(
+    'form_case_ids_case_importer',
+    'Show the form and case ids download button on the case importer',
+    TAG_SOLUTIONS_OPEN,
+    namespaces=[NAMESPACE_DOMAIN],
+)
 
 HIDE_HQ_ON_MOBILE_EXPERIENCE = StaticToggle(
     'hide_hq_on_mobile_experience',


### PR DESCRIPTION
https://trello.com/c/9gtDQmYG/15-feature-flag-enabling-access-to-form-and-case-ids-generated-upon-import

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a new flag to show these case and form ids

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
`form_case_ids_case_importer`

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
Support will need to turn on this new flag to see those links. 
