### PR TITLE
Removed custom eslint plugin from stickler

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,10 +30,6 @@ module.exports = {
         "d3": false,
     },
 
-    "plugins": [
-        "eslint-dimagi",
-    ],
-
     // http://eslint.org/docs/rules/
     // http://eslint.org/docs/user-guide/configuring#configuring-rules
     "rules": {
@@ -61,7 +57,5 @@ module.exports = {
         "space-before-blocks": ["error"],
         "space-in-parens": ["error", "never"],
         "space-infix-ops": ["error"],   // match flake8 E225
-
-        "eslint-dimagi/no-unblessed-new": ["error", ["Date", "Error", "FormData", "Option", "RegExp", "Clipboard", "MutationObserver"]],
     }
 };

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -10,6 +10,5 @@ linters:
     config: .flake8
   eslint:
     config: ./.eslintrc.js
-    install_plugins: true
 #  pytype:  # failing due to timeout
 #    config: ./.pytype.cfg


### PR DESCRIPTION
##### SUMMARY
[This error](https://github.com/dimagi/commcare-hq/pull/27743#pullrequestreview-428279278) has been popping up on recent PRs. [Stickler docs](https://stickler-ci.com/docs) say `install_plugins` now requires a paid plan.