### PR TITLE
Infobip backend improvements

### DIFF
--- a/corehq/apps/sms/templates/sms/whatsapp_templates.html
+++ b/corehq/apps/sms/templates/sms/whatsapp_templates.html
@@ -36,11 +36,15 @@
         <tr>
           <td>{{ template.name }}</td>
           <td>
-            {% for component in template.components %}
-              {% if component.type == 'BODY' %}
-                {{ component.text }}
-              {% endif %}
-            {% endfor %}
+            {% if template.components %}
+              {% for component in template.components %}
+                {% if component.type == 'BODY' %}
+                  {{ component.text }}
+                {% endif %}
+              {% endfor %}
+            {% else %}
+              {{ template.body }}
+            {% endif %}
           </td>
           <td>{{ template.category }}</td>
           <td>{{ template.status }}</td>

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -2135,23 +2135,34 @@ class WhatsAppTemplatesView(BaseMessagingSectionView):
     @property
     def page_context(self):
         context = super(WhatsAppTemplatesView, self).page_context
-        from corehq.messaging.smsbackends.turn.models import SQLTurnWhatsAppBackend, generate_template_string
-        try:
-            turn_backend = SQLTurnWhatsAppBackend.active_objects.get(domain=self.domain)
-        except SQLTurnWhatsAppBackend.MultipleObjectsReturned:
+        from corehq.messaging.smsbackends.turn.models import SQLTurnWhatsAppBackend
+        from corehq.messaging.smsbackends.infobip.models import SQLInfobipBackend
+
+        turn_backend = SQLTurnWhatsAppBackend.active_objects.filter(
+            domain=self.domain,
+            hq_api_id=SQLTurnWhatsAppBackend.get_api_id()
+        )
+        infobip_backend = SQLInfobipBackend.active_objects.filter(
+            domain=self.domain,
+            hq_api_id=SQLInfobipBackend.get_api_id()
+        )
+
+        if (turn_backend.count() + infobip_backend.count()) > 1:
             messages.error(
                 self.request,
-                _("You have multiple Turn backends configured. Please remove the ones you don't use.")
+                _("You have multiple gateways that support whatsapp templates (infobip, turn) configured."
+                  " Please remove the ones you don't use.")
             )
-        except SQLTurnWhatsAppBackend.DoesNotExist:
+        elif (turn_backend.count() + infobip_backend.count()) == 0:
             messages.error(
                 self.request,
-                _("You have no Turn backends configured. Please configure one before proceeding ")
+                _("You have no gateways that support whatsapp templates (infobip, turn) configured."
+                  " Please configure one before proceeding ")
             )
         else:
-            templates = turn_backend.get_all_templates()
+            wa_active_backend = turn_backend.get() if turn_backend.count() else infobip_backend.get()
+            templates = wa_active_backend.get_all_templates()
             for template in templates:
-                template['template_string'] = generate_template_string(template)
+                template['template_string'] = wa_active_backend.generate_template_string(template)
             context.update({'wa_templates': templates})
-        finally:
-            return context
+        return context

--- a/corehq/messaging/smsbackends/infobip/forms.py
+++ b/corehq/messaging/smsbackends/infobip/forms.py
@@ -16,8 +16,8 @@ class InfobipBackendForm(BackendForm):
     )
     scenario_key = TrimmedCharField(
         label=_("Scenario Key"),
-        help_text=_("Enables sendimg messages via whatsapp, viber, line and voice channel with or without automatic "
-                    "failover to another channel according to the specific scenario."),
+        help_text=_("Enables sendimg messages via whatsapp, viber, line and voice channel with or "
+                    "without automatic failover to another channel according to the specific scenario."),
         required=False
     )
 

--- a/corehq/messaging/smsbackends/infobip/forms.py
+++ b/corehq/messaging/smsbackends/infobip/forms.py
@@ -22,15 +22,8 @@ class InfobipBackendForm(BackendForm):
     )
 
     def clean_scenario_key(self):
