### PR TITLE
Added cast to string when looking up couch doc by id during couch to …

### DIFF
--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -185,7 +185,7 @@ class SyncSQLToCouchMixin(object):
         if not self._migration_couch_id:
             return None
         cls = self._migration_get_couch_model_class()
-        return cls.get(self._migration_couch_id)
+        return cls.get(str(self._migration_couch_id))
 
     def _migration_get_or_create_couch_object(self):
         cls = self._migration_get_couch_model_class()


### PR DESCRIPTION
…sql sync

Fixes https://sentry.io/organizations/dimagi/issues/1716775559/ which has thus far only happened on staging.

Caused by https://github.com/dimagi/commcare-hq/pull/27516/ because the new sql model's id is a real UUID, so using it to look up the corresponding couch document by id is failing.