### PR TITLE
remove domain admin check for editing location fields

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -277,7 +277,6 @@ class LocationFieldsView(CustomDataModelMixin, BaseLocationView):
 
     @method_decorator(require_can_edit_locations)
     @method_decorator(locations_access_required)
-    @method_decorator(domain_admin_required)
     @method_decorator(check_pending_locations_import())
     def dispatch(self, request, *args, **kwargs):
         return super(LocationFieldsView, self).dispatch(request, *args, **kwargs)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1077

##### SUMMARY
Currently to access the page edit location fields, there is a requirement for the user to have permissions to edit locations and also to be domain admin however the link is already visible if the user has the permission to edit locations but they get a 404 when they click on the link.
The domain admin by default already has access to permissions to edit locations.

This PR updates the check for the user to only need the ability to edit locations since that should be all that is needed to edit location fields.

##### RISK ASSESSMENT / QA PLAN
This change should not come as a surprise to users since the link was already visible and would have probably been reported as a bug if they tried accessing it via a non-domain admin. But if the domain admins ignored that misbehaviour and were okay with the 404 for their web/mobile users, in those cases those web/mobile users will get access now.

##### PRODUCT DESCRIPTION
This would expose the link to edit location fields to all users that have ability to edit locations irrespective of them being domain admin or not.

marking as "do not merge" to get feedback