### PR TITLE
Fix user.username sentry tag

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -210,7 +210,7 @@ class SentryContextMiddleware(MiddlewareMixin):
         with configure_scope() as scope:
             if getattr(request, 'couch_user', None):
                 scope.set_extra('couch_user_id', request.couch_user.get_id)
-                scope.set_tag('user.username', request.couch_user.get_id)
+                scope.set_tag('user.username', request.couch_user.username)
 
             if getattr(request, 'domain', None):
                 scope.set_tag('domain', request.domain)


### PR DESCRIPTION
Previously set to user id accidentally. Before that it didn't exist

##### SUMMARY
Simple mistake in https://github.com/dimagi/commcare-hq/pull/27424. No serious consequences, just shows the wrong thing in that field
