### PR TITLE
[ICDS Dashboard] Find the fact sheet data at same level for which it was queried

### DIFF
--- a/custom/icds_reports/reports/fact_sheets.py
+++ b/custom/icds_reports/reports/fact_sheets.py
@@ -528,24 +528,22 @@ class FactSheetsReport(object):
 
         return fact_sheet_data_config
 
-    def data_sources(self, config, loc_level=None):
-        if not loc_level:
-            loc_level = self.loc_level
+    def data_sources(self, config):
         return {
             'AggChildHealthMonthlyDataSource': AggChildHealthMonthlyDataSource(
                 config=config,
-                loc_level=loc_level,
+                loc_level=self.loc_level,
                 show_test=self.show_test,
                 beta=self.beta
             ),
             'AggCCSRecordMonthlyDataSource': AggCCSRecordMonthlyDataSource(
                 config=config,
-                loc_level=loc_level,
+                loc_level=self.loc_level,
                 show_test=self.show_test,
             ),
             'AggAWCMonthlyDataSource': AggAWCMonthlyDataSource(
                 config=config,
-                loc_level=loc_level,
+                loc_level=self.loc_level,
                 show_test=self.show_test,
                 beta=self.beta
             )
@@ -559,8 +557,7 @@ class FactSheetsReport(object):
         }
         return NationalAggregationDataSource(
             national_config,
-            self.data_sources(config=national_config,
-                              loc_level=get_location_level(1) if self.beta else self.loc_level)[data_source_name],
+            self.data_sources(config=national_config)[data_source_name],
             show_test=self.show_test,
             beta=self.beta
         ).get_data()

--- a/custom/icds_reports/reports/fact_sheets.py
+++ b/custom/icds_reports/reports/fact_sheets.py
@@ -12,7 +12,7 @@ from custom.icds_reports.sqldata.agg_ccs_record_monthly import AggCCSRecordMonth
 from custom.icds_reports.sqldata.agg_child_health_monthly import AggChildHealthMonthlyDataSource
 from custom.icds_reports.sqldata.national_aggregation import NationalAggregationDataSource
 from custom.icds_reports.utils import person_is_beneficiary_column, default_age_interval
-from custom.icds_reports.utils import get_location_level
+
 
 class FactSheetsReport(object):
 

--- a/custom/icds_reports/reports/fact_sheets.py
+++ b/custom/icds_reports/reports/fact_sheets.py
@@ -528,22 +528,24 @@ class FactSheetsReport(object):
 
         return fact_sheet_data_config
 
-    def data_sources(self, config):
+    def data_sources(self, config, loc_level=None):
+        if not loc_level:
+            loc_level = self.loc_level
         return {
             'AggChildHealthMonthlyDataSource': AggChildHealthMonthlyDataSource(
                 config=config,
-                loc_level=self.loc_level,
+                loc_level=loc_level,
                 show_test=self.show_test,
                 beta=self.beta
             ),
             'AggCCSRecordMonthlyDataSource': AggCCSRecordMonthlyDataSource(
                 config=config,
-                loc_level=self.loc_level,
+                loc_level=loc_level,
                 show_test=self.show_test,
             ),
             'AggAWCMonthlyDataSource': AggAWCMonthlyDataSource(
                 config=config,
-                loc_level=self.loc_level,
+                loc_level=loc_level,
                 show_test=self.show_test,
                 beta=self.beta
             )
@@ -557,7 +559,8 @@ class FactSheetsReport(object):
         }
         return NationalAggregationDataSource(
             national_config,
-            self.data_sources(config=national_config)[data_source_name],
+            self.data_sources(config=national_config,
+                              loc_level=1 if self.beta else self.loc_level)[data_source_name],
             show_test=self.show_test,
             beta=self.beta
         ).get_data()

--- a/custom/icds_reports/reports/fact_sheets.py
+++ b/custom/icds_reports/reports/fact_sheets.py
@@ -12,7 +12,7 @@ from custom.icds_reports.sqldata.agg_ccs_record_monthly import AggCCSRecordMonth
 from custom.icds_reports.sqldata.agg_child_health_monthly import AggChildHealthMonthlyDataSource
 from custom.icds_reports.sqldata.national_aggregation import NationalAggregationDataSource
 from custom.icds_reports.utils import person_is_beneficiary_column, default_age_interval
-
+from custom.icds_reports.utils import get_location_level
 
 class FactSheetsReport(object):
 
@@ -560,7 +560,7 @@ class FactSheetsReport(object):
         return NationalAggregationDataSource(
             national_config,
             self.data_sources(config=national_config,
-                              loc_level=1 if self.beta else self.loc_level)[data_source_name],
+                              loc_level=get_location_level(1) if self.beta else self.loc_level)[data_source_name],
             show_test=self.show_test,
             beta=self.beta
         ).get_data()

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -426,8 +426,6 @@ def get_location_filter(location_id, domain, include_object=False):
         sql_location = SQLLocation.objects.get(location_id=location_id, domain=domain)
     except SQLLocation.DoesNotExist:
         return {'aggregation_level': 1}
-    if include_object:
-        config['sql_location'] = sql_location
     config.update(
         {
             ('%s_id' % ancestor.location_type.code): ancestor.location_id

--- a/custom/icds_reports/utils/__init__.py
+++ b/custom/icds_reports/utils/__init__.py
@@ -433,6 +433,10 @@ def get_location_filter(location_id, domain, include_object=False):
         }
     )
     config['aggregation_level'] = len(config) + 1
+
+    if include_object:
+        config['sql_location'] = sql_location
+
     return config
 
 


### PR DESCRIPTION
The national average on the fact sheet is the value of that indicator at the national level for previous month, So it does not make sense to find all that aggregate data level below 1 which will just slow it down. So, making it to use only agg level 1.

Context:
This is a part of [this](https://dimagi-dev.atlassian.net/browse/QA-968) ticket of fact sheet giving 500s while load testing. I may raise more such PRs as I investigate more.