### PR TITLE
fix 500 on app summary page 

### DIFF
--- a/corehq/apps/app_manager/app_schemas/app_case_metadata.py
+++ b/corehq/apps/app_manager/app_schemas/app_case_metadata.py
@@ -521,7 +521,8 @@ class AppCaseMetadata(JsonObject):
         parts = field.split('/')
         if parts and parts[0] == 'user':
             root_case_type = USERCASE_TYPE
-            field = field.split('user/')[1]
+            if len(parts) > 1:
+                field = field.split('user/')[1]
 
         error = None
         try:


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10848

##### SUMMARY
When `field = 'user/'` this throws a 500.
