### PR TITLE
Report web-apps/formplayer request failures to datadog & sentry

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -255,7 +255,7 @@ WebFormSession.prototype.handleFailure = function (resp, action, textStatus, fai
 
     hqImport('cloudcare/js/util').reportFormplayerErrorToHQ({
         type: 'webformsession_request_failure',
-        action: action,
+        request: action,
         readableErrorMessage: errorMessage,
         statusText: resp.statusText,
         state: resp.state ? resp.state() : null,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -118,7 +118,6 @@ function WebFormSession(params) {
     self.urls = {
         xform: params.xform_url,
     };
-    self.reportFormplayerErrorToHQ = params.reportFormplayerErrorToHQ;
 
 
     self.blockingRequestInProgress = false;
@@ -254,7 +253,7 @@ WebFormSession.prototype.handleFailure = function (resp, action, textStatus, fai
         errorMessage = Formplayer.Utils.touchformsError(resp.responseJSON.message);
     }
 
-    self.reportFormplayerErrorToHQ({
+    hqImport('cloudcare/js/util').reportFormplayerErrorToHQ({
         type: 'webformsession_request_failure',
         action: action,
         readableErrorMessage: errorMessage,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -254,7 +254,12 @@ WebFormSession.prototype.handleFailure = function (resp, action, textStatus, fai
         errorMessage = Formplayer.Utils.touchformsError(resp.responseJSON.message);
     }
 
-    self.reportFormplayerErrorToHQ(resp, action, errorMessage);
+    try {
+        self.reportFormplayerErrorToHQ(resp, action, errorMessage);
+    } catch (e) {
+        console.error("reportFormplayerErrorToHQ failed hard and there is no where else to report this error", e);
+    }
+
     if (failureCallback) {
         failureCallback();
     }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -117,7 +117,7 @@ function WebFormSession(params) {
 
     self.urls = {
         xform: params.xform_url,
-        errorReportUrl: params.error_report_url
+        errorReportUrl: params.error_report_url,
     };
 
 
@@ -557,11 +557,11 @@ WebFormSession.prototype.reportFormplayerErrorToHQ = function (resp, action, err
         data: JSON.stringify(data),
         contentType: "application/json",
         dataType: "json",
-        success: function (resp) {
-            console.log('Successfully reported error: ' + JSON.stringify(data));
+        success: function () {
+            console.info('Successfully reported error: ' + JSON.stringify(data));
         },
-        error: function (resp, textStatus) {
-            console.log('Failed to report error: ' + JSON.stringify(data));
+        error: function () {
+            console.error('Failed to report error: ' + JSON.stringify(data));
         },
     });
 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -150,6 +150,7 @@ FormplayerFrontend.reqres.setHandler('handleNotification', function (notificatio
 });
 
 FormplayerFrontend.on('startForm', function (data) {
+    var reverse = hqImport("hqwebapp/js/initial_page_data").reverse;
     FormplayerFrontend.request("clearMenu");
     FormplayerFrontend.Menus.Util.showBreadcrumbs(data.breadcrumbs);
 
@@ -157,6 +158,7 @@ FormplayerFrontend.on('startForm', function (data) {
     data.onLoadingComplete = formplayerLoadingComplete;
     var user = FormplayerFrontend.request('currentUser');
     data.xform_url = user.formplayer_url;
+    data.error_report_url = reverse('report_formplayer_error');
     data.domain = user.domain;
     data.username = user.username;
     data.restoreAs = user.restoreAs;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -159,7 +159,7 @@ FormplayerFrontend.on('startForm', function (data) {
     data.onLoadingComplete = formplayerLoadingComplete;
     var user = FormplayerFrontend.request('currentUser');
     data.xform_url = user.formplayer_url;
-    data.reportFormplayerErrorToHQ =  reportFormplayerErrorToHQ
+    data.reportFormplayerErrorToHQ =  reportFormplayerErrorToHQ;
     data.domain = user.domain;
     data.username = user.username;
     data.restoreAs = user.restoreAs;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -14,7 +14,9 @@ var formplayerLoading = hqImport('cloudcare/js/util').formplayerLoading;
 var formplayerLoadingComplete = hqImport('cloudcare/js/util').formplayerLoadingComplete;
 var formplayerSyncComplete = hqImport('cloudcare/js/util').formplayerSyncComplete;
 var clearUserDataComplete = hqImport('cloudcare/js/util').clearUserDataComplete;
+var reportFormplayerErrorToHQ = hqImport('cloudcare/js/util').reportFormplayerErrorToHQ;
 var appcues = hqImport('analytix/js/appcues');
+
 
 FormplayerFrontend.on("before:start", function () {
     var RegionContainer = Marionette.LayoutView.extend({
@@ -150,7 +152,6 @@ FormplayerFrontend.reqres.setHandler('handleNotification', function (notificatio
 });
 
 FormplayerFrontend.on('startForm', function (data) {
-    var reverse = hqImport("hqwebapp/js/initial_page_data").reverse;
     FormplayerFrontend.request("clearMenu");
     FormplayerFrontend.Menus.Util.showBreadcrumbs(data.breadcrumbs);
 
@@ -158,7 +159,7 @@ FormplayerFrontend.on('startForm', function (data) {
     data.onLoadingComplete = formplayerLoadingComplete;
     var user = FormplayerFrontend.request('currentUser');
     data.xform_url = user.formplayer_url;
-    data.error_report_url = reverse('report_formplayer_error');
+    data.reportFormplayerErrorToHQ =  reportFormplayerErrorToHQ
     data.domain = user.domain;
     data.username = user.username;
     data.restoreAs = user.restoreAs;

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -14,9 +14,7 @@ var formplayerLoading = hqImport('cloudcare/js/util').formplayerLoading;
 var formplayerLoadingComplete = hqImport('cloudcare/js/util').formplayerLoadingComplete;
 var formplayerSyncComplete = hqImport('cloudcare/js/util').formplayerSyncComplete;
 var clearUserDataComplete = hqImport('cloudcare/js/util').clearUserDataComplete;
-var reportFormplayerErrorToHQ = hqImport('cloudcare/js/util').reportFormplayerErrorToHQ;
 var appcues = hqImport('analytix/js/appcues');
-
 
 FormplayerFrontend.on("before:start", function () {
     var RegionContainer = Marionette.LayoutView.extend({
@@ -159,7 +157,6 @@ FormplayerFrontend.on('startForm', function (data) {
     data.onLoadingComplete = formplayerLoadingComplete;
     var user = FormplayerFrontend.request('currentUser');
     data.xform_url = user.formplayer_url;
-    data.reportFormplayerErrorToHQ =  reportFormplayerErrorToHQ;
     data.domain = user.domain;
     data.username = user.username;
     data.restoreAs = user.restoreAs;

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -32,6 +32,11 @@ hqDefine('cloudcare/js/util', function () {
             message = gettext("Sorry, an error occurred while processing that request.");
         }
         _show(message, $el, null, "alert alert-danger");
+        reportFormplayerErrorToHQ({
+            type: 'show_error_notification',
+            message: message,
+        });
+
     };
 
     var showWarning = function (message, $el) {
@@ -44,6 +49,10 @@ hqDefine('cloudcare/js/util', function () {
     var showHTMLError = function (message, $el, autoHideTime) {
         message = message || gettext("Sorry, an error occurred while processing that request.");
         _show(message, $el, autoHideTime, "", true);
+        reportFormplayerErrorToHQ({
+            type: 'show_error_notification',
+            message: message,
+        });
     };
 
     var showSuccess = function (message, $el, autoHideTime, isHTML) {
@@ -121,6 +130,28 @@ hqDefine('cloudcare/js/util', function () {
         NProgress.done();
     };
 
+    var reportFormplayerErrorToHQ = function (data) {
+        try {
+            var reverse = hqImport("hqwebapp/js/initial_page_data").reverse;
+
+            $.ajax({
+                type: 'POST',
+                url: reverse('report_formplayer_error'),
+                data: JSON.stringify(data),
+                contentType: "application/json",
+                dataType: "json",
+                success: function () {
+                    console.info('Successfully reported error: ' + JSON.stringify(data));
+                },
+                error: function () {
+                    console.error('Failed to report error: ' + JSON.stringify(data));
+                },
+            });
+        } catch (e) {
+            console.error("reportFormplayerErrorToHQ failed hard and there is no where else to report this error", e);
+        }
+    };
+
     return {
         getFormUrl: getFormUrl,
         getSubmitUrl: getSubmitUrl,
@@ -132,5 +163,6 @@ hqDefine('cloudcare/js/util', function () {
         formplayerLoading: formplayerLoading,
         formplayerLoadingComplete: formplayerLoadingComplete,
         formplayerSyncComplete: formplayerSyncComplete,
+        reportFormplayerErrorToHQ: reportFormplayerErrorToHQ,
     };
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -141,14 +141,14 @@ hqDefine('cloudcare/js/util', function () {
                 contentType: "application/json",
                 dataType: "json",
                 success: function () {
-                    console.info('Successfully reported error: ' + JSON.stringify(data));
+                    window.console.info('Successfully reported error: ' + JSON.stringify(data));
                 },
                 error: function () {
-                    console.error('Failed to report error: ' + JSON.stringify(data));
+                    window.console.error('Failed to report error: ' + JSON.stringify(data));
                 },
             });
         } catch (e) {
-            console.error(
+            window.console.error(
                 "reportFormplayerErrorToHQ failed hard and there is nowhere " +
                 "else to report this error: " + JSON.stringify(data),
                 e,

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -148,7 +148,11 @@ hqDefine('cloudcare/js/util', function () {
                 },
             });
         } catch (e) {
-            console.error("reportFormplayerErrorToHQ failed hard and there is no where else to report this error", e);
+            console.error(
+                "reportFormplayerErrorToHQ failed hard and there is nowhere " +
+                "else to report this error: " + JSON.stringify(data),
+                e,
+            );
         }
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -151,7 +151,7 @@ hqDefine('cloudcare/js/util', function () {
             window.console.error(
                 "reportFormplayerErrorToHQ failed hard and there is nowhere " +
                 "else to report this error: " + JSON.stringify(data),
-                e,
+                e
             );
         }
     };

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -82,6 +82,7 @@
   {% registerurl 'list_form_exports' request.domain %}
   {% registerurl 'case_data' request.domain '---' %}
   {% registerurl 'render_form_data' request.domain '---' %}
+  {% registerurl 'report_formplayer_error' request.domain %}
 
   <!-- For now we won't touch this since the form entry code is coupled with it  -->
 

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -31,6 +31,7 @@
   {% registerurl 'list_form_exports' request.domain %}
   {% registerurl 'case_data' request.domain '---' %}
   {% registerurl 'render_form_data' request.domain '---' %}
+  {% registerurl 'report_formplayer_error' request.domain %}
 
   <section id="case-crumbs" style="width: 800px"></section>
   <section id="cases"></section>

--- a/corehq/apps/cloudcare/tests/test_doc_tests.py
+++ b/corehq/apps/cloudcare/tests/test_doc_tests.py
@@ -1,0 +1,8 @@
+import doctest
+
+import corehq.apps.cloudcare.views
+
+
+def test_view_doctests():
+    results = doctest.testmod(corehq.apps.cloudcare.views)
+    assert results.failed == 0, results

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -10,6 +10,7 @@ from corehq.apps.cloudcare.views import (
     ReadableQuestions,
     default,
     form_context,
+    report_formplayer_error,
 )
 
 app_urls = [
@@ -23,6 +24,7 @@ app_urls = [
         name=FormplayerPreviewSingleApp.urlname,
     ),
     url(r'^preview_app/(?P<app_id>[\w-]+)/$', PreviewAppView.as_view(), name=PreviewAppView.urlname),
+    url(r'^report_formplayer_error', report_formplayer_error, name='report_formplayer_error')
 ]
 
 api_urls = [

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -496,6 +496,17 @@ def report_formplayer_error(request, domain):
 
 
 def _message_to_tag_value(message, allowed_chars=string.ascii_lowercase + '_'):
+    """
+    Turn a long user-facing error message into a short slug that can be used as a datadog tag value
+
+    passes through unidecode to get something ascii-compatible to work with,
+    then uses the first four space-delimited words and filters out unwanted characters.
+
+    >>> _message_to_tag_value('Sorry, an error occurred while processing that request.')
+    'sorry_an_error_occurred'
+    >>> _message_to_tag_value('Another process prevented us from servicing your request. Please try again later.')
+    'another_process_prevented_us'
+    """
     message_tag = '_'.join(unidecode(message).split(' ')[:4]).lower()
     message_tag = ''.join(c for c in message_tag if c in allowed_chars)
     return message_tag

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -1,4 +1,5 @@
 import json
+import string
 from xml.etree import cElementTree as ElementTree
 
 from django.conf import settings
@@ -23,6 +24,7 @@ import six.moves.urllib.error
 import six.moves.urllib.parse
 import six.moves.urllib.request
 from couchdbkit import ResourceConflict
+from unidecode import unidecode
 
 from casexml.apps.phone.fixtures import generator
 from corehq.util.metrics import metrics_counter
@@ -468,12 +470,32 @@ class EditCloudcareUserPermissionsView(BaseUserSettingsView):
 @login_and_domain_required
 def report_formplayer_error(request, domain):
     data = json.loads(request.body)
-    metrics_counter('commcare.formplayer.browser_error_reports', tags={
-        'action': data.get('action'),
-        'statusText': data.get('statusText'),
-        'state': data.get('state'),
-        'status': data.get('status'),
-        'domain': domain,
-    })
-    notify_error(message='Formplayer error reported from the browser', details=data)
+    error_type = data.get('type')
+    if error_type == 'webformsession_request_failure':
+        metrics_counter('commcare.formplayer.webformsession_request_failure', tags={
+            'action': data.get('action'),
+            'statusText': data.get('statusText'),
+            'state': data.get('state'),
+            'status': data.get('status'),
+            'domain': domain,
+        })
+        notify_error(message='Formplayer: request failure in web form session', details=data)
+    elif error_type == 'show_error_notification':
+        message = data.get('message')
+        metrics_counter('commcare.formplayer.show_error_notification', tags={
+            'message': _message_to_tag_value(message or 'no_message'),
+            'domain': domain,
+        })
+        notify_error(message=f'Formplayer: showed error to user: {message}', details=data)
+    else:
+        metrics_counter('commcare.formplayer.unknown_error_type', tags={
+            'domain': domain,
+        })
+        notify_error(message=f'Formplayer: unknown error type', details=data)
     return JsonResponse({'status': 'ok'})
+
+
+def _message_to_tag_value(message, allowed_chars=string.ascii_lowercase + '_'):
+    message_tag = '_'.join(unidecode(message).split(' ')[:4]).lower()
+    message_tag = ''.join(c for c in message_tag if c in allowed_chars)
+    return message_tag

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -495,7 +495,7 @@ def report_formplayer_error(request, domain):
     return JsonResponse({'status': 'ok'})
 
 
-def _message_to_tag_value(message, allowed_chars=string.ascii_lowercase + '_'):
+def _message_to_tag_value(message, allowed_chars=string.ascii_lowercase + string.digits + '_'):
     """
     Turn a long user-facing error message into a short slug that can be used as a datadog tag value
 
@@ -506,6 +506,8 @@ def _message_to_tag_value(message, allowed_chars=string.ascii_lowercase + '_'):
     'sorry_an_error_occurred'
     >>> _message_to_tag_value('Another process prevented us from servicing your request. Please try again later.')
     'another_process_prevented_us'
+    >>> _message_to_tag_value('509 Unknown Status Code')
+    '509_unknown_status_code'
     """
     message_tag = '_'.join(unidecode(message).split(' ')[:4]).lower()
     message_tag = ''.join(c for c in message_tag if c in allowed_chars)

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -473,7 +473,7 @@ def report_formplayer_error(request, domain):
     error_type = data.get('type')
     if error_type == 'webformsession_request_failure':
         metrics_counter('commcare.formplayer.webformsession_request_failure', tags={
-            'action': data.get('action'),
+            'request': data.get('request'),
             'statusText': data.get('statusText'),
             'state': data.get('state'),
             'status': data.get('status'),

--- a/corehq/ex-submodules/dimagi/utils/logging.py
+++ b/corehq/ex-submodules/dimagi/utils/logging.py
@@ -7,7 +7,7 @@ notify_logger = logging.getLogger('notify')
 
 
 def notify_error(message, details=None):
-    notify_logger.error(message, extra=details)
+    notify_logger.error(message, extra={'details': details})
 
 
 def notify_exception(request, message=None, details=None, exec_info=None):


### PR DESCRIPTION
##### SUMMARY

Our current web apps / formplayer metrics/logging strategy relies on (1) formplayer returning non-2xx responses for any kind of error and (2) formplayer reporting any issues it has to datadog/sentry. I think both of those are provably untrue, and not super-quickly fixable, so I think we need corroborating metrics that we report to HQ from the browser when we encounter clear/known errors states.

This PR reports to datadog and sentry whenever a request to formplayer fails (for any reason) while filling out a form. To datadog we report the values that have a fixed set of values like status code, status text (which I think is "accepted"/"rejected"), and also domain. To sentry we report everything we've got.