-        value = self.cleaned_data.get("scenario_key")
-        if value is None:
-            return None
-        else:
-            value = value.strip()
-            if value == "":
-                return None
-            else:
-                return value
+        value = self.cleaned_data.get("scenario_key") or ""
+        return value.strip() or None
 
     @property
     def gateway_specific_fields(self):

--- a/corehq/messaging/smsbackends/infobip/forms.py
+++ b/corehq/messaging/smsbackends/infobip/forms.py
@@ -11,10 +11,26 @@ class InfobipBackendForm(BackendForm):
     auth_token = TrimmedCharField(
         label=_("Auth Token"),
     )
-
+    personalized_subdomain = TrimmedCharField(
+        label=_("Personalized Subdomain"),
+    )
     scenario_key = TrimmedCharField(
         label=_("Scenario Key"),
+        help_text=_("Enables sendimg messages via whatsapp, viber, line and voice channel with or without automatic "
+                    "failover to another channel according to the specific scenario."),
+        required=False
     )
+
+    def clean_scenario_key(self):
+        value = self.cleaned_data.get("scenario_key")
+        if value is None:
+            return None
+        else:
+            value = value.strip()
+            if value == "":
+                return None
+            else:
+                return value
 
     @property
     def gateway_specific_fields(self):
@@ -22,5 +38,6 @@ class InfobipBackendForm(BackendForm):
             _("Infobip Settings"),
             'account_sid',
             'auth_token',
+            'personalized_subdomain',
             'scenario_key'
         )

--- a/corehq/messaging/smsbackends/infobip/models.py
+++ b/corehq/messaging/smsbackends/infobip/models.py
@@ -1,9 +1,8 @@
-import requests, json
+import requests
+import json
 from corehq.apps.sms.models import SQLSMSBackend, SMS
 from corehq.apps.sms.util import clean_phone_number
 from corehq.messaging.smsbackends.infobip.forms import InfobipBackendForm
-# Importing some functions from turn model file.
-# Probably these functions should be included into some file that contains other utility functions/helpers.
 from corehq.messaging.smsbackends.turn.models import is_whatsapp_template_message, get_template_hsm_parts
 from corehq.messaging.smsbackends.turn.exceptions import WhatsAppTemplateStringException
 
@@ -82,7 +81,11 @@ class SQLInfobipBackend(SQLSMSBackend):
                 parts = get_template_hsm_parts(msg.text)
             except WhatsAppTemplateStringException:
                 msg.set_system_error(SMS.ERROR_MESSAGE_FORMAT_INVALID)
-            payload['whatsApp'] = {'templateName': parts.template_name, 'language': parts.lang_code, 'templateData': parts.params}
+            payload['whatsApp'] = {
+                'templateName': parts.template_name,
+                'language': parts.lang_code,
+                'templateData': parts.params
+            }
         else:
             payload['whatsApp'] = {'text': msg.text}
 

--- a/corehq/messaging/smsbackends/infobip/views.py
+++ b/corehq/messaging/smsbackends/infobip/views.py
@@ -20,9 +20,7 @@ class InfobipIncomingMessageView(IncomingBackendView):
             message_content = message.get('message')
             if message_content.get('type') == 'TEXT':
                 body = message_content.get('text', {})
