### PR TITLE
Removed logged out middleware

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -13,13 +13,9 @@ from django.contrib.auth.views import LogoutView
 from django.utils.deprecation import MiddlewareMixin
 
 from corehq.apps.domain.models import Domain
-from corehq.apps.domain.utils import get_domain_from_url, legacy_domain_re
-from corehq.apps.linked_domain.dbaccessors import get_domain_master_link
+from corehq.apps.domain.utils import legacy_domain_re
 from corehq.const import OPENROSA_DEFAULT_VERSION
-from corehq.toggles import LOGOUT_SENSITIVE_DOMAIN
-from corehq.util.soft_assert import soft_assert
 from dimagi.utils.logging import notify_exception
-from dimagi.utils.web import get_ip
 
 from dimagi.utils.parsing import json_format_datetime, string_to_utc_datetime
 
@@ -268,45 +264,3 @@ class SelectiveSessionMiddleware(SessionMiddleware):
         if self._bypass_sessions(request):
             request.session.save = lambda *x: None
             request._bypass_sessions = True
-
-
-class LoggedOutDomainUserMiddleware(MiddlewareMixin):
-    """Soft assert with domain and client IP details if user is logged out
-
-    Used to get a lead on what was happening when someone tried to
-    access a page and was not logged in.
-    """
-
-    def process_request(self, request):
-        if request.user.is_authenticated:
-            return
-        domain_name = get_domain_from_url(request.path)
-        if self.is_logout_sensitive_domain(domain_name):
-            msg = "Unauthenticated client"
-            data = {
-                "domain": domain_name,
-                "ip_address": get_ip(request),
-                "path_info": request.path_info,
-            }
-            _soft_assert_is_authenticated(False, msg, data)
-            notify_exception(request, msg, details=data)
-
-    def is_logout_sensitive_domain(self, domain_name):
-        if domain_name:
-            if LOGOUT_SENSITIVE_DOMAIN.enabled(domain_name):
-                return True
-            link = get_domain_master_link(domain_name)
-            if link and LOGOUT_SENSITIVE_DOMAIN.enabled(link.master_domain):
-                return True
-        return False
-
-
-_soft_assert_is_authenticated = soft_assert(
-    to=['{}@{}'.format(email, 'dimagi.com') for email in [
-        'jschweers',
-        'cellowitz',
-        'kcowger',
-        'btalbot',
-    ]],
-    exponential_backoff=False,
-)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1954,10 +1954,3 @@ ONE_PHONE_NUMBER_MULTIPLE_CONTACTS = StaticToggle(
     Otherwise the recipient has no way to know who they're supposed to be enter information about.
     """
 )
-
-LOGOUT_SENSITIVE_DOMAIN = StaticToggle(
-    'logout_sensitive_domain',
-    'Get details about clients that are not logged in',
-    TAG_INTERNAL,
-    namespaces=[NAMESPACE_DOMAIN],
-)

--- a/settings.py
+++ b/settings.py
@@ -145,7 +145,6 @@ MIDDLEWARE = [
     'django_otp.middleware.OTPMiddleware',
     'django_user_agents.middleware.UserAgentMiddleware',
     'corehq.middleware.OpenRosaMiddleware',
-    'corehq.middleware.LoggedOutDomainUserMiddleware',
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
     'corehq.middleware.SentryContextMiddleware',


### PR DESCRIPTION
Reverts https://github.com/dimagi/commcare-hq/pull/27681/ which has served its purpose. We can still investigate logout issues using the proxy logs if needed.