### PR TITLE
Handle empty fixture values

### DIFF
--- a/custom/abt/reports/fixture_utils.py
+++ b/custom/abt/reports/fixture_utils.py
@@ -231,7 +231,7 @@ def fixture_data_item_to_dict(
 
     """
     return {
-        key: field_list.field_list[0].field_value
+        key: field_list.field_list[0].field_value if field_list.field_list else None
         for key, field_list in data_item.fields.items()
     }
 

--- a/custom/abt/reports/tests/test_fixture_utils.py
+++ b/custom/abt/reports/tests/test_fixture_utils.py
@@ -76,6 +76,28 @@ def test_fixture_data_item_to_dict():
     })
 
 
+def test_empty_fixture_data_item_to_dict():
+    data_item = FixtureDataItem(
+        domain='test-domain',
+        data_type_id='123456',
+        fields={
+            'id': FieldList(
+                doc_type='FieldList',
+                field_list=[]
+            ),
+            'name': FieldList(
+                doc_type='FieldList',
+                field_list=[]
+            )
+        }
+    )
+    dict_ = fixture_data_item_to_dict(data_item)
+    assert_equal(dict_, {
+        'id': None,
+        'name': None,
+    })
+
+
 def test_doctests():
     results = doctest.testmod(fixture_utils)
     assert results.failed == 0


### PR DESCRIPTION
Context: [Sentry](https://sentry.io/organizations/dimagi/issues/1704514626/?project=136860)

##### SUMMARY
One of the VectorLink location fixtures had an empty row. This change returns None if a value is missing.
