### PR TITLE
separate content filter for messaging history

### DIFF
--- a/corehq/apps/sms/filters.py
+++ b/corehq/apps/sms/filters.py
@@ -46,8 +46,6 @@ class EventTypeFilter(BaseMultipleOptionFilter):
         (MessagingEvent.SOURCE_BROADCAST, ugettext_noop('Broadcast')),
         (MessagingEvent.SOURCE_KEYWORD, ugettext_noop('Keyword')),
         (MessagingEvent.SOURCE_REMINDER, ugettext_noop('Conditional Alert')),
-        (MessagingEvent.CONTENT_SMS_SURVEY, ugettext_noop('Survey')),
-        (MessagingEvent.CONTENT_SMS_CALLBACK, ugettext_noop('Callback')),
         (MessagingEvent.SOURCE_UNRECOGNIZED, ugettext_noop('Unrecognized')),
         (MessagingEvent.SOURCE_OTHER, ugettext_noop('Other')),
     ]
@@ -55,8 +53,22 @@ class EventTypeFilter(BaseMultipleOptionFilter):
         MessagingEvent.SOURCE_BROADCAST,
         MessagingEvent.SOURCE_KEYWORD,
         MessagingEvent.SOURCE_REMINDER,
-        MessagingEvent.CONTENT_SMS_SURVEY,
     ]
+
+
+class EventContentFilter(BaseMultipleOptionFilter):
+    label = ugettext_noop('Content Type')
+    default_text = ugettext_noop('All')
+    slug = 'content_type'
+
+    @property
+    def options(self):
+        return [
+            (MessagingEvent.CONTENT_SMS_SURVEY, ugettext_noop('SMS Survey')),
+            (MessagingEvent.CONTENT_SMS_CALLBACK, ugettext_noop('SMS Callback')),
+            (MessagingEvent.CONTENT_SMS, ugettext_noop('Other SMS')),
+            (MessagingEvent.CONTENT_EMAIL, ugettext_noop('Email')),
+        ]
 
 
 class EventStatusFilter(BaseSingleOptionFilter):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Number 3 from https://docs.google.com/document/d/1IxjuWQqTmJZP5Iem20ilTQ6mc4KB6muVVtWUVt0kL5U/edit

This went in a slightly different way than the doc outlines by splitting out the content and source options from the current filter. That slightly changes existing behavior, but seems both the most reasonable way to interpret this kind of filter and not very disruptive. In deciding options, I kept the two types of SMS in the old filter, then added a catchall for the other sms types.

Generally speaking, these filter on the part of the Type column after the `|`

<img width="1182" alt="Screen Shot 2020-06-16 at 10 09 25 PM" src="https://user-images.githubusercontent.com/6844721/84847134-5f252a00-b01e-11ea-9f70-2dd7ab32355a.png">
