### PR TITLE
Add ability to control which non-admin roles can assign a non-admin role

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -295,7 +295,9 @@ class UserRole(QuickCachedDocumentMixin, Document):
         choices=[page.id for page in ALL_LANDING_PAGES],
     )
     permissions = SchemaProperty(Permissions)
+    # role can be assigned by all non-admins
     is_non_admin_editable = BooleanProperty(default=False)
+    # role assignable by specific non-admins
     assignable_by = StringListProperty(default=[])
     is_archived = BooleanProperty(default=False)
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -296,6 +296,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
     )
     permissions = SchemaProperty(Permissions)
     is_non_admin_editable = BooleanProperty(default=False)
+    assignable_by = StringListProperty(default=[])
     is_archived = BooleanProperty(default=False)
 
     def get_qualified_id(self):

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -45,6 +45,17 @@ hqDefine('users/js/roles',[
                     }),
                 };
 
+                data.manageRoleAssignments = {
+                    all: data.is_non_admin_editable,
+                    specific: ko.utils.arrayMap(o.nonAdminRoles, function (role) {
+                        return {
+                            path: role._id,
+                            name: role.name,
+                            value: data.assignable_by.indexOf(role._id) !== -1,
+                        };
+                    }),
+                };
+
                 self = ko.mapping.fromJS(data);
                 self.reportPermissions.filteredSpecific = ko.computed(function () {
                     return ko.utils.arrayFilter(self.reportPermissions.specific(), function (report) {
@@ -82,6 +93,12 @@ hqDefine('users/js/roles',[
                     return app.value;
                 }), function (app) {
                     return app.path;
+                });
+                data.is_non_admin_editable = data.manageRoleAssignments.all;
+                data.assignable_by = ko.utils.arrayMap(ko.utils.arrayFilter(data.manageRoleAssignments.specific, function (role) {
+                    return role.value;
+                }), function (role) {
+                    return role.path;
                 });
                 return data;
             },

--- a/corehq/apps/users/static/users/js/roles_and_permissions.js
+++ b/corehq/apps/users/static/users/js/roles_and_permissions.js
@@ -56,6 +56,7 @@ hqDefine("users/js/roles_and_permissions",[
 
         userRoles.initUserRoles($userRolesTable, {
             userRoles: initialPageData.get("user_roles"),
+            nonAdminRoles: initialPageData.get("non_admin_roles"),
             defaultRole: initialPageData.get("default_role"),
             saveUrl: url("post_user_role"),
             deleteUrl: url("delete_user_role"),

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -1,10 +1,8 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-<div data-bind="modal: roleBeingEdited" tabindex="-1" role="dialog"
-     class="modal fade">
-  <div data-bind="with: roleBeingEdited"
-       class="modal-dialog">
+<div data-bind="modal: roleBeingEdited" tabindex="-1" role="dialog" class="modal fade">
+  <div data-bind="with: roleBeingEdited" class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
         <button type="button"
@@ -18,8 +16,7 @@
       <div class="modal-body">
         <div class="form form-horizontal">
           <div class="form-group">
-            <label class="col-sm-4 control-label"
-                   for="role-name">
+            <label class="col-sm-4 control-label" for="role-name">
               {% trans "Role Name" %}
             </label>
             <div class="col-sm-8 controls">
@@ -43,109 +40,140 @@
 
           {# BEGIN web_users permissions #}
           <div class="form-group" data-bind="visible: permissions.access_all_locations">
-
             <div class="col-sm-2 controls">
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-web-users-checkbox"
-                       data-bind="checked: permissions.edit_web_users,
-                                                  disable: !$root.allowEdit" />
-                <label for="edit-web-users-checkbox"><span class="sr-only">{% trans "Edit & View Web Users" %}</span></label>
+                       data-bind="checked: permissions.edit_web_users, disable: !$root.allowEdit" />
+                <label for="edit-web-users-checkbox">
+                  <span class="sr-only">
+                    {% trans "Edit & View Web Users" %}
+                  </span>
+                </label>
               </div>
             </div>
 
             <div class="col-sm-2 controls">
-
               {# PLACEHOLDER checkbox when edit_web_users is true #}
               <div class="form-check" data-bind="visible: permissions.edit_web_users()">
                 <input type="checkbox" checked="checked" disabled="disabled" />
-                <label><span class="sr-only">{% trans "View-Only Web Users" %}</span></label>
-              </div> {# end PLACEHOLDER #}
+                <label>
+                  <span class="sr-only">
+                    {% trans "View-Only Web Users" %}
+                  </span>
+                </label>
+              </div>
+              {# end PLACEHOLDER #}
 
               {# REAL checkbox that controls view_web_users permission #}
               <div class="form-check" data-bind="visible: !permissions.edit_web_users()">
                 <input type="checkbox"
                        id="view-web-users-checkbox"
                        data-bind="checked: permissions.view_web_users,
-                                                  disable: !$root.allowEdit" />
-                <label for="view-web-users-checkbox"><span class="sr-only">{% trans "View-Only Web Users" %}</span></label>
-              </div> {# END REAL checkbox #}
-
+                                  disable: !$root.allowEdit" />
+                <label for="view-web-users-checkbox">
+                  <span class="sr-only">
+                    {% trans "View-Only Web Users" %}
+                  </span>
+                </label>
+              </div>
+              {# END REAL checkbox #}
             </div>
+
             <div class="col-sm-8 control-label">
               {% blocktrans %}
                 <strong>Web Users</strong> &mdash; invite new web users, manage account settings, remove membership
               {% endblocktrans %}
             </div>
-          </div> {# END web_users permissions #}
+          </div>
+          {# END web_users permissions #}
 
           {#  BEGIN commcare_users permissions #}
           <div class="form-group">
-
             <div class="col-sm-2 controls">
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-commcare-users-checkbox"
-                       data-bind="checked: permissions.edit_commcare_users,
-                                                  disable: !$root.allowEdit" />
-                <label for="edit-commcare-users-checkbox"><span class="sr-only">{% trans "Edit & View Mobile Workers" %}</span></label>
+                       data-bind="checked: permissions.edit_commcare_users, disable: !$root.allowEdit" />
+                <label for="edit-commcare-users-checkbox">
+                  <span class="sr-only">
+                    {% trans "Edit & View Mobile Workers" %}
+                  </span>
+                </label>
               </div>
             </div>
 
             <div class="col-sm-2 controls">
-
               {# PLACEHOLDER checkbox when edit_commcare_users is true #}
               <div class="form-check" data-bind="visible: permissions.edit_commcare_users()">
                 <input type="checkbox" checked="checked" disabled="disabled" />
-                <label><span class="sr-only">{% trans "View-Only Mobile Workers" %}</span></label>
-              </div> {# end PLACEHOLDER #}
+                <label>
+                  <span class="sr-only">
+                    {% trans "View-Only Mobile Workers" %}
+                  </span>
+                </label>
+              </div>
+              {# end PLACEHOLDER #}
 
               {# REAL checkbox that controls view_commcare_users permission #}
               <div class="form-check" data-bind="visible: !permissions.edit_commcare_users()">
                 <input type="checkbox"
                        id="view-commcare-users-checkbox"
                        data-bind="checked: permissions.view_commcare_users,
-                                                  disable: (permissions.edit_commcare_users() && $root.allowEdit) || !$root.allowEdit" />
-                <label for="view-commcare-users-checkbox"><span class="sr-only">{% trans "View-Only Mobile Workers" %}</span></label>
-              </div> {# END REAL checkbox #}
+                                  disable: (permissions.edit_commcare_users() && $root.allowEdit) || !$root.allowEdit" />
+                <label for="view-commcare-users-checkbox">
+                  <span class="sr-only">
+                    {% trans "View-Only Mobile Workers" %}
+                  </span>
+                </label>
+              </div>
+              {# END REAL checkbox #}
 
             </div>
             <div class="col-sm-8 control-label">
               {% blocktrans %}
-                <strong>Mobile Workers</strong> &mdash; create new accounts, manage account settings, deactivate or delete mobile workers. This permission also allows users to login as any mobile worker in Web Apps.
+                <strong>Mobile Workers</strong> &mdash; create new accounts, manage account settings,deactivate or delete mobile workers. This permission also allows users to login as any mobile worker in Web Apps.
               {% endblocktrans %}
             </div>
-          </div> {# END commcare_users permissions #}
+          </div>
+          {# END commcare_users permissions #}
 
           {#  BEGIN groups permissions #}
           <div class="form-group" data-bind="visible: permissions.access_all_locations">
-
             <div class="col-sm-2 controls">
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-groups-checkbox"
-                       data-bind="checked: permissions.edit_groups,
-                                                  disable: !$root.allowEdit" />
-                <label for="edit-groups-checkbox"><span class="sr-only">{% trans "Edit & View Groups" %}</span></label>
+                       data-bind="checked: permissions.edit_groups, disable: !$root.allowEdit" />
+                <label for="edit-groups-checkbox">
+                  <span class="sr-only">
+                    {% trans "Edit & View Groups" %}
+                  </span>
+                </label>
               </div>
             </div>
 
             <div class="col-sm-2 controls">
-
               {# PLACEHOLDER checkbox when edit_groups is true #}
               <div class="form-check" data-bind="visible: permissions.edit_groups()">
                 <input type="checkbox" checked="checked" disabled="disabled" />
                 <label><span class="sr-only">{% trans "View-Only Groups" %}</span></label>
-              </div> {# end PLACEHOLDER #}
+              </div>
+              {# end PLACEHOLDER #}
 
               {# REAL checkbox that controls view_groups permission #}
               <div class="form-check" data-bind="visible: !permissions.edit_groups()">
                 <input type="checkbox"
                        id="view-groups-checkbox"
                        data-bind="checked: permissions.view_groups,
-                                                  disable: (permissions.edit_groups() && $root.allowEdit) || !$root.allowEdit" />
-                <label for="view-groups-checkbox"><span class="sr-only">{% trans "View-Only Groups" %}</span></label>
-              </div>{# END REAL checkbox #}
+                                  disable: (permissions.edit_groups() && $root.allowEdit) || !$root.allowEdit" />
+                <label for="view-groups-checkbox">
+                  <span class="sr-only">
+                    {% trans "View-Only Groups" %}
+                  </span>
+                </label>
+              </div>
+              {# END REAL checkbox #}
             </div>
 
             <div class="col-sm-8 control-label">
@@ -160,18 +188,19 @@
                 <label>
                   {% trans "Allow changing group membership." %}
                 </label>
-              </div>{# end PLACEHOLDER #}
+              </div>
+              {# end PLACEHOLDER #}
 
               {# REAL checkbox for edit_users_in_groups #}
               <div class="form-check" data-bind="visible: !permissions.edit_commcare_users() && permissions.edit_groups()">
                 <input type="checkbox"
                        id="edit-users-groups-checkbox"
-                       data-bind="checked: permissions.edit_users_in_groups,
-                                                  disable: !$root.allowEdit" />
+                       data-bind="checked: permissions.edit_users_in_groups, disable: !$root.allowEdit" />
                 <label for="edit-users-groups-checkbox">
                   {% trans "Allow changing group membership." %}
                 </label>
-              </div>{# end REAL #}
+              </div>
+              {# end REAL #}
 
               {# PLACEHOLDER checkbox when edit_groups is false #}
               <div class="form-check" data-bind="visible: !permissions.edit_groups()">
@@ -179,10 +208,11 @@
                 <label>
                   {% trans "Allow changing group membership (requires edit groups)." %}
                 </label>
-              </div>{# end PLACEHOLDER #}
-
+              </div>
+              {# end PLACEHOLDER #}
             </div>
-          </div> {#  END groups permissions #}
+          </div>
+          {#  END groups permissions #}
 
           {# BEGIN locations permissions #}
           <div class="form-group">
@@ -190,27 +220,39 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-locations-checkbox"
-                       data-bind="checked: permissions.edit_locations,
-                                                  disable: !$root.allowEdit" />
-                <label for="edit-locations-checkbox"><span class="sr-only">{% trans "Edit & View Locations" %}</span></label>
+                       data-bind="checked: permissions.edit_locations, disable: !$root.allowEdit" />
+                <label for="edit-locations-checkbox">
+                  <span class="sr-only">
+                    {% trans "Edit & View Locations" %}
+                  </span>
+                </label>
               </div>
             </div>
             <div class="col-sm-2 controls">
-
               {# PLACEHOLDER checkbox when edit_locations is true #}
               <div class="form-check" data-bind="visible: permissions.edit_locations()">
                 <input type="checkbox" checked="checked" disabled="disabled" />
-                <label><span class="sr-only">{% trans "View-Only Locations" %}</span></label>
-              </div> {# end PLACEHOLDER #}
+                <label>
+                  <span class="sr-only">
+                    {% trans "View-Only Locations" %}
+                  </span>
+                </label>
+              </div>
+              {# end PLACEHOLDER #}
 
               {# REAL checkbox that controls view_locations permission #}
               <div class="form-check" data-bind="visible: !permissions.edit_locations()">
                 <input type="checkbox"
                        id="view-locations-checkbox"
                        data-bind="checked: permissions.view_locations,
-                                                  disable: (permissions.edit_locations() && $root.allowEdit) || !$root.allowEdit" />
-                <label for="view-locations-checkbox"><span class="sr-only">{% trans "View-Only Locations" %}</span></label>
-              </div>{# end REAL checkbox #}
+                                  disable: (permissions.edit_locations() && $root.allowEdit) || !$root.allowEdit" />
+                <label for="view-locations-checkbox">
+                  <span class="sr-only">
+                    {% trans "View-Only Locations" %}
+                  </span>
+                </label>
+              </div>
+              {# end REAL checkbox #}
 
             </div>
             <div class="col-sm-8 control-label">
@@ -225,18 +267,19 @@
                 <label>
                   {% trans "Allow changing workers at a location." %}
                 </label>
-              </div>{# end PLACEHOLDER #}
+              </div>
+              {# end PLACEHOLDER #}
 
               {# REAL checkbox for edit_users_in_groups #}
               <div class="form-check" data-bind="visible: !permissions.edit_commcare_users() && permissions.edit_locations()">
                 <input type="checkbox"
                        id="edit-users-locations-checkbox"
-                       data-bind="checked: permissions.edit_users_in_locations,
-                                                  disable: !$root.allowEdit" />
+                       data-bind="checked: permissions.edit_users_in_locations, disable: !$root.allowEdit" />
                 <label for="edit-users-locations-checkbox">
                   {% trans "Allow changing workers at a location." %}
                 </label>
-              </div>{# end REAL #}
+              </div>
+              {# end REAL #}
 
               {# PLACEHOLDER checkbox when edit_locations is false #}
               <div class="form-check" data-bind="visible: !permissions.edit_locations()">
@@ -247,7 +290,8 @@
               </div>{# end PLACEHOLDER #}
 
             </div>
-          </div> {# END locations permissions #}
+          </div>
+          {# END locations permissions #}
 
           {# BEGIN data permissions #}
           <div class="form-group">
@@ -255,9 +299,12 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-data-checkbox"
-                       data-bind="checked: permissions.edit_data,
-                                                  disable: !$root.allowEdit" />
-                <label for="edit-data-checkbox"><span class="sr-only">{% trans "Edit & View Data" %}</span></label>
+                       data-bind="checked: permissions.edit_data, disable: !$root.allowEdit" />
+                <label for="edit-data-checkbox">
+                  <span class="sr-only">
+                    {% trans "Edit & View Data" %}
+                  </span>
+                </label>
               </div>
             </div>
             <div class="col-sm-2 controls">
@@ -276,33 +323,43 @@
           {# BEGIN dropzone permissions #}
           {% if request|toggle_enabled:"DATA_FILE_DOWNLOAD" %}
           <div class="form-group">
-
             <div class="col-sm-2 controls">
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-dropzone-checkbox"
-                       data-bind="checked: permissions.edit_file_dropzone,
-                                                  disable: !$root.allowEdit" />
-                <label for="edit-dropzone-checkbox"><span class="sr-only">{% trans "Edit & Download files from the Dropzone " %}</span></label>
+                       data-bind="checked: permissions.edit_file_dropzone, disable: !$root.allowEdit" />
+                <label for="edit-dropzone-checkbox">
+                  <span class="sr-only">
+                    {% trans "Edit & Download files from the Dropzone " %}
+                  </span>
+                </label>
               </div>
             </div>
 
             <div class="col-sm-2 controls">
-
               {# PLACEHOLDER checkbox when edit_file_dropzone is true #}
               <div class="form-check" data-bind="visible: permissions.edit_file_dropzone()">
                 <input type="checkbox" checked="checked" disabled="disabled" />
-                <label><span class="sr-only">{% trans "View-Only Dropzone" %}</span></label>
-              </div> {# end PLACEHOLDER #}
+                <label>
+                  <span class="sr-only">
+                    {% trans "View-Only Dropzone" %}
+                  </span>
+                </label>
+              </div>
+              {# end PLACEHOLDER #}
 
               {# REAL checkbox that controls view_file_dropzone permission #}
               <div class="form-check" data-bind="visible: !permissions.edit_file_dropzone()">
                 <input type="checkbox"
                        id="view-dropzone-checkbox"
-                       data-bind="checked: permissions.view_file_dropzone,
-                                                  disable: !$root.allowEdit" />
-                <label for="view-dropzone-checkbox"><span class="sr-only">{% trans "Download-Only files from the Dropzone" %}</span></label>
-              </div> {# END REAL checkbox #}
+                       data-bind="checked: permissions.view_file_dropzone, disable: !$root.allowEdit" />
+                <label for="view-dropzone-checkbox">
+                  <span class="sr-only">
+                    {% trans "Download-Only files from the Dropzone" %}
+                  </span>
+                </label>
+              </div>
+              {# END REAL checkbox #}
 
             </div>
             <div class="col-sm-8 control-label">
@@ -310,7 +367,8 @@
                 <strong>Dropzone</strong> &mdash; Upload and download files from the file Dropzone
               {% endblocktrans %}
             </div>
-          </div> {# END dropzone permissions #}
+          </div>
+          {# END dropzone permissions #}
           {% endif %}
 
           {# BEGIN API permission #}
@@ -319,9 +377,12 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-api-checkbox"
-                       data-bind="checked: permissions.access_api,
-                                  disable: !$root.allowEdit" />
-                <label for="edit-api-checkbox"><span class="sr-only">{% trans "Access APIs" %}</span></label>
+                       data-bind="checked: permissions.access_api, disable: !$root.allowEdit" />
+                <label for="edit-api-checkbox">
+                  <span class="sr-only">
+                    {% trans "Access APIs" %}
+                  </span>
+                </label>
               </div>
             </div>
             <div class="col-sm-2 controls">
@@ -335,7 +396,8 @@
                 Specific APIs may require additional permissions.
               {% endblocktrans %}
             </div>
-          </div> {# END API permission #}
+          </div>
+          {# END API permission #}
 
           {% if request|toggle_enabled:"EXPORT_OWNERSHIP" %}
             {# BEGIN Shared Export permissions #}
@@ -344,9 +406,12 @@
                 <div class="form-check">
                   <input type="checkbox"
                          id="edit-shared-exports-checkbox"
-                         data-bind="checked: permissions.edit_shared_exports,
-                                                  disable: !$root.allowEdit" />
-                  <label for="edit-shared-exports-checkbox"><span class="sr-only">{% trans "Edit & View Shared Exports" %}</span></label>
+                         data-bind="checked: permissions.edit_shared_exports, disable: !$root.allowEdit" />
+                  <label for="edit-shared-exports-checkbox">
+                    <span class="sr-only">
+                      {% trans "Edit & View Shared Exports" %}
+                    </span>
+                  </label>
                 </div>
               </div>
               <div class="col-sm-2 controls">
@@ -359,7 +424,8 @@
                   <strong>Shared Exports</strong> &mdash; access and edit the content and structure of shared exports
                 {% endblocktrans %}
               </div>
-            </div> {# END Shared Export permissions #}
+            </div>
+          {# END Shared Export permissions #}
           {% endif %}
 
           {# BEGIN Applications permissions #}
@@ -368,9 +434,12 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-apps-checkbox"
-                       data-bind="checked: permissions.edit_apps,
-                                                  disable: !$root.allowEdit" />
-                <label for="edit-apps-checkbox"><span class="sr-only">{% trans "Edit & View Apps" %}</span></label>
+                       data-bind="checked: permissions.edit_apps, disable: !$root.allowEdit" />
+                <label for="edit-apps-checkbox">
+                  <span class="sr-only">
+                    {% trans "Edit & View Apps" %}
+                  </span>
+                </label>
               </div>
             </div>
             <div class="col-sm-2 controls">
@@ -384,7 +453,8 @@
                 and configuration of all applications.
               {% endblocktrans %}
             </div>
-          </div> {# END Applications permissions #}
+          </div>
+          {# END Applications permissions #}
 
           {# BEGIN Roles & Permissions permissions #}
           <div class="form-group" data-bind="visible: permissions.access_all_locations">
@@ -397,9 +467,12 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="view-roles-checkbox"
-                       data-bind="checked: permissions.view_roles,
-                                                  disable: !$root.allowEdit" />
-                <label for="view-roles-checkbox"><span class="sr-only">{% trans "View Roles and Permssions" %}</span></label>
+                       data-bind="checked: permissions.view_roles, disable: !$root.allowEdit" />
+                <label for="view-roles-checkbox">
+                  <span class="sr-only">
+                    {% trans "View Roles and Permssions" %}
+                  </span>
+                </label>
               </div>
             </div>
             <div class="col-sm-8 control-label">
@@ -408,7 +481,8 @@
                 roles &amp; permissions (only Admins can edit roles)
               {% endblocktrans %}
             </div>
-          </div> {# END Roles & Permissions permissions #}
+          </div>
+          {# END Roles & Permissions permissions #}
 
           <legend>
             {% trans "Other Settings" %}
@@ -423,8 +497,7 @@
                 <div class="form-check">
                   <input type="checkbox"
                          id="edit-motech-checkbox"
-                         data-bind="checked: permissions.edit_motech,
-                                                  disable: !$root.allowEdit" />
+                         data-bind="checked: permissions.edit_motech, disable: !$root.allowEdit" />
                   <label for="edit-motech-checkbox">
                     {% trans "Allow role to manage integration with other systems." %}
                   </label>
@@ -441,8 +514,7 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="edit-billing-checkbox"
-                       data-bind="checked: permissions.edit_billing,
-                                                  disable: !$root.allowEdit" />
+                       data-bind="checked: permissions.edit_billing, disable: !$root.allowEdit" />
                 <label for="edit-billing-checkbox">
                   {% trans "Allow role to manage subscription information." %}
                 </label>
@@ -452,7 +524,7 @@
 
           <div class="form-group"
                data-bind="css: { 'has-error': hasUnpermittedLocationRestriction },
-                                    visible: $root.canRestrictAccessByLocation || hasUnpermittedLocationRestriction">
+                          visible: $root.canRestrictAccessByLocation || hasUnpermittedLocationRestriction">
             <label class="col-sm-4 control-label">
               {% trans "Full Organization Access" %}
             </label>
@@ -461,12 +533,13 @@
                 <input type="checkbox"
                        id="allow-data-all-access-checkbox"
                        data-bind="checked: permissions.access_all_locations,
-                                                  disable: hasUnpermittedLocationRestriction || !$root.allowEdit" />
+                                  disable: hasUnpermittedLocationRestriction || !$root.allowEdit" />
                 <label for="allow-data-all-access-checkbox">
                   {% trans "Allow role to access data from all locations." %}
                 </label>
               </div>
-              <div class="help-block alert alert-warning" data-bind="visible: !hasUnpermittedLocationRestriction && !permissions.access_all_locations()">
+              <div class="help-block alert alert-warning"
+                   data-bind="visible: !hasUnpermittedLocationRestriction && !permissions.access_all_locations()">
                 {% blocktrans %}
                   Make sure any users assigned this role also have a location assigned to them.
                   Users without assigned locations will not be permitted to log in.
@@ -489,16 +562,14 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="access-all-reports-checkbox"
-                       data-bind="checked: reportPermissions.all,
-                                                  disable: !$root.allowEdit" />
+                       data-bind="checked: reportPermissions.all, disable: !$root.allowEdit" />
                 <label for="access-all-reports-checkbox">
                   {% trans "Allow role to access all reports." %}
                 </label>
               </div>
             </div>
           </div>
-          <div class="form-group"
-               data-bind="visible: !reportPermissions.all()">
+          <div class="form-group" data-bind="visible: !reportPermissions.all()">
             <label class="col-sm-4 control-label">
               {% trans "Access Specific Reports" %}
             </label>
@@ -511,9 +582,8 @@
                      data-bind="foreach: reportPermissions.specific, slideVisible: !reportPermissions.all()">
                   <div class="form-check">
                     <input type="checkbox"
-                           data-bind="checked: value,
-                                                          attr: { 'id': slug() + '-checkbox' },
-                                                          disable: !$root.allowEdit" />
+                           data-bind="checked: value, attr: { 'id': slug() + '-checkbox' },
+                                      disable: !$root.allowEdit" />
                     <label data-bind="attr: { 'for': slug() + '-checkbox' }">
                       <span data-bind="html: name"></span>
                     </label>
@@ -531,8 +601,7 @@
                 <div class="form-check">
                   <input type="checkbox"
                          id="access-all-webapps-checkbox"
-                         data-bind="checked: webAppsPermissions.all,
-                                                      disable: !$root.allowEdit" />
+                         data-bind="checked: webAppsPermissions.all, disable: !$root.allowEdit" />
                   <label for="access-all-webapps-checkbox">
                     {% trans "Allow role to view all Web Apps." %}
                   </label>
@@ -553,9 +622,8 @@
                        data-bind="foreach: webAppsPermissions.specific, slideVisible: !webAppsPermissions.all()">
                     <div class="form-check">
                       <input type="checkbox"
-                             data-bind="checked: value,
-                                                              attr: { 'id': 'app-' + path() + '-checkbox' },
-                                                              disable: !$root.allowEdit" />
+                             data-bind="checked: value, attr: { 'id': 'app-' + path() + '-checkbox' },
+                                        disable: !$root.allowEdit" />
                       <label data-bind="attr: { 'for': 'app-' + path() + '-checkbox' }">
                         <span data-bind="html: name"></span>
                       </label>
@@ -608,7 +676,11 @@
                          id="edit-mobile-checkbox"
                          data-bind="checked: permissions.access_mobile_endpoints,
                                     disable: !$root.allowEdit" />
-                                  <label for="edit-mobile-checkbox"><span class="sr-only">{% trans "Access to Offline Mobile Apps" %}</span></label>
+                <label for="edit-mobile-checkbox">
+                  <span class="sr-only">
+                    {% trans "Access to Offline Mobile Apps" %}
+                  </span>
+                </label>
               </div>
             </div>
             <div class="col-sm-2 controls">
@@ -654,9 +726,8 @@
                        data-bind="foreach: manageAppReleasePermissions.specific, slideVisible: !manageAppReleasePermissions.all()">
                     <div class="form-check">
                       <input type="checkbox"
-                             data-bind="checked: value,
-                                                              attr: { 'id': 'release-' + path() + '-checkbox' },
-                                                              disable: !$root.allowEdit" />
+                             data-bind="checked: value, attr: { 'id': 'release-' + path() + '-checkbox' },
+                                        disable: !$root.allowEdit" />
                       <label data-bind="attr: { 'for': 'release-' + path() + '-checkbox' }">
                         <span data-bind="html: name"></span>
                       </label>
@@ -672,13 +743,13 @@
               {% trans "Default Landing Page" %}
             </label>
             <div class="col-sm-8 controls">
-              <select class="form-control" id="landing-page" data-bind="
-                                options: $root.landingPageChoices,
+              <select class="form-control" id="landing-page"
+                      data-bind="options: $root.landingPageChoices,
                                 optionsText: 'name',
                                 optionsValue: 'id',
                                 value: default_landing_page,
-                                disable: !$root.allowEdit
-                            "></select>
+                                disable: !$root.allowEdit">
+              </select>
             </div>
           </div>
           <div class="form-group">
@@ -689,8 +760,7 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="report-issue-checkbox"
-                       data-bind="checked: permissions.report_an_issue,
-                                                  disable: !$root.allowEdit" />
+                       data-bind="checked: permissions.report_an_issue, disable: !$root.allowEdit" />
                 <label for="report-issue-checkbox">
                   {% trans "Allow this role to report issues." %}
                 </label>
@@ -705,8 +775,7 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="non-admin-edit-checkbox"
-                       data-bind="checked: manageRoleAssignments.all,
-                                                  disable: !$root.allowEdit" />
+                       data-bind="checked: manageRoleAssignments.all, disable: !$root.allowEdit" />
                 <label for="non-admin-edit-checkbox">
                   {% trans "Allow all non-admins to assign this role to other users." %}
                 </label>
@@ -727,9 +796,8 @@
                      data-bind="foreach: manageRoleAssignments.specific, slideVisible: !manageRoleAssignments.all()">
                   <div class="form-check">
                     <input type="checkbox"
-                           data-bind="checked: value,
-                                                            attr: { 'id': 'role-' + path() + '-checkbox' },
-                                                            disable: !$root.allowEdit" />
+                           data-bind="checked: value, attr: { 'id': 'role-' + path() + '-checkbox' },
+                                      disable: !$root.allowEdit" />
                     <label data-bind="attr: { 'for': 'role-' + path() + '-checkbox' }">
                       <span data-bind="html: name"></span>
                     </label>
@@ -748,7 +816,8 @@
             {% trans "Cancel" %}
           </button>
           <div data-bind="saveButton2: $root.modalSaveButton.state,
-                                    saveOptions: $root.modalSaveButton.saveOptions"></div>
+                          saveOptions: $root.modalSaveButton.saveOptions">
+          </div>
         {% else %}
           <button type="button"
                   class="btn btn-default"

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -705,11 +705,36 @@
               <div class="form-check">
                 <input type="checkbox"
                        id="non-admin-edit-checkbox"
-                       data-bind="checked: is_non_admin_editable,
+                       data-bind="checked: manageRoleAssignments.all,
                                                   disable: !$root.allowEdit" />
                 <label for="non-admin-edit-checkbox">
-                  {% trans "Allow non-admins to assign this role to other users." %}
+                  {% trans "Allow all non-admins to assign this role to other users." %}
                 </label>
+              </div>
+            </div>
+          </div>
+          <div class="form-group"
+               data-bind="visible: !manageRoleAssignments.all()">
+            <label class="col-sm-4 control-label">
+              {% trans "Manage Role Assignment" %}
+            </label>
+            <div class="col-sm-8 controls">
+              <div class="panel panel-default">
+                <div class="panel-heading">
+                  {% trans "Select which other roles can assign this role:" %}
+                </div>
+                <div class="panel-body"
+                     data-bind="foreach: manageRoleAssignments.specific, slideVisible: !manageRoleAssignments.all()">
+                  <div class="form-check">
+                    <input type="checkbox"
+                           data-bind="checked: value,
+                                                            attr: { 'id': 'role-' + path() + '-checkbox' },
+                                                            disable: !$root.allowEdit" />
+                    <label data-bind="attr: { 'for': 'role-' + path() + '-checkbox' }">
+                      <span data-bind="html: name"></span>
+                    </label>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -8,6 +8,7 @@
   {% registerurl "post_user_role" domain %}
   {% registerurl "delete_user_role" domain %}
   {% initial_page_data "user_roles" user_roles %}
+  {% initial_page_data "non_admin_roles" non_admin_roles %}
   {% initial_page_data "can_edit_roles" can_edit_roles %}
   {% initial_page_data "default_role" default_role %}
   {% initial_page_data "report_list" report_list %}

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -1199,7 +1199,12 @@ def _get_editable_role_choices(domain, couch_user, allow_admin_role):
 
     roles = UserRole.by_domain(domain)
     if not couch_user.is_domain_admin(domain):
-        roles = [role for role in roles if role.is_non_admin_editable]
+        user_role = couch_user.get_role()
+        user_role_id = user_role.get_id if user_role else None
+        roles = [
+            role for role in roles
+            if role.is_non_admin_editable or (user_role_id and user_role_id in role.assignable_by)
+        ]
     elif allow_admin_role:
         roles = [AdminUserRole(domain=domain)] + roles
     return [role_to_choice(role) for role in roles]

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -548,6 +548,7 @@ class ListRolesView(BaseRoleAccessView):
                 "update the existing roles."))
         return {
             'user_roles': self.user_roles,
+            'non_admin_roles': self.user_roles[1:],
             'can_edit_roles': self.can_edit_roles,
             'default_role': UserRole.get_default(),
             'report_list': get_possible_reports(self.domain),


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1414

##### SUMMARY
Add ability to let a role be assigned only by specific roles

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
Enhancing the ability to control if a role can be assigned by non admins.
Just like on the roles UI a user has ability to give access to all reports or few reports to a role, adding a similar UI interface for a user to define a role assignable by specific roles and not all non-admins, so that when other non-admin users who can assign a role to a mobile or web user, they only see roles marked as accessibly for all non-admins or marked accessible for their own role.

Sneak preview [here](https://recordit.co/LvvsHZRqC4)

@dimagi/product happy to put this behind a feature flag if needed.