### PR TITLE
allow web user upload with mobile workers

### DIFF
--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -365,6 +365,7 @@ class CallCenterUtilsUserCaseTests(TestCase):
         results = create_or_update_users_and_groups(
             TEST_DOMAIN,
             list(user_upload),
+            None
         )
         self.assertEqual(results['errors'], [])
 

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -392,7 +392,7 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
 
                 if role:
                     role_qualified_id = roles_by_name[role].get_qualified_id()
-                    user.set_role(domain, role_id)
+                    user.set_role(domain, role_qualified_id)
 
                 if web_user:
                     user.user_data.update({'login_as_user': web_user})

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from datetime import datetime
 
 from django.db import DEFAULT_DB_ALIAS
 from django.utils.translation import ugettext as _
@@ -25,7 +26,7 @@ from corehq.apps.user_importer.validation import (
     get_user_import_validators,
     is_password,
 )
-from corehq.apps.users.models import CommCareUser, CouchUser, UserRole
+from corehq.apps.users.models import CommCareUser, CouchUser, UserRole, Invitation
 from corehq.apps.users.util import normalize_username
 
 required_headers = set(['username'])
@@ -34,7 +35,7 @@ allowed_headers = set([
     'uncategorized_data', 'user_id', 'is_active', 'is_account_confirmed', 'send_confirmation_email',
     'location_code', 'role',
     'User IMEIs (read only)', 'registered_on (read only)', 'last_submission (read only)',
-    'last_sync (read only)'
+    'last_sync (read only)', 'web_user'
 ]) | required_headers
 old_headers = {
     # 'old_header_name': 'new_header_name'
@@ -316,7 +317,8 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                 location_codes = [location_codes]
             # ignore empty
             location_codes = [code for code in location_codes if code]
-            role = row.get('role', '')
+            role = row.get('role', None)
+            web_user = row.get('web_user')
 
             try:
                 username = normalize_username(str(username), domain) if username else None
@@ -340,7 +342,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
 
                     # note: explicitly not including "None" here because that's the default value if not set.
                     # False means it was set explicitly to that value
-                    if is_account_confirmed is False:
+                    if is_account_confirmed is False and not web_user:
                         raise UserUploadError(_(
                             f"You can only set 'Is Account Confirmed' to 'False' on a new User."
                         ))
@@ -350,7 +352,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                     status_row['flag'] = 'updated'
                 else:
                     kwargs = {}
-                    if is_account_confirmed is not None:
+                    if is_account_confirmed is not None and not web_user:
                         kwargs['is_account_confirmed'] = is_account_confirmed
                     user = CommCareUser.create(domain, username, password, commit=False, **kwargs)
                     status_row['flag'] = 'created'
@@ -389,11 +391,37 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                         user.reset_locations(location_ids, commit=False)
 
                 if role:
-                    user.set_role(domain, roles_by_name[role].get_qualified_id())
+                    role = roles_by_name[role].get_qualified_id()
+                    user.set_role(domain, role)
+
+                if web_user:
+                    user.user_data.update({'login_as_user': web_user})
 
                 user.save()
 
-                if send_account_confirmation_email:
+                if web_user:
+                    current_user = CouchUser.get_by_username(web_user)
+                    if not current_user and is_account_confirmed:
+                        raise UserUploadError(_(
+                            f"You can only set 'Is Account Confirmed' to 'True' on an existing Web User."
+                        ))
+                    if current_user and not current_user.is_member_of(domain) and is_account_confirmed:
+                        current_user.add_as_web_user(domain, role=role, location_id=user.location_id)
+                    elif not current_user or not current_user.is_member_of(domain):
+                        invite_data = {
+                            'email': web_user,
+                            'invited_by': 'Mobile User Upload',
+                            'invited_on': datetime.utcnow(),
+                            'domain': domain,
+                            'role': role,
+                            'supply_point': user.location_id
+                        }
+                        invite = Invitation(**invite_data)
+                        invite.save()
+                        if send_account_confirmation_email:
+                            invite.send_activation_email()
+
+                if send_account_confirmation_email and not web_user:
                     send_account_confirmation_if_necessary(user)
 
                 if is_password(password):

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -267,7 +267,7 @@ def get_location_from_site_code(site_code, location_cache):
         )
 
 
-def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, update_progress=None, upload_user=None):
+def create_or_update_users_and_groups(domain, user_specs, upload_user, group_memoizer=None, update_progress=None):
     ret = {"errors": [], "rows": []}
 
     group_memoizer = group_memoizer or GroupMemoizer(domain)
@@ -391,8 +391,8 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                         user.reset_locations(location_ids, commit=False)
 
                 if role:
