### PR TITLE
automatically log in users with one valid mobile worker

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -157,6 +157,22 @@ class FormplayerMain(View):
                     response.delete_cookie(cookie_name)
                     return response
 
+        elif request.couch_user.has_permission(domain, 'limited_login_as'):
+            login_as_users = login_as_user_query(
+                domain,
+                request.couch_user,
+                search_string='',
+                limit=1,
+                offset=0
+            ).run()
+            if login_as_users.total == 1:
+                def set_cookie(response):
+                    response.set_cookie(cookie_name, user.username)
+                    return response
+
+                user = CouchUser.get_by_username(login_as_users.hits[0]['username'])
+                return user, set_cookie
+
         return request.couch_user, set_cookie
 
     def get(self, request, domain):

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -167,7 +167,7 @@ class FormplayerMain(View):
             ).run()
             if login_as_users.total == 1:
                 def set_cookie(response):
-                    response.set_cookie(cookie_name, user.username)
+                    response.set_cookie(cookie_name, user.raw_username)
                     return response
 
                 user = CouchUser.get_by_username(login_as_users.hits[0]['username'])


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For users eligible to login with a limited set of mobile workers, this causes them to "login as" that worker automatically if there is only one.

Put the do not merge label up, because I want to play around with it a bit more on staging, but I expect no future changes