### PR TITLE
Fixed runaway ping_login poll when inactivity setting is flipped

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -25,6 +25,12 @@ hqDefine('hqwebapp/js/inactivity', [
         if (lastRequest) {
             millisLeft = timeout - (new Date() - new Date(lastRequest));
             log("last request was " + lastRequest + ", so there are " + (millisLeft / 1000 / 60) + " minutes left in the session");
+
+            // Prevent runaway polling if the page is loaded and secure sessions is then turned OFF, which
+            // will result in the user never getting logged out and eventually a negative number of millisLeft.
+            // If the session just "expired", it might be a timing issue, so keep polling, but back off as more
+            // time passes.
+            millisLeft = Math.abs(millisLeft);
         } else {
             log("no last request, so there are " + (millisLeft / 1000 / 60) + " minutes left in the session");
         }

--- a/corehq/apps/hqwebapp/static/hqwebapp/spec/inactivity_spec.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/spec/inactivity_spec.js
@@ -38,5 +38,19 @@ describe('inactivity', function () {
             tolerantAssert(response.delay, 3 * 1000);
             assert.isTrue(response.show_warning);
         });
+
+        it('should use absolute value in case session appears expired', function () {
+            // last request 15 minutes ago => -5 minutes left
+            var response = module.calculateDelayAndWarning(timeout, new Date() - 15 * 60 * 1000);
+            tolerantAssert(response.delay, 3 * 60 * 1000);
+            assert.isFalse(response.show_warning);
+        });
+
+        it('should use absolute value in case session is very expired', function () {
+            // last request 30 minutes ago => -20 minutes left
+            var response = module.calculateDelayAndWarning(timeout, new Date() - 30 * 60 * 1000);
+            tolerantAssert(response.delay, 18 * 60 * 1000);
+            assert.isFalse(response.show_warning);
+        });
     });
 });


### PR DESCRIPTION
##### SUMMARY
Fixes the auto-logout part of https://dimagi-dev.atlassian.net/browse/SAAS-10952

It's an edge case, only affecting pages that were loaded while secure sessions was off and are left open a while after secure sessions is flipped to on, but it's easy enough to fix.

I piggybacked on the existing behavior for the sake of not making the code much more complicated.