### PR TITLE
Updated data cleaning to only edit properties that user touched

### DIFF
--- a/corehq/apps/reports/static/reports/js/data_corrections.js
+++ b/corehq/apps/reports/static/reports/js/data_corrections.js
@@ -244,12 +244,17 @@ hqDefine("reports/js/data_corrections", [
         self.submitForm = function (model, e) {
             var $button = $(e.currentTarget);
             $button.disableButton();
+
+            // Filter properties to those that are dirty, and transform to name => value object
+            var properties = _.chain(self.properties)
+                .filter(function (prop) { return prop.dirty(); })
+                .indexBy('name')
+                .mapObject(function (model) { return model.value(); })
+            .value();
             $.post({
                 url: options.saveUrl,
                 data: {
-                    properties: JSON.stringify(_.mapObject(self.properties, function (model) {
-                        return model.value();
-                    })),
+                    properties: JSON.stringify(properties),
                 },
                 success: function () {
                     window.location.reload();


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-10806

We were already noting which properties were dirty in the UI but were still passing them all to the server.

##### PRODUCT DESCRIPTION
Stop the clean case data feature from explicitly saving all blank properties as blank and instead only update properties that are explicitly updated in the clean case data form.