### PR TITLE
fix pagination of location and location type APIs

### DIFF
--- a/corehq/apps/locations/resources/v0_5.py
+++ b/corehq/apps/locations/resources/v0_5.py
@@ -47,11 +47,11 @@ class LocationTypeResource(BaseLocationsResource):
             "domain": ('exact',),
         }
 
-    def get_resource_uri(self, bundle_or_obj=None):
+    def get_resource_uri(self, bundle_or_obj=None, url_name='api_dispatch_list'):
         if isinstance(bundle_or_obj, Bundle):
             obj = bundle_or_obj.obj
         elif bundle_or_obj is None:
-            return None
+            return super().get_resource_uri(bundle_or_obj, url_name)
         else:
             obj = bundle_or_obj
 
@@ -96,11 +96,11 @@ class LocationResource(BaseLocationsResource):
             'longitude': ALL,
         }
 
-    def get_resource_uri(self, bundle_or_obj=None):
+    def get_resource_uri(self, bundle_or_obj=None, url_name='api_dispatch_list'):
         if isinstance(bundle_or_obj, Bundle):
             obj = bundle_or_obj.obj
         elif bundle_or_obj is None:
-            return None
+            return super().get_resource_uri(bundle_or_obj, url_name)
         else:
             obj = bundle_or_obj
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Currently the pagination parameters (e.g. `next`) of the location apis are always empty. This is because we are improperly setting the resource URI on the list view so tastypie [can't render them](https://github.com/django-tastypie/django-tastypie/blob/master/tastypie/paginator.py#L152-L154)

The relevant side effect of this is that it's impossible to paginate through locations with the DET which relies on the `next` param to handle pagination.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

not necessary to announce
