### PR TITLE
Add test utils for reentrant redis locks

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
+++ b/corehq/apps/data_interfaces/tests/test_auto_case_updates.py
@@ -40,6 +40,7 @@ from corehq.form_processor.tests.utils import (
 )
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.toggles import NAMESPACE_DOMAIN, RUN_AUTO_CASE_UPDATES_ON_SAVE
+from corehq.tests.locks import reentrant_redis_locks
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.test_utils import set_parent_case as set_actual_parent_case
 
@@ -900,6 +901,7 @@ class CaseRuleOnSaveTests(BaseCaseRuleTest):
         self.disable_updates_on_save()
 
     @run_with_all_backends
+    @reentrant_redis_locks
     def test_run_on_save(self):
         self.enable_updates_on_save()
 

--- a/corehq/tests/locks.py
+++ b/corehq/tests/locks.py
@@ -1,0 +1,80 @@
+import logging
+from contextlib import contextmanager
+from threading import RLock
+from unittest.mock import patch
+
+import attr
+
+import dimagi.utils.couch as module
+
+log = logging.getLogger(__name__)
+
+
+def reentrant_redis_locks(test=None):
+    """Decorator/context manager to enable reentrant redis locks
+
+    This is useful for tests that do things like acquire a lock and then
+    fire off a celery task (which will usually be executed synchronously
+    in tests) before the lock is released.
+
+    Usage as decorator:
+
+        @reentrant_redis_locks
+        def test_something():
+            ...
+
+    Usage as context manager:
+
+        def test_something():
+            with reentrant_redis_locks():
+                ...
+    """
+    def get_reentrant_lock(key, **kw):
+        try:
+            lock = locks[key]
+        except KeyError:
+            lock = locks[key] = ReentrantTestLock(key, locks)
+        return lock
+
+    @contextmanager
+    def context():
+        with patch.object(module, "get_redis_client", client):
+            try:
+                yield
+            finally:
+                assert not locks, f"unreleased {locks.values()}"
+
+    locks = {}
+    client = TestRedisClient(get_reentrant_lock)
+    manager = context()
+    return manager if test is None else manager(test)
+
+
+@attr.s
+class TestRedisClient:
+    lock = attr.ib()
+
+    def __call__(self):
+        return self
+
+
+@attr.s
+class ReentrantTestLock:
+    name = attr.ib()
+    locks = attr.ib(repr=False)
+    level = attr.ib(default=0, init=False)
+    lock = attr.ib(factory=RLock, init=False, repr=False)
+
+    def acquire(self, **kw):
+        self.level += 1
+        try:
+            return self.lock.acquire(**kw)
+        finally:
+            log.debug("acquire %s [%s]", self.name, self.level)
+
+    def release(self):
+        self.level -= 1
+        log.debug("release %s [%s]", self.name, self.level)
+        if self.level <= 0:
+            self.locks.pop(self.name, None)
+        self.lock.release()

--- a/corehq/tests/noseplugins/redislocks.py
+++ b/corehq/tests/noseplugins/redislocks.py
@@ -15,13 +15,9 @@ log = logging.getLogger(__name__)
 _LOCK = Lock()
 
 
-class ReentrantRedisLocksPlugin(Plugin):
-    """A plugin to measure times of testing events
-
-    Measure elapsed time before setup, during setup, during test, and
-    during teardown events. Outputs the results as CSV.
-    """
-    name = "reentrant-redis-locks"
+class RedisLockTimeoutPlugin(Plugin):
+    """A plugin that causes blocking redis locks to error on lock timeout"""
+    name = "test-redis-locks"
     enabled = True
 
     def configure(self, options, conf):

--- a/corehq/tests/noseplugins/redislocks.py
+++ b/corehq/tests/noseplugins/redislocks.py
@@ -1,0 +1,78 @@
+import logging
+from datetime import datetime
+from threading import Lock
+from unittest.mock import patch
+
+import attr
+from nose.plugins import Plugin
+
+import dimagi.utils.couch as module
+from dimagi.utils.couch import get_redis_client
+
+from corehq.tests.noseplugins.uniformresult import uniform_description
+
+log = logging.getLogger(__name__)
+_LOCK = Lock()
+
+
+class ReentrantRedisLocksPlugin(Plugin):
+    """A plugin to measure times of testing events
+
+    Measure elapsed time before setup, during setup, during test, and
+    during teardown events. Outputs the results as CSV.
+    """
+    name = "reentrant-redis-locks"
+    enabled = True
+
+    def configure(self, options, conf):
+        """Do not call super (always enabled)"""
+        self.patch = patch.object(module, "get_redis_client", TestRedisClient)
+
+    def startTest(self, case):
+        assert _LOCK.acquire(blocking=False), \
+            f"{uniform_description(case.test)}: concurrent tests not supported"
+        self.patch.start()
+
+    def stopTest(self, case):
+        self.patch.stop()
+        _LOCK.release()
+
+
+class TestRedisClient:
+
+    def lock(self, key, **kw):
+        timeout = kw["timeout"]
+        lock = get_redis_client().lock(key, **kw)
+        return TestLock(key, lock, timeout)
+
+
+@attr.s
+class TestLock:
+    name = attr.ib()
+    lock = attr.ib(repr=False)
+    timeout = attr.ib()
+
+    def acquire(self, **kw):
+        start = datetime.now()
+        log.info("acquire %s", self)
+        try:
+            return self.lock.acquire(**kw)
+        finally:
+            elapsed = datetime.now() - start
+            if elapsed.total_seconds() > self.timeout / 2:
+                self.release()
+                raise TimeoutError(f"locked for {elapsed} (timeout={self.timeout}s)")
+
+    def release(self):
+        log.info("release %s", self)
+        self.lock.release()
+
+    def __enter__(self):
+        self.acquire(blocking=True)
+
+    def __exit__(self, *exc_info):
+        self.release()
+
+
+class TimeoutError(Exception):
+    """Error raised when lock timeout is approached during tests"""

