### PR TITLE
Kev/sms messaging email filter

### DIFF
--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -758,10 +758,11 @@ class MessagingEventsReport(BaseMessagingEventReport):
             data = data.filter(event_status_filter)
 
         if self.phone_number_or_email_filter:
-            if self.phone_number_or_email_filter.isdigit():
-                data = data.filter(messagingsubevent__sms__phone_number__contains=self.phone_number_or_email_filter)
-            else:
-                data = data.filter(messagingsubevent__email__recipient_address__contains=self.phone_number_or_email_filter)
+            phone_qs = data.filter(
+                messagingsubevent__sms__phone_number__contains=self.phone_number_or_email_filter)
+            email_qs = data.filter(
+                messagingsubevent__email__recipient_address__icontains=self.phone_number_or_email_filter)
+            data = (email_qs | phone_qs) if self.phone_number_or_email_filter.isdigit() else email_qs
 
         # We need to call distinct() on this because it's doing an
         # outer join to sms_messagingsubevent in order to filter on

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -54,7 +54,7 @@ from corehq.apps.sms.filters import (
     EventStatusFilter,
     EventTypeFilter,
     MessageTypeFilter,
-    PhoneNumberFilter,
+    PhoneNumberOrEmailFilter,
     PhoneNumberReportFilter,
 )
 from corehq.apps.sms.mixin import apply_leniency
@@ -630,7 +630,7 @@ class MessagingEventsReport(BaseMessagingEventReport):
         DatespanFilter,
         EventTypeFilter,
         EventStatusFilter,
-        PhoneNumberFilter,
+        PhoneNumberOrEmailFilter,
     ]
     ajax_pagination = True
 
@@ -653,8 +653,8 @@ class MessagingEventsReport(BaseMessagingEventReport):
 
     @property
     @memoized
-    def phone_number_filter(self):
-        value = PhoneNumberFilter.get_value(self.request, self.domain)
+    def phone_number_or_email_filter(self):
+        value = PhoneNumberOrEmailFilter.get_value(self.request, self.domain)
         if isinstance(value, str):
             return value.strip()
 
@@ -757,11 +757,11 @@ class MessagingEventsReport(BaseMessagingEventReport):
         if event_status_filter:
             data = data.filter(event_status_filter)
 
-        if self.phone_number_filter:
-            if self.phone_number_filter.isdigit():
-                data = data.filter(messagingsubevent__sms__phone_number__contains=self.phone_number_filter)
+        if self.phone_number_or_email_filter:
+            if self.phone_number_or_email_filter.isdigit():
+                data = data.filter(messagingsubevent__sms__phone_number__contains=self.phone_number_or_email_filter)
             else:
-                data = data.filter(messagingsubevent__email__recipient_address__contains=self.phone_number_filter)
+                data = data.filter(messagingsubevent__email__recipient_address__contains=self.phone_number_or_email_filter)
 
         # We need to call distinct() on this because it's doing an
         # outer join to sms_messagingsubevent in order to filter on
@@ -780,7 +780,7 @@ class MessagingEventsReport(BaseMessagingEventReport):
             {'name': 'enddate', 'value': self.datespan.enddate.strftime('%Y-%m-%d')},
             {'name': EventTypeFilter.slug, 'value': EventTypeFilter.get_value(self.request, self.domain)},
             {'name': EventStatusFilter.slug, 'value': EventStatusFilter.get_value(self.request, self.domain)},
-            {'name': PhoneNumberFilter.slug, 'value': PhoneNumberFilter.get_value(self.request, self.domain)},
+            {'name': PhoneNumberOrEmailFilter.slug, 'value': PhoneNumberOrEmailFilter.get_value(self.request, self.domain)},
         ]
 
     @property
@@ -1133,8 +1133,8 @@ class PhoneNumberReport(BaseCommConnectLogReport):
 
     @property
     @memoized
-    def phone_number_filter(self):
-        value = self._filter['phone_number_filter']
+    def phone_number_or_email_filter(self):
+        value = self._filter['phone_number_or_email_filter']
         if isinstance(value, str):
             return apply_leniency(value.strip())
 

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -758,7 +758,10 @@ class MessagingEventsReport(BaseMessagingEventReport):
             data = data.filter(event_status_filter)
 
         if self.phone_number_filter:
-            data = data.filter(messagingsubevent__sms__phone_number__contains=self.phone_number_filter)
+            if self.phone_number_filter.isdigit():
+                data = data.filter(messagingsubevent__sms__phone_number__contains=self.phone_number_filter)
+            else:
+                data = data.filter(messagingsubevent__email__recipient_address__contains=self.phone_number_filter)
 
         # We need to call distinct() on this because it's doing an
         # outer join to sms_messagingsubevent in order to filter on

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -781,7 +781,8 @@ class MessagingEventsReport(BaseMessagingEventReport):
             {'name': 'enddate', 'value': self.datespan.enddate.strftime('%Y-%m-%d')},
             {'name': EventTypeFilter.slug, 'value': EventTypeFilter.get_value(self.request, self.domain)},
             {'name': EventStatusFilter.slug, 'value': EventStatusFilter.get_value(self.request, self.domain)},
