### PR TITLE
expose all links temporarily

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -159,8 +159,7 @@ class ProjectReportsTab(UITab):
                 'url': reverse(UserConfigReportsHomeView.urlname, args=[self.domain]),
                 'icon': 'icon-tasks fa fa-wrench',
             })
-        if (toggles.DOWNLOAD_LOCATION_REASSIGNMENT_REQUEST_TEMPLATE.enabled(self.domain)
-                and not toggles.PERFORM_LOCATION_REASSIGNMENT.enabled(self.couch_user.username)):
+        if toggles.PERFORM_LOCATION_REASSIGNMENT.enabled(self.couch_user.username):
             from custom.icds.location_reassignment.views import LocationReassignmentDownloadOnlyView
             tools.append({
                 'title': _(LocationReassignmentDownloadOnlyView.section_name),
@@ -1515,8 +1514,7 @@ class ProjectUsersTab(UITab):
                 'show_in_dropdown': True,
             })
 
-        if (toggles.DOWNLOAD_LOCATION_REASSIGNMENT_REQUEST_TEMPLATE.enabled(self.domain)
-                and toggles.PERFORM_LOCATION_REASSIGNMENT.enabled(self.couch_user.username)):
+        if toggles.PERFORM_LOCATION_REASSIGNMENT.enabled(self.couch_user.username):
             from custom.icds.location_reassignment.views import LocationReassignmentView
             menu.append({
                 'title': _("Location Reassignment"),

--- a/custom/icds/location_reassignment/views.py
+++ b/custom/icds/location_reassignment/views.py
@@ -52,7 +52,7 @@ from custom.icds.location_reassignment.tasks import (
 
 
 @location_safe
-@method_decorator([toggles.DOWNLOAD_LOCATION_REASSIGNMENT_REQUEST_TEMPLATE.required_decorator()], name='dispatch')
+@method_decorator([toggles.PERFORM_LOCATION_REASSIGNMENT.required_decorator()], name='dispatch')
 class LocationReassignmentDownloadOnlyView(BaseProjectReportSectionView):
     section_name = ugettext_lazy("Download Location Reassignment Template")
 
@@ -253,7 +253,7 @@ class LocationReassignmentView(BaseLocationView):
 
 
 
-@toggles.DOWNLOAD_LOCATION_REASSIGNMENT_REQUEST_TEMPLATE.required_decorator()
+@toggles.PERFORM_LOCATION_REASSIGNMENT.required_decorator()
 @require_GET
 @location_safe
 def download_location_reassignment_template(request, domain):

--- a/custom/icds/location_reassignment/views.py
+++ b/custom/icds/location_reassignment/views.py
@@ -252,7 +252,6 @@ class LocationReassignmentView(BaseLocationView):
             "Your request has been submitted. We will notify you via email once completed."))
 
 
-
 @toggles.PERFORM_LOCATION_REASSIGNMENT.required_decorator()
 @require_GET
 @location_safe


### PR DESCRIPTION
In order to do UAT on TCL without exposing the functionality to all users, temporarily moving everything to the user level FF control. This would be reverted when we want to roll this out to all users.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
