### PR TITLE
Location reassignment fix descendants check

### DIFF
--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -260,11 +260,11 @@ class Parser(object):
             .values_list('site_code', flat=True)
         )
         if len(deprecating_locations_site_codes) != len(self.site_codes_to_be_deprecated):
-            self.errors.append(f"Found {len(deprecating_locations_site_codes)} locations for "
+            self.errors.append(f"Found {len(deprecating_locations_site_codes)} location(s) for "
                                f"{len(self.site_codes_to_be_deprecated)} deprecating site codes")
         missing_site_codes = set(self.site_codes_to_be_deprecated) - set(deprecating_locations_site_codes)
         if missing_site_codes:
-            self.errors.append(f"Could not find old locations with site codes {','.join(missing_site_codes)}")
+            self.errors.append(f"Could not find old location(s) with site codes {','.join(missing_site_codes)}")
 
     def _validate_descendants_deprecated(self):
         """

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -291,7 +291,7 @@ class Parser(object):
                     if not descendants_sites_codes:
                         continue
                     if operation == EXTRACT_OPERATION:
-                        if not set(descendants_sites_codes) & site_codes_to_be_deprecated:
+                        if not (set(descendants_sites_codes) & site_codes_to_be_deprecated):
                             self.errors.append(
                                 f"Location {location.site_code} is getting deprecated via {operation} "
                                 f"but none of its descendants")

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -288,6 +288,8 @@ class Parser(object):
                         self.errors.append(f"Could not find old location with site code {old_site_code}")
                         continue
                     descendants_sites_codes = location.child_locations().values_list('site_code', flat=True)
+                    if not descendants_sites_codes:
+                        continue
                     if operation == EXTRACT_OPERATION:
                         if not set(descendants_sites_codes) & site_codes_to_be_deprecated:
                             self.errors.append(


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1278

##### SUMMARY
When checking for descendants getting archived or performing in an operation, in case there are no descendants, HQ should not complain.
The logic around it was recently updated in https://github.com/dimagi/commcare-hq/commit/d2b85b5c12218f34f08512542b835a16a75042ff#diff-0a2b06adf5cfe8b41c18b93ccf555aeaR286 when a different check for extract was added where in case of no descendants the logic results in an error whereas in case of other operations it would just pass.
This PR updates to skip any check for descendants in case they are not present at the first place.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