-            {'name': PhoneNumberOrEmailFilter.slug, 'value': PhoneNumberOrEmailFilter.get_value(self.request, self.domain)},
+            {'name': PhoneNumberOrEmailFilter.slug,
+             'value': PhoneNumberOrEmailFilter.get_value(self.request, self.domain)},
         ]
 
     @property

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -1135,8 +1135,8 @@ class PhoneNumberReport(BaseCommConnectLogReport):
 
     @property
     @memoized
-    def phone_number_or_email_filter(self):
-        value = self._filter['phone_number_or_email_filter']
+    def phone_number_filter(self):
+        value = self._filter['phone_number_filter']
         if isinstance(value, str):
             return apply_leniency(value.strip())
 

--- a/corehq/apps/sms/filters.py
+++ b/corehq/apps/sms/filters.py
@@ -86,6 +86,13 @@ class RequiredPhoneNumberFilter(PhoneNumberFilter):
         return context
 
 
+class PhoneNumberOrEmailFilter(BaseSimpleFilter):
+    slug = "phone_number_or_email_address"
+    label = ugettext_lazy("Phone Number or Email Address")
+    help_inline = ugettext_lazy("Enter a full or partial phone number or a full or partial email address to filter "
+                                "results")
+
+
 class PhoneNumberReportFilter(BaseReportFilter):
     label = ugettext_noop("Phone Number")
     slug = "phone_number_filter"

--- a/corehq/apps/sms/filters.py
+++ b/corehq/apps/sms/filters.py
@@ -89,8 +89,8 @@ class RequiredPhoneNumberFilter(PhoneNumberFilter):
 class PhoneNumberOrEmailFilter(BaseSimpleFilter):
     slug = "phone_number_or_email_address"
     label = ugettext_lazy("Phone Number or Email Address")
-    help_inline = ugettext_lazy("Enter a full or partial phone number or a full or partial email address to filter "
-                                "results")
+    help_inline = ugettext_lazy("Enter a full or partial phone number or a full or partial email "
+                                "address to filter results")
 
 
 class PhoneNumberReportFilter(BaseReportFilter):

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -147,7 +147,7 @@ class EmailContent(Content):
             date=datetime.utcnow(),
             couch_recipient_doc_type=logged_event.recipient_type,
             couch_recipient=logged_event.recipient_id,
-            messaging_subevent_id=logged_event.pk,
+            messaging_subevent_id=logged_subevent.pk,
             recipient_address=email_address,
             subject=subject,
             body=message,

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -1,6 +1,8 @@
 import jsonfield as old_jsonfield
 from contextlib import contextmanager
 from copy import deepcopy
+from datetime import datetime
+
 from corehq.apps.accounting.utils import domain_is_on_trial
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.app_manager.exceptions import FormNotFoundException
@@ -12,7 +14,7 @@ from corehq.apps.smsforms.util import form_requires_input, critical_section_for_
 from corehq.form_processor.utils import is_commcarecase
 from corehq.messaging.scheduling.models.abstract import Content
 from corehq.apps.reminders.models import EmailUsage
-from corehq.apps.sms.models import MessagingEvent, PhoneNumber, PhoneBlacklist
+from corehq.apps.sms.models import MessagingEvent, PhoneNumber, PhoneBlacklist, Email
 from corehq.apps.sms.util import touchforms_error_is_config_error, get_formplayer_exception
 from corehq.apps.smsforms.models import SQLXFormsSession
 from memoized import memoized
@@ -139,6 +141,18 @@ class EmailContent(Content):
             return
 
         send_mail_async.delay(subject, message, settings.DEFAULT_FROM_EMAIL, [email_address])
+
+        email = Email(
+            domain=logged_event.domain,
+            date=datetime.utcnow(),
+            couch_recipient_doc_type=logged_event.recipient_type,
+            couch_recipient=logged_event.recipient_id,
+            messaging_subevent_id=logged_event.pk,
+            recipient_address=email_address,
+            subject=subject,
+            body=message,
+        )
+        email.save()
         email_usage.update_count()
         logged_subevent.completed()
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Related to 4 on https://trello.com/c/9WmNXire/67-improve-reporting-for-e-messaging. 
Related PR https://github.com/dimagi/commcare-hq/pull/27794

##### SUMMARY
Depends on Email model https://github.com/dimagi/commcare-hq/pull/27788

Allows user to query on email address as well. 
<img width="948" alt="Screen Shot 2020-06-12 at 5 18 43 PM" src="https://user-images.githubusercontent.com/615126/84690679-de2c3c80-af10-11ea-9475-aefec36869e5.png">

Changes two places:

1. The task that sends out emails will also create an email row in the db.
2. On the messaging history, changes the phone number field to also allow email address.

The query will always search on emails, and also will search on phone numbers if the query only contains digits. The returned results will be a union of both, if applicable.

e.g. where `email`=`knguyen123@dimagi.com` and `phone2`=`12345`

## When querying 123:
(both email and phone show up)

<img width="1122" alt="Screen Shot 2020-06-15 at 12 54 42 PM" src="https://user-images.githubusercontent.com/615126/84690969-572b9400-af11-11ea-9c13-e12373393a6f.png">



## When querying n123:
(only email)
<img width="1153" alt="Screen Shot 2020-06-15 at 12 54 54 PM" src="https://user-images.githubusercontent.com/615126/84690972-598dee00-af11-11ea-8f57-2c043e2779cd.png">

