### PR TITLE
retry in case of failures with celery

### DIFF
--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -159,6 +159,6 @@ def queue_task_with_retries(task_to_queue, *args, **kwargs):
             # break from while if no issues
             break
         except Exception:
-            # wait for a minute before trying again
-            sleep(60)
+            # wait for five minutes before trying again
+            sleep(300)
             retries += 1

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -152,13 +152,11 @@ def run_messaging_rule(domain, rule_id):
 
 
 def queue_task_with_retries(task_to_queue, *args, **kwargs):
-    retries = 0
-    while retries < 5:
+    for attempt in range(5):
         try:
             task_to_queue.delay(*args, **kwargs)
-            # break from while if no issues
+            # break from loop if no issues
             break
         except Exception:
             # wait for five minutes before trying again
             sleep(300)
-            retries += 1

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -1,5 +1,7 @@
 from time import sleep
 
+from billiard.exceptions import SoftTimeLimitExceeded
+
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.sms import tasks as sms_tasks
 from corehq.form_processor.exceptions import CaseNotFound
@@ -157,6 +159,6 @@ def queue_task_with_retries(task_to_queue, *args, **kwargs):
             task_to_queue.delay(*args, **kwargs)
             # break from loop if no issues
             break
-        except Exception:
+        except SoftTimeLimitExceeded:
             # wait for five minutes before trying again
             sleep(300)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -160,5 +160,7 @@ def queue_task_with_retries(task_to_queue, *args, **kwargs):
             # break from loop if no issues
             break
         except SoftTimeLimitExceeded:
+            if attempt == 4:
+                raise
             # wait for five minutes before trying again
             sleep(300)


### PR DESCRIPTION
To avoid [such error](https://sentry.io/organizations/dimagi/issues/1631921255/events/464d3217fe9546f48723bc509411ac38/?project=1545828&statsPeriod=14d)

##### SUMMARY
A re-run ran for few days and failed due to error above, asking for a better error handling
More context on https://dimagi-dev.atlassian.net/browse/ICDS-1485