### PR TITLE
allow empty filter values in report builder reports

### DIFF
--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -395,8 +395,17 @@ class DynamicChoiceListFilter(BaseFilter):
         if selection:
             choices = selection if isinstance(selection, list) else [selection]
             typed_choices = [transform_from_datatype(self.datatype)(c) for c in choices]
-            return self.choice_provider.get_sorted_choices_for_values(typed_choices, user)
+            transformed_choices = [self._transform_for_default_value(tc) for tc in typed_choices]
+            return self.choice_provider.get_sorted_choices_for_values(transformed_choices, user)
         return self.default_value(user)
+
+    @staticmethod
+    def _transform_for_default_value(choice):
+        from corehq.apps.userreports.reports.filters.values import EMPTY_CHOICE
+        if choice == EMPTY_CHOICE:
+            return ''
+        else:
+            return choice
 
     def default_value(self, request_user=None):
         from corehq.apps.userreports.reports.filters.values import SHOW_ALL_CHOICE

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -10,7 +10,7 @@ from corehq.apps.es import GroupES, UserES
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports_core.filters import Choice
 from corehq.apps.userreports.exceptions import ColumnNotFoundError
-from corehq.apps.userreports.reports.filters.values import SHOW_ALL_CHOICE
+from corehq.apps.userreports.reports.filters.values import SHOW_ALL_CHOICE, EMPTY_CHOICE, NONE_CHOICE
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.apps.users.util import raw_username
@@ -187,6 +187,10 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
         return []
 
     def _make_choice_from_value(self, value):
+        if value is None:
+            return Choice(NONE_CHOICE, '[Missing]')
+        elif not value:
+            return Choice(EMPTY_CHOICE, '[Empty]')
         return Choice(value, value)
 
 

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -149,7 +149,7 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
 
     def query(self, query_context):
         try:
-            return [Choice(value, value)
+            return [self._make_choice_from_value(value)
                     for value in self.get_values_for_query(query_context)]
         except ColumnNotFoundError:
             return []
@@ -185,6 +185,9 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
 
     def get_choices_for_known_values(self, values, user):
         return []
+
+    def _make_choice_from_value(self, value):
+        return Choice(value, value)
 
 
 class MultiFieldDataSourceColumnChoiceProvider(DataSourceColumnChoiceProvider):

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -189,7 +189,7 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
     def _make_choice_from_value(self, value):
         if value is None:
             return Choice(NONE_CHOICE, '[Missing]')
-        elif not value:
+        elif value == "":
             return Choice(EMPTY_CHOICE, '[Empty]')
         return Choice(value, value)
 

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -298,6 +298,9 @@ class ChoiceListFilterValue(FilterValue):
     def is_null(self):
         return NONE_CHOICE in [choice.value for choice in self.value]
 
+    def _get_value_without_nulls(self):
+        return [choice for choice in self.value if choice.value != NONE_CHOICE]
+
     @property
     def _ancestor_filter(self):
         """
@@ -320,26 +323,40 @@ class ChoiceListFilterValue(FilterValue):
     def to_sql_filter(self):
         if self.show_all:
             return None
-        if self.is_null:
-            return ISNULLFilter(self.filter['field'])
 
-        in_filter = INFilter(
-            self.filter['field'],
-            get_INFilter_bindparams(self.filter['slug'], self.value)
-        )
-        if self._ancestor_filter:
-            return ANDFilter(
-                [self._ancestor_filter.sql_filter(), in_filter]
+        sql_filters = []
+        if self.is_null:
+            sql_filters.append(ISNULLFilter(self.filter['field']))
+
+        non_null_values = self._get_value_without_nulls()
+        if non_null_values:
+            in_filter = INFilter(
+                self.filter['field'],
+                get_INFilter_bindparams(self.filter['slug'], non_null_values)
+            )
+            if self._ancestor_filter:
+                sql_filters.append(ANDFilter([
+                    self._ancestor_filter.sql_filter(),
+                    in_filter,
+                ]))
+            else:
+                sql_filters.append(in_filter)
+        elif self._ancestor_filter:
+            sql_filters.append(self._ancestor_filter.sql_filter())
+
+        if len(sql_filters) > 1:
+            return ORFilter(
+                sql_filters
             )
         else:
-            return in_filter
+            return sql_filters[0]
 
     def to_sql_values(self):
-        if self.show_all or self.is_null:
+        if self.show_all:
             return {}
         values = {
             get_INFilter_element_bindparam(self.filter['slug'], i): val.value
-            for i, val in enumerate(self.value)
+            for i, val in enumerate(self._get_value_without_nulls())
         }
         if self._ancestor_filter:
             values.update(self._ancestor_filter.sql_value())

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -31,8 +31,11 @@ from corehq.apps.reports.util import (
     get_INFilter_element_bindparam,
 )
 
-SHOW_ALL_CHOICE = '_all'  # todo: if someone wants to name an actually choice "_all" this will break
+# todo: if someone wants to name an actual choice any of these values, it will break
+SHOW_ALL_CHOICE = '_all'
 NONE_CHOICE = "\u2400"
+EMPTY_CHOICE = '_cchq_empty'
+
 CHOICE_DELIMITER = "\u001f"
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/xRBl3440/46-report-builder-upgrades / https://docs.google.com/document/d/1cRFJ3AKGHnJRO2sLaTEOW4o9Z-jOYejONzv_jjW6X8Y/edit#

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This supports specifying "empty" values in dynamic choice list filters (affecting report builder reports and UCRs), allowing users to filter data where the property is is empty or not set.

The filters look like this:
![image](https://user-images.githubusercontent.com/66555/83257391-99846f80-a1b4-11ea-93aa-a73dce37e807.png)

And only render if there is underlying data that is either `null` or an empty string, respectively.

I'm proposing releasing this to everyone, though could put behind a flag if that doesn't seem right.

I didn't actually dig into what causes a UCR to have null data versus empty, but I had both types locally so thought I should support both.

Review by commit

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

I don't believe this is high risk.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
