### PR TITLE
use correct name for operator

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -260,7 +260,7 @@ class DataSourceProperty(object):
         if configuration['format'] == 'Value Not Equal':
             filter.update({
                 'type': 'pre',
-                'pre_operator': "IS DISTINCT FROM",
+                'pre_operator': "distinct from",
                 # pre_value already set by "pre" clause
             })
         return filter


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The previous PR was broken
https://sentry.io/organizations/dimagi/issues/1701706249/?project=136860&query=is%3Aunresolved

This is how we refer to that operator https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/reports/filters/values.py#L149