### PR TITLE
Paginate save case properties panel

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -423,6 +423,8 @@ class FormActions(DocumentSchema):
         names.update(list(self.case_preload.preload.values()))
         for subcase in self.subcases:
             names.update(list(subcase.case_properties.keys()))
+        names.update(list(self.usercase_update.update.keys()))
+        names.update(list(self.usercase_preload.preload.values()))
         return names
 
     def count_subcases_per_repeat_context(self):

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -292,6 +292,13 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                 _(case_properties).each(function (p) {
                     action.case_properties.push(caseProperty.wrap(p, action));
                 });
+
+                // needed for compatibility with shared templates
+                action.searchAndFilter = false;
+                action.visible_case_properties = ko.computed(function () {
+                    return action.case_properties();
+                });
+
                 _(preload).each(function (p) {
                     action.preload.push(casePreloadProperty.wrap(p, action));
                 });
@@ -312,6 +319,13 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                 _(case_properties).each(function (p) {
                     action.case_properties.push(caseProperty.wrap(p, action));
                 });
+
+                // needed for compatibility with shared templates
+                action.searchAndFilter = false;
+                action.visible_case_properties = ko.computed(function () {
+                    return action.case_properties();
+                });
+
                 return action;
             }));
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/advanced/case_config_ui.js
@@ -62,7 +62,6 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                         success: function (data) {
                             var app_manager = hqImport('app_manager/js/app_manager');
                             app_manager.updateDOM(data.update);
-                            self.caseConfigViewModel.ensureBlankProperties();
                             self.setPropertiesMap(data.propertiesMap);
                             self.requires(self.caseConfigViewModel.load_update_cases().length > 0 ? 'case' : 'none');
                         },
@@ -156,10 +155,6 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                 }
             };
 
-            self.ensureBlankProperties = function () {
-                self.caseConfigViewModel.ensureBlankProperties();
-            };
-
             self.getQuestions = function (filter, excludeHidden, includeRepeat) {
                 return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat);
             };
@@ -174,7 +169,6 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
 
             self.change = function () {
                 self.saveButton.fire('change');
-                self.ensureBlankProperties();
             };
 
             self.caseConfigViewModel = caseConfigViewModel(self, params);
@@ -219,7 +213,6 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                     // https://gist.github.com/mkelly12/424774/#comment-92080
                     $home.find('input').on('textchange', self.change);
 
-                    self.ensureBlankProperties();
                     self.initAccordion();
                     $('#case-configuration-tab').on('click', function () {
                         self.initAccordion();
@@ -369,35 +362,6 @@ hqDefine('app_manager/js/forms/advanced/case_config_ui', function () {
                         }
                     }
                 }
-            };
-
-            self.ensureBlankProperties = function () {
-                var items = [];
-                var actions = self.load_update_cases();
-                for (var i = 0; i < actions.length; i++) {
-                    items.push({
-                        properties: actions[i].preload(),
-                        addProperty: actions[i].addPreload,
-                    });
-                    items.push({
-                        properties: actions[i].case_properties(),
-                        addProperty: actions[i].addProperty,
-                    });
-                }
-                actions = self.open_cases();
-                for (i = 0; i < actions.length; i++) {
-                    items.push({
-                        properties: actions[i].case_properties(),
-                        addProperty: actions[i].addProperty,
-                    });
-                }
-                _(items).each(function (item) {
-                    var properties = item.properties;
-                    var last = properties[properties.length - 1];
-                    if (last && !last.isBlank()) {
-                        item.addProperty();
-                    }
-                });
             };
 
             self.addFormAction = function (action) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -131,13 +131,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             self.questionScores = questionScores;
             self.caseConfigViewModel = caseConfigViewModel(self);
 
-            self.ensureBlankProperties = function () {
-                self.caseConfigViewModel.case_transaction.ensureBlankProperties();
-                _(self.caseConfigViewModel.subcases()).each(function (case_transaction) {
-                    case_transaction.ensureBlankProperties();
-                });
-            };
-
             self.getQuestions = function (filter, excludeHidden, includeRepeat, excludeTrigger) {
                 return caseConfigUtils.getQuestions(self.questions(), filter, excludeHidden, includeRepeat, excludeTrigger);
             };
