### PR TITLE
add passed filename name into attached file

### DIFF
--- a/custom/icds/location_reassignment/tasks.py
+++ b/custom/icds/location_reassignment/tasks.py
@@ -101,7 +101,8 @@ def email_household_details(domain, transitions, uploaded_filename, user_email):
             from_email=settings.DEFAULT_FROM_EMAIL
         )
         if filestream:
-            email.attach(filename="Households.xlsx", content=filestream.read())
+            email.attach(filename=f"Households - {uploaded_filename.split('.')[0]}.xlsx",
+                         content=filestream.read())
         else:
             email.body += "There were no house hold details found. "
         email.body += f"Please note that the households are fetched only for " \


### PR DESCRIPTION
Second request on https://dimagi-dev.atlassian.net/browse/QA-1307

##### SUMMARY
Make it easy to know which file the household dump was generated for

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
