### PR TITLE
Extend visibility of volatility warning based on user feedback

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -43,7 +43,7 @@ hqDefine('cloudcare/js/util', function () {
         if (message === undefined) {
             return;
         }
-        _show(message, $el, 5000, "alert alert-warning");
+        _show(message, $el, 30000, "alert alert-warning");
     };
 
     var showHTMLError = function (message, $el, autoHideTime) {


### PR DESCRIPTION
Users have indicated that the 5s visibility window into the volatility warning is too short.