### PR TITLE
Fixed API access for domain using mirrored permissions

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -224,7 +224,7 @@ def _login_or_challenge(challenge_fn, allow_cc_users=False, api_key=False, allow
                     if (
                         couch_user
                         and (allow_cc_users or couch_user.is_web_user())
-                        and couch_user.is_member_of(domain)
+                        and couch_user.is_member_of(domain, allow_mirroring=True)
                     ):
                         clear_login_attempts(couch_user)
                         return fn(request, domain, *args, **kwargs)


### PR DESCRIPTION
##### SUMMARY
Fixes a bug in https://github.com/dimagi/commcare-hq/pull/27510 where users who are members of the source domain but not the mirror can't issue API calls against the mirror.

##### FEATURE FLAG
No flag, but using this feature depends on a developer-facing config.

##### RISK ASSESSMENT / QA PLAN
Working on tests in a followup PR.