### PR TITLE
Location reassignment skip worker case

### DIFF
--- a/custom/icds/location_reassignment/const.py
+++ b/custom/icds/location_reassignment/const.py
@@ -65,6 +65,11 @@ HAVE_APPENDED_LOCATION_NAMES = [AWC_CODE, SUPERVISOR_CODE]
 
 HOUSEHOLD_CASE_TYPE = "household"
 PERSON_CASE_TYPE = "person"
+WORKER_CASE_TYPE = "worker"
+
+CASE_TYPES_TO_IGNORE = [
+    WORKER_CASE_TYPE
+]
 
 # title mapped to headers for the sheet
 SHEETS_TO_IGNORE = {

--- a/custom/icds/location_reassignment/download.py
+++ b/custom/icds/location_reassignment/download.py
@@ -307,7 +307,7 @@ class OtherCases(object):
         _, case_ids = get_case_ids_for_reassignment(self.domain, location.location_id)
         if not case_ids:
             return rows_per_case_type
-        cases = CaseAccessors(self.domain).get_cases(list(case_ids))
+        cases = CaseAccessors(self.domain).get_cases(case_ids)
         for case in cases:
             rows_per_case_type[case.type].append([
                 '',

--- a/custom/icds/location_reassignment/utils.py
+++ b/custom/icds/location_reassignment/utils.py
@@ -20,7 +20,7 @@ def get_case_ids_for_reassignment(domain, location_id):
     """
     :return: for cases that belong to location_id return
     a dict mapping for all case ids under a household id and
-    a set of all other case ids
+    a list of all other case ids
     """
     all_case_ids = CaseAccessorSQL.get_case_ids_in_domain_by_owners(domain, [location_id])
     all_cases = CaseAccessors(domain).get_cases(all_case_ids)
@@ -32,7 +32,7 @@ def get_case_ids_for_reassignment(domain, location_id):
         other_case_ids.remove(household_case_id)
         other_case_ids = other_case_ids - set(household_child_case_ids)
         child_case_ids_per_household_id[household_case_id] = household_child_case_ids
-    return child_case_ids_per_household_id, other_case_ids
+    return child_case_ids_per_household_id, list(other_case_ids)
 
 
 def get_household_case_ids(domain, location_id):

--- a/custom/icds/location_reassignment/utils.py
+++ b/custom/icds/location_reassignment/utils.py
@@ -8,8 +8,10 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from custom.icds.location_reassignment.const import (
     AWC_CODE,
+    CASE_TYPES_TO_IGNORE,
     HOUSEHOLD_CASE_TYPE,
 )
 
@@ -21,7 +23,8 @@ def get_case_ids_for_reassignment(domain, location_id):
     a set of all other case ids
     """
     all_case_ids = CaseAccessorSQL.get_case_ids_in_domain_by_owners(domain, [location_id])
-    other_case_ids = set(all_case_ids)
+    all_cases = CaseAccessors(domain).get_cases(all_case_ids)
+    other_case_ids = set([case.case_id for case in all_cases if case.type not in CASE_TYPES_TO_IGNORE])
     child_case_ids_per_household_id = {}
     for household_case_id in get_household_case_ids(domain, location_id):
         household_child_case_ids = get_household_child_case_ids_by_owner(


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1492

##### SUMMARY
As a part of ticket above, we reassigned all cases assigned to a location in https://github.com/dimagi/commcare-hq/pull/27455 and https://github.com/dimagi/commcare-hq/pull/27480. It was found out that the `worker` case is a special case that is created and assigned to a new location on creation. It is bound to the commcare-user and is updated and also reassigned back to the old location in case the user is updated/deactivated in location reassignment case.
Hence it was decided to skip reassignment for worker case.
If any new locations are created, their worker case would be blank and that has been confirmed as the correct expectation.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`