### PR TITLE
add "is empty" and "exists" as options for default report builder filters

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -84,6 +84,7 @@ REPORT_BUILDER_FILTER_TYPE_MAP = {
     'Date': 'date',
     'Numeric': 'numeric',
     'Value': 'pre',
+    'Is Empty': 'is_empty',
 }
 
 STATIC_CASE_PROPS = [
@@ -226,6 +227,12 @@ class DataSourceProperty(object):
         }
         if configuration['format'] == 'Date':
             filter.update({'compare_as_string': True})
+        if configuration['format'] == 'Is Empty':
+            filter.update({
+                'type': 'pre',
+                'pre_operator': "",
+                'pre_value': "",  # for now assume strings - this may not always work
+            })
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_NAME_PROPERTY_ID:
             filter.update({"choice_provider": {"type": "owner"}})
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_USER_NAME_PROPERTY_ID:

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -85,6 +85,7 @@ REPORT_BUILDER_FILTER_TYPE_MAP = {
     'Numeric': 'numeric',
     'Value': 'pre',
     'Is Empty': 'is_empty',
+    'Exists': 'exists',
 }
 
 STATIC_CASE_PROPS = [
@@ -231,7 +232,13 @@ class DataSourceProperty(object):
             filter.update({
                 'type': 'pre',
                 'pre_operator': "",
-                'pre_value': "",  # for now assume strings - this may not always work
+                'pre_value': "",  # for now assume strings - this may not always work but None crashes
+            })
+        if configuration['format'] == 'Exists':
+            filter.update({
+                'type': 'pre',
+                'pre_operator': "!=",
+                'pre_value': "",
             })
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_NAME_PROPERTY_ID:
             filter.update({"choice_provider": {"type": "owner"}})

--- a/corehq/apps/userreports/static/userreports/js/builder_view_models.js
+++ b/corehq/apps/userreports/static/userreports/js/builder_view_models.js
@@ -82,6 +82,9 @@ hqDefine('userreports/js/builder_view_models', function () {
         // PropertyListItem is representing columns
 
         self.format = ko.observable("");
+        self.acceptsFormatValue = ko.computed(function () {
+            return self.format() !== "Is Empty" && self.format() !== "Exists"
+        });
 
         var constants = hqImport('userreports/js/constants');
         self.calculationOptions = ko.pureComputed(function () {

--- a/corehq/apps/userreports/static/userreports/js/builder_view_models.js
+++ b/corehq/apps/userreports/static/userreports/js/builder_view_models.js
@@ -83,7 +83,7 @@ hqDefine('userreports/js/builder_view_models', function () {
 
         self.format = ko.observable("");
         self.acceptsFormatValue = ko.computed(function () {
-            return self.format() !== "Is Empty" && self.format() !== "Exists"
+            return self.format() !== "Is Empty" && self.format() !== "Exists";
         });
 
         var constants = hqImport('userreports/js/constants');

--- a/corehq/apps/userreports/static/userreports/js/constants.js
+++ b/corehq/apps/userreports/static/userreports/js/constants.js
@@ -4,7 +4,7 @@ hqDefine('userreports/js/constants', function () {
     var GROUP_BY = "Group By";
     return {
         FORMAT_OPTIONS: ["Choice", "Date"],
-        DEFAULT_FILTER_FORMAT_OPTIONS: ["Value", "Date"],
+        DEFAULT_FILTER_FORMAT_OPTIONS: ["Value", "Date", "Is Empty"],
         COUNT_PER_CHOICE: COUNT_PER_CHOICE,
         SUM: SUM,
         GROUP_BY: GROUP_BY,

--- a/corehq/apps/userreports/static/userreports/js/constants.js
+++ b/corehq/apps/userreports/static/userreports/js/constants.js
@@ -4,7 +4,7 @@ hqDefine('userreports/js/constants', function () {
     var GROUP_BY = "Group By";
     return {
         FORMAT_OPTIONS: ["Choice", "Date"],
-        DEFAULT_FILTER_FORMAT_OPTIONS: ["Value", "Date", "Is Empty"],
+        DEFAULT_FILTER_FORMAT_OPTIONS: ["Value", "Date", "Is Empty", "Exists"],
         COUNT_PER_CHOICE: COUNT_PER_CHOICE,
         SUM: SUM,
         GROUP_BY: GROUP_BY,

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -478,7 +478,10 @@ hqDefine('userreports/js/report_config', function () {
                     default_filters = _.filter(
                         default_filters,
                         function (c) {
-                            return c.property && (c.pre_value || c.pre_operator || c.format === "Is Empty");
+                            return c.property && (
+                                c.pre_value || c.pre_operator ||
+                                c.format === "Is Empty" || c.format === "Exists"
+                            );
                         }
                     );
                     return {

--- a/corehq/apps/userreports/static/userreports/js/report_config.js
+++ b/corehq/apps/userreports/static/userreports/js/report_config.js
@@ -477,7 +477,9 @@ hqDefine('userreports/js/report_config', function () {
                     var default_filters = JSON.parse(self.defaultFilterList.serializedProperties());
                     default_filters = _.filter(
                         default_filters,
-                        function (c) {return c.property && (c.pre_value || c.pre_operator);}
+                        function (c) {
+                            return c.property && (c.pre_value || c.pre_operator || c.format === "Is Empty");
+                        }
                     );
                     return {
                         "existing_report": self.existingReportId,

--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -171,10 +171,10 @@ TODO:
                 attr: {disabled: !existsInCurrentVersion()}
             "></select>
       <!--/ko-->
-      <!--ko if: $data.format() === 'Is Empty'-->
+      <!--ko if: !$data.acceptsFormatValue() -->
       <label>{% trans "N/A" %}</label>
       <!--/ko-->
-      <!--ko if: $data.format() !== 'Date' && $data.format() !== 'Is Empty'-->
+      <!--ko if: $data.format() !== 'Date' && $data.acceptsFormatValue() -->
       <input type="text" class="form-control input-sm" data-bind="
                 textInput: filterValue,
                 attr: {disabled: !existsInCurrentVersion()}

--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -171,12 +171,16 @@ TODO:
                 attr: {disabled: !existsInCurrentVersion()}
             "></select>
       <!--/ko-->
-      <!--ko if: $data.format() !== 'Date'-->
+      <!--ko if: $data.format() === 'Is Empty'-->
+      <label>{% trans "N/A" %}</label>
+      <!--/ko-->
+      <!--ko if: $data.format() !== 'Date' && $data.format() !== 'Is Empty'-->
       <input type="text" class="form-control input-sm" data-bind="
                 textInput: filterValue,
                 attr: {disabled: !existsInCurrentVersion()}
             "/>
       <!--/ko-->
+
       <label class="help-block" data-bind="if: $parent.showWarnings() && !(filterValue() || filterOperator())">
         {% trans "Filter Value should not be blank." %}</label>
     </td>

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -742,7 +742,12 @@ class ReportPreview(BaseDomainView):
             except BadBuilderConfigError as e:
                 return json_response({'status': 'error', 'message': str(e)}, status_code=400)
 
-        return json_response({'status': 'error', 'message': 'Invalid report configuration'}, status_code=400)
+        else:
+            return json_response({
+                'status': 'error',
+                'message': 'Invalid report configuration',
+                'errors': bound_form.errors,
+            }, status_code=400)
 
 
 def _assert_report_delete_privileges(request):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/xRBl3440/46-report-builder-upgrades / https://docs.google.com/document/d/1cRFJ3AKGHnJRO2sLaTEOW4o9Z-jOYejONzv_jjW6X8Y/edit#

This PR attempts to address "Must have: Ability to filter by != (e.g not equal to) in Default Filters
And specifically NOT EQUAL TO blank" to the extend I could with the time I had.

Cal pointed out the product UX is rather confusing, and the right long term solution is probably to substantially rework the default filter UI to be a bit more configurable. Depending on the urgency of this going out that might make more sense to do instead of this change.

Else the short term solution to address potential product confusion is to put these options behind a flag

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently this just checks using `== ""` or `!= ""`. Interestingly, both seem to exclude null values (I would have expected the latter to include them).

Adds two new options for default filters in report builder:
![image](https://user-images.githubusercontent.com/66555/83272121-13bfee80-a1cb-11ea-859f-9dc9a6960584.png)

I decided to release this to everyone, though we could put behind a flag if we want.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

I don't think this will break anything, though I do expect there to be quirks around empty strings versus null data and possibly some datatype issues I haven't anticipated *only when using this feature*.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
