### PR TITLE
Open up a few utility views for location-restricted users

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -484,6 +484,7 @@ class EditCloudcareUserPermissionsView(BaseUserSettingsView):
 
 
 @waf_allow('XSS_BODY')
+@location_safe
 @login_and_domain_required
 def report_formplayer_error(request, domain):
     data = json.loads(request.body)

--- a/corehq/apps/export/views/download.py
+++ b/corehq/apps/export/views/download.py
@@ -462,6 +462,7 @@ def prepare_form_multimedia(request, domain):
 
 
 @require_GET
+@location_safe
 @login_and_domain_required
 def has_multimedia(request, domain):
     """Checks to see if this form export has multimedia available to export

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -28,7 +28,7 @@ class BaseFilter(object):
     Base object for filters.
     """
     template = None
-    # setting this to True makes the report using the filter a location_safe report (has_location_filter())
+    # setting this to True makes the report using the filter a location_safe report (report_has_location_filter())
     location_filter = False
 
     def __init__(self, name, params=None):

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -18,11 +18,13 @@ def get_expanded_columns(column_configs, data_source_config):
     }
 
 
-def has_location_filter(view_fn, *args, **kwargs):
+def report_has_location_filter(config_id, domain):
     """check that the report has at least one location based filter or
     location choice provider filter
     """
-    report, _ = get_report_config(config_id=kwargs.get('subreport_slug'), domain=kwargs.get('domain'))
+    if not (config_id and domain):
+        return False
+    report, _ = get_report_config(config_id=config_id, domain=domain)
     return any(
         getattr(getattr(filter_, 'choice_provider', None), 'location_safe', False) or
         getattr(filter_, 'location_filter', False)

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -65,7 +65,7 @@ from corehq.apps.userreports.reports.data_source import (
 )
 from corehq.apps.userreports.reports.util import (
     ReportExport,
-    has_location_filter,
+    report_has_location_filter,
 )
 from corehq.apps.userreports.tasks import export_ucr_async
 from corehq.apps.userreports.util import (
@@ -134,6 +134,11 @@ def tmp_report_config(report_config):
     report_config.delete()
 
 
+def _ucr_view_is_safe(view_fn, *args, **kwargs):
+    return report_has_location_filter(config_id=kwargs.get('subreport_slug'),
+                                      domain=kwargs.get('domain'))
+
+
 class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     section_name = ugettext_noop("Reports")
     template_name = 'userreports/configurable_report.html'
@@ -157,7 +162,7 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     @use_datatables
     @use_nvd3
     @track_domain_request(calculated_prop='cp_n_viewed_ucr_reports')
-    @conditionally_location_safe(has_location_filter)
+    @conditionally_location_safe(_ucr_view_is_safe)
     def dispatch(self, request, *args, **kwargs):
         if self.should_redirect_to_paywall(request):
             from corehq.apps.userreports.views import paywall_home
@@ -636,7 +641,7 @@ class DownloadUCRStatusView(BaseDomainView):
         else:
             raise Http403()
 
-    @conditionally_location_safe(has_location_filter)
+    @conditionally_location_safe(_ucr_view_is_safe)
     def dispatch(self, *args, **kwargs):
         return super(DownloadUCRStatusView, self).dispatch(*args, **kwargs)
 
@@ -669,8 +674,7 @@ class DownloadUCRStatusView(BaseDomainView):
 
 
 def _safe_download_poll(view_fn, request, domain, download_id, *args, **kwargs):
-    config_id = request.GET.get('config_id')
-    return config_id and has_location_filter(None, domain=domain, subreport_slug=config_id)
+    return report_has_location_filter(request.GET.get('config_id'), domain)
 
 
 @conditionally_location_safe(_safe_download_poll)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -68,7 +68,7 @@ from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.linked_domain.models import DomainLink, ReportLinkDetail
 from corehq.apps.linked_domain.ucr import create_linked_ucr
 from corehq.apps.linked_domain.util import is_linked_report
-from corehq.apps.locations.permissions import conditionally_location_safe
+from corehq.apps.locations.permissions import conditionally_location_safe, location_safe
 from corehq.apps.reports.daterange import get_simple_dateranges
 from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
 from corehq.apps.saved_reports.models import ReportConfig
@@ -1417,6 +1417,7 @@ def export_sql_adapter_view(request, domain, adapter, too_large_redirect_url):
         return export_response(Temp(path), params.format, adapter.display_name)
 
 
+@location_safe
 @login_and_domain_required
 def data_source_status(request, domain, config_id):
     config, _ = get_datasource_config_or_404(config_id, domain)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -123,7 +123,7 @@ from corehq.apps.userreports.reports.builder.sources import (
 from corehq.apps.userreports.reports.filters.choice_providers import (
     ChoiceQueryContext,
 )
-from corehq.apps.userreports.reports.util import has_location_filter
+from corehq.apps.userreports.reports.util import report_has_location_filter
 from corehq.apps.userreports.reports.view import ConfigurableReportView
 from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.apps.userreports.tasks import (
@@ -1439,7 +1439,7 @@ def _get_report_filter(domain, report_id, filter_id):
 
 
 def _is_location_safe_choice_list(view_fn, request, domain, report_id, filter_id, **view_kwargs):
-    return has_location_filter(view_fn, domain=domain, subreport_slug=report_id)
+    return report_has_location_filter(config_id=report_id, domain=domain)
 
 
 @login_and_domain_required


### PR DESCRIPTION
This should cut down on some of the [noise in sentry](https://sentry.io/organizations/dimagi/issues/?project=136860&query=is%3Aunresolved+"someone+was+just+denied+access"&statsPeriod=14d)

##### PRODUCT DESCRIPTION
Our logging shows a few places where location-restricted users are getting 403 errors in secondary page workflows.  This PR fixes those workflows.  Specifically:

* Automatic error reporting from formplayer
* Export page "does this export have multimedia?" thing
* UCR and report builder "your report is still being populated" warning