### PR TITLE
Tests on ES2

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -747,7 +747,7 @@ SUMOLOGIC_URL = None
 # on both a single instance or distributed setup this should assume localhost
 ELASTICSEARCH_HOST = 'localhost'
 ELASTICSEARCH_PORT = 9200
-ELASTICSEARCH_MAJOR_VERSION = 1
+ELASTICSEARCH_MAJOR_VERSION = 2
 # If elasticsearch queries take more than this, they result in timeout errors
 ES_SEARCH_TIMEOUT = 30
 


### PR DESCRIPTION
It looks like our travis is ES2 but the tests use ES interface 1 due to this setting not being updated.