### PR TITLE
Mk/location reassignment reassign all cases 2

### DIFF
--- a/custom/icds/location_reassignment/const.py
+++ b/custom/icds/location_reassignment/const.py
@@ -28,6 +28,9 @@ AWC_CODE_COLUMN = 'AWC Code (11 digits)'
 HOUSEHOLD_MEMBER_DETAILS_COLUMN = 'Names of HH Members with Age and Gender'
 HOUSEHOLD_ID_COLUMN = 'Household ID in ICDS-CAS (Do Not Modify)'
 
+CASE_NAME = 'Name'
+CASE_ID_COLUMN = 'Case ID in ICDS-CAS (Do Not Modify)'
+
 # Dumper
 OLD_LOCATION_CODE_COLUMN = "Old location code"
 TRANSITION_COLUMN = "Transition"

--- a/custom/icds/location_reassignment/forms.py
+++ b/custom/icds/location_reassignment/forms.py
@@ -29,11 +29,11 @@ class LocationReassignmentRequestForm(BulkUploadForm):
                                f"(Only for {SPLIT_OPERATION} and {EXTRACT_OPERATION})"))]
     action_type = forms.ChoiceField(choices=ACTION_TYPE_CHOICES,
                                     initial=VALIDATE,
-                                    widget=SelectToggle(choices=ACTION_TYPE_CHOICES))
+                                    )
 
     def crispy_form_fields(self, context):
         crispy_form_fields = super(LocationReassignmentRequestForm, self).crispy_form_fields(context)
         crispy_form_fields.extend([
-            crispy.Div(InlineField('action_type'), css_class="col-sm-6"),
+            crispy.Div(InlineField('action_type'), css_class="col-sm-4"),
         ])
         return crispy_form_fields

