### PR TITLE
Allow non-admins to access locations API

### DIFF
--- a/corehq/apps/locations/resources/v0_5.py
+++ b/corehq/apps/locations/resources/v0_5.py
@@ -4,7 +4,11 @@ from tastypie.constants import ALL
 from tastypie.resources import ModelResource
 
 from corehq.apps.api.resources import HqBaseResource
-from corehq.apps.api.resources.auth import DomainAdminAuthentication
+from corehq.apps.api.resources.auth import (
+    DomainAdminAuthentication,
+    RequirePermissionAuthentication,
+)
+from corehq.apps.users.models import Permissions
 from corehq.util.view_utils import absolute_reverse
 
 from ..models import LocationType, SQLLocation
@@ -56,7 +60,7 @@ class LocationResource(ModelResource, HqBaseResource):
         resource_name = 'location'
         detail_uri_name = 'location_id'
         queryset = SQLLocation.objects.filter(is_archived=False).all()
-        authentication = DomainAdminAuthentication()
+        authentication = RequirePermissionAuthentication(Permissions.edit_locations)
         allowed_methods = ['get']
         fields = [
             'id',


### PR DESCRIPTION
I don't think there's any particular reason this API requires admin permissions, and the change was easy, so I just went for it.  Even though the API is read-only, I used the edit permission, as that is in line with the other APIs, and I imagine we'll want to add write permission to this eventually anyways.

##### RISK ASSESSMENT / QA PLAN
:cowboy_hat_face: 

##### PRODUCT DESCRIPTION
This change allows non-admin users to access the locations API, as long as their role has "edit locations" permission.
