### PR TITLE
Location Reassignment: Improvements to checks for site codes

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -26,6 +26,7 @@ from corehq.apps.es import UserES
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import Select2Ajax
 from corehq.apps.locations.permissions import LOCATION_ACCESS_DENIED
+from corehq.apps.locations.util import valid_location_site_code
 from corehq.apps.users.forms import (
     NewMobileWorkerForm,
     generate_strong_password,
@@ -246,8 +247,7 @@ class LocationForm(forms.Form):
 
         if site_code:
             site_code = site_code.lower()
-            slug_regex = re.compile(r'^[-_\w\d]+$')
-            if not slug_regex.match(site_code):
+            if not valid_location_site_code(site_code):
                 raise forms.ValidationError(_(
                     'The site code cannot contain spaces or special characters.'
                 ))

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -21,16 +21,11 @@ from corehq.apps.custom_data_fields.edit_entity import (
     CustomDataEditor,
     get_prefixed,
 )
-from corehq.apps.domain.models import Domain
 from corehq.apps.es import UserES
 from corehq.apps.hqwebapp import crispy as hqcrispy
 from corehq.apps.hqwebapp.widgets import Select2Ajax
 from corehq.apps.locations.permissions import LOCATION_ACCESS_DENIED
 from corehq.apps.locations.util import valid_location_site_code
-from corehq.apps.users.forms import (
-    NewMobileWorkerForm,
-    generate_strong_password,
-)
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import user_display_string
 from corehq.util.quickcache import quickcache

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -2,12 +2,13 @@ import re
 import tempfile
 from collections import OrderedDict
 
+from django.db.models import Q
+
 from memoized import memoized
 
 from couchexport.models import Format
 from couchexport.writers import Excel2007ExportWriter
 from dimagi.utils.couch.loosechange import map_reduce
-from django.db.models import Q
 from soil import DownloadBase
 from soil.util import expose_blob_download
 

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 from collections import OrderedDict
 
@@ -336,3 +337,8 @@ def get_locations_from_ids(location_ids, domain, base_queryset=None):
     if len(locations) != expected_count:
         raise SQLLocation.DoesNotExist('One or more of the locations was not found.')
     return locations
+
+
+def valid_location_site_code(site_code):
+    slug_regex = re.compile(r'^[-_\w\d]+$')
+    return slug_regex.match(site_code)

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -27,7 +27,7 @@ from custom.icds.location_reassignment.models import Transition
 
 def parse_site_code(site_code):
     if site_code:
-        return str(site_code)
+        return str(site_code).lower()
     return ''
 
 

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import attr
 
 from corehq.apps.locations.models import LocationType, SQLLocation
+from corehq.apps.locations.util import valid_location_site_code
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 from custom.icds.location_reassignment.const import (
@@ -68,14 +69,23 @@ class TransitionRow(object):
             errors.append(f"No change in location code for operation {self.operation}. "
                           f"Got old: '{self.old_site_code}' and new: '{self.new_site_code}'")
 
+        if not valid_location_site_code(self.old_site_code):
+            errors.append(f"Got invalid location code '{self.old_site_code}' for operation {self.operation}")
+        if not valid_location_site_code(self.new_site_code):
+            errors.append(f"Got invalid location code '{self.new_site_code}' for operation {self.operation}")
         if bool(self.new_username) != bool(self.old_username):
             errors.append(f"Need both old and new username for {self.operation} operation "
                           f"on location '{self.old_site_code}'")
         if not self.new_location_details.get('name', '').strip():
             errors.append(f"Missing new location name for {self.new_site_code}")
-        if self.expects_parent and not self.new_location_details.get('parent_site_code'):
+        parent_site_code = self.new_location_details.get('parent_site_code')
+        if parent_site_code:
+            if not valid_location_site_code(parent_site_code):
+                errors.append(f"Got invalid parent location code '{parent_site_code}' "
+                              f"for new location '{self.new_site_code}' for operation {self.operation}")
+        if self.expects_parent and not parent_site_code:
             errors.append(f"Need parent for '{self.new_site_code}'")
-        if not self.expects_parent and self.new_location_details.get('parent_site_code'):
+        if not self.expects_parent and parent_site_code:
             errors.append(f"Unexpected parent set for '{self.new_site_code}'")
         return errors
 

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -25,6 +25,12 @@ from custom.icds.location_reassignment.const import (
 from custom.icds.location_reassignment.models import Transition
 
 
+def parse_site_code(site_code):
+    if site_code:
+        return str(site_code)
+    return ''
+
+
 class TransitionRow(object):
     """
     An object representation of each row in excel
@@ -135,12 +141,12 @@ class Parser(object):
                 transition_row = TransitionRow(
                     location_type=location_type_code,
                     operation=operation,
-                    old_site_code=row.get(CURRENT_SITE_CODE_COLUMN),
-                    new_site_code=row.get(NEW_SITE_CODE_COLUMN),
+                    old_site_code=parse_site_code(row.get(CURRENT_SITE_CODE_COLUMN)),
+                    new_site_code=parse_site_code(row.get(NEW_SITE_CODE_COLUMN)),
                     expects_parent=expects_parent,
                     new_location_details={
                         'name': row.get(NEW_NAME),
-                        'parent_site_code': row.get(NEW_PARENT_SITE_CODE),
+                        'parent_site_code': parse_site_code(row.get(NEW_PARENT_SITE_CODE)),
                         'lgd_code': row.get(NEW_LGD_CODE),
                         'sub_district_name': row.get(NEW_SUB_DISTRICT_NAME)
                     },

--- a/custom/icds/location_reassignment/tests/test_parser.py
+++ b/custom/icds/location_reassignment/tests/test_parser.py
@@ -51,8 +51,8 @@ class TestParser(TestCase):
              'AWC-111', 'Supervisor 1', '11', '11',
              'username1', 'username1', 'Extract'),
             # valid operation to move 112 -> 131
-            ('AWC 2', 'AWC 3', '112', '131', 'AWC-112',
-             'AWC-131', 'Supervisor 2', '11', '13',
+            ('AWC 2', 'AWC 3', 112, 131, 'AWC-112',
+             'AWC-131', 'Supervisor 2', '11', 13,
              'username2', 'username3', 'Move'),
             # valid operation to merge 113 114 -> 132 but
             # with different lgd code for new location in 114

--- a/custom/icds/location_reassignment/tests/test_parser.py
+++ b/custom/icds/location_reassignment/tests/test_parser.py
@@ -79,7 +79,12 @@ class TestParser(TestCase):
             # valid operation to move 12 -> 13
             ('Supervisor 2', 'Supervisor 3', '12', '13', 'Sup-12',
              'Sup-13', 'State 1', '1', '1',
-             'username5', 'username6', 'Move'))),
+             'username5', 'username6', 'Move'),
+            # invalid values for site codes
+            ('Supervisor 4', 'Supervisor 5', 'Invalid $ite #code', 'NEW-- $ite #code', 'Sup-12',
+             'Sup-14', 'State 1', '1', '?--123--?',
+             'username7', 'username8', 'Move'),
+        )),
         ('state', (
             # invalid row with unknown operation
             ('State 1', 'State 1', '1', '1', 'State-1',
@@ -156,6 +161,10 @@ class TestParser(TestCase):
             self.assertEqual(errors, [
                 "Invalid Operation Unknown",
                 "Missing location code for operation Split. Got old: '11' and new: ''",
+                "Got invalid location code 'invalid $ite #code' for operation Move",
+                "Got invalid location code 'new-- $ite #code' for operation Move",
+                "Got invalid parent location code '?--123--?' for new location "
+                "'new-- $ite #code' for operation Move",
                 "No change in location code for operation Extract. Got old: '111' and new: '111'",
                 "New location 132 passed with different information",
                 "Missing new location name for 134"


### PR DESCRIPTION
##### SUMMARY
Some improvements for site codes
1. [Ticket](https://dimagi-dev.atlassian.net/browse/QA-1223?focusedCommentId=48380) -> always consider them as strings. A site code is meant to be a string and using them as integers, if received as integers from excel workbook can lead to errors
2. They should always be lower case
3. [Ticket](https://dimagi-dev.atlassian.net/browse/QA-1265) -> they should not have special characters

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
