### PR TITLE
Ignore case_type when data cleaning

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -68,7 +68,16 @@ PROPERTY_TAG_STOCK = 'stock'
 
 # Yeah... let's not hard code this list everywhere
 # This list comes from casexml.apps.case.xml.parser.CaseActionBase.from_v2
-KNOWN_CASE_PROPERTIES = ["type", "name", "case_name", "external_id", "user_id", "owner_id", "opened_on"]
+KNOWN_CASE_PROPERTIES = [
+    "type",
+    "case_type",
+    "name",
+    "case_name",
+    "external_id",
+    "user_id",
+    "owner_id",
+    "opened_on",
+]
 
 # Attributes found on a case block. <case case_id="..." date_modified="..." ...>
 CASE_ATTRIBUTES = {

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1235,7 +1235,7 @@ def case_property_names(request, domain, case_id):
     if case.external_id:
         all_property_names.add('external_id')
 
-    return json_response(sorted(all_property_names))
+    return json_response(sorted(all_property_names, key=lambda item: item.lower()))
 
 
 @location_safe


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-10806

https://github.com/dimagi/commcare-hq/commit/2b844a979e5a50959cd6a9472d829bf4e9e90dab excluded a few more system properties from case cleaning, but also dropped `case_type`, I'm guessing unintentionally.

Experimenting in a shell, calling `submit_case_blocks` with `case_type` in the `update` updates the case's type. Calling it with `type` in `update` doesn't seem to do anything - it doesn't update the type and also doesn't add a `type` property.

@esoergel I'm assuming this isn't going to cause a problem when generating export schemas, which is the one other usage of `KNOWN_CASE_PROPERTIES`: https://github.com/dimagi/commcare-hq/blob/3465254c0714c694e3038811cfdd6baef9be1d4c/corehq/apps/export/models/new.py#L2207 ...do you know if that's true?

##### PRODUCT DESCRIPTION
This prevents `case_type` from appearing in data cleaning.