### PR TITLE
Use slug and timestamp as report export name

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -34,6 +34,7 @@ from corehq.elastic import (
 )
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.pillows.mappings.app_mapping import APP_INDEX
+from corehq.util.dates import get_timestamp_for_filename
 from corehq.util.files import TransientTempfile, safe_filename_header
 from corehq.util.metrics import metrics_gauge
 from corehq.util.soft_assert import soft_assert
@@ -189,7 +190,7 @@ def export_all_rows_task(ReportClass, report_state, recipient_list=None, subject
         # This uses the user's first domain to store the file in the blobdb
         report.domain = report.request.couch_user.get_domains()[0]
 
-    hash_id = _store_excel_in_blobdb(report_class, file, report.domain)
+    hash_id = _store_excel_in_blobdb(report_class, file, report.domain, report.slug)
     if not recipient_list:
         recipient_list = [report.request.couch_user.get_email()]
     for recipient in recipient_list:
@@ -221,13 +222,14 @@ def _send_email(user, report, hash_id, recipient, subject=None):
     send_report_download_email(report.name, recipient, link, subject)
 
 
-def _store_excel_in_blobdb(report_class, file, domain):
+def _store_excel_in_blobdb(report_class, file, domain, report_slug):
     key = uuid.uuid4().hex
     expired = 60 * 24 * 7  # 7 days
     db = get_blob_db()
 
     kw = {
         "domain": domain,
+        "name": f"{report_slug}-{get_timestamp_for_filename()}",
         "parent_id": key,
         "type_code": CODES.tempfile,
         "key": key,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -2079,7 +2079,7 @@ def export_report(request, domain, export_hash, format):
             response = HttpResponse(file, Format.FORMAT_DICT[format])
             response['Content-Length'] = file.size
             response['Content-Disposition'] = 'attachment; filename="{filename}.{extension}"'.format(
-                filename=export_hash,
+                filename=meta.name or export_hash,
                 extension=Format.FORMAT_DICT[format]['extension']
             )
             return response


### PR DESCRIPTION
This was implemented for the INDDEX project, but is generally useful, and
implemented generically.  At the moment it uses report slug and the full timestamp, but I could see a case being made for including the domain name too - though not sure most end users would need that.

##### PRODUCT DESCRIPTION
Currently, when you have a report sent to you over email, the downloaded filename looks like  `267800f74ea343b6905251108efc3747.xlsx`.  This changes that to something like `worker_activity-2020-05-18T21.31.39.xlsx`.