--- a/corehq/tests/test_locks.py
+++ b/corehq/tests/test_locks.py
@@ -1,0 +1,66 @@
+from testil import assert_raises, eq
+
+from dimagi.utils.couch import get_redis_lock
+
+from corehq.util.test_utils import timelimit
+
+from .locks import ReentrantTestLock, reentrant_redis_locks
+from .noseplugins.redislocks import TestLock, TimeoutError
+
+
+def test_redislocks_nose_plugin():
+    lock1 = get_redis_lock(__name__, timeout=0.5, name="test")
+    assert isinstance(lock1.lock, TestLock), lock1.lock
+    lock1.acquire()
+    lock2 = get_redis_lock(__name__, timeout=0.5, name="test")
+    with assert_raises(TimeoutError):
+        lock2.acquire()
+    # lock1.release() -> LockError: Cannot release a lock that's no longer owned
+
+
+@timelimit(0.1)
+def test_reentrant_redis_locks():
+    with reentrant_redis_locks():
+        simulate_reentrant_lock()
+
+
+@timelimit(0.1)
+@reentrant_redis_locks
+def test_reentrant_redis_locks_decorator():
+    simulate_reentrant_lock()
+
+
+def simulate_reentrant_lock():
+    lock1 = get_redis_lock(__name__, timeout=0.5, name="test")
+    lock2 = get_redis_lock(__name__, timeout=0.5, name="test")
+    assert isinstance(lock1.lock, ReentrantTestLock), lock1.lock
+    assert isinstance(lock2.lock, ReentrantTestLock), lock2.lock
+    with lock1, lock2:
+        pass  # no deadlock, no errors
+
+
+@timelimit(0.1)
+def test_unreleased_lock():
+    msg = "unreleased dict_values([ReentrantTestLock(name='unreleased', level=1)])"
+    with assert_raises(AssertionError, msg=msg):
+        with reentrant_redis_locks():
+            lock = get_redis_lock("unreleased", timeout=0.5, name="test")
+            lock.acquire()
+    lock.release()
+
+
+@timelimit(0.1)
+def test_extra_lock_release():
+    with reentrant_redis_locks():
+        lock = get_redis_lock("unreleased", timeout=0.5, name="test")
+        lock.acquire()
+        lock.release()
+        with assert_raises(RuntimeError):
+            lock.release()
+
+
+def test_decorator_name():
+    @reentrant_redis_locks
+    def fake_test():
+        pass
+    eq(fake_test.__name__, "fake_test")

--- a/testsettings.py
+++ b/testsettings.py
@@ -36,7 +36,7 @@ NOSE_PLUGINS = [
     'corehq.tests.noseplugins.dividedwerun.DividedWeRunPlugin',
     'corehq.tests.noseplugins.djangomigrations.DjangoMigrationsPlugin',
     'corehq.tests.noseplugins.cmdline_params.CmdLineParametersPlugin',
-    'corehq.tests.noseplugins.redislocks.ReentrantRedisLocksPlugin',
+    'corehq.tests.noseplugins.redislocks.RedisLockTimeoutPlugin',
     'corehq.tests.noseplugins.uniformresult.UniformTestResultPlugin',
 
     # The following are not enabled by default

--- a/testsettings.py
+++ b/testsettings.py
@@ -36,6 +36,7 @@ NOSE_PLUGINS = [
     'corehq.tests.noseplugins.dividedwerun.DividedWeRunPlugin',
     'corehq.tests.noseplugins.djangomigrations.DjangoMigrationsPlugin',
     'corehq.tests.noseplugins.cmdline_params.CmdLineParametersPlugin',
+    'corehq.tests.noseplugins.redislocks.ReentrantRedisLocksPlugin',
     'corehq.tests.noseplugins.uniformresult.UniformTestResultPlugin',
 
     # The following are not enabled by default


### PR DESCRIPTION
Some tests were waiting for lock timeouts due to double acquire. The nose plugin will cause this situation to error out, and those failures should be able to be resolved with `reentrant_redis_locks` decorator/context manager.

`./manage.py test corehq.apps.data_interfaces.tests.test_auto_case_updates`
before: Ran 35 tests in 294.054s
after: Ran 35 tests in 50.866s

The offending test in that module was `CaseRuleOnSaveTests.test_run_on_save`, which does two reentrant locks.