### PR TITLE
Ce/all invites

### DIFF
--- a/corehq/apps/domain/static/domain/js/select.js
+++ b/corehq/apps/domain/static/domain/js/select.js
@@ -14,9 +14,8 @@ hqDefine("domain/js/select", [
         assertProperties.assert(options, ['domainLinks', 'invitationLinks']);
         var self = {};
 
-        self.allInvitationLinks = ko.observableArray(options.invitationLinks);
         self.allDomainLinks = ko.observableArray(options.domainLinks);
-        self.invitationLinks = ko.observableArray();
+        self.invitationLinks = ko.observableArray(options.invitationLinks);
         self.domainLinks = ko.observableArray();
 
         self.query = ko.observable('');
@@ -25,7 +24,6 @@ hqDefine("domain/js/select", [
             return link.display_name.toLowerCase().indexOf(self.query().toLowerCase()) !== -1;
         };
         self.search = function () {
-            self.invitationLinks(_.filter(self.allInvitationLinks(), self._match));
             self.domainLinks(_.filter(self.allDomainLinks(), self._match));
         };
 

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -11,7 +11,7 @@
   {% initial_page_data 'domain_links' domain_links %}
 
 <div id="all-links" class="ko-template">
-  <div class="btn-toolbar" data-bind="visible: invitationLinks().length">
+  <div class="btn-toolbar" data-bind="visible: invitationLinks().length > 1">
     <a class="btn btn-primary"
        href="{% url "accept_all_invitations" %}">
       <i class="fa fa-envelope"></i>
@@ -22,7 +22,7 @@
 
   <div class="panel panel-info" data-bind="visible: invitationLinks().length">
     <div class="panel-heading ">
-      <h3 class="panel-title" style="padding-top: 7px;">
+      <h3 class="panel-title">
         {% trans 'My Invitations' %}
       </h3>
     </div>
@@ -30,12 +30,12 @@
       <table class="table table-striped table-responsive">
         <thead>
           <tr>
-            <th>Project Name
+            <th>{% trans 'Project Name' %}
             </th>
           </tr>
         </thead>
         <tbody data-bind="foreach: invitationLinks">
-          <tr style="padding-bottom: 6px;">
+          <tr>
             <td>
               
               <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
@@ -55,7 +55,7 @@
     <div class="panel-heading ">
       <div class="row">
         <div class="col-sm-6">
-          <h3 class="panel-title" style="padding-top: 7px;">
+          <h3 class="panel-title">
             {% trans 'My Projects' %}
           </h3>
         </div>
@@ -73,11 +73,11 @@
       <table class="table table-striped table-responsive">
         <thead>
           <tr>
-            <th>Project Name
+            <th>{% trans 'Project Name' %}
             </th>
           </tr>
         </thead>
-        <tbody class="nav nav-pills nav-stacked" data-bind="foreach: domainLinks">
+        <tbody data-bind="foreach: domainLinks">
           <tr>
             <td>
               <a data-bind="attr: {href: url}, text: display_name">

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -10,34 +10,84 @@
   {% initial_page_data 'invitation_links' invitation_links %}
   {% initial_page_data 'domain_links' domain_links %}
 
-  <div id="all-links" class="ko-template">
-    <div class="row">
-      <div class="col-sm-4">
-        <ul class="list-unstyled" data-bind="visible: invitationLinks().length, foreach: invitationLinks">
-          <li style="padding-bottom: 6px;">
-            <a data-bind="attr: {href: url}" class="btn btn-primary btn-xs">
-              <i class='fa fa-envelope'></i>
-              {% trans "Accept" %}
-            </a>
-            <!-- ko text: display_name --><!-- /ko -->
-          </li>
-        </ul>
-        <ul class="nav nav-pills nav-stacked" data-bind="foreach: domainLinks">
-          <li><a data-bind="attr: {href: url}, text: display_name"></a></li>
-        </ul>
-      </div>
-      <div class="col-sm-4">
-        <!-- spacer -->
-      </div>
-      <div class="col-sm-4">
-        <div class="pull-right">
+<div id="all-links" class="ko-template">
+  <div class="btn-toolbar" data-bind="visible: invitationLinks().length">
+    <a class="btn btn-primary"
+       href="{% url "accept_all_invitations" %}">
+      <i class="fa fa-envelope"></i>
+      {% trans 'Accept All Invitations' %}
+    </a>
+  </div>
+  <p/>
+
+  <div class="panel panel-info" data-bind="visible: invitationLinks().length">
+    <div class="panel-heading ">
+      <h3 class="panel-title" style="padding-top: 7px;">
+        {% trans 'My Invitations' %}
+      </h3>
+    </div>
+    <div class="panel-body">
+      <table class="table table-striped table-responsive">
+        <thead>
+          <tr>
+            <th>Project Name
+            </th>
+          </tr>
+        </thead>
+        <tbody data-bind="foreach: invitationLinks">
+          <tr style="padding-bottom: 6px;">
+            <td>
+              
+              <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
+                <i class='fa fa-envelope'>
+                </i>
+                {% trans "Accept" %}
+              </a>
+              <!-- ko text: display_name -->
+              <!-- /ko -->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="panel panel-default">
+    <div class="panel-heading ">
+      <div class="row">
+        <div class="col-sm-6">
+          <h3 class="panel-title" style="padding-top: 7px;">
+            {% trans 'My Projects' %}
+          </h3>
+        </div>
+        <div class="col-sm-6">
           <search-box data-apply-bindings="false"
                       params="value: query,
                               action: search,
                               immediate: true,
-                              placeholder: '{% trans_html_attr "Search Projects..." %}'"></search-box>
+                              placeholder: '{% trans_html_attr "Search Projects..." %}'">
+          </search-box>
         </div>
       </div>
     </div>
+    <div class="panel-body">
+      <table class="table table-striped table-responsive">
+        <thead>
+          <tr>
+            <th>Project Name
+            </th>
+          </tr>
+        </thead>
+        <tbody class="nav nav-pills nav-stacked" data-bind="foreach: domainLinks">
+          <tr>
+            <td>
+              <a data-bind="attr: {href: url}, text: display_name">
+              </a>
+            </td>
+          </tr>
+        </tbody>
+        
+      </table>
+    </div>
   </div>
+</div>
 {% endblock %}

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -38,7 +38,7 @@ from corehq.apps.domain.views.accounting import (
     WireInvoiceView,
     pause_subscription,
 )
-from corehq.apps.domain.views.base import select
+from corehq.apps.domain.views.base import select, accept_all_invitations
 from corehq.apps.domain.views.fixtures import LocationFixtureConfigView
 from corehq.apps.domain.views.internal import (
     ActivateTransferDomainView,
@@ -96,6 +96,7 @@ PASSWORD_RESET_DONE_KWARGS = {
 urlpatterns = [
     url(r'^domain/select/$', select, name='domain_select'),
     url(r'^domain/select_redirect/$', select, {'do_not_redirect': True}, name='domain_select_redirect'),
+    url('^accept_all_invitations/$', accept_all_invitations, name='accept_all_invitations'),
     url(r'^domain/transfer/(?P<guid>\w+)/activate$',
         ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),
     url(r'^domain/transfer/(?P<guid>\w+)/deactivate$',

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -50,7 +50,7 @@ def select(request, do_not_redirect=False, next_view=None):
         'domain_links': domain_links,
         'invitation_links': [{
             'display_name': i.domain,
-            'url': reverse("domain_accept_invitation", args=[i.domain, i.uuid]),
+            'url': reverse("domain_accept_invitation", args=[i.domain, i.uuid]) + '?no_redirect=true',
         } for i in open_invitations] if show_invitations else [],
         'current_page': {'page_name': _('Select A Project')},
     }
@@ -92,8 +92,9 @@ def accept_all_invitations(request):
     user = request.couch_user
     invites = Invitation.by_email(user.username)
     for invitation in invites:
-        _invite(invitation, user)
-        messages.success(request,  _(f'You have been added to the "{invitation.domain}" project space.'))
+        if not invitation.is_expired:
+            _invite(invitation, user)
+            messages.success(request, _(f'You have been added to the "{invitation.domain}" project space.'))
     return HttpResponseRedirect(reverse('domain_select_redirect'))
 
 

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -14,6 +15,7 @@ from corehq.apps.domain.decorators import (
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import normalize_domain_name
+from corehq.apps.hqwebapp.utils import send_confirmation_email
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.users.models import Invitation
 from corehq.util.quickcache import quickcache
@@ -76,6 +78,23 @@ def select(request, do_not_redirect=False, next_view=None):
 
         del request.session['last_visited_domain']
         return render(request, domain_select_template, additional_context)
+
+
+@login_required
+def accept_all_invitations(request):
+    def _invite(invitation, user):
+        user.add_as_web_user(invitation.domain, role=invitation.role,
+                             location_id=invitation.supply_point, program_id=invitation.program)
+        invitation.is_accepted = True
+        invitation.save()
+        send_confirmation_email(invitation)
+
+    user = request.couch_user
+    invites = Invitation.by_email(user.username)
+    for invitation in invites:
+        _invite(invitation, user)
+        messages.success(request,  _(f'You have been added to the "{invitation.domain}" project space.'))
+    return HttpResponseRedirect(reverse('domain_select_redirect'))
 
 
 @quickcache(['couch_user.username'])

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2617,9 +2617,9 @@ class Invitation(models.Model):
         params = {
             "domain": self.domain,
             "url": url,
-            'days': remaining_days,
+            "days": remaining_days,
             "inviter": inviter.formatted_name,
-            'url_prefix': get_static_url_prefix(),
+            "url_prefix": get_static_url_prefix(),
         }
 
         domain_request = DomainRequest.by_email(self.domain, self.email, is_approved=True)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -66,7 +66,6 @@ from corehq.apps.registration.forms import (
 )
 from corehq.apps.registration.utils import activate_new_user
 from corehq.apps.reports.util import get_possible_reports
-from corehq.apps.settings.views import MyProjectsList
 from corehq.apps.sms.mixin import BadSMSConfigException
 from corehq.apps.sms.verify import (
     VERIFICATION__ALREADY_IN_USE,
@@ -862,7 +861,7 @@ class UserInvitationView(object):
         return _('You have been added to the "%s" project space.') % self.domain
 
     def redirect_to_on_success(self, email, domain):
-        if Invitation.by_email(email).count() > 0:
+        if Invitation.by_email(email).count() > 0 and not self.request.GET.get('no_redirect'):
             return reverse("domain_select_redirect")
         else:
             return reverse("domain_homepage", args=[domain,])

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -790,7 +790,7 @@ class UserInvitationView(object):
                                                  invited=invitation.email,
                                                  current=request.couch_user.username,
                                              ))
-                return HttpResponseRedirect(self.redirect_to_on_success(self.domain))
+                return HttpResponseRedirect(self.redirect_to_on_success(invitation.email, self.domain))
 
             if not is_invited_user:
                 messages.error(request, _("The invited user {invited} and your user {current} do not match!").format(
@@ -803,7 +803,7 @@ class UserInvitationView(object):
                                "Current user accepted a project invitation",
                                {"Current user accepted a project invitation": "yes"})
                 send_hubspot_form(HUBSPOT_EXISTING_USER_INVITE_FORM, request)
-                return HttpResponseRedirect(self.redirect_to_on_success(self.domain))
+                return HttpResponseRedirect(self.redirect_to_on_success(invitation.email, self.domain))
             else:
                 mobile_user = CouchUser.from_django_user(request.user).is_commcare_user()
                 context.update({
@@ -828,7 +828,7 @@ class UserInvitationView(object):
                                    "New User Accepted a project invitation",
                                    {"New User Accepted a project invitation": "yes"})
                     send_hubspot_form(HUBSPOT_NEW_USER_INVITE_FORM, request, user)
-                    return HttpResponseRedirect(self.redirect_to_on_success(invitation.domain))
+                    return HttpResponseRedirect(self.redirect_to_on_success(invitation.email, invitation.domain))
             else:
                 if CouchUser.get_by_username(invitation.email):
                     return HttpResponseRedirect(reverse("login") + '?next=' +
@@ -861,8 +861,8 @@ class UserInvitationView(object):
     def success_msg(self):
         return _('You have been added to the "%s" project space.') % self.domain
 
-    def redirect_to_on_success(self, domain):
-        if Invitation.by_email(user.user_name).count() > 0:
+    def redirect_to_on_success(self, email, domain):
+        if Invitation.by_email(email).count() > 0:
             return reverse("domain_select_redirect")
         else:
             return reverse("domain_homepage", args=[domain,])


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This makes two related changes. It allows users to accept all pending invites from the domain select page, and to facilitate that process, redirects users to that page after accepting an invite if they still have some pending.

@orangejenny 
Putting this up for review with the UI I showed today (but default buttons and moved to the left). Will look more at tables tomorrow but wanted to let the rest be reviewed