### PR TITLE
combine null and empty choices in UCR / report builder filters

### DIFF
--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -414,6 +414,10 @@ def get_installed_custom_modules():
     return [import_module(module) for module in settings.CUSTOM_MODULES]
 
 
+def get_null_empty_value_bindparam(field_slug):
+    return f'{field_slug}_empty_eq'
+
+
 def get_INFilter_element_bindparam(base_name, index):
     return '%s_%d' % (base_name, index)
 

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -395,17 +395,8 @@ class DynamicChoiceListFilter(BaseFilter):
         if selection:
             choices = selection if isinstance(selection, list) else [selection]
             typed_choices = [transform_from_datatype(self.datatype)(c) for c in choices]
-            transformed_choices = [self._transform_for_default_value(tc) for tc in typed_choices]
-            return self.choice_provider.get_sorted_choices_for_values(transformed_choices, user)
+            return self.choice_provider.get_sorted_choices_for_values(typed_choices, user)
         return self.default_value(user)
-
-    @staticmethod
-    def _transform_for_default_value(choice):
-        from corehq.apps.userreports.reports.filters.values import EMPTY_CHOICE
-        if choice == EMPTY_CHOICE:
-            return ''
-        else:
-            return choice
 
     def default_value(self, request_user=None):
         from corehq.apps.userreports.reports.filters.values import SHOW_ALL_CHOICE

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -191,7 +191,7 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
 
     def _make_choice_from_value(self, value):
         if value is None or value == '':
-            return Choice(NONE_CHOICE, '[Missing]')
+            return Choice(NONE_CHOICE, '[Blank]')
         return Choice(value, value)
 
     @staticmethod

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -201,11 +201,9 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
 
     @staticmethod
     def _deduplicate_choices(choices):
-        found_values = set()
-        for choice in choices:
-            if choice.value not in found_values:
-                yield choice
-                found_values.add(choice.value)
+        # don't return more than one result with the same value
+        # this can happen e.g. for NONE_CHOICE values
+        return {choice.value: choice for choice in choices}.values()
 
 
 class MultiFieldDataSourceColumnChoiceProvider(DataSourceColumnChoiceProvider):

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -10,7 +10,7 @@ from corehq.apps.es import GroupES, UserES
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.reports_core.filters import Choice
 from corehq.apps.userreports.exceptions import ColumnNotFoundError
-from corehq.apps.userreports.reports.filters.values import SHOW_ALL_CHOICE, EMPTY_CHOICE, NONE_CHOICE
+from corehq.apps.userreports.reports.filters.values import SHOW_ALL_CHOICE, NONE_CHOICE
 from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.apps.users.util import raw_username
@@ -190,10 +190,8 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
         return []
 
     def _make_choice_from_value(self, value):
-        if value is None:
+        if value is None or value == '':
             return Choice(NONE_CHOICE, '[Missing]')
-        elif value == "":
-            return Choice(EMPTY_CHOICE, '[Empty]')
         return Choice(value, value)
 
     @staticmethod

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -34,7 +34,6 @@ from corehq.apps.reports.util import (
 # todo: if someone wants to name an actual choice any of these values, it will break
 SHOW_ALL_CHOICE = '_all'
 NONE_CHOICE = "\u2400"
-EMPTY_CHOICE = '_cchq_empty'
 
 CHOICE_DELIMITER = "\u001f"
 

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -325,8 +325,6 @@ class ChoiceListFilterValue(FilterValue):
             return None
 
         sql_filters = []
-        if self.is_null:
-            sql_filters.append(ISNULLFilter(self.filter['field']))
 
         non_null_values = self._get_value_without_nulls()
         if non_null_values:
@@ -343,6 +341,9 @@ class ChoiceListFilterValue(FilterValue):
                 sql_filters.append(in_filter)
         elif self._ancestor_filter:
             sql_filters.append(self._ancestor_filter.sql_filter())
+
+        if self.is_null:
+            sql_filters.append(ISNULLFilter(self.filter['field']))
 
         if len(sql_filters) > 1:
             return ORFilter(


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Related to https://docs.google.com/document/d/1cRFJ3AKGHnJRO2sLaTEOW4o9Z-jOYejONzv_jjW6X8Y/edit

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is a follow up to https://github.com/dimagi/commcare-hq/pull/27645 and merges the "missing" and "empty" values into a single value called "blank" which checks for both null and empty (string) data.

Review by commit.
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->


##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
