### PR TITLE
Run messaging rule concurrently on each shard

### DIFF
--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -54,9 +54,8 @@ def update_current_MALT():
 def build_last_month_GIR():
     def _last_month_datespan():
         today = datetime.date.today()
-        for i in range(3):
-            first_of_this_month = datetime.date(day=1, month=today.month, year=today.year)
-            last_month = first_of_this_month - datetime.timedelta(days=1)
+        first_of_this_month = datetime.date(day=1, month=today.month, year=today.year)
+        last_month = first_of_this_month - datetime.timedelta(days=1)
         return DateSpan.from_month(last_month.month, last_month.year)
 
     last_month = _last_month_datespan()

--- a/corehq/apps/data_analytics/tasks.py
+++ b/corehq/apps/data_analytics/tasks.py
@@ -54,8 +54,9 @@ def update_current_MALT():
 def build_last_month_GIR():
     def _last_month_datespan():
         today = datetime.date.today()
-        first_of_this_month = datetime.date(day=1, month=today.month, year=today.year)
-        last_month = first_of_this_month - datetime.timedelta(days=1)
+        for i in range(3):
+            first_of_this_month = datetime.date(day=1, month=today.month, year=today.year)
+            last_month = first_of_this_month - datetime.timedelta(days=1)
         return DateSpan.from_month(last_month.month, last_month.year)
 
     last_month = _last_month_datespan()

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -1100,7 +1100,7 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
             run_messaging_rule_for_shard(self.domain, rule_id, 'default')
             sync_patch.assert_has_calls(
                 [
-                    call(self.domain, [case1.case_id, case2.case_id], rule_id)
+                    call(self.domain, (case1.case_id, case2.case_id), rule_id)
                 ],
                 any_order=True
             )

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -1107,7 +1107,6 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
                 )
             else:
                 self.assertEqual(shard_rule_patch.call_count, 0)
-        toggles.SHARDED_RUN_MESSAGING_RULE.set(self.domain, False, toggles.NAMESPACE_DOMAIN)
 
     @run_with_all_backends
     @patch('corehq.messaging.scheduling.models.content.SMSContent.send')

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -1084,10 +1084,11 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
     @patch('corehq.messaging.tasks.sync_case_chunk_for_messaging_rule.delay')
     def test_run_messaging_rule_sharded(self, task_patch):
         toggles.SHARDED_RUN_MESSAGING_RULE.set(self.domain, True, toggles.NAMESPACE_DOMAIN)
+        self.addCleanup(toggles.SHARDED_RUN_MESSAGING_RULE.set, self.domain, False, toggles.NAMESPACE_DOMAIN)
         rule_id = self._setup_rule()
         with create_case(self.domain, 'person') as case1, create_case(self.domain, 'person') as case2:
             run_messaging_rule(self.domain, rule_id)
