### PR TITLE
fix var name

### DIFF
--- a/corehq/util/model_log.py
+++ b/corehq/util/model_log.py
@@ -28,9 +28,9 @@ def log_model_change(user, model_object, message=None, fields_changed=None):
 
     return LogEntry.objects.log_action(
         user_id=user.pk,
-        content_type_id=get_content_type_for_model(object).pk,
+        content_type_id=get_content_type_for_model(model_object).pk,
         object_id=model_object.pk,
-        object_repr=force_text(object),
+        object_repr=force_text(model_object),
         action_flag=CHANGE,
         change_message=message,
     )


### PR DESCRIPTION
I am not sure how this survived for this long
https://github.com/dimagi/commcare-hq/pull/27262/files#diff-72e53f486b6679169cfd1887ab20a264R31
There is a definite exception currently.

```
File "/Users/manishkangia/.virtualenvs/commcare-hq/lib/python3.6/site-packages/django/contrib/admin/options.py", line 64, in get_content_type_for_model
    return ContentType.objects.get_for_model(obj, for_concrete_model=False)
  File "/Users/manishkangia/.virtualenvs/commcare-hq/lib/python3.6/site-packages/django/contrib/contenttypes/models.py", line 43, in get_for_model
    opts = self._get_opts(model, for_concrete_model)
  File "/Users/manishkangia/.virtualenvs/commcare-hq/lib/python3.6/site-packages/django/contrib/contenttypes/models.py", line 31, in _get_opts
    return model._meta
AttributeError: type object 'object' has no attribute '_meta'
```
