### PR TITLE
More about contractors and messaging

### DIFF
--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -34,11 +34,11 @@ from corehq.apps.sms.models import SQLMobileBackend
 from corehq.apps.sms.util import (
     ALLOWED_SURVEY_DATE_FORMATS,
     get_sms_backend_classes,
+    is_superuser_or_contractor,
     strip_plus,
     validate_phone_number,
 )
 from corehq.apps.users.models import CommCareUser, CouchUser
-from corehq.toggles import IS_CONTRACTOR
 
 ENABLED = "ENABLED"
 DISABLED = "DISABLED"
@@ -1290,10 +1290,6 @@ class InitiateAddSMSBackendForm(Form):
                 ), css_class='col-sm-3 col-md-2 col-lg-2'),
             ),
         )
-
-
-def is_superuser_or_contractor(user: CouchUser):
-    return IS_CONTRACTOR.enabled(user.username) or user.is_superuser
 
 
 class SubscribeSMSForm(Form):

--- a/corehq/apps/sms/templates/sms/gateway_list.html
+++ b/corehq/apps/sms/templates/sms/gateway_list.html
@@ -32,7 +32,7 @@
       {% endfor %}
       </tbody>
     </table>
-    {% if request.couch_user.is_superuser %}
+    {% if is_system_admin %}
       <p class="text-danger">
         <i class="fa fa-info-circle"></i>
         {% blocktrans %}

--- a/corehq/apps/sms/tests/test_util.py
+++ b/corehq/apps/sms/tests/test_util.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from django.test import TestCase
 
