### PR TITLE
Comment out stickler pytype config

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -11,5 +11,5 @@ linters:
   eslint:
     config: ./.eslintrc.js
     install_plugins: true
-  pytype:
-    config: ./.pytype.cfg
+#  pytype:  # failing due to timeout
+#    config: ./.pytype.cfg


### PR DESCRIPTION
This is failing on most if not all HQ PRs. Probably best to remove it to be respectful of stickler resources while we find a resolution.