### PR TITLE
Location reassignment name format changes

### DIFF
--- a/custom/icds/location_reassignment/const.py
+++ b/custom/icds/location_reassignment/const.py
@@ -55,7 +55,11 @@ LGD_CODE = "lgd_code"
 MAP_LOCATION_NAME = "map_location_name"
 
 AWC_CODE = "awc"
+SUPERVISOR_CODE = "supervisor"  # also called "Sector" at times
 BLOCK_CODE = "block"  # also called "Project" at times
+# location types that append raw name and site code together as the final location name
+HAVE_APPENDED_LOCATION_NAMES = [AWC_CODE, SUPERVISOR_CODE]
+
 HOUSEHOLD_CASE_TYPE = "household"
 PERSON_CASE_TYPE = "person"
 

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -40,13 +40,13 @@ class TransitionRow(object):
     An object representation of each row in excel
     """
     def __init__(self, location_type, operation, old_site_code, new_site_code, expects_parent,
-                 new_location_details=None, old_username=None, new_username=None):
+                 new_location_details, old_username=None, new_username=None):
         self.location_type = location_type
         self.operation = operation
         self.old_site_code = old_site_code
         self.new_site_code = new_site_code
         self.expects_parent = expects_parent
-        self.new_location_details = new_location_details or {}
+        self.new_location_details = new_location_details
         self.old_username = old_username
         self.new_username = new_username
 

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -79,7 +79,7 @@ class TransitionRow(object):
         if bool(self.new_username) != bool(self.old_username):
             errors.append(f"Need both old and new username for {self.operation} operation "
                           f"on location '{self.old_site_code}'")
-        if not self.new_location_details.get('name', '').strip():
+        if not self.new_location_details.get('name', ''):
             errors.append(f"Missing new location name for {self.new_site_code}")
         parent_site_code = self.new_location_details.get('parent_site_code')
         if parent_site_code:
@@ -162,7 +162,7 @@ class Parser(object):
                     new_site_code=parse_site_code(row.get(NEW_SITE_CODE_COLUMN)),
                     expects_parent=expects_parent,
                     new_location_details={
-                        'name': row.get(NEW_NAME),
+                        'name': row.get(NEW_NAME, '').strip(),
                         'parent_site_code': parse_site_code(row.get(NEW_PARENT_SITE_CODE)),
                         'lgd_code': row.get(NEW_LGD_CODE),
                         'sub_district_name': row.get(NEW_SUB_DISTRICT_NAME)

--- a/custom/icds/location_reassignment/parser.py
+++ b/custom/icds/location_reassignment/parser.py
@@ -10,6 +10,7 @@ from custom.icds.location_reassignment.const import (
     AWC_CODE_COLUMN,
     CURRENT_SITE_CODE_COLUMN,
     EXTRACT_OPERATION,
+    HAVE_APPENDED_LOCATION_NAMES,
     HOUSEHOLD_ID_COLUMN,
     MERGE_OPERATION,
     NEW_LGD_CODE,
@@ -26,7 +27,10 @@ from custom.icds.location_reassignment.const import (
     VALID_OPERATIONS,
 )
 from custom.icds.location_reassignment.models import Transition
-from custom.icds.location_reassignment.utils import get_household_case_ids
+from custom.icds.location_reassignment.utils import (
+    append_location_name_and_site_code,
+    get_household_case_ids,
+)
 
 
 def parse_site_code(site_code):
@@ -49,6 +53,13 @@ class TransitionRow(object):
         self.new_location_details = new_location_details
         self.old_username = old_username
         self.new_username = new_username
+
+        if location_type in HAVE_APPENDED_LOCATION_NAMES:
+            if self.new_location_details['name'] and self.new_site_code:
+                self.new_location_details['name'] = append_location_name_and_site_code(
+                    self.new_location_details['name'],
+                    new_site_code
+                )
 
     def validate(self):
         """

