### PR TITLE
Fixed dropzone permissions to work with domain mirroring

### DIFF
--- a/corehq/apps/export/templates/export/download_data_files.html
+++ b/corehq/apps/export/templates/export/download_data_files.html
@@ -71,50 +71,45 @@
       <div class="spacer"></div>
       <div class="row">
         <div class="col-sm-9 col-md-8 col-lg-8">
-          <form action="#" method="POST" enctype="multipart/form-data">
+          <form action="#" method="POST" enctype="multipart/form-data" class="form form-horizontal">
             {% csrf_token %}
             <fieldset>
               <legend>{% trans "Upload file for transfer" %}</legend>
 
-              <div class="row">
-                <div class="form-group">
-                  <label class="control-label col-md-2 requiredField">
-                    {% trans "Description" %}<span class="asteriskField">*</span>
-                  </label>
-                  <div class="controls col-md-6">
-                    <input class="textinput textInput form-control"
-                           name="description"
-                           required=""
-                           type="text" />
-                  </div>
+              <div class="form-group">
+                <label class="control-label col-md-2 requiredField">
+                  {% trans "Description" %}<span class="asteriskField">*</span>
+                </label>
+                <div class="controls col-md-6">
+                  <input class="textinput textInput form-control"
+                         name="description"
+                         required=""
+                         type="text" />
                 </div>
               </div>
 
-              <div class="row">
-                <div class="form-group">
-                  <label class="control-label col-md-2 requiredField">
-                    {% trans "File" %}<span class="asteriskField">*</span>
-                  </label>
-                  <div class="controls col-md-6">
-                    <input name="file"
-                           required=""
-                           type="file" />
-                  </div>
+              <div class="form-group">
+                <label class="control-label col-md-2 requiredField">
+                  {% trans "File" %}<span class="asteriskField">*</span>
+                </label>
+                <div class="controls col-md-6">
+                  <input name="file"
+                         required=""
+                         type="file" />
                 </div>
               </div>
-              <div class="row">
-                <div class="form-group">
-                  <label class="control-label col-md-2 requiredField">
-                    {% trans "Delete after" %}<span class="asteriskField">*</span>
-                  </label>
-                  <div class="controls col-md-6">
-                    <select name="ttl">
-                      <option value="12">{% trans "12 hours" %}</option>
-                      <option selected="selected" value="24">{% trans "1 day" %}</option>
-                      <option value="48">{% trans "2 days" %}</option>
-                      <option value="72">{% trans "3 days" %}</option>
-                    </select>
-                  </div>
+
+              <div class="form-group">
+                <label class="control-label col-md-2 requiredField">
+                  {% trans "Delete after" %}<span class="asteriskField">*</span>
+                </label>
+                <div class="controls col-md-6">
+                  <select name="ttl" class="form-control">
+                    <option value="12">{% trans "12 hours" %}</option>
+                    <option selected="selected" value="24">{% trans "1 day" %}</option>
+                    <option value="48">{% trans "2 days" %}</option>
+                    <option value="72">{% trans "3 days" %}</option>
+                  </select>
                 </div>
               </div>
 

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -52,16 +52,10 @@ def can_upload_data_files(domain, couch_user):
 
 
 def _has_data_file_permission(domain, couch_user, read_only=True):
-    from corehq.apps.users.models import DomainMembershipError
-    try:
-        role = couch_user.get_role(domain)
-    except DomainMembershipError:
+    if not toggles.DATA_FILE_DOWNLOAD.enabled(domain):
         return False
 
-    if not (role and toggles.DATA_FILE_DOWNLOAD.enabled(domain)):
-        return False
-
-    return role.permissions.edit_file_dropzone or (read_only and role.permissions.view_file_dropzone)
+    return couch_user.can_edit_file_dropzone() or (read_only and couch_user.can_view_file_dropzone())
 
 
 def can_view_sms_exports(couch_user, domain):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -783,6 +783,7 @@ class ProjectDataTab(UITab):
             export_data_views.append({
                 'title': _(DataFileDownloadList.page_title),
                 'url': reverse(DataFileDownloadList.urlname, args=(self.domain,)),
+                'icon': 'fa fa-file-text-o',
                 'show_in_dropdown': True,
                 'subpages': []
             })


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SUPPORT-2254

##### FEATURE FLAG
Dropzone

##### RISK ASSESSMENT / QA PLAN
Minor, no QA.

##### PRODUCT DESCRIPTION
Fixes dropzone link not appearing for users relying on mirrored permissions.

UI changes are minor. Before:
![Screen Shot 2020-06-16 at 9 11 49 PM](https://user-images.githubusercontent.com/1486591/84843533-284b1600-b016-11ea-9ded-e06589336eca.png)

After:
![Screen Shot 2020-06-16 at 9 12 52 PM](https://user-images.githubusercontent.com/1486591/84843558-35680500-b016-11ea-853c-1eb20045b99b.png)
