### PR TITLE
use plaintext password for auth managers

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -367,12 +367,12 @@ class Repeater(QuickCachedDocumentMixin, Document):
         if self.auth_type == BASIC_AUTH:
             return BasicAuthManager(
                 self.username,
-                self.password,
+                self.plaintext_password,
             )
         if self.auth_type == DIGEST_AUTH:
             return DigestAuthManager(
                 self.username,
-                self.password,
+                self.plaintext_password,
             )
         if self.auth_type == OAUTH1:
             raise NotImplementedError(_(
@@ -381,7 +381,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
         if self.auth_type == BEARER_AUTH:
             return BearerAuthManager(
                 self.username,
-                self.password,
+                self.plaintext_password,
             )
         # OAuth 2.0 coming when Repeaters use ConnectionSettings
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The old auth models used the `plaintext_password` not the encoded version. It appears to be necessary for auth to work. I think otherwise we are sending an obfuscated password to auth with.