### PR TITLE
Removed MULTI_MASTER_BYPASS_VERSION_CHECK feature flag

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -161,7 +161,4 @@ class CommCareFeatureSupportMixin(object):
 
     @property
     def enable_multi_master(self):
-        return (
-            self._require_minimum_version('2.47.4')
-            or toggles.MULTI_MASTER_BYPASS_VERSION_CHECK.enabled(self.domain)
-        ) and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(self.domain)
+        return self._require_minimum_version('2.47.4') and toggles.MULTI_MASTER_LINKED_DOMAINS.enabled(self.domain)

--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -69,11 +69,6 @@ class CopyApplicationForm(forms.Form):
         domain_obj = Domain.get_by_name(domain)
         if domain_obj is None:
             raise forms.ValidationError("A valid project space is required.")
-        if toggles.MULTI_MASTER_BYPASS_VERSION_CHECK.enabled(domain):
-            raise forms.ValidationError("""
-                Copying an app to a domain that uses multi-master linked apps and bypasses
-                the minimum CommCare version check requires developer intervention.
-            """)
         return domain
 
     def clean(self):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1461,13 +1461,6 @@ MULTI_MASTER_LINKED_DOMAINS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-MULTI_MASTER_BYPASS_VERSION_CHECK = StaticToggle(
-    'MULTI_MASTER_BYPASS_VERSION_CHECK',
-    "Bypass minimum CommCare version check for multi master usage. For use only by ICDS.",
-    TAG_CUSTOM,
-    [NAMESPACE_DOMAIN],
-)
-
 SUMOLOGIC_LOGS = DynamicallyPredictablyRandomToggle(
     'sumologic_logs',
     'Send logs to sumologic',


### PR DESCRIPTION
##### SUMMARY
See https://github.com/dimagi/commcare-hq/pull/26318

This was created for ICDS to be able to use multimaster despite being on a pre-2.47.4 version of CommCare, subject to the dreaded [xform crashing bug](https://dimagi-dev.atlassian.net/browse/ICDS-343) and requiring the addition of `ResourceOverride` objects when copying an app.

ICDS apps are now pinned to 2.48, so this is no longer an issue.

##### FEATURE FLAG
Removes "Bypass minimum CommCare version check for multi master usage. For use only by ICDS."

##### RISK ASSESSMENT / QA PLAN
Low risk, no QA.
