### PR TITLE
Allow End-User Lock Eviction

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -14,6 +14,7 @@ var formplayerLoading = hqImport('cloudcare/js/util').formplayerLoading;
 var formplayerLoadingComplete = hqImport('cloudcare/js/util').formplayerLoadingComplete;
 var formplayerSyncComplete = hqImport('cloudcare/js/util').formplayerSyncComplete;
 var clearUserDataComplete = hqImport('cloudcare/js/util').clearUserDataComplete;
+var breakLocksComplete = hqImport('cloudcare/js/util').breakLocksComplete;
 var appcues = hqImport('analytix/js/appcues');
 
 FormplayerFrontend.on("before:start", function () {
@@ -568,6 +569,35 @@ FormplayerFrontend.on('refreshApplication', function (appId) {
         $("#cloudcare-notifications").empty();
         FormplayerFrontend.trigger('navigateHome');
     });
+});
+
+/**
+ * breakLocks
+ *
+ * Sends a request to formplayer to wipe out all application and user db for the
+ * current user. Returns the ajax promise.
+ */
+FormplayerFrontend.reqres.setHandler('breakLocks', function () {
+    var user = FormplayerFrontend.request('currentUser'),
+        formplayer_url = user.formplayer_url,
+        resp,
+        options = {
+            url: formplayer_url + "/break_locks",
+            data: JSON.stringify({
+                domain: user.domain,
+                username: user.username,
+                restoreAs: user.restoreAs,
+            }),
+        };
+    Util.setCrossDomainAjaxOptions(options);
+    formplayerLoading();
+    resp = $.ajax(options);
+    resp.fail(function () {
+        formplayerLoadingComplete(true);
+    }).done(function (response) {
+        breakLocksComplete(response.hasOwnProperty('exception'), response.message);
+    });
+    return resp;
 });
 
 /**

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -43,6 +43,10 @@ FormplayerFrontend.module("Apps", function (Apps, FormplayerFrontend, Backbone, 
                     new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_LANG }),
                     new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_DISPLAY }),
                 ]);
+            } else {
+		    settings.push(
+		    new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.BREAK_LOCKS })
+		    );
             }
             settings.push(
                 new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.CLEAR_USER_DATA })

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/controller.js
@@ -44,9 +44,9 @@ FormplayerFrontend.module("Apps", function (Apps, FormplayerFrontend, Backbone, 
                     new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.SET_DISPLAY }),
                 ]);
             } else {
-		    settings.push(
-		    new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.BREAK_LOCKS })
-		    );
+                settings.push(
+                    new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.BREAK_LOCKS })
+                );
             }
             settings.push(
                 new Backbone.Model({ slug: FormplayerFrontend.Layout.Views.SettingSlugs.CLEAR_USER_DATA })

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -80,6 +80,28 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         },
     });
 
+     /**
+     * Break exising locks
+     * Available only for Web Apps
+     */
+    var BreakLocksView = Marionette.ItemView.extend({
+        template: '#break-locks-setting-template',
+        tagName: 'tr',
+        ui: {
+            breakLocks: '.js-break-locks',
+        },
+        events: {
+            'click @ui.breakLocks': 'onClickBreakLocks',
+        },
+        onClickBreakLocks: function (e) {
+            var promise = FormplayerFrontend.request('breakLocks');
+            $(e.currentTarget).prop('disabled', true);
+            promise.done(function () {
+                $(e.currentTarget).prop('disabled', false);
+            });
+        },
+    });
+
     Views.SettingsView = Marionette.CompositeView.extend({
         ui: {
             done: '.js-done',
@@ -92,6 +114,8 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
                 return DisplaySettingView;
             } else if (item.get('slug') === Views.SettingSlugs.CLEAR_USER_DATA) {
                 return ClearUserDataView;
+            } else if (item.get('slug') === Views.SettingSlugs.BREAK_LOCKS) {
+                return BreakLocksView
             }
         },
         events: {
@@ -107,6 +131,7 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         SET_LANG: 'lang',
         SET_DISPLAY: 'display',
         CLEAR_USER_DATA: 'clear-user-data',
+        BREAK_LOCKS: 'break-locks',
     };
 
 });

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/layout/views/settings.js
@@ -80,7 +80,7 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
         },
     });
 
-     /**
+    /**
      * Break exising locks
      * Available only for Web Apps
      */
@@ -115,7 +115,7 @@ FormplayerFrontend.module("Layout.Views", function (Views, FormplayerFrontend, B
             } else if (item.get('slug') === Views.SettingSlugs.CLEAR_USER_DATA) {
                 return ClearUserDataView;
             } else if (item.get('slug') === Views.SettingSlugs.BREAK_LOCKS) {
-                return BreakLocksView
+                return BreakLocksView;
             }
         },
         events: {

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -136,7 +136,7 @@ hqDefine('cloudcare/js/util', function () {
         } else {
             showSuccess(message, $('#cloudcare-notifications'), 5000);
         }
-    }
+    };
 
     var hideLoading = function (selector) {
         NProgress.done();

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -126,6 +126,18 @@ hqDefine('cloudcare/js/util', function () {
         }
     };
 
+    var breakLocksComplete = function (isError, message) {
+        hideLoading();
+        if (isError) {
+            showError(
+                gettext('Error breaking locks. Please report an issue if this persists.'),
+                $('#cloudcare-notifications')
+            );
+        } else {
+            showSuccess(message, $('#cloudcare-notifications'), 5000);
+        }
+    }
+
     var hideLoading = function (selector) {
         NProgress.done();
     };
@@ -164,6 +176,7 @@ hqDefine('cloudcare/js/util', function () {
         showHTMLError: showHTMLError,
         showSuccess: showSuccess,
         clearUserDataComplete: clearUserDataComplete,
+        breakLocksComplete: breakLocksComplete,
         formplayerLoading: formplayerLoading,
         formplayerLoadingComplete: formplayerLoadingComplete,
         formplayerSyncComplete: formplayerSyncComplete,

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -37,3 +37,8 @@
   <th>{% trans "Clear user data" %}</th>
   <td><button class="js-clear-user-data btn btn-sm btn-danger">{% trans "Clear" %}</button></td>
 </script>
+<script type="text/template" id="break-locks-setting-template">
+	  <th>{% trans "Break Pending Request Locks" %}</th>
+	    <td><button class="js-break-locks btn btn-sm btn-danger">{% trans "Break" %}</button></td>
+</script>
+~


### PR DESCRIPTION
Certain user facing actions can take extremely long amounts of time in Formplayer, leaving users hung. This exposes a UI button (similar to 'clear user data') to trigger a lock eviction, which will request threads holding the lock to interrupt and safely exit. 

Relies on: https://github.com/dimagi/formplayer/pull/722

![image](https://user-images.githubusercontent.com/155066/81460470-8eb95a80-9173-11ea-8c58-93e5829b21a0.png)

##### SUMMARY
Still need to decide whether this is acceptable to expose to end users. Unfortunately it will be quite hard to make this an admin action which can be targeted at other users, and we're already occasionally having issues with bad locks, so I'm defaulting to this being public.

I believe this process is safe, as lock eviction can't actually kill a thread or unsafely expose the lock in the current design, it simply forces an interrupt.

##### PRODUCT DESCRIPTION
Allows users to cancel long-running requests in Web Apps
