### PR TITLE
Updated menu tabs to run _is_viewable before locations check

### DIFF
--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -135,6 +135,13 @@ class UITab(object):
         if not self.show_by_default and not self.is_active_tab:
             return False
 
+        # Run tab-specific logic first, so that dropdown generation can assume any necessary data is present
+        try:
+            if not self._is_viewable:
+                return False
+        except AttributeError:
+            return False
+
         if not self.can_access_all_locations:
             if self.dropdown_items and not self.filtered_dropdown_items:
                 # location-safe filtering makes this whole tab inaccessible
@@ -144,10 +151,7 @@ class UITab(object):
             if not self.dropdown_items and not url_is_location_safe(self.url):
                 return False
 
-        try:
-            return self._is_viewable
-        except AttributeError:
-            return False
+        return True
 
     @property
     @memoized


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/COV-7

When 2FA is required for a domain but not set up for a particular user, the 2FA check [triggers a 403](https://github.com/dimagi/commcare-hq/blob/acc388a6d456ec0be54c11210fd1ac772abdfa75/corehq/apps/domain/decorators.py#L103-L104), rendered with the `otp_required.html` template, which tells the user how to set it up. There's no context passed, so there's no known domain.

This breaks the menu generation for location restricted users, because the [location-restricted user check](https://github.com/dimagi/commcare-hq/blob/acc388a6d456ec0be54c11210fd1ac772abdfa75/corehq/tabs/uitab.py#L139https://github.com/dimagi/commcare-hq/blob/acc388a6d456ec0be54c11210fd1ac772abdfa75/corehq/tabs/uitab.py#L139) runs all of the menu logic for each tab to determine if the user has access to anything in that tab, which breaks without a domain due to privilege-checking.

The generic `403.html` gets around this issue by [not displaying the menu at all](https://github.com/dimagi/commcare-hq/blob/acc388a6d456ec0be54c11210fd1ac772abdfa75/corehq/apps/hqwebapp/templates/403.html#L4). I could do that here, too, but this code change should be sufficient and is an improvement: tabs generating their content ought to be able to assume that their basic requirements have been met.

##### RISK ASSESSMENT / QA PLAN
Bugfix, tested locally, not planning to QA.

##### PRODUCT DESCRIPTION
Prevents 500s seen by location-restricted users on projects that require 2FA.
