### PR TITLE
Initial enterprise linked domains

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -96,7 +96,7 @@ def login_and_domain_required(view_func):
                 raise Http404()
             return call_view()
 
-        if couch_user.is_member_of(domain_obj):
+        if couch_user.is_member_of(domain_obj, include_enterprise=True):
             if _is_missing_two_factor(view_func, req):
                 return TemplateResponse(request=req, template='two_factor/core/otp_required.html', status=403)
             elif not _can_access_project_page(req):
@@ -111,12 +111,6 @@ def login_and_domain_required(view_func):
             if not _can_access_project_page(req):
                 return _redirect_to_project_access_upgrade(req)
             return call_view()
-
-        from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
-        master_link = get_domain_master_link(domain_obj.name)
-        if master_link and not master_link.is_remote:
-            if ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
-                return call_view()
 
         if couch_user.is_web_user() and domain_obj.allow_domain_requests:
             from corehq.apps.users.views import DomainRequestView

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -45,6 +45,7 @@ from corehq.apps.hqwebapp.signals import clear_login_attempts
 from corehq.apps.users.models import CouchUser
 from corehq.toggles import (
     DATA_MIGRATION,
+    ENTERPRISE_LINKED_DOMAINS,
     IS_CONTRACTOR,
     PUBLISH_CUSTOM_REPORTS,
     TWO_FACTOR_SUPERUSER_ROLLOUT,
@@ -100,9 +101,9 @@ def login_and_domain_required(view_func):
                 return TemplateResponse(request=req, template='two_factor/core/otp_required.html', status=403)
             elif not _can_access_project_page(req):
                 return _redirect_to_project_access_upgrade(req)
-            else:
-                return call_view()
-        elif user.is_superuser:
+            return call_view()
+
+        if user.is_superuser:
             if domain_obj.restrict_superusers and not _page_is_whitelisted(req.path, domain_obj.name):
                 from corehq.apps.hqwebapp.views import no_permissions
                 msg = "This project space restricts superuser access.  You must request an invite to access it."
@@ -110,11 +111,18 @@ def login_and_domain_required(view_func):
             if not _can_access_project_page(req):
                 return _redirect_to_project_access_upgrade(req)
             return call_view()
-        elif couch_user.is_web_user() and domain_obj.allow_domain_requests:
+
+        from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
+        master_link = get_domain_master_link(domain_obj.name)
+        if master_link and not master_link.is_remote:
+            if ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
+                return call_view()
+
+        if couch_user.is_web_user() and domain_obj.allow_domain_requests:
             from corehq.apps.users.views import DomainRequestView
             return DomainRequestView.as_view()(req, *args, **kwargs)
-        else:
-            raise Http404
+
+        raise Http404
 
     return _inner
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -738,12 +738,7 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
             return "Snapshot of %s" % self.copied_from.display_name()
         return self.hr_name or self.name
 
-    def long_display_name(self):
-        if self.is_snapshot:
-            return format_html("Snapshot of {}", self.copied_from.display_name())
-        return self.hr_name or self.name
-
-    __str__ = long_display_name
+    __str__ = display_name
 
     def get_license_display(self):
         return LICENSES.get(self.license)

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -22,7 +22,7 @@
       {% endif %}
       <h2>{% trans "My Projects" %}</h2>
       <ul class="nav nav-pills nav-stacked">
-        {% for link in user_domain_links %}
+        {% for link in domain_links %}
           <li><a href="{{ link.url }}">{{ link.name }}</a></li>
         {% endfor %}
       </ul>

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -26,6 +26,14 @@
           <li><a href="{% url next_view domain.name %}">{{ domain.display_name }}</a></li>
         {% endfor %}
       </ul>
+      {% if linked_domains_for_user %}
+        <h2>{% trans "All Projects" %}</h2>
+        <ul class="nav nav-pills nav-stacked">
+          {% for domain in linked_domains_for_user %}
+            <li><a href="{% url next_view domain.name %}">{{ domain.display_name }}</a></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
     </div>
     <div class="col-sm-4">
     </div>

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -26,10 +26,10 @@
           <li><a href="{{ link.url }}">{{ link.name }}</a></li>
         {% endfor %}
       </ul>
-      {% if linked_domain_links %}
+      {% if enterprise_domain_links %}
         <h2>{% trans "Enterprise Projects" %}</h2>
         <ul class="nav nav-pills nav-stacked">
-          {% for link in linked_domain_links %}
+          {% for link in enterprise_domain_links %}
             <li><a href="{{ link.url }}">{{ link.name }}</a></li>
           {% endfor %}
         </ul>

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -22,8 +22,8 @@
       {% endif %}
       <h2>{% trans "My Projects" %}</h2>
       <ul class="nav nav-pills nav-stacked">
-        {% for domain in domains_for_user %}
-          <li><a href="{% url next_view domain.name %}">{{ domain.display_name }}</a></li>
+        {% for link in user_domain_links %}
+          <li><a href="{{ link.url }}">{{ link.name }}</a></li>
         {% endfor %}
       </ul>
       {% if linked_domains_for_user %}

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -7,12 +7,6 @@
 {% block page_content %}
   <div class="row">
     <div class="col-sm-4">
-      <h2>{% trans "My Projects" %}</h2>
-      <ul class="nav nav-pills nav-stacked">
-        {% for domain in domains_for_user %}
-          <li><a href="{% url next_view domain.name %}">{{ domain.display_name }}</a></li>
-        {% endfor %}
-      </ul>
       {% if open_invitations %}
         <h2>{% trans "Project Invitations" %}</h2>
         <ul class="list-unstyled">
@@ -26,6 +20,12 @@
           {% endfor %}
         </ul>
       {% endif %}
+      <h2>{% trans "My Projects" %}</h2>
+      <ul class="nav nav-pills nav-stacked">
+        {% for domain in domains_for_user %}
+          <li><a href="{% url next_view domain.name %}">{{ domain.display_name }}</a></li>
+        {% endfor %}
+      </ul>
     </div>
     <div class="col-sm-4">
     </div>

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -26,11 +26,11 @@
           <li><a href="{{ link.url }}">{{ link.name }}</a></li>
         {% endfor %}
       </ul>
-      {% if linked_domains_for_user %}
-        <h2>{% trans "All Projects" %}</h2>
+      {% if linked_domain_links %}
+        <h2>{% trans "Enterprise Projects" %}</h2>
         <ul class="nav nav-pills nav-stacked">
-          {% for domain in linked_domains_for_user %}
-            <li><a href="{% url next_view domain.name %}">{{ domain.display_name }}</a></li>
+          {% for link in linked_domain_links %}
+            <li><a href="{{ link.url }}">{{ link.name }}</a></li>
           {% endfor %}
         </ul>
       {% endif %}

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -35,17 +35,5 @@
         </ul>
       {% endif %}
     </div>
-    <div class="col-sm-4">
-    </div>
-    <div class="col-sm-4">
-      {% if not restrict_domain_creation or request.user.is_superuser %}
-        {% if not hide_create_new_project %}
-          <aside class="well">
-            <h3>{% trans "Have a new idea?" %}</h3>
-            <a class="btn btn-primary" href="{% url "registration_domain" %}">{% trans "Create a Blank Project" %}</a>
-          </aside>
-        {% endif %}
-      {% endif %}
-    </div>
   </div>
 {% endblock %}

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -78,24 +78,22 @@ Link = namedtuple('Link', ('name', 'url'))
 
 @quickcache(['couch_user.username'])
 def get_domain_dropdown_links(couch_user, view_name="domain_homepage"):
-    domains = Domain.active_for_user(couch_user)
     domain_links = [Link(
         name=domain_obj.display_name(),
         url=reverse(view_name, args=[domain_obj.name]),
-    ) for domain_obj in domains]
+    ) for domain_obj in Domain.active_for_user(couch_user)]
 
     enterprise_domain_links = []
     domains = {d.name for d in domain_links}
