### PR TITLE
send desktop reminder to user's email instead of username if available

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -471,7 +471,6 @@ def eula_agreement(request):
 @login_required
 @require_POST
 def send_mobile_reminder(request):
-    send_mobile_experience_reminder(request.user.username,
+    send_mobile_experience_reminder(request.couch_user.email or request.user.username,
                                     request.couch_user.full_name)
-
     return HttpResponse()


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-10863

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In this view we were assuming that `user.username` was an email address, but for mobile workers that is not the case, so use `email` first unless it's empty, then fall back to `username`.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