--- a/custom/icds/location_reassignment/forms.py
+++ b/custom/icds/location_reassignment/forms.py
@@ -15,11 +15,14 @@ from custom.icds.location_reassignment.const import (
 class LocationReassignmentRequestForm(BulkUploadForm):
     VALIDATE = "validate"
     EMAIL_HOUSEHOLDS = "email_households"
+    EMAIL_OTHER_CASES = "email_other_cases"
     UPDATE = "update"
     REASSIGN_HOUSEHOLDS = "reassign_households"
     ACTION_TYPE_CHOICES = [(VALIDATE, ugettext("Validate")),
                            (EMAIL_HOUSEHOLDS, ugettext("Email Households "
                                                        f"(Only for {SPLIT_OPERATION} and {EXTRACT_OPERATION})")),
+                           (EMAIL_OTHER_CASES, ugettext("Email Other Cases "
+                                                        f"(Only for {SPLIT_OPERATION} and {EXTRACT_OPERATION})")),
                            (UPDATE, ugettext("Perform Reassignment")),
                            (REASSIGN_HOUSEHOLDS, ugettext(
                                "Reassign Households "

--- a/custom/icds/location_reassignment/forms.py
+++ b/custom/icds/location_reassignment/forms.py
@@ -18,6 +18,7 @@ class LocationReassignmentRequestForm(BulkUploadForm):
     EMAIL_OTHER_CASES = "email_other_cases"
     UPDATE = "update"
     REASSIGN_HOUSEHOLDS = "reassign_households"
+    REASSIGN_OTHER_CASES = "reassign_other_cases"
     ACTION_TYPE_CHOICES = [(VALIDATE, ugettext("Validate")),
                            (EMAIL_HOUSEHOLDS, ugettext("Email Households "
                                                        f"(Only for {SPLIT_OPERATION} and {EXTRACT_OPERATION})")),
@@ -26,7 +27,11 @@ class LocationReassignmentRequestForm(BulkUploadForm):
                            (UPDATE, ugettext("Perform Reassignment")),
                            (REASSIGN_HOUSEHOLDS, ugettext(
                                "Reassign Households "
-                               f"(Only for {SPLIT_OPERATION} and {EXTRACT_OPERATION})"))]
+                               f"(Only for {SPLIT_OPERATION} and {EXTRACT_OPERATION})")),
+                           (REASSIGN_OTHER_CASES, ugettext(
+                               "Reassign Other Cases "
+                               f"(Only for {SPLIT_OPERATION} and {EXTRACT_OPERATION})")),
+                           ]
     action_type = forms.ChoiceField(choices=ACTION_TYPE_CHOICES,
                                     initial=VALIDATE,
                                     )

--- a/custom/icds/location_reassignment/tasks.py
+++ b/custom/icds/location_reassignment/tasks.py
@@ -11,7 +11,7 @@ from corehq.apps.userreports.data_source_providers import (
 from corehq.apps.userreports.specs import EvaluationContext
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from custom.icds.location_reassignment.download import Households
+from custom.icds.location_reassignment.download import Households, OtherCases
 from custom.icds.location_reassignment.models import Transition
 from custom.icds.location_reassignment.processor import (
     HouseholdReassignmentProcessor,
@@ -105,6 +105,41 @@ def email_household_details(domain, transitions, uploaded_filename, user_email):
             email.body += "There were no house hold details found. "
         email.body += f"Please note that the households are fetched only for " \
                       f"{', '.join(Households.valid_operations)}."
+        email.send()
+
+
+@task
+def email_other_cases_details(domain, transitions, uploaded_filename, user_email):
+    try:
+        transition_objs = [Transition(**transition) for transition in transitions]
+        filestream = OtherCases(domain).dump(transition_objs)
+    except Exception as e:
+        email = EmailMessage(
+            subject=f"[{settings.SERVER_ENVIRONMENT}] - Location Reassignment Other Cases Dump Failed",
+            body=linebreaksbr(
+                f"The request could not be completed for file {uploaded_filename}. Something went wrong.\n"
+                f"Error raised : {e}.\n"
+                "Please report an issue if needed."
+            ),
+            to=[user_email],
+            from_email=settings.DEFAULT_FROM_EMAIL
+        )
+        email.content_subtype = "html"
+        email.send()
+        raise e
+    else:
+        email = EmailMessage(
+            subject=f"[{settings.SERVER_ENVIRONMENT}] - Location Reassignment Other Cases Dump Completed",
+            body=f"The request has been successfully completed for file {uploaded_filename}. ",
+            to=[user_email],
+            from_email=settings.DEFAULT_FROM_EMAIL
+        )
+        if filestream:
+            email.attach(filename="Other Cases.zip", content=filestream.read())
+        else:
+            email.body += "There were no cases found. "
+        email.body += f"Please note that the cases are fetched only for " \
+                      f"{', '.join(OtherCases.valid_operations)}."
         email.send()
 
 

--- a/custom/icds/location_reassignment/utils.py
+++ b/custom/icds/location_reassignment/utils.py
@@ -80,6 +80,7 @@ def get_supervisor_id(domain, location_id):
         return new_location.parent.location_id
 
 
+# ToDo: make this as a async task
 def reassign_household(domain, household_case_id, old_owner_id, new_owner_id, supervisor_id,
                        deprecation_time=None, household_child_case_ids=None):
     from custom.icds.location_reassignment.tasks import process_ucr_changes
@@ -109,6 +110,7 @@ def reassign_household(domain, household_case_id, old_owner_id, new_owner_id, su
     process_ucr_changes.delay(domain, case_ids)
 
 
+# ToDo: make this as a async task
 def reassign_cases(domain, case_ids, new_owner_id):
     case_blocks = []
     for case_id in case_ids:

--- a/custom/icds/static/icds/js/location_reassignment.js
+++ b/custom/icds/static/icds/js/location_reassignment.js
@@ -3,7 +3,6 @@ hqDefine("icds/js/location_reassignment", [
     'knockout',
     'hqwebapp/js/assert_properties',
     'locations/js/search',
-    'hqwebapp/js/components.ko',  // select toggle widget
 ], function (
     $,
     ko,


### PR DESCRIPTION
This is the second half for https://github.com/dimagi/commcare-hq/pull/27455

##### SUMMARY
This PR allows reassignment for cases that are not covered by household reassignment for extract and split operations.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`

In interest of speed to make this available for QA/UAT, this has let to duplication of code which i clean up as a follow up PR soon and will also include the ToDos marked.
