### PR TITLE
Upgrade pip tools to work with pip 20.1 (fix travis tests)

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -5,226 +5,227 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 alabaster==0.7.12         # via sphinx
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
+architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
-attrs==18.2.0
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, sphinx
-beautifulsoup4==4.8.1
-billiard==3.5.0.4
-boto3==1.10.14
+beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 click==7.0                # via pip-tools
 cloudant==2.12.0          # via jsonobject-couchdbkit
 colorama==0.4.1           # via sniffer
-commcaretranslationchecker==0.9.3.5
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
 commonmark==0.9.1         # via recommonmark
-concurrent-log-handler==0.9.12
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-coverage==4.5.1
-csiphash==0.0.5
+coverage==4.5.1           # via -r requirements/test-requirements.in
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, ipython, jsonpath-rw, traitlets
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-debug-toolbar==2.0
-django-extensions==2.2.5
-django-formtools==2.1
-git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-debug-toolbar==2.0  # via -r requirements/dev-requirements.in
+django-extensions==2.2.5  # via -r requirements/dev-requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose  # via -r requirements/test-requirements.in
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
-docutils==0.15.2
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
+docutils==0.15.2          # via -r requirements/dev-requirements.in, botocore, recommonmark, sphinx
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
 entrypoints==0.3          # via flake8
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-fakecouch==0.0.15
-faker==0.8.15
-fixture==1.5.11
-flake8==3.7.9
-flaky==3.6.0
-freezegun==0.3.12
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-gnureadline==6.3.8
-graphviz==0.13.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+fakecouch==0.0.15         # via -r requirements/test-requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+fixture==1.5.11           # via -r requirements/dev-requirements.in
+flake8==3.7.9             # via -r requirements/dev-requirements.in
+flaky==3.6.0              # via -r requirements/test-requirements.in
+freezegun==0.3.12         # via -r requirements/test-requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+gnureadline==6.3.8        # via -r requirements/dev-requirements.in
+graphviz==0.13.1          # via -r requirements/dev-requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
+httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via email-validator, requests
 imagesize==1.1.0          # via sphinx
-ipdb==0.11
+ipdb==0.11                # via -r requirements/dev-requirements.in
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2
-iso8601==0.1.12
+ipython==5.2.2            # via -r requirements/dev-requirements.in, ipdb
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jenkinsapi==0.2.28
-jinja2==2.10.3
+jenkinsapi==0.2.28        # via -r requirements/dev-requirements.in
+jinja2==2.10.3            # via -r requirements/requirements.in, sphinx
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
 linecache2==1.0.0         # via traceback2
-lxml==4.3.5
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
 mccabe==0.6.1             # via flake8
-mock==2.0.0
-modernize==0.7
+mock==2.0.0               # via -r requirements/requirements.in
+modernize==0.7            # via -r requirements/dev-requirements.in
 msgpack-python==0.5.6     # via ddtrace
-nose-exclude==0.5.0
-nose==1.3.7
-openpyxl==2.6.4
+nose-exclude==0.5.0       # via -r requirements/test-requirements.in
+nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude, sniffer
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 packaging==19.2           # via sphinx
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
-phonenumberslite==8.10.22
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
 pickleshare==0.7.5        # via ipython
-pillow==6.2.2
-pip-tools==4.4.0
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
+pip-tools==5.1.0          # via -r requirements/test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
 prompt-toolkit==1.0.18    # via ipython
-psutil==5.7.0
-psycogreen==1.0.1
-psycopg2==2.8.5
+psutil==5.7.0             # via -r requirements/dev-requirements.in
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in, sqlalchemy-postgres-copy
 ptyprocess==0.6.0         # via pexpect
