### PR TITLE
Configurable inactivity timeout at domain level

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -1,6 +1,4 @@
 import datetime
-import json
-import time
 
 from django.db import transaction
 from django.urls import reverse
@@ -741,9 +739,9 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         strong_mobile_passwords = domain.strong_mobile_passwords
         msgs = []
         if secure_sessions:
-            msgs.append(_("Your project has enabled a 30 minute session timeout setting. "
+            msgs.append(_("Your project has enabled a {} minute session timeout setting. "
                           "By changing to a different plan, you will lose the ability to "
-                          "enforce this shorter timeout policy."))
+                          "enforce this shorter timeout policy.").format(domain.secure_timeout))
         if two_factor:
             msgs.append(_("Two factor authentication is currently required of all of your "
                           "web users for this project space.  By changing to a different "

--- a/corehq/apps/cloudcare/templates/formplayer/settings_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/settings_view.html
@@ -41,4 +41,3 @@
 	  <th>{% trans "Break Pending Request Locks" %}</th>
 	    <td><button class="js-break-locks btn btn-sm btn-danger">{% trans "Break" %}</button></td>
 </script>
-~

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -114,7 +114,7 @@ from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.permissions import can_manage_releases
-from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR
+from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, SECURE_SESSION_TIMEOUT
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
@@ -579,7 +579,14 @@ class PrivacySecurityForm(forms.Form):
     secure_sessions = BooleanField(
         label=ugettext_lazy("Shorten Inactivity Timeout"),
         required=False,
-        help_text=ugettext_lazy("All web users on this project will be logged out after 30 minutes of inactivity")
+        help_text=ugettext_lazy("All web users on this project will be logged out after {} minutes "
+                                "of inactivity".format(settings.SECURE_TIMEOUT))
+    )
+    secure_sessions_timeout = IntegerField(
+        label=ugettext_lazy("Inactivity Timeout Length"),
+        required=False,
+        help_text=ugettext_lazy("Override the default {}-minute length of the inactivity timeout. Has "
+                                "no effect unless inactivity timeout is in use".format(settings.SECURE_TIMEOUT))
     )
     allow_domain_requests = BooleanField(
         label=ugettext_lazy("Web user requests"),
@@ -609,15 +616,19 @@ class PrivacySecurityForm(forms.Form):
         self.helper[0] = twbscrispy.PrependedText('restrict_superusers', '')
         self.helper[1] = twbscrispy.PrependedText('secure_submissions', '')
         self.helper[2] = twbscrispy.PrependedText('secure_sessions', '')
-        self.helper[3] = twbscrispy.PrependedText('allow_domain_requests', '')
-        self.helper[4] = twbscrispy.PrependedText('hipaa_compliant', '')
-        self.helper[5] = twbscrispy.PrependedText('two_factor_auth', '')
-        self.helper[6] = twbscrispy.PrependedText('strong_mobile_passwords', '')
+        self.helper[3] = crispy.Field('secure_sessions_timeout')
+        self.helper[4] = twbscrispy.PrependedText('allow_domain_requests', '')
+        self.helper[5] = twbscrispy.PrependedText('hipaa_compliant', '')
+        self.helper[6] = twbscrispy.PrependedText('two_factor_auth', '')
+        self.helper[7] = twbscrispy.PrependedText('strong_mobile_passwords', '')
+
         if not domain_has_privilege(domain, privileges.ADVANCED_DOMAIN_SECURITY):
+            self.helper.layout.pop(7)
             self.helper.layout.pop(6)
-            self.helper.layout.pop(5)
         if not HIPAA_COMPLIANCE_CHECKBOX.enabled(user_name):
-            self.helper.layout.pop(4)
+            self.helper.layout.pop(5)
+        if not SECURE_SESSION_TIMEOUT.enabled(domain):
+            self.helper.layout.pop(3)
         if not domain_has_privilege(domain, privileges.ADVANCED_DOMAIN_SECURITY):
             self.helper.layout.pop(2)
         self.helper.all().wrap_together(crispy.Fieldset, 'Edit Privacy Settings')
@@ -635,6 +646,7 @@ class PrivacySecurityForm(forms.Form):
         domain.restrict_superusers = self.cleaned_data.get('restrict_superusers', False)
         domain.allow_domain_requests = self.cleaned_data.get('allow_domain_requests', False)
         domain.secure_sessions = self.cleaned_data.get('secure_sessions', False)
+        domain.secure_sessions_timeout = self.cleaned_data.get('secure_sessions_timeout', False)
         domain.two_factor_auth = self.cleaned_data.get('two_factor_auth', False)
         domain.strong_mobile_passwords = self.cleaned_data.get('strong_mobile_passwords', False)
         secure_submissions = self.cleaned_data.get(

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -310,6 +310,7 @@ class EditPrivacySecurityView(BaseAdminProjectSettingsView):
     def privacy_form(self):
         initial = {
             "secure_submissions": self.domain_object.secure_submissions,
+            "secure_sessions_timeout": self.domain_object.secure_sessions_timeout,
             "restrict_superusers": self.domain_object.restrict_superusers,
             "allow_domain_requests": self.domain_object.allow_domain_requests,
             "hipaa_compliant": self.domain_object.hipaa_compliant,

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -7,6 +7,7 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from corehq.apps.domain.auth import formplayer_auth
+from corehq.apps.domain.models import Domain
 from corehq.apps.hqadmin.utils import get_django_user_from_session, get_session
 from corehq.apps.users.models import CouchUser
 
@@ -52,7 +53,11 @@ class SessionDetailsView(View):
 
         # reset the session's expiry if there's some formplayer activity
         secure_session = session.get('secure_session')
-        secure_session_timeout = session.get('secure_session_timeout', settings.SECURE_TIMEOUT)
+        secure_session_timeout = settings.SECURE_TIMEOUT
+        domain = data.get('domain')
+        if domain:
+            domain_obj = Domain.get_by_name(domain)
+            secure_session_timeout = domain_obj.secure_timeout or secure_session_timeout
         timeout = secure_session_timeout if secure_session else settings.INACTIVITY_TIMEOUT
         session.set_expiry(timeout * 60)
         session.save()

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -57,7 +57,8 @@ class SessionDetailsView(View):
         domain = data.get('domain')
         if domain:
             domain_obj = Domain.get_by_name(domain)
-            secure_session_timeout = domain_obj.secure_timeout or secure_session_timeout
+            if domain_obj:
+                secure_session_timeout = domain_obj.secure_timeout or secure_session_timeout
         timeout = secure_session_timeout if secure_session else settings.INACTIVITY_TIMEOUT
         session.set_expiry(timeout * 60)
         session.save()

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -52,7 +52,8 @@ class SessionDetailsView(View):
 
         # reset the session's expiry if there's some formplayer activity
         secure_session = session.get('secure_session')
-        timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
+        secure_session_timeout = session.get('secure_session_timeout', settings.SECURE_TIMEOUT)
+        timeout = secure_session_timeout if secure_session else settings.INACTIVITY_TIMEOUT
         session.set_expiry(timeout * 60)
         session.save()
 

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -143,24 +143,33 @@ class TimeoutMiddleware(MiddlewareMixin):
             return
 
         secure_session = request.session.get('secure_session')
-        timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
         domain = getattr(request, "domain", None)
+        domain_obj = Domain.get_by_name(domain) if domain else None
         now = datetime.datetime.utcnow()
 
         # figure out if we want to switch to secure_sessions
         change_to_secure_session = (
             not secure_session
             and (
-                (domain and Domain.is_secure_session_required(domain))
+                (domain_obj and domain_obj.secure_sessions)
                 or self._user_requires_secure_session(request.couch_user)))
 
+        timeout = None
+        if secure_session or change_to_secure_session:
+            if domain_obj:
+                timeout = domain_obj.secure_timeout
+            if not timeout:
+                timeout = settings.SECURE_TIMEOUT
+        else:
+            timeout = settings.INACTIVITY_TIMEOUT
+
         if change_to_secure_session:
-            timeout = settings.SECURE_TIMEOUT
             # force re-authentication if the user has been logged in longer than the secure timeout
             if self._session_expired(timeout, request.user.last_login, now):
                 LogoutView.as_view(template_name=settings.BASE_TEMPLATE)(request)
                 # this must be after logout so it is attached to the new session
                 request.session['secure_session'] = True
+                request.session['secure_session_timeout'] = timeout
                 request.session.set_expiry(timeout * 60)
                 return HttpResponseRedirect(reverse('login') + '?next=' + request.path)
 

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -169,7 +169,6 @@ class TimeoutMiddleware(MiddlewareMixin):
                 LogoutView.as_view(template_name=settings.BASE_TEMPLATE)(request)
                 # this must be after logout so it is attached to the new session
                 request.session['secure_session'] = True
-                request.session['secure_session_timeout'] = timeout
                 request.session.set_expiry(timeout * 60)
                 return HttpResponseRedirect(reverse('login') + '?next=' + request.path)
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -794,6 +794,13 @@ FORM_LINK_WORKFLOW = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+SECURE_SESSION_TIMEOUT = StaticToggle(
+    'secure_session_timeout',
+    "Allow domain to override default length of inactivity timeout",
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+)
+
 # not referenced in code directly but passed through to vellum
 # see toggles_dict
 


### PR DESCRIPTION
##### SUMMARY
Allow domains to configure the length of inactive sessions. For allowing COVID to slightly lengthen their session lengths while we work on a better auto-logout experience in web apps.

Behind a feature flag because this isn't intended to exist for long.

##### FEATURE FLAG
New feature flag: Allow domain to override default length of inactivity timeout

##### RISK ASSESSMENT / QA PLAN
Feature flagged, tested locally, not requesting QA.

##### PRODUCT DESCRIPTION
<img width="752" alt="Screen Shot 2020-05-21 at 4 36 40 AM" src="https://user-images.githubusercontent.com/1486591/82540240-b964c500-9b1c-11ea-9d75-67967cdd3964.png">
