### PR TITLE
enforce rule to not allow reusing usernames from deleted users

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -2,6 +2,11 @@ import datetime
 import json
 import re
 
+from crispy_forms import bootstrap as twbscrispy
+from crispy_forms import layout as crispy
+from crispy_forms.bootstrap import InlineField, StrictButton
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Fieldset, Layout, Submit
 from django import forms
 from django.conf import settings
 from django.contrib.auth.forms import SetPasswordForm
@@ -15,17 +20,8 @@ from django.utils.safestring import mark_safe
 from django.utils.text import format_lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
-
-from crispy_forms import bootstrap as twbscrispy
-from crispy_forms import layout as crispy
-from crispy_forms.bootstrap import InlineField, StrictButton
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Fieldset, Layout, Submit
 from django_countries.data import COUNTRIES
 from memoized import memoized
-
-from corehq.toggles import TWO_STAGE_USER_PROVISIONING
-from dimagi.utils.django.fields import TrimmedCharField
 
 from corehq import toggles
 from corehq.apps.analytics.tasks import set_analytics_opt_out
@@ -44,9 +40,12 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.permissions import user_can_access_location_id
 from corehq.apps.programs.models import Program
 from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter
-from corehq.apps.users.models import CouchUser, UserRole
+from corehq.apps.users.dbaccessors.all_commcare_users import user_exists
+from corehq.apps.users.models import UserRole
 from corehq.apps.users.util import cc_user_domain, format_username
+from corehq.toggles import TWO_STAGE_USER_PROVISIONING
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
+from dimagi.utils.django.fields import TrimmedCharField
 
 mark_safe_lazy = lazy(mark_safe, str)
 
@@ -81,7 +80,10 @@ def clean_mobile_worker_username(domain, username, name_too_long_message=None,
     username = format_username(username, domain)
     validate_username(username)
 
-    if CouchUser.username_exists(username):
+    exists = user_exists(username)
+    if exists.exists:
+        if exists.is_deleted:
+            raise forms.ValidationError(_('This username was used previously.'))
         raise forms.ValidationError(name_exists_message or
             _('This Mobile Worker already exists.'))
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -710,8 +710,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         exists = user_exists(full_username)
         if exists.exists:
             if exists.is_deleted:
-                result = {'warning': _('Username {} belonged to a user that was deleted.'
-                                       ' Reusing it may have unexpected consequences.').format(username)}
+                result = {'error': _('Username {} belonged to a user that was deleted.').format(username)}
             else:
                 result = {'error': _('Username {} is already taken').format(username)}
         else:

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -710,7 +710,8 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
         exists = user_exists(full_username)
         if exists.exists:
             if exists.is_deleted:
-                result = {'error': _('Username {} belonged to a user that was deleted.').format(username)}
+                result = {'error': _('Username {} belonged to a user that was deleted'
+                                     ' and cannot be reused').format(username)}
             else:
                 result = {'error': _('Username {} is already taken').format(username)}
         else:


### PR DESCRIPTION
##### SUMMARY
Since the introduction of the backend changes to warn users when reusing
a username from a deleted user, the UI has not permitted the creation
of those users (even though the backed would allow it): https://github.com/dimagi/commcare-hq/pull/18746

This commit changes the backed to respond with an error message if
the username of a user who has been deleted is used to create a new user.

##### RISK ASSESSMENT / QA PLAN
The only functional change here is that the UI now shows an error message instead of a warning.