--- a/custom/icds/location_reassignment/tests/test_parser.py
+++ b/custom/icds/location_reassignment/tests/test_parser.py
@@ -88,7 +88,10 @@ class TestParser(TestCase):
         ('state', (
             # invalid row with unknown operation
             ('State 1', 'State 1', '1', '1', 'State-1',
-             'State-11', 'username4', 'username4', 'Unknown')))
+             'State-11', 'username4', 'username4', 'Unknown'),
+            ('State 2', 'State 3', '2', '3', '',
+             '', '', '', 'Move'),
+        ))
     )
 
     @classmethod
@@ -121,7 +124,7 @@ class TestParser(TestCase):
                         'old_site_codes': ['112'],
                         'new_site_codes': ['131'],
                         'new_location_details': {
-                            '131': {'name': 'AWC 3', 'parent_site_code': '13', 'lgd_code': 'AWC-131',
+                            '131': {'name': 'AWC 3 [131]', 'parent_site_code': '13', 'lgd_code': 'AWC-131',
                                     'sub_district_name': None}},
                         'user_transitions': {'username2': 'username3'}
                     },
@@ -132,7 +135,7 @@ class TestParser(TestCase):
                         'old_site_codes': ['115'],
                         'new_site_codes': ['133'],
                         'new_location_details': {
-                            '133': {'name': 'AWC 8', 'parent_site_code': '12', 'lgd_code': 'AWC-133',
+                            '133': {'name': 'AWC 8 [133]', 'parent_site_code': '12', 'lgd_code': 'AWC-133',
                                     'sub_district_name': None}},
                         'user_transitions': {'username6': 'username7'}
                     }
@@ -150,13 +153,32 @@ class TestParser(TestCase):
                  'new_site_codes': ['13'],
                  'new_location_details': {
                      '13': {
-                         'name': 'Supervisor 3',
+                         'name': 'Supervisor 3 [13]',
                          'parent_site_code': '1',
                          'lgd_code': 'Sup-13',
                          'sub_district_name': None
                      }
                  },
                  'user_transitions': {'username5': 'username6'}}
+            )
+            self.assertEqual(len(parser.valid_transitions['state']), 1)
+            state_transition = attr.asdict(parser.valid_transitions['state'][0])
+            self.assertEqual(
+                state_transition,
+                {'domain': self.domain,
+                 'location_type_code': 'state',
+                 'operation': 'Move',
+                 'old_site_codes': ['2'],
+                 'new_site_codes': ['3'],
+                 'new_location_details': {
+                     '3': {
+                         'name': 'State 3',
+                         'parent_site_code': '',
+                         'lgd_code': '',
+                         'sub_district_name': None
+                     }
+                 },
+                 'user_transitions': {}}
             )
             self.assertEqual(errors, [
                 "Invalid Operation Unknown",

--- a/custom/icds/location_reassignment/utils.py
+++ b/custom/icds/location_reassignment/utils.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from xml.etree import cElementTree as ElementTree
 
@@ -87,3 +88,13 @@ def reassign_household_case(domain, household_case_id, old_owner_id, new_owner_i
     if case_blocks:
         submit_case_blocks(case_blocks, domain, user_id=SYSTEM_USER_ID)
     process_ucr_changes.delay(domain, case_ids)
+
+
+def split_location_name_and_site_code(name):
+    # Location Name [location code]
+    pattern = r"(.+)\s*\[(.+)\]"
+    match = re.match(pattern, name)
+    if match:
+        return match.groups()
+    return name, None
+

--- a/custom/icds/location_reassignment/utils.py
+++ b/custom/icds/location_reassignment/utils.py
@@ -98,3 +98,6 @@ def split_location_name_and_site_code(name):
         return match.groups()
     return name, None
 
+
+def append_location_name_and_site_code(name, site_code):
+    return f"{name.rstrip()} [{site_code}]"


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1464

##### SUMMARY
For awc and supervisor level the names for locations on HQ are present as a concatenation of the raw name and site code as "Location Name [location site code]"
This PR addresses that change so that users are not confused when they download a template and when the users upload information for new locations to be created, the concatenation is done here as well.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
