### PR TITLE
Updated warning logic

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -68,6 +68,7 @@ log("poll again in " + (millisLeft - 2 * 60 * 1000) / 1000 / 60 + " minutes");
         };
 
         var hideWarningModal = function () {
+            warningActive = false;
             $warningModal.modal('hide');
         };
 


### PR DESCRIPTION
If this isn't cleared, and `isWarning` is still true when the real login modal pops up, the warning modal can appear on top of the login modal when you move your mouse, due to [this handler](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js#L164-L169).