### PR TITLE
Bulk modify web users

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -401,6 +401,10 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
                 user.save()
 
                 if web_user:
+                    if not upload_user.can_edit_web_users():
+                        raise UserUploadError(_(
+                            "Only users with the edit web users permission can upload web users"
+                        )
                     current_user = CouchUser.get_by_username(web_user)
                     if remove_web_user:
                         if not current_user or not current_user.is_member_of(domain):

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -437,7 +437,10 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
                         elif current_user.is_member_of(domain):
                             # edit existing user in the domain
                             current_user.set_role(domain, role_qualified_id)
-                            current_user.set_location(user.location_id)
+                            if user.location_id:
+                                current_user.set_location(domain, user.location_id)
+                            else:
+                                current_user.unset_location(domain)
 
                 if send_account_confirmation_email and not web_user:
                     send_account_confirmation_if_necessary(user)

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -413,6 +413,7 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
                             ))
                         else:
                             current_user.delete_domain_membership(domain)
+                            current_user.save()
                     else:
                         if not role:
                             raise UserUploadError(_(
@@ -445,6 +446,7 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
                                 current_user.set_location(domain, user.location_id)
                             else:
                                 current_user.unset_location(domain)
+                            current_user.save()
 
                 if send_account_confirmation_email and not web_user:
                     send_account_confirmation_if_necessary(user)

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -414,6 +414,10 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
                         else:
                             current_user.delete_domain_membership(domain)
                     else:
+                        if not role:
+                            raise UserUploadError(_(
+                                f"You cannot upload a web user without a role. {web_user} does not have a role"
+                            ))
                         if not current_user and is_account_confirmed:
                             raise UserUploadError(_(
                                 f"You can only set 'Is Account Confirmed' to 'True' on an existing Web User. {web_user} is a new username."

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -404,7 +404,7 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
                     if not upload_user.can_edit_web_users():
                         raise UserUploadError(_(
                             "Only users with the edit web users permission can upload web users"
-                        )
+                        ))
                     current_user = CouchUser.get_by_username(web_user)
                     if remove_web_user:
                         if not current_user or not current_user.is_member_of(domain):

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -35,7 +35,7 @@ allowed_headers = set([
     'uncategorized_data', 'user_id', 'is_active', 'is_account_confirmed', 'send_confirmation_email',
     'location_code', 'role',
     'User IMEIs (read only)', 'registered_on (read only)', 'last_submission (read only)',
-    'last_sync (read only)', 'web_user'
+    'last_sync (read only)', 'web_user', 'remove_web_user'
 ]) | required_headers
 old_headers = {
     # 'old_header_name': 'new_header_name'
@@ -327,6 +327,7 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
                 is_active = spec_value_to_boolean_or_none(row, 'is_active')
                 is_account_confirmed = spec_value_to_boolean_or_none(row, 'is_account_confirmed')
                 send_account_confirmation_email = spec_value_to_boolean_or_none(row, 'send_confirmation_email')
+                remove_web_user = spec_value_to_boolean_or_none(row, 'remove_web_user')
 
                 if user_id:
                     user = CommCareUser.get_by_user_id(user_id, domain)
@@ -401,25 +402,38 @@ def create_or_update_users_and_groups(domain, user_specs, upload_user, group_mem
 
                 if web_user:
                     current_user = CouchUser.get_by_username(web_user)
-                    if not current_user and is_account_confirmed:
-                        raise UserUploadError(_(
-                            f"You can only set 'Is Account Confirmed' to 'True' on an existing Web User. {web_user} is a new username."
-                        ))
-                    if current_user and not current_user.is_member_of(domain) and is_account_confirmed:
-                        current_user.add_as_web_user(domain, role=role_qualified_id, location_id=user.location_id)
-                    elif not current_user or not current_user.is_member_of(domain):
-                        invite_data = {
-                            'email': web_user,
-                            'invited_by': upload_user.user_id,
-                            'invited_on': datetime.utcnow(),
-                            'domain': domain,
-                            'role': role_qualified_id,
-                            'supply_point': user.location_id
-                        }
-                        invite = Invitation(**invite_data)
-                        invite.save()
-                        if send_account_confirmation_email:
-                            invite.send_activation_email()
+                    if remove_web_user:
+                        if not current_user or not current_user.is_member_of(domain):
+                            raise UserUploadError(_(
+                                f"You cannot remove a web user that is not a member of this project. {web_user} is not a member."
+                            ))
+                        else:
+                            current_user.delete_domain_membership(domain)
+                    else:
+                        if not current_user and is_account_confirmed:
+                            raise UserUploadError(_(
+                                f"You can only set 'Is Account Confirmed' to 'True' on an existing Web User. {web_user} is a new username."
+                            ))
+                        if current_user and not current_user.is_member_of(domain) and is_account_confirmed:
+                            current_user.add_as_web_user(domain, role=role_qualified_id, location_id=user.location_id)
+                        elif not current_user or not current_user.is_member_of(domain):
+                            invite_data = {
+                                'email': web_user,
+                                'invited_by': upload_user.user_id,
+                                'invited_on': datetime.utcnow(),
+                                'domain': domain,
+                                'role': role_qualified_id,
+                                'supply_point': user.location_id
+                            }
+                            invite = Invitation(**invite_data)
+                            invite.save()
+                            if send_account_confirmation_email:
+                                invite.send_activation_email()
+
+                        elif current_user.is_member_of(domain):
+                            # edit existing user in the domain
+                            current_user.set_role(domain, role_qualified_id)
+                            current_user.set_location(user.location_id)
 
                 if send_account_confirmation_email and not web_user:
                     send_account_confirmation_if_necessary(user)

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -337,7 +337,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         self.assertTrue(mock_invite.send_activation_email.called)
 
     @mock.patch('corehq.apps.user_importer.importer.Invitation')
-    def test_upload_add_web_user(self, mock_invitation):
+    def test_upload_add_web_user(self, mock_invitation_class):
         username = 'a@a.com'
         web_user = WebUser.create(self.other_domain.name, username, 'password')
         mock_invite = mock_invitation_class.return_value

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -324,7 +324,8 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
                 self._get_spec(
                     web_user='a@a.com',
                     is_account_confirmed='False',
-                    send_confirmation_email='True'
+                    send_confirmation_email='True',
+                    role=self.role.name
                 )
             ],
             [],
@@ -338,7 +339,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         web_user = WebUser.create('other-domain', username, 'password')
         import_users_and_groups(
             self.domain.name,
-            [self._get_spec(web_user='a@a.com', is_account_confirmed='True')],
+            [self._get_spec(web_user='a@a.com', is_account_confirmed='True', role=self.role.name)],
             [],
             mock.MagicMock()
         )

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -38,12 +38,6 @@ logger = get_task_logger(__name__)
 
 
 @task(serializer='pickle')
-def bulk_upload_async(domain, user_specs, group_specs):
-    # remove this after deploying `import_users_and_groups`
-    return import_users_and_groups(domain, user_specs, group_specs)
-
-
-@task(serializer='pickle')
 def bulk_download_usernames_async(domain, download_id, user_filters):
     from corehq.apps.users.bulk_download import dump_usernames
     dump_usernames(domain, download_id, user_filters, bulk_download_usernames_async)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This lets users modify or remove web users via mobile worker bulk upload https://trello.com/c/tGCvDxgu/61-enterprise-user-management-ability-to-de-provision-users

The second commit is unrelated cleanup that I found when looking through this code.

Commit 1 should be reviewed with `?w=1`