### PR TITLE
Add Upload Progress Tracking for Bulk Upload Cases to Case Group

### DIFF
--- a/corehq/apps/data_interfaces/static/data_interfaces/js/manage_case_groups.js
+++ b/corehq/apps/data_interfaces/static/data_interfaces/js/manage_case_groups.js
@@ -34,10 +34,19 @@ hqDefine("data_interfaces/js/manage_case_groups", [
                         },
                         success: function (data) {
                             if (data) {
-                                isPollingActive = false;
-                                $('#upload-notice').html(
-                                    _.template($('#template-bulk-status').text())(data)
-                                );
+                                if (data.inProgress) {
+                                    isPollingActive = true;
+                                    attempts = 0;
+                                    $('#upload-progress').html(
+                                        _.template($('#template-upload-progress').text())(data)
+                                    );
+                                    retry();
+                                } else {
+                                    isPollingActive = false;
+                                    $('#upload-notice').html(
+                                        _.template($('#template-bulk-status').text())(data)
+                                    );
+                                }
                             } else {
                                 retry();
                             }

--- a/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
@@ -9,7 +9,7 @@
   <h3>
     {% blocktrans %}
       Cases in Group
-      <a href="#" id="toggle-group-name">{{ group_name }} <small><i class="fa fa-edit"> Edit</i></small></a>
+      <a href="#" id="toggle-group-name">{{ group_name }} <small><i class="fa fa-edit"></i> Edit</small></a>
     {% endblocktrans %}
   </h3>
   <div id="edit-group-name" class="hide">

--- a/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/manage_case_groups.html
@@ -16,6 +16,13 @@
     {% crispy update_case_group_form %}
   </div>
   {% if bulk_upload_id %}
+
+    <script type="text/html" id="template-upload-progress">
+      <p>
+        <%=current%> / <%=total%> {% trans 'cases processed. Please do not refresh or close this page.' %}
+      </p>
+    </script>
+
     <script type="template/html" id="template-bulk-status">
       <% if (success.length > 0) { %>
       <div class="alert alert-success">
@@ -40,9 +47,13 @@
       <% } %>
     </script>
     <div id="upload-notice">
-      <i class='fa fa-spin fa-spinner'></i>
-      {% trans 'Processing file...' %}
-      <hr />
+      <div class="alert alert-info">
+        <h4>
+          <i class='fa fa-spin fa-spinner'></i>
+          {% trans 'Processing file...' %}
+        </h4>
+        <div id="upload-progress"></div>
+      </div>
     </div>
   {% endif %}
 {% endblock %}
@@ -97,15 +108,20 @@
 {% endblock %}
 
 {% block pagination_footer %}
-  <div class="accordion-group" style="margin-top:5px;">
+  <hr />
+  <div class="accordion-group" style="margin-top:5px; margin-bottom: 20px;">
     <div class="accordion-heading">
-      <a class="accordion-toggle" data-toggle="collapse" href="#bulk-upload-accordion">
+      <a class="accordion-toggle btn btn-default" data-toggle="collapse" href="#bulk-upload-accordion">
         {% trans 'Bulk upload cases to group' %}
       </a>
     </div>
     <div id="bulk-upload-accordion" class="accordion-body collapse">
       <div class="accordion-inner">
-        {% include "hqwebapp/partials/bulk_upload.html" %}
+        <div class="panel panel-modern-gray panel-form-only">
+          <div class="panel-body">
+            {% include "hqwebapp/partials/bulk_upload.html" %}
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -10,7 +10,7 @@ from corehq.apps.hqcase.utils import get_case_by_identifier
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 
 
-def add_cases_to_case_group(domain, case_group_id, uploaded_data):
+def add_cases_to_case_group(domain, case_group_id, uploaded_data, progress_tracker):
     response = {
         'errors': [],
         'success': [],
@@ -21,7 +21,9 @@ def add_cases_to_case_group(domain, case_group_id, uploaded_data):
         response['errors'].append(_("The case group was not found."))
         return response
 
-    for row in uploaded_data:
+    num_rows = len(uploaded_data)
+    progress_tracker(0, num_rows)
+    for row_number, row in enumerate(uploaded_data):
         identifier = row.get('case_identifier')
         case = None
         if identifier is not None:
@@ -46,6 +48,7 @@ def add_cases_to_case_group(domain, case_group_id, uploaded_data):
                 _("Case with identifier '{}' has been added to this "
                   "group.").format(identifier)
             )
+        progress_tracker(row_number + 1, num_rows)
 
     if response['success']:
         case_group.save()

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -27,14 +27,25 @@ def add_cases_to_case_group(domain, case_group_id, uploaded_data):
         if identifier is not None:
             case = get_case_by_identifier(domain, str(identifier))
         if not case:
-            response['errors'].append(_("Could not find case with identifier '%s'." % identifier))
+            response['errors'].append(
+                _("Could not find case with identifier '{}'.").format(identifier)
+            )
         elif case.doc_type != 'CommCareCase':
-            response['errors'].append(_("It looks like the case with identifier '%s' is deleted" % identifier))
+            response['errors'].append(
+                _("It looks like the case with identifier '{}' "
+                  "is marked as deleted.").format(identifier)
+              )
         elif case.case_id in case_group.cases:
-            response['errors'].append(_("A case with identifier %s already exists in this group." % identifier))
+            response['errors'].append(
+                _("A case with identifier '{}' already exists in this "
+                  "group.").format(identifier)
+            )
         else:
             case_group.cases.append(case.case_id)
-            response['success'].append(_("Case with identifier '%s' has been added to this group." % identifier))
+            response['success'].append(
+                _("Case with identifier '{}' has been added to this "
+                  "group.").format(identifier)
+            )
 
     if response['success']:
         case_group.save()

--- a/corehq/apps/data_interfaces/utils.py
+++ b/corehq/apps/data_interfaces/utils.py
@@ -36,7 +36,7 @@ def add_cases_to_case_group(domain, case_group_id, uploaded_data, progress_track
             response['errors'].append(
                 _("It looks like the case with identifier '{}' "
                   "is marked as deleted.").format(identifier)
-              )
+            )
         elif case.case_id in case_group.cases:
             response['errors'].append(
                 _("A case with identifier '{}' already exists in this "


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10841

##### SUMMARY
For files with a lot of cases, the bulk upload in Manage Case Group times out, as there is no way of tracking upload progress. I added a simple way of tracking this progress using the existing upload status framework that exists on this page. Ideally, we should be using something more robust like soil in the way download exports tracks download tasks (but this time for uploads)...but for an effort 3 ticket I didn't want to spend that much time going down that rabbit hole, which would definitely require some QA on top. This is a really simple & naive change ON PURPOSE. 😃 

##### RISK ASSESSMENT / QA PLAN
I think it's a very small isolated change that we should be ok.

##### PRODUCT DESCRIPTION
In the Manage Case Group page, for bulk uploads with a lot of cases the user will see a simple progress indicator like the following:
![Screen Shot 2020-05-19 at 4 36 07 PM](https://user-images.githubusercontent.com/716573/82381103-3c87fd00-99ef-11ea-94d9-5d6b0ec8a5ba.png)

I also quickly prettified the upload bulk cases button area:
![Screen Shot 2020-05-19 at 4 33 28 PM](https://user-images.githubusercontent.com/716573/82381152-53c6ea80-99ef-11ea-8501-3fce2201ec13.png)

