### PR TITLE
Have docker-compose declare zookeeper as a dependency of kafka

### DIFF
--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -57,6 +57,8 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
     ports:
       - "9092:9092"
+    depends_on:
+      - zookeeper
 
   zookeeper:
     extends:


### PR DESCRIPTION
Hoping this helps with our kafka-related travis build issues

##### SUMMARY

According to https://docs.docker.com/compose/startup-order/
this establishes a start up order that may decrease the frequency
with which dockerized kafka has issues during startup that leave
it in a broken state.

I don't know how correlated it is with test failure, but in this example https://travis-ci.org/github/dimagi/commcare-hq/jobs/683335876#L244 we can see kafka started before zookeeper, which may reduce its chance of ever making it to a healthy state.

Even with this change in order (and assuming my mental model is right and this is even relevant) there's still a race condition; it just gives zookeeper a head start to favor the outcome we prefer

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
