### PR TITLE
account for national view

### DIFF
--- a/custom/icds_reports/reports/fact_sheets.py
+++ b/custom/icds_reports/reports/fact_sheets.py
@@ -624,7 +624,7 @@ class FactSheetsReport(object):
 
         all_data = self._get_all_data(data_sources)
 
-        sql_location = self.config['sql_location']
+        sql_location = self.config.get('sql_location')
         months = [
             dt.strftime("%b %Y") for dt in rrule(
                 MONTHLY,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When viewing this report at a national level, no location is selected so this element did not exist in the dictionary. The function already properly handles null `sql_location` in line 641