### PR TITLE
Added access_api permission

### DIFF
--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -62,7 +62,11 @@ class LoginAndDomainAuthentication(Authentication):
             }
 
     def is_authenticated(self, request, **kwargs):
-        return self._auth_test(request, wrappers=[self._get_auth_decorator(request), api_auth], **kwargs)
+        return self._auth_test(request, wrappers=[
+            self._get_auth_decorator(request),
+            api_auth,
+            require_permission('access_api', login_decorator=self._get_auth_decorator(request)),
+        ], **kwargs)
 
     def _get_auth_decorator(self, request):
         # the initial digest request doesn't have any authorization, so default to

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -65,7 +65,7 @@ class LoginAndDomainAuthentication(Authentication):
         return self._auth_test(request, wrappers=[
             self._get_auth_decorator(request),
             api_auth,
-            require_permission('access_api', login_decorator=self._get_auth_decorator(request)),
+            require_permission('access_api'),
         ], **kwargs)
 
     def _get_auth_decorator(self, request):

--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -65,7 +65,7 @@ class LoginAndDomainAuthentication(Authentication):
         return self._auth_test(request, wrappers=[
             self._get_auth_decorator(request),
             api_auth,
-            require_permission('access_api'),
+            require_permission('access_api', login_decorator=self._get_auth_decorator(request)),
         ], **kwargs)
 
     def _get_auth_decorator(self, request):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -127,6 +127,7 @@ class Permissions(DocumentSchema):
     edit_apps = BooleanProperty(default=False)
     edit_shared_exports = BooleanProperty(default=False)
     access_all_locations = BooleanProperty(default=True)
+    access_api = BooleanProperty(default=True)
 
     view_reports = BooleanProperty(default=False)
     view_report_list = StringListProperty(default=[])
@@ -237,6 +238,7 @@ class Permissions(DocumentSchema):
             edit_shared_exports=True,
             view_file_dropzone=True,
             edit_file_dropzone=True,
+            access_api=True,
         )
 
 

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -313,6 +313,30 @@
           </div> {# END dropzone permissions #}
           {% endif %}
 
+          {# BEGIN API permission #}
+          <div class="form-group">
+            <div class="col-sm-2 controls">
+              <div class="form-check">
+                <input type="checkbox"
+                       id="edit-api-checkbox"
+                       data-bind="checked: permissions.access_api,
+                                  disable: !$root.allowEdit" />
+                <label for="edit-api-checkbox"><span class="sr-only">{% trans "Access APIs" %}</span></label>
+              </div>
+            </div>
+            <div class="col-sm-2 controls">
+              <div class="form-check-placeholder">
+                <label></label>
+              </div>
+            </div>
+            <div class="col-sm-8 control-label">
+              {% blocktrans %}
+                <strong>Access APIs</strong> &mdash; use CommCare HQ APIs to read and update data.
+                Specific APIs may require additional permissions.
+              {% endblocktrans %}
+            </div>
+          </div> {# END API permission #}
+
           {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
             {# BEGIN Shared Export permissions #}
             <div class="form-group">


### PR DESCRIPTION
##### SUMMARY
https://trello.com/c/boqyWbR2/33-api-access-permission

##### RISK ASSESSMENT / QA PLAN
Tested locally that `curl -v -u <USERNAME> http://localhost:8000/a/bosco/api/v0.5/user/` succeeds when the new permission is true and 401s when it's false.

##### PRODUCT DESCRIPTION
Adds a new permission that is required to access any of HQ's APIs. The new permission defaults to true, so this will not affect existing users/roles. It does allow users to start revoking API access from existing roles and to create new roles that don't allow API access.

<img width="641" alt="Screen Shot 2020-05-14 at 6 54 03 PM" src="https://user-images.githubusercontent.com/1486591/81993718-505ce900-9614-11ea-9bd2-905db17d9202.png">
