### PR TITLE
THR child datapull

### DIFF
--- a/custom/icds_reports/management/commands/sql_scripts/build_thr_child_table.sql
+++ b/custom/icds_reports/management/commands/sql_scripts/build_thr_child_table.sql
@@ -14,3 +14,22 @@ INSERT INTO "icds_dashboard_child_health_thr_forms" (
                 child_health_case_id IS NOT NULL
           WINDOW w AS (PARTITION BY supervisor_id, child_health_case_id)
           );
+/* Custom Scan (Citus INSERT ... SELECT via coordinator)  (cost=0.00..0.00 rows=0 width=0)
+   ->  Unique  (cost=0.00..0.00 rows=0 width=0)
+         ->  Sort  (cost=0.00..0.00 rows=0 width=0)
+               Sort Key: remote_scan.case_id
+               ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+                     Task Count: 64
+                     Tasks Shown: One of 64
+                     ->  Task
+                           Node: host=100.71.184.232 port=6432 dbname=icds_ucr
+                           ->  Unique  (cost=506909.94..508506.42 rows=113291 width=155)
+                                 ->  Sort  (cost=506909.94..507708.18 rows=319296 width=155)
+                                       Sort Key: "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea".child_health_case_id
+                                       ->  WindowAgg  (cost=439533.21..448313.85 rows=319296 width=155)
+                                             ->  Sort  (cost=439533.21..440331.45 rows=319296 width=113)
+                                                   Sort Key: "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea".supervisor_id, "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea".child_health_case_id
+                                                   ->  Gather  (cost=1000.00..387329.01 rows=319296 width=113)
+                                                         Workers Planned: 6
+                                                         ->  Parallel Seq Scan on "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea_104058" "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea"  (cost=0.00..354399.41 rows=53216 width=113)
+                                                               Filter: ((child_health_case_id IS NOT NULL) AND (timeend >= '2020-02-01 00:00:00'::timestamp without time zone) AND (timeend < '2020-03-01 00:00:00'::timestamp without time zone))*/

--- a/custom/icds_reports/management/commands/sql_scripts/build_thr_child_table.sql
+++ b/custom/icds_reports/management/commands/sql_scripts/build_thr_child_table.sql
@@ -1,0 +1,16 @@
+DELETE FROM "icds_dashboard_child_health_thr_forms" where month='2020-02-01';
+INSERT INTO "icds_dashboard_child_health_thr_forms" (
+          state_id, supervisor_id, month, case_id, latest_time_end_processed, days_ration_given_child
+        ) (
+          SELECT DISTINCT ON (child_health_case_id)
+            state_id AS state_id,
+            LAST_VALUE(supervisor_id) over w AS supervisor_id,
+            '2020-02-01' AS month,
+            child_health_case_id AS case_id,
+            MAX(timeend) over w AS latest_time_end_processed,
+            CASE WHEN SUM(days_ration_given_child) over w > 32767 THEN 32767 ELSE SUM(days_ration_given_child) over w END AS days_ration_given_child
+          FROM "ucr_icds-cas_static-dashboard_thr_forms_b8bca6ea"
+          WHERE timeend >= '2020-02-01' AND timeend < '2020-03-01' AND
+                child_health_case_id IS NOT NULL
+          WINDOW w AS (PARTITION BY supervisor_id, child_health_case_id)
+          );

--- a/custom/icds_reports/management/commands/sql_scripts/update_child_health_thr.sql
+++ b/custom/icds_reports/management/commands/sql_scripts/update_child_health_thr.sql
@@ -11,3 +11,30 @@ left join icds_dashboard_child_health_thr_forms thr on
         child_health_monthly.case_id = thr.case_id
         )
 where child_health_monthly.month='2020-02-01' and state_is_test is distinct from 1
