### PR TITLE
Better check for user permissions to update users groups

### DIFF
--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -22,7 +22,9 @@
   {% endif %}
   <ul class="nav nav-tabs sticky-tabs" id="user-settings-tabs" style="margin-bottom: 10px;">
     <li><a href="#basic-info" data-toggle="tab">{% trans "Basic" %}</a></li>
-    <li><a href="#groups" data-toggle="tab">{% trans "Groups" %}</a></li>
+    {% if can_view_groups %}
+      <li><a href="#groups" data-toggle="tab">{% trans "Groups" %}</a></li>
+    {% endif %}
     {% if commtrack_enabled or uses_locations %}
       <li><a href="#commtrack-data" data-toggle="tab">{% trans "Locations" %}</a></li>
     {% endif %}
@@ -40,11 +42,13 @@
       </div>
     </div>
 
-    <div class="tab-pane" id="groups">
-      <div class="panel-body">
-        {% include 'users/partials/commcare_user_groups.html' %}
+    {% if can_view_groups %}
+      <div class="tab-pane" id="groups">
+        <div class="panel-body">
+          {% include 'users/partials/commcare_user_groups.html' %}
+        </div>
       </div>
-    </div>
+    {% endif %}
     {% if commtrack %}
       <div class="tab-pane" id="commtrack-data">
         <div class="panel-body">

--- a/corehq/apps/users/templates/users/partials/commcare_user_groups.html
+++ b/corehq/apps/users/templates/users/partials/commcare_user_groups.html
@@ -29,16 +29,20 @@
             {% trans "Group Memberships" %}
           </legend>
           <div class="form-group">
-            <label class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
-              {% trans "Group Membership" %}
-            </label>
-            <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6 controls-text">
-              <ul>
-                {% for group in group_names %}
-                  <li>{{ group }}</li>
-                {% endfor %}
-              </ul>
-            </div>
+            {% if group_names %}
+              <label class="col-xs-12 col-sm-4 col-md-4 col-lg-2 control-label">
+                {% trans "Group Membership" %}
+              </label>
+              <div class="col-xs-12 col-sm-8 col-md-8 col-lg-6 controls-text">
+                <ul>
+                  {% for group in group_names %}
+                    <li>{{ group }}</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% else %}
+              {% trans "No groups are assigned to this user." %}
+            {% endif %}
           </div>
         </div>
       {% else %}

--- a/corehq/apps/users/templates/users/partials/commcare_user_groups.html
+++ b/corehq/apps/users/templates/users/partials/commcare_user_groups.html
@@ -23,7 +23,7 @@
         {% endif %}
       </p>
     {% else %}
-      {% if request.is_view_only %}
+      {% if not can_edit_groups %}
         <div class="form form-horizontal">
           <legend>
             {% trans "Group Memberships" %}

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -272,6 +272,7 @@ class EditCommCareUserView(BaseEditUserView):
             'hide_password_feedback': settings.ENABLE_DRACONIAN_SECURITY_FEATURES,
             'group_names': [g.name for g in self.groups],
             'can_edit_groups': self.user_can_edit_groups,
+            'can_view_groups': self.user_can_view_groups,
         }
         if self.commtrack_form.errors:
             messages.error(self.request, _(
@@ -316,6 +317,11 @@ class EditCommCareUserView(BaseEditUserView):
     @memoized
     def user_can_edit_groups(self):
         return self.request.couch_user.has_permission(self.domain, 'edit_groups')
+
+    @property
+    @memoized
+    def user_can_view_groups(self):
+        return self.request.couch_user.has_permission(self.domain, 'view_groups')
 
     @property
     def parent_pages(self):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1443

##### SUMMARY
There was an awesome improvement done last year where [the groups form was not accounted for](https://github.com/dimagi/commcare-hq/pull/23343/files#r430241379). This PR address that form.
Currently the view has checks on ability to edit/view commcare user but not for ability to edit/view groups.

##### RISK ASSESSMENT / QA PLAN
Will be requesting Kishan to do a sanity check on staging

##### PRODUCT DESCRIPTION
User facing changes when editing a mobile worker, user would
1. see the groups tab if they have access to "View groups"
2. edit the content under groups tab if they have access to "Edit groups"
Earlier they could see it if they had permission to view commcare users, irrespective of their permission to manage groups.
Also, added a nice message
`No groups are assigned to this user.`
 in case there are no groups when viewing the read only view.

@dimagi/product 

