### PR TITLE
Extend existing BlobDB dumps

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -11,8 +11,8 @@ from .targzipdb import TarGzipBlobDB
 
 class BlobDbBackendExporter(object):
 
-    def __init__(self, filename):
-        self.db = TarGzipBlobDB(filename)
+    def __init__(self, filename, extends):
+        self.db = TarGzipBlobDB(filename, extends)
         self.total_blobs = 0
         self.not_found = 0
 
@@ -45,7 +45,8 @@ class BlobExporter(ABC):
     def slug(self):
         raise NotImplementedError
 
-    def migrate(self, filename, chunk_size=100, limit_to_db=None, force=False):
+    def migrate(self, filename, chunk_size=100, limit_to_db=None, extends=(),
+                force=False):
         if not self.domain:
             raise ExportError("Must specify domain")
 
@@ -55,7 +56,7 @@ class BlobExporter(ABC):
                 "To re-run the export use 'reset'".format(self.slug)
             )
 
-        migrator = BlobDbBackendExporter(filename)
+        migrator = BlobDbBackendExporter(filename, extends)
         with migrator:
             self._migrate(migrator, chunk_size, limit_to_db)
         print("Processed {} {} objects".format(migrator.total_blobs, self.slug))

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -39,12 +39,16 @@ class Command(BaseCommand):
         parser.add_argument('--limit-to-db', dest='limit_to_db',
                             help="When specifying a SQL importer use this to restrict "
                                  "the exporter to a single database.")
+        parser.add_argument('--extend', dest='extends', action='append', default=[],
+                            help='Extend a previous export file. '
+                                 'You can extend multiple files.')
 
     @change_log_level('boto3', logging.WARNING)
     @change_log_level('botocore', logging.WARNING)
     def handle(self, domain=None, reset=False,
                chunk_size=100, all=None, limit_to_db=None, **options):
         exporters = options.get('exporters')
+        extends = options.get('extends')
 
         if not domain:
             raise CommandError(USAGE)
@@ -65,6 +69,11 @@ class Command(BaseCommand):
                                    f"Remove the file and re-run the command.")
 
             exporter = exporter_cls(domain)
-            total, skips = exporter.migrate(export_filename, chunk_size=chunk_size, limit_to_db=limit_to_db)
+            total, skips = exporter.migrate(
+                export_filename,
+                chunk_size=chunk_size,
+                limit_to_db=limit_to_db,
+                extends=extends,
+            )
             if skips:
                 sys.exit(skips)

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
     def handle(self, domain=None, reset=False,
                chunk_size=100, all=None, limit_to_db=None, **options):
         exporters = options.get('exporters')
-        extends = options.get('extends')
+        extends = options['extends']
 
         if not domain:
             raise CommandError(USAGE)
@@ -63,7 +63,7 @@ class Command(BaseCommand):
                 raise CommandError(USAGE)
 
             self.stdout.write("\nRunning exporter: {}\n{}".format(exporter_slug, '-' * 50))
-            export_filename = get_export_filename(exporter_slug, domain)
+            export_filename = get_export_filename(exporter_slug, domain, extends)
             if os.path.exists(export_filename):
                 raise CommandError(f"Export file '{export_filename}' exists. "
                                    f"Remove the file and re-run the command.")

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -65,5 +65,30 @@ class TarGzipBlobDB(AbstractBlobDB):
         raise NotImplementedError
 
 
-def get_export_filename(slug, domain):
-    return f'export-{domain}-{slug}-blobs.tar.gz'
+def get_export_filename(slug, domain, extends):
+    """
+    Returns a filename that includes filenames in ``extends``
+
+    >>> get_export_filename('multimedia', 'domain',
+    ...                     ['oldexport.tar.gz', 'olderexport.tar.gz'])
+    'export-domain-multimedia-blobs-extends-oldexport+olderexport.tar.gz'
+
+    """
+    filenames = [strip_tar_gz(f) for f in extends]
+    _extends = '-extends-' + '+'.join(filenames) if filenames else ''
+    return f'export-{domain}-{slug}-blobs{_extends}.tar.gz'
+
+
+def strip_tar_gz(filename):
+    """
+    Strips ".tar.gz" extensions.
+
+    >>> strip_tar_gz('spam.tar.gz')
+    'spam'
+    >>> strip_tar_gz('spam.ham')
+    'spam.ham'
+
+    """
+    if filename.endswith('.tar.gz'):
+        return filename[:-7]
+    return filename


### PR DESCRIPTION
##### SUMMARY
Implements a suggestion by @esoergel to add new dump files that extend existing dump files, instead of appending, which is slow to do for tar.gz files using Python's tarfile library.

Also follows up on [a comment](https://github.com/dimagi/commcare-hq/pull/27747#discussion_r437733650) by @millerdev about the `TarGzipBlobDB.exists()` method.


##### RISK ASSESSMENT / QA PLAN
Low risk. No QA required.


##### PRODUCT DESCRIPTION
Allows migrations to new hosting environments to extend exports of attachments with attachments added since the last export.
