### PR TITLE
Locations bulk upload improvements

### DIFF
--- a/corehq/apps/locations/tasks.py
+++ b/corehq/apps/locations/tasks.py
@@ -13,7 +13,10 @@ from corehq.apps.commtrack.models import (
     sync_supply_point,
 )
 from corehq.apps.es.users import UserES
-from corehq.apps.locations.bulk_management import new_locations_import
+from corehq.apps.locations.bulk_management import (
+    LocationUploadResult,
+    new_locations_import,
+)
 from corehq.apps.locations.const import LOCK_LOCATIONS_TIMEOUT
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.util import dump_locations
@@ -100,35 +103,39 @@ def download_locations_async(domain, download_id, include_consumption, headers_o
 @serial_task('{domain}', default_retry_delay=5 * 60, timeout=LOCK_LOCATIONS_TIMEOUT, max_retries=12,
              queue=settings.CELERY_MAIN_QUEUE, ignore_result=False)
 def import_locations_async(domain, file_ref_id, user_id):
-    importer = MultiExcelImporter(import_locations_async, file_ref_id)
-    user = CouchUser.get_by_user_id(user_id)
-    results = new_locations_import(domain, importer, user)
-    importer.mark_complete()
+    try:
+        importer = MultiExcelImporter(import_locations_async, file_ref_id)
+        user = CouchUser.get_by_user_id(user_id)
+        results = new_locations_import(domain, importer, user)
+        importer.mark_complete()
 
-    if LOCATIONS_IN_UCR.enabled(domain):
-        # We must rebuild datasources once the location import is complete in
-        # case child locations were not updated, but a parent location was.
-        # For example if a state was updated, the county may reference the state
-        # and need to have its row updated
-        datasources = get_datasources_for_domain(domain, "Location", include_static=True)
-        for datasource in datasources:
-            rebuild_indicators_in_place.delay(
-                datasource.get_id, initiated_by=user.username, source='import_locations'
+        if LOCATIONS_IN_UCR.enabled(domain):
+            # We must rebuild datasources once the location import is complete in
+            # case child locations were not updated, but a parent location was.
+            # For example if a state was updated, the county may reference the state
+            # and need to have its row updated
+            datasources = get_datasources_for_domain(domain, "Location", include_static=True)
+            for datasource in datasources:
+                rebuild_indicators_in_place.delay(
+                    datasource.get_id, initiated_by=user.username, source='import_locations'
+                )
+
+        if getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False):
+            # Log results because they are not sent to the view when
+            # CELERY_TASK_ALWAYS_EAGER is true
+            logging.getLogger(__name__).info(
+                "import_locations_async %s results: %s -> success=%s",
+                file_ref_id,
+                " ".join(
+                    "%s=%r" % (name, getattr(results, name))
+                    for name in ["messages", "warnings", "errors"]
+                    if getattr(results, name)
+                ),
+                results.success,
             )
-
-    if getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False):
-        # Log results because they are not sent to the view when
-        # CELERY_TASK_ALWAYS_EAGER is true
-        logging.getLogger(__name__).info(
-            "import_locations_async %s results: %s -> success=%s",
-            file_ref_id,
-            " ".join(
-                "%s=%r" % (name, getattr(results, name))
-                for name in ["messages", "warnings", "errors"]
-                if getattr(results, name)
-            ),
-            results.success,
-        )
+    except Exception as e:
+        results = LocationUploadResult()
+        results.errors = [str(e)]
 
     return {
         'messages': {

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -43,6 +43,7 @@ from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
 from corehq.apps.users.forms import MultipleSelectionForm
 from corehq.util import reverse
 from corehq.util.files import file_extention_from_filename
+from corehq.util.workbook_json.excel import WorkbookJSONError, get_workbook
 
 from .analytics import users_have_locations
 from .const import ROOT_LOCATION_TYPE
@@ -932,8 +933,15 @@ class LocationImportView(BaseLocationView):
         if not args:
             messages.error(request, _('no domain specified'))
             return self.get(request, *args, **kwargs)
-        if upload.content_type != 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+
+        if not upload.name.endswith('.xlsx'):
             messages.error(request, _("Invalid file-format. Please upload a valid xlsx file."))
+            return self.get(request, *args, **kwargs)
+
+        try:
+            get_workbook(upload)
+        except WorkbookJSONError as e:
+            messages.error(request, e)
             return self.get(request, *args, **kwargs)
 
         domain = args[0]

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -49,7 +49,12 @@ from .analytics import users_have_locations
 from .const import ROOT_LOCATION_TYPE
 from .dbaccessors import get_users_assigned_to_locations
 from .exceptions import LocationConsistencyError
-from .forms import LocationFormSet, RelatedLocationForm, UsersAtLocationForm, LocationFilterForm
+from .forms import (
+    LocationFilterForm,
+    LocationFormSet,
+    RelatedLocationForm,
+    UsersAtLocationForm,
+)
 from .models import LocationType, SQLLocation, filter_for_archived
 from .permissions import (
     can_edit_location,

--- a/corehq/util/workbook_json/excel.py
+++ b/corehq/util/workbook_json/excel.py
@@ -235,6 +235,7 @@ class WorkbookJSONReader(object):
             tmp = NamedTemporaryFile(mode='wb', suffix='.xlsx', delete=False)
             file_or_filename.seek(0)
             tmp.write(file_or_filename.read())
+            file_or_filename.seek(0)
             tmp.close()
             file_or_filename = tmp.name
         try:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1496

##### SUMMARY
Copying over from how we ensure the file uploaded is valid one for [user upload](https://github.com/dimagi/commcare-hq/blob/7cd8b855255a0a76c2e79d3920559fc6e64fff55/corehq/apps/users/views/mobile/users.py#L1017-L1021), to confirm both the file extension and format in a more reliable way for locations upload as well.
Also improved on what we show to the user in case of error during the import.

As for the code,
Looks like there is a need to make a common util that does this because this is done at multiple places. May be move the check to the bulk upload form `BulkUploadForm`? but leaving that for a later day

##### RISK ASSESSMENT / QA PLAN
I tested this myself locally and it worked as expected. A valid upload went through whereas the one with invalid file notified the user. Also check error message in case the task fails

##### PRODUCT DESCRIPTION
When doing a bulk locations upload,
Earlier the check was for pretty specific and lead to false errors.
The page now gives a valid error
when a doc file is uploaded
```
Invalid file-format. Please upload a valid xlsx file.
```

and when i upload a bad excel file
```
Upload failed! Please make sure you are using a valid Excel 2007 or later (.xlsx) file. Error details: File is not a zip file.
```
This is same as user's upload.

The "File is not a zip file" is confusing though, which i tried to see if we can resolve but it is coming from the third party excel library as the error message.

Also when there is an error in the upload, which happens during the import in celery task
The error shown was
`Problem importing data! Please try again or report an issue.`

I updated that for the user to know what exactly went wrong, so now it would be
```
Upload failed! Details:
'NoneType' object has no attribute 'has_permission'
```
(i made that to happen by failing the user lookup)