-            self.assertEqual(task_patch.call_count, 2)
+            self.assertEqual(task_patch.call_count, 1)
             task_patch.assert_has_calls(
                 [
                     call(self.domain, [case1.case_id, case2.case_id], rule_id)

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from mock import call, patch
 
+from corehq import toggles
 from corehq.apps.app_manager.models import (
     AdvancedForm,
     AdvancedModule,
@@ -1047,9 +1048,7 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
             self.assertEqual(instances[0].schedule_revision, schedule.get_schedule_revision())
             self.assertTrue(instances[0].active)
 
-    @run_with_all_backends
-    @patch('corehq.messaging.tasks.sync_case_for_messaging_rule.delay')
-    def test_run_messaging_rule(self, task_patch):
+    def _setup_rule(self):
         schedule = AlertSchedule.create_simple_alert(
             self.domain,
             SMSContent(message={'en': 'Hello'})
@@ -1064,17 +1063,38 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
         )
 
         AutomaticUpdateRule.clear_caches(self.domain, AutomaticUpdateRule.WORKFLOW_SCHEDULING)
+        return rule.pk
 
+    @run_with_all_backends
+    @patch('corehq.messaging.tasks.sync_case_for_messaging_rule.delay')
+    def test_run_messaging_rule(self, task_patch):
+        rule_id = self._setup_rule()
         with create_case(self.domain, 'person') as case1, create_case(self.domain, 'person') as case2:
-            run_messaging_rule(self.domain, rule.pk)
+            run_messaging_rule(self.domain, rule_id)
             self.assertEqual(task_patch.call_count, 2)
             task_patch.assert_has_calls(
                 [
-                    call(self.domain, case1.case_id, rule.pk),
-                    call(self.domain, case2.case_id, rule.pk),
+                    call(self.domain, case1.case_id, rule_id),
+                    call(self.domain, case2.case_id, rule_id),
                 ],
                 any_order=True
             )
+
+    @run_with_all_backends
+    @patch('corehq.messaging.tasks.sync_case_chunk_for_messaging_rule.delay')
+    def test_run_messaging_rule_sharded(self, task_patch):
+        toggles.SHARDED_RUN_MESSAGING_RULE.set(self.domain, True, toggles.NAMESPACE_DOMAIN)
+        rule_id = self._setup_rule()
+        with create_case(self.domain, 'person') as case1, create_case(self.domain, 'person') as case2:
+            run_messaging_rule(self.domain, rule_id)
+            self.assertEqual(task_patch.call_count, 2)
+            task_patch.assert_has_calls(
+                [
+                    call(self.domain, [case1.case_id, case2.case_id], rule_id)
+                ],
+                any_order=True
+            )
+        toggles.SHARDED_RUN_MESSAGING_RULE.set(self.domain, False, toggles.NAMESPACE_DOMAIN)
 
     @run_with_all_backends
     @patch('corehq.messaging.scheduling.models.content.SMSContent.send')

--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -30,7 +30,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqcase.utils import update_case
 from corehq.apps.users.models import CommCareUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-from corehq.form_processor.tests.utils import run_with_all_backends, only_run_with_partitioned_database
+from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.messaging.scheduling.const import (
     VISIT_WINDOW_DUE_DATE,
     VISIT_WINDOW_END,

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -115,22 +115,16 @@ def initiate_messaging_rule_run(rule):
 
 
 def paginated_case_ids(domain, case_type, db_alias=None):
-    q = Q(domain=domain, type=case_type, deleted=False)
+    args = [
+        CommCareCaseSQL,
+        Q(domain=domain, type=case_type, deleted=False)
+    ]
     if db_alias:
-        row_generator = paginate_query(
-            db_alias,
-            CommCareCaseSQL,
-            q,
-            values=['case_id'],
-            load_source='run_messaging_rule'
-        )
+        fn = paginate_query
+        args = [db_alias] + args
     else:
-        row_generator = paginate_query_across_partitioned_databases(
-            CommCareCaseSQL,
-            q,
-            values=['case_id'],
-            load_source='run_messaging_rule'
-        )
+        fn = paginate_query_across_partitioned_databases
+    row_generator = fn(*args, values=['case_id'], load_source='run_messaging_rule')
     for row in row_generator:
         yield row[0]
 

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -47,7 +47,7 @@ def sync_case_for_messaging_rule(self, domain, case_id, rule_id):
 
 
 @no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True)
-def sync_case_chunk_for_messaging_rule(self, domain, case_id_chunk, rule_id):
+def sync_case_chunk_for_messaging_rule(domain, case_id_chunk, rule_id):
     for case_id in case_id_chunk:
         try:
             with CriticalSection([get_sync_key(case_id)], timeout=5 * 60):

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -7,9 +7,14 @@ from corehq.form_processor.utils import should_use_sql_backend
 from corehq.messaging.scheduling.tasks import delete_schedule_instances_for_cases
 from corehq.messaging.scheduling.util import utcnow
 from corehq.messaging.util import MessagingRuleProgressHelper, use_phone_entries
-from corehq.sql_db.util import paginate_query_across_partitioned_databases
+from corehq.sql_db.util import (
+    get_db_aliases_for_partitioned_query,
+    paginate_query,
+    paginate_query_across_partitioned_databases
+)
 from corehq.util.celery_utils import no_result_task
 from corehq.util.metrics.load_counters import case_load_counter
+from dimagi.utils.chunked import chunked
 from dimagi.utils.couch import CriticalSection
 from django.conf import settings
 from django.db.models import Q
@@ -38,6 +43,17 @@ def sync_case_for_messaging_rule(self, domain, case_id, rule_id):
             _sync_case_for_messaging_rule(domain, case_id, rule_id)
     except Exception as e:
         self.retry(exc=e)
+
+
+@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
+                default_retry_delay=5 * 60, max_retries=12, bind=True)
+def sync_case_chunk_for_messaging_rule(self, domain, case_id_chunk, rule_id):
+    for case_id in case_id_chunk:
+        try:
+            with CriticalSection([get_sync_key(case_id)], timeout=5 * 60):
+                _sync_case_for_messaging_rule(domain, case_id, rule_id)
+        except Exception:
+            sync_case_for_messaging_rule.delay(domain, case_id, rule_id)
 
 
 def _sync_case_for_messaging(domain, case_id):
@@ -97,13 +113,23 @@ def initiate_messaging_rule_run(rule):
     transaction.on_commit(lambda: run_messaging_rule.delay(rule.domain, rule.pk))
 
 
-def paginated_case_ids(domain, case_type):
-    row_generator = paginate_query_across_partitioned_databases(
-        CommCareCaseSQL,
-        Q(domain=domain, type=case_type, deleted=False),
-        values=['case_id'],
-        load_source='run_messaging_rule'
-    )
+def paginated_case_ids(domain, case_type, db_alias=None):
+    q = Q(domain=domain, type=case_type, deleted=False)
+    if db_alias:
+        row_generator = paginate_query(
+            db_alias,
+            CommCareCaseSQL,
+            q,
+            values=['case_id'],
+            load_source='run_messaging_rule'
+        )
+    else:
+        row_generator = paginate_query_across_partitioned_databases(
+            CommCareCaseSQL,
+            q,
+            values=['case_id'],
+            load_source='run_messaging_rule'
+        )
     for row in row_generator:
         yield row[0]
 
@@ -128,23 +154,49 @@ def run_messaging_rule(domain, rule_id):
     if not rule:
         return
 
-    incr = 0
     progress_helper = MessagingRuleProgressHelper(rule_id)
-    progress_helper.set_initial_progress()
 
-    for case_id in get_case_ids_for_messaging_rule(domain, rule.case_type):
-        sync_case_for_messaging_rule.delay(domain, case_id, rule_id)
-        incr += 1
-        if incr >= 1000:
-            progress_helper.increase_total_case_count(incr)
-            incr = 0
-            if progress_helper.is_canceled():
-                break
+    def _run_rule_sequentially():
+        incr = 0
+        progress_helper.set_initial_progress()
+        for case_id in get_case_ids_for_messaging_rule(domain, rule.case_type):
+            sync_case_for_messaging_rule.delay(domain, case_id, rule_id)
+            incr += 1
+            if incr >= 1000:
+                progress_helper.increase_total_case_count(incr)
+                incr = 0
+                if progress_helper.is_canceled():
+                    break
 
-    progress_helper.increase_total_case_count(incr)
+        progress_helper.increase_total_case_count(incr)
 
-    # By putting this task last in the queue, the rule should be marked
-    # complete at about the time that the last tasks are finishing up.
-    # This beats saving the task results in the database and using a
-    # celery chord which would be more taxing on system resources.
-    set_rule_complete.delay(rule_id)
+        # By putting this task last in the queue, the rule should be marked
+        # complete at about the time that the last tasks are finishing up.
+        # This beats saving the task results in the database and using a
+        # celery chord which would be more taxing on system resources.
+        set_rule_complete.delay(rule_id)
+
+    def _run_rule_on_multiple_shards():
+        db_aliases = get_db_aliases_for_partitioned_query()
+        progress_helper.set_initial_progress(shard_count=len(db_aliases))
+        for db_alias in db_aliases:
+            run_messaging_rule_for_shard.delay(domain, rule_id, db_alias)
+
+
+@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_RULE_QUEUE, acks_late=True,
+                soft_time_limit=15 * settings.CELERY_TASK_SOFT_TIME_LIMIT)
+def run_messaging_rule_for_shard(domain, rule_id, db_alias):
+    rule = _get_cached_rule(domain, rule_id)
+    if not rule:
+        return
+
+    chunk_size = getattr(settings, 'MESSAGING_RULE_CASE_CHUNK_SIZE', 100)
+    progress_helper = MessagingRuleProgressHelper(rule_id)
+    for case_id_chunk in chunked(paginated_case_ids(domain, rule.case_type, db_alias), chunk_size):
+        sync_case_chunk_for_messaging_rule.delay(domain, case_id_chunk, rule_id)
+        progress_helper.increase_total_case_count(len(case_id_chunk))
+        if progress_helper.is_canceled():
+            break
+    progress_helper.mark_shard_complete(db_alias)
+    if progress_helper.all_shards_complete():
+        set_rule_complete.delay(rule_id)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -176,7 +176,7 @@ def run_messaging_rule(domain, rule_id):
         for db_alias in db_aliases:
             run_messaging_rule_for_shard.delay(domain, rule_id, db_alias)
 
-    if toggles.SHARDED_RUN_MESSAGING_RULE.enabled(domain):
+    if toggles.SHARDED_RUN_MESSAGING_RULE.enabled(domain) and should_use_sql_backend(domain):
         _run_rule_on_multiple_shards()
     else:
         _run_rule_sequentially()

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -46,8 +46,7 @@ def sync_case_for_messaging_rule(self, domain, case_id, rule_id):
         self.retry(exc=e)
 
 
-@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True,
-                default_retry_delay=5 * 60, max_retries=12, bind=True)
+@no_result_task(serializer='pickle', queue=settings.CELERY_REMINDER_CASE_UPDATE_QUEUE, acks_late=True)
 def sync_case_chunk_for_messaging_rule(self, domain, case_id_chunk, rule_id):
     for case_id in case_id_chunk:
         try:
