### PR TITLE
use distinct from in default filter

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -260,7 +260,7 @@ class DataSourceProperty(object):
         if configuration['format'] == 'Value Not Equal':
             filter.update({
                 'type': 'pre',
-                'pre_operator': "!=",
+                'pre_operator': "IS DISTINCT FROM",
                 # pre_value already set by "pre" clause
             })
         return filter


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Equality comparisons with null values in postgres return null. `IS DISTINCT FROM` is the expected behavior from the user in almost every case (and required for the use case we built this feature for).

```
calellowitz=# select 5 != null;
 ?column?
----------

(1 row)
```
```
calellowitz=# select 5 IS DISTINCT FROM null;
 ?column?
----------
 t
(1 row)
```