### PR TITLE
Do not deactivate users in case of extract

### DIFF
--- a/custom/icds/location_reassignment/models.py
+++ b/custom/icds/location_reassignment/models.py
@@ -64,7 +64,7 @@ class Transition(object):
         new_locations_created = self._create_missing_new_locations()
         self.operation_obj.new_locations.extend(new_locations_created)
         self.operation_obj.perform()
-        if self.operation != EXTRACT_OPERATION:
+        if self.operation.deactivates_old_users:
             for old_location in self.operation_obj.old_locations:
                 deactivate_users_at_location(old_location.location_id)
         for old_username, new_username in self.user_transitions.items():
@@ -114,6 +114,7 @@ class Transition(object):
 
 class BaseOperation(metaclass=ABCMeta):
     type = None
+    deactivates_old_users = True
     expected_old_locations = ONE
     expected_new_locations = ONE
 
@@ -234,6 +235,7 @@ class SplitOperation(BaseOperation):
 
 class ExtractOperation(BaseOperation):
     type = EXTRACT_OPERATION
+    deactivates_old_users = False
 
     def perform(self):
         timestamp = datetime.utcnow()

--- a/custom/icds/location_reassignment/models.py
+++ b/custom/icds/location_reassignment/models.py
@@ -64,8 +64,9 @@ class Transition(object):
         new_locations_created = self._create_missing_new_locations()
         self.operation_obj.new_locations.extend(new_locations_created)
         self.operation_obj.perform()
-        for old_location in self.operation_obj.old_locations:
-            deactivate_users_at_location(old_location.location_id)
+        if self.operation != EXTRACT_OPERATION:
+            for old_location in self.operation_obj.old_locations:
+                deactivate_users_at_location(old_location.location_id)
         for old_username, new_username in self.user_transitions.items():
             update_usercase.delay(self.domain, old_username, new_username)
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1238

##### SUMMARY
An oversight, in case of extract operation. Old location is not archived and old users should not get deactivated as well. This PR addresses the latter which was missed in original impelementation.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