-                    role = roles_by_name[role].get_qualified_id()
-                    user.set_role(domain, role)
+                    role_qualified_id = roles_by_name[role].get_qualified_id()
+                    user.set_role(domain, role_id)
 
                 if web_user:
                     user.user_data.update({'login_as_user': web_user})
@@ -406,14 +406,14 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                             f"You can only set 'Is Account Confirmed' to 'True' on an existing Web User. {web_user} is a new username."
                         ))
                     if current_user and not current_user.is_member_of(domain) and is_account_confirmed:
-                        current_user.add_as_web_user(domain, role=role, location_id=user.location_id)
+                        current_user.add_as_web_user(domain, role=role_qualified_id, location_id=user.location_id)
                     elif not current_user or not current_user.is_member_of(domain):
                         invite_data = {
                             'email': web_user,
                             'invited_by': upload_user.username,
                             'invited_on': datetime.utcnow(),
                             'domain': domain,
-                            'role': role,
+                            'role': role_qualified_id,
                             'supply_point': user.location_id
                         }
                         invite = Invitation(**invite_data)

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -267,7 +267,7 @@ def get_location_from_site_code(site_code, location_cache):
         )
 
 
-def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, update_progress=None):
+def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, update_progress=None, upload_user=None):
     ret = {"errors": [], "rows": []}
 
     group_memoizer = group_memoizer or GroupMemoizer(domain)
@@ -403,14 +403,14 @@ def create_or_update_users_and_groups(domain, user_specs, group_memoizer=None, u
                     current_user = CouchUser.get_by_username(web_user)
                     if not current_user and is_account_confirmed:
                         raise UserUploadError(_(
-                            f"You can only set 'Is Account Confirmed' to 'True' on an existing Web User."
+                            f"You can only set 'Is Account Confirmed' to 'True' on an existing Web User. {web_user} is a new username."
                         ))
                     if current_user and not current_user.is_member_of(domain) and is_account_confirmed:
                         current_user.add_as_web_user(domain, role=role, location_id=user.location_id)
                     elif not current_user or not current_user.is_member_of(domain):
                         invite_data = {
                             'email': web_user,
-                            'invited_by': 'Mobile User Upload',
+                            'invited_by': upload_user.username,
                             'invited_on': datetime.utcnow(),
                             'domain': domain,
                             'role': role,

--- a/corehq/apps/user_importer/tasks.py
+++ b/corehq/apps/user_importer/tasks.py
@@ -6,7 +6,7 @@ from soil import DownloadBase
 
 
 @task(serializer='pickle')
-def import_users_and_groups(domain, user_specs, group_specs, user=None):
+def import_users_and_groups(domain, user_specs, group_specs, upload_user):
     from corehq.apps.user_importer.importer import create_or_update_users_and_groups, create_or_update_groups
     task = import_users_and_groups
     DownloadBase.set_progress(task, 0, 100)
@@ -24,9 +24,9 @@ def import_users_and_groups(domain, user_specs, group_specs, user=None):
     user_results = create_or_update_users_and_groups(
         domain,
         user_specs,
+        upload_user=upload_user,
         group_memoizer=group_memoizer,
-        update_progress=functools.partial(_update_progress, start=len(group_specs)),
-        upload_user=user
+        update_progress=functools.partial(_update_progress, start=len(group_specs))
     )
     results = {
         'errors': group_results['errors'] + user_results['errors'],

--- a/corehq/apps/user_importer/tasks.py
+++ b/corehq/apps/user_importer/tasks.py
@@ -6,7 +6,7 @@ from soil import DownloadBase
 
 
 @task(serializer='pickle')
-def import_users_and_groups(domain, user_specs, group_specs):
+def import_users_and_groups(domain, user_specs, group_specs, user=None):
     from corehq.apps.user_importer.importer import create_or_update_users_and_groups, create_or_update_groups
     task = import_users_and_groups
     DownloadBase.set_progress(task, 0, 100)
@@ -25,7 +25,8 @@ def import_users_and_groups(domain, user_specs, group_specs):
         domain,
         user_specs,
         group_memoizer=group_memoizer,
-        update_progress=functools.partial(_update_progress, start=len(group_specs))
+        update_progress=functools.partial(_update_progress, start=len(group_specs)),
+        upload_user=user
     )
     results = {
         'errors': group_results['errors'] + user_results['errors'],

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -61,6 +61,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(user_id='missing')],
             [],
+            None
         )
 
         self.assertIsNone(self.user)
@@ -74,6 +75,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=self.loc1.site_code)],
             [],
