### PR TITLE
Ce/limit login as

### DIFF
--- a/corehq/apps/cloudcare/esaccessors.py
+++ b/corehq/apps/cloudcare/esaccessors.py
@@ -74,7 +74,8 @@ def login_as_user_query(
         ).location_ids()
         user_es = user_es.location(list(loc_ids))
 
-    if couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as)):
+    if (couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as)) and
+        not couch_user.has_permission(domain, get_permission_name(Permissions.edit_commcare_users))):
         user_es = user_es.filter(
             filters.nested(
                 'user_data_es',

--- a/corehq/apps/cloudcare/esaccessors.py
+++ b/corehq/apps/cloudcare/esaccessors.py
@@ -74,8 +74,7 @@ def login_as_user_query(
         ).location_ids()
         user_es = user_es.location(list(loc_ids))
 
-    if (couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as)) and
-        not couch_user.has_permission(domain, get_permission_name(Permissions.edit_commcare_users))):
+    if _limit_login_as(couch_user):
         user_es = user_es.filter(
             filters.nested(
                 'user_data_es',
@@ -86,3 +85,7 @@ def login_as_user_query(
             )
         )
     return user_es.mobile_users()
+
+def _limit_login_as(couch_user):
+    return (couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as)) and
+            not couch_user.has_permission(domain, get_permission_name(Permissions.edit_commcare_users)))

--- a/corehq/apps/cloudcare/esaccessors.py
+++ b/corehq/apps/cloudcare/esaccessors.py
@@ -74,7 +74,7 @@ def login_as_user_query(
         ).location_ids()
         user_es = user_es.location(list(loc_ids))
 
-    if _limit_login_as(couch_user):
+    if _limit_login_as(couch_user, domain):
         user_es = user_es.filter(
             filters.nested(
                 'user_data_es',
@@ -86,6 +86,6 @@ def login_as_user_query(
         )
     return user_es.mobile_users()
 
-def _limit_login_as(couch_user):
+def _limit_login_as(couch_user, domain):
     return (couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as)) and
             not couch_user.has_permission(domain, get_permission_name(Permissions.edit_commcare_users)))

--- a/corehq/apps/cloudcare/esaccessors.py
+++ b/corehq/apps/cloudcare/esaccessors.py
@@ -86,6 +86,7 @@ def login_as_user_query(
         )
     return user_es.mobile_users()
 
+
 def _limit_login_as(couch_user, domain):
-    return (couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as)) and
-            not couch_user.has_permission(domain, get_permission_name(Permissions.edit_commcare_users)))
+    return (couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as))
+            and not couch_user.has_permission(domain, get_permission_name(Permissions.edit_commcare_users)))

--- a/corehq/apps/cloudcare/esaccessors.py
+++ b/corehq/apps/cloudcare/esaccessors.py
@@ -74,7 +74,7 @@ def login_as_user_query(
         ).location_ids()
         user_es = user_es.location(list(loc_ids))
 
-    if not couch_user.has_permission(domain, get_permission_name(Permissions.login_as_all_users)):
+    if couch_user.has_permission(domain, get_permission_name(Permissions.limited_login_as)):
         user_es = user_es.filter(
             filters.nested(
                 'user_data_es',

--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -131,3 +131,19 @@ class TestCloudcareESAccessors(SimpleTestCase):
             ).count(),
             2,
         )
+
+    def test_limited_users(self):
+        self.self._send_user_to_es(username='superman')
+        self.self._send_user_to_es(username='robin', user_data={'login_as_user': 'batman'})
+
+        self.assertEqual(
+            login_as_user_query(
+                self.domain,
+                MagicMock(username='batman', **{'has_permission.return_value': True}),
+                None,
+                10,
+                0,
+                []
+            ).count(),
+            1
+        )

--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -133,8 +133,8 @@ class TestCloudcareESAccessors(SimpleTestCase):
         )
 
     def test_limited_users(self):
