### PR TITLE
Fixed 'Submitted by' label to show non-domain users

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1520,7 +1520,7 @@ def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
     if getattr(form, 'auth_context', None):
         auth_context = AuthContext(form.auth_context)
         auth_context_user_id = auth_context.user_id
-        auth_user_info = get_doc_info_by_id(domain, auth_context_user_id)
+        auth_user_info = get_doc_info_by_id(None, auth_context_user_id)
     else:
         auth_user_info = get_doc_info_by_id(domain, None)
         auth_context = AuthContext(
@@ -1541,7 +1541,7 @@ def _get_form_metadata_context(domain, form, timezone, support_enabled=False):
             display='admin',
         )
     else:
-        user_info = get_doc_info_by_id(domain, meta_userID)
+        user_info = get_doc_info_by_id(None, meta_userID)
 
     return {
         "form_meta_data": form_meta_data,


### PR DESCRIPTION
https://trello.com/c/p5aVn2Ua/20-clearer-submission-as-labels

Old behavior: the top right area here showed email addresses for domain members but ids for non-members.

![Screen Shot 2020-05-08 at 1 08 53 PM](https://user-images.githubusercontent.com/1486591/81430234-1b8cf580-912d-11ea-8b6f-4f8ad9cab154.png)

New behavior: show email address for all submitters. It's reasonable for users to see who has submitted data in their domain, even if the submitter is not (or no longer) a member of the domain.