### PR TITLE
Location reassignment fix households

### DIFF
--- a/custom/icds/location_reassignment/download.py
+++ b/custom/icds/location_reassignment/download.py
@@ -212,9 +212,10 @@ class Households(object):
         which holds details all household cases assigned to it
         """
         rows = {}
-        for operation, details in transitions.items():
+        for transition in transitions:
+            operation = transition.operation
             if operation in self.valid_operations:
-                rows.update(self._get_rows_for_location(operation, details))
+                rows.update(self._get_rows_for_transition(transition))
         if rows:
             stream = io.BytesIO()
             headers = [[site_code, self.headers] for site_code in rows]
@@ -222,14 +223,10 @@ class Households(object):
             stream.seek(0)
             return stream
 
-    def _get_rows_for_location(self, operation, details):
+    def _get_rows_for_transition(self, transition):
         rows = {}
-        if operation == SPLIT_OPERATION:
-            for site_code in details.keys():
-                rows[site_code] = self._build_rows(site_code)
-        elif operation == EXTRACT_OPERATION:
-            for site_code in details.values():
-                rows[site_code] = self._build_rows(site_code)
+        for site_code in transition.old_site_codes:
+            rows[site_code] = self._build_rows(site_code)
         return rows
 
     def _build_rows(self, site_code):

--- a/custom/icds/location_reassignment/tasks.py
+++ b/custom/icds/location_reassignment/tasks.py
@@ -76,7 +76,7 @@ def reassign_cases_for_owner(domain, old_location_id, new_location_id, deprecati
 @task
 def email_household_details(domain, transitions, uploaded_filename, user_email):
     try:
-        transition_objs = [Transition(*transition) for transition in transitions]
+        transition_objs = [Transition(**transition) for transition in transitions]
         filestream = Households(domain).dump(transition_objs)
     except Exception as e:
         email = EmailMessage(

--- a/custom/icds/location_reassignment/tasks.py
+++ b/custom/icds/location_reassignment/tasks.py
@@ -20,8 +20,8 @@ from custom.icds.location_reassignment.processor import (
 from custom.icds.location_reassignment.utils import (
     get_case_ids_for_reassignment,
     get_supervisor_id,
-    reassign_household,
     reassign_cases,
+    reassign_household,
 )
 
 

--- a/custom/icds/location_reassignment/tasks.py
+++ b/custom/icds/location_reassignment/tasks.py
@@ -12,6 +12,7 @@ from corehq.apps.userreports.specs import EvaluationContext
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from custom.icds.location_reassignment.download import Households
+from custom.icds.location_reassignment.models import Transition
 from custom.icds.location_reassignment.processor import (
     HouseholdReassignmentProcessor,
     Processor,
@@ -75,7 +76,8 @@ def reassign_cases_for_owner(domain, old_location_id, new_location_id, deprecati
 @task
 def email_household_details(domain, transitions, uploaded_filename, user_email):
     try:
-        filestream = Households(domain).dump(transitions)
+        transition_objs = [Transition(*transition) for transition in transitions]
+        filestream = Households(domain).dump(transition_objs)
     except Exception as e:
         email = EmailMessage(
             subject=f"[{settings.SERVER_ENVIRONMENT}] - Location Reassignment Household Dump Failed",

--- a/custom/icds/location_reassignment/tests/test_download.py
+++ b/custom/icds/location_reassignment/tests/test_download.py
@@ -1,0 +1,110 @@
+from unittest import TestCase
+
+from mock import call, patch
+
+from corehq.util.workbook_json.excel import get_workbook
+from custom.icds.location_reassignment.const import (
+    AWC_CODE_COLUMN,
+    AWC_NAME_COLUMN,
+    EXTRACT_OPERATION,
+    HOUSEHOLD_ID_COLUMN,
+    HOUSEHOLD_MEMBER_DETAILS_COLUMN,
+    MERGE_OPERATION,
+    MOVE_OPERATION,
+    PERSON_CASE_TYPE,
+    SPLIT_OPERATION,
+)
+from custom.icds.location_reassignment.download import Households
+from custom.icds.location_reassignment.models import Transition
+from custom.icds.location_reassignment.tests.utils import (
+    CommCareCaseStub,
+    Location,
+)
+
+
+class TestHouseholds(TestCase):
+    domain = 'test'
+
+    @patch('custom.icds.location_reassignment.download.get_household_child_cases_by_owner')
+    @patch('corehq.form_processor.interfaces.dbaccessors.CaseAccessors.get_case')
+    @patch('custom.icds.location_reassignment.download.get_household_case_ids')
+    @patch('corehq.apps.locations.models.SQLLocation.active_objects.get')
+    def test_dump(self, get_location_mock, get_household_case_ids_mock, case_accessor_mock, child_cases_mock):
+        location = Location(site_code='123', location_id='123654789')
+        get_location_mock.return_value = location
+        get_household_case_ids_mock.return_value = ['1', '2']
+        case_accessor_mock.return_value = CommCareCaseStub(
+            '100', 'A House', {'hh_reg_date': '20/1/1988', 'hh_religion': 'Above All'})
+        child_cases_mock.return_value = [
+            CommCareCaseStub('101', 'A Person', {'age_at_reg': '4', 'sex': 'M'}),
+            CommCareCaseStub('102', 'B Person', {'age_at_reg': '5', 'sex': 'F'}),
+        ]
+        transitions = [
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=MOVE_OPERATION,
+                old_site_codes=['111'],
+                new_site_codes=['112']),
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=MERGE_OPERATION,
+                old_site_codes=['113', '114'],
+                new_site_codes=['115']),
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=SPLIT_OPERATION,
+                old_site_codes=['116'],
+                new_site_codes=['117', '118']),
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=EXTRACT_OPERATION,
+                old_site_codes=['119'],
+                new_site_codes=['120'])
+        ]
+
+        filestream = Households(self.domain).dump(transitions)
+
+        get_location_mock.assert_has_calls([
+            call(domain='test', site_code='116'),
+            call(domain='test', site_code='119')
+        ])
+        get_household_case_ids_mock.assert_has_calls([
+            call(self.domain, location.location_id),
+            call(self.domain, location.location_id)
+        ])
+        case_accessor_mock.assert_has_calls([
+            call('1'), call('2')
+        ])
+        child_cases_mock.assert_has_calls([
+            call(self.domain, '1', location.location_id, [PERSON_CASE_TYPE]),
+            call(self.domain, '2', location.location_id, [PERSON_CASE_TYPE])
+        ])
+
+        workbook = get_workbook(filestream)
+        self.assertEqual(len(workbook.worksheets), 2)
+        expected_row = {
+            AWC_NAME_COLUMN: '',
+            AWC_CODE_COLUMN: '',
+            'Name of Household': 'A House',
+            'Date of Registration': '20/1/1988',
+            'Religion': 'Above All',
+            'Caste': '',
+            'APL/BPL': '',
+            'Number of Household Members': 2,
+            HOUSEHOLD_MEMBER_DETAILS_COLUMN: 'A Person (4/M), B Person (5/F)',
+            HOUSEHOLD_ID_COLUMN: '100'
+        }
+        worksheet1_rows = list(workbook.worksheets_by_title['116'])
+        self.assertEqual(
+            worksheet1_rows,
+            [expected_row, expected_row]
+        )
+        worksheet2_rows = list(workbook.worksheets_by_title['119'])
+        self.assertEqual(
+            worksheet2_rows,
+            [expected_row, expected_row]
+        )

--- a/custom/icds/location_reassignment/tests/test_dumper.py
+++ b/custom/icds/location_reassignment/tests/test_dumper.py
@@ -1,41 +1,22 @@
-from collections import namedtuple
 from unittest import TestCase
 
-from mock import call, patch
+from mock import patch
 
 from corehq.util.workbook_json.excel import get_workbook
 from custom.icds.location_reassignment.const import (
     ARCHIVED_COLUMN,
-    AWC_CODE_COLUMN,
-    AWC_NAME_COLUMN,
     CASE_COUNT_COLUMN,
     EXTRACT_OPERATION,
-    HOUSEHOLD_ID_COLUMN,
-    HOUSEHOLD_MEMBER_DETAILS_COLUMN,
     MERGE_OPERATION,
     MISSING_COLUMN,
     MOVE_OPERATION,
     NEW_LOCATION_CODE_COLUMN,
     OLD_LOCATION_CODE_COLUMN,
-    PERSON_CASE_TYPE,
     SPLIT_OPERATION,
     TRANSITION_COLUMN,
 )
-from custom.icds.location_reassignment.download import Households
 from custom.icds.location_reassignment.dumper import Dumper
 from custom.icds.location_reassignment.models import Transition
-
-Location = namedtuple('Location', ['location_id', 'site_code'])
-
-
-class CommCareCaseStub(object):
-    def __init__(self, case_id, name, case_json):
-        self.case_id = case_id
-        self.name = name
-        self.case_json = case_json
-
-    def get_case_property(self, case_property):
-        return self.case_json.get(case_property)
 
 
 class TestDumper(TestCase):
@@ -129,92 +110,4 @@ class TestDumper(TestCase):
                  NEW_LOCATION_CODE_COLUMN: '120',
                  MISSING_COLUMN: True, ARCHIVED_COLUMN: True, CASE_COUNT_COLUMN: 0}
             ]
-        )
-
-
-class TestHouseholds(TestCase):
-    domain = 'test'
-
-    @patch('custom.icds.location_reassignment.download.get_household_child_cases_by_owner')
-    @patch('corehq.form_processor.interfaces.dbaccessors.CaseAccessors.get_case')
-    @patch('custom.icds.location_reassignment.download.get_household_case_ids')
-    @patch('corehq.apps.locations.models.SQLLocation.active_objects.get')
-    def test_dump(self, get_location_mock, get_household_case_ids_mock, case_accessor_mock, child_cases_mock):
-        location = Location(site_code='123', location_id='123654789')
-        get_location_mock.return_value = location
-        get_household_case_ids_mock.return_value = ['1', '2']
-        case_accessor_mock.return_value = CommCareCaseStub(
-            '100', 'A House', {'hh_reg_date': '20/1/1988', 'hh_religion': 'Above All'})
-        child_cases_mock.return_value = [
-            CommCareCaseStub('101', 'A Person', {'age_at_reg': '4', 'sex': 'M'}),
-            CommCareCaseStub('102', 'B Person', {'age_at_reg': '5', 'sex': 'F'}),
-        ]
-        transitions = [
-            Transition(
-                domain=self.domain,
-                location_type_code='awc',
-                operation=MOVE_OPERATION,
-                old_site_codes=['111'],
-                new_site_codes=['112']),
-            Transition(
-                domain=self.domain,
-                location_type_code='awc',
-                operation=MERGE_OPERATION,
-                old_site_codes=['113', '114'],
-                new_site_codes=['115']),
-            Transition(
-                domain=self.domain,
-                location_type_code='awc',
-                operation=SPLIT_OPERATION,
-                old_site_codes=['116'],
-                new_site_codes=['117', '118']),
-            Transition(
-                domain=self.domain,
-                location_type_code='awc',
-                operation=EXTRACT_OPERATION,
-                old_site_codes=['119'],
-                new_site_codes=['120'])
-        ]
-
-        filestream = Households(self.domain).dump(transitions)
-
-        get_location_mock.assert_has_calls([
-            call(domain='test', site_code='116'),
-            call(domain='test', site_code='119')
-        ])
-        get_household_case_ids_mock.assert_has_calls([
-            call(self.domain, location.location_id),
-            call(self.domain, location.location_id)
-        ])
-        case_accessor_mock.assert_has_calls([
-            call('1'), call('2')
-        ])
-        child_cases_mock.assert_has_calls([
-            call(self.domain, '1', location.location_id, [PERSON_CASE_TYPE]),
-            call(self.domain, '2', location.location_id, [PERSON_CASE_TYPE])
-        ])
-
-        workbook = get_workbook(filestream)
-        self.assertEqual(len(workbook.worksheets), 2)
-        expected_row = {
-            AWC_NAME_COLUMN: '',
-            AWC_CODE_COLUMN: '',
-            'Name of Household': 'A House',
-            'Date of Registration': '20/1/1988',
-            'Religion': 'Above All',
-            'Caste': '',
-            'APL/BPL': '',
-            'Number of Household Members': 2,
-            HOUSEHOLD_MEMBER_DETAILS_COLUMN: 'A Person (4/M), B Person (5/F)',
-            HOUSEHOLD_ID_COLUMN: '100'
-        }
-        worksheet1_rows = list(workbook.worksheets_by_title['116'])
-        self.assertEqual(
-            worksheet1_rows,
-            [expected_row, expected_row]
-        )
-        worksheet2_rows = list(workbook.worksheets_by_title['119'])
-        self.assertEqual(
-            worksheet2_rows,
-            [expected_row, expected_row]
         )

--- a/custom/icds/location_reassignment/tests/test_dumper.py
+++ b/custom/icds/location_reassignment/tests/test_dumper.py
@@ -149,12 +149,32 @@ class TestHouseholds(TestCase):
             CommCareCaseStub('101', 'A Person', {'age_at_reg': '4', 'sex': 'M'}),
             CommCareCaseStub('102', 'B Person', {'age_at_reg': '5', 'sex': 'F'}),
         ]
-        transitions = {
-            MOVE_OPERATION: {'112': '111'},  # new: old
-            MERGE_OPERATION: {'115': ['113', '114']},  # new: old
-            SPLIT_OPERATION: {'116': ['117', '118']},  # old: new
-            EXTRACT_OPERATION: {'120': '119'}  # new: old
-        }
+        transitions = [
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=MOVE_OPERATION,
+                old_site_codes=['111'],
+                new_site_codes=['112']),
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=MERGE_OPERATION,
+                old_site_codes=['113', '114'],
+                new_site_codes=['115']),
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=SPLIT_OPERATION,
+                old_site_codes=['116'],
+                new_site_codes=['117', '118']),
+            Transition(
+                domain=self.domain,
+                location_type_code='awc',
+                operation=EXTRACT_OPERATION,
+                old_site_codes=['119'],
+                new_site_codes=['120'])
+        ]
 
         filestream = Households(self.domain).dump(transitions)
 

--- a/custom/icds/location_reassignment/tests/utils.py
+++ b/custom/icds/location_reassignment/tests/utils.py
@@ -1,0 +1,13 @@
+from collections import namedtuple
+
+Location = namedtuple('Location', ['location_id', 'site_code'])
+
+
+class CommCareCaseStub(object):
+    def __init__(self, case_id, name, case_json):
+        self.case_id = case_id
+        self.name = name
+        self.case_json = case_json
+
+    def get_case_property(self, case_property):
+        return self.case_json.get(case_property)

--- a/custom/icds/location_reassignment/views.py
+++ b/custom/icds/location_reassignment/views.py
@@ -190,7 +190,7 @@ class LocationReassignmentView(BaseLocationView):
         return response
 
     def _process_request_for_email_households(self, parser, request, uploaded_filename):
-        awc_transitions = parser.valid_transitions_json(for_location_type=AWC_CODE)
+        awc_transitions = parser.valid_transitions_json(for_location_type=AWC_CODE).get(AWC_CODE)
         if awc_transitions:
             email_household_details.delay(self.domain, awc_transitions,
                                           uploaded_filename, request.user.email)


### PR DESCRIPTION
Fix Households

##### SUMMARY
When the location reassignment structure was realigned, the arguments to Households were incorrectly updated [here](https://github.com/dimagi/commcare-hq/commit/baf8cdf58805ab0576e64b6d19fbe84cb8e1ab8d#diff-ea46acecf30cee21b470a0402bea8863R159)

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`

better to review by commit