### PR TITLE
UTF-8 encode unicode data

### DIFF
--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -224,6 +224,8 @@ def simple_post(domain, url, data, *, headers, auth, verify,
     POST with a cleaner API, and return the actual HTTPResponse object, so
     that error codes can be interpreted.
     """
+    if isinstance(data, str):
+        data = data.encode('utf-8')  # can't pass unicode to http request posts
     default_headers = CaseInsensitiveDict({
         "content-type": "text/xml",
         "content-length": str(len(data)),

--- a/corehq/motech/tests/test_simple_post.py
+++ b/corehq/motech/tests/test_simple_post.py
@@ -21,7 +21,7 @@ def test_simple_post():
         simple_post(
             domain=TEST_DOMAIN,
             url=TEST_API_URL,
-            data='<payload id="abc123"><parrot status="dead" /></payload>',
+            data='<payload id="abc123"><parrot status="déad" /></payload>',
             headers={'Content-Type': 'text/xml+parrot'},
             auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
             verify=True,
@@ -32,10 +32,10 @@ def test_simple_post():
             'POST',
             TEST_API_URL,
             auth=(TEST_API_USERNAME, TEST_API_PASSWORD),
-            data='<payload id="abc123"><parrot status="dead" /></payload>',
+            data=b'<payload id="abc123"><parrot status="d\xc3\xa9ad" /></payload>',
             headers={
                 'Content-Type': 'text/xml+parrot',
-                'content-length': '55',
+                'content-length': '56',
             },
             timeout=REQUEST_TIMEOUT,
         )


### PR DESCRIPTION
This partially reverts https://github.com/dimagi/commcare-hq/pull/27506/files, to go back to utf-8 encoding repeater payloads when submitting them.  There are only two usages of this function, and they both used the old version of the code (that is, nothing new was switched to this functionality which might break with the behavior change)

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
This partially reverts https://github.com/dimagi/commcare-hq/pull/27506/files, to go back to utf-8 encoding repeater payloads when submitting them.