### PR TITLE
Moved last_visited_domain from request to cache

### DIFF
--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -1,11 +1,9 @@
-# Use modern Python
-
 from django.template.response import TemplateResponse
-# External imports
 from django.utils.deprecation import MiddlewareMixin
 
+from dimagi.utils.couch.cache import cache_core
+
 from corehq.apps.accounting.models import DefaultProductPlan, Subscription
-from corehq.apps.domain.models import DomainAuditRecordEntry
 from corehq.toggles import DATA_MIGRATION
 
 
@@ -49,13 +47,31 @@ class DomainHistoryMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         if hasattr(request, 'domain') and getattr(response, '_remember_domain', True):
-            self.remember_domain_visit(request, response)
+            self.remember_domain_visit(request)
         return response
 
-    def remember_domain_visit(self, request, response):
-        last_visited_domain = request.session.get('last_visited_domain')
-        if last_visited_domain != request.domain:
-            request.session['last_visited_domain'] = request.domain
+    def remember_domain_visit(self, request):
+        if hasattr(request, 'couch_user') and request.couch_user:
+            last_visited_domain = get_last_visited_domain(request.couch_user)
+            if last_visited_domain != request.domain:
+                set_last_visited_domain(request.couch_user, request.domain)
+
+
+def get_last_visited_domain(couch_user):
+    client = cache_core.get_redis_client()
+    return client.get(_last_visited_domain_cache_key(couch_user))
+
+
+def set_last_visited_domain(couch_user, domain):
+    client = cache_core.get_redis_client()
+    cache_expiration = 60 * 60 * 24
+    cache_key = _last_visited_domain_cache_key(couch_user)
+    client.set(cache_key, domain)
+    client.expire(cache_key, cache_expiration)
+
+
+def _last_visited_domain_cache_key(couch_user):
+    return 'last-visited-domain-%s' % couch_user.username
 
 
 class DomainMigrationMiddleware(MiddlewareMixin):

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -52,9 +52,7 @@ class DomainHistoryMiddleware(MiddlewareMixin):
 
     def remember_domain_visit(self, request):
         if hasattr(request, 'couch_user') and request.couch_user:
-            last_visited_domain = get_last_visited_domain(request.couch_user)
-            if last_visited_domain != request.domain:
-                set_last_visited_domain(request.couch_user, request.domain)
+            set_last_visited_domain(request.couch_user, request.domain)
 
 
 def get_last_visited_domain(couch_user):

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -64,7 +64,7 @@ def get_last_visited_domain(couch_user):
 
 def set_last_visited_domain(couch_user, domain):
     client = cache_core.get_redis_client()
-    cache_expiration = 60 * 60 * 24
+    cache_expiration = 60 * 60 * 24 * 7
     cache_key = _last_visited_domain_cache_key(couch_user)
     client.set(cache_key, domain)
     client.expire(cache_key, cache_expiration)

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -64,8 +64,7 @@ def set_last_visited_domain(couch_user, domain):
     client = cache_core.get_redis_client()
     cache_expiration = 60 * 60 * 24 * 7
     cache_key = _last_visited_domain_cache_key(couch_user)
-    client.set(cache_key, domain)
-    client.expire(cache_key, cache_expiration)
+    client.set(cache_key, domain, timeout=cache_expiration)
 
 
 def _last_visited_domain_cache_key(couch_user):

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -27,35 +27,24 @@
       </h3>
     </div>
     <div class="panel-body">
-      <table class="table table-striped table-responsive">
-        <thead>
-          <tr>
-            <th>{% trans 'Project Name' %}
-            </th>
-          </tr>
-        </thead>
-        <tbody data-bind="foreach: invitationLinks">
-          <tr>
-            <td>
-              
-              <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
-                <i class='fa fa-envelope'>
-                </i>
-                {% trans "Accept" %}
-              </a>
-              <!-- ko text: display_name -->
-              <!-- /ko -->
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul class="list-unstyled" data-bind="foreach: invitationLinks">
+        <li style="padding-bottom: 6px;">
+          <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
+            <i class='fa fa-envelope'>
+            </i>
+            {% trans "Accept" %}
+          </a>
+          <!-- ko text: display_name -->
+          <!-- /ko -->
+        </li>
+      </ul>
     </div>
   </div>
   <div class="panel panel-default">
     <div class="panel-heading ">
       <div class="row">
         <div class="col-sm-6">
-          <h3 class="panel-title">
+          <h3 class="panel-title" style="padding-top: 7px;">
             {% trans 'My Projects' %}
           </h3>
         </div>
@@ -70,23 +59,11 @@
       </div>
     </div>
     <div class="panel-body">
-      <table class="table table-striped table-responsive">
-        <thead>
-          <tr>
-            <th>{% trans 'Project Name' %}
-            </th>
-          </tr>
-        </thead>
-        <tbody data-bind="foreach: domainLinks">
-          <tr>
-            <td>
-              <a data-bind="attr: {href: url}, text: display_name">
-              </a>
-            </td>
-          </tr>
-        </tbody>
-        
-      </table>
+      <ul class="nav nav-pills nav-stacked" data-bind="foreach: domainLinks">
+        <li>
+          <a data-bind="attr: {href: url}, text: display_name"></a>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -18,6 +18,7 @@ from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.utils import send_confirmation_email
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.users.models import Invitation
+from corehq.apps.domain.middleware import get_last_visited_domain, set_last_visited_domain
 from corehq.util.quickcache import quickcache
 
 
@@ -56,7 +57,7 @@ def select(request, do_not_redirect=False, next_view=None):
     }
 
     domain_select_template = "domain/select.html"
-    last_visited_domain = request.session.get('last_visited_domain')
+    last_visited_domain = get_last_visited_domain(request.couch_user)
     if open_invitations \
        or do_not_redirect \
        or not last_visited_domain:
@@ -76,7 +77,7 @@ def select(request, do_not_redirect=False, next_view=None):
                 except Http404:
                     pass
 
-        del request.session['last_visited_domain']
+        set_last_visited_domain(request.couch_user, None)
         return render(request, domain_select_template, additional_context)
 
 


### PR DESCRIPTION
##### SUMMARY
Because last visited domain is stored in the request, it gets cleared on logout. Move it to redis so works better for users affected by the shortened inactivity timeout.

UI updates are minor followup for https://github.com/dimagi/commcare-hq/pull/27708, discussed with Cal.

##### RISK ASSESSMENT / QA PLAN
Minor, no QA.

##### PRODUCT DESCRIPTION
Not worth announcing.
