### PR TITLE
Added labels to feature flags in popup when copying app

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_view_application.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_view_application.js
@@ -39,15 +39,12 @@ hqDefine("app_manager/js/app_view_application", function () {
                         if (toggles.length) {
                             var template = _.template($modal.find("script").html()),
                                 $ul = $modal.find("ul").html(""),
-                                $selectAll = $(template({
-                                    slug: "",
-                                    label: gettext("<span class='label label-default'>" + gettext("Select All") +
-                                    "</span>"),
-                                }));
-                            $selectAll.find("input:checkbox").change(function () {
-                                $ul.find("input:checkbox").prop('checked', $(this).prop('checked'));
+                                allSelected = false;
+                            $modal.find(".select-all").click(function (e) {
+                                allSelected = !allSelected;
+                                $(e.currentTarget).text(allSelected ? gettext("Select None") : gettext("Select All"));
+                                $ul.find("input:checkbox").prop('checked', allSelected);
                             });
-                            $ul.append($selectAll);
                             _.each(toggles, function (toggle) {
                                 $ul.append(template(toggle));
                             });

--- a/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/toggle_diff_modal.html
@@ -10,10 +10,17 @@
         <h4 class="modal-title">{% trans "Feature Discrepancy" %}</h4>
       </div>
       <div class="modal-body form-horizontal">
-        {% blocktrans %}
-          The following features are not turned on in the domain to which you're copying.
-          Select any that you wish to copy along with this application.
-        {% endblocktrans %}
+        <p>
+          {% blocktrans %}
+            The following features are not turned on in the domain to which you're copying.
+            Select any that you wish to copy along with this application.
+          {% endblocktrans %}
+        </p>
+        <div>
+          <button class="btn btn-default btn-xs select-all">
+            {% trans "Select All" %}
+          </button>
+        </div>
         <ul class="list-unstyled"></ul>
       </div>
       <div class="modal-footer">
@@ -26,6 +33,7 @@
     <li class="checkbox">
       <label>
         <input type="checkbox" data-slug="<%= slug %>" />
+        <span class='label label-<%= tag_css_class %>'><%= tag_name %></span>
         <%= label %>
       </label>
     </li>


### PR DESCRIPTION
##### SUMMARY
Minor UI changes to the popup for copying feature flags when copying an app.

##### FEATURE FLAG
Only superusers see this popup.

##### RISK ASSESSMENT / QA PLAN
Minor and superuser-only, no QA.

##### PRODUCT DESCRIPTION
before
![Screen Shot 2020-05-31 at 2 45 06 PM](https://user-images.githubusercontent.com/1486591/83360253-e9e30500-a34d-11ea-919d-70b0da1f6921.png)

after
![Screen Shot 2020-05-31 at 2 48 12 PM](https://user-images.githubusercontent.com/1486591/83360257-ee0f2280-a34d-11ea-8cbb-62b627b0b8b7.png)
