### PR TITLE
fix bad reference to "closed" property in case schemas

### DIFF
--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -12,6 +12,7 @@ CASE_ID_SOURCE = 'case_id'
 
 # maps Case fields to the API field names used in CommCareCaseResource
 CASE_API_PATH_MAP = {
+    'closed': 'closed',
     'date_closed': 'date_closed',
     'date_modified': 'date_modified',
     'external_id': 'properties.external_id',


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Had been `"properties.closed"` but should just be `"closed"`.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

DET schemas

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