-    for domain_obj in domain_links:
-        domain = domain_obj.name
+    for link in domain_links:
+        domain = link.name
         if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(domain):
-            links = get_linked_domains(domain)
-            links = [link for link in links if link.linked_domain not in domains]
-            linked_domains = [Domain.get_by_name(link.linked_domain) for link in links]
+            links = [link for link in get_linked_domains(domain) if link.linked_domain not in domains]
+            enterprise_domains = [Domain.get_by_name(link.linked_domain) for link in links]
             enterprise_domain_links.extend([Link(
                 name=d.display_name(),
                 url=reverse(view_name, args=[d.name])
-            ) for d in linked_domains if d])
+            ) for d in enterprise_domains if d])
 
     domain_links = sorted(domain_links, key=lambda link: link.name.lower())
     enterprise_domain_links = sorted(enterprise_domain_links, key=lambda link: link.name.lower())

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -59,7 +59,7 @@ def select(request, do_not_redirect=False, next_view=None):
         if domain_obj and domain_obj.is_active:
             # mirrors logic in login_and_domain_required
             if (
-                request.couch_user.is_member_of(domain_obj)
+                request.couch_user.is_member_of(domain_obj, include_enterprise=True)
                 or (request.user.is_superuser and not domain_obj.restrict_superusers)
                 or domain_obj.is_snapshot
             ):

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -85,12 +85,12 @@ def get_domain_dropdown_links(couch_user, view_name="domain_homepage"):
     ) for domain_obj in domains]
 
     enterprise_domain_links = []
