### PR TITLE
use async indicator objects to process docs

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -369,8 +369,13 @@ def build_indicators_with_agg_queue(indicator_doc_ids):
     build_async_indicators(indicator_doc_ids)
 
 
+@task(queue=settings.CELERY_LOCATION_REASSIGNMENT_QUEUE, ignore_result=True, acks_late=True)
+def build_indicators_with_location_reassignment_queue(indicator_doc_ids):
+    build_async_indicators(indicator_doc_ids, use_shard_col=False)
+
+
 @task(serializer='pickle', queue=UCR_INDICATOR_CELERY_QUEUE, ignore_result=True, acks_late=True)
-def build_async_indicators(indicator_doc_ids):
+def build_async_indicators(indicator_doc_ids, use_shard_col=True):
     # written to be used with _queue_indicators, indicator_doc_ids must
     #   be a chunk of 100
     memoizers = {'configs': {}, 'adapters': {}}
@@ -499,7 +504,7 @@ def build_async_indicators(indicator_doc_ids):
                     indicators = [indicator_by_doc_id[doc_id] for doc_id in doc_ids]
                     try:
                         with _metrics_timer('update', adapter.config._id):
-                            adapter.save_rows(rows, use_shard_col=True)
+                            adapter.save_rows(rows, use_shard_col=use_shard_col)
                     except Exception as e:
                         failed_indicators.union(indicators)
                         message = str(e)
@@ -514,7 +519,7 @@ def build_async_indicators(indicator_doc_ids):
             with _metrics_timer('single_batch_delete'):
                 for adapter, docs in docs_to_delete_by_adapter.items():
                     with _metrics_timer('delete', adapter.config._id):
-                        adapter.bulk_delete(docs)
+                        adapter.bulk_delete(docs, use_shard_col=use_shard_col)
 
         # delete fully processed indicators
         processed_indicators = set(all_indicators) - failed_indicators

--- a/custom/icds/location_reassignment/tasks.py
+++ b/custom/icds/location_reassignment/tasks.py
@@ -8,7 +8,11 @@ from corehq.apps.userreports.data_source_providers import (
     DynamicDataSourceProvider,
     StaticDataSourceProvider,
 )
+from corehq.apps.userreports.models import AsyncIndicator
 from corehq.apps.userreports.specs import EvaluationContext
+from corehq.apps.userreports.tasks import (
+    build_indicators_with_location_reassignment_queue,
+)
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from custom.icds.location_reassignment.download import Households, OtherCases
@@ -204,6 +208,7 @@ def process_other_cases_reassignment(domain, reassignments, uploaded_filename, u
 @task(queue=settings.CELERY_LOCATION_REASSIGNMENT_QUEUE)
 def process_ucr_changes(domain, case_ids):
     cases = CaseAccessorSQL.get_cases(case_ids)
+    cases_by_id = {case.case_id: case for case in cases}
     docs = [case.to_json() for case in cases]
     data_source_providers = [DynamicDataSourceProvider(), StaticDataSourceProvider()]
 
@@ -218,12 +223,17 @@ def process_ucr_changes(domain, case_ids):
         for config in all_configs
     ]
 
+    async_configs_by_doc_id = {}
     for doc in docs:
         eval_context = EvaluationContext(doc)
         for adapter in adapters:
             if adapter.config.filter(doc, eval_context):
-                rows_to_save = adapter.get_all_values(doc, eval_context)
-                if rows_to_save:
-                    adapter.save_rows(rows_to_save, use_shard_col=False)
-                else:
-                    adapter.delete(doc, use_shard_col=False)
+                async_configs_by_doc_id[doc['_id']].append(adapter.config._id)
+
+    doc_ids = list(async_configs_by_doc_id.keys())
+    doc_type_by_id = {
+        _id: cases_by_id[_id].metadata.document_type
+        for _id in doc_ids
+    }
+    AsyncIndicator.bulk_update_records(async_configs_by_doc_id, domain, doc_type_by_id)
+    build_indicators_with_location_reassignment_queue(doc_ids)


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/27309/files#r419560572
and
the [original implementation](https://github.com/dimagi/commcare-hq/pull/27309/files#diff-3b4c3c247d459d787341a615e11c058cR164) is a bit brittle in a way that if in between the case reassignment and `process_ucr_change`, if any case is processed via `AsyncIndicator` where `use_shard_col` is not set as False, the UCR data sources partitioning on `owner_id` would end up with a new row getting created for the case. Same would happen if `process_ucr_changes` would fail as observed [here](https://dimagi-dev.atlassian.net/browse/QA-1301?focusedCommentId=51672) where this [failure](https://sentry.io/organizations/dimagi/issues/1678061430/events/?environment=india&project=136860&statsPeriod=14d) happened.

##### SUMMARY
This PR
1. processes the changes through AsyncIndicator so that all updates for these cases are done together
2. locks the AsyncIndicators for the relevant cases in a way that they are not processed in the interim between case reassignment and processing of ucr changes.

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