-py-kissmetrics==1.0.1
-pycco==0.5.1
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pycco==0.5.1              # via -r requirements/requirements.in
 pycodestyle==2.5.0        # via flake8
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
+pycryptodome==3.9.2       # via -r requirements/requirements.in
 pyflakes==2.1.1           # via flake8
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, ipython, pycco, sphinx
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
 pyparsing==2.4.5          # via packaging
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker, freezegun
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
 python-termstyle==0.1.10  # via sniffer
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, jenkinsapi, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-recommonmark==0.6.0
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests-mock==1.7.0
-requests==2.22.0
+recommonmark==0.6.0       # via -r requirements/dev-requirements.in
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests-mock==1.7.0      # via -r requirements/test-requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, jenkinsapi, requests-mock, sphinx, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-sh==1.09
-simpleeval==0.9.8
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
-simplejson==3.16.0
-six==1.13.0
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
-sniffer==0.4.0
+sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx
-socketpool==0.5.3
+socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sphinx-rtd-theme==0.4.3
-sphinx==2.2.1
+sphinx-rtd-theme==0.4.3   # via -r requirements/dev-requirements.in
+sphinx==2.2.1             # via -r requirements/dev-requirements.in, recommonmark, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-django==0.5
+sphinxcontrib-django==0.5  # via -r requirements/dev-requirements.in
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.16.1
-sqlalchemy-postgres-copy==0.5.0
-sqlalchemy==1.3.10
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 sqlparse==0.3.0           # via django-debug-toolbar
-stripe==1.67.0
-suds-jurko==0.6
-testil==1.1
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
+testil==1.1               # via -r requirements/test-requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
+tinys3==0.1.12            # via -r requirements/requirements.in
 traceback2==1.4.0         # via unittest2
 traitlets==4.3.3          # via ipython
-transifex-client==0.12.4
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+transifex-client==0.12.4  # via -r requirements/dev-requirements.in
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
-unittest2==1.1.0
+unidecode==0.04.20        # via -r requirements/requirements.in
+unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
-wheel==0.29.0
+werkzeug==0.11.15         # via -r requirements/requirements.in
+wheel==0.29.0             # via -r requirements/dev-requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==20.1                 # via pip-tools
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, ipdb, ipython, python-levenshtein, python-termstyle, sphinx, tinycss2

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -4,183 +4,183 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
-attrs==18.2.0
+architect==0.5.6          # via -r requirements/requirements.in
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, flower
-billiard==3.5.0.4
-boto3==1.10.14
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
-certifi==2019.9.11
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results, flower
+certifi==2019.9.11        # via -r requirements/prod-requirements.in, requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 cloudant==2.12.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.3.5
-concurrent-log-handler==0.9.12
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-cryptography==2.8
-csiphash==0.0.5
+cryptography==2.8         # via -r requirements/prod-requirements.in, pyopenssl
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, ipython, jsonpath-rw, traitlets
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-formtools==2.1
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator, eventlet
 docutils==0.15.2          # via botocore
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
-errand-boy==0.3.8
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
+errand-boy==0.3.8         # via -r requirements/prod-requirements.in
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-faker==0.8.15
-flower==0.9.2
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+flower==0.9.2             # via -r requirements/prod-requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, eventlet, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
-idna==2.8
+httpagentparser==1.9.0    # via -r requirements/requirements.in
+idna==2.8                 # via -r requirements/prod-requirements.in, email-validator, requests
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2
-iso8601==0.1.12
+ipython==5.2.2            # via -r requirements/prod-requirements.in
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jinja2==2.10.3
+jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
-lxml==4.3.5
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0
+mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-ndg-httpsclient==0.5.1
-openpyxl==2.6.4
+ndg-httpsclient==0.5.1    # via -r requirements/prod-requirements.in
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
-phonenumberslite==8.10.22
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
 pickleshare==0.7.5        # via ipython
-pillow==6.2.2
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
 prompt-toolkit==1.0.18    # via ipython
-psycogreen==1.0.1
-psycopg2==2.8.5
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in
 ptyprocess==0.6.0         # via pexpect
-py-kissmetrics==1.0.1
-pyasn1==0.4.7
-pycco==0.5.1
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pyasn1==0.4.7             # via -r requirements/prod-requirements.in, ndg-httpsclient
+pycco==0.5.1              # via -r requirements/requirements.in
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pycryptodome==3.9.2       # via -r requirements/requirements.in
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, ipython, pycco
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
-pyopenssl==19.0.0
+pyopenssl==19.0.0         # via -r requirements/prod-requirements.in, ndg-httpsclient
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, flower, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests==2.22.0
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-setproctitle==1.1.9
-sh==1.09
-simpleeval==0.9.8
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+setproctitle==1.1.9       # via -r requirements/prod-requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
-simplejson==3.16.0
-six==1.13.0
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
-socketpool==0.5.3
-sqlagg==0.16.1
-sqlalchemy==1.3.10
-stripe==1.67.0
-suds-jurko==0.6
+socketpool==0.5.3         # via -r requirements/requirements.in
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
-tornado==4.5.3
+tinys3==0.1.12            # via -r requirements/requirements.in
+tornado==4.5.3            # via -r requirements/prod-requirements.in, flower
 traitlets==4.3.3          # via ipython
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
+unidecode==0.04.20        # via -r requirements/requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
-uwsgi==2.0.18
+uwsgi==2.0.18             # via -r requirements/prod-requirements.in
 vine==1.3.0               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
+werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==19.3.1
+pip==19.3.1               # via -r requirements/prod-requirements.in
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, ipython, python-levenshtein, tinycss2

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -4,164 +4,164 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
-attrs==18.2.0
+architect==0.5.6          # via -r requirements/requirements.in
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
-billiard==3.5.0.4
-boto3==1.10.14
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 cloudant==2.12.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.3.5
-concurrent-log-handler==0.9.12
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-csiphash==0.0.5
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, jsonpath-rw
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-formtools==2.1
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-faker==0.8.15
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
+httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via email-validator, requests
-iso8601==0.1.12
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jinja2==2.10.3
+jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
-lxml==4.3.5
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0
+mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-openpyxl==2.6.4
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
-phonenumberslite==8.10.22
-pillow==6.2.2
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
-psycogreen==1.0.1
-psycopg2==2.8.5
-py-kissmetrics==1.0.1
-pycco==0.5.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pycco==0.5.1              # via -r requirements/requirements.in
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pycryptodome==3.9.2       # via -r requirements/requirements.in
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, pycco
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests==2.22.0
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-sh==1.09
-simpleeval==0.9.8
-simplejson==3.16.0
-six==1.13.0
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
-socketpool==0.5.3
-sqlagg==0.16.1
-sqlalchemy==1.3.10
-stripe==1.67.0
-suds-jurko==0.6
+socketpool==0.5.3         # via -r requirements/requirements.in
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+tinys3==0.1.12            # via -r requirements/requirements.in
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
+unidecode==0.04.20        # via -r requirements/requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
+werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -4,182 +4,183 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
+architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
-attrs==18.2.0
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
-beautifulsoup4==4.8.1
-billiard==3.5.0.4
-boto3==1.10.14
+beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 click==7.0                # via pip-tools
 cloudant==2.12.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.3.5
-concurrent-log-handler==0.9.12
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-coverage==4.5.1
-csiphash==0.0.5
+coverage==4.5.1           # via -r requirements/test-requirements.in
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, jsonpath-rw
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-formtools==2.1
-git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose  # via -r requirements/test-requirements.in
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-fakecouch==0.0.15
-faker==0.8.15
-flaky==3.6.0
-freezegun==0.3.12
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+fakecouch==0.0.15         # via -r requirements/test-requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+flaky==3.6.0              # via -r requirements/test-requirements.in
+freezegun==0.3.12         # via -r requirements/test-requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
+httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via email-validator, requests
-iso8601==0.1.12
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jinja2==2.10.3
+jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
 linecache2==1.0.0         # via traceback2
-lxml==4.3.5
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0
+mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-nose-exclude==0.5.0
-nose==1.3.7
-openpyxl==2.6.4
+nose-exclude==0.5.0       # via -r requirements/test-requirements.in
+nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
-phonenumberslite==8.10.22
-pillow==6.2.2
-pip-tools==4.4.0
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
+pip-tools==5.1.0          # via -r requirements/test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
-psycogreen==1.0.1
-psycopg2==2.8.5
-py-kissmetrics==1.0.1
-pycco==0.5.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in, sqlalchemy-postgres-copy
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pycco==0.5.1              # via -r requirements/requirements.in
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pycryptodome==3.9.2       # via -r requirements/requirements.in
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, pycco
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker, freezegun
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests-mock==1.7.0
-requests==2.22.0
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests-mock==1.7.0      # via -r requirements/test-requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-mock, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-sh==1.09
-simpleeval==0.9.8
-simplejson==3.16.0
-six==1.13.0
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
 smartypants==2.0.1        # via pycco
-socketpool==0.5.3
+socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.16.1
-sqlalchemy-postgres-copy==0.5.0
-sqlalchemy==1.3.10
-stripe==1.67.0
-suds-jurko==0.6
-testil==1.1
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
+testil==1.1               # via -r requirements/test-requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
+tinys3==0.1.12            # via -r requirements/requirements.in
 traceback2==1.4.0         # via unittest2
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
-unittest2==1.1.0
+unidecode==0.04.20        # via -r requirements/requirements.in
+unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
+werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==20.1                 # via pip-tools
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -5,226 +5,227 @@
 #    `make requirements` or `make upgrade-requirements`
 #
 alabaster==0.7.12         # via sphinx
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
+architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
-attrs==18.2.0
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, sphinx
-beautifulsoup4==4.8.1
-billiard==3.5.0.4
-boto3==1.10.14
+beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 click==7.0                # via pip-tools
 cloudant==2.12.0          # via jsonobject-couchdbkit
 colorama==0.4.1           # via sniffer
