### PR TITLE
use last day for real instead of today

### DIFF
--- a/corehq/apps/reports/tests/test_daterange.py
+++ b/corehq/apps/reports/tests/test_daterange.py
@@ -58,7 +58,7 @@ class KnownRangesTests(SimpleTestCase):
 
         start_date, end_date = get_daterange_start_end_dates('thismonth')
         self.assertEqual(start_date, datetime.date(year=1829, month=8, day=1))
-        self.assertEqual(end_date, self.first_performance)
+        self.assertEqual(end_date, datetime.date(year=1829, month=8, day=31))
 
     @patch('datetime.date')
     def test_lastmonth(self, date_patch):

--- a/corehq/util/dates.py
+++ b/corehq/util/dates.py
@@ -69,8 +69,8 @@ def get_first_last_days(year, month):
 
 def get_current_month_date_range(reference_date=None):
     reference_date = reference_date or datetime.date.today()
-    date_start = datetime.date(reference_date.year, reference_date.month, 1)
-    return date_start, reference_date
+    month_year, month = reference_date.year, reference_date.month
+    return get_first_last_days(month_year, month)
 
 
 def get_previous_month_date_range(reference_date=None):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1262

##### SUMMARY
When looking for current month range, HQ used the current date as the end date itself which looks unexpected. 
Pinging @kaapstorm who added this originally [here](https://github.com/dimagi/commcare-hq/pull/10390/files#diff-c8ce528df690a03a8d238cf3c9c1d01dR80) to check if that was intentional and if he can remember now :)


##### PRODUCT DESCRIPTION
When an app builder sets up for a report to filter on dates for current month, currently HQ uses the range as the first date of current month up till the current day (would be 1st May and 7th May if checked today). 
This PR now changes current month range to be the first and last day of the current month instead (now would be 1st May and 31st May if checked today)