@@ -151,13 +144,11 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
 
             self.change = function () {
                 self.saveButton.fire('change');
-                self.ensureBlankProperties();
                 self.forceRefreshTextchangeBinding(self.home);
             };
 
             self.usercaseChange = function () {
                 self.saveUsercaseButton.fire('change');
-                self.caseConfigViewModel.usercase_transaction.ensureBlankProperties();
                 self.forceRefreshTextchangeBinding($('#usercase-config-ko'));
             };
 
@@ -187,7 +178,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                             // all select2's are represented by an input[type="hidden"]
                             .on('change', 'select, input[type="hidden"]', self.change)
                             .on('click', 'a', self.change);
-                        self.ensureBlankProperties();
                         self.forceRefreshTextchangeBinding($home);
                     }
 
@@ -197,7 +187,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                             $usercaseMgmt.on('textchange', 'input', self.usercaseChange)
                                 .on('change', 'select, input[type="hidden"]', self.usercaseChange)
                                 .on('click', 'a', self.usercaseChange);
-                            self.caseConfigViewModel.usercase_transaction.ensureBlankProperties();
                         } else {
                             $usercaseMgmt.find('input').prop('disabled', true);
                             $usercaseMgmt.find('select').prop('disabled', true);
@@ -402,14 +391,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
 
             self.unwrap = function () {
                 ko.mapping.toJS(self, mapping(self));
-            };
-
-            self.ensureBlankProperties = function () {
-                var properties = self.case_properties()
-                var last = properties[properties.length - 1];
-                if (last && !last.isBlank()) {
-                    self.addProperty();
-                }
             };
 
             return self;

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -318,6 +318,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             }
 
             // Pagination and search
+            self.searchAndFilter = true;
             self.case_property_query = ko.observable('');
             self.filtered_case_properties = ko.computed(function () {
                 return _.filter(self.case_properties(), function (item) {

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -322,7 +322,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             self.case_property_query = ko.observable('');
             self.filtered_case_properties = ko.computed(function () {
                 return _.filter(self.case_properties(), function (item) {
-                    return item.path().indexOf(self.case_property_query()) !== -1;
+                    return item.path().indexOf(self.case_property_query()) !== -1 || item.key().indexOf(self.case_property_query()) !== -1;
                 });
             });
             self.visible_case_properties = ko.observableArray();

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -438,9 +438,6 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
             wrap: function (data, case_transaction) {
                 var self = ko.mapping.fromJS(data, caseProperty.mapping);
                 self.case_transaction = case_transaction;
-                self.isBlank = ko.computed(function () {
-                    return !self.key() && !self.path();
-                });
                 self.caseType = ko.computed(function () {
                     return self.case_transaction.case_type();
                 });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -203,7 +203,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                             $usercaseMgmt.find('select').prop('disabled', true);
                             $usercaseMgmt.find('a').off('click');
                             // Remove "Load properties" / "Save properties" link
-                            _.each($usercaseMgmt.find('.firstProperty'), function (elem) {
+                            _.each($usercaseMgmt.find('.add-property'), function (elem) {
                                 elem.remove();
                             });
                         }

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -326,6 +326,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 });
             });
             self.visible_case_properties = ko.observableArray();
+            self.pagination_reset_flag = ko.observable(false);
             self.goToPage = function (page) {
                 page = page || 1;
                 var props = self.filtered_case_properties();
@@ -362,6 +363,9 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 hqImport('analytix/js/google').track.event('Case Management', analyticsAction, 'Save Properties (remove)');
                 self.case_properties.remove(property);
                 self.visible_case_properties.remove(property);
+                if (!self.visible_case_properties().length) {
+                    self.pagination_reset_flag(!self.pagination_reset_flag());
+                }
                 saveButton.fire('change');
             };
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -335,7 +335,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                 self.visible_case_properties(props);
             };
             // Don't allow changing per page; "Add Property" button is where the per page changer usually is
-            self.per_page = ko.observable(25);
+            self.per_page = ko.observable(10);
             self.total_case_properties = ko.computed(function () {
                 return self.filtered_case_properties().length;
             });

--- a/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/case_config_ui.js
@@ -416,6 +416,7 @@ hqDefine('app_manager/js/forms/case_config_ui', function () {
                         required: true,
                     }, self));
                 });