@@ -198,6 +197,6 @@ def run_messaging_rule_for_shard(domain, rule_id, db_alias):
         if progress_helper.is_canceled():
             break
     progress_helper.mark_shard_complete(db_alias)
-    if progress_helper.all_shards_complete():
+    if progress_helper.all_shards_completed():
         # this should get triggered for the last shard
         set_rule_complete.delay(rule_id)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -196,7 +196,7 @@ def run_messaging_rule_for_shard(domain, rule_id, db_alias):
         progress_helper.increase_total_case_count(len(case_id_chunk))
         if progress_helper.is_canceled():
             break
-    progress_helper.mark_shard_complete(db_alias)
-    if progress_helper.all_shards_completed():
+    all_shards_complete = progress_helper.mark_shard_complete(db_alias)
+    if all_shards_complete:
         # this should get triggered for the last shard
         set_rule_complete.delay(rule_id)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -199,4 +199,5 @@ def run_messaging_rule_for_shard(domain, rule_id, db_alias):
             break
     progress_helper.mark_shard_complete(db_alias)
     if progress_helper.all_shards_complete():
+        # this should get triggered for the last shard
         set_rule_complete.delay(rule_id)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1913,3 +1913,10 @@ RESTRICT_LOGIN_AS = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )
+
+SHARDED_RUN_MESSAGING_RULE = StaticToggle(
+    'sharded_run_messaging_rule',
+    'Trigger concurrent tasks per each shard for conditional case alerts ',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1916,7 +1916,8 @@ RESTRICT_LOGIN_AS = StaticToggle(
 
 SHARDED_RUN_MESSAGING_RULE = StaticToggle(
     'sharded_run_messaging_rule',
-    'Trigger concurrent tasks per each shard for conditional case alerts ',
+    'Trigger concurrent tasks per each shard for conditional case alerts'
+    'Applies to SQL domains only',
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )


### PR DESCRIPTION
There are two changes to improve conditional alert activation performance (within a toggle)
1.  For sharded DBs, this allows triggering concurrent tasks for each shard instead of one single task that loops through all cases. This should reduce the case iteration time by a factor of 20.
2. When doing sharded run, 100 cases are synced in one task, instead of one case per each task. This should reduce number of tasks triggered by a factor of hundred.

@orangejenny 

