### PR TITLE
Disable django compress in tests

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
+++ b/corehq/apps/hqwebapp/templatetags/tests/test_tag.py
@@ -24,7 +24,6 @@ def template_dirs(*relative_dirs):
 
 
 @template_dirs("templates")
-@override_settings(COMPRESS_ENABLED=False)
 class TagTest(SimpleTestCase):
 
     @staticmethod

--- a/settings.py
+++ b/settings.py
@@ -764,13 +764,13 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 DIGEST_LOGIN_FACTORY = 'django_digest.NoEmailLoginFactory'
 
 # Django Compressor
-COMPRESS_PRECOMPILERS = (
+COMPRESS_PRECOMPILERS = AVAILABLE_COMPRESS_PRECOMPILERS = (
     ('text/less', 'corehq.apps.hqwebapp.precompilers.LessFilter'),
 )
 # if not overwritten in localsettings, these will be replaced by the value they return
 # using the local DEBUG value (which we don't have access to here yet)
-COMPRESS_ENABLED = lambda: not DEBUG
-COMPRESS_OFFLINE = lambda: not DEBUG
+COMPRESS_ENABLED = lambda: not DEBUG and not UNIT_TESTING
+COMPRESS_OFFLINE = lambda: not DEBUG and not UNIT_TESTING
 COMPRESS_JS_COMPRESSOR = 'corehq.apps.hqwebapp.uglify.JsUglifySourcemapCompressor'
 # use 'compressor.js.JsCompressor' for faster local compressing (will get rid of source maps)
 COMPRESS_CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter',
@@ -986,6 +986,16 @@ if callable(COMPRESS_ENABLED):
     COMPRESS_ENABLED = COMPRESS_ENABLED()
 if callable(COMPRESS_OFFLINE):
     COMPRESS_OFFLINE = COMPRESS_OFFLINE()
+if UNIT_TESTING or not COMPRESS_ENABLED:
+    # COMPRESS_COMPILERS overrides COMPRESS_ENABLED = False, so must be
+    # cleared to disable compression completely. CSS/less compression is
+    # very slow and should especially be avoided in tests. Tests that
+    # need to test compression should use
+    # @override_settings(
+    #     COMPRESS_ENABLED=True,
+    #     COMPRESS_PRECOMPILERS=settings.AVAILABLE_COMPRESS_PRECOMPILERS,
+    # )
+    COMPRESS_PRECOMPILERS = ()
 
 
 # Unless DISABLE_SERVER_SIDE_CURSORS has explicitly been set, default to True because Django >= 1.11.1 and our


### PR DESCRIPTION
Found while profiling `auditcare.tests.auth:AuthenticationTestCase.testRepeatedFailedLogin`, which was super slow due to compression.