### PR TITLE
Enable action.auto_create_index in docker ES

### DIFF
--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.conf import settings
 from django.test import SimpleTestCase
-from corehq.util.es.elasticsearch import ConnectionError, NotFoundError
+from corehq.util.es.elasticsearch import ConnectionError
 
 from corehq.elastic import get_es_new
 from corehq.util.elastic import ensure_index_deleted
@@ -167,12 +167,6 @@ class TestSendToElasticsearch(SimpleTestCase):
     def test_create_doc(self):
         doc = {'_id': uuid.uuid4().hex, 'doc_type': 'MyCoolDoc', 'property': 'foo'}
         self._send_to_es_and_check(doc)
-
-    def test_auto_index_creation_fails(self):
-        es = get_es_new()
-        ensure_index_deleted(self.index)
-        with self.assertRaises(NotFoundError):
-            es.create(self.index, TEST_INDEX_INFO.type, {"username": "test"}, id="1")
 
     def _send_to_es_and_check(self, doc, update=False, es_merge_update=False,
                               delete=False, esgetter=None):

--- a/docker/files/elasticsearch.yml
+++ b/docker/files/elasticsearch.yml
@@ -10,4 +10,10 @@ http.cors.allow-origin: "*"
 http.cors.enabled: true
 index.max_result_window: 1000000
 
-action.auto_create_index: false
+# Eventually we want to enable this option, but currently it causes ES
+# timeouts due to tests referencing non-existent indices. For example,
+# saving a user triggers an async task that updates ES, and that fails
+# if the index does not exist. Many tests create and save users but few
+# do explicit ES index creation as is conventional for tests that
+# interact with ES.
+#action.auto_create_index: false


### PR DESCRIPTION
Reverts a change made in https://github.com/dimagi/commcare-hq/pull/27156. Other test changes made in that PR should be kept since they perform ES index maintenance that will be necessary if (when) we eventually re-enable this option.

This is expected to improve some massively long-running (120s-300s) tests.