### PR TITLE
Replaced an app.modules with app.get_modules()

### DIFF
--- a/corehq/apps/translations/app_translations/download.py
+++ b/corehq/apps/translations/app_translations/download.py
@@ -24,7 +24,7 @@ def get_bulk_app_single_sheet_by_name(app, lang, eligible_for_transifex_only=Fal
     checker = EligibleForTransifexChecker(app)
 
     rows = []
-    for module in app.modules:
+    for module in app.get_modules():
         if eligible_for_transifex_only and checker.exclude_module(module):
             continue
         sheet_name = get_module_sheet_name(module)


### PR DESCRIPTION
[get_modules comes from IndexedSchema](https://github.com/dimagi/commcare-hq/blob/b4b97356e4f2bc4f63828ca525da28bd453c8e86/corehq/apps/app_manager/models.py#L5038) so it populates the `_parent` attributes. Using `app.modules` instead results in intermittent errors like `AttributeError: 'AdvancedModule' object has no attribute '_parent'`

Invisible because the error is only happening in a shell.