### PR TITLE
Updated build_requirejs to fail deploy if r.js fails

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -143,7 +143,9 @@ def _r_js(local=False, no_optimize=False):
 
     _save_r_js_config(config)
 
-    call(["node", "bower_components/r.js/dist/r.js", "-o", BUILD_JS_FILENAME])
+    ret = call(["node", "bower_components/r.js/dist/r.js", "-o", BUILD_JS_FILENAME])
+    if ret:
+        exit(1)
 
     return config, local_js_dirs
 


### PR DESCRIPTION
When `r.js` fails, typically some other part of the build fails eventually, but it isn't always obvious where the original error happened.