### PR TITLE
pull return out of loop and open case

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -349,8 +349,8 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
             self._set_constant_properties(case, config)
             self._set_referral_properties(case, original_id)
             case_blocks.append(case.to_xml(V2).decode('utf-8'))
-            case_blocks = ''.join(case_blocks)
-            return case_blocks
+        case_blocks = ''.join(case_blocks)
+        return case_blocks
 
     def _get_updated_case_id(self, original_case_id, case_id_map):
         if original_case_id in case_id_map:
@@ -377,6 +377,8 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
             case.case_json[name] = value
 
     def _set_referral_properties(self, case, original_case_id):
+        # make sure new case is open
+        case.closed = False
         case.case_json['cchq_referral_source_domain'] = self.repeater.domain
         case.case_json['cchq_referral_source_case_id'] = original_case_id
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes two bugs in the ReferCaseRepeater workflow. The big change is setting all cases to open (otherwise the body of `case.to_xml()` is just a `<close/>` tag). It also fixes a dumb mistake where the return and string join were inside a loop.

Currently working on getting tests for this, but wanted this up to start so that it could be reviewed and deployed as soon as possible