### PR TITLE
Add separate sms metrics

### DIFF
--- a/corehq/apps/sms/api.py
+++ b/corehq/apps/sms/api.py
@@ -344,7 +344,7 @@ def _get_backend_tag(backend=None, backend_id=None):
             backend = None
 
     if not backend:
-        return None
+        return 'unknown'
     elif backend.is_global:
         return backend.name
     else:


### PR DESCRIPTION
Replacing https://github.com/dimagi/commcare-hq/pull/27351

##### SUMMARY
`sms_load_counter` is used in exports as well, so it is not really what we want to track. This is what was causing the issue in #27351

This adds back the ability to group sms by both backend and status.