### PR TITLE
[ICDS Dashboard]: Removal of extra condition in the Child growth tracker report

### DIFF
--- a/custom/icds_reports/static/js/directives/download/download.directive.js
+++ b/custom/icds_reports/static/js/directives/download/download.directive.js
@@ -457,7 +457,7 @@ function DownloadController($rootScope, $location, locationHierarchy, locationsS
 
     vm.hasErrors = function () {
         var beneficiaryListErrors = vm.isChildBeneficiaryListSelected() && (vm.selectedFilterOptions().length === 0 || !vm.isDistrictOrBelowSelected());
-        var growthListErrors = vm.isChildGrowthTrackerSelected() && (vm.selectedFilterOptions().length === 0 || !vm.isDistrictOrBelowSelected());
+        var growthListErrors = vm.isChildGrowthTrackerSelected() && !vm.isDistrictOrBelowSelected();
         var incentiveReportErrors = vm.isIncentiveReportSelected() && !vm.isStateSelected();
         var ladySupervisorReportErrors = false;
         if (!vm.haveAccessToFeatures) {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
Removed the vm.selectedFilterOptions condition for the child growth tracker report as the same is not required for the report.
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