+                self.pagination_reset_flag(!self.pagination_reset_flag());
             };
 
             self.unwrap = function () {

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config.html
@@ -52,15 +52,8 @@
     </div>
   {% endif %}
 
-  <div data-bind="if: allow.case_preload()">
-    <div class="panel panel-appmanager case-properties wide-select2s"
-         data-bind="template: 'case-config:case-transaction:case-properties'"></div>
-  </div>
-
-  <div data-bind="if: !allow.case_preload()">
-    <div class="panel panel-appmanager"
-         data-bind="template: 'case-config:case-transaction:case-properties'"></div>
-  </div>
+  <div class="panel panel-appmanager case-properties wide-select2s"
+       data-bind="template: 'case-config:case-transaction:case-properties'"></div>
 
   <div class="panel panel-appmanager">
     <div class="panel-heading">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -139,12 +139,9 @@
                        'has-error': validateProperty || validateQuestion,
                      }">
         <td class="col-sm-1 text-center">
-          <a href="#"
-             class="btn btn-danger"
-             data-bind="click: $parent.removePreload,
-                        visible: !(isBlank() && $index() === $parent.case_preload().length - 1)">
+          <button class="btn btn-danger" data-bind="click: $parent.removePreload">
             <i class="fa fa-remove"></i>
-          </a>
+          </button>
         </td>
         <td class="col-sm-5">
           <div class="full-width-select2"
@@ -218,12 +215,9 @@
                     }">
         <td class="col-sm-1 text-center"
             data-bind="if: $parent.hasPrivilege">
-          <a href="#"
-             class="btn btn-danger"
-             data-bind="click: $parent.removeProperty,
-                        visible: !required() && !(isBlank() && $index() === $parent.case_properties().length - 1)">
+          <button class="btn btn-danger" data-bind="click: $parent.removeProperty, visible: !required()">
             <i class="fa fa-remove"></i>
-          </a>
+          </button>
         </td>
         <td class="col-sm-5">
           <div class="full-width-select2"

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -177,13 +177,12 @@
          data-bind="visible: !case_preload().length">
       {% trans "No properties will be loaded" %}
     </div>
-    <a href="#"
-       class="firstProperty btn btn-default"
-       data-bind="click: addPreload,
-                  visible: !case_preload().length">
-      <i class="fa fa-plus"></i>
-      {% trans "Load properties" %}
-    </a>
+    <div class="add-property">
+      <button class="btn btn-default" data-bind="click: addPreload">
+        <i class="fa fa-plus"></i>
+        {% trans "Add Property" %}
+      </button>
+    </div>
   </div>
 </script>
 
@@ -276,13 +275,12 @@
          data-bind="visible: !case_properties().length">
       {% trans "No properties will be saved" %}
     </div>
