### PR TITLE
Add session_started and session_ended metrics for sms form sessions

### DIFF
--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -11,6 +11,7 @@ from couchdbkit import MultipleResultsFound
 from corehq.apps.sms.util import strip_plus
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.messaging.scheduling.util import utcnow
+from corehq.util.metrics import metrics_counter
 
 from . import signals
 
@@ -103,15 +104,30 @@ class SQLXFormsSession(models.Model):
         if not self.session_is_open:
             return
 
-        self.mark_completed(False)
-
-        if self.submit_partially_completed_forms:
-            submit_unfinished_form(self)
+        try:
+            if self.submit_partially_completed_forms:
+                submit_unfinished_form(self)
+        finally:
+            # this needs to be called after the submission, but regardless of whether it succeeded
+            # thus the try/finally
+            self.mark_completed(False)
 
     def mark_completed(self, completed):
         self.session_is_open = False
         self.completed = completed
         self.modified_time = self.end_time = utcnow()
+
+        metrics_counter('commcare.smsforms.session_ended', 1, tags={
+            'domain': self.domain,
+            'workflow': self.workflow,
+            'status': (
+                'success' if self.completed and self.submission_id else
+                'terminated_partial_submission' if not self.completed and self.submission_id else
+                'terminated_without_submission' if not self.completed and not self.submission_id else
+                # Not sure if/how this could ever happen, but worth tracking if it does
+                'completed_without_submission'
+            )
+        })
 
     @property
     def related_subevent(self):

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -21,6 +21,8 @@ from corehq.apps.sms.models import MessagingEvent, PhoneNumber, PhoneBlacklist
 from corehq.apps.sms.util import format_message_list, touchforms_error_is_config_error, get_formplayer_exception
 from corehq.apps.smsforms.models import SQLXFormsSession
 from memoized import memoized
+
+from corehq.util.metrics import metrics_counter
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.modules import to_function
 from django.conf import settings
@@ -326,6 +328,8 @@ class SMSSurveyContent(Content):
 
     def send_first_message(self, domain, recipient, phone_entry_or_number, session, responses, logged_subevent,
             workflow):
+
+        metrics_counter('commcare.smsforms.session_started', 1, tags={'domain': domain, 'workflow': workflow})
         if len(responses) > 0:
             message = format_message_list(responses)
             metadata = MessageMetadata(


### PR DESCRIPTION
##### SUMMARY
Not sure how useful a pattern this is, but it occurred to me that I'd get some amount more of assurance if I could establish a baseline on these metrics, so I cherry picked this from https://github.com/dimagi/commcare-hq/pull/27668.

If others agree it's reasonably safe to do so, I'd like to deploy this to prod nowish so when we deploy that PR, there's a baseline to compare it to