-commcaretranslationchecker==0.9.3.5
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
 commonmark==0.9.1         # via recommonmark
-concurrent-log-handler==0.9.12
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-coverage==4.5.1
-csiphash==0.0.5
+coverage==4.5.1           # via -r requirements/test-requirements.in
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, ipython, jsonpath-rw, traitlets
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-debug-toolbar==2.0
-django-extensions==2.2.5
-django-formtools==2.1
-git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-debug-toolbar==2.0  # via -r requirements/dev-requirements.in
+django-extensions==2.2.5  # via -r requirements/dev-requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose  # via -r requirements/test-requirements.in
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
-docutils==0.15.2
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
+docutils==0.15.2          # via -r requirements/dev-requirements.in, botocore, recommonmark, sphinx
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
 entrypoints==0.3          # via flake8
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-fakecouch==0.0.15
-faker==0.8.15
-fixture==1.5.11
-flake8==3.7.9
-flaky==3.6.0
-freezegun==0.3.12
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-gnureadline==6.3.8
-graphviz==0.13.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+fakecouch==0.0.15         # via -r requirements/test-requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+fixture==1.5.11           # via -r requirements/dev-requirements.in
+flake8==3.7.9             # via -r requirements/dev-requirements.in
+flaky==3.6.0              # via -r requirements/test-requirements.in
+freezegun==0.3.12         # via -r requirements/test-requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+gnureadline==6.3.8        # via -r requirements/dev-requirements.in
+graphviz==0.13.1          # via -r requirements/dev-requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
+httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via email-validator, requests
 imagesize==1.1.0          # via sphinx
-ipdb==0.11
+ipdb==0.11                # via -r requirements/dev-requirements.in
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2
-iso8601==0.1.12
+ipython==5.2.2            # via -r requirements/dev-requirements.in, ipdb
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jenkinsapi==0.2.28
-jinja2==2.10.3
+jenkinsapi==0.2.28        # via -r requirements/dev-requirements.in
+jinja2==2.10.3            # via -r requirements/requirements.in, sphinx
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
 linecache2==1.0.0         # via traceback2
-lxml==4.3.5
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
 mccabe==0.6.1             # via flake8
-mock==2.0.0
-modernize==0.7
+mock==2.0.0               # via -r requirements/requirements.in
+modernize==0.7            # via -r requirements/dev-requirements.in
 msgpack-python==0.5.6     # via ddtrace
-nose-exclude==0.5.0
-nose==1.3.7
-openpyxl==2.6.4
+nose-exclude==0.5.0       # via -r requirements/test-requirements.in
+nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude, sniffer
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 packaging==19.2           # via sphinx
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
-phonenumberslite==8.10.22
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
 pickleshare==0.7.5        # via ipython
-pillow==6.2.2
-pip-tools==4.4.0
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
+pip-tools==5.1.0          # via -r requirements/test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
 prompt-toolkit==1.0.18    # via ipython
-psutil==5.7.0
-psycogreen==1.0.1
-psycopg2==2.8.5
+psutil==5.7.0             # via -r requirements/dev-requirements.in
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in, sqlalchemy-postgres-copy
 ptyprocess==0.6.0         # via pexpect
-py-kissmetrics==1.0.1
-pycco==0.5.1
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pycco==0.5.1              # via -r requirements/requirements.in
 pycodestyle==2.5.0        # via flake8
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
+pycryptodome==3.9.2       # via -r requirements/requirements.in
 pyflakes==2.1.1           # via flake8
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, ipython, pycco, sphinx
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
 pyparsing==2.4.5          # via packaging
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker, freezegun
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
 python-termstyle==0.1.10  # via sniffer
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, jenkinsapi, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-recommonmark==0.6.0
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests-mock==1.7.0
-requests==2.22.0
+recommonmark==0.6.0       # via -r requirements/dev-requirements.in
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests-mock==1.7.0      # via -r requirements/test-requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, jenkinsapi, requests-mock, sphinx, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-sh==1.09
-simpleeval==0.9.8
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
-simplejson==3.16.0
-six==1.13.0
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
-sniffer==0.4.0
+sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx
-socketpool==0.5.3
+socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sphinx-rtd-theme==0.4.3
-sphinx==2.2.1
+sphinx-rtd-theme==0.4.3   # via -r requirements/dev-requirements.in
+sphinx==2.2.1             # via -r requirements/dev-requirements.in, recommonmark, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-django==0.5
+sphinxcontrib-django==0.5  # via -r requirements/dev-requirements.in
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.16.1
-sqlalchemy-postgres-copy==0.5.0
-sqlalchemy==1.3.10
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 sqlparse==0.3.0           # via django-debug-toolbar
-stripe==1.67.0
-suds-jurko==0.6
-testil==1.1
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
+testil==1.1               # via -r requirements/test-requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
+tinys3==0.1.12            # via -r requirements/requirements.in
 traceback2==1.4.0         # via unittest2
 traitlets==4.3.3          # via ipython
