### PR TITLE
support sending account confirmation emails from bulk upload

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -31,7 +31,8 @@ from corehq.apps.users.util import normalize_username
 required_headers = set(['username'])
 allowed_headers = set([
     'data', 'email', 'group', 'language', 'name', 'password', 'phone-number',
-    'uncategorized_data', 'user_id', 'is_active', 'is_account_confirmed', 'location_code', 'role',
+    'uncategorized_data', 'user_id', 'is_active', 'is_account_confirmed', 'send_confirmation_email',
+    'location_code', 'role',
     'User IMEIs (read only)', 'registered_on (read only)', 'last_submission (read only)',
     'last_sync (read only)'
 ]) | required_headers

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -11,6 +11,7 @@ from couchdbkit.exceptions import (
 )
 
 from corehq.apps.user_importer.helpers import spec_value_to_boolean_or_none
+from corehq.apps.users.account_confirmation import send_account_confirmation_if_necessary
 from dimagi.utils.parsing import string_to_boolean
 
 from corehq import privileges
@@ -322,6 +323,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
 
                 is_active = spec_value_to_boolean_or_none(row, 'is_active')
                 is_account_confirmed = spec_value_to_boolean_or_none(row, 'is_account_confirmed')
+                send_account_confirmation_email = spec_value_to_boolean_or_none(row, 'send_confirmation_email')
 
                 if user_id:
                     user = CommCareUser.get_by_user_id(user_id, domain)
@@ -389,6 +391,9 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                     user.set_role(domain, roles_by_name[role].get_qualified_id())
 
                 user.save()
+
+                if send_account_confirmation_email:
+                    send_account_confirmation_if_necessary(user)
 
                 if is_password(password):
                     # Without this line, digest auth doesn't work.

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -21,8 +21,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         super().setUpClass()
         delete_all_users()
         cls.domain_name = 'mydomain'
-        cls.domain = Domain(name=cls.domain_name)
-        cls.domain.save()
+        cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
 
         permissions = Permissions(edit_apps=True, view_reports=True)
         cls.role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'edit-apps')

--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -29,6 +29,7 @@ def get_user_import_validators(domain_obj, all_specs, allowed_groups=None, allow
         UsernameValidator(domain),
         BooleanColumnValidator(domain, 'is_active'),
         BooleanColumnValidator(domain, 'is_account_confirmed'),
+        BooleanColumnValidator(domain, 'send_confirmation_email'),
         RequiredFieldsValidator(domain),
         DuplicateValidator(domain, 'username', all_specs),
         DuplicateValidator(domain, 'user_id', all_specs),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Allows sending account confirmation emails during bulk upload by adding a column with the heading "send_confirmation_email" and a truthy value..  These emails are sent immediately (asynchronously) upon upload. This can also be used to re-send confirmation emails in bulk.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
https://confluence.dimagi.com/display/ccinternal/Two-Stage+Mobile+Worker+Account+Creation

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
[Documented here](https://confluence.dimagi.com/display/ccinternal/Two-Stage+Mobile+Worker+Account+Creation)