### PR TITLE
Added web users to UserES.role_id

### DIFF
--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -151,7 +151,10 @@ def is_practice_user(practice_mode=True):
 
 
 def role_id(role_id):
-    return filters.term('domain_membership.role_id', role_id)
+    return filters.OR(
+        filters.term("domain_membership.role_id", role_id),     # mobile users
+        filters.term("domain_memberships.role_id", role_id)     # web users
+    )
 
 
 def is_active(active=True):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -391,19 +391,8 @@ class UserRole(QuickCachedDocumentMixin, Document):
 
     @property
     def ids_of_assigned_users(self):
-        from corehq.apps.api.es import UserES
-        query = {"query": {"bool": {"must": [{"term": {"user.doc_type": "WebUser"}},
-                                             {"term": {"user.domain_memberships.role_id": self.get_id}},
-                                             {"term": {"user.domain_memberships.domain": self.domain}},
-                                             {"term": {"user.is_active": True}},
-                                             {"term": {"user.base_doc": "couchuser"}}],
-                                    }}, "fields": []}
-        query_results = UserES(self.domain).run_query(es_query=query, security_check=False)
-        assigned_user_ids = []
-        for user in query_results['hits'].get('hits', []):
-            assigned_user_ids.append(user['_id'])
-
-        return assigned_user_ids
+        from corehq.apps.es.users import UserES
+        return UserES().is_active().domain(self.domain).role_id(self._id).values_list('_id', flat=True)
 
     @classmethod
     def get_preset_permission_by_name(cls, name):


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-10906

Old query was returning no results. Not sure what's wrong with it or when it broke; the quickest fix was to just use `corehq.apps.es.user.UserES` instead.

The new query intentionally includes both web and mobile users, since both can have roles assigned.

##### RISK ASSESSMENT / QA PLAN
Minor, no QA.

##### PRODUCT DESCRIPTION
The "Delete Role" button should be hidden if there are any users assigned to the role. This was broken and is now fixed.