### PR TITLE
Retry on S3 SlowDown errors

### DIFF
--- a/corehq/blobs/retry_s3db.py
+++ b/corehq/blobs/retry_s3db.py
@@ -5,7 +5,7 @@ from dimagi.utils.retry import retry_on
 
 def retry_on_slow_down(func):
     retry = retry_on(ClientError, should_retry=_is_slow_down,
-                     delays=_up_to_two_mins())
+                     delays=(1, 2, 4, 8, 16, 32, 64, 128))
     return retry(func)
 
 
@@ -15,9 +15,3 @@ def _is_slow_down(err: ClientError):
         and 'Code' in err.response['Error']
         and err.response['Error']['Code'] == 'SlowDown'
     )
-
-
-def _up_to_two_mins():
-    for x in range(1, 8):
-        yield 2 ** x  # 2 to 128
-    yield None

--- a/corehq/blobs/retry_s3db.py
+++ b/corehq/blobs/retry_s3db.py
@@ -1,0 +1,23 @@
+from botocore.exceptions import ClientError
+
+from dimagi.utils.retry import retry_on
+
+
+def retry_on_slow_down(func):
+    retry = retry_on(ClientError, should_retry=_is_slow_down,
+                     delays=_up_to_two_mins())
+    return retry(func)
+
+
+def _is_slow_down(err: ClientError):
+    return (
+        'Error' in err.response
+        and 'Code' in err.response['Error']
+        and err.response['Error']['Code'] == 'SlowDown'
+    )
+
+
+def _up_to_two_mins():
+    for x in range(1, 8):
+        yield 2 ** x  # 2 to 128
+    yield None

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -11,7 +11,7 @@ Initialize a docker machine for minio (skip if you already have one):
 
 Start the minio service:
 
-    mkdir -p ~/.minio/data && mkdir ~/.minio/conf
+    mkdir -p ~/.minio/{data,conf}
 
     # INSECURE KEY VALUES FOR TESTING ONLY, DO NOT USE IN PRODUCTION!
     docker run -p 9988:9000 --name minio1 --detach \

--- a/corehq/ex-submodules/dimagi/utils/retry.py
+++ b/corehq/ex-submodules/dimagi/utils/retry.py
@@ -2,7 +2,11 @@ from functools import wraps
 from time import sleep
 
 
-def retry_on(*errors, should_retry=lambda err: True):
+def retry_on(
+    *errors,
+    should_retry=lambda err: True,
+    delays=(0.1, 1, 2, 4, 8, None),
+):
     """Make a decorator to retry function on any of the given errors
 
     Retry up to 5 times with exponential backoff. Raise the last
@@ -10,17 +14,20 @@ def retry_on(*errors, should_retry=lambda err: True):
 
     :param *errors: One or more errors (exception classes) to catch and retry.
     :param should_retry: Optional function taking one argument, an
-    exception instance, that returns true to signal a retry and false
-    to signal that the error should be re-raised.
+        exception instance, that returns true to signal a retry and false
+        to signal that the error should be re-raised.
+    :param delays: An iterable of delays given in seconds. It must
+        terminate in ``None`` to raise an error in ``errors``, otherwise
+        it will stop retrying silently.
     :returns: a decorator to be applied to functions that should be
-    retried if they raise one of the given errors.
+        retried if they raise one of the given errors.
     """
     errors = tuple(errors)
 
     def retry_decorator(func):
         @wraps(func)
         def retry(*args, **kw):
-            for delay in [0.1, 1, 2, 4, 8, None]:
+            for delay in delays:
                 try:
                     return func(*args, **kw)
                 except errors as err:

--- a/corehq/ex-submodules/dimagi/utils/retry.py
+++ b/corehq/ex-submodules/dimagi/utils/retry.py
@@ -1,11 +1,12 @@
 from functools import wraps
+from itertools import chain
 from time import sleep
 
 
 def retry_on(
     *errors,
     should_retry=lambda err: True,
-    delays=(0.1, 1, 2, 4, 8, None),
+    delays=(0.1, 1, 2, 4, 8),
 ):
     """Make a decorator to retry function on any of the given errors
 
@@ -16,9 +17,7 @@ def retry_on(
     :param should_retry: Optional function taking one argument, an
         exception instance, that returns true to signal a retry and false
         to signal that the error should be re-raised.
-    :param delays: An iterable of delays given in seconds. It must
-        terminate in ``None`` to raise an error in ``errors``, otherwise
-        it will stop retrying silently.
+    :param delays: A list of delays given in seconds.
     :returns: a decorator to be applied to functions that should be
         retried if they raise one of the given errors.
     """
@@ -27,7 +26,7 @@ def retry_on(
     def retry_decorator(func):
         @wraps(func)
         def retry(*args, **kw):
-            for delay in delays:
+            for delay in chain(delays, [None]):
                 try:
                     return func(*args, **kw)
                 except errors as err:

--- a/corehq/ex-submodules/dimagi/utils/tests/test_retry.py
+++ b/corehq/ex-submodules/dimagi/utils/tests/test_retry.py
@@ -51,32 +51,13 @@ def test_retry_on_non_retry_error():
 
 
 @timelimit
-def test_retry_with_unterminated_delays():
-    def delays():
-        for x in range(1, 5):
-            yield 2 ** x
-
-    retry = mod.retry_on(Error, delays=delays())
-    func, calls = make_retry_function(retry, 5, Error)
-    with mock_retry_sleep() as sleeps:  # Does not raise
-        func(1)
-    eq(sleeps, [2, 4, 8, 16])
-    eq(len(calls), 4)
-
-
-@timelimit
-def test_retry_with_noneterminated_delays():
-    def delays():
-        for x in range(1, 5):
-            yield 2 ** x
-        yield None
-
-    retry = mod.retry_on(Error, delays=delays())
-    func, calls = make_retry_function(retry, 5, Error)
+def test_retry_with_delays():
+    retry = mod.retry_on(Error, delays=[2 ** x for x in range(5)])
+    func, calls = make_retry_function(retry, 6, Error)
     with mock_retry_sleep() as sleeps, assert_raises(Error):
         func(1)
-    eq(sleeps, [2, 4, 8, 16])
-    eq(len(calls), 5)
+    eq(sleeps, [1, 2, 4, 8, 16])
+    eq(len(calls), 6)
 
 
 class Error(Exception):


### PR DESCRIPTION
Dumping (a lot of) BlobDB data has resulted in S3 sending us a SlowDown error: [Sentry](https://sentry.io/organizations/dimagi/issues/1674124004/?environment=production&project=136860&query=is%3Aunresolved+clienterror&statsPeriod=14d)

##### SUMMARY

This change backs off exponentially. It follows the pattern used for [database errors](https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/dimagi/utils/couch/database.py#L195).

Implements feedback on #27560 
