### PR TITLE
add "not equal" option to report builder default filters

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -90,6 +90,7 @@ REPORT_BUILDER_FILTER_TYPE_MAP = {
     'Value': 'pre',
     'Is Empty': 'is_empty',
     'Exists': 'exists',
+    'Value Not Equal': 'value_not_equal',
 }
 
 STATIC_CASE_PROPS = [
@@ -255,6 +256,13 @@ class DataSourceProperty(object):
                 'type': 'pre',
                 'pre_operator': "!=",
                 'pre_value': "",
+            })
+        if configuration['format'] == 'Value Not Equal':
+            print('settting not equal')
+            filter.update({
+                'type': 'pre',
+                'pre_operator': "!=",
+                # pre_value already set by "pre" clause
             })
         return filter
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -232,18 +232,6 @@ class DataSourceProperty(object):
         }
         if configuration['format'] == 'Date':
             filter.update({'compare_as_string': True})
-        if configuration['format'] == 'Is Empty':
-            filter.update({
-                'type': 'pre',
-                'pre_operator': "",
-                'pre_value': "",  # for now assume strings - this may not always work but None crashes
-            })
-        if configuration['format'] == 'Exists':
-            filter.update({
-                'type': 'pre',
-                'pre_operator': "!=",
-                'pre_value': "",
-            })
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_NAME_PROPERTY_ID:
             filter.update({"choice_provider": {"type": "owner"}})
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_USER_NAME_PROPERTY_ID:
@@ -255,6 +243,18 @@ class DataSourceProperty(object):
                 'type': 'pre',  # type could have been "date"
                 'pre_operator': configuration.get('pre_operator', None),
                 'pre_value': configuration.get('pre_value', []),
+            })
+        if configuration['format'] == 'Is Empty':
+            filter.update({
+                'type': 'pre',
+                'pre_operator': "",
+                'pre_value': "",  # for now assume strings - this may not always work but None crashes
+            })
+        if configuration['format'] == 'Exists':
+            filter.update({
+                'type': 'pre',
+                'pre_operator': "!=",
+                'pre_value': "",
             })
         return filter
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -258,7 +258,6 @@ class DataSourceProperty(object):
                 'pre_value': "",
             })
         if configuration['format'] == 'Value Not Equal':
-            print('settting not equal')
             filter.update({
                 'type': 'pre',
                 'pre_operator': "!=",

--- a/corehq/apps/userreports/static/userreports/js/constants.js
+++ b/corehq/apps/userreports/static/userreports/js/constants.js
@@ -4,7 +4,7 @@ hqDefine('userreports/js/constants', function () {
     var GROUP_BY = "Group By";
     return {
         FORMAT_OPTIONS: ["Choice", "Date"],
-        DEFAULT_FILTER_FORMAT_OPTIONS: ["Value", "Date", "Is Empty", "Exists"],
+        DEFAULT_FILTER_FORMAT_OPTIONS: ["Value", "Date", "Is Empty", "Exists", "Value Not Equal"],
         COUNT_PER_CHOICE: COUNT_PER_CHOICE,
         SUM: SUM,
         GROUP_BY: GROUP_BY,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://docs.google.com/document/d/1cRFJ3AKGHnJRO2sLaTEOW4o9Z-jOYejONzv_jjW6X8Y/edit?ts=5ed27b71

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Very similar to https://github.com/dimagi/commcare-hq/pull/27650/

![image](https://user-images.githubusercontent.com/66555/83336309-ad160000-a2b2-11ea-8d8d-14a98e4b56eb.png)

I'm still not sure these should be all-user-facing, but I didn't have time to put it behind a flag.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
