### PR TITLE
Fix "Manage releases per location"

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -2267,12 +2267,6 @@ class ManageReleasesByLocationForm(forms.Form):
             self.add_error('app_id', _("Please select application"))
         return self.cleaned_data.get('app_id')
 
-    @staticmethod
-    def extract_location_id(location_id_slug):
-        from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
-        selected_ids = ExpandedMobileWorkerFilter.selected_location_ids([location_id_slug])
-        return selected_ids[0] if selected_ids else None
-
     def clean_location_id(self):
         if not self.cleaned_data.get('location_id'):
             self.add_error('location_id', _("Please select location"))
@@ -2293,7 +2287,7 @@ class ManageReleasesByLocationForm(forms.Form):
                 self.add_error('version', e)
 
     def save(self):
-        location_id = self.extract_location_id(self.cleaned_data['location_id'])
+        location_id = self.cleaned_data['location_id']
         version = self.cleaned_data['version']
         app_id = self.cleaned_data['app_id']
         try:

--- a/corehq/apps/domain/views/releases.py
+++ b/corehq/apps/domain/views/releases.py
@@ -58,12 +58,9 @@ class ManageReleasesByLocation(BaseProjectSettingsView):
     def page_context(self):
         app_names = {app.id: app.name for app in get_brief_apps_in_domain(self.domain, include_remote=True)}
         q = AppReleaseByLocation.objects.filter(domain=self.domain)
-        location_id_slug = self.request.GET.get('location_id')
-        location_id = None
-        if location_id_slug:
-            location_id = self.form.extract_location_id(location_id_slug)
-            if location_id:
-                q = q.filter(location_id=location_id)
+        location_id = self.request.GET.get('location_id')
+        if location_id:
+            q = q.filter(location_id=location_id)
         if self.request.GET.get('app_id'):
             q = q.filter(app_id=self.request.GET.get('app_id'))
         version = self.request.GET.get('version')
@@ -83,7 +80,7 @@ class ManageReleasesByLocation(BaseProjectSettingsView):
             'manage_releases_by_location_form': self.form,
             'app_releases_by_location': app_releases_by_location,
             'selected_build_details': ({'id': version, 'text': version} if version else None),
-            'selected_location_details': ({'id': location_id_slug,
+            'selected_location_details': ({'id': location_id,
                                            'text': self._location_path_display(location_id)}
                                           if location_id else None),
         }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-648
https://sentry.io/organizations/dimagi/issues/1631701106/?project=136860&query=is%3Aunresolved

Remove logic to strip the namespacing from locations selected from the `LocationOptionsController`
Namespacing was removed in https://github.com/dimagi/commcare-hq/commit/65236966130290d90006c5ca6ee2b4b687ad804c, but this usage was overlooked.

@mkangia @orangejenny FYI

##### FEATURE FLAG
Manage releases per location

##### PRODUCT DESCRIPTION
The "Manage releases per location" feature was 500ing whenever you attempted to create a new release rule.  The filtering by location was also broken.  This PR fixes those issues.
