### PR TITLE
return None to handle notify no cases

### DIFF
--- a/custom/icds/location_reassignment/download.py
+++ b/custom/icds/location_reassignment/download.py
@@ -281,6 +281,8 @@ class OtherCases(object):
         which holds details of all cases assigned to it
         """
         data = self._generate_data(transitions)
+        if not data:
+            return None
         zipstream = io.BytesIO()
         with zipfile.ZipFile(zipstream, "w") as z:
             for case_type, sheets in data.items():


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1329?focusedCommentId=53128

##### SUMMARY
We do have the setup to [notify users if there were no cases](https://github.com/dimagi/commcare-hq/blob/331399b293292348f5f1ac34026ba4a092f98c96/custom/icds/location_reassignment/tasks.py#L142) found, but the `dump` method was not communicating that well.


##### FEATURE FLAG
`LOCATION_REASSIGNMENT`
