### PR TITLE
Back off on S3 SlowDown error

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -11,6 +11,7 @@ architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, sphinx
+backoff==1.10.0           # via -r requirements/requirements.in
 beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -212,6 +212,7 @@ transifex-client==0.12.4  # via -r requirements/dev-requirements.in
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -168,6 +168,7 @@ traitlets==4.3.3          # via ipython
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -9,6 +9,7 @@ amqp==2.5.2               # via kombu
 architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, flower
+backoff==1.10.0           # via -r requirements/requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -152,6 +152,7 @@ tinys3==0.1.12            # via -r requirements/requirements.in
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -9,6 +9,7 @@ amqp==2.5.2               # via kombu
 architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
+backoff==1.10.0           # via -r requirements/requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -169,6 +169,7 @@ traceback2==1.4.0         # via unittest2
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -10,6 +10,7 @@ architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
+backoff==1.10.0           # via -r requirements/requirements.in
 beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -11,6 +11,7 @@ architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, sphinx
+backoff==1.10.0           # via -r requirements/requirements.in
 beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -212,6 +212,7 @@ transifex-client==0.12.4  # via -r requirements/dev-requirements.in
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk, transifex-client

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -168,6 +168,7 @@ traitlets==4.3.3          # via ipython
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -9,6 +9,7 @@ amqp==2.5.2               # via kombu
 architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, flower
+backoff==1.10.0           # via -r requirements/requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,5 @@
 attrs~=18.1
+backoff
 iso8601==0.1.12
 jsonobject==0.9.9
 jsonobject-couchdbkit~=1.0.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -48,6 +48,7 @@ schema
 suds-jurko==0.6
 tropo-webapi-python==0.1.3
 text-unidecode>=1.2
+typing-extensions  # Can be removed after upgrading to Python 3.8
 xlrd==1.0.0
 simplejson~=3.11
 sh==1.09

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -152,6 +152,7 @@ tinys3==0.1.12            # via -r requirements/requirements.in
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk
 user-agents==2.0          # via django-user-agents

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,6 +9,7 @@ amqp==2.5.2               # via kombu
 architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
+backoff==1.10.0           # via -r requirements/requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -169,6 +169,7 @@ traceback2==1.4.0         # via unittest2
 tropo-webapi-python==0.1.3  # via -r requirements/requirements.in
 turn-python==0.0.1        # via -r requirements/requirements.in
 twilio==6.5.1             # via -r requirements/requirements.in
+typing-extensions==3.7.4.2  # via -r requirements/requirements.in
 ua-parser==0.8.0          # via user-agents
 unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.6           # via botocore, elasticsearch, elasticsearch2, py-kissmetrics, requests, sentry-sdk

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -10,6 +10,7 @@ architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field
+backoff==1.10.0           # via -r requirements/requirements.in
 beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in


### PR DESCRIPTION
Dumping (a lot of) BlobDB data has resulted in S3 sending us a SlowDown error. (HTTP 503 fwiw) 

[Sentry](https://sentry.io/organizations/dimagi/issues/1674124004/?environment=production&project=136860&query=is%3Aunresolved+clienterror&statsPeriod=14d)

##### SUMMARY

This change backs off exponentially. It follows [the pattern used by commcare-export](https://github.com/dimagi/commcare-export/blob/master/commcare_export/commcare_hq_client.py#L91).