-    domain_names = {d.name for d in domain_links}
+    domains = {d.name for d in domain_links}
     for domain_obj in domain_links:
         domain = domain_obj.name
         if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(domain):
             links = get_linked_domains(domain)
-            links = [link for link in links if link.linked_domain not in domain_names]
+            links = [link for link in links if link.linked_domain not in domains]
             linked_domains = [Domain.get_by_name(link.linked_domain) for link in links]
             enterprise_domain_links.extend([Link(
                 name=d.display_name(),

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -46,7 +46,6 @@ def select(request, do_not_redirect=False, next_view=None):
         'linked_domain_links': linked_domain_links,
         'open_invitations': [] if next_view else open_invitations,
         'current_page': {'page_name': _('Select A Project')},
-        'hide_create_new_project': bool(next_view),
     }
 
     domain_select_template = "domain/select.html"

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -88,7 +88,7 @@ def get_domain_dropdown_links(couch_user, view_name="domain_homepage"):
     domain_names = {d.name for d in domain_links}
     for domain_obj in domain_links:
         domain = domain_obj.name
-        if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(domain) and couch_user.is_domain_admin(domain):
+        if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(domain):
             links = get_linked_domains(domain)
             links = [link for link in links if link.linked_domain not in domain_names]
             linked_domains = [Domain.get_by_name(link.linked_domain) for link in links]

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -34,16 +34,16 @@ def select(request, do_not_redirect=False, next_view=None):
 
     # next_view must be a url that expects exactly one parameter, a domain name
     next_view = next_view or request.GET.get('next_view') or "domain_homepage"
-    (user_domain_links, linked_domain_links) = get_domain_dropdown_links(request.couch_user, view_name=next_view)
-    if not user_domain_links:
+    (domain_links, enterprise_domain_links) = get_domain_dropdown_links(request.couch_user, view_name=next_view)
+    if not domain_links:
         return redirect('registration_domain')
 
     email = request.couch_user.get_email()
     open_invitations = [e for e in SQLInvitation.by_email(email) if not e.is_expired]
 
     additional_context = {
-        'user_domain_links': user_domain_links,
-        'linked_domain_links': linked_domain_links,
+        'domain_links': domain_links,
+        'enterprise_domain_links': enterprise_domain_links,
         'open_invitations': [] if next_view else open_invitations,
         'current_page': {'page_name': _('Select A Project')},
     }
@@ -84,7 +84,7 @@ def get_domain_dropdown_links(couch_user, view_name="domain_homepage"):
         url=reverse(view_name, args=[domain_obj.name]),
     ) for domain_obj in domains]
 
-    linked_domain_links = []
+    enterprise_domain_links = []
     domain_names = {d.name for d in domain_links}
     for domain_obj in domain_links:
         domain = domain_obj.name
@@ -92,15 +92,15 @@ def get_domain_dropdown_links(couch_user, view_name="domain_homepage"):
             links = get_linked_domains(domain)
             links = [link for link in links if link.linked_domain not in domain_names]
             linked_domains = [Domain.get_by_name(link.linked_domain) for link in links]
