### PR TITLE
allow filtering by domain

### DIFF
--- a/corehq/blobs/management/commands/run_blob_migration.py
+++ b/corehq/blobs/management/commands/run_blob_migration.py
@@ -74,6 +74,7 @@ class Command(BaseCommand):
                 "parameter. Example value: 20180109-20190109"
             ),
         )
+        add_argument('--domain', help="Limit migration to a single domain")
         add_argument(
             '--process_day_by_day',
             action='store_true',


### PR DESCRIPTION
##### SUMMARY
Specifically for CAS it makes sense to filter on domain since there is a special index on `type_code, created_on` when `domain = 'icds-cas'
