### PR TITLE
Dump BlobMeta as uncompressed

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -8,11 +8,12 @@ from django.db import router
 from corehq.apps.dump_reload.exceptions import DomainDumpError
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
+    BlobMetaIteratorBuilder,
     FilteredModelIteratorBuilder,
     SimpleFilter,
     UniqueFilteredModelIteratorBuilder,
     UserIDFilter,
-    UsernameFilter
+    UsernameFilter,
 )
 from corehq.apps.dump_reload.sql.serialization import JsonLinesSerializer
 from corehq.apps.dump_reload.util import get_model_label, get_model_class
@@ -22,7 +23,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
 [APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP[iterator.model_label].append(iterator) for iterator in [
     FilteredModelIteratorBuilder('locations.LocationType', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('locations.SQLLocation', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('blobs.BlobMeta', SimpleFilter('domain')),
+    BlobMetaIteratorBuilder('blobs.BlobMeta', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.XFormInstanceSQL', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('form_processor.XFormOperationSQL', SimpleFilter('form__domain')),
     FilteredModelIteratorBuilder('form_processor.CommCareCaseSQL', SimpleFilter('domain')),

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -105,3 +105,19 @@ class UniqueFilteredModelIteratorBuilder(FilteredModelIteratorBuilder):
         querysets = self.querysets()
         for querysets in querysets:
             yield _unique(querysets)
+
+
+class BlobMetaIteratorBuilder(FilteredModelIteratorBuilder):
+    """
+    When blobs are exported they are not compressed. By setting
+    ``BlobMeta.compressed_length`` to ``None`` we cause
+    ``BlobMeta.is_compressed`` to return False.
+    """
+    def iterators(self):
+        def reset_compressed_length(queryset):
+            for blob_meta in queryset:
+                blob_meta.compressed_length = None
+                yield blob_meta
+
+        for queryset in self.querysets():
+            yield reset_compressed_length(queryset)


### PR DESCRIPTION
Opening as a draft PR to confirm that I'm approaching this the right way.

`TarGzipBlobDB.copy_blob()` cannot change meta for the blobs it is exporting, because the meta must still be true for the blobs in the source environment.

So the approach I have taken is to change the blob meta as it's being dumped from Postgres.

Am I right in believing that when the blobs are loaded in the destination environment, `FooBlobDB.copy_blob()` would need to know to update blob meta if the blob will be compressed. I'm thinking I should change the method signature for `AbstractBlobDB.copy_blob()` to accept a "update_meta" boolean param, which, if set, subclasses must update the blob meta with the compressed length of the new blob.

This could duplicate code that is currently in the `put()` method, so I'll refactor that if necessary.


##### SUMMARY
Fixes `BlobMeta.compressed_length` for migrated blobs.


##### RISK ASSESSMENT / QA PLAN
*Open to suggestions here.*
