### PR TITLE
Fixed problems with inactivity timeout

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -78,16 +78,14 @@ log("poll again in " + (millisLeft - 2 * 60 * 1000) / 1000 / 60 + " minutes");
         };
 
         var hideWarningModal = function (showLogin) {
-            $warningModal.one('hidden.bs.modal', function () {
-                if (showLogin) {
-                    $modal.modal({backdrop: 'static', keyboard: false});
-                }
-                // This flag should already have been turned off when the warning modal was shown,
-                // but just in case, make sure it's really off. Wait until the modal is fully hidden
-                // to avoid issues with code trying to re-show this popup just as we're closing it.
-                shouldShowWarning = false;
-            });
             $warningModal.modal('hide');
+            if (showLogin) {
+                $modal.modal({backdrop: 'static', keyboard: false});
+            }
+            // This flag should already have been turned off when the warning modal was shown,
+            // but just in case, make sure it's really off. Wait until the modal is fully hidden
+            // to avoid issues with code trying to re-show this popup just as we're closing it.
+            shouldShowWarning = false;
         };
 
         var pollToShowModal = function () {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -193,7 +193,7 @@ log("session successfully extended, hiding warning popup if it's open");
 
         // Send no-op request to server to extend session when there's client-side user activity on this page.
         // _.throttle will prevent this from happening too often.
-        var keepAliveTimeout = timeout / 5;
+        var keepAliveTimeout = 60 * 1000;
 log("page loaded, will send a keep-alive request to server every click/keypress, at most once every " + (keepAliveTimeout / 1000 / 60) + " minutes");
         $("body").on("keypress click", _.throttle(function () {
             extendSession();

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -338,6 +338,7 @@
       {% initial_page_data 'secure_timeout_username' request.couch_user.username %}
       {% registerurl 'iframe_login' request.project.name %}
       {% registerurl 'iframe_login_new_window' %}
+      {% registerurl 'login_new_window' %}
       {% registerurl 'ping_login' %}
       {% registerurl 'ping_session' %}
       {% include 'hqwebapp/includes/inactivity_modal.html' %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -336,10 +336,10 @@
     {% if request.user.is_authenticated and request.project.secure_timeout %}
       {% initial_page_data 'secure_timeout' request.project.secure_timeout %}
       {% initial_page_data 'secure_timeout_username' request.couch_user.username %}
-      {% registerurl 'bsd_license' %}
       {% registerurl 'iframe_login' request.project.name %}
       {% registerurl 'iframe_login_new_window' %}
       {% registerurl 'ping_login' %}
+      {% registerurl 'ping_session' %}
       {% include 'hqwebapp/includes/inactivity_modal.html' %}
     {% endif %}
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -338,11 +338,11 @@
       {% initial_page_data 'secure_timeout_username' request.couch_user.username %}
       {% registerurl 'iframe_login' request.project.name %}
       {% registerurl 'iframe_login_new_window' %}
-      {% registerurl 'login_new_window' %}
       {% registerurl 'ping_login' %}
       {% registerurl 'ping_session' %}
       {% include 'hqwebapp/includes/inactivity_modal.html' %}
     {% endif %}
+    {% registerurl 'login_new_window' %}
 
     {# 30 Day Trial #}
     {% include 'hqwebapp/includes/modal_30_day_trial.html' %}

--- a/corehq/apps/hqwebapp/templates/hqwebapp/iframe_login.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/iframe_login.html
@@ -41,12 +41,13 @@
     <script src="{% static 'blazy/blazy.js' %}"></script>
     <script>
       new Blazy({container: 'body'});
-      var username = (new URLSearchParams(window.location.search)).get("username");
-      if (username) {
+      var username = (new URLSearchParams(window.location.search)).get("username"),
+          element = document.getElementById('id_auth-username');
+      if (username && element) {
         if (username.endsWith("commcarehq.org")) {
           username = username.split("@")[0];
         }
-        document.getElementById('id_auth-username').value = username;
+        element.value = username;
       }
     </script>
   </body>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/iframe_login.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/iframe_login.html
@@ -48,6 +48,7 @@
           username = username.split("@")[0];
         }
         element.value = username;
+        element.readOnly = true;
       }
     </script>
   </body>

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -26,6 +26,7 @@ from corehq.apps.hqwebapp.views import (
     osdd,
     password_change,
     ping_login,
+    ping_session,
     quick_find,
     redirect_to_default,
     redirect_to_dimagi,
@@ -82,6 +83,7 @@ urlpatterns = [
     url(r'^hq/admin/session_details/$', SessionDetailsView.as_view(),
         name=SessionDetailsView.urlname),
     url(r'^ping_login/$', ping_login, name='ping_login'),
+    url(r'^ping_session/$', ping_session, name='ping_session'),
     url(r'^relogin/$', login_new_window, name='login_new_window'),
     url(r'^relogin/iframe/$', iframe_login_new_window, name='iframe_login_new_window'),
 

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -493,8 +493,20 @@ def logout(req, default_domain_redirect='domain_login'):
         return HttpResponseRedirect(reverse('login'))
 
 
+# ping_login and ping_session are both tiny views used in user inactivity and session expiration handling
+# They are identical except that ping_session extends the user's current session, while ping_login does not.
+# This difference is controlled in SelectiveSessionMiddleware, which makes ping_login bypass sessions.
 @two_factor_exempt
 def ping_login(request):
+    return JsonResponse({
+        'success': request.user.is_authenticated,
+        'last_request': request.session.get('last_request'),
+        'username': request.user.username,
+    })
+
+
+@two_factor_exempt
+def ping_session(request):
     return JsonResponse({
         'success': request.user.is_authenticated,
         'last_request': request.session.get('last_request'),


### PR DESCRIPTION
More followup for https://github.com/dimagi/commcare-hq/pull/27630

Fixes modal backdrops sometimes not being cleared, causing screen to "freeze" because it's covered by an invisible div.

Adds a client-side activity handler, so that clicks and keypresses are interpreted as activity. This works by sending HQ a new request, `ping_session`, which extends the session. This means that when the 2-minute warning pops up, you don't actually have to click the "Extend session" button, clicking out of the modal will also extend the session. I left the modal alone, with the button, because the alternative seemed to be showing a modal that says "click anywhere *except* in this popup to extend your session" which is weird.