### PR TITLE
Refer case repeater

### DIFF
--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -18,6 +18,7 @@ REPEATER_CLASSES = (
     'corehq.motech.repeaters.models.CaseRepeater',
     'corehq.motech.repeaters.models.CreateCaseRepeater',
     'corehq.motech.repeaters.models.UpdateCaseRepeater',
+    'corehq.motech.repeaters.models.ReferCaseRepeater',
     'corehq.motech.repeaters.models.ShortFormRepeater',
     'corehq.motech.repeaters.models.AppStructureRepeater',
     'corehq.motech.repeaters.models.UserRepeater',

--- a/corehq/motech/repeaters/exceptions.py
+++ b/corehq/motech/repeaters/exceptions.py
@@ -1,2 +1,6 @@
 class RequestConnectionError(Exception):
     pass
+
+
+class ReferralError(Exception):
+    pass

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -92,6 +92,8 @@ from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.parsing import json_format_datetime
 from dimagi.utils.post import simple_post
 
+from corehq import toggles
+
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.models import CommCareUser
@@ -108,6 +110,7 @@ from corehq.motech.repeaters.repeater_generators import (
     FormRepeaterJsonPayloadGenerator,
     FormRepeaterXMLPayloadGenerator,
     LocationPayloadGenerator,
+    ReferCasePayloadGenerator,
     ShortFormRepeaterJsonPayloadGenerator,
     UserPayloadGenerator,
 )
@@ -535,6 +538,26 @@ class UpdateCaseRepeater(CaseRepeater):
 
     def allowed_to_forward(self, payload):
         return super(UpdateCaseRepeater, self).allowed_to_forward(payload) and len(payload.xform_ids) > 1
+
+
+class ReferCaseRepeater(CaseRepeater):
+    """
+    A repeater that triggers off case changes but sends a form creating cases in
+    another commcare project
+    """
+    friendly_name = _("Forward Cases To Another Commcare Project")
+
+    payload_generator_classes = (ReferCasePayloadGenerator,)
+
+    @classmethod
+    def available_for_domain(cls, domain):
+        """Returns whether this repeater can be used by a particular domain
+        """
+        return toggles.REFER_CASE_REPEATER.enabled(domain)
+
+    def get_url(self, repeat_record):
+        new_domain = self.payload_doc(repeat_record).get_case_property('new_domain')
+        return self.url.format(domain=new_domain)
 
 
 class ShortFormRepeater(Repeater):

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -540,9 +540,9 @@ class UpdateCaseRepeater(CaseRepeater):
         return super(UpdateCaseRepeater, self).allowed_to_forward(payload) and len(payload.xform_ids) > 1
 
 
-class ReferCaseRepeater(CaseRepeater):
+class ReferCaseRepeater(CreateCaseRepeater):
     """
-    A repeater that triggers off case changes but sends a form creating cases in
+    A repeater that triggers off case creation but sends a form creating cases in
     another commcare project
     """
     friendly_name = _("Forward Cases To Another Commcare Project")

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -549,6 +549,10 @@ class ReferCaseRepeater(CaseRepeater):
 
     payload_generator_classes = (ReferCasePayloadGenerator,)
 
+    def form_class_name(self):
+        # Note this class does not exist but this property is only used to construct the URL
+        return 'ReferCaseRepeater'
+
     @classmethod
     def available_for_domain(cls, domain):
         """Returns whether this repeater can be used by a particular domain

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -282,7 +282,11 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
 
     def get_payload(self, repeat_record, payload_doc):
 
-        case_ids_to_forward = payload_doc.get_case_property('cases_to_forward').split(' ')
+        case_ids_to_forward = payload_doc.get_case_property('cases_to_forward')
+        if not case_ids_to_forward:
+            raise ReferralError(f'No cases included in transfer. Please add case ids to "cases_to_forward" property')
+        else:
+            case_ids_to_forward = case_ids_to_forward.split(' ')
         new_owner = payload_doc.get_case_property('new_owner')
         cases_to_forward = CaseAccessors(payload_doc.domain).get_cases(case_ids_to_forward)
         case_ids_to_forward = set(case_ids_to_forward)

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -313,7 +313,7 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
                 constant_properties
             )
 
-        case_blocks = self._get_case_blocks(cases_to_forward, case_ids_to_forward, case_type_configs)
+        case_blocks = self._get_case_blocks(cases_to_forward, case_ids_to_forward, case_type_configs, new_owner)
         return render_to_string('hqcase/xml/case_block.xml', {
             'xmlns': SYSTEM_FORM_XMLNS,
             'case_block': case_blocks,
@@ -324,7 +324,7 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
             'device_id': "ReferCaseRepeater",
         })
 
-    def _get_case_blocks(self):
+    def _get_case_blocks(self, cases_to_forward, case_ids_to_forward, case_type_configs, new_owner):
         case_blocks = []
         case_id_map = {}
         for case in cases_to_forward:

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -319,17 +319,17 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
                 if key.startswith(constant_prefix):
                     property_name = key[len(constant_prefix):]
                     constant_properties.append((property_name, value))
-            whitelist = payload_doc.case_json.get(f'{case_type}_whitelist', '').split(' ')
-            blacklist = payload_doc.case_json.get(f'{case_type}_blacklist', '').split(' ')
+            whitelist = payload_doc.case_json.get(f'{case_type}_whitelist')
+            blacklist = payload_doc.case_json.get(f'{case_type}_blacklist')
             if blacklist and whitelist:
                 raise ReferralError(f'both blacklist and whitelist included for {case_type}')
             if not blacklist and not whitelist:
                 raise ReferralError(f'blacklist or whitelist not included for {case_type}')
             if blacklist:
-                listed_properties = blacklist
+                listed_properties = blacklist.split(' ')
                 use_blacklist = True
             else:
-                listed_properties = whitelist
+                listed_properties = whitelist.split(' ')
                 use_blacklist = False
             case_type_configs[case_type] = CaseTypeReferralConfig(
                 use_blacklist,

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -15,6 +15,7 @@ from casexml.apps.case.xml import V2
 from dimagi.utils.parsing import json_format_datetime
 
 from corehq.apps.receiverwrapper.exceptions import DuplicateFormatException
+from corehq.apps.users.models import CouchUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.repeaters.exceptions import ReferralError
 

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -4,7 +4,10 @@ from collections import namedtuple
 from datetime import datetime
 from uuid import uuid4
 
+import attr
+
 from django.core.serializers.json import DjangoJSONEncoder
+from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
 from casexml.apps.case.xform import get_case_ids_from_form
@@ -12,6 +15,8 @@ from casexml.apps.case.xml import V2
 from dimagi.utils.parsing import json_format_datetime
 
 from corehq.apps.receiverwrapper.exceptions import DuplicateFormatException
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.motech.repeaters.exceptions import ReferralError
 
 
 def _get_test_form(domain):
@@ -259,6 +264,103 @@ class CaseRepeaterJsonPayloadGenerator(BasePayloadGenerator):
                 user_id='user1', prop_a=True, prop_b='value'
             )
         )
+
+
+@attr.s
+class CaseTypeReferralConfig(object):
+    #if false, listed_properties is a whitelist
+    use_blacklist = attr.ib()
+    listed_properties = attr.ib()
+    constant_properties = attr.ib()
+
+
+class ReferCasePayloadGenerator(BasePayloadGenerator):
+
+    def get_payload(self, repeat_record, payload_doc):
+
+        def _update_case_id(original_case_id, case_id_map):
+            if original_case_id in case_id_map:
+                new_case_id = case_id_map[original_case_id]
+            else:
+                new_case_id = uuid4().hex
+                case_id_map[original_case_id] = new_case_id
+            return new_case_id
+
+        def _update_case_properties_with_blacklist(case, config):
+            for name in config.listed_properties:
+                if name in case.case_json:
+                    del case.case_json[name]
+
+        def _update_case_properties_with_whitelist(case, config):
+            new_json = {}
+            for name in config.listed_properties:
+                if name in case.case_json:
+                    new_json[name] = case.case_json[name]
+            case.case_json = new_json
+
+        def _set_constant_properties(case, config):
+            for name, value in config.constant_properties:
+                case.case_json[name] = value
+
+        case_ids_to_forward = payload_doc.get_case_property('cases_to_forward').split(' ')
+        new_owner = payload_doc.get_case_property('new_owner')
+        cases_to_forward = CaseAccessors(payload_doc.domain).get_cases(case_ids_to_forward)
+        case_ids_to_forward = set(case_ids_to_forward)
+        included_case_types = payload_doc.get_case_property('case_types').split(' ')
+        case_type_configs = {}
+        for case_type in included_case_types:
+            constant_properties = []
+            for key, value in payload_doc.case_json.items():
+                constant_prefix = f'{case_type}_setter_'
+                if key.startswith(constant_prefix):
+                    property_name = key[len(constant_prefix):]
+                    constant_properties.append((property_name, value))
+            whitelist = payload_doc.get_case_property(f'{case_type}_whitelist')
+            blacklist = payload_doc.get_case_property(f'{case_type}_blacklist')
+            if blacklist and whitelist:
+                raise ReferralError(f'both blacklist and whitelist included for {case_type}')
+            if not blacklist and not whitelist:
+                raise ReferralError(f'blacklist or whitelist not included for {case_type}')
+            if blacklist:
+                listed_properties = blacklist
+                use_blacklist = True
+            else:
+                listed_properties = whitelist
+                use_blacklist = False
+            case_type_configs[case_type] = CaseTypeReferralConfig(
+                use_blacklist,
+                listed_properties,
+                constant_properties
+            )
+
+        case_blocks = []
+        case_id_map = {}
+        for case in cases_to_forward:
+            original_id = case.case_id
+            indices = case.indices
+            case.case_id = _update_case_id(original_id, case_id_map)
+            case.owner_id = new_owner
+            for index in indices:
+                if index.referenced_id in case_ids_to_forward:
+                    index.referenced_id = _update_case_id(index.referenced_id, case_id_map)
+                else:
+                    raise ReferralError(f'case {original_id} included without referenced case {index.referenced_id}')
+            config = case_type_configs[case.type]
+            if config.use_blacklist:
+                _update_case_properties_with_blacklist(case, config)
+            else:
+                _update_case_properties_with_whitelist(case, config)
+            _set_constant_properties(case, config)
+            case_blocks.append(case.to_xml(V2))
+        return render_to_string('hqcase/xml/case_block.xml', {
+            'xmlns': SYSTEM_FORM_XMLNS,
+            'case_block': case_blocks,
+            'time': datetime.utcnow(),
+            'uid': uuid4().hex,
+            'username': self.repeater.username,
+            'user_id': CouchUser.get_by_username(self.repeater.username).user_id,
+            'device_id': "ReferCaseRepeater",
+        })
 
 
 class AppStructureGenerator(BasePayloadGenerator):

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -19,6 +19,9 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.motech.repeaters.exceptions import ReferralError
 
 
+SYSTEM_FORM_XMLNS = 'http://commcarehq.org/case'
+
+
 def _get_test_form(domain):
     from corehq.form_processor.utils import TestFormMetadata
     from corehq.form_processor.utils import get_simple_wrapped_form

--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -319,8 +319,8 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
                 if key.startswith(constant_prefix):
                     property_name = key[len(constant_prefix):]
                     constant_properties.append((property_name, value))
-            whitelist = payload_doc.get_case_property(f'{case_type}_whitelist')
-            blacklist = payload_doc.get_case_property(f'{case_type}_blacklist')
+            whitelist = payload_doc.case_json.get(f'{case_type}_whitelist', '').split(' ')
+            blacklist = payload_doc.case_json.get(f'{case_type}_blacklist', '').split(' ')
             if blacklist and whitelist:
                 raise ReferralError(f'both blacklist and whitelist included for {case_type}')
             if not blacklist and not whitelist:
@@ -355,7 +355,8 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
             else:
                 _update_case_properties_with_whitelist(case, config)
             _set_constant_properties(case, config)
-            case_blocks.append(case.to_xml(V2))
+            case_blocks.append(case.to_xml(V2).decode('utf-8'))
+            case_blocks = ''.join(case_blocks)
         return render_to_string('hqcase/xml/case_block.xml', {
             'xmlns': SYSTEM_FORM_XMLNS,
             'case_block': case_blocks,

--- a/corehq/motech/repeaters/signals.py
+++ b/corehq/motech/repeaters/signals.py
@@ -14,6 +14,7 @@ from corehq.form_processor.models import CommCareCaseSQL
 from corehq.motech.repeaters.models import (
     CreateCaseRepeater,
     UpdateCaseRepeater,
+    ReferCaseRepeater
 )
 
 
@@ -28,6 +29,7 @@ def create_case_repeat_records(sender, case, **kwargs):
     create_repeat_records(CaseRepeater, case)
     create_repeat_records(CreateCaseRepeater, case)
     create_repeat_records(UpdateCaseRepeater, case)
+    create_repeat_records(ReferCaseRepeater, case)
 
 
 def create_short_form_repeat_records(sender, xform, **kwargs):

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -48,6 +48,8 @@ urlpatterns = [
         {'repeater_type': 'CaseRepeater'}, name=EditCaseRepeaterView.urlname),
     url(r'^forwarding/edit/FormRepeater/(?P<repeater_id>\w+)/$', EditFormRepeaterView.as_view(),
         {'repeater_type': 'FormRepeater'}, name=EditFormRepeaterView.urlname),
+    url(r'^forwarding/edit/ReferCaseRepeater/(?P<repeater_id>\w+)/$', EditCaseRepeaterView.as_view(),
+        {'repeater_type': 'ReferCaseRepeater'}, name=EditCaseRepeaterView.urlname),
     url(r'^forwarding/edit/OpenmrsRepeater/(?P<repeater_id>\w+)/$', EditOpenmrsRepeaterView.as_view(),
         {'repeater_type': 'OpenmrsRepeater'}, name=EditOpenmrsRepeaterView.urlname),
     url(r'^forwarding/edit/Dhis2Repeater/(?P<repeater_id>\w+)/$', EditDhis2RepeaterView.as_view(),

--- a/corehq/motech/urls.py
+++ b/corehq/motech/urls.py
@@ -40,6 +40,8 @@ urlpatterns = [
         {'repeater_type': 'Dhis2EntityRepeater'}, name=AddDhis2EntityRepeaterView.urlname),
     url(r'^forwarding/new/SearchByParamsRepeater/$', AddCaseRepeaterView.as_view(),
         {'repeater_type': 'SearchByParamsRepeater'}, name=AddCaseRepeaterView.urlname),
+    url(r'^forwarding/new/ReferCaseRepeater/$', AddCaseRepeaterView.as_view(),
+        {'repeater_type': 'ReferCaseRepeater'}, name=AddCaseRepeaterView.urlname),
     url(r'^forwarding/new/(?P<repeater_type>\w+)/$', AddRepeaterView.as_view(), name=AddRepeaterView.urlname),
 
     url(r'^forwarding/edit/CaseRepeater/(?P<repeater_id>\w+)/$', EditCaseRepeaterView.as_view(),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1899,3 +1899,10 @@ ICDS_LOCATION_REASSIGNMENT_AGG = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     relevant_environments={'icds', 'india'},
 )
+
+REFER_CASE_REPEATER = StaticToggle(
+    'refer_case_repeater',
+    'COVID: Allow refer case repeaters to be setup',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This implements a new repeater that allows sending cases to a different project space.

The spec is https://docs.google.com/document/d/11NJ2lLBU5AQJVaeF5vko-n3pN9anPutYGJSSXqqkZ3I/edit#heading=h.1j7wj62si3n8
The bottom includes the list of expected case properties for this to work correctly

I tagged a bunch of people I thought were either working on covid or had recent repeater experience.

This is not totally complete (the rendered xform is not exactly correct), but the structure will remain the same, just cleaning up the xml bugs. I do plan to comment that code a little more as well, but left comments on the PR to allow easier review at this point