### PR TITLE
Add NANP region code to incoming Trumpia phone #s

### DIFF
--- a/corehq/messaging/smsbackends/trumpia/tests/test_incoming.py
+++ b/corehq/messaging/smsbackends/trumpia/tests/test_incoming.py
@@ -46,8 +46,19 @@ class IncomingTest(TestCase):
         response, log = self.make_request("the message")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(log.text, "the message")
+        self.assertEqual(log.phone_number, "+17777722222")
         self.assertEqual(log.direction, INCOMING)
         self.assertEqual(log.backend_message_id, "1234561234567asdf123")
+
+    def test_incoming_non_nanp_number(self):
+        response, log = self.make_request("the message", phone="0123456789")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(log.phone_number, "+0123456789")
+
+    def test_incoming_non_nanp_number2(self):
+        response, log = self.make_request("the message", phone="1234567890")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(log.phone_number, "+1234567890")
 
     def test_incoming_with_keyword(self):
         response, log = self.make_request("ca va", "REPLY")
@@ -56,9 +67,9 @@ class IncomingTest(TestCase):
         self.assertEqual(log.direction, INCOMING)
         self.assertEqual(log.backend_message_id, "1234561234567asdf123")
 
-    def make_request(self, message, keyword=""):
+    def make_request(self, message, keyword="", phone=None):
         xml = EXAMPLE_PUSH.format(
-            phone_number=self.phone_number,
+            phone_number=phone or self.phone_number,
             keyword=keyword,
             message=message,
         )

--- a/corehq/messaging/smsbackends/trumpia/views.py
+++ b/corehq/messaging/smsbackends/trumpia/views.py
@@ -28,6 +28,7 @@ class TrumpiaIncomingView(IncomingBackendView):
         text = data.get("CONTENTS")
         if not phone_number or not text:
             return HttpResponseBadRequest("PHONENUMBER or CONTENTS are missing")
+        phone_number = add_nanp_prefix(phone_number)
         sms = incoming(
             phone_number,
             text,
@@ -80,3 +81,14 @@ def parse_incoming(xml):
     for element in root:
         data[element.tag] = element.text
     return data
+
+
+def add_nanp_prefix(number, region_code="1"):
+    """Add country code to North American Numbering Plan phone number
+
+    https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers
+    #United_States,_Canada,_and_other_NANP_countries
+    """
+    if len(number) == 10 and number[0] not in "01":
+        number = region_code + number
+    return number


### PR DESCRIPTION
The Trumpia gateway does not add the region code but the SMS system requires it to allow contacts to be looked up by their phone number.