-            linked_domain_links.extend([Link(
+            enterprise_domain_links.extend([Link(
                 name=d.display_name(),
                 url=reverse(view_name, args=[d.name])
             ) for d in linked_domains if d])
 
     domain_links = sorted(domain_links, key=lambda link: link.name.lower())
-    linked_domain_links = sorted(linked_domain_links, key=lambda link: link.name.lower())
+    enterprise_domain_links = sorted(enterprise_domain_links, key=lambda link: link.name.lower())
 
-    return (domain_links, linked_domain_links)
+    return (domain_links, enterprise_domain_links)
 
 
 class DomainViewMixin(object):

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
@@ -10,7 +10,7 @@
     {% if show_linked_domains_link %}
         <li class="divider" />
         <li>
-            <a href="{% url 'domain_select' %}">
+            <a href="{% url 'domain_select_redirect' %}">
                 <i class="fa fa-building dropdown-icon"></i> {% trans 'Enterprise Projects' %}
             </a>
         </li>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <ul class="dropdown-menu dropdown-menu-right" role="menu">
-    {% if domain_list %}
+    {% if domain_links %}
         <li class="dropdown-header nav-header">{% trans 'Change Project' %}</li>
-        {% for d in domain_list %}
+        {% for d in domain_links %}
             <li><a href="{{ d.url }}">{{ d.name }}</a></li>
         {% endfor %}
     {% endif %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/includes/domain_list_dropdown.html
@@ -7,6 +7,15 @@
         {% endfor %}
     {% endif %}
 
+    {% if show_linked_domains_link %}
+        <li class="divider" />
+        <li>
+            <a href="{% url 'domain_select' %}">
+                <i class="fa fa-building dropdown-icon"></i> {% trans 'Enterprise Projects' %}
+            </a>
+        </li>
+    {% endif %}
+
     {% if not restrict_domain_creation or request.user.is_superuser %}
         <li class="divider" />
         <li>

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -121,11 +121,11 @@ def domains_for_user(context, request, selected_domain=None):
     """
 
     from corehq.apps.domain.views.base import get_domain_dropdown_links
-    (domain_list, linked_domain_list) = get_domain_dropdown_links(request.couch_user)
+    (domain_links, enterprise_domain_links) = get_domain_dropdown_links(request.couch_user)
     context = {
-        'domain_list': domain_list,
+        'domain_links': domain_links,
         'current_domain': selected_domain,
-        'show_linked_domains_link': bool(linked_domain_list),
+        'show_linked_domains_link': bool(enterprise_domain_links),
     }
     return mark_safe(render_to_string('hqwebapp/includes/domain_list_dropdown.html', context, request))
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -121,10 +121,11 @@ def domains_for_user(context, request, selected_domain=None):
     """
 
     from corehq.apps.domain.views.base import get_domain_dropdown_links
-    domain_list = get_domain_dropdown_links(request.couch_user)
+    (domain_list, linked_domain_list) = get_domain_dropdown_links(request.couch_user)
     context = {
         'domain_list': domain_list,
         'current_domain': selected_domain,
+        'show_linked_domains_link': bool(linked_domain_list),
     }
     return mark_safe(render_to_string('hqwebapp/includes/domain_list_dropdown.html', context, request))
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -29,7 +29,6 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.exceptions import AlreadyRenderedException
 from corehq.apps.hqwebapp.models import MaintenanceAlert
 from corehq.motech.utils import pformat_json
-from corehq.util.quickcache import quickcache
 from corehq.util.soft_assert import soft_assert
 
 register = template.Library()
@@ -113,15 +112,6 @@ def cachebuster(url):
     return resource_versions.get(url, "")
 
 
-@quickcache(['couch_user.username'])
-def _get_domain_list(couch_user):
-    domains = Domain.active_for_user(couch_user)
-    return [{
-        'url': reverse('domain_homepage', args=[domain_obj.name]),
-        'name': domain_obj.long_display_name(),
-    } for domain_obj in domains]
-
-
 @register.simple_tag(takes_context=True)
 def domains_for_user(context, request, selected_domain=None):
     """
@@ -130,12 +120,13 @@ def domains_for_user(context, request, selected_domain=None):
     the user doc updates via save.
     """
 
-    domain_list = _get_domain_list(request.couch_user)
-    ctxt = {
-        'domain_list': sorted(domain_list, key=lambda domain: domain['name'].lower()),
+    from corehq.apps.domain.views.base import get_domain_dropdown_links
+    domain_list = get_domain_dropdown_links(request.couch_user)
+    context = {
+        'domain_list': domain_list,
         'current_domain': selected_domain,
     }
-    return mark_safe(render_to_string('hqwebapp/includes/domain_list_dropdown.html', ctxt, request))
+    return mark_safe(render_to_string('hqwebapp/includes/domain_list_dropdown.html', context, request))
 
 
 @register.simple_tag

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -1089,7 +1089,8 @@ def quick_find(request):
         return HttpResponseBadRequest('GET param "q" must be provided')
 
     def deal_with_doc(doc, domain, doc_info_fn):
-        if request.couch_user.is_superuser or (domain and request.couch_user.is_member_of(domain)):
+        is_domain_member = domain and request.couch_user.is_member_of(domain, include_enterprise=True)
+        if is_domain_member or request.couch_user.is_superuser:
             doc_info = doc_info_fn(doc)
         else:
             raise Http404()

--- a/corehq/apps/linked_domain/tests/test_enterprise.py
+++ b/corehq/apps/linked_domain/tests/test_enterprise.py
@@ -1,9 +1,11 @@
+import mock
+
 from django.test.testcases import TestCase
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.linked_domain.models import DomainLink
-from corehq.apps.users.models import WebUser
+from corehq.apps.users.models import DomainMembership, Permissions, UserRole, WebUser
 from corehq.util.test_utils import flag_enabled
 
 
@@ -12,13 +14,38 @@ class EnterpriseLinkedDomainTest(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        # Set up domains
         cls.master_domain = 'domain'
         create_domain(cls.master_domain)
         cls.linked_domain = 'domain-2'
         create_domain(cls.linked_domain)
         cls.domain_link = DomainLink.link_domains(cls.linked_domain, cls.master_domain)
+
+        # Set up users
         cls.web_user_admin = WebUser.create(cls.master_domain, 'emma', 'badpassword', 'e@aol.com', is_admin=True)
         cls.web_user_non_admin = WebUser.create(cls.master_domain, 'clementine', 'worsepassword', 'c@aol.com')
+
+    def setUp(self):
+        patches = [
+            mock.patch.object(DomainMembership, 'role', self._master_role()),
+            mock.patch.object(WebUser, 'has_permission', WebUser.has_permission.__wrapped__),
+        ]
+        for patch in patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    @classmethod
+    def _master_role(cls):
+        return UserRole(
+            domain=cls.master_domain,
+            permissions=Permissions(
+                view_web_users=True,
+                edit_web_users=False,
+                view_groups=True,
+                edit_groups=False,
+            )
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -30,7 +57,14 @@ class EnterpriseLinkedDomainTest(TestCase):
         super().tearDownClass()
 
     def test_is_domain_admin(self):
-        self.assertTrue(self.web_user_admin.is_domain_admin(self.master_domain))
-        self.assertTrue(self.web_user_admin.is_domain_admin(self.linked_domain))
-        self.assertFalse(self.web_user_non_admin.is_domain_admin(self.master_domain))
-        self.assertFalse(self.web_user_non_admin.is_domain_admin(self.linked_domain))
+        for domain in (self.master_domain, self.linked_domain):
+            self.assertTrue(self.web_user_admin.is_domain_admin(domain))
+            self.assertFalse(self.web_user_non_admin.is_domain_admin(domain))
+
+            # Non-admin's permissions should match self._master_role
+            self.assertTrue(self.web_user_non_admin.has_permission(domain, "view_groups"))
+            self.assertFalse(self.web_user_non_admin.has_permission(domain, "edit_groups"))
+
+            # Admin's role is also self._master_role because of the patch, but is_admin gets checked first
+            self.assertTrue(self.web_user_admin.has_permission(domain, "view_groups"))
+            self.assertTrue(self.web_user_admin.has_permission(domain, "edit_groups"))

--- a/corehq/apps/linked_domain/tests/test_enterprise.py
+++ b/corehq/apps/linked_domain/tests/test_enterprise.py
@@ -1,0 +1,36 @@
+from django.test.testcases import TestCase
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.linked_domain.models import DomainLink
+from corehq.apps.users.models import WebUser
+from corehq.util.test_utils import flag_enabled
+
+
+@flag_enabled('ENTERPRISE_LINKED_DOMAINS')
+class EnterpriseLinkedDomainTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.master_domain = 'domain'
+        create_domain(cls.master_domain)
+        cls.linked_domain = 'domain-2'
+        create_domain(cls.linked_domain)
+        cls.domain_link = DomainLink.link_domains(cls.linked_domain, cls.master_domain)
+        cls.web_user_admin = WebUser.create(cls.master_domain, 'emma', 'badpassword', 'e@aol.com', is_admin=True)
+        cls.web_user_non_admin = WebUser.create(cls.master_domain, 'clementine', 'worsepassword', 'c@aol.com')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_link.delete()
+        cls.web_user_admin.delete()
+        cls.web_user_non_admin.delete()
+        Domain.get_by_name(cls.master_domain).delete()
+        Domain.get_by_name(cls.linked_domain).delete()
+        super().tearDownClass()
+
+    def test_is_domain_admin(self):
+        self.assertTrue(self.web_user_admin.is_domain_admin(self.master_domain))
+        self.assertTrue(self.web_user_admin.is_domain_admin(self.linked_domain))
+        self.assertFalse(self.web_user_non_admin.is_domain_admin(self.master_domain))
+        self.assertFalse(self.web_user_non_admin.is_domain_admin(self.linked_domain))

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -251,18 +251,12 @@ class MyProjectsList(BaseMyAccountView):
         return super(MyProjectsList, self).dispatch(request, *args, **kwargs)
 
     @property
-    def all_domains(self):
-        all_domains = self.request.couch_user.get_domains()
-        for d in all_domains:
-            yield {
-                'name': d,
-                'is_admin': self.request.couch_user.is_domain_admin(d)
-            }
-
-    @property
     def page_context(self):
         return {
-            'domains': self.all_domains,
+            'domains': [{
+                'name': d,
+                'is_admin': self.request.couch_user.is_domain_admin(d)
+            } for d in self.request.couch_user.get_domains()],
             'web_user': self.request.couch_user.is_web_user
         }
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -526,13 +526,24 @@ class DomainMembership(Membership):
 
 class IsMemberOfMixin(DocumentSchema):
 
-    def _is_member_of(self, domain):
-        return domain in self.get_domains() or (
-            self.is_global_admin() and
-            not domain_restricts_superusers(domain)
-        )
+    def _is_member_of(self, domain, include_enterprise):
+        if self.is_global_admin() and not domain_restricts_superusers(domain):
+            return True
 
-    def is_member_of(self, domain_qs):
+        domains = self.get_domains()
+        if domain in domains:
+            return True
+
+        if include_enterprise:
+            for domain in domains:
+                master_link = get_domain_master_link(domain)
+                if master_link and not master_link.is_remote:
+                    if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
+                        return self.get_domain_membership(master_link.master_domain)
+
+        return False
+
+    def is_member_of(self, domain_qs, include_enterprise=False):
         """
         takes either a domain name or a domain object and returns whether the user is part of that domain
         either natively or through a team
@@ -542,7 +553,7 @@ class IsMemberOfMixin(DocumentSchema):
             domain = domain_qs.name
         except Exception:
             domain = domain_qs
-        return self._is_member_of(domain)
+        return self._is_member_of(domain, include_enterprise)
 
     def is_global_admin(self):
         # subclasses to override if they want this functionality

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1446,7 +1446,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             return None
 
     def clear_quickcache_for_user(self):
-        from corehq.apps.hqwebapp.templatetags.hq_shared_tags import _get_domain_list
+        from corehq.apps.domain.views.base import get_domain_dropdown_links
         from corehq.apps.sms.util import is_user_contact_active
 
         self.get_by_username.clear(self.__class__, self.username)
@@ -1460,7 +1460,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             self.get_by_user_id.clear(self.__class__, self.user_id, domain)
             is_user_contact_active.clear(domain, self.user_id)
         Domain.active_for_couch_user.clear(self)
-        _get_domain_list.clear(self)
+        get_domain_dropdown_links.clear(self)
 
     @classmethod
     @quickcache(['userID', 'domain'])

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -535,11 +535,11 @@ class IsMemberOfMixin(DocumentSchema):
             return True
 
         if include_enterprise:
-            for domain in domains:
-                master_link = get_domain_master_link(domain)
-                if master_link and not master_link.is_remote:
-                    if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
-                        return self.get_domain_membership(master_link.master_domain)
+            # If this is a linked domain, return true if the usesr is a member of the master
+            master_link = get_domain_master_link(domain)
+            if master_link and not master_link.is_remote:
+                if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
+                    return self.get_domain_membership(master_link.master_domain)
 
         return False
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -705,14 +705,16 @@ class _AuthorizableMixin(IsMemberOfMixin):
                 return False
             return membership.has_permission(permission, data)
 
-        if _domain_membership_has_permission(self.get_domain_membership(domain)):
-            return True
+        domain_membership = self.get_domain_membership(domain)
+        if domain_membership:
+            return _domain_membership_has_permission(domain_membership)
 
         master_link = get_domain_master_link(domain)
         if master_link and not master_link.is_remote:
             if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
-                if _domain_membership_has_permission(self.get_domain_membership(master_link.master_domain)):
-                    return True
+                master_membership = self.get_domain_membership(master_link.master_domain)
+                if master_membership:
+                    return _domain_membership_has_permission(master_membership)
 
         return False
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1555,7 +1555,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         else:
             membership = self.get_domain_membership(domain) or self.get_enterprise_membership(domain)
             if not membership:
-                return False
+                return []
             return membership.viewable_reports() or []
 
     def can_view_some_reports(self, domain):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -524,30 +524,6 @@ class DomainMembership(Membership):
         app_label = 'users'
 
 
-class OrgMembership(Membership):
-    organization = StringProperty()
-    team_ids = StringListProperty(default=[]) # a set of ids corresponding to which teams the user is a member of
-
-
-class OrgMembershipError(Exception):
-    pass
-
-
-class CustomDomainMembership(DomainMembership):
-    custom_role = SchemaProperty(UserRole)
-
-    @property
-    def role(self):
-        if self.is_admin:
-            return AdminUserRole(self.domain)
-        else:
-            return self.custom_role
-
-    def set_permission(self, permission, value, data=None):
-        self.custom_role.domain = self.domain
-        self.custom_role.permissions.set(permission, value, data)
-
-
 class IsMemberOfMixin(DocumentSchema):
 
     def _is_member_of(self, domain):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -697,14 +697,24 @@ class _AuthorizableMixin(IsMemberOfMixin):
             elif self.is_domain_admin(domain):
                 return True
 
-        dm = self.get_domain_membership(domain)
-        if dm:
-            # an admin has access to all features by default, restrict that if needed
-            if dm.is_admin and restrict_global_admin:
+        def _domain_membership_has_permission(membership):
+            if not membership:
                 return False
-            return dm.has_permission(permission, data)
-        else:
-            return False
+            # an admin has access to all features by default, restrict that if needed
+            if membership.is_admin and restrict_global_admin:
+                return False
+            return membership.has_permission(permission, data)
+
+        if _domain_membership_has_permission(self.get_domain_membership(domain)):
+            return True
+
+        master_link = get_domain_master_link(domain)
+        if master_link and not master_link.is_remote:
+            if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
+                if _domain_membership_has_permission(self.get_domain_membership(master_link.master_domain)):
+                    return True
+
+        return False
 
     @memoized
     def get_role(self, domain=None, checking_global_admin=True):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1154,10 +1154,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             raise NotImplementedError(f'Unrecognized user type {self.doc_type!r}')
 
     @property
-    def projects(self):
-        return list(map(Domain.get_by_name, self.get_domains()))
-
-    @property
     def full_name(self):
         return ("%s %s" % (self.first_name or '', self.last_name or '')).strip()
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -743,7 +743,11 @@ class _AuthorizableMixin(IsMemberOfMixin):
         except TypeError:
             return _("Unknown User")
         except DomainMembershipError:
-            return _("Dimagi User") if self.is_global_admin() else _("Unauthorized User")
+            if self.is_global_admin():
+                return _("Dimagi User")
+            if self.get_enterprise_membership(domain):
+                return _("Enterprise User")
+            return _("Unauthorized User")
         except Exception:
             return None
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -535,11 +535,11 @@ class IsMemberOfMixin(DocumentSchema):
             return True
 
         if include_enterprise:
-            # If this is a linked domain, return true if the usesr is a member of the master
+            # If this is a linked domain, return true if the user is a member of the master
             master_link = get_domain_master_link(domain)
             if master_link and not master_link.is_remote:
                 if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
-                    return self.get_domain_membership(master_link.master_domain)
+                    return bool(self.get_domain_membership(master_link.master_domain))
 
         return False
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -663,7 +663,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
             return True
 
         membership = self.get_domain_membership(domain) or self.get_enterprise_membership(domain)
-        return membership.is_admin or False
+        return membership.is_admin if membership else False
 
     def get_domains(self):
         domains = [dm.domain for dm in self.domain_memberships]
@@ -1554,6 +1554,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
                 return role.permissions.view_report_list
         else:
             membership = self.get_domain_membership(domain) or self.get_enterprise_membership(domain)
+            if not membership:
+                return False
             return membership.viewable_reports() or []
 
     def can_view_some_reports(self, domain):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -59,6 +59,7 @@ from corehq.apps.domain.utils import (
     normalize_domain_name,
 )
 from corehq.apps.hqwebapp.tasks import send_html_email_async
+from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
 from corehq.apps.sms.mixin import CommCareMobileContactMixin, apply_leniency
 from corehq.apps.users.landing_pages import ALL_LANDING_PAGES
 from corehq.apps.users.permissions import EXPORT_PERMISSIONS
@@ -663,14 +664,22 @@ class _AuthorizableMixin(IsMemberOfMixin):
                 # this is a hack needed because we can't pass parameters from views
                 domain = self.current_domain
             else:
-                return False # no domain, no admin
+                return False  # no domain, no admin
         if self.is_global_admin() and (domain is None or not domain_restricts_superusers(domain)):
             return True
+
         dm = self.get_domain_membership(domain)
         if dm:
             return dm.is_admin
-        else:
-            return False
+
+        master_link = get_domain_master_link(domain)
+        if master_link and not master_link.is_remote:
+            if toggles.ENTERPRISE_LINKED_DOMAINS.enabled(master_link.master_domain):
+                dm = self.get_domain_membership(master_link.master_domain)
+                if dm:
+                    return dm.is_admin
+
+        return False
 
     def get_domains(self):
         domains = [dm.domain for dm in self.domain_memberships]

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -952,7 +952,7 @@ class ApplicationsTab(UITab):
         couch_user = self.couch_user
         return (self.domain and couch_user
                 and (couch_user.is_web_user() or couch_user.can_edit_apps())
-                and (couch_user.is_member_of(self.domain) or couch_user.is_superuser)
+                and (couch_user.is_member_of(self.domain, include_enterprise=True) or couch_user.is_superuser)
                 and has_privilege(self._request, privileges.PROJECT_ACCESS))
 
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1454,6 +1454,14 @@ LINKED_DOMAINS = StaticToggle(
     notification_emails=['aking'],
 )
 
+ENTERPRISE_LINKED_DOMAINS = StaticToggle(
+    'enterprise_linked_domains',
+    'Give this domain enterprise functionality as related to any domains linked to it. '
+    'Incompatible with remote linked project spaces.',
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)
+
 MULTI_MASTER_LINKED_DOMAINS = StaticToggle(
     'multi_master_linked_domains',
     "Allow linked apps to pull from multiple master apps in the upstream domain",

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -45,8 +45,8 @@ def get_per_domain_context(project, request=None):
 
     def allow_report_issue(user, domain):
         if toggles.ICDS.enabled(domain) and user.is_commcare_user():
-            role = user.get_domain_membership(domain).role
-            if not role:
+            membership = user.get_domain_membership(domain)
+            if not membership or not membership.role:
                 return False
         return user.has_permission(domain, 'report_an_issue')
 


### PR DESCRIPTION
##### SUMMARY
https://trello.com/c/wRKqEipZ/23-enterprise-web-users-want-to-automatically-have-the-same-level-of-access-across-all-counties

##### FEATURE FLAG
New flag: Give this domain enterprise functionality as related to any domains linked to it.

##### PRODUCT DESCRIPTION
This adds a feature flag to turn on for a linked domain's **master** domain. With the flag on, any web users who are domain admins in the master domain will automatically have admin privileges on all domains linked to that master.

Any web users who are members of the master domain but not admins will be automatically granted access to linked domains, with the same level of access they have on the master.

This is handled similar to superuser access: these users will be able to log into and modify the linked domains, but they are not considered members of the linked domain, so they will not show up in places like the linked domains' lists of web users.

These users will see an "Enterprise Projects" link in the domain dropdown:
<img width="301" alt="Screen Shot 2020-05-11 at 7 23 58 PM" src="https://user-images.githubusercontent.com/1486591/81621674-0201dd00-93bd-11ea-965d-1c1f611808e6.png">

This link goes to the pre-existing domain selection page, where you get sent if you log into HQ and we can't automatically redirect you to your most recently used domain. The select page has a new section for "Enterprise Projects":
<img width="1108" alt="Screen Shot 2020-05-11 at 7 25 24 PM" src="https://user-images.githubusercontent.com/1486591/81621742-307fb800-93bd-11ea-9209-52cf9cbda06c.png">

This new flag does not work with remote linked domains. It also does not work with location restrictions.

This has nothing to do with the current "enterprise admins" that are configured via billing. It is built on top of linked domains.

fyi @dimagi/product 

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-1294)