### PR TITLE
set soft time limit much higher than default

### DIFF
--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -122,7 +122,7 @@ def set_rule_complete(rule_id):
 
 
 @no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
-                soft_time_limit=15*settings.CELERY_TASK_SOFT_TIME_LIMIT)
+                soft_time_limit=15 * settings.CELERY_TASK_SOFT_TIME_LIMIT)
 def run_messaging_rule(domain, rule_id):
     rule = _get_cached_rule(domain, rule_id)
     if not rule:

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -121,7 +121,8 @@ def set_rule_complete(rule_id):
     MessagingRuleProgressHelper(rule_id).set_rule_complete()
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True)
+@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
+                soft_time_limit=15*settings.CELERY_TASK_SOFT_TIME_LIMIT)
 def run_messaging_rule(domain, rule_id):
     rule = _get_cached_rule(domain, rule_id)
     if not rule:


### PR DESCRIPTION
To avoid [such error](https://sentry.io/organizations/dimagi/issues/1631921255/events/464d3217fe9546f48723bc509411ac38/?project=1545828&statsPeriod=14d)

https://docs.celeryproject.org/en/v4.1.0/userguide/tasks.html#Task.soft_time_limit

##### SUMMARY
A `run_messaging_rule` task ran for few days and failed due to error linked above. 
Currently the soft limit is set to two days (setting CELERY_TASK_SOFT_TIME_LIMIT), 
after which any celery task is killed by raising `SoftTimeLimitExceeded`. 
This PR updates the soft limit for this task to be 15 times the current setting i.e 30 days

More context on https://dimagi-dev.atlassian.net/browse/ICDS-1485