-        self.self._send_user_to_es(username='superman')
-        self.self._send_user_to_es(username='robin', user_data={'login_as_user': 'batman'})
+        self._send_user_to_es(username='superman')
+        self._send_user_to_es(username='robin', user_data={'login_as_user': 'batman'})
 
         with patch('corehq.apps.cloudcare.esaccessors._limit_login_as', return_value=True):
             self.assertEqual(

--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -136,14 +136,15 @@ class TestCloudcareESAccessors(SimpleTestCase):
         self.self._send_user_to_es(username='superman')
         self.self._send_user_to_es(username='robin', user_data={'login_as_user': 'batman'})
 
-        self.assertEqual(
-            login_as_user_query(
-                self.domain,
-                MagicMock(username='batman', **{'has_permission.return_value': True}),
-                None,
-                10,
-                0,
-                []
-            ).count(),
-            1
-        )
+        with patch('corehq.apps.cloudcare.esaccessors._limit_login_as', return_value=True):
+            self.assertEqual(
+                login_as_user_query(
+                    self.domain,
+                    MagicMock(username='batman'),
+                    None,
+                    10,
+                    0,
+                    []
+                ).count(),
+                1
+            )

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -74,7 +74,7 @@ from corehq.apps.hqwebapp.decorators import (
 )
 from corehq.apps.locations.permissions import location_safe
 from corehq.apps.reports.formdetails import readable
-from corehq.apps.users.decorators import require_can_edit_commcare_users
+from corehq.apps.users.decorators import require_can_login_as
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.util import format_username
 from corehq.apps.users.views import BaseUserSettingsView
@@ -285,7 +285,7 @@ class LoginAsUsers(View):
     urlname = 'login_as_users'
 
     @method_decorator(login_and_domain_required)
-    @method_decorator(require_can_edit_commcare_users)
+    @method_decorator(require_can_login_as)
     @method_decorator(requires_privilege_for_commcare_user(privileges.CLOUDCARE))
     def dispatch(self, *args, **kwargs):
         return super(LoginAsUsers, self).dispatch(*args, **kwargs)

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -230,7 +230,7 @@ def can_use_restore_as(request):
         return True
 
     return (
-        request.couch_user.can_edit_commcare_users() and
+        request.couch_user.can_login_as(request.domain) and
         has_privilege(request, privileges.LOGIN_AS)
     )
 

--- a/corehq/apps/users/decorators.py
+++ b/corehq/apps/users/decorators.py
@@ -94,6 +94,7 @@ require_can_edit_or_view_groups = require_permission(
     'edit_groups', view_only_permission='view_groups'
 )
 require_can_view_roles = require_permission('view_roles')
+require_can_login_as = require_permission_raw(lambda user, domain: user.can_login_as(domain))
 
 
 def require_permission_to_edit_user(view_func):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -143,7 +143,7 @@ class Permissions(DocumentSchema):
     manage_releases = BooleanProperty(default=True)
     manage_releases_list = StringListProperty(default=[])
 
-    login_as_all_users = BooleanProperty(default=True)
+    limited_login_as = BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, data):
@@ -1606,6 +1606,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             permission_slug for permission_slug in self._get_viewable_report_slugs(domain)
             if permission_slug in EXPORT_PERMISSIONS
         ])
+
+    def can_login_as(self, domain):
+        return self.has_permission(domain, 'edit_commcare_users') or self.has_permission(domain, 'limited_login_as')
 
     def is_current_web_user(self, request):
         return self.user_id == request.couch_user.user_id

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -544,16 +544,16 @@
           {% if request|toggle_enabled:"RESTRICT_LOGIN_AS" %}
             <div class="form-group">
             <label class="col-sm-4 control-label">
-              {% trans "Login-As All Users" %}
+              {% trans "Limit Login-As" %}
             </label>
             <div class="col-sm-8 controls">
               <div class="form-check">
                 <input type="checkbox"
                        id="non-admin-edit-checkbox"
