### PR TITLE
update list to be comma separated string instead

### DIFF
--- a/custom/icds/location_reassignment/models.py
+++ b/custom/icds/location_reassignment/models.py
@@ -201,14 +201,14 @@ class MergeOperation(BaseOperation):
         timestamp = datetime.utcnow()
         new_location = self.new_locations[0]
         for old_location in self.old_locations:
-            old_location.metadata[DEPRECATED_TO] = [new_location.location_id]
+            old_location.metadata[DEPRECATED_TO] = f"{new_location.location_id}"
             old_location.metadata[DEPRECATED_AT] = timestamp
             old_location.metadata[DEPRECATED_VIA] = self.type
             old_location.is_archived = True
             old_location.archived_on = timestamp
             old_location.save()
 
-        new_location.metadata[DEPRECATES] = [l.location_id for l in self.old_locations]
+        new_location.metadata[DEPRECATES] = ",".join([l.location_id for l in self.old_locations])
         new_location.metadata[DEPRECATES_AT] = timestamp
         new_location.metadata[DEPRECATES_VIA] = self.type
         new_location.save()
@@ -224,7 +224,7 @@ class SplitOperation(BaseOperation):
     def perform(self):
         timestamp = datetime.utcnow()
         old_location = self.old_locations[0]
-        old_location.metadata[DEPRECATED_TO] = [l.location_id for l in self.new_locations]
+        old_location.metadata[DEPRECATED_TO] = ",".join([l.location_id for l in self.new_locations])
         old_location.metadata[DEPRECATED_AT] = timestamp
         old_location.metadata[DEPRECATED_VIA] = self.type
         old_location.is_archived = True
@@ -232,7 +232,7 @@ class SplitOperation(BaseOperation):
         old_location.save()
 
         for new_location in self.new_locations:
-            new_location.metadata[DEPRECATES] = [old_location.location_id]
+            new_location.metadata[DEPRECATES] = f"{old_location.location_id}"
             new_location.metadata[DEPRECATES_AT] = timestamp
             new_location.metadata[DEPRECATES_VIA] = self.type
             new_location.save()
@@ -246,12 +246,12 @@ class ExtractOperation(BaseOperation):
         timestamp = datetime.utcnow()
         old_location = self.old_locations[0]
         new_location = self.new_locations[0]
-        old_location.metadata[DEPRECATED_TO] = [new_location.location_id]
+        old_location.metadata[DEPRECATED_TO] = f"{new_location.location_id}"
         old_location.metadata[DEPRECATED_AT] = timestamp
         old_location.metadata[DEPRECATED_VIA] = self.type
         old_location.save()
 
-        new_location.metadata[DEPRECATES] = [old_location.location_id]
+        new_location.metadata[DEPRECATES] = f"{old_location.location_id}"
         new_location.metadata[DEPRECATES_AT] = timestamp
         new_location.metadata[DEPRECATES_VIA] = self.type
         new_location.save()
@@ -265,14 +265,14 @@ class MoveOperation(BaseOperation):
         timestamp = datetime.utcnow()
         old_location = self.old_locations[0]
         new_location = self.new_locations[0]
-        old_location.metadata[DEPRECATED_TO] = [new_location.location_id]
+        old_location.metadata[DEPRECATED_TO] = ",".join([new_location.location_id])
         old_location.metadata[DEPRECATED_AT] = timestamp
         old_location.metadata[DEPRECATED_VIA] = self.type
         old_location.is_archived = True
         old_location.archived_on = timestamp
         old_location.save()
 
-        new_location.metadata[DEPRECATES] = [old_location.location_id]
+        new_location.metadata[DEPRECATES] = f"{old_location.location_id}"
         new_location.metadata[DEPRECATES_AT] = timestamp
         new_location.metadata[DEPRECATES_VIA] = self.type
         new_location.save()

--- a/custom/icds/location_reassignment/tests/test_models.py
+++ b/custom/icds/location_reassignment/tests/test_models.py
@@ -63,8 +63,8 @@ class BaseTest(TestCase):
     def _validate_operation(self, operation, archived):
         old_locations = operation.old_locations
         new_locations = operation.new_locations
-        old_location_ids = [loc.location_id for loc in old_locations]
-        new_location_ids = [loc.location_id for loc in new_locations]
+        old_location_ids = ",".join([loc.location_id for loc in old_locations])
+        new_location_ids = ",".join([loc.location_id for loc in new_locations])
         operation_time = old_locations[0].metadata[DEPRECATED_AT]
         self.assertIsInstance(operation_time, datetime)
         for old_location in old_locations:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1249?focusedCommentId=48658

##### SUMMARY
Using a list in metadata causes it to be saved as a string at times if its saved from the UI and possibly from upload as well, so replace that to be a string of comma-separated locations ids instead.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`

fyi @calellowitz 
let me know if you want me to hold off on merge for this til you make changes on dashboard.
