### PR TITLE
Add KAFKA_ADVERTISED_PORT to docker kafka environment

### DIFF
--- a/docker/hq-compose-services.yml
+++ b/docker/hq-compose-services.yml
@@ -55,6 +55,7 @@ services:
       service: kafka
     environment:
       KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
+      KAFKA_ADVERTISED_PORT: 9092
     ports:
       - "9092:9092"
 


### PR DESCRIPTION
I'm running rootless docker on Ubuntu and kafka was failing to start. The log output was:
```
Starting hqservice_kafka_1 ... done
Attaching to hqservice_kafka_1
kafka_1          | Cannot connect to the Docker daemon. Is the docker daemon running on this host?
kafka_1          |   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
kafka_1          |                                  Dload  Upload   Total   Spent    Left  Speed
100  5224  100  5224    0     0  18659      0 --:--:-- --:--:-- --:--:-- 21064
kafka_1          | wait.sh: waiting 15 seconds for zookeeper:2181
kafka_1          | wait.sh: zookeeper:2181 is available after 0 seconds
kafka_1          | waiting for kafka to be ready
kafka_1          | [2020-06-17 00:37:04,932] FATAL  (kafka.Kafka$)
kafka_1          | java.lang.NumberFormatException: For input string: ""
kafka_1          | 	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
kafka_1          | 	at java.lang.Integer.parseInt(Integer.java:592)
kafka_1          | 	at java.lang.Integer.parseInt(Integer.java:615)
kafka_1          | 	at scala.collection.immutable.StringLike$class.toInt(StringLike.scala:247)
kafka_1          | 	at scala.collection.immutable.StringOps.toInt(StringOps.scala:30)
kafka_1          | 	at kafka.utils.VerifiableProperties.getIntInRange(VerifiableProperties.scala:75)
kafka_1          | 	at kafka.utils.VerifiableProperties.getInt(VerifiableProperties.scala:58)
kafka_1          | 	at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:110)
kafka_1          | 	at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:31)
kafka_1          | 	at kafka.Kafka$.main(Kafka.scala:35)
kafka_1          | 	at kafka.Kafka.main(Kafka.scala)
hqservice_kafka_1 exited with code 0
```

The error `Cannot connect to the Docker daemon.` is the important part there. That error is [emitted by `start-kafka.sh`](https://github.com/wurstmeister/kafka-docker/blob/0.8.2.2-1/start-kafka.sh#L7). I'm not sure if it has something to do with running docker in rootless mode, or something else. It may also be resolved by a newer version of wurstmeister/kafka. The version we are running (0.8.2.2-1) is quite old.