### PR TITLE
Match link visibility to that of view for LocationFieldsView

### DIFF
--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -81,7 +81,7 @@
             </a>
           {% endif %}
 
-          {% if request.can_access_all_locations and not request.is_view_only %}
+          {% if user_is_domain_admin %}
             <a class="btn btn-default track-usage-link" href="{% url "location_fields_view" domain %}"
                data-category="Organization Structure" data-action="Edit Location Fields">
               <i class="fa fa-edit"></i>

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -275,7 +275,6 @@ class LocationFieldsView(CustomDataModelMixin, BaseLocationView):
     entity_string = ugettext_lazy("Location")
     template_name = "custom_data_fields/custom_data_fields.html"
 
-    @method_decorator(require_can_edit_locations)
     @method_decorator(locations_access_required)
     @method_decorator(domain_admin_required)
     @method_decorator(check_pending_locations_import())

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -212,6 +212,7 @@ class LocationsListView(BaseLocationView):
             'has_location_types': has_location_types,
             'can_edit_root': self.can_access_all_locations,
             'location_search_help': ExpandedMobileWorkerFilter.location_search_help,
+            'user_is_domain_admin': self.request.couch_user.is_domain_admin(self.domain),
         }
 
     def get_visible_locations(self):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1077


##### SUMMARY
Currently to access the page edit location fields, there is a requirement for the user to have permissions to edit locations and also to be domain admin however the link is already visible if the user has the permission to access data from all locations but they get a 404 when they click on the link.
The domain admin by default already has access to permissions to edit locations.

This PR 
1. removes the redundant permission check for editing locations since being a domain admin already covers it, when visiting locations custom fields view
2. updates the link to be visible only to domain admins and not everyone who has access to data from all locations

##### RISK ASSESSMENT / QA PLAN
Users who didn't have access to the page but could see the link, will stop seeing it now, so no problem there.

##### PRODUCT DESCRIPTION
Users who didn't have access to the page but could see the link, will stop seeing it now.