-transifex-client==0.12.4
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+transifex-client==0.12.4  # via -r requirements/dev-requirements.in
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
-unittest2==1.1.0
+unidecode==0.04.20        # via -r requirements/requirements.in
+unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
-wheel==0.29.0
+werkzeug==0.11.15         # via -r requirements/requirements.in
+wheel==0.29.0             # via -r requirements/dev-requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==20.1                 # via pip-tools
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, ipdb, ipython, python-levenshtein, python-termstyle, sphinx, tinycss2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -4,183 +4,183 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
-attrs==18.2.0
+architect==0.5.6          # via -r requirements/requirements.in
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, flower
-billiard==3.5.0.4
-boto3==1.10.14
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
-certifi==2019.9.11
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results, flower
+certifi==2019.9.11        # via -r requirements/prod-requirements.in, requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 cloudant==2.12.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.3.5
-concurrent-log-handler==0.9.12
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-cryptography==2.8
-csiphash==0.0.5
+cryptography==2.8         # via -r requirements/prod-requirements.in, pyopenssl
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, ipython, jsonpath-rw, traitlets
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-formtools==2.1
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator, eventlet
 docutils==0.15.2          # via botocore
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
-errand-boy==0.3.8
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
+errand-boy==0.3.8         # via -r requirements/prod-requirements.in
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-faker==0.8.15
-flower==0.9.2
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+flower==0.9.2             # via -r requirements/prod-requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, eventlet, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
-idna==2.8
+httpagentparser==1.9.0    # via -r requirements/requirements.in
+idna==2.8                 # via -r requirements/prod-requirements.in, email-validator, requests
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2
-iso8601==0.1.12
+ipython==5.2.2            # via -r requirements/prod-requirements.in
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jinja2==2.10.3
+jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
-lxml==4.3.5
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0
+mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-ndg-httpsclient==0.5.1
-openpyxl==2.6.4
+ndg-httpsclient==0.5.1    # via -r requirements/prod-requirements.in
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
-phonenumberslite==8.10.22
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
 pickleshare==0.7.5        # via ipython
-pillow==6.2.2
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
 prompt-toolkit==1.0.18    # via ipython
-psycogreen==1.0.1
-psycopg2==2.8.5
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in
 ptyprocess==0.6.0         # via pexpect
-py-kissmetrics==1.0.1
-pyasn1==0.4.7
-pycco==0.5.1
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pyasn1==0.4.7             # via -r requirements/prod-requirements.in, ndg-httpsclient
+pycco==0.5.1              # via -r requirements/requirements.in
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pycryptodome==3.9.2       # via -r requirements/requirements.in
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, ipython, pycco
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
-pyopenssl==19.0.0
+pyopenssl==19.0.0         # via -r requirements/prod-requirements.in, ndg-httpsclient
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, flower, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests==2.22.0
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-setproctitle==1.1.9
-sh==1.09
-simpleeval==0.9.8
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+setproctitle==1.1.9       # via -r requirements/prod-requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
-simplejson==3.16.0
-six==1.13.0
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
-socketpool==0.5.3
-sqlagg==0.16.1
-sqlalchemy==1.3.10
-stripe==1.67.0
-suds-jurko==0.6
+socketpool==0.5.3         # via -r requirements/requirements.in
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
-tornado==4.5.3
+tinys3==0.1.12            # via -r requirements/requirements.in
+tornado==4.5.3            # via -r requirements/prod-requirements.in, flower
 traitlets==4.3.3          # via ipython
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
+unidecode==0.04.20        # via -r requirements/requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
-uwsgi==2.0.18
+uwsgi==2.0.18             # via -r requirements/prod-requirements.in
 vine==1.3.0               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
+werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==19.3.1
+pip==19.3.1               # via -r requirements/prod-requirements.in
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, ipython, python-levenshtein, tinycss2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,164 +4,164 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
-attrs==18.2.0
+architect==0.5.6          # via -r requirements/requirements.in
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
-billiard==3.5.0.4
-boto3==1.10.14
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 cloudant==2.12.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.3.5
-concurrent-log-handler==0.9.12
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-csiphash==0.0.5
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, jsonpath-rw
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-formtools==2.1
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-faker==0.8.15
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
+httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via email-validator, requests
-iso8601==0.1.12
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jinja2==2.10.3
+jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
-lxml==4.3.5
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0
+mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-openpyxl==2.6.4
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
-phonenumberslite==8.10.22
-pillow==6.2.2
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
-psycogreen==1.0.1
-psycopg2==2.8.5
-py-kissmetrics==1.0.1
-pycco==0.5.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pycco==0.5.1              # via -r requirements/requirements.in
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pycryptodome==3.9.2       # via -r requirements/requirements.in
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, pycco
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests==2.22.0
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-sh==1.09
-simpleeval==0.9.8
-simplejson==3.16.0
-six==1.13.0
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
-socketpool==0.5.3
-sqlagg==0.16.1
-sqlalchemy==1.3.10
-stripe==1.67.0
-suds-jurko==0.6
+socketpool==0.5.3         # via -r requirements/requirements.in
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+tinys3==0.1.12            # via -r requirements/requirements.in
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
+unidecode==0.04.20        # via -r requirements/requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
+werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -6,7 +6,7 @@ git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
 fakecouch==0.0.15
 nose==1.3.7
 nose-exclude==0.5.0
-pip-tools>4.2.0
+pip-tools>5
 testil
 unittest2
 requests-mock

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,182 +4,183 @@
 #
 #    `make requirements` or `make upgrade-requirements`
 #
-alembic==0.8.6
+alembic==0.8.6            # via -r requirements/requirements.in
 amqp==2.5.2               # via kombu
-architect==0.5.6
+architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
-attrs==18.2.0
+attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
-beautifulsoup4==4.8.1
-billiard==3.5.0.4
-boto3==1.10.14
+beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
+boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
 click==7.0                # via pip-tools
 cloudant==2.12.0          # via jsonobject-couchdbkit
-commcaretranslationchecker==0.9.3.5
-concurrent-log-handler==0.9.12
+commcaretranslationchecker==0.9.3.5  # via -r requirements/requirements.in
+concurrent-log-handler==0.9.12  # via -r requirements/requirements.in
 contextlib2==0.5.5        # via schema
-coverage==4.5.1
-csiphash==0.0.5
+coverage==4.5.1           # via -r requirements/test-requirements.in
+csiphash==0.0.5           # via -r requirements/requirements.in
 cssselect2==0.2.2         # via cairosvg, weasyprint
-datadog==0.15.0
-ddtrace==0.14.1
-decorator==4.0.11
-defusedxml==0.5.0
-diff-match-patch==20120106
-dimagi-memoized==1.1.3
-django-angular==2.2.4
+datadog==0.15.0           # via -r requirements/requirements.in
+ddtrace==0.14.1           # via -r requirements/requirements.in
+decorator==4.0.11         # via -r requirements/requirements.in, datadog, jsonpath-rw
+defusedxml==0.5.0         # via -r requirements/requirements.in, cairosvg
+diff-match-patch==20120106  # via -r requirements/requirements.in
+dimagi-memoized==1.1.3    # via -r requirements/requirements.in
+django-angular==2.2.4     # via -r requirements/requirements.in
 django-appconf==1.0.3     # via django-compressor, django-statici18n
-django-braces==1.13.0
-django-bulk-update==2.2.0
-django-celery-results==1.0.4
-django-compressor==2.1
-django-countries==4.6
-django-crispy-forms==1.7.0
-django-cte==1.1.4
-django-formtools==2.1
-git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose
-django-otp==0.3.13
-django-partial-index==0.6.0
+django-braces==1.13.0     # via -r requirements/requirements.in
+django-bulk-update==2.2.0  # via -r requirements/requirements.in
+django-celery-results==1.0.4  # via -r requirements/requirements.in
+django-compressor==2.1    # via -r requirements/requirements.in
+django-countries==4.6     # via -r requirements/requirements.in
+django-crispy-forms==1.7.0  # via -r requirements/requirements.in
+django-cte==1.1.4         # via -r requirements/requirements.in
+django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
+git+git://github.com/millerdev/django-nose@fast-first-1.4.4#egg=django-nose  # via -r requirements/test-requirements.in
+django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
-django-prbac==0.0.8
+django-prbac==0.0.8       # via -r requirements/requirements.in
 django-ranged-response==0.2.0  # via django-simple-captcha
