### PR TITLE
honor data dictionary case property datatypes in DET config downloads

### DIFF
--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -35,10 +35,18 @@ class DefaultDETSchemaHelper(object):
     """
     Helper to do datatype transformations, etc. during schema generation
     """
-
     @staticmethod
     def transform_path(input_path):
         return input_path
+
+    @staticmethod
+    def get_map_via(export_item):
+        return {
+            datatypes.DATA_TYPE_DATETIME: MAP_VIA_STR2DATE,
+            datatypes.DATA_TYPE_DATE: MAP_VIA_STR2DATE,
+            datatypes.DATA_TYPE_INTEGER: MAP_VIA_STR2NUM,
+            datatypes.DATA_TYPE_DECIMAL: MAP_VIA_STR2NUM,
+        }.get(export_item.datatype, '')
 
 
 class CaseDETSchemaHelper(DefaultDETSchemaHelper):
@@ -155,14 +163,5 @@ def _get_det_row_for_export_column(column, helper):
     return DETRow(
         source_field=helper.transform_path(column.item.readable_path),
         field=column.label,
-        map_via=_get_det_map_for_export_item_datatype(column.item.datatype)
+        map_via=helper.get_map_via(column.item)
     )
-
-
-def _get_det_map_for_export_item_datatype(datatype):
-    return {
-        datatypes.DATA_TYPE_DATETIME: MAP_VIA_STR2DATE,
-        datatypes.DATA_TYPE_DATE: MAP_VIA_STR2DATE,
-        datatypes.DATA_TYPE_INTEGER: MAP_VIA_STR2NUM,
-        datatypes.DATA_TYPE_DECIMAL: MAP_VIA_STR2NUM,
-    }.get(datatype, '')

--- a/corehq/apps/export/det/schema_generator.py
+++ b/corehq/apps/export/det/schema_generator.py
@@ -1,5 +1,6 @@
 from django.utils.translation import ugettext_lazy as _
 
+from corehq.apps.data_dictionary.models import CaseProperty
 from corehq.apps.export.det.base import DETRow, DETTable, DETConfig
 from corehq.apps.export.det.exceptions import DETConfigError
 from corehq.apps.export.models import FormExportInstance, CaseExportInstance
@@ -53,11 +54,19 @@ class CaseDETSchemaHelper(DefaultDETSchemaHelper):
     """
     Schema helper for cases
     """
+    def __init__(self, dd_property_types):
+        self.dd_property_types = dd_property_types
 
     @staticmethod
     def transform_path(input_path):
         # either return hard-coded lookup or add prefix
         return CASE_API_PATH_MAP.get(input_path, f'{PROPERTIES_PREFIX}{input_path}')
+
+    def get_map_via(self, export_item):
+        explicit_type = super().get_map_via(export_item)
+        if not explicit_type and export_item.readable_path in self.dd_property_types:
+            return _dd_type_to_det_type(self.dd_property_types[export_item.readable_path])
+        return explicit_type
 
 
 class RepeatDETSchemaHelper(DefaultDETSchemaHelper):
@@ -96,11 +105,38 @@ def generate_from_case_export_instance(export_instance, output_file):
         rows=[],
     )
     output = DETConfig(name=export_instance.name, tables=[main_output_table])
-    helper = CaseDETSchemaHelper()
+
+    dd_property_types_by_name = _get_dd_property_types(export_instance.domain, export_instance.case_type)
+    helper = CaseDETSchemaHelper(dd_property_types=dd_property_types_by_name)
     _add_rows_for_table(main_input_table, main_output_table, helper=helper)
     _add_id_row_if_necessary(main_output_table, CASE_ID_SOURCE)
     # todo: add rows for other tables
     output.export_to_file(output_file)
+
+
+def _get_dd_property_types(domain, case_type):
+    """
+    Get a dictionary of property types by name (from the data dictionary) for a given
+    domain, case_type. e.g.
+    {
+      "name": "plain",
+      "location": "gps",
+      "event_date": "date",
+    }
+    """
+    return dict(
+        CaseProperty.objects.filter(
+            case_type__domain=domain,
+            case_type__name=case_type,
+        ).values_list('name', 'data_type')
+    )
+
+
+def _dd_type_to_det_type(data_dictionary_datatype):
+    return {
+        'date': MAP_VIA_STR2DATE,
+        'number': MAP_VIA_STR2NUM,
+    }.get(data_dictionary_datatype, '')
 
 
 def generate_from_form_export_instance(export_instance, output_file):

--- a/corehq/apps/export/tests/data/det/case_export_instance.json
+++ b/corehq/apps/export/tests/data/det/case_export_instance.json
@@ -369,7 +369,7 @@
                     "is_advanced": false,
                     "is_deleted": false,
                     "item": {
-                        "datatype": null,
+                        "datatype": "datetime",
                         "doc_type": "ExportItem",
                         "inferred": false,
                         "inferred_from": [],

--- a/corehq/apps/export/tests/test_det_schema_generation.py
+++ b/corehq/apps/export/tests/test_det_schema_generation.py
@@ -9,7 +9,7 @@ from corehq.apps.export.det.exceptions import DETConfigError
 from corehq.apps.export.det.schema_generator import (
     generate_from_form_export_instance,
     generate_from_case_export_instance,
-    _transform_path_for_case_properties,
+    CaseDETSchemaHelper,
 )
 from corehq.apps.export.models import FormExportInstance, CaseExportInstance
 from corehq.util.test_utils import TestFileMixin
@@ -46,7 +46,7 @@ class TestDETFCaseInstance(SimpleTestCase, TestFileMixin):
             self.assertEqual(len(main_table.selected_columns), len(data_by_headings))
             for i, input_column in enumerate(main_table.selected_columns):
                 self.assertEqual(input_column.label, data_by_headings[i]['Field'])
-                self.assertEqual(_transform_path_for_case_properties(input_column.item.readable_path),
+                self.assertEqual(CaseDETSchemaHelper.transform_path(input_column.item.readable_path),
                                  data_by_headings[i]['Source Field'])
 
             # note: subtables not supported


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Review by commit. :blowfish: 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Downloading a data export tool config file for cases will now properly set datatypes for known types that are configured in the data dictionary.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
You need two flags for this to be relevant:

- Show an option to download data export tool schemas from the exports list view
- Project level data dictionary of cases

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

None needed.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
