### PR TITLE
add case filter for location with descendants

### DIFF
--- a/corehq/apps/userreports/reports/builder/const.py
+++ b/corehq/apps/userreports/reports/builder/const.py
@@ -1,6 +1,7 @@
 COMPUTED_USER_NAME_PROPERTY_ID = "computed/user_name"
 COMPUTED_OWNER_NAME_PROPERTY_ID = "computed/owner_name"
 COMPUTED_OWNER_LOCATION_PROPERTY_ID = "computed/owner_location"
+COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID = "computed/owner_location_with_descendants"
 
 UI_AGG_AVERAGE = "Average"
 UI_AGG_COUNT_PER_CHOICE = "Count per Choice"

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -55,6 +55,7 @@ from corehq.apps.userreports.reports.builder.columns import (
 )
 from corehq.apps.userreports.reports.builder.const import (
     COMPUTED_OWNER_LOCATION_PROPERTY_ID,
+    COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
     COMPUTED_OWNER_NAME_PROPERTY_ID,
     COMPUTED_USER_NAME_PROPERTY_ID,
     PROPERTY_TYPE_CASE_PROP,
@@ -169,7 +170,9 @@ class DataSourceProperty(object):
         elif self._type == PROPERTY_TYPE_META:
             return FormMetaColumnOption(self._id, self._data_types, self._text, self._source)
         elif self._type == PROPERTY_TYPE_CASE_PROP:
-            if self._id == COMPUTED_OWNER_NAME_PROPERTY_ID or self._id == COMPUTED_OWNER_LOCATION_PROPERTY_ID:
+            if self._id in (
+                    COMPUTED_OWNER_NAME_PROPERTY_ID, COMPUTED_OWNER_LOCATION_PROPERTY_ID,
+                    COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID):
                 return OwnernameComputedCasePropertyOption(self._id, self._data_types, self._text)
             elif self._id == COMPUTED_USER_NAME_PROPERTY_ID:
                 return UsernameComputedCasePropertyOption(self._id, self._data_types, self._text)
@@ -230,6 +233,8 @@ class DataSourceProperty(object):
             filter.update({"choice_provider": {"type": "user"}})
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_LOCATION_PROPERTY_ID:
             filter.update({"choice_provider": {"type": "location"}})
+        if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID:
+            filter.update({"choice_provider": {"type": "location", "include_descendants": True}})
         if configuration.get('pre_value') or configuration.get('pre_operator'):
             filter.update({
                 'type': 'pre',  # type could have been "date"
@@ -573,6 +578,8 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
 
         if SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER.enabled(self.domain):
             properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID] = self._get_owner_location_pseudo_property()
+            properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID] = \
+                self._get_owner_location_with_descendants_pseudo_property()
         return properties
 
     @staticmethod
@@ -597,6 +604,17 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
             id=COMPUTED_OWNER_LOCATION_PROPERTY_ID,
             text=_('Case Owner (Location)'),
             source=COMPUTED_OWNER_LOCATION_PROPERTY_ID,
+            data_types=["string"],
+        )
+
+    @classmethod
+    def _get_owner_location_with_descendants_pseudo_property(cls):
+        # similar to the location property but also include descendants
+        return DataSourceProperty(
+            type=PROPERTY_TYPE_CASE_PROP,
+            id=COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
+            text=_('Case Owner (Location w/ Descendants)'),
+            source=COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
             data_types=["string"],
         )
 

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -139,7 +139,7 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
         self.assertEqual(COMPUTED_OWNER_LOCATION_PROPERTY_ID, owner_location_prop.get_id())
         self.assertEqual('Case Owner (Location)', owner_location_prop.get_text())
         owner_location_prop_w_descendants = \
-            builder.data_source_properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID ]
+            builder.data_source_properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID]
         self.assertEqual(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
                          owner_location_prop_w_descendants.get_id())
         self.assertEqual('Case Owner (Location w/ Descendants)', owner_location_prop_w_descendants.get_text())

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -22,6 +22,7 @@ from corehq.apps.userreports.reports.builder.columns import (
     MultiselectQuestionColumnOption,
 )
 from corehq.apps.userreports.reports.builder.const import COMPUTED_OWNER_LOCATION_PROPERTY_ID
+from corehq.apps.userreports.reports.builder.const import COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID
 from corehq.apps.userreports.reports.builder.forms import (
     ConfigureListReportForm,
     ConfigureTableReportForm,
@@ -133,9 +134,15 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
     def test_owner_as_location(self):
         builder = DataSourceBuilder(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
         self.assertTrue(COMPUTED_OWNER_LOCATION_PROPERTY_ID in builder.data_source_properties)
+        self.assertTrue(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID in builder.data_source_properties)
         owner_location_prop = builder.data_source_properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID]
         self.assertEqual(COMPUTED_OWNER_LOCATION_PROPERTY_ID, owner_location_prop.get_id())
         self.assertEqual('Case Owner (Location)', owner_location_prop.get_text())
+        owner_location_prop_w_descendants = \
+            builder.data_source_properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID ]
+        self.assertEqual(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
+                         owner_location_prop_w_descendants.get_id())
+        self.assertEqual('Case Owner (Location w/ Descendants)', owner_location_prop_w_descendants.get_text())
 
 
 class DataSourceReferenceTest(ReportBuilderDBTest):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1168,7 +1168,6 @@ SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER = StaticToggle(
     'This can be used to create report builder reports that are location-safe.',
     TAG_SOLUTIONS_OPEN,
     [NAMESPACE_DOMAIN],
-    help_link='https://confluence.dimagi.com/display/internal/Demo+Mobile+Workers',
 )
 
 MOBILE_USER_DEMO_MODE = StaticToggle(


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

https://dimagi-dev.atlassian.net/browse/SAAS-10890

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
Show an additional "Owner (Location)" property in report builder reports.

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
:shipit: 
##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Adds another choice to the dropdown ("Case Owner (Location w/ Descendants)") which turns on include_descendants in the filter.
