### PR TITLE
Set charset=utf-8 in default headers

### DIFF
--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -149,7 +149,7 @@ class Requests(object):
 
     def post(self, endpoint, data=None, json=None, *args, **kwargs):
         kwargs.setdefault('headers', {
-            'Content-type': 'application/json',
+            'Content-type': 'application/json; charset=utf-8',
             'Accept': 'application/json'
         })
         url = get_endpoint_url(self.base_url, endpoint)
@@ -158,7 +158,7 @@ class Requests(object):
 
     def put(self, endpoint, data=None, json=None, *args, **kwargs):
         kwargs.setdefault('headers', {
-            'Content-type': 'application/json',
+            'Content-type': 'application/json; charset=utf-8',
             'Accept': 'application/json'
         })
         url = get_endpoint_url(self.base_url, endpoint)
@@ -226,7 +226,7 @@ def simple_post(domain, url, data, *, headers, auth_manager, verify,
         # non-ASCII characters as 'data:application/octet-stream;base64,...'
         data = data.encode('utf-8')
     default_headers = CaseInsensitiveDict({
-        "content-type": "text/xml",
+        "content-type": "text/xml; charset=utf-8",
         "content-length": str(len(data)),
     })
     default_headers.update(headers)

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -30,7 +30,7 @@ class UnpackRequestArgsTests(SimpleTestCase):
         self.content_json = json.dumps(content)
         self.request_method = 'POST'
         self.request_headers = {
-            'Content-type': 'application/json',
+            'Content-type': 'application/json; charset=utf-8',
             'Accept': 'application/json'
         }
         self.status_code = 201

--- a/corehq/motech/tests/test_requests.py
+++ b/corehq/motech/tests/test_requests.py
@@ -54,7 +54,10 @@ class SendRequestTests(SimpleTestCase):
             'http://dhis2.example.org/2.3.4/api/dataValueSets',
             data=None,
             json=payload,
-            headers={'Content-type': 'application/json', 'Accept': 'application/json'},
+            headers={
+                'Content-type': 'application/json; charset=utf-8',
+                'Accept': 'application/json'
+            },
             timeout=REQUEST_TIMEOUT,
         )
 


### PR DESCRIPTION
Context: Email conversation following retro for encoding Unicode post data as UTF-8

##### SUMMARY
Declares character set encoding for remote API server.

##### FEATURE FLAG
Applies to all data forwarding (Pro Plan and higher)

##### RISK ASSESSMENT / QA PLAN
- [x] Staged
- [ ] XML-formatted form forwarder tested with non-ASCII payload (uses `simple_post()` function)
- [ ] JSON-formatted form forwarder tested with non-ASCII payload
- [ ] OpenMRS forwarder tested with non-ASCII payload (uses Requests class `post()` method)
- [ ] DHIS2 forwarder tested with non-ASCII payload (uses Requests class `put()` method)