-django-redis-sessions==0.6.1
-django-redis==4.10.0
-django-simple-captcha==0.5.9
-django-statici18n==1.3.0
-django-tastypie==0.14.2
-django-transfer==0.4
-django-two-factor-auth==1.6.2
-django-user-agents==0.3.2
-django-websocket-redis==0.5.2
-django==1.11.28
-djangorestframework==3.11.0
-dnspython==1.15.0
+django-redis-sessions==0.6.1  # via -r requirements/requirements.in
+django-redis==4.10.0      # via -r requirements/requirements.in
+django-simple-captcha==0.5.9  # via -r requirements/requirements.in
+django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-tastypie==0.14.2   # via -r requirements/requirements.in
+django-transfer==0.4      # via -r requirements/requirements.in
+django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-user-agents==0.3.2  # via -r requirements/requirements.in
+django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django==1.11.28           # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+djangorestframework==3.11.0  # via -r requirements/requirements.in
+dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
-dropbox==9.3.0
-elasticsearch2==2.5.1
-elasticsearch==1.9.0
-email_validator==1.0.3
+dropbox==9.3.0            # via -r requirements/requirements.in
+elasticsearch2==2.5.1     # via -r requirements/requirements.in
+elasticsearch==1.9.0      # via -r requirements/requirements.in
+email_validator==1.0.3    # via -r requirements/requirements.in
 et-xmlfile==1.0.1         # via openpyxl
-ethiopian-date-converter==0.1.5
-eulxml==1.1.3
-fakecouch==0.0.15
-faker==0.8.15
-flaky==3.6.0
-freezegun==0.3.12
-funcsigs==1.0.2
-gevent==1.4.0
-ghdiff==0.4
-gipc==1.0.1
-greenlet==0.4.15
-gunicorn==20.0.0
-hiredis==0.2.0
+ethiopian-date-converter==0.1.5  # via -r requirements/requirements.in
+eulxml==1.1.3             # via -r requirements/requirements.in
+fakecouch==0.0.15         # via -r requirements/test-requirements.in
+faker==0.8.15             # via -r requirements/requirements.in
+flaky==3.6.0              # via -r requirements/test-requirements.in
+freezegun==0.3.12         # via -r requirements/test-requirements.in
+funcsigs==1.0.2           # via -r requirements/requirements.in
+gevent==1.4.0             # via -r requirements/requirements.in, django-websocket-redis, gipc
+ghdiff==0.4               # via -r requirements/requirements.in
+gipc==1.0.1               # via -r requirements/requirements.in
+greenlet==0.4.15          # via -r requirements/requirements.in, django-websocket-redis, gevent
+gunicorn==20.0.0          # via -r requirements/requirements.in
+hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.0.1           # via weasyprint
-httpagentparser==1.9.0
+httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via email-validator, requests
-iso8601==0.1.12
+iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
-jinja2==2.10.3
+jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
-json-delta==2.0
-jsonfield==1.0.3
-jsonobject-couchdbkit==1.0.1
-jsonobject==0.9.9
-jsonpath-rw==1.4.0
-kafka-python==1.4.7
-kombu==4.2.2.post1
-laboratory==0.2.0
+json-delta==2.0           # via -r requirements/requirements.in
+jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
+jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
+jsonpath-rw==1.4.0        # via -r requirements/requirements.in
+kafka-python==1.4.7       # via -r requirements/requirements.in
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
+laboratory==0.2.0         # via -r requirements/requirements.in
 linecache2==1.0.0         # via traceback2
-lxml==4.3.5
+lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.0               # via alembic
-markdown==2.2.1
+markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
-mock==2.0.0
+mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-nose-exclude==0.5.0
-nose==1.3.7
-openpyxl==2.6.4
+nose-exclude==0.5.0       # via -r requirements/test-requirements.in
+nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude
+openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
-phonenumberslite==8.10.22
-pillow==6.2.2
-pip-tools==4.4.0
+phonenumberslite==8.10.22  # via -r requirements/requirements.in
+pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, django-simple-captcha
+pip-tools==5.1.0          # via -r requirements/test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
-polib==1.1.0
-prometheus-client==0.7.1
-psycogreen==1.0.1
-psycopg2==2.8.5
-py-kissmetrics==1.0.1
-pycco==0.5.1
+polib==1.1.0              # via -r requirements/requirements.in
+prometheus-client==0.7.1  # via -r requirements/requirements.in
+psycogreen==1.0.1         # via -r requirements/requirements.in
+psycopg2==2.8.5           # via -r requirements/requirements.in, sqlalchemy-postgres-copy
+py-kissmetrics==1.0.1     # via -r requirements/requirements.in
+pycco==0.5.1              # via -r requirements/requirements.in
 pycparser==2.19           # via cffi
