### PR TITLE
Remove toggle for concurrent message rules

### DIFF
--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -176,7 +176,7 @@ def run_messaging_rule(domain, rule_id):
         for db_alias in db_aliases:
             run_messaging_rule_for_shard.delay(domain, rule_id, db_alias)
 
-    if toggles.SHARDED_RUN_MESSAGING_RULE.enabled(domain) and should_use_sql_backend(domain):
+    if should_use_sql_backend(domain):
         _run_rule_on_multiple_shards()
     else:
         _run_rule_sequentially()

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1913,11 +1913,3 @@ RESTRICT_LOGIN_AS = StaticToggle(
     TAG_CUSTOM,
     namespaces=[NAMESPACE_DOMAIN]
 )
-
-SHARDED_RUN_MESSAGING_RULE = StaticToggle(
-    'sharded_run_messaging_rule',
-    'Trigger concurrent tasks per each shard for conditional case alerts'
-    'Applies to SQL domains only',
-    TAG_CUSTOM,
-    namespaces=[NAMESPACE_DOMAIN]
-)


### PR DESCRIPTION
This went well on ICDS and staging with good improvements in speed. So, removing the toggle.

FYI @mkangia 