### PR TITLE
Fix Trumpia gateway KEYWORD handling

### DIFF
--- a/corehq/messaging/smsbackends/trumpia/tests/test_incoming.py
+++ b/corehq/messaging/smsbackends/trumpia/tests/test_incoming.py
@@ -52,7 +52,7 @@ class IncomingTest(TestCase):
     def test_incoming_with_keyword(self):
         response, log = self.make_request("ca va", "REPLY")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(log.text, "REPLY ca va")
+        self.assertEqual(log.text, "ca va")
         self.assertEqual(log.direction, INCOMING)
         self.assertEqual(log.backend_message_id, "1234561234567asdf123")
 

--- a/corehq/messaging/smsbackends/trumpia/views.py
+++ b/corehq/messaging/smsbackends/trumpia/views.py
@@ -24,8 +24,8 @@ class TrumpiaIncomingView(IncomingBackendView):
             # status of 200OK when an empty GET/POST is received.
             return HttpResponse(status=200)
         data = parse_incoming(xml)
-        phone_number = data["PHONENUMBER"]
-        text = " ".join(data[k] for k in ["KEYWORD", "CONTENTS"] if data.get(k))
+        phone_number = data.get("PHONENUMBER")
+        text = data.get("CONTENTS")
         if not phone_number or not text:
             return HttpResponseBadRequest("PHONENUMBER or CONTENTS are missing")
         sms = incoming(


### PR DESCRIPTION
The keyword tag is just an identifier. In this instance it has REPLY to let you know that the inbound message is a reply. The actual content of the message is within CONTENTS.