### PR TITLE
Show either editable or read-only property descriptions

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -265,7 +265,7 @@
                                },
                                afterRenderFunc: $root.makePopover"></inline-edit>
           <!-- /ko -->
-          <!-- ko if: $data.description -->
+          <!-- ko if: $data.description() && !$parent.hasPrivilege -->
             <p data-bind="text: $data.description"></p>
           <!-- /ko -->
         </td>


### PR DESCRIPTION
##### SUMMARY
Noticed on field-dev. This should display either the editable view or the read-only view, depending on the user's permissions, but not both.

##### FEATURE FLAG
Data Dictionary

##### PRODUCT DESCRIPTION
Old behavior:

![Screen Shot 2020-05-01 at 2 49 51 PM](https://user-images.githubusercontent.com/1486591/80832664-14109e00-8bbb-11ea-88ad-2840de1ac0f1.png)

