### PR TITLE
Minor additions to relogin workflow

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -139,10 +139,10 @@ hqDefine('hqwebapp/js/inactivity', [
         });
 
         // Keep track of when user is actively typing
-        $("body").on("keypress", _.throttle(function () {
+        $("body").on("keypress mousemove", _.throttle(function () {
             keyboardOrMouseActive = true;
         }, 100, {trailing: false}));
-        $("body").on("keypress", _.debounce(function () {
+        $("body").on("keypress mousemove", _.debounce(function () {
             keyboardOrMouseActive = false;
             if (warningActive) {
                 showWarningModal();

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -51,6 +51,8 @@ hqDefine('hqwebapp/js/inactivity', [
         var showWarningModal = function () {
             warningActive = true;
             if (!keyboardOrMouseActive) {
+                // force select2s closed, or they show on top of the backdrop
+                $(".select2-hidden-accessible").select2('close');
                 $warningModal.modal('show');
             }
         };

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -337,7 +337,7 @@
       {% initial_page_data 'secure_timeout' request.project.secure_timeout %}
       {% initial_page_data 'secure_timeout_username' request.couch_user.username %}
       {% registerurl 'bsd_license' %}
-      {% registerurl 'iframe_login' domain %}
+      {% registerurl 'iframe_login' request.project.name %}
       {% registerurl 'iframe_login_new_window' %}
       {% registerurl 'ping_login' %}
       {% include 'hqwebapp/includes/inactivity_modal.html' %}


### PR DESCRIPTION
##### SUMMARY
Another minor PR into https://github.com/dimagi/commcare-hq/pull/27630:
* Fixes select2 dropdown showing on top of modal backdrop by closing select2s before showing the popup. To mitigate this, the logic to wait for the user to stop typing now also waits for mouse movement to stop.
* Fixes 500 on pages accessed by mobile workers that they don't have access to (which should 403).

##### RISK ASSESSMENT / QA PLAN
Tested locally

##### PRODUCT DESCRIPTION
See https://github.com/dimagi/commcare-hq/pull/27630