-pycryptodome==3.9.2
-pygithub==1.35
-pygments==2.4.2
-pygooglechart==0.4.0
+pycryptodome==3.9.2       # via -r requirements/requirements.in
+pygithub==1.35            # via -r requirements/requirements.in
+pygments==2.4.2           # via -r requirements/requirements.in, pycco
+pygooglechart==0.4.0      # via -r requirements/requirements.in
 pyjwt==1.7.1              # via pygithub, twilio
 pyphen==0.9.5             # via weasyprint
 pysocks==1.7.1            # via twilio
 pystache==0.5.4           # via pycco
-python-dateutil==2.8.0
+python-dateutil==2.8.0    # via -r requirements/requirements.in, botocore, django-tastypie, faker, freezegun
 python-editor==1.0.4      # via alembic
-python-imap==1.0.0
-python-levenshtein==0.12.0
-python-magic==0.4.15
+python-imap==1.0.0        # via -r requirements/requirements.in
+python-levenshtein==0.12.0  # via -r requirements/requirements.in
+python-magic==0.4.15      # via -r requirements/requirements.in
 python-mimeparse==1.6.0   # via django-tastypie
-pytz==2019.3
-pyyaml==5.1.2
-pyzxcvbn==0.8.0
-qrcode==4.0.4
-quickcache==0.5.4
+pytz==2019.3              # via -r requirements/requirements.in, babel, celery, django, twilio
+pyyaml==5.1.2             # via -r requirements/requirements.in
+pyzxcvbn==0.8.0           # via -r requirements/requirements.in
+qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
+quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis-py-cluster==1.3.6
-redis==2.10.6
-reportlab==3.0
-requests-mock==1.7.0
-requests==2.22.0
+redis-py-cluster==1.3.6   # via -r requirements/requirements.in
+redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
+reportlab==3.0            # via -r requirements/requirements.in
+requests-mock==1.7.0      # via -r requirements/test-requirements.in
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-mock, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
-schema==0.7.1
-sentry-sdk==0.13.5
-sh==1.09
-simpleeval==0.9.8
-simplejson==3.16.0
-six==1.13.0
+schema==0.7.1             # via -r requirements/requirements.in
+sentry-sdk==0.13.5        # via -r requirements/requirements.in
+sh==1.09                  # via -r requirements/requirements.in
+simpleeval==0.9.8         # via -r requirements/requirements.in
+simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
 smartypants==2.0.1        # via pycco
-socketpool==0.5.3
+socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.16.1
-sqlalchemy-postgres-copy==0.5.0
-sqlalchemy==1.3.10
-stripe==1.67.0
-suds-jurko==0.6
-testil==1.1
+sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
+sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
+stripe==1.67.0            # via -r requirements/requirements.in
+suds-jurko==0.6           # via -r requirements/requirements.in
+testil==1.1               # via -r requirements/test-requirements.in
 text-unidecode==1.2       # via faker
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
-tinys3==0.1.12
+tinys3==0.1.12            # via -r requirements/requirements.in
 traceback2==1.4.0         # via unittest2
-tropo-webapi-python==0.1.3
-turn-python==0.0.1
-twilio==6.5.1
+tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
+turn-python==0.0.1        # via -r requirements/requirements.in
+twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
-unidecode==0.04.20
-unittest2==1.1.0
+unidecode==0.04.20        # via -r requirements/requirements.in
+unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents
 vine==1.3.0               # via amqp
-weasyprint==0.42.3
+weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via html5lib, tinycss2
-werkzeug==0.11.15
+werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.11.2             # via ddtrace
-xlrd==1.0.0
-xlwt==1.3.0
+xlrd==1.0.0               # via -r requirements/requirements.in
+xlwt==1.3.0               # via -r requirements/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==20.1                 # via pip-tools
 setuptools==41.6.0        # via cairocffi, django-websocket-redis, gunicorn, python-levenshtein, tinycss2


### PR DESCRIPTION
##### SUMMARY
This I think from a little local testing is what's causing the travis failure on build 4. We've tended to see this happen when pip comes out with a new version, and I think we've talked about pinning pip to let these updates not block all PRs until they're fixed. Presumably we'd then need to replace it this crappy process for updating pip-tools to match the pip version with a better one, since other things start to break if we're pinning to old pip versions