+
+/* Aggregate  (cost=0.00..0.00 rows=0 width=0)
+   ->  Custom Scan (Citus Real-Time)  (cost=0.00..0.00 rows=0 width=0)
+         Task Count: 64
+         Tasks Shown: One of 64
+         ->  Task
+               Node: host=100.71.184.232 port=6432 dbname=icds_ucr
+               ->  Finalize Aggregate  (cost=182115.73..182115.74 rows=1 width=8)
+                     ->  Gather  (cost=182115.31..182115.72 rows=4 width=8)
+                           Workers Planned: 4
+                           ->  Partial Aggregate  (cost=181115.31..181115.32 rows=1 width=8)
+                                 ->  Nested Loop Left Join  (cost=1.54..181115.23 rows=10 width=6)
+                                       ->  Merge Join  (cost=0.99..181108.30 rows=10 width=111)
+                                             Merge Cond: (awc_location.doc_id = child_health_monthly.awc_id)
+                                             Join Filter: (child_health_monthly.supervisor_id = awc_location.supervisor_id)
+                                             ->  Parallel Index Scan using awc_location_indx6_102840 on awc_location_102840 awc_location  (cost=0.55..71626.29 rows=197665 width=63)
+                                                   Filter: (state_is_test IS DISTINCT FROM 1)
+                                             ->  Materialize  (cost=0.43..103229.79 rows=910057 width=144)
+                                                   ->  Merge Append  (cost=0.43..100954.65 rows=910057 width=144)
+                                                         Sort Key: child_health_monthly.awc_id
+                                                         ->  Index Scan using "child_health_monthly_2020-02-01_512124_awc_id_idx" on "child_health_monthly_2020-02-01_512124" child_health_monthly  (cost=0.42..91854.07 rows=910057 width=144)
+                                                               Filter: (month = '2020-02-01'::date)
+                                       ->  Index Scan using icds_dashboard_child_health_thr_forms_pkey_102200 on icds_dashboard_child_health_thr_forms_102200 thr  (cost=0.55..0.68 rows=1 width=109)
+                                             Index Cond: ((child_health_monthly.supervisor_id = supervisor_id) AND (child_health_monthly.case_id = (case_id)::text) AND (child_health_monthly.month = month) AND (month = '2020-02-01'::date))
+                                             Filter: (child_health_monthly.state_id = (state_id)::text)
+(24 rows)
+*/

--- a/custom/icds_reports/management/commands/sql_scripts/update_child_health_thr.sql
+++ b/custom/icds_reports/management/commands/sql_scripts/update_child_health_thr.sql
@@ -1,0 +1,13 @@
+select SUM(CASE WHEN thr_eligible=1 THEN COALESCE(thr.days_ration_given_child, 0) ELSE 0 END)
+from child_health_monthly inner join  awc_location ON (
+      (child_health_monthly.supervisor_id = awc_location.supervisor_id) AND
+      ("awc_location"."doc_id" = "child_health_monthly"."awc_id")
+  )
+left join icds_dashboard_child_health_thr_forms thr on
+        (
+        child_health_monthly.state_id= thr.state_id AND
+        child_health_monthly.month = thr.month AND
+        child_health_monthly.supervisor_id = thr.supervisor_id AND
+        child_health_monthly.case_id = thr.case_id
+        )
+where child_health_monthly.month='2020-02-01' and state_is_test is distinct from 1

--- a/custom/icds_reports/management/commands/update_thr_fix_data.py
+++ b/custom/icds_reports/management/commands/update_thr_fix_data.py
@@ -1,0 +1,31 @@
+import os
+
+from django.core.management.base import BaseCommand
+
+from django.db import connections, transaction
+
+from corehq.sql_db.connections import get_icds_ucr_citus_db_alias
+
+
+@transaction.atomic
+def _run_custom_sql_script(command):
+    db_alias = get_icds_ucr_citus_db_alias()
+    if not db_alias:
+        return
+
+    with connections[db_alias].cursor() as cursor:
+        cursor.execute(command)
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+
+        print(f"RUNNING FOR {date}")
+        thr_path = os.path.join(os.path.dirname(__file__), 'sql_scripts',
+                                'build_thr_child_table.sql')
+
+        print("RUNNING THR TABLE")
+        with open(thr_path, "r", encoding='utf-8') as sql_file:
+            sql_to_execute = sql_file.read()
+            _run_custom_sql_script(sql_to_execute)

--- a/custom/icds_reports/management/commands/update_thr_fix_data.py
+++ b/custom/icds_reports/management/commands/update_thr_fix_data.py
@@ -21,7 +21,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        print(f"RUNNING FOR {date}")
         thr_path = os.path.join(os.path.dirname(__file__), 'sql_scripts',
                                 'build_thr_child_table.sql')
 


### PR DESCRIPTION
total number of days THR was given.
This is for children. Doing like this because data correction for the recent bug found in this is not done yet.


Execution plan
1. first run the management command
2. then run the `update_child_health_thr.sql` manually to pull the count.