### PR TITLE
Couch to SQL forms & cases: add system for encoding diffs in patch forms

### DIFF
--- a/corehq/apps/couch_sql_migration/casediff.py
+++ b/corehq/apps/couch_sql_migration/casediff.py
@@ -1,7 +1,9 @@
+import json
 import logging
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial
+from xml.sax.saxutils import unescape
 
 import attr
 
@@ -115,7 +117,7 @@ def diff_case(sql_case, couch_case, dd_count):
         return couch_case, diffs, changes
     diffs = diff(couch_case, sql_json)
     if diffs:
-        if is_case_patched(diffs):
+        if is_case_patched(case_id, diffs):
             return couch_case, [], []
         form_diffs = diff_case_forms(couch_case, sql_json)
         if form_diffs:
@@ -312,15 +314,48 @@ class StockTransactionLoader:
                     yield report.report_type, tx
 
 
-def is_case_patched(diffs):
-    from .casepatch import PatchForm
-    if not (len(diffs) == 1
-            and diffs[0].diff_type == "set_mismatch"
-            and list(diffs[0].path) == ["xform_ids", "[*]"]
-            and diffs[0].new_value):
+def is_case_patched(case_id, diffs):
+    """Check if case has been patched
+
+    The case has been patched if at least one patch form has been
+    applied to the SQL case and if all of the given diffs are
+    unpatchable and match an unpatchable diff encoded in one of the
+    patch forms.
+
+    The "xform_ids" diff is a special exception because it is not
+    patchable and is not required to be present in the patch form.
+
+    :returns: True if the case has been patched else False.
+    """
+    def is_patched(form_ids):
+        forms = get_sql_forms(form_ids, ordered=True)
+        for form in reversed(forms):
+            if form.xmlns == PatchForm.xmlns:
+                discard_unpatched(form.form_data.get("diff"))
+                if not unpatched:
+                    return True
         return False
-    form_ids = diffs[0].new_value.split(",")
-    return any(f.xmlns == PatchForm.xmlns for f in get_sql_forms(form_ids))
+
+    def discard_unpatched(patch_data):
+        data = json.loads(unescape(patch_data)) if patch_data else {}
+        if data.get("case_id") != case_id:
+            return
+        for diff in data.get("diffs", []):
+            diff.pop("reason", None)
+            path = tuple(diff["path"])
+            if path in unpatched and diff_to_json(unpatched[path]) == diff:
+                unpatched.pop(path)
+
+    from .casepatch import PatchForm, is_patchable, diff_to_json
+    unpatched = {tuple(d.path): d for d in diffs if not is_patchable(d)}
+    xform_ids = unpatched.pop(("xform_ids", "[*]"), None)
+    return (
+        xform_ids is not None
+        and xform_ids.diff_type == "set_mismatch"
+        and xform_ids.new_value
+        and len(diffs) == len(unpatched) + 1  # false if any diffs are patchable
+        and is_patched(xform_ids.new_value.split(","))
+    )
 
 
 def diff_case_forms(couch_json, sql_json):
@@ -497,5 +532,5 @@ def get_couch_form(form_id):
 
 
 @retry_on_sql_error
-def get_sql_forms(form_id):
-    return FormAccessorSQL.get_forms(form_id)
+def get_sql_forms(form_id, **kw):
+    return FormAccessorSQL.get_forms(form_id, **kw)

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -134,8 +134,11 @@ class PatchCase:
 
 
 def cannot_patch(diffs):
-    return any(d.path[0] in ILLEGAL_PROPS for d in diffs) \
-        or all(d.path[0] in IGNORE_PROPS for d in diffs)
+    props = {d.path[0] for d in diffs}
+    if props == {"xform_ids"}:
+        # can patch xform_ids diff (patch => ignore the diff)
+        return False
+    return props & ILLEGAL_PROPS or not props - IGNORE_PROPS
 
 
 def has_known_props(diffs):
@@ -152,8 +155,19 @@ def iter_dynamic_properties(diffs):
         yield name, diff.old_value
 
 
