### PR TITLE
fixes keyword update conflict

### DIFF
--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -124,7 +124,7 @@ class RecordListField(Field):
 
 class KeywordForm(Form):
     domain = None
-    survey_keyword_id = None
+    keyword_id = None
     keyword = CharField(label=ugettext_noop("Keyword"))
     description = TrimmedCharField(label=ugettext_noop("Description"))
     override_open_sessions = BooleanField(
@@ -212,6 +212,9 @@ class KeywordForm(Form):
     def __init__(self, *args, **kwargs):
         if 'domain' in kwargs:
             self.domain = kwargs.pop('domain')
+
+        if 'keyword_id' in kwargs:
+            self.keyword_id = kwargs.pop('keyword_id')
 
         self.process_structured_sms = False
         if 'process_structured' in kwargs:
@@ -460,7 +463,7 @@ class KeywordForm(Form):
         if len(value.split()) > 1:
             raise ValidationError(_("Keyword should be one word."))
         duplicate = Keyword.get_keyword(self.domain, value)
-        if duplicate and duplicate.couch_id != self.survey_keyword_id:
+        if duplicate and duplicate.couch_id != self.keyword_id:
             raise ValidationError(_("Keyword already exists."))
         return value
 

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -41,10 +41,6 @@ class AddStructuredKeywordView(BaseMessagingSectionView):
         return Keyword(domain=self.domain)
 
     @property
-    def keyword_form(self):
-        raise NotImplementedError("you must implement keyword_form")
-
-    @property
     def page_context(self):
         return {
             'form': self.keyword_form,
@@ -55,7 +51,8 @@ class AddStructuredKeywordView(BaseMessagingSectionView):
     def keyword_form(self):
         if self.request.method == 'POST':
             return KeywordForm(
-                self.request.POST, domain=self.domain,
+                self.request.POST,
+                domain=self.domain,
                 process_structured=self.process_structured_message,
             )
         return KeywordForm(
@@ -161,13 +158,17 @@ class EditStructuredKeywordView(AddStructuredKeywordView):
         initial = self.get_initial_values()
         if self.request.method == 'POST':
             form = KeywordForm(
-                self.request.POST, domain=self.domain, initial=initial,
+                self.request.POST,
+                domain=self.domain,
+                initial=initial,
+                keyword_id=self.keyword_id,
                 process_structured=self.process_structured_message,
             )
             form._sk_id = self.keyword_id
             return form
         return KeywordForm(
-            domain=self.domain, initial=initial,
+            domain=self.domain,
+            initial=initial,
             process_structured=self.process_structured_message,
         )
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=98&projectKey=SAAS&modal=detail&selectedIssue=SAAS-10912

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There was a bug where new keyword updates were getting a validation error because the keyword exists in the db. This is because the `couch_id` primary key in the db needs to be checked agains the form `keyword_id` to check that an update is happening, but the `keyword_id` was not being set. 

The fix grabs the `keyword_id` from the url route and populates the empty `keyword_id` so the check works. Also renames `survey_keyword_id` to `keyword_id` and removes a frivolous function.