### PR TITLE
fix BadValueError when FilterSpec.wrap is called

### DIFF
--- a/corehq/apps/userreports/reports/filters/specs.py
+++ b/corehq/apps/userreports/reports/filters/specs.py
@@ -86,7 +86,7 @@ class FilterSpec(JsonObject):
         if 'pre_value' in doc:
             pre_value = doc['pre_value']
             data_type = doc['datatype']
-            if data_type == 'string' and type(pre_value) != 'str':
+            if data_type == 'string':
                 doc['pre_value'] = str(pre_value)
 
         return super().wrap(*args, **kwargs)

--- a/corehq/apps/userreports/reports/filters/specs.py
+++ b/corehq/apps/userreports/reports/filters/specs.py
@@ -76,6 +76,21 @@ class FilterSpec(JsonObject):
     def get_display(self):
         return self.display or self.slug
 
+    @classmethod
+    def wrap(cls, *args, **kwargs):
+        # Because pre_value is set to DefaultProperty, pre_value is automatically
+        # interpreted to be a datatype when it's fetched by jsonobject.
+        # This fails hard when the spec expects a string
+        # and gets something else...like a date.
+        doc = args[0]
+        if 'pre_value' in doc:
+            pre_value = doc['pre_value']
+            data_type = doc['datatype']
+            if data_type == 'string' and type(pre_value) != 'str':
+                doc['pre_value'] = str(pre_value)
+
+        return super().wrap(*args, **kwargs)
+
 
 class DateFilterSpec(FilterSpec):
     compare_as_string = BooleanProperty(default=False)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10688

##### SUMMARY
when wrapping a doc that has a `date`-type looking object (like `2019-09-14`), `jsonobject` already parses the original string as a `datetime.date`—because the `pre_value` field is set to be a `DefaultProperty` type (I'm not sure why so I didn't change this)—and this formatted value is passed in the `args` of `wrap`. This makes sure that if `pre_value` is expected to be a `string`, then force it to be a string.