### PR TITLE
Upgrade travis OS to 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python: 2.7
+os: linux
+dist: bionic
 sudo: required
 group: edge
 branches:


### PR DESCRIPTION
Elasticssearch 7 docker image is having some bugs on 16.04 and works okay on 18.04. So upgrading the image here in a separate PR to see build times apart from the ES7 PR.