### PR TITLE
only override COMPRESS_PRECOMPILERS in tests

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -986,7 +986,7 @@ if callable(COMPRESS_ENABLED):
     COMPRESS_ENABLED = COMPRESS_ENABLED()
 if callable(COMPRESS_OFFLINE):
     COMPRESS_OFFLINE = COMPRESS_OFFLINE()
-if UNIT_TESTING or not COMPRESS_ENABLED:
+if UNIT_TESTING:
     # COMPRESS_COMPILERS overrides COMPRESS_ENABLED = False, so must be
     # cleared to disable compression completely. CSS/less compression is
     # very slow and should especially be avoided in tests. Tests that


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/dimagi/commcare-hq/pull/27475 appears to have broken client side css. This keeps it fully disabled in tests, but functional for local dev environments.