### PR TITLE
[ci skip] fix default formplayer port in docs

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -300,7 +300,7 @@ Formplayer is a Java service that allows us to use applications on the web inste
 
 In `localsettings.py`:
 ```
-FORMPLAYER_URL = 'http://localhost:8010'
+FORMPLAYER_URL = 'http://localhost:8080'
 LOCAL_APPS += ('django_extensions',)
 ```
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY

The instructions reference [this file](https://github.com/dimagi/formplayer/blob/master/config/application.example.properties#L7) which uses port 8080 not 8010.
<!--- Describe the change below, including rationale and design decisions -->
