### PR TITLE
Block data interfaces for icds-cas

### DIFF
--- a/corehq/apps/data_interfaces/dispatcher.py
+++ b/corehq/apps/data_interfaces/dispatcher.py
@@ -4,12 +4,10 @@ from django_prbac.utils import has_privilege
 
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
-from corehq.apps.reports.dispatcher import (
-    ReportDispatcher,
-    datespan_default,
-)
+from corehq.apps.reports.dispatcher import ReportDispatcher, datespan_default
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
+from custom.icds.view_utils import check_data_interfaces_blocked_for_domain
 
 require_can_edit_data = require_permission(Permissions.edit_data)
 
@@ -21,6 +19,7 @@ class EditDataInterfaceDispatcher(ReportDispatcher):
     map_name = 'EDIT_DATA_INTERFACES'
 
     @method_decorator(require_can_edit_data)
+    @method_decorator(check_data_interfaces_blocked_for_domain)
     @datespan_default
     def dispatch(self, request, *args, **kwargs):
         from corehq.apps.case_importer.base import ImportCases

--- a/corehq/apps/data_interfaces/dispatcher.py
+++ b/corehq/apps/data_interfaces/dispatcher.py
@@ -5,7 +5,6 @@ from django_prbac.utils import has_privilege
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.reports.dispatcher import (
-    ProjectReportDispatcher,
     ReportDispatcher,
     datespan_default,
 )

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -69,7 +69,6 @@ from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.workbook_json.excel import WorkbookJSONError, get_workbook
-from custom.icds.view_utils import check_data_interfaces_blocked_for_domain
 from no_exceptions.exceptions import Http403
 
 from .dispatcher import require_form_management_privilege

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -617,7 +617,6 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
     ACTION_DEACTIVATE = 'deactivate'
 
     @method_decorator(requires_privilege_with_fallback(privileges.DATA_CLEANUP))
-    @method_decorator(check_data_interfaces_blocked_for_domain)
     def dispatch(self, *args, **kwargs):
         return super(AutomaticUpdateRuleListView, self).dispatch(*args, **kwargs)
 

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -69,6 +69,7 @@ from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.util.timezones.conversions import ServerTime
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.workbook_json.excel import WorkbookJSONError, get_workbook
+from custom.icds.view_utils import check_data_interfaces_blocked_for_domain
 from no_exceptions.exceptions import Http403
 
 from .dispatcher import require_form_management_privilege
@@ -602,7 +603,6 @@ def find_by_id(request, domain):
     })
 
 
-
 class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
     template_name = 'data_interfaces/list_automatic_update_rules.html'
     urlname = 'automatic_update_rule_list'
@@ -617,6 +617,7 @@ class AutomaticUpdateRuleListView(DataInterfaceSection, CRUDPaginatedViewMixin):
     ACTION_DEACTIVATE = 'deactivate'
 
     @method_decorator(requires_privilege_with_fallback(privileges.DATA_CLEANUP))
+    @method_decorator(check_data_interfaces_blocked_for_domain)
     def dispatch(self, *args, **kwargs):
         return super(AutomaticUpdateRuleListView, self).dispatch(*args, **kwargs)
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -98,6 +98,7 @@ from corehq.tabs.utils import (
     sidebar_to_dropdown,
 )
 from corehq.toggles import PUBLISH_CUSTOM_REPORTS
+from custom.icds.view_utils import data_interfaces_blocked_for_domain
 from custom.icds.views.hosted_ccz import ManageHostedCCZ, ManageHostedCCZLink
 
 
@@ -789,7 +790,7 @@ class ProjectDataTab(UITab):
         if export_data_views:
             items.append([_("Export Data"), export_data_views])
 
