### PR TITLE
do not force password if web user

### DIFF
--- a/corehq/apps/user_importer/validation.py
+++ b/corehq/apps/user_importer/validation.py
@@ -183,9 +183,10 @@ class NewUserPasswordValidator(ImportValidator):
         user_id = spec.get('user_id')
         password = spec.get('password')
         is_account_confirmed = spec_value_to_boolean_or_none(spec, 'is_account_confirmed')
+        web_user = spec.get('web_user')
 
         # explicitly check is_account_confirmed against False because None is the default
-        if not user_id and not is_password(password) and is_account_confirmed is not False:
+        if not user_id and not is_password(password) and is_account_confirmed is not False and not web_user:
             return self.error_message
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We do not want to force users to create mobile worker passwords if they are uploading a web user. That way web users can be directly added even for mobile workers that will not be authenticated.