### PR TITLE
Added allowance for None domain in can_login_as

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -231,9 +231,11 @@ def can_use_restore_as(request):
     if request.couch_user.is_superuser:
         return True
 
+    domain = getattr(request, 'domain', None)
+
     return (
-        request.couch_user.can_login_as(request.domain) and
-        has_privilege(request, privileges.LOGIN_AS)
+        request.couch_user.can_login_as(domain)
+        and has_privilege(request, privileges.LOGIN_AS)
     )
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1594,7 +1594,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
     def can_login_as(self, domain=None):
         return (
             self.has_permission(domain, 'edit_commcare_users')
-            or self.has_permission(domain, 'limited_login_as'
+            or self.has_permission(domain, 'limited_login_as')
         )
 
     def is_current_web_user(self, request):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1591,8 +1591,11 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             if permission_slug in EXPORT_PERMISSIONS
         ])
 
-    def can_login_as(self, domain):
-        return self.has_permission(domain, 'edit_commcare_users') or self.has_permission(domain, 'limited_login_as')
+    def can_login_as(self, domain=None):
+        return (
+            self.has_permission(domain, 'edit_commcare_users')
+            or self.has_permission(domain, 'limited_login_as'
+        )
 
     def is_current_web_user(self, request):
         return self.user_id == request.couch_user.user_id


### PR DESCRIPTION
##### SUMMARY
Followup for https://github.com/dimagi/commcare-hq/commit/0dd9c9f2ede0a0781b31984de936527e7524b796

When running js tests locally, `domain` isn't provided.