### PR TITLE
allow multiple operations

### DIFF
--- a/custom/icds/location_reassignment/models.py
+++ b/custom/icds/location_reassignment/models.py
@@ -158,18 +158,9 @@ class BaseOperation(metaclass=ABCMeta):
                                                                     site_code__in=self.new_site_codes))
 
         for old_location in self.old_locations:
-            if (old_location.metadata.get(DEPRECATED_TO)
-                    or old_location.metadata.get(DEPRECATED_AT)
-                    or old_location.metadata.get(DEPRECATED_VIA)):
-                self.errors.append("%s operation: location %s with site code %s is already deprecated." % (
+            if not self._can_perform_deprecation(old_location):
+                self.errors.append("%s operation: location %s with site code %s cannot be deprecated again." % (
                     self.type, old_location.name, old_location.site_code))
-                valid = False
-        for new_location in self.new_locations:
-            if (new_location.metadata.get(DEPRECATES)
-                    or new_location.metadata.get(DEPRECATES_AT)
-                    or new_location.metadata.get(DEPRECATES_VIA)):
-                self.errors.append("%s operation: location %s with site code %s is already deprecated." % (
-                    self.type, new_location.name, new_location.site_code))
                 valid = False
 
         return valid
@@ -183,6 +174,12 @@ class BaseOperation(metaclass=ABCMeta):
             self.errors.append("%s operation: Got %s %s location." % (self.type, count, location_type_code))
             valid = False
         return valid
+
+    @staticmethod
+    def _can_perform_deprecation(location):
+        if location.metadata.get(DEPRECATED_VIA) and location.metadata.get(DEPRECATED_VIA) != EXTRACT_OPERATION:
+            return False
+        return True
 
     @abstractmethod
     def perform(self):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1458

##### SUMMARY
Initially HQ didn't permit multiple operations on a single location. It was highlighted that we should allow multiple operations on a location.
This stems from the specific "extract" operation that does not archive old locations.
Like if location B was extracted from A, A is not archived and can be used for another operation in future.
For this, we could have entirely removed the check for deprecation related metafields because an archived location would not get fetched anyway when searching for it via site code and would result in an error during fetch itself.
Still retaining check ensuring that the location's last operation was "extract" only and nothing else in case a deprecated location is say unarchived(likely) or fails to archive during a non-extract operation(highly unlikely)

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
