### PR TITLE
Added support for app logo in web apps

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -194,6 +194,7 @@ ANDROID_LOGO_PROPERTY_MAPPING = {
     'hq_logo_android_home': 'brand-banner-home',
     'hq_logo_android_login': 'brand-banner-login',
     'hq_logo_android_demo': 'brand-banner-home-demo',
+    'hq_logo_web_apps': 'brand-banner-web-apps',
 }
 
 

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -103,6 +103,14 @@
   supports_linked_app: true
   force: true
 
+- name: "Web Apps Logo"
+  description: "Upload a file to serve as an app logo in Web Apps"
+  id: "logo_web_apps"
+  widget: "image_uploader"
+  privilege: "commcare_logo_uploader"
+  supports_linked_app: true
+  force: true
+
 - disabled: true
   name: "Server User Registration"
   description: "Whether users registered on the phone need to be registered with the submission server."

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -63,6 +63,7 @@
     - properties.logo_android_home
     - properties.logo_android_login
     - properties.logo_android_demo
+    - properties.logo_web_apps
     - hq.auto_gps_capture
     - properties.cc-login-duration-seconds
     - properties.cc-log-entity-detail-enabled

--- a/corehq/apps/app_manager/static_strings.py
+++ b/corehq/apps/app_manager/static_strings.py
@@ -205,6 +205,7 @@ STATICALLY_ANALYZABLE_TRANSLATIONS = [
     ugettext_noop('Update on every sync'),
     ugettext_noop('Upload a file to serve as a demo logo on Android phones'),
     ugettext_noop('Upload a file to serve as a login logo on Android phones'),
+    ugettext_noop('Upload a file to serve as an app logo in Web Apps'),
     ugettext_noop('Use Secure Submissions'),
     ugettext_noop('Use project level setting'),
     ugettext_noop('Use a different base URL for all app URLs. This makes the phone send forms, sync and look for updates from a differnent URL. Main use case is to allow migrating ICDS to a new cluster.'),

--- a/corehq/apps/app_manager/static_strings.py
+++ b/corehq/apps/app_manager/static_strings.py
@@ -216,6 +216,7 @@ STATICALLY_ANALYZABLE_TRANSLATIONS = [
     ugettext_noop('We frequently release new versions of CommCare Mobile. Use the latest version to take advantage of new features and bug fixes. Note that if you are using CommCare for Android you must also update your version of CommCare from the Google Play Store.'),
     ugettext_noop('We suggest moving to CommCare 2.0 and above, unless your project is using referrals'),
     ugettext_noop('Web App'),
+    ugettext_noop('Web Apps Logo'),
     ugettext_noop('Weekly Log Sending Frequency'),
     ugettext_noop('Weekly'),
     ugettext_noop("What characters to allow users to input"),

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/views.js
@@ -13,6 +13,14 @@ FormplayerFrontend.module("Apps.Views", function (Views, FormplayerFrontend, Bac
             e.preventDefault();
             FormplayerFrontend.trigger("app:select", this.model.get('_id'));
         },
+
+        templateHelpers: function () {
+            var imageUri = this.options.model.get('imageUri');
+            var appId = this.options.model.get('_id');
+            return {
+                imageUrl: imageUri && appId ? FormplayerFrontend.request('resourceMap', imageUri, appId) : "",
+            };
+        },
     });
 
     Views.BaseAppView = {
@@ -111,9 +119,11 @@ FormplayerFrontend.module("Apps.Views", function (Views, FormplayerFrontend, Bac
         },
         templateHelpers: function () {
             var currentApp = FormplayerFrontend.request("appselect:getApp", this.appId),
-                appName = currentApp.get('name');
+                appName = currentApp.get('name'),
+                imageUri = currentApp.get('imageUri');
             return {
                 appName: appName,
+                imageUrl: imageUri && this.appId ? FormplayerFrontend.request('resourceMap', imageUri, this.appId) : "",
             };
         },
         startApp: function () {

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -111,8 +111,10 @@
   <div class="container">
     <div class="spacer"></div>
     <div class="col-xs-6 col-sm-4 col-xs-offset-3 col-sm-offset-4">
-      <div class="appicon appicon-default js-start-app">
-        <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
+      <div class="appicon appicon-default js-start-app" <% if (imageUrl) { %>style="background-image: url('<%= imageUrl %>');"<% } %>>
+        <% if (!imageUrl) { %>
+          <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
+        <% } %>
         <div class="appicon-title">
           <h3><%= appName %></h3>
         </div>
@@ -123,8 +125,10 @@
 </script>
 
 <script id="row-template" type="text/template">
-  <div class="appicon appicon-default">
-    <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
+  <div class="appicon appicon-default" <% if (imageUrl) { %>style="background-image: url('<%= imageUrl %>');"<% } %>>
+    <% if (!imageUrl) { %>
+      <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
+    <% } %>
     <div class="appicon-title">
       <h3><%- name %></h3>
     </div>

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -131,7 +131,7 @@ class FormplayerMain(View):
             # User has access via domain mirroring
             pass
         if role:
-            apps = [app for app in apps if role.permissions.view_web_app(app)]
+            apps = [_format_app(app) for app in apps if role.permissions.view_web_app(app)]
         apps = sorted(apps, key=lambda app: app['name'])
         return apps
 
@@ -272,7 +272,7 @@ class FormplayerPreviewSingleApp(View):
         context = {
             "domain": domain,
             "language": language,
-            "apps": [app],
+            "apps": [_format_app(app)],
             "maps_api_key": settings.GMAPS_API_KEY,
             "username": request.user.username,
             "formplayer_url": settings.FORMPLAYER_URL,
@@ -364,6 +364,11 @@ class LoginAsUsers(View):
             'location': user.sql_location.to_json() if user.sql_location else None,
         }
         return formatted_user
+
+
+def _format_app(app):
+    app['imageUri'] = app.get('logo_refs', {}).get('hq_logo_android_home', {}).get('path', '')
+    return app
 
 
 @login_and_domain_required

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -367,7 +367,7 @@ class LoginAsUsers(View):
 
 
 def _format_app(app):
-    app['imageUri'] = app.get('logo_refs', {}).get('hq_logo_android_home', {}).get('path', '')
+    app['imageUri'] = app.get('logo_refs', {}).get('hq_logo_web_apps', {}).get('path', '')
     return app
 
 

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
@@ -52,6 +52,8 @@
 
 .appicon, .gridicon {
   background-color: @cc-neutral-mid;
+  background-repeat: no-repeat;
+  background-position: center top;
   text-align: center;
   color: white;
   position: relative;


### PR DESCRIPTION
This came up in field-dev and sounded pretty easy to implement.

Marking don't merge pending feedback from @dimagi/product 

This adds a "Web Apps Logo" to use as the app tile in web apps.

This isn't a perfect example because the logo covers the app name. The image is not resized, and it's centered and aligned to the top, so that you can do either a logo that's intended to cover the whole tile or one that's smaller and meant to sit above the app name like the CommCare logo does.

![Screen Shot 2020-06-16 at 6 00 54 PM](https://user-images.githubusercontent.com/1486591/84832591-9504e700-affb-11ea-8ce9-3891acf36153.png)

