### PR TITLE
remove update_usercase

### DIFF
--- a/custom/icds/location_reassignment/models.py
+++ b/custom/icds/location_reassignment/models.py
@@ -64,7 +64,6 @@ class Transition(object):
 
     @transaction.atomic()
     def perform(self):
-        from custom.icds.location_reassignment.tasks import update_usercase
         if not self.valid():
             raise InvalidTransitionError(", ".join(self.errors))
         new_locations_created = self._create_missing_new_locations()
@@ -73,8 +72,6 @@ class Transition(object):
         if self.operation_obj.deactivates_old_users:
             for old_location in self.operation_obj.old_locations:
                 deactivate_users_at_location(old_location.location_id)
-        for old_username, new_username in self.user_transitions.items():
-            update_usercase.delay(self.domain, old_username, new_username)
 
     def valid(self):
         return self.operation_obj.valid()

--- a/custom/icds/location_reassignment/tasks.py
+++ b/custom/icds/location_reassignment/tasks.py
@@ -4,20 +4,14 @@ from django.template.defaultfilters import linebreaksbr
 
 from celery.task import task
 
-from casexml.apps.case.mock import CaseBlock
-
-from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.userreports.data_source_providers import (
     DynamicDataSourceProvider,
     StaticDataSourceProvider,
 )
 from corehq.apps.userreports.specs import EvaluationContext
 from corehq.apps.userreports.util import get_indicator_adapter
-from corehq.apps.users.models import CouchUser
-from corehq.apps.users.util import SYSTEM_USER_ID, normalize_username
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from custom.icds.location_reassignment.download import Households
-from custom.icds.location_reassignment.exceptions import InvalidUserTransition
 from custom.icds.location_reassignment.processor import (
     HouseholdReassignmentProcessor,
     Processor,
@@ -69,32 +63,6 @@ def reassign_household_and_child_cases_for_owner(domain, old_location_id, new_lo
     for household_case_id in household_case_ids:
         reassign_household_case(domain, household_case_id, old_location_id, new_location_id, supervisor_id,
                                 deprecation_time)
-
-
-@task(queue=settings.CELERY_LOCATION_REASSIGNMENT_QUEUE)
-def update_usercase(domain, old_username, new_username):
-    if "@" not in old_username:
-        old_username = normalize_username(old_username, domain)
-    if "@" not in new_username:
-        new_username = normalize_username(new_username, domain)
-    old_user = CouchUser.get_by_username(old_username)
-    new_user = CouchUser.get_by_username(new_username)
-    if old_user and new_user and old_user.is_commcare_user() and new_user.is_commcare_user():
-        old_user_usercase = old_user.get_usercase()
-        new_user_usercase = new_user.get_usercase()
-        # pick values that are not already present on the new user's usercase, populated already via HQ
-        updates = {}
-        for key in set(old_user_usercase.case_json.keys()) - set(new_user_usercase.case_json.keys()):
-            updates[key] = old_user_usercase.case_json[key]
-        if updates:
-            case_block = CaseBlock(new_user_usercase.case_id,
-                                   update=old_user_usercase.case_json,
-                                   user_id=SYSTEM_USER_ID).as_text()
-            submit_case_blocks([case_block], domain, user_id=SYSTEM_USER_ID)
-    else:
-        raise InvalidUserTransition("Invalid Transition with old user %s and new user %s" % (
-            old_username, new_username
-        ))
 
 
 @task

--- a/custom/icds/location_reassignment/tests/test_models.py
+++ b/custom/icds/location_reassignment/tests/test_models.py
@@ -125,9 +125,8 @@ class TestMoveOperation(TestOperation):
 
 
 class TestTransition(BaseTest):
-    @patch('custom.icds.location_reassignment.tasks.update_usercase.delay')
     @patch('custom.icds.location_reassignment.models.deactivate_users_at_location')
-    def test_perform(self, deactivate_users_mock, update_usercase_mock):
+    def test_perform(self, deactivate_users_mock):
         transition = Transition(domain=self.domain, location_type_code='city', operation=MoveOperation.type)
         transition.add(
             old_site_code=self.locations['Boston'].site_code,
@@ -150,11 +149,9 @@ class TestTransition(BaseTest):
         self.assertEqual(new_location.metadata[LGD_CODE], 'New Boston LGD Code')
         self.assertEqual(new_location.metadata[MAP_LOCATION_NAME], 'New Boston Sub District')
         deactivate_users_mock.assert_called_with(self.locations['Boston'].location_id)
-        update_usercase_mock.assert_called_with(self.domain, "ethan", "aquaman")
 
-    @patch('custom.icds.location_reassignment.tasks.update_usercase.delay')
     @patch('custom.icds.location_reassignment.models.deactivate_users_at_location')
-    def test_invalid_operation(self, deactivate_users_mock, update_usercase_mock):
+    def test_invalid_operation(self, deactivate_users_mock):
         transition = Transition(domain=self.domain, location_type_code='city', operation=MoveOperation.type)
         transition.add(
             old_site_code='missing_old_location',
@@ -175,9 +172,7 @@ class TestTransition(BaseTest):
         self.assertEqual(SQLLocation.objects.filter(domain=self.domain, site_code='new_boston').count(), 0,
                          "Unexpected new location created")
         deactivate_users_mock.assert_not_called()
-        update_usercase_mock.assert_not_called()
 
-    @patch('custom.icds.location_reassignment.tasks.update_usercase.delay')
     @patch('custom.icds.location_reassignment.models.deactivate_users_at_location')
     def test_can_perform_deprecation(self, *mocks):
         transition = Transition(domain=self.domain, location_type_code='city', operation=MoveOperation.type)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1212

##### SUMMARY
As decided on the ticket, copying over commcare-user case properties was removed altogether.

There was not a reliable way of handling this for a merge operation where commcare-user case properties for multiple users would need to be copied over to one commcare-user case, leading to discussions with [app builders](https://dimagi-dev.atlassian.net/browse/QA-1212?focusedCommentId=48787) which led to suggestions for copying over only specific properties which was not considered ideal. This was then extended to say that only for move operation where the mapping is strictly 1 to 1, it was okay to copy over case properties.
The fallback was to ask user to enter information again. Then in order to keep things simple, it was decided to drop it entirely and ask the user re-enter the data.
More on the ticket.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
