### PR TITLE
add monitoring metrics for pending user confirmations

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -361,10 +361,8 @@ def gauge_pending_user_confirmations():
     from corehq.apps.users.analytics import get_inactive_commcare_users_in_domain
     for doc in Domain.get_all(include_docs=False):
         domain_name = doc['key']
-        num_unconfirmed = [
-            u.is_account_confirmed
-            for u in get_inactive_commcare_users_in_domain(domain_name)
-        ].count(False)
+        users = get_inactive_commcare_users_in_domain(domain_name)
+        num_unconfirmed = sum(1 for u in users if not u.is_account_confirmed)
         if num_unconfirmed:
             metrics_gauge(
                 metric_name, num_unconfirmed, tags={

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.db import transaction
+from django.db.models import Count
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -16,6 +17,7 @@ from couchdbkit import BulkSaveError, ResourceConflict
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xform import get_case_ids_from_form
+from corehq.util.metrics import metrics_gauge
 from couchforms.exceptions import UnexpectedDeletedXForm
 from dimagi.utils.couch.bulk import BulkFetchException
 from dimagi.utils.logging import notify_exception
@@ -341,3 +343,32 @@ def process_reporting_metadata_staging():
     run_again = run_periodic_task_again(process_reporting_metadata_staging_schedule, start, duration)
     if run_again and UserReportingMetadataStaging.objects.exists():
         process_reporting_metadata_staging.delay()
+
+
+@periodic_task(run_every=crontab(minute='*/10'), queue='background_queue')
+def gauge_pending_user_confirmations():
+    metric_name = 'commcare.pending_user_confirmations'
+    from corehq.apps.users.models import Invitation
+    for stats in (Invitation.objects.filter(is_accepted=False).all()
+                  .values('domain').annotate(Count('domain'))):
+        metrics_gauge(
+            metric_name, stats['domain__count'], tags={
+                'domain': stats['domain'],
+                'user_type': 'web',
+            }
+        )
+
+    from corehq.apps.users.analytics import get_inactive_commcare_users_in_domain
+    for doc in Domain.get_all(include_docs=False):
+        domain_name = doc['key']
+        num_unconfirmed = [
+            u.is_account_confirmed
+            for u in get_inactive_commcare_users_in_domain(domain_name)
+        ].count(False)
+        if num_unconfirmed:
+            metrics_gauge(
+                metric_name, num_unconfirmed, tags={
+                    'domain': domain_name,
+                    'user_type': 'mobile',
+                }
+            )


### PR DESCRIPTION
##### SUMMARY
pushes a metrics gauge for the number of pending user confirmations / invites by domain and user type (web/mobile)