-ILLEGAL_PROPS = {"actions", "*"}
-IGNORE_PROPS = {"opened_by", "external_id"}
+ILLEGAL_PROPS = {"actions", "domain", "*"}
+IGNORE_PROPS = {
+    "closed_by",
+    "closed_on",
+    "deleted_on",
+    "external_id",  # deprecated
+    "modified_by",
+    "modified_on",
+    "opened_by",
+    "opened_on",
+    "server_modified_on",
+    "xform_ids",
+}
 STATIC_PROPS = {
     "case_id",
     "closed",

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -133,6 +133,25 @@ class PatchCase:
             yield CommCareCaseIndex.wrap(diff.old_value)
 
 
+def cannot_patch(diffs):
+    return any(d.path[0] in ILLEGAL_PROPS for d in diffs) \
+        or all(d.path[0] in IGNORE_PROPS for d in diffs)
+
+
+def has_known_props(diffs):
+    return any(d.path[0] in KNOWN_PROPERTIES for d in diffs)
+
+
+def iter_dynamic_properties(diffs):
+    for diff in diffs:
+        name = diff.path[0]
+        if name in STATIC_PROPS:
+            continue
+        if len(diff.path) > 1 or not isinstance(diff.old_value, str):
+            raise CannotPatch([diff])
+        yield name, diff.old_value
+
+
 ILLEGAL_PROPS = {"actions", "*"}
 IGNORE_PROPS = {"opened_by", "external_id"}
 STATIC_PROPS = {
@@ -165,25 +184,6 @@ STATIC_PROPS = {
     "@user_id",         # user_id
     "hq_user_id",       # external_id
 }
-
-
-def cannot_patch(diffs):
-    return any(d.path[0] in ILLEGAL_PROPS for d in diffs) \
-        or all(d.path[0] in IGNORE_PROPS for d in diffs)
-
-
-def has_known_props(diffs):
-    return any(d.path[0] in KNOWN_PROPERTIES for d in diffs)
-
-
-def iter_dynamic_properties(diffs):
-    for diff in diffs:
-        name = diff.path[0]
-        if name in STATIC_PROPS:
-            continue
-        if len(diff.path) > 1 or not isinstance(diff.old_value, str):
-            raise CannotPatch([diff])
-        yield name, diff.old_value
 
 
 @attr.s

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -1,7 +1,9 @@
+import json
 import logging
 from datetime import datetime
 from functools import partial, wraps
 from uuid import uuid4
+from xml.sax.saxutils import escape
 
 from django.template.loader import render_to_string
 
@@ -98,7 +100,7 @@ class PatchCase:
             updates.extend([const.CASE_ACTION_CREATE, const.CASE_ACTION_UPDATE])
             self._dynamic_properties = self.case.dynamic_case_properties()
         else:
-            if cannot_patch(self.diffs):
+            if has_illegal_props(self.diffs):
                 raise CannotPatch(self.diffs)
             props = dict(iter_dynamic_properties(self.diffs))
             self._dynamic_properties = props
@@ -133,12 +135,8 @@ class PatchCase:
             yield CommCareCaseIndex.wrap(diff.old_value)
 
 
-def cannot_patch(diffs):
-    props = {d.path[0] for d in diffs}
-    if props == {"xform_ids"}:
-        # can patch xform_ids diff (patch => ignore the diff)
-        return False
-    return props & ILLEGAL_PROPS or not props - IGNORE_PROPS
+def has_illegal_props(diffs):
+    return any(d.path[0] in ILLEGAL_PROPS for d in diffs)
 
 
 def has_known_props(diffs):
@@ -155,12 +153,13 @@ def iter_dynamic_properties(diffs):
         yield name, diff.old_value
 
 
-ILLEGAL_PROPS = {"actions", "domain", "*"}
-IGNORE_PROPS = {
+ILLEGAL_PROPS = {"actions", "case_id", "domain", "*"}
+UNPATCHABLE_PROPS = {
     "closed_by",
     "closed_on",
     "deleted_on",
-    "external_id",  # deprecated
+    "deletion_id",
+    "external_id",
     "modified_by",
     "modified_on",
     "opened_by",
@@ -218,9 +217,10 @@ class PatchForm:
     def get_xml(self):
         updates = self._case._updates
         case_block = get_case_xml(self._case, updates, version='2.0')
+        diff_block = get_diff_block(self._case)
         return render_to_string('hqcase/xml/case_block.xml', {
             'xmlns': self.xmlns,
-            'case_block': case_block.decode('utf-8'),
+            'case_block': case_block.decode('utf-8') + diff_block,
             'time': json_format_datetime(self.received_on),
             'uid': self.form_id,
             'username': "",
@@ -257,6 +257,52 @@ def add_patch_operation(sql_form):
         date=datetime.utcnow(),
         operation="Couch to SQL case patch"
     ))
+
+
+def get_diff_block(case):
+    """Get XML element containing case diff data
+
+    Some early patch forms were submitted without this element.
+
+    :param case: `PatchCase` instance.
+    :returns: A "<diff>" XML element string containing XML-escaped
+    JSON-encoded case diff data, some of which may be patched.
+
+    ```json
+    {
+        "case_id": case.case_id,
+        "diffs": [
+            {
+                "path": diff.path,
+                "old": diff.old_value,  # omitted if old_value is MISSING
+                "new": diff.new_value,  # omitted if new_value is MISSING
+                "patch": true if patched else false
+                "reason": "...",  # omitted if reason for change is unknown
+            },
+            ...
+        ]
+    }
+    ```
+    """
+    diffs = [diff_to_json(d) for d in sorted(case.diffs, key=lambda d: d.path)]
+    data = {"case_id": case.case_id, "diffs": diffs}
+    return f"<diff>{escape(json.dumps(data))}</diff>"
+
+
+def diff_to_json(diff):
+    assert diff.old_value is not MISSING or diff.new_value is not MISSING, diff
+    obj = {"path": list(diff.path), "patch": is_patchable(diff)}
+    if diff.old_value is not MISSING:
+        obj["old"] = diff.old_value
+    if diff.new_value is not MISSING:
+        obj["new"] = diff.new_value
+    if getattr(diff, "reason", ""):
+        obj["reason"] = diff.reason
+    return obj
+
+
+def is_patchable(diff):
+    return diff.path[0] not in UNPATCHABLE_PROPS
 
 
 class CannotPatch(Exception):

--- a/corehq/apps/couch_sql_migration/casepatch.py
+++ b/corehq/apps/couch_sql_migration/casepatch.py
@@ -148,9 +148,13 @@ def iter_dynamic_properties(diffs):
         name = diff.path[0]
         if name in STATIC_PROPS:
             continue
-        if len(diff.path) > 1 or not isinstance(diff.old_value, str):
+        if diff.old_value is MISSING:
+            value = ""
+        elif len(diff.path) > 1 or not isinstance(diff.old_value, str):
             raise CannotPatch([diff])
-        yield name, diff.old_value
+        else:
+            value = diff.old_value
+        yield name, value
 
 
 ILLEGAL_PROPS = {"actions", "case_id", "domain", "*"}
@@ -289,13 +293,13 @@ def get_diff_block(case):
     return f"<diff>{escape(json.dumps(data))}</diff>"
 
 
-def diff_to_json(diff):
+def diff_to_json(diff, new_value=None):
     assert diff.old_value is not MISSING or diff.new_value is not MISSING, diff
     obj = {"path": list(diff.path), "patch": is_patchable(diff)}
     if diff.old_value is not MISSING:
         obj["old"] = diff.old_value
     if diff.new_value is not MISSING:
-        obj["new"] = diff.new_value
+        obj["new"] = diff.new_value if new_value is None else new_value
     if getattr(diff, "reason", ""):
         obj["reason"] = diff.reason
     return obj

--- a/corehq/apps/couch_sql_migration/tests/test_casepatch.py
+++ b/corehq/apps/couch_sql_migration/tests/test_casepatch.py
@@ -11,6 +11,27 @@ def test_cannot_patch_opened_by_alone():
         mod.PatchCase(FakeCase(), diffs)
 
 
+def test_cannot_patch_closed_by_alone():
+    diffs = [Diff("diff", ["closed_by"], "old", "new")]
+    with assert_raises(mod.CannotPatch):
+        mod.PatchCase(FakeCase(), diffs)
+
+
+def test_cannot_patch_modified_by_alone():
+    diffs = [Diff("diff", ["modified_by"], "old", "new")]
+    with assert_raises(mod.CannotPatch):
+        mod.PatchCase(FakeCase(), diffs)
+
+
+def test_cannot_patch_opened_by_with_xform_ids():
+    diffs = [
+        Diff("diff", ["opened_by"], "old", "new"),
+        Diff("diff", ["xform_ids", "[*]"], "old", "new"),
+    ]
+    with assert_raises(mod.CannotPatch):
+        mod.PatchCase(FakeCase(), diffs)
+
+
 def test_can_patch_opened_by_with_user_id():
     diffs = [
         Diff("diff", ["opened_by"], "old", "new"),


### PR DESCRIPTION
This is a powerful new feature that allows us to automatically "patch" a SQL case to a state that as closely as possible resembles the state of the Couch case. All patched diffs are encoded in the patch form for future reference (at least until the [form is removed](https://github.com/dimagi/commcare-hq/issues/27315)). Patch forms can be archived to effectively to revert the patch.

Review by commit 🐡 