### PR TITLE
Remove domain-level inactivity timeout

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.conf import settings
 from django.db import transaction
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -741,7 +742,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         if secure_sessions:
             msgs.append(_("Your project has enabled a {} minute session timeout setting. "
                           "By changing to a different plan, you will lose the ability to "
-                          "enforce this shorter timeout policy.").format(domain.secure_timeout))
+                          "enforce this shorter timeout policy.").format(settings.SECURE_TIMEOUT))
         if two_factor:
             msgs.append(_("Two factor authentication is currently required of all of your "
                           "web users for this project space.  By changing to a different "

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -114,7 +114,7 @@ from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.permissions import can_manage_releases
-from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, SECURE_SESSION_TIMEOUT
+from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
@@ -582,12 +582,6 @@ class PrivacySecurityForm(forms.Form):
         help_text=ugettext_lazy("All web users on this project will be logged out after {} minutes "
                                 "of inactivity").format(settings.SECURE_TIMEOUT)
     )
-    secure_sessions_timeout = IntegerField(
-        label=ugettext_lazy("Inactivity Timeout Length"),
-        required=False,
-        help_text=ugettext_lazy("Override the default {}-minute length of the inactivity timeout. Has "
-                                "no effect unless inactivity timeout is in use").format(settings.SECURE_TIMEOUT)
-    )
     allow_domain_requests = BooleanField(
         label=ugettext_lazy("Web user requests"),
         required=False,
@@ -616,19 +610,16 @@ class PrivacySecurityForm(forms.Form):
         self.helper[0] = twbscrispy.PrependedText('restrict_superusers', '')
         self.helper[1] = twbscrispy.PrependedText('secure_submissions', '')
         self.helper[2] = twbscrispy.PrependedText('secure_sessions', '')
-        self.helper[3] = crispy.Field('secure_sessions_timeout')
-        self.helper[4] = twbscrispy.PrependedText('allow_domain_requests', '')
-        self.helper[5] = twbscrispy.PrependedText('hipaa_compliant', '')
-        self.helper[6] = twbscrispy.PrependedText('two_factor_auth', '')
-        self.helper[7] = twbscrispy.PrependedText('strong_mobile_passwords', '')
+        self.helper[3] = twbscrispy.PrependedText('allow_domain_requests', '')
+        self.helper[4] = twbscrispy.PrependedText('hipaa_compliant', '')
+        self.helper[5] = twbscrispy.PrependedText('two_factor_auth', '')
+        self.helper[6] = twbscrispy.PrependedText('strong_mobile_passwords', '')
 
         if not domain_has_privilege(domain, privileges.ADVANCED_DOMAIN_SECURITY):
-            self.helper.layout.pop(7)
             self.helper.layout.pop(6)
-        if not HIPAA_COMPLIANCE_CHECKBOX.enabled(user_name):
             self.helper.layout.pop(5)
-        if not SECURE_SESSION_TIMEOUT.enabled(domain):
-            self.helper.layout.pop(3)
+        if not HIPAA_COMPLIANCE_CHECKBOX.enabled(user_name):
+            self.helper.layout.pop(4)
         if not domain_has_privilege(domain, privileges.ADVANCED_DOMAIN_SECURITY):
             self.helper.layout.pop(2)
         self.helper.all().wrap_together(crispy.Fieldset, 'Edit Privacy Settings')
@@ -646,7 +637,6 @@ class PrivacySecurityForm(forms.Form):
         domain.restrict_superusers = self.cleaned_data.get('restrict_superusers', False)
         domain.allow_domain_requests = self.cleaned_data.get('allow_domain_requests', False)
         domain.secure_sessions = self.cleaned_data.get('secure_sessions', False)
-        domain.secure_sessions_timeout = self.cleaned_data.get('secure_sessions_timeout', None)
         domain.two_factor_auth = self.cleaned_data.get('two_factor_auth', False)
         domain.strong_mobile_passwords = self.cleaned_data.get('strong_mobile_passwords', False)
         secure_submissions = self.cleaned_data.get(

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -437,13 +437,10 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
 
     # when turned on, use settings.SECURE_TIMEOUT for sessions of users who are members of this domain
     secure_sessions = BooleanProperty(default=False)
-    secure_sessions_timeout = IntegerProperty()
 
     @property
     def secure_timeout(self):
         if self.secure_sessions:
-            if toggles.SECURE_SESSION_TIMEOUT.enabled(self.name):
-                return self.secure_sessions_timeout or settings.SECURE_TIMEOUT
             return settings.SECURE_TIMEOUT
         return None
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -438,12 +438,6 @@ class Domain(QuickCachedDocumentMixin, BlobMixin, Document, SnapshotMixin):
     # when turned on, use settings.SECURE_TIMEOUT for sessions of users who are members of this domain
     secure_sessions = BooleanProperty(default=False)
 
-    @property
-    def secure_timeout(self):
-        if self.secure_sessions:
-            return settings.SECURE_TIMEOUT
-        return None
-
     two_factor_auth = BooleanProperty(default=False)
     strong_mobile_passwords = BooleanProperty(default=False)
 

--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -310,7 +310,6 @@ class EditPrivacySecurityView(BaseAdminProjectSettingsView):
     def privacy_form(self):
         initial = {
             "secure_submissions": self.domain_object.secure_submissions,
-            "secure_sessions_timeout": self.domain_object.secure_sessions_timeout,
             "restrict_superusers": self.domain_object.restrict_superusers,
             "allow_domain_requests": self.domain_object.allow_domain_requests,
             "hipaa_compliant": self.domain_object.hipaa_compliant,

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -7,7 +7,6 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from corehq.apps.domain.auth import formplayer_auth
-from corehq.apps.domain.models import Domain
 from corehq.apps.hqadmin.utils import get_django_user_from_session, get_session
 from corehq.apps.users.models import CouchUser
 
@@ -53,15 +52,7 @@ class SessionDetailsView(View):
 
         # reset the session's expiry if there's some formplayer activity
         secure_session = session.get('secure_session')
-        if secure_session:
-            timeout = settings.SECURE_TIMEOUT
-            domain = data.get('domain')
-            if domain:
-                domain_obj = Domain.get_by_name(domain)
-                if domain_obj:
-                    timeout = domain_obj.secure_timeout or timeout
-        else:
-            timeout = settings.INACTIVITY_TIMEOUT
+        timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
 
         session.set_expiry(timeout * 60)
         session.save()

--- a/corehq/apps/hqwebapp/session_details_endpoint/views.py
+++ b/corehq/apps/hqwebapp/session_details_endpoint/views.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 
 from django.conf import settings
@@ -5,6 +6,8 @@ from django.http import Http404, HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
+
+from dimagi.utils.parsing import json_format_datetime
 
 from corehq.apps.domain.auth import formplayer_auth
 from corehq.apps.hqadmin.utils import get_django_user_from_session, get_session
@@ -55,6 +58,7 @@ class SessionDetailsView(View):
         timeout = settings.SECURE_TIMEOUT if secure_session else settings.INACTIVITY_TIMEOUT
 
         session.set_expiry(timeout * 60)
+        session['last_request'] = json_format_datetime(datetime.datetime.utcnow())
         session.save()
 
         return JsonResponse({

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -333,8 +333,8 @@
       {% endif %}
     {% endif %}
 
-    {% if request.user.is_authenticated and request.project.secure_timeout %}
-      {% initial_page_data 'secure_timeout' request.project.secure_timeout %}
+    {% if request.user.is_authenticated and SECURE_TIMEOUT %}
+      {% initial_page_data 'secure_timeout' SECURE_TIMEOUT %}
       {% initial_page_data 'secure_timeout_username' request.couch_user.username %}
       {% registerurl 'iframe_domain_login' request.project.name %}
       {% registerurl 'iframe_domain_login_new_window' %}

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -158,15 +158,8 @@ class TimeoutMiddleware(MiddlewareMixin):
                 (domain_obj and domain_obj.secure_sessions)
                 or self._user_requires_secure_session(request.couch_user)))
 
-        timeout = None
-        if secure_session or change_to_secure_session:
-            if domain_obj:
-                timeout = domain_obj.secure_timeout
-            if not timeout:
-                timeout = settings.SECURE_TIMEOUT
-        else:
-            timeout = settings.INACTIVITY_TIMEOUT
-
+        use_secure_timeout = secure_session or change_to_secure_session
+        timeout = settings.SECURE_TIMEOUT if use_secure_timeout else settings.INACTIVITY_TIMEOUT
         if change_to_secure_session:
             # force re-authentication if the user has been logged in longer than the secure timeout
             if self._session_expired(timeout, request.user.last_login, now):

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -66,6 +66,7 @@ def get_per_domain_context(project, request=None):
         'CUSTOM_LOGO_URL': custom_logo_url,
         'allow_report_an_issue': allow_report_an_issue,
         'EULA_COMPLIANCE': getattr(settings, 'EULA_COMPLIANCE', False),
+        'SECURE_TIMEOUT': settings.SECURE_TIMEOUT if project and project.secure_sessions else None,
     }
 
 


### PR DESCRIPTION
##### SUMMARY
Removes the domain setting added in https://github.com/dimagi/commcare-hq/pull/27571

##### FEATURE FLAG
Removes flag: Allow domain to override default length of inactivity timeout

##### RISK ASSESSMENT / QA PLAN
Fairly small, tested locally.