-                       data-bind="checked: permissions.login_as_all_users,
+                       data-bind="checked: permissions.limited_login_as,
                                   disable: !$root.allowEdit" />
                 <label for="non-admin-edit-checkbox">
-                  {% trans "Allow the user to login as in any user in web apps." %}
+                  {% trans "Allow the user to login as only specified users in Web Apps." %}
                 </label>
               </div>
             </div>

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -551,7 +551,7 @@
                 <input type="checkbox"
                        id="non-admin-edit-checkbox"
                        data-bind="checked: permissions.login_as_all_users,
-                                                  disable: !$root.allowEdit" />
+                                  disable: !$root.allowEdit" />
                 <label for="non-admin-edit-checkbox">
                   {% trans "Allow the user to login as in any user in web apps." %}
                 </label>

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -112,7 +112,7 @@
             </div>
             <div class="col-sm-8 control-label">
               {% blocktrans %}
-                <strong>Mobile Workers</strong> &mdash; create new accounts, manage account settings, deactivate or delete mobile workers
+                <strong>Mobile Workers</strong> &mdash; create new accounts, manage account settings, deactivate or delete mobile workers. This permission also allows users to login as any mobile worker in Web Apps.
               {% endblocktrans %}
             </div>
           </div> {# END commcare_users permissions #}

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1921,7 +1921,7 @@ RESTRICT_LOGIN_AS = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     description="""
-    Adds a permission that can be set on user roles to only allow those users to "login as" other users that set custom user property "login_as_user" to the first user's username.
+    Adds a permission that can be set on user roles to allow login as, but only as a limited set of users. Users with this enabled can "login as" other users that set custom user property "login_as_user" to the first user's username.
     For example, if web user a@a.com has this permission set on their role, they can only login as mobile users who have the custom property "login_as_user" set to "a@a.com".
     """
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1922,6 +1922,6 @@ RESTRICT_LOGIN_AS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     description="""
     Adds a permission that can be set on user roles to only allow those users to "login as" other users that set custom user property "login_as_user" to the first user's username.
-    For example, if User A has this permission set on their role, the can only login as User B if User B has the custom property "login_as_user" set to "A".
+    For example, if web user a@a.com has this permission set on their role, they can only login as mobile users who have the custom property "login_as_user" set to "a@a.com".
     """
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1919,5 +1919,9 @@ RESTRICT_LOGIN_AS = StaticToggle(
     'restrict_login_as',
     'COVID: Limit allowed users for login as',
     TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN]
+    namespaces=[NAMESPACE_DOMAIN],
+    description="""
+    Adds a permission that can be set on user roles to only allow those users to "login as" other users that set custom user proper "login_as_user" to the first users' username.
+    For example, if User A has this permission set on their role, the can only login as User B if User B has the custom property "login_as_user" set to "A".
+    """
 )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1921,7 +1921,7 @@ RESTRICT_LOGIN_AS = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN],
     description="""
-    Adds a permission that can be set on user roles to only allow those users to "login as" other users that set custom user proper "login_as_user" to the first users' username.
+    Adds a permission that can be set on user roles to only allow those users to "login as" other users that set custom user property "login_as_user" to the first user's username.
     For example, if User A has this permission set on their role, the can only login as User B if User B has the custom property "login_as_user" set to "A".
     """
 )


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a follow up to https://github.com/dimagi/commcare-hq/pull/27450
It refactors the logic a bit so that we don't have to give users "edit commcare user" privilege to login as other users if those users come from a whitelist. Giving users "edit commcare user" will continue to allow them to login as anyone.

New permission screenshot is below.

<img width="593" alt="Screen Shot 2020-05-12 at 11 08 27 PM" src="https://user-images.githubusercontent.com/6844721/81767090-8b8cda00-94a5-11ea-83b1-97e6bee9f3b2.png">
