### PR TITLE
`generate_identifier()` to support AuthManager

### DIFF
--- a/corehq/motech/openmrs/repeater_helpers.py
+++ b/corehq/motech/openmrs/repeater_helpers.py
@@ -15,6 +15,7 @@ from corehq.apps.case_importer import util as importer_util
 from corehq.apps.case_importer.const import LookupErrors
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.motech.auth import AuthManager
 from corehq.motech.openmrs.const import (
     ADDRESS_PROPERTIES,
     LOCATION_OPENMRS_UUID,
@@ -254,8 +255,10 @@ def create_patient(requests, info, case_config):
 
 def authenticate_session(requests):
     login_data = {
-        'uname': requests.username,
-        'pw': requests.password,
+        # `requests.auth_manager` has `username` and `password`
+        # attributes because we use BasicAuthManager for OpenMRS.
+        'uname': requests.auth_manager.username,
+        'pw': requests.auth_manager.password,
         'submit': 'Log In',
         'redirect': '',
         'refererURL': '',
@@ -314,21 +317,23 @@ def generate_identifier(requests, identifier_type):
     If the identifier source doesn't return an identifier, return None.
     If anything goes wrong ... return None.
 
-    The idgen module is not a REST API. It does not use API
-    authentication. The user has to be logged in using the HTML login
-    page, and the resulting authenticated session used for sending
-    requests.
+    Partners in Health have written basic auth support for the idgen
+    module, but it is not yet widely used. Until then, requests must use
+    a session that has been authenticated with the HTML login page.
     """
     identifier = None
     source_id = None
+
+    # Create a new Requests session to log in using an HTML login page.
+    # See `authenticate_session()` for details.
     with Requests(
         domain_name=requests.domain_name,
         base_url=requests.base_url,
-        username=requests.username,
-        password=requests.password,
         verify=requests.verify,
+        auth_manager=requests.auth_manager,
         notify_addresses=requests.notify_addresses,
         payload_id=requests.payload_id,
+        logger=requests.logger,
     ) as requests_session:
         authenticate_session(requests_session)
         try:

--- a/corehq/motech/openmrs/tests/test_repeater_helpers.py
+++ b/corehq/motech/openmrs/tests/test_repeater_helpers.py
@@ -1,0 +1,34 @@
+from unittest import skip
+
+from nose.tools import assert_regexp_matches
+
+from corehq.motech.auth import BasicAuthManager
+from corehq.motech.openmrs.repeater_helpers import generate_identifier
+from corehq.motech.requests import Requests
+
+DOMAIN = 'openmrs-test'
+BASE_URL = 'https://demo.mybahmni.org/openmrs/'
+USERNAME = 'superman'
+PASSWORD = 'Admin123'
+
+# Patient identifier type for use by the Bahmni Registration System
+# https://demo.mybahmni.org/openmrs/admin/patients/patientIdentifierType.form?patientIdentifierTypeId=3
+IDENTIFIER_TYPE = '81433852-3f10-11e4-adec-0800271c1b75'
+
+
+@skip('Uses third-party web services')
+def test_generate_identifier():
+    auth_manager = BasicAuthManager(USERNAME, PASSWORD)
+    requests = Requests(
+        DOMAIN,
+        BASE_URL,
+        verify=False,  # demo.mybahmni.org uses a self-issued cert
+        auth_manager=auth_manager,
+        logger=dummy_logger,
+    )
+    identifier = generate_identifier(requests, IDENTIFIER_TYPE)
+    assert_regexp_matches(identifier, r'^BAH\d{6}$')  # e.g. BAH203001
+
+
+def dummy_logger(*args, **kwargs):
+    pass


### PR DESCRIPTION
Context: [Sentry](https://sentry.io/organizations/dimagi/issues/1713870873/?project=136860)

##### SUMMARY
When a patient is registered in CommCare, and does not already exist in OpenMRS, CommCare may need to ask OpenMRS to generate a new identifier for them. That request was erroring, because it was not using `requests.auth_manager` for its credentials.

This change resolves that, and adds a test for it. The test is skipped by default because it uses a third-party OpenMRS demo instance.

##### FEATURE FLAG
OpenMRS Integration