+            None
         )
         self.assertEqual(self.user.location_id, self.loc1._id)
         self.assertEqual(self.user.location_id, self.user.user_data.get('commcare_location_id'))
@@ -89,6 +91,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         result = create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code='unknownsite')],
+            None
         )
         self.assertEqual(len(result["rows"]), 1)
 
@@ -99,6 +102,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=[a.site_code for a in [self.loc1, self.loc2]])],
             [],
+            None
         )
         # first location should be primary location
         self.assertEqual(self.user.location_id, self.loc1._id)
@@ -116,6 +120,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=[a.site_code for a in [self.loc1, self.loc2]])],
             [],
+            None
         )
 
         # deassign all locations
@@ -123,6 +128,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=[], user_id=self.user._id)],
             [],
+            None
         )
 
         # user should have no locations
@@ -137,6 +143,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code=[a.site_code for a in [self.loc1, self.loc2]])],
+            None
         )
 
         # user's primary location should be loc1
@@ -149,6 +156,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code=[self.loc2.site_code], user_id=self.user._id)],
+            None
         )
 
         # user's location should now be loc2
@@ -164,13 +172,15 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         # first assign to loc1
         create_or_update_users_and_groups(
             self.domain.name,
-            [self._get_spec(location_code=[self.loc1.site_code])]
+            [self._get_spec(location_code=[self.loc1.site_code])],
+            None
         )
 
         # reassign to loc2
         create_or_update_users_and_groups(
             self.domain.name,
-            [self._get_spec(location_code=[self.loc2.site_code], user_id=self.user._id)]
+            [self._get_spec(location_code=[self.loc2.site_code], user_id=self.user._id)],
+            None
         )
 
         # user's location should now be loc2
@@ -190,6 +200,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(name=1234)],
             [],
+            None
         )
         self.assertEqual(self.user.full_name, "1234")
 
@@ -202,6 +213,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(name=None)],
             [],
+            None
         )
         self.assertEqual(self.user.full_name, "")
 
@@ -214,6 +226,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(email=email)],
             [],
+            None
         )
         self.assertEqual(self.user.email, email.lower())
 
@@ -222,6 +235,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(role=self.role.name)],
             [],
+            None
         )
         self.assertEqual(self.user.get_role(self.domain_name).name, self.role.name)
 
@@ -230,6 +244,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(is_active='')],
             [],
+            None
         )
         self.assertTrue(self.user.is_active)
 
@@ -238,6 +253,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec()],
             [],
+            None
         )
         self.assertIsNotNone(self.user)
 
@@ -245,6 +261,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(user_id=self.user._id, username='')],
             [],
+            None
         )
 
     def test_update_user_numeric_username(self):
@@ -252,6 +269,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(username=123)],
             [],
+            None
         )
         self.assertIsNotNone(
             CommCareUser.get_by_username('{}@{}.commcarehq.org'.format('123', self.domain.name))
@@ -262,6 +280,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(delete_keys=['is_active'], is_account_confirmed='False')],
             [],
+            None
         )
         user = self.user
         self.assertIsNotNone(user)
@@ -292,6 +311,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
                 ),
             ],
             [],
+            None
         )
         self.assertEqual(mock_account_confirm_email.call_count, 1)
         self.assertEqual('with_email', mock_account_confirm_email.call_args[0][0].raw_username)
@@ -336,6 +356,7 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             list(user_spec + self.user_specs),
             [],
+            None
         )['messages']['rows']
         self.assertEqual(rows[0]['flag'], "'password' values must be unique")
 
@@ -347,5 +368,6 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             list([updated_user_spec]),
             [],
+            None
         )['messages']['rows']
         self.assertEqual(rows[0]['flag'], 'Password is not strong enough. Try making your password more complex.')

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1044,7 +1044,7 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
             self.domain,
             list(self.user_specs),
             list(self.group_specs),
-            user=request.couch_user
+            request.couch_user
         )
         task_ref.set_task(task)
         return HttpResponseRedirect(

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -1044,6 +1044,7 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
             self.domain,
             list(self.user_specs),
             list(self.group_specs),
+            user=request.couch_user
         )
         task_ref.set_task(task)
         return HttpResponseRedirect(


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This builds on (or hijacks) the work to create confirmation emails for mobile worker uploads, adding a column to also add a web user upon upload. It uses the same two columns (assuming if a web user is being added, confirmation for a mobile worker is unnecessary). Behavior is mostly the same, except that you cannot directly add a web user that does not exist, you must create an invitation instead.

The web user being added has the same role and location as the mobile worker, and the mobile worker is set up to automatically show up in that user's login as list if login as has been restricted.