### PR TITLE
add mirror domains to allowed web apps domains

### DIFF
--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -133,7 +133,7 @@ def _restoring_as_yourself(couch_user, as_user_obj):
 
 
 def _ensure_valid_domain(domain, couch_user):
-    if not couch_user.is_member_of(domain):
+    if not couch_user.is_member_of(domain, allow_mirroring=True):
         raise RestorePermissionDenied(_("{} was not in the domain {}").format(couch_user.username, domain))
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is Part 2 of https://github.com/dimagi/commcare-hq/pull/27742

It fixes two related issues that continued to prevent these users from using web apps. First, the session view was not returning the mirror domains to formplayer, which was causing formplayer to believe these users were not authorized for that domain. Second, the restore view also checks whether the web user is a member. That has been updated to allow mirror domains as well.