### PR TITLE
Revert "Removed caching logic from SMS chat contacts" and tweak cache

### DIFF
--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -673,12 +673,14 @@ def get_contact_info(domain):
         contact_info = contact_data.get(row[3])
         row[0] = contact_info[0] if contact_info else _('(unknown)')
 
-    # Save the data to the cache for faster lookup next time
-    try:
-        client.set(cache_key, json.dumps(data))
-        client.expire(cache_key, cache_expiration)
-    except:
-        pass
+    # Save the data to the cache for faster lookup next time.
+    # If there isn't much data, don't bother with the cache, responsiveness is more important.
+    if len(data) > 100:
+        try:
+            client.set(cache_key, json.dumps(data))
+            client.expire(cache_key, cache_expiration)
+        except:
+            pass
 
     return data
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -32,6 +32,7 @@ from couchexport.export import export_raw
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
 from dimagi.utils.couch import CriticalSection
+from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.decorators.view import get_file
 from dimagi.utils.logging import notify_exception
@@ -621,6 +622,17 @@ def get_mobile_worker_contact_info(domain_obj, user_ids):
 
 
 def get_contact_info(domain):
+    # If the data has been cached, just retrieve it from there
+    cache_key = 'sms-chat-contact-list-%s' % domain
+    cache_expiration = 30 * 60
+    try:
+        client = cache_core.get_redis_client()
+        cached_data = client.get(cache_key)
+        if cached_data:
+            return json.loads(cached_data)
+    except:
+        pass
+
     domain_obj = Domain.get_by_name(domain, strict=True)
     case_ids = []
     mobile_worker_ids = []
@@ -660,6 +672,13 @@ def get_contact_info(domain):
     for row in data:
         contact_info = contact_data.get(row[3])
         row[0] = contact_info[0] if contact_info else _('(unknown)')
+
+    # Save the data to the cache for faster lookup next time
+    try:
+        client.set(cache_key, json.dumps(data))
+        client.expire(cache_key, cache_expiration)
+    except:
+        pass
 
     return data
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -625,13 +625,10 @@ def get_contact_info(domain):
     # If the data has been cached, just retrieve it from there
     cache_key = 'sms-chat-contact-list-%s' % domain
     cache_expiration = 30 * 60
-    try:
-        client = cache_core.get_redis_client()
-        cached_data = client.get(cache_key)
-        if cached_data:
-            return json.loads(cached_data)
-    except:
-        pass
+    client = cache_core.get_redis_client()
+    cached_data = client.get(cache_key)
+    if cached_data:
+        return json.loads(cached_data)
 
     domain_obj = Domain.get_by_name(domain, strict=True)
     case_ids = []


### PR DESCRIPTION
This puts back the cache that was removed in dimagi/commcare-hq#27253 but only populates it when there are more than a handful of cases. This is acceptable for the project that needed the cache removed, which needs responsiveness but has few cases, and it restores the old behavior for other projects.

Unfortunately, performance turns out to be bad because phone numbers are in sql but their names are not necessarily (each phone number is tied to either a user or a case). To support searching by name, the page fetches every phone number in the domain and then pulls either a couch user/case or a sql case for each of them. So page load is terrible on large domains (up to 150K phone numbers) but the cache limits this terribleness to the first page load, and it's not quite trivial to rework the page to make it better overall.