### PR TITLE
Update .eslintrc.js to allow single-line functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     // http://eslint.org/docs/user-guide/configuring#configuring-rules
     "rules": {
         // First option can be off, warn, or error
-        "brace-style": ["error", "1tbs"],
+        "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
         "camelcase": ["error", {"properties": "never"}],
         "comma-dangle": ["warn", "always-multiline"],
         "curly": ["error"],


### PR DESCRIPTION
Single-line functions are nice occasionally, like when using [_.chain](https://underscorejs.org/#chain).