-    <a href="#"
-       class="firstProperty btn btn-default"
-       data-bind="click: addProperty,
-                  visible: !case_properties().length && $parent.hasPrivilege">
-      <i class="fa fa-plus"></i>
-      {% trans "Save properties" %}
-    </a>
+    <div class="add-property">
+      <button class="btn btn-default" data-bind="click: addProperty, visible: $parent.hasPrivilege">
+        <i class="fa fa-plus"></i>
+        {% trans "Add Property" %}
+      </button>
+    </div>
     <!-- ko if: !case_properties().length && !$parent.hasPrivilege -->
       <p>
         {% blocktrans %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -1,3 +1,4 @@
+{% load hq_shared_tags %}
 {% load i18n %}
 
 <script type="text/html"
@@ -187,6 +188,15 @@
         id="case-config:case-transaction:case-properties">
   <div class="panel-heading">
     <h4 class="panel-title panel-title-nolink">
+      <div class="pull-right"
+           style="max-width: 25%; margin-top: -5px;"
+           data-bind="visible: case_properties().length">
+        <search-box data-apply-bindings="false"
+                    params="value: case_property_query,
+                            action: goToPage,
+                            immediate: true,
+                            placeholder: '{% trans_html_attr "Search properties..." %}'"></search-box>
+      </div>
       <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
       {% trans "Save Questions to Case Properties" %}
     </h4>
@@ -207,7 +217,7 @@
       </tr>
       </thead>
 
-      <tbody data-bind="foreach: case_properties">
+      <tbody data-bind="foreach: visible_case_properties">
       <tr class="form-group"
           data-bind="css: {
                       'has-error': validate,
@@ -265,6 +275,13 @@
       </tr>
       </tbody>
     </table>
+    <div class="pull-right" data-bind="visible: filtered_case_properties().length">
+      <pagination data-apply-bindings="false"
+                  params="goToPage: goToPage,
+                          perPage: per_page,
+                          totalItems: total_case_properties,
+                          inlinePageListOnly: true"></pagination>
+    </div>
     <div class="alert alert-info"
          data-bind="visible: !case_properties().length">
       {% trans "No properties will be saved" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -283,6 +283,7 @@
                     params="goToPage: goToPage,
                             perPage: per_page,
                             totalItems: total_case_properties,
+                            resetFlag: pagination_reset_flag,
                             inlinePageListOnly: true"></pagination>
       </div>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/case_config_ko_templates.html
@@ -188,14 +188,16 @@
         id="case-config:case-transaction:case-properties">
   <div class="panel-heading">
     <h4 class="panel-title panel-title-nolink">
-      <div class="pull-right"
-           style="max-width: 25%; margin-top: -5px;"
-           data-bind="visible: case_properties().length">
-        <search-box data-apply-bindings="false"
-                    params="value: case_property_query,
-                            action: goToPage,
-                            immediate: true,
-                            placeholder: '{% trans_html_attr "Search properties..." %}'"></search-box>
+      <div data-bind="if: searchAndFilter">
+        <div class="pull-right"
+             style="max-width: 25%; margin-top: -5px;"
+             data-bind="visible: case_properties().length">
+          <search-box data-apply-bindings="false"
+                      params="value: case_property_query,
+                              action: goToPage,
+                              immediate: true,
+                              placeholder: '{% trans_html_attr "Search properties..." %}'"></search-box>
+        </div>
       </div>
       <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
       {% trans "Save Questions to Case Properties" %}
@@ -275,12 +277,14 @@
       </tr>
       </tbody>
     </table>
-    <div class="pull-right" data-bind="visible: filtered_case_properties().length">
-      <pagination data-apply-bindings="false"
-                  params="goToPage: goToPage,
-                          perPage: per_page,
-                          totalItems: total_case_properties,
-                          inlinePageListOnly: true"></pagination>
+    <div data-bind="if: searchAndFilter">
+      <div class="pull-right" data-bind="visible: filtered_case_properties().length">
+        <pagination data-apply-bindings="false"
+                    params="goToPage: goToPage,
+                            perPage: per_page,
+                            totalItems: total_case_properties,
+                            inlinePageListOnly: true"></pagination>
+      </div>
     </div>
     <div class="alert alert-info"
          data-bind="visible: !case_properties().length">

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/usercase_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/usercase_config.html
@@ -3,20 +3,7 @@
 
 <script type="text/html" id="usercase-config:case-transaction">
   <div class="row top-spacer">
-    <div class="panel panel-appmanager">
-      <div class="panel-heading">
-        <h4 class="panel-title panel-title-nolink">
-          <i class="fa fa-arrow-right"></i><i class="fa fa-save"></i>
-          {% trans "Load the following case properties into the form" %}
-        </h4>
-      </div>
-      <div class="panel-body">
-        <p>{% trans "User properties can now be loaded in the form builer with easy references" %}</p>
-        <p><img src="{% static 'app_manager/images/user-properties-loading-moved.png' %}"></p>
-      </div>
-    </div>
-    <div class="panel panel-appmanager"
-         data-bind="template: 'case-config:case-transaction:case-properties'"></div>
+    <div class="panel panel-appmanager" data-bind="template: 'case-config:case-transaction:case-properties'"></div>
   </div>
 </script>
 

--- a/corehq/apps/hqwebapp/static/app_manager/less/panel.less
+++ b/corehq/apps/hqwebapp/static/app_manager/less/panel.less
@@ -38,6 +38,10 @@
   .collapsing {
     overflow: hidden;
   }
+
+  .pagination {
+    margin: 0;
+  }
 }
 
 .panel-appmanager-form {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -3,6 +3,9 @@
  *
  *  Include the <pagination> element on on your knockout page with the following parameters:
  *      goToPage(page): A function that updates your view with new items for the given page.
+ *          Note that calling this function from within your code will not correctly jump to
+ *          the given page because it will not update the component's internal state. If you need
+ *          to programatically change pages, see resetFlag.
  *      perPage: A knockout observable that holds the number of items per page.
  *          This will be updated when the user changes the number of items using the dropdown.
  *          This should be used in your `goToPage` function to return the correct number of items.
@@ -20,6 +23,8 @@
  *          logic before loading, e.g., they aren't loaded until an ajax request brings back their content.
  *      itemsTextTemplate: Optional. A string that contains <%= firstItem %>, <%= lastItem %>, <%= maxItems %>
  *          which shows up next to the left of the limit dropdown.
+ *      resetFlag: Optional. An observable. If provided, this widget will subscribe to changes on this observable
+ *          and, on change, will go back to the first page.
  *
  *  See releases_table.html for an example.
  */
@@ -49,6 +54,11 @@ hqDefine('hqwebapp/js/components/pagination', [
                     if (self.slug) {
                         $.cookie(self.perPageCookieName, newValue, { expires: 365, path: '/' });
                     }
+                });
+            }
+            if (params.resetFlag) {
+                params.resetFlag.subscribe(function () {
+                    self.goToPage(1);
                 });
             }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/pagination.js
@@ -38,10 +38,6 @@ hqDefine('hqwebapp/js/components/pagination', [
             self.currentPage = ko.observable(self.currentPage || 1);
 
             self.totalItems = params.totalItems;
-            self.totalItems.subscribe(function (newValue) {
-                self.goToPage(1);
-            });
-
             self.slug = params.slug;
             self.inlinePageListOnly = !!params.inlinePageListOnly;
             self.perPage = ko.isObservable(params.perPage) ? params.perPage : ko.observable(params.perPage);

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/components/search_box.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/components/search_box.js
@@ -28,7 +28,9 @@ hqDefine('hqwebapp/js/components/search_box', [
             self.placeholder = params.placeholder || '';
             self.immediate = params.immediate;
 
-            self.clickAction = params.action;
+            self.clickAction = function () {
+                self.action();
+            };
             self.keypressAction = function (model, e) {
                 if (e.keyCode === 13) {
                     self.action();


### PR DESCRIPTION
##### SUMMARY
https://trello.com/c/P4BHcSVO/44-commcare-management-page-exceptionally-slow

https://dimagi-dev.atlassian.net/browse/SAAS-10925

Branches off of https://github.com/dimagi/commcare-hq/pull/27722, first new commit is "Removed some code related to case_preload".

##### RISK ASSESSMENT / QA PLAN
[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-1379)

##### PRODUCT DESCRIPTION
This adds a search box and pagination to the save case properties panel in form settings. It also alters the UI so that, instead of there always being a blank dropdown and case property text box at the end of the list, there's an "Add property" button.

Screenshot shows 5 items per page for the sake of making a small screenshot, but in reality there will be 25 properties per page.

New properties will be added to the current page, even if that means there are more than 25 on the current page. The properties will get readjusted the next time you change pages so there will again be 25 per page. When you remove properties, if you remove all properties on a page, you will get sent back to the first page.

![Screen Shot 2020-06-08 at 12 40 50 PM](https://user-images.githubusercontent.com/1486591/84057460-b58eca80-a985-11ea-9583-aca66d21f1b1.png)