-            elif message_content.get('type') == 'VIDEO':
-                body = message_content.get('caption', {})
-            elif message_content.get('type') == 'AUDIO':
+            elif message_content.get('type') in ['IMAGE', 'AUDIO', 'VIDEO', 'DOCUMENT']:
                 body = message_content.get('caption', {})
 
             incoming_sms(

--- a/corehq/messaging/smsbackends/infobip/views.py
+++ b/corehq/messaging/smsbackends/infobip/views.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse
 
 
 class InfobipIncomingMessageView(IncomingBackendView):
-    urlname = 'infobip_message'
+    urlname = 'infobip_sms'
 
     @property
     def backend_class(self):
@@ -20,14 +20,17 @@ class InfobipIncomingMessageView(IncomingBackendView):
             message_content = message.get('message')
             if message_content.get('type') == 'TEXT':
                 body = message_content.get('text', {})
-            # TODO: Add other message types here
+            elif message_content.get('type') == 'VIDEO':
+                body = message_content.get('caption', {})
+            elif message_content.get('type') == 'AUDIO':
+                body = message_content.get('caption', {})
 
-        incoming_sms(
-            from_,
-            body,
-            SQLInfobipBackend.get_api_id(),
-            backend_message_id=message_sid,
-            domain_scope=self.domain,
-            backend_id=self.backend_couch_id
-        )
+            incoming_sms(
+                from_,
+                body,
+                SQLInfobipBackend.get_api_id(),
+                backend_message_id=message_sid,
+                domain_scope=self.domain,
+                backend_id=self.backend_couch_id
+            )
         return HttpResponse("")

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1184,6 +1184,7 @@ class MessagingTab(UITab):
     def whatsapp_urls(self):
         from corehq.apps.sms.models import SQLMobileBackend
         from corehq.messaging.smsbackends.turn.models import SQLTurnWhatsAppBackend
+        from corehq.messaging.smsbackends.infobip.models import SQLInfobipBackend
         from corehq.apps.sms.views import WhatsAppTemplatesView
         whatsapp_urls = []
 
@@ -1191,9 +1192,13 @@ class MessagingTab(UITab):
             SQLTurnWhatsAppBackend.get_api_id() in
             (b.get_api_id() for b in
              SQLMobileBackend.get_domain_backends(SQLMobileBackend.SMS, self.domain)))
+        domain_has_infobip_integration = (
+            SQLInfobipBackend.get_api_id() in
+            (b.get_api_id() for b in
+             SQLMobileBackend.get_domain_backends(SQLMobileBackend.SMS, self.domain)))
         user_is_admin = (self.couch_user.is_superuser or self.couch_user.is_domain_admin(self.domain))
 
-        if user_is_admin and domain_has_turn_integration:
+        if user_is_admin and (domain_has_turn_integration or domain_has_infobip_integration):
             whatsapp_urls.append({
                 'title': _('Template Management'),
                 'url': reverse(WhatsAppTemplatesView.urlname, args=[self.domain]),


### PR DESCRIPTION
##### SUMMARY
Improvements:

1. Whatsapp templates support for Infobip backend;
2. Scenario key is now optional (failover to pure SMS channel in case scenario key is not privided);
3. Personalized subdomain is not hardcoded anymore, it is added as mandatory backend parameter instead;
4. Added support for messaging channels: viber. line and voice;
5. Manage Templates page - bug with multiple non-global backends fixed. 

No 5. - bug description: 
In case there are 2+ backends of any type configured for one domain, following error message is displayed on Manage Templates page: "You have multiple Turn backends configured. Please remove the ones you don't use.". 
Solution: Fixed by adding filter hq_api_id=SQLTurnWhatsAppBackend.get_api_id() to queryset: turn_backend = SQLTurnWhatsAppBackend.active_objects.get(domain=self.domain).


In corehq.messaging.smsbackends.infobip.models two functions are imported from corehq.messaging.smsbackends.turn.models. These functions are helper functions and probably better way of doing this would be to include them into some file that contains other utility functions/helpers. I didn't want to do this before consulting with others. There might be a reason why these functions were added to corehq.messaging.smsbackends.turn.models that I am not aware of.

Similarly, In order to add Infobip backend to Template Management section (see attached screenshot), I had to add a few lines of code in corehq/apps/sms/views.py. There are some better ways of handling multiple Turn/Infobip backends on this page. Probably I could add one switch - for example a select box in the top of the page with all configured Infobip/Turn backends. I didn't want to implement it before discussing here because there might be a reason why multiple Turn backend support was not added in the first place.

![image](https://user-images.githubusercontent.com/16632752/83399054-d6dd3d00-a400-11ea-931c-1486f67a42cd.png)

##### FEATURE FLAG
/

##### RISK ASSESSMENT / QA PLAN
This branch is deployed and tested on staging.

##### PRODUCT DESCRIPTION
/
