### PR TITLE
Added the modified on colum

### DIFF
--- a/custom/icds_reports/ucr/data_sources/person_cases_v3.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v3.json
@@ -822,7 +822,13 @@
         "datatype": "date",
         "type": "raw",
         "property_name": "last_reported_fever_date"
-      }
+      },
+      {
+        "column_id": "modified_on",
+        "datatype": "datetime",
+        "type": "raw",
+        "property_name": "modified_on"
+      },
     ],
     "named_expressions": {},
     "named_filters": {},

--- a/custom/icds_reports/ucr/data_sources/person_cases_v3.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v3.json
@@ -828,7 +828,7 @@
         "datatype": "datetime",
         "type": "raw",
         "property_name": "modified_on"
-      },
+      }
     ],
     "named_expressions": {},
     "named_filters": {},


### PR DESCRIPTION
This adds back the modified on column deleted here: https://github.com/dimagi/commcare-hq/commit/464f9bf8120d0e7a76261538ee67b9aff9464d22#diff-e20b33ac6eec9e5b3250c3cb74734355
Removal of this column was preventing any other change going into the ucr. So Adding it back.

Not making it constant as null, Because I think it will again cause the changes to be skipped as this column already has data.
