### PR TITLE
Removed domain restriction from some CouchUser.get_by_user_id calls

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -106,7 +106,7 @@ class _Importer(object):
 
     @cached_property
     def user(self):
-        return CouchUser.get_by_user_id(self.config.couch_user_id, self.domain)
+        return CouchUser.get_by_user_id(self.config.couch_user_id)
 
     def add_caseblock(self, caseblock):
         self._unsubmitted_caseblocks.append(caseblock)

--- a/corehq/apps/users/dbaccessors/couch_users.py
+++ b/corehq/apps/users/dbaccessors/couch_users.py
@@ -21,7 +21,7 @@ def get_user_id_by_username(username):
 
 def get_display_name_for_user_id(domain, user_id, default=None):
     if user_id:
-        user = CouchUser.get_by_user_id(user_id, domain)
+        user = CouchUser.get_by_user_id(user_id)
         if user:
             return user.full_name
     return default

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -157,7 +157,7 @@ class DefaultProjectUserSettingsView(BaseUserSettingsView):
     def redirect(self):
         redirect = None
         has_project_access = has_privilege(self.request, privileges.PROJECT_ACCESS)
-        user = CouchUser.get_by_user_id(self.couch_user._id, self.domain)
+        user = CouchUser.get_by_user_id(self.couch_user._id)
         if user:
             if ((user.has_permission(self.domain, 'edit_commcare_users')
                     or user.has_permission(self.domain, 'view_commcare_users'))

--- a/corehq/messaging/templating.py
+++ b/corehq/messaging/templating.py
@@ -220,7 +220,7 @@ class CaseMessagingTemplateParam(SimpleDictTemplateParam):
             return self.__last_modified_by_result
 
         try:
-            modified_by = CouchUser.get_by_user_id(self.__case.modified_by, domain=self.__domain)
+            modified_by = CouchUser.get_by_user_id(self.__case.modified_by)
         except KeyError:
             modified_by = None
 


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-10907

The `DefaultProjectUserSettingsView` fixes the reported bug, where mirrored users get a 404 if they access users via the HQ dashboard. Then I grepped for `get_by_user_id` and updated a few other places where we should include mirrored users.

##### FEATURE FLAG
Domain permission mirroring (not a flag, but Dimagi-controlled config)

##### PRODUCT DESCRIPTION
Not worth announcing. Allows access for users with mirrored permissions in a few places they didn't already have it.
