### PR TITLE
More User-Centric Message for clear user data in web apps

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -34,7 +34,7 @@
   </td>
 </script>
 <script type="text/template" id="clear-user-data-setting-template">
-  <th>{% trans "Clear user data" %}</th>
+  <th>{% trans "Clear logged in user cache" %}</th>
   <td><button class="js-clear-user-data btn btn-sm btn-danger">{% trans "Clear" %}</button></td>
 </script>
 <script type="text/template" id="break-locks-setting-template">


### PR DESCRIPTION
The Web Apps action  "clear user data" is labeled directly with that name, which isn't accurate in the user's mental model of what the action performs.

NOTE: shouldn't be pulled until we can review where this is mentioned in our docs and update.