### PR TITLE
[ci skip] add help link to location safe report builder flag

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1167,7 +1167,8 @@ SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER = StaticToggle(
     'Show an additional "Owner (Location)" property in report builder reports. '
     'This can be used to create report builder reports that are location-safe.',
     TAG_SOLUTIONS_OPEN,
-    [NAMESPACE_DOMAIN]
+    [NAMESPACE_DOMAIN],
+    help_link='https://confluence.dimagi.com/display/internal/Demo+Mobile+Workers',
 )
 
 MOBILE_USER_DEMO_MODE = StaticToggle(


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://confluence.dimagi.com/display/ccinternal/Enable+creation+of+report+builder+reports+that+are+location+safe

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
https://www.commcarehq.org/hq/flags/edit/show_owner_location_property_in_report_builder/

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
