### PR TITLE
Fixed mobile UCR caching error

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -173,7 +173,7 @@ class BaseReportFixtureProvider(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def report_config_to_fixture(self, report_config, restore_user):
+    def report_config_to_fixtures(self, report_config, restore_user):
         """Standard function for testing
         :returns: list of fixture elements"""
         raise NotImplementedError
@@ -204,7 +204,7 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
         reports_elem = E.reports(last_sync=_format_last_sync_time(restore_user))
         for report_config in report_configs:
             try:
-                reports_elem.extend(self.report_config_to_fixture(report_config, restore_user))
+                reports_elem.extend(self.report_config_to_fixtures(report_config, restore_user))
             except ReportConfigurationNotFoundError as err:
                 logging.exception('Error generating report fixture: {}'.format(err))
                 continue
@@ -218,7 +218,7 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
         root.append(reports_elem)
         return [root]
 
-    def report_config_to_fixture(self, report_config, restore_user):
+    def report_config_to_fixtures(self, report_config, restore_user):
         def _row_to_row_elem(deferred_fields, filter_options_by_field, row, index, is_total_row=False):
             row_elem = E.row(index=str(index), is_total_row=str(is_total_row))
             if toggles.ADD_ROW_INDEX_TO_MOBILE_UCRS.enabled(restore_user.domain):
@@ -345,7 +345,7 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
         fixtures = []
         for report_config in report_configs:
             try:
-                fixtures.extend(self.report_config_to_fixture(report_config, restore_user))
+                fixtures.extend(self.report_config_to_fixtures(report_config, restore_user))
             except ReportConfigurationNotFoundError as err:
                 logging.exception('Error generating report fixture: {}'.format(err))
                 continue
@@ -358,7 +358,7 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
                     raise
         return fixtures
 
-    def report_config_to_fixture(self, report_config, restore_user):
+    def report_config_to_fixtures(self, report_config, restore_user):
         def _row_to_row_elem(deferred_fields, filter_options_by_field, row, index, is_total_row=False):
             row_elem = E.row(index=str(index), is_total_row=str(is_total_row))
             if toggles.ADD_ROW_INDEX_TO_MOBILE_UCRS.enabled(restore_user.domain):

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -332,8 +332,8 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
 
     def _empty_v2_fixtures(self, report_uuid):
         return [
-            E.fixture(id=self._report_fixture_id(report_uuid)),
-            E.fixture(id=self._report_filter_id(report_uuid))
+            E.fixture(id=self.report_fixture_id(report_uuid)),
+            E.fixture(id=self.report_filter_id(report_uuid))
         ]
 
     def _v2_fixtures(self, restore_user, report_configs):
@@ -372,22 +372,22 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
         for row in rows:
             rows_elem.append(row)
 
-        report_filter_elem = E.fixture(id=ReportFixturesProviderV2._report_filter_id(report_config.uuid))
+        report_filter_elem = E.fixture(id=ReportFixturesProviderV2.report_filter_id(report_config.uuid))
         report_filter_elem.append(filters_elem)
 
         report_elem = E.fixture(
-            id=ReportFixturesProviderV2._report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
+            id=ReportFixturesProviderV2.report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
             report_id=report_config.report_id, indexed='true'
         )
         report_elem.append(rows_elem)
         return [report_filter_elem, report_elem]
 
     @staticmethod
-    def _report_fixture_id(report_uuid):
+    def report_fixture_id(report_uuid):
         return 'commcare-reports:' + report_uuid
 
     @staticmethod
-    def _report_filter_id(report_uuid):
+    def report_filter_id(report_uuid):
         return 'commcare-reports-filters:' + report_uuid
 
 

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -237,7 +237,7 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
         for row in row_elements:
             rows_elem.append(row)
 
-        report_elem = E.report(id=ReportFixturesProviderV1.report_fixture_id(report_config.uuid), report_id=report_config.report_id)
+        report_elem = E.report(id=self.report_fixture_id(report_config.uuid), report_id=report_config.report_id)
         report_elem.append(filters_elem)
         report_elem.append(rows_elem)
         return [report_elem]
@@ -377,11 +377,11 @@ class ReportFixturesProviderV2(BaseReportFixtureProvider):
         for row in rows:
             rows_elem.append(row)
 
-        report_filter_elem = E.fixture(id=ReportFixturesProviderV2.report_filter_id(report_config.uuid))
+        report_filter_elem = E.fixture(id=self.report_filter_id(report_config.uuid))
         report_filter_elem.append(filters_elem)
 
         report_elem = E.fixture(
-            id=ReportFixturesProviderV2.report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
+            id=self.report_fixture_id(report_config.uuid), user_id=restore_user.user_id,
             report_id=report_config.report_id, indexed='true'
         )
         report_elem.append(rows_elem)

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -237,10 +237,15 @@ class ReportFixturesProviderV1(BaseReportFixtureProvider):
         for row in row_elements:
             rows_elem.append(row)
 
-        report_elem = E.report(id=report_config.uuid, report_id=report_config.report_id)
+        report_elem = E.report(id=ReportFixturesProviderV1.report_fixture_id(report_config.uuid), report_id=report_config.report_id)
         report_elem.append(filters_elem)
         report_elem.append(rows_elem)
         return [report_elem]
+
+    @staticmethod
+    def report_fixture_id(report_uuid):
+        return report_uuid
+
 
 
 class ReportFixturesProviderV2(BaseReportFixtureProvider):

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -58,7 +58,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
             mock.total_column_ids = ['baz']
             report_datasource.from_spec.return_value = mock
             last_sync_time_patch.return_value = datetime(2017, 9, 11, 6, 35, 20).isoformat()
-            fixtures = provider.report_config_to_fixture(report_app_config, user)
+            fixtures = provider.report_config_to_fixtures(report_app_config, user)
             report = E.restore()
             report.extend(fixtures)
             self.assertXMLEqual(
@@ -99,7 +99,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
             mock.final_column_ids = ['foo', 'bar', 'baz']
             report_datasource.from_spec.return_value = mock
             last_sync_time_patch.return_value = datetime(2017, 9, 11, 6, 35, 20).isoformat()
-            fixtures = provider.report_config_to_fixture(report_app_config, user)
+            fixtures = provider.report_config_to_fixtures(report_app_config, user)
             report = E.restore()
             report.extend(fixtures)
             self.assertXMLEqual(

--- a/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
+++ b/corehq/apps/app_manager/tests/test_report_fixtures_provider.py
@@ -60,7 +60,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
             last_sync_time_patch.return_value = datetime(2017, 9, 11, 6, 35, 20).isoformat()
             fixtures = provider.report_config_to_fixtures(report_app_config, user)
             report = E.restore()
-            report.extend(fixtures)
+            report.extend(fixtures.values())
             self.assertXMLEqual(
                 etree.tostring(report, pretty_print=True).decode('utf-8'),
                 self.get_xml(expected_filename).decode('utf-8')
@@ -101,7 +101,7 @@ class ReportFixturesProviderTests(SimpleTestCase, TestXmlMixin):
             last_sync_time_patch.return_value = datetime(2017, 9, 11, 6, 35, 20).isoformat()
             fixtures = provider.report_config_to_fixtures(report_app_config, user)
             report = E.restore()
-            report.extend(fixtures)
+            report.extend(fixtures.values())
             self.assertXMLEqual(
                 etree.tostring(report, pretty_print=True).decode('utf-8'),
                 self.get_xml('expected_v2_report_total').decode('utf-8')

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -59,10 +59,9 @@ def _get_report_fixture_for_user(domain, report_id, ota_user):
     :param report_id: the index to the result from get_report_configs()
     :param ota_user: the OTARestoreCommCareUser for which to get the report fixture
     """
-    xml = ReportFixturesProviderV1().report_config_to_fixtures(
-        get_report_configs(domain)[report_id], ota_user
-    )
-    return etree.tostring(xml)
+    config = get_report_configs(domain)[report_id]
+    fixtures = ReportFixturesProviderV1().report_config_to_fixtures(config, ota_user)
+    return etree.tostring(fixtures[ReportFixturesProviderV1.report_fixture_id(config.uuid)])
 
 
 def get_report_fixture_for_user(domain, report_id, ota_user):

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -59,7 +59,7 @@ def _get_report_fixture_for_user(domain, report_id, ota_user):
     :param report_id: the index to the result from get_report_configs()
     :param ota_user: the OTARestoreCommCareUser for which to get the report fixture
     """
-    xml = ReportFixturesProviderV1().report_config_to_fixture(
+    xml = ReportFixturesProviderV1().report_config_to_fixtures(
         get_report_configs(domain)[report_id], ota_user
     )
     return etree.tostring(xml)

--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -405,7 +405,7 @@ class LSAggregatePerformanceIndicator(LSIndicator):
     def clear_caches(self):
         get_report_configs.clear(self.domain)
         for report_id in REPORT_IDS:
-            get_report_fixture_for_user.clear(self.domain, report_id, self.restore_user)
+            _get_report_fixture_for_user.clear(self.domain, report_id, self.restore_user)
 
     @property
     @memoized


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/ICDS-1377

https://sentry.io/organizations/dimagi/issues/1540038230
https://sentry.io/organizations/dimagi/issues/1539541951

Introduced in https://github.com/dimagi/commcare-hq/pull/25712/, which changed `report_config_to_fixture` to return a list, which could no longer be quickcached.