+from nose.tools import assert_false, assert_true
+
 from corehq.apps.hqcase.utils import update_case
 from corehq.apps.sms.mixin import apply_leniency
 from corehq.apps.sms.util import (
@@ -8,11 +10,12 @@ from corehq.apps.sms.util import (
     clean_phone_number,
     get_contact,
     is_contact_active,
+    is_superuser_or_contractor,
 )
-from corehq.apps.users.models import CommCareUser
+from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.utils import is_commcarecase
-from corehq.util.test_utils import create_test_case
+from corehq.util.test_utils import create_test_case, flag_enabled
 
 
 class UtilTestCase(TestCase):
@@ -73,3 +76,19 @@ class UtilTestCase(TestCase):
         self.assertEqual('16175551234', apply_leniency(' 1 (617) 555-1234 '))
         self.assertEqual('16175551234', apply_leniency(' 1.617.555.1234 '))
         self.assertEqual('16175551234', apply_leniency(' +1 617 555 1234 '))
+
+
+def test_contractor():
+    user = CouchUser(username="eric")
+    with flag_enabled('IS_CONTRACTOR'):
+        assert_true(is_superuser_or_contractor(user))
+
+
+def test_superuser():
+    user = CouchUser(username="john", is_superuser=True)
+    assert_true(is_superuser_or_contractor(user))
+
+
+def test_normal_user():
+    user = CouchUser(username="michael")
+    assert_false(is_superuser_or_contractor(user))

--- a/corehq/apps/sms/tests/test_views.py
+++ b/corehq/apps/sms/tests/test_views.py
@@ -131,7 +131,7 @@ def domain_admin():
 @contextmanager
 def contractor():
     with domain_admin() as user, flag_enabled('IS_CONTRACTOR'):
-        yield
+        yield user
 
 
 @contextmanager

--- a/corehq/apps/sms/tests/test_views.py
+++ b/corehq/apps/sms/tests/test_views.py
@@ -111,7 +111,7 @@ class GatewayViewTests(TestCase):
 def normal_user():
     user = WebUser.create(DOMAIN_NAME, USERNAME, PASSWORD)
     try:
-        yield user
+        yield
     finally:
         user.delete()
 
@@ -123,21 +123,21 @@ def domain_admin():
     user.set_role(DOMAIN_NAME, "admin")
     user.save()
     try:
-        yield user
+        yield
     finally:
         user.delete()
 
 
 @contextmanager
 def contractor():
-    with domain_admin() as user, flag_enabled('IS_CONTRACTOR'):
-        yield user
+    with domain_admin(), flag_enabled('IS_CONTRACTOR'):
+        yield
 
 
 @contextmanager
 def superuser():
     user = WebUser.create(DOMAIN_NAME, USERNAME, PASSWORD, is_superuser=True)
     try:
-        yield user
+        yield
     finally:
         user.delete()

--- a/corehq/apps/sms/tests/test_views.py
+++ b/corehq/apps/sms/tests/test_views.py
@@ -1,0 +1,144 @@
+from contextlib import contextmanager
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from corehq.apps.accounting.models import (
+    BillingAccount,
+    DefaultProductPlan,
+    SoftwarePlanEdition,
+    Subscription,
+)
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.sms.views import AddDomainGatewayView
+from corehq.apps.users.models import WebUser
+from corehq.messaging.smsbackends.telerivet.models import SQLTelerivetBackend
+from corehq.messaging.smsbackends.twilio.models import SQLTwilioBackend
+from corehq.util.test_utils import flag_enabled
+
+DOMAIN_NAME = 'test-domain'
+USERNAME = "terry"
+PASSWORD = "sp@m_sp4m-spAm!"
+ADMIN_USER = "admin@example.com"
+
+
+class GatewayViewTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project = create_domain(DOMAIN_NAME)
+
+        account, __ = BillingAccount.get_or_create_account_by_domain(
+            DOMAIN_NAME, created_by=ADMIN_USER
+        )
+        plan = DefaultProductPlan.get_default_plan_version(
+            edition=SoftwarePlanEdition.ADVANCED
+        )
+        Subscription.new_domain_subscription(
+            account,
+            DOMAIN_NAME,
+            plan,
+            web_user=ADMIN_USER,
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.twilio_url = reverse(AddDomainGatewayView.urlname, kwargs={
+            'domain': DOMAIN_NAME,
+            'hq_api_id': SQLTwilioBackend.get_api_id()
+        })
+        self.telerivet_url = reverse(AddDomainGatewayView.urlname, kwargs={
+            'domain': DOMAIN_NAME,
+            'hq_api_id': SQLTelerivetBackend.get_api_id()
+        })
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.delete()
+        super().tearDownClass()
+
+    def test_superuser(self):
+        """
+        Superusers can add Twilio gateways
+        """
+        with superuser():
+            self.client.login(username=USERNAME, password=PASSWORD)
+            response = self.client.get(self.twilio_url)
+            page_name = response.context['page']['page_name']
+            self.assertEqual(page_name, 'Add Twilio Gateway')
+
+    def test_contractor(self):
+        """
+        Contractors can add Twilio gateways
+        """
+        with contractor():
+            self.client.login(username=USERNAME, password=PASSWORD)
+            response = self.client.get(self.twilio_url)
+            page_name = response.context['page']['page_name']
+            self.assertEqual(page_name, 'Add Twilio Gateway')
+
+    def test_domain_admin_twilio(self):
+        """
+        Domain admins can't add Twilio gateways
+        """
+        with domain_admin():
+            self.client.login(username=USERNAME, password=PASSWORD)
+            response = self.client.get(self.twilio_url)
+            self.assertEqual(response.status_code, 404)
+
+    def test_domain_admin_telerivet(self):
+        """
+        Domain admins can add Telerivet gateways
+        """
+        with domain_admin():
+            self.client.login(username=USERNAME, password=PASSWORD)
+            response = self.client.get(self.telerivet_url)
+            page_name = response.context['page']['page_name']
+            self.assertEqual(page_name, 'Add Telerivet (Android) Gateway')
+
+    def test_normal_user(self):
+        """
+        Normal users are redirected
+        """
+        with normal_user():
+            self.client.login(username=USERNAME, password=PASSWORD)
+            response = self.client.get(self.twilio_url)
+            self.assertEqual(response.status_code, 302)
+
+
+@contextmanager
+def normal_user():
+    user = WebUser.create(DOMAIN_NAME, USERNAME, PASSWORD)
+    try:
+        yield user
+    finally:
+        user.delete()
+
+
+@contextmanager
+def domain_admin():
+    user = WebUser.create(DOMAIN_NAME, USERNAME, PASSWORD)
+    user.add_domain_membership(DOMAIN_NAME, is_admin=True)
+    user.set_role(DOMAIN_NAME, "admin")
+    user.save()
+    try:
+        yield user
+    finally:
+        user.delete()
+
+
+@contextmanager
+def contractor():
+    with domain_admin() as user:
+        with flag_enabled('IS_CONTRACTOR'):
+            yield user
+
+
+@contextmanager
+def superuser():
+    user = WebUser.create(DOMAIN_NAME, USERNAME, PASSWORD, is_superuser=True)
+    try:
+        yield user
+    finally:
+        user.delete()

--- a/corehq/apps/sms/tests/test_views.py
+++ b/corehq/apps/sms/tests/test_views.py
@@ -130,9 +130,8 @@ def domain_admin():
 
 @contextmanager
 def contractor():
-    with domain_admin() as user:
-        with flag_enabled('IS_CONTRACTOR'):
-            yield user
+    with domain_admin() as user, flag_enabled('IS_CONTRACTOR'):
+        yield
 
 
 @contextmanager

--- a/corehq/apps/sms/util.py
+++ b/corehq/apps/sms/util.py
@@ -16,6 +16,7 @@ from dimagi.utils.parsing import json_format_datetime
 from corehq.apps.hqcase.utils import submit_case_block_from_template
 from corehq.apps.translations.models import SMSTranslations
 from corehq.apps.users.models import CouchUser
+from corehq.toggles import IS_CONTRACTOR
 from corehq.util.quickcache import quickcache
 
 
@@ -325,3 +326,7 @@ def get_language_list(domain):
     result = set(sms_translations.langs)
     result.discard('*')
     return list(result)
+
+
+def is_superuser_or_contractor(user: CouchUser):
+    return IS_CONTRACTOR.enabled(user.username) or user.is_superuser

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -118,6 +118,7 @@ from corehq.apps.sms.util import (
     get_contact,
     get_or_create_sms_translations,
     get_sms_backend_classes,
+    is_superuser_or_contractor,
 )
 from corehq.apps.smsbillables.utils import \
     country_name_from_isd_code_or_empty as country_name_from_code
@@ -164,7 +165,7 @@ class BaseMessagingSectionView(BaseDomainView):
 
     @cached_property
     def is_system_admin(self):
-        return self.request.couch_user.is_superuser
+        return is_superuser_or_contractor(self.request.couch_user)
 
     @cached_property
     def is_granted_messaging_access(self):
@@ -1000,6 +1001,7 @@ class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView)
         context.update({
             'initiate_new_form': InitiateAddSMSBackendForm(user=self.request.couch_user),
             'extra_backend_mappings': extra_backend_mappings,
+            'is_system_admin': self.is_system_admin,
         })
         return context
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1128,8 +1128,8 @@ class AddGatewayViewMixin(object):
     """
 
     @property
-    def is_superuser(self):
-        return self.request.couch_user.is_superuser
+    def is_system_admin(self):
+        return is_superuser_or_contractor(self.request.couch_user)
 
     @property
     @memoized
@@ -1141,7 +1141,7 @@ class AddGatewayViewMixin(object):
     def backend_class(self):
         # Superusers can create/edit any backend
         # Regular users can only create/edit Telerivet backends for now
-        if not self.is_superuser and self.hq_api_id != SQLTelerivetBackend.get_api_id():
+        if not self.is_system_admin and self.hq_api_id != SQLTelerivetBackend.get_api_id():
             raise Http404()
         backend_classes = get_sms_backend_classes()
         try:


### PR DESCRIPTION
Follows on from #27489

##### SUMMARY
Adds permissions for views. Adds tests.

##### FEATURE FLAG
`IS_CONTRACTOR`

##### PRODUCT DESCRIPTION
Contractors can now manage messaging gateways. Previously only superusers could.
