### PR TITLE
Fixed 'Go back to organization strucutre' link on the export_status page

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -1055,7 +1055,7 @@ class DownloadLocationStatusView(BaseLocationView):
             next_url = reverse(FilteredLocationDownload.urlname, args=[self.domain])
             next_url_text = _("Go back to organization download")
         else:
-            next_url = reverse("manage_locations", args=[self.domain])
+            next_url = reverse(LocationsListView.urlname, args=[self.domain])
             next_url_text = _("Go back to organization structure")
         context.update({
             'domain': self.domain,

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -1055,7 +1055,7 @@ class DownloadLocationStatusView(BaseLocationView):
             next_url = reverse(FilteredLocationDownload.urlname, args=[self.domain])
             next_url_text = _("Go back to organization download")
         else:
-            next_url = reverse("location_export", args=[self.domain])
+            next_url = reverse("manage_locations", args=[self.domain])
             next_url_text = _("Go back to organization structure")
         context.update({
             'domain': self.domain,


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10857

##### SUMMARY
The link called 'go back to organization structure' in the 'Download Organization Structure Status' page (export_status) was not working. It now correctly returns to the organization structure.

##### FEATURE FLAG
NA
##### RISK ASSESSMENT / QA PLAN
NA
##### PRODUCT DESCRIPTION
NA