### PR TITLE
Ce/default login as

### DIFF
--- a/corehq/apps/cloudcare/tests/test_esaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_esaccessors.py
@@ -148,3 +148,21 @@ class TestCloudcareESAccessors(SimpleTestCase):
                 ).count(),
                 1
             )
+
+    def test_default_user(self):
+        self._send_user_to_es(username='superman')
+        self._send_user_to_es(username='robin', user_data={'login_as_user': 'batman'})
+        self._send_user_to_es(username='superwoman', user_data={'login_as_user': 'default'})
+
+        with patch('corehq.apps.cloudcare.esaccessors._limit_login_as', return_value=True):
+            self.assertEqual(
+                login_as_user_query(
+                    self.domain,
+                    MagicMock(username='batman'),
+                    None,
+                    10,
+                    0,
+                    []
+                ).count(),
+                2
+            )

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -145,6 +145,7 @@ class Permissions(DocumentSchema):
     manage_releases_list = StringListProperty(default=[])
 
     limited_login_as = BooleanProperty(default=False)
+    access_default_login_as_user = BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -573,11 +573,27 @@
             <div class="col-sm-8 controls">
               <div class="form-check">
                 <input type="checkbox"
-                       id="non-admin-edit-checkbox"
+                       id="limited-login-as-checkbox"
                        data-bind="checked: permissions.limited_login_as,
                                   disable: !$root.allowEdit" />
-                <label for="non-admin-edit-checkbox">
+                <label for="limited-login-as-checkbox">
                   {% trans "Allow the user to login as only specified users in Web Apps." %}
+                </label>
+              </div>
+            </div>
+            </div>
+            <div class="form-group">
+            <label class="col-sm-4 control-label">
+              {% trans "Login-As Default User" %}
+            </label>
+            <div class="col-sm-8 controls">
+              <div class="form-check">
+                <input type="checkbox"
+                       id="default-login-as-checkbox"
+                       data-bind="checked: permissions.access_default_login_as_user,
+                                  disable: !$root.allowEdit" />
+                <label for="limited-login-as-checkbox">
+                  {% trans "Allow the user to login as the default user in Web Apps." %}
                 </label>
               </div>
             </div>

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -592,7 +592,7 @@
                        id="default-login-as-checkbox"
                        data-bind="checked: permissions.access_default_login_as_user,
                                   disable: !$root.allowEdit" />
-                <label for="limited-login-as-checkbox">
+                <label for="default-login-as-checkbox">
                   {% trans "Allow the user to login as the default user in Web Apps." %}
                 </label>
               </div>


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows domains to specify a default login_as user for restricted web users, and control who has access to that user. It is controlled by the same feature flag as the other login as restrictions.