### PR TITLE
Revert "PR feedback on logout inactivity"

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/inactivity.js
@@ -112,8 +112,8 @@ hqDefine('hqwebapp/js/inactivity', [
                     if (!data.success) {
                         log("ping_login failed, showing login modal");
                         var $body = $modal.find(".modal-body");
-                        var src = initialPageData.reverse('iframe_domain_login');
-                        src += "?next=" + initialPageData.reverse('iframe_domain_login_new_window');
+                        var src = initialPageData.reverse('iframe_login');
+                        src += "?next=" + initialPageData.reverse('iframe_login_new_window');
                         src += "&username=" + initialPageData.get('secure_timeout_username');
                         $modal.on('shown.bs.modal', function () {
                             var content = _.template('<iframe src="<%= src %>" height="<%= height %>" width="<%= width %>" style="border: none;"></iframe>')({

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -336,8 +336,8 @@
     {% if request.user.is_authenticated and request.project.secure_timeout %}
       {% initial_page_data 'secure_timeout' request.project.secure_timeout %}
       {% initial_page_data 'secure_timeout_username' request.couch_user.username %}
-      {% registerurl 'iframe_domain_login' request.project.name %}
-      {% registerurl 'iframe_domain_login_new_window' %}
+      {% registerurl 'iframe_login' request.project.name %}
+      {% registerurl 'iframe_login_new_window' %}
       {% registerurl 'ping_login' %}
       {% registerurl 'ping_session' %}
       {% include 'hqwebapp/includes/inactivity_modal.html' %}

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -16,8 +16,8 @@ from corehq.apps.hqwebapp.views import (
     debug_notify,
     domain_login,
     dropbox_upload,
-    iframe_domain_login,
-    iframe_domain_login_new_window,
+    iframe_login,
+    iframe_login_new_window,
     jserror,
     login,
     login_new_window,
@@ -85,14 +85,14 @@ urlpatterns = [
     url(r'^ping_login/$', ping_login, name='ping_login'),
     url(r'^ping_session/$', ping_session, name='ping_session'),
     url(r'^relogin/$', login_new_window, name='login_new_window'),
-    url(r'^relogin/iframe/$', iframe_domain_login_new_window, name='iframe_domain_login_new_window'),
+    url(r'^relogin/iframe/$', iframe_login_new_window, name='iframe_login_new_window'),
 
 ]
 
 domain_specific = [
     url(r'^$', redirect_to_default, name='domain_homepage'),
     url(r'^login/$', domain_login, name='domain_login'),
-    url(r'^login/iframe/$', iframe_domain_login, name='iframe_domain_login'),
+    url(r'^login/iframe/$', iframe_login, name='iframe_login'),
     url(r'^retreive_download/(?P<download_id>(?:dl-)?[0-9a-fA-Z]{25,32})/$',
         retrieve_download, {'template': 'hqwebapp/includes/file_download.html'},
         name='hq_soil_download'),

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -449,9 +449,8 @@ def domain_login(req, domain, custom_template_name=None, extra_context=None):
     return _login(req, domain, custom_template_name, extra_context)
 
 
-@location_safe
-def iframe_domain_login(req, domain):
-    return domain_login(req, domain, custom_template_name="hqwebapp/iframe_domain_login.html", extra_context={
+def iframe_login(req, domain):
+    return domain_login(req, domain, custom_template_name="hqwebapp/iframe_login.html", extra_context={
         'current_page': {'page_name': _('Your session has expired')},
     })
 
@@ -497,7 +496,6 @@ def logout(req, default_domain_redirect='domain_login'):
 # ping_login and ping_session are both tiny views used in user inactivity and session expiration handling
 # They are identical except that ping_session extends the user's current session, while ping_login does not.
 # This difference is controlled in SelectiveSessionMiddleware, which makes ping_login bypass sessions.
-@location_safe
 @two_factor_exempt
 def ping_login(request):
     return JsonResponse({
@@ -507,7 +505,6 @@ def ping_login(request):
     })
 
 
-@location_safe
 @two_factor_exempt
 def ping_session(request):
     return JsonResponse({
@@ -517,15 +514,13 @@ def ping_session(request):
     })
 
 
-@location_safe
 @login_required
 def login_new_window(request):
     return render_static(request, "hqwebapp/close_window.html", _("Thank you for logging in!"))
 
 
-@location_safe
 @login_required
-def iframe_domain_login_new_window(request):
+def iframe_login_new_window(request):
     return TemplateView.as_view(template_name='hqwebapp/iframe_close_window.html')(request)
 
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#27699

I think this is going to cause 404s for users who had a page open pre-deploy and get the logout popup post-deploy - at least, I'm seeing that behavior locally and am just going to revert this until I have a chance to think more about this issue.