### PR TITLE
Manually implement form setters/getters for connection settings model

### DIFF
--- a/corehq/motech/forms.py
+++ b/corehq/motech/forms.py
@@ -18,7 +18,7 @@ class ConnectionSettingsForm(forms.ModelForm):
     plaintext_password = forms.CharField(
         label=_('Password'),
         required=False,
-        widget=forms.PasswordInput,
+        widget=forms.PasswordInput(render_value=True),
     )
     skip_cert_verify = forms.BooleanField(
         label=_('Skip certificate verification'),
@@ -46,10 +46,15 @@ class ConnectionSettingsForm(forms.ModelForm):
 
     def __init__(self, *args, domain, **kwargs):
         self.domain = domain  # Passed by ``FormSet.form_kwargs``
+        instance = kwargs.get('instance', None)
+        if instance:
+            kwargs['initial'] = {'plaintext_password': instance.plaintext_password, }
+
         super().__init__(*args, **kwargs)
 
     def save(self, commit=True):
         self.instance.domain = self.domain
+        self.instance.plaintext_password = self.cleaned_data['plaintext_password']
         return super().save(commit)
 
 


### PR DESCRIPTION
Fix for [Incremental Export Auth Error](https://sentry.io/organizations/dimagi/issues/1638151669/), caused by passwords not being properly set by the form.

##### SUMMARY
As far as I can tell, the old implementation shouldn't have worked, since django forms don't recognize model properties as fields, so the getter/setters for the `plaintext_password` field were being bypassed entirely, but I don't know a lot about this.

I couldn't find any other forms which followed the pattern to try to debug it, so I just implemented the serialization manually, which worked when I tested it locally.