### PR TITLE
limit login as to specified users

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -143,6 +143,8 @@ class Permissions(DocumentSchema):
     manage_releases = BooleanProperty(default=True)
     manage_releases_list = StringListProperty(default=[])
 
+    login_as_all_users = BooleanProperty(default=True)
+
     @classmethod
     def wrap(cls, data):
         # this is why you don't store module paths in the database...

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -541,6 +541,24 @@
               </div>
             </div>
           {% endif %}
+          {% if request|toggle_enabled:"RESTRICT_LOGIN_AS" %}
+            <div class="form-group">
+            <label class="col-sm-4 control-label">
+              {% trans "Login-As All Users" %}
+            </label>
+            <div class="col-sm-8 controls">
+              <div class="form-check">
+                <input type="checkbox"
+                       id="non-admin-edit-checkbox"
+                       data-bind="checked: permissions.login_as_all_users,
+                                                  disable: !$root.allowEdit" />
+                <label for="non-admin-edit-checkbox">
+                  {% trans "Allow the user to login as in any user in web apps." %}
+                </label>
+              </div>
+            </div>
+            </div>
+          {% endif %}
           {% if request|toggle_enabled:"RESTRICT_APP_RELEASE" %}
             <div class="form-group">
               <label class="col-sm-4 control-label">

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1914,3 +1914,10 @@ REFER_CASE_REPEATER = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )
+
+RESTRICT_LOGIN_AS = StaticToggle(
+    'restrict_login_as',
+    'COVID: Limit allowed users for login as',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This work comes out of https://trello.com/c/Tgx9Fam0/21-login-as-user-restrictions

It is meant to address the use case where each web user that we are trying to restrict maps to a single mobile worker (1 to 1 relationship between mobile user in this domain, and web user that has access to multiple domains).

It works by creating a new permission to restrict login as to specific users. Those users are assigned via custom user data. Restricted users only see those for whom `login_as_user` is set to their username.

I attached a screenshot of the only UI change (the new permission in the edit role modal). It is hidden behind a feature flag.
<img width="583" alt="Screen Shot 2020-05-11 at 7 45 23 PM" src="https://user-images.githubusercontent.com/6844721/81622820-04196b00-93c0-11ea-8818-94729f001c72.png">
