### PR TITLE
Revert "Have docker-compose declare zookeeper as a dependency of kafka"

### DIFF
--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -57,8 +57,6 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
     ports:
       - "9092:9092"
-    depends_on:
-      - zookeeper
 
   zookeeper:
     extends:


### PR DESCRIPTION
@dannyroberts I think #27389 did not have the effect you intended

- Travis tests use **docker/hq-compose.yml** (not the file modified in this PR)

  https://github.com/dimagi/commcare-hq/blob/824f81fd5472a35f060590cb77ac1346b19ebd8d/scripts/docker#L136-L144

- It broke the docker script for me locally. When I run `scripts/docker ps` I get
  `ERROR: Cannot extend service 'kafka' in .../docker/hq-compose-services.yml: services with 'depends_on' cannot be extended`