### PR TITLE
Fix SESSION_COOKIE_SECURE & CSRF_COOKIE_SECURE values

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -962,9 +962,6 @@ REQUIRE_TWO_FACTOR_FOR_SUPERUSERS = False
 # that adds messages to the partition with the fewest unprocessed messages
 USE_KAFKA_SHORTEST_BACKLOG_PARTITIONER = False
 
-SESSION_COOKIE_SECURE = CSRF_COOKIE_SECURE = not DEBUG
-SESSION_COOKIE_HTTPONLY = CSRF_COOKIE_HTTPONLY = True
-
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)
@@ -994,6 +991,13 @@ if callable(COMPRESS_ENABLED):
     COMPRESS_ENABLED = COMPRESS_ENABLED()
 if callable(COMPRESS_OFFLINE):
     COMPRESS_OFFLINE = COMPRESS_OFFLINE()
+
+# These default values can't be overridden.
+# Should you someday need to do so, use the lambda/if callable pattern above
+SESSION_COOKIE_SECURE = CSRF_COOKIE_SECURE = lambda: not DEBUG
+SESSION_COOKIE_HTTPONLY = CSRF_COOKIE_HTTPONLY = True
+
+
 if UNIT_TESTING:
     # COMPRESS_COMPILERS overrides COMPRESS_ENABLED = False, so must be
     # cleared to disable compression completely. CSS/less compression is


### PR DESCRIPTION
was previously being always set to False.

##### SUMMARY
Originally introduced in https://github.com/dimagi/commcare-hq/pull/27514, broken shortly after (with all good intentions) in https://github.com/dimagi/commcare-hq/pull/27568

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
