### PR TITLE
Add archived on to json

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -486,7 +486,7 @@ class SQLLocation(AdjListModel):
             'domain': self.domain,
             'external_id': self.external_id,
             'is_archived': self.is_archived,
-            'archived_on': self.archived_on.isoformat(),
+            'archived_on': self.archived_on.isoformat() if self.archived_on else None,
             'last_modified': self.last_modified.isoformat(),
             'latitude': float(self.latitude) if self.latitude else None,
             'longitude': float(self.longitude) if self.longitude else None,

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -486,6 +486,7 @@ class SQLLocation(AdjListModel):
             'domain': self.domain,
             'external_id': self.external_id,
             'is_archived': self.is_archived,
+            'archived_on': self.archived_on.isoformat(),
             'last_modified': self.last_modified.isoformat(),
             'latitude': float(self.latitude) if self.latitude else None,
             'longitude': float(self.longitude) if self.longitude else None,

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -166,6 +166,7 @@ class LocationsTest(TestCase):
         loc.archive()
         loc.refresh_from_db()
         self.assertIsInstance(loc.archived_on, datetime.datetime)
+        self.assertEqual(loc.archived_on.isoformat(), loc.to_json()['archived_on'])
         loc.unarchive()
         loc.refresh_from_db()
         self.assertIsNone(loc.archived_on)

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -884,6 +884,7 @@ class LocationRepeaterTest(TestCase, DomainSubscriptionMixin):
                 'domain': self.domain,
                 'external_id': None,
                 'is_archived': False,
+                'archived_on': None,
                 'last_modified': location.last_modified.isoformat(),
                 'latitude': None,
                 'lineage': [],


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1283

##### SUMMARY
Follow up to https://github.com/dimagi/commcare-hq/pull/27319 to reveal timestamp on raw_doc page by adding to `to_json`