-        if self.can_edit_commcare_data:
+        if self.can_edit_commcare_data and not data_interfaces_blocked_for_domain(self.domain):
             from corehq.apps.data_interfaces.dispatcher \
                 import EditDataInterfaceDispatcher
             edit_section = EditDataInterfaceDispatcher.navigation_sections(

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -790,20 +790,23 @@ class ProjectDataTab(UITab):
         if export_data_views:
             items.append([_("Export Data"), export_data_views])
 
-        if self.can_edit_commcare_data and not data_interfaces_blocked_for_domain(self.domain):
-            from corehq.apps.data_interfaces.dispatcher \
-                import EditDataInterfaceDispatcher
-            edit_section = EditDataInterfaceDispatcher.navigation_sections(
-                request=self._request, domain=self.domain)
-
-            from corehq.apps.data_interfaces.views import AutomaticUpdateRuleListView
+        if self.can_edit_commcare_data:
+            edit_section = None
+            if not data_interfaces_blocked_for_domain(self.domain):
+                from corehq.apps.data_interfaces.dispatcher import EditDataInterfaceDispatcher
+                edit_section = EditDataInterfaceDispatcher.navigation_sections(
+                    request=self._request, domain=self.domain)
 
             if self.can_use_data_cleanup:
-                edit_section[0][1].append({
+                from corehq.apps.data_interfaces.views import AutomaticUpdateRuleListView
+                automatic_update_rule_list_view = {
                     'title': _(AutomaticUpdateRuleListView.page_title),
                     'url': reverse(AutomaticUpdateRuleListView.urlname, args=[self.domain]),
-                })
-
+                }
+                if edit_section:
+                    edit_section[0][1].append(automatic_update_rule_list_view)
+                else:
+                    edit_section = [(ugettext_lazy('Edit Data'), [automatic_update_rule_list_view])]
             items.extend(edit_section)
 
         if ((toggles.EXPLORE_CASE_DATA.enabled_for_request(self._request) or

--- a/custom/icds/const.py
+++ b/custom/icds/const.py
@@ -1,5 +1,8 @@
 from django.conf import settings
 
+ICDS_DOMAIN = 'icds-cas'
+IS_ICDS_ENVIRONMENT = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
+
 SUPERVISOR_APP_ID = '48cc1709b7f62ffea24cc6634a00660c'
 VHND_SURVEY_XMLNS = "http://openrosa.org/formdesigner/A1C9EF1B-8B42-43AB-BA81-9484DB9D8293"
 

--- a/custom/icds/view_utils.py
+++ b/custom/icds/view_utils.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy
+
+from corehq.apps.hqwebapp.views import no_permissions
+from custom.icds.const import ICDS_DOMAIN, IS_ICDS_ENVIRONMENT
+
+DATA_INTERFACE_ACCESS_DENIED = mark_safe(ugettext_lazy(
+    "This project has blocked access to interfaces that edit data for forms and cases"
+))
+
+
+def check_data_interfaces_blocked_for_domain(view_func):
+    @wraps(view_func)
+    def _inner(request, domain, *args, **kwargs):
+        if data_interfaces_blocked_for_domain(domain):
+            return no_permissions(request, message=DATA_INTERFACE_ACCESS_DENIED)
+        else:
+            return view_func(request, domain, *args, **kwargs)
+    return _inner
+
+
+def data_interfaces_blocked_for_domain(domain):
+    return IS_ICDS_ENVIRONMENT and domain == ICDS_DOMAIN


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1525

##### SUMMARY
Most internal dimagi users have been given data access on ICDS in order to view and edit data.
It has been raised that the UI on ICDS should not give anyone access to edit any form or case data. 
Note that app builders, support and other members still need access to view data and update few data points like fixtures, SMSes so we can't completely revoke the data access.

This PR just blocks the views under "Edit Data" sidebar section under "Data" tab which includes the following:
1. Reassign Cases
2. Import cases
3. Manage forms

Automatically Close Cases is left out because that is still needed for app builders to set rules.

It was confirmed that these views were not being used anyway so there should not be any real change in operations.

There can be more views that would get blocked so this PR does a very specific check for the environment and the domain, in a way that it can be reused on more views in future. 
It's not put behind a feature flag so that the views are strictly inaccessible without any workarounds.

##### ENVIRONMENTS
ICDS

suggest review by commit