### PR TITLE
Avoid using Secure cookies in dev

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -958,6 +958,8 @@ REQUIRE_TWO_FACTOR_FOR_SUPERUSERS = False
 # that adds messages to the partition with the fewest unprocessed messages
 USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER = False
 
+SESSION_COOKIE_SECURE = CSRF_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_HTTPONLY = CSRF_COOKIE_HTTPONLY = True
 
 try:
     # try to see if there's an environmental variable set for local_settings
@@ -2134,9 +2136,6 @@ if SENTRY_DSN:
     SENTRY_CONFIGURED = True
 else:
     SENTRY_CONFIGURED = False
-
-SESSION_COOKIE_SECURE = CSRF_COOKIE_SECURE = True
-SESSION_COOKIE_HTTPONLY = CSRF_COOKIE_HTTPONLY = True
 
 if RESTRICT_USED_PASSWORDS_FOR_NIC_COMPLIANCE:
     AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
##### SUMMARY

Avoid using Secure cookies in dev since secure means don't send over http, and our dev environments mostly use http. I had foreseen the possibility that this would happen which I even noted in https://github.com/dimagi/commcare-hq/pull/27514, but somehow I deceived myself with whatever test I did because I came to the wrong conclusion there. (I think I already had a cookie not marked `Secure`, and it continued to send, whereas logging out and back in caused the cookie to be marked `Secure` and thus not send. Something like that.)

