### PR TITLE
Don't include case name column in emailed reports

### DIFF
--- a/corehq/apps/reports/standard/cases/case_list_explorer.py
+++ b/corehq/apps/reports/standard/cases/case_list_explorer.py
@@ -106,6 +106,12 @@ class CaseListExplorer(CaseListReport):
 
     @property
     def columns(self):
+        view_case_column = DataTablesColumn(
+            _("View Case"),
+            prop_name='_link',
+            sortable=False,
+        )
+
         if self._is_exporting:
             persistent_cols = [
                 DataTablesColumn(
@@ -114,6 +120,8 @@ class CaseListExplorer(CaseListReport):
                     sortable=True,
                 )
             ]
+        elif self.is_rendered_as_email:
+            persistent_cols = [view_case_column]
         else:
             persistent_cols = [
                 DataTablesColumn(
@@ -122,11 +130,7 @@ class CaseListExplorer(CaseListReport):
                     sortable=True,
                     visible=False,
                 ),
-                DataTablesColumn(
-                    _("View Case"),
-                    prop_name='_link',
-                    sortable=False,
-                )
+                view_case_column,
             ]
 
         return persistent_cols + [


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/Ii7pSxgM/72-cle-includes-case-name-by-default-for-exports
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The CLE was incorrectly including the hidden Case Name column when sending emailed reports even if this column wasn't selected as a column in the report. 
This change only adds the case name column if the user selects it.
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
Case List Explorer
##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
