### PR TITLE
Set email status to error when sending fails

### DIFF
--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -102,11 +102,13 @@ def send_mail_async(self, subject, message, from_email, recipient_list, messagin
                 'messaging_event_id': messaging_event_id,
             }
         )
-        mark_subevent_gateway_error(messaging_event_id, e, retrying=True)
+        if messaging_event_id is not None:
+            mark_subevent_gateway_error(messaging_event_id, e, retrying=True)
         try:
             self.retry(exc=e)
         except MaxRetriesExceededError:
-            mark_subevent_gateway_error(messaging_event_id, e, retrying=False)
+            if messaging_event_id is not None:
+                mark_subevent_gateway_error(messaging_event_id, e, retrying=False)
 
 
 @task(serializer='pickle', queue="email_queue",
@@ -148,10 +150,11 @@ def send_html_email_async(self, subject, recipient, html_content,
         )
         try:
             self.retry(exc=e)
-            mark_subevent_gateway_error(messaging_event_id, e, retrying=True)
+            if messaging_event_id is not None:
+                mark_subevent_gateway_error(messaging_event_id, e, retrying=True)
         except MaxRetriesExceededError:
-            from dimagi.utils.django.email import mark_subevent_gateway_error
-            mark_subevent_gateway_error(messaging_event_id, e, retrying=False)
+            if messaging_event_id is not None:
+                mark_subevent_gateway_error(messaging_event_id, e, retrying=False)
 
 
 @task(serializer='pickle', queue="email_queue",

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -994,6 +994,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     ERROR_NO_EMAIL_ADDRESS = 'NO_EMAIL_ADDRESS'
     ERROR_TRIAL_EMAIL_LIMIT_REACHED = 'TRIAL_EMAIL_LIMIT_REACHED'
     ERROR_EMAIL_BOUNCED = 'EMAIL_BOUNCED'
+    ERROR_EMAIL_GATEWAY = 'EMAIL_GATEWAY_ERROR'
 
     ERROR_MESSAGES = {
         ERROR_NO_RECIPIENT:
@@ -1045,7 +1046,8 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         ERROR_TRIAL_EMAIL_LIMIT_REACHED:
             ugettext_noop("Cannot send any more reminder emails. The limit for "
                 "sending reminder emails on a Trial plan has been reached."),
-        ERROR_EMAIL_BOUNCED: ugettext_noop("Email Bounced")
+        ERROR_EMAIL_BOUNCED: ugettext_noop("Email Bounced"),
+        ERROR_EMAIL_GATEWAY: ugettext_noop("Email Gateway Error"),
     }
 
     domain = models.CharField(max_length=126, null=False, db_index=True)

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -155,7 +155,6 @@ class EmailContent(Content):
         email.save()
 
         email_usage.update_count()
-        logged_subevent.completed()
 
 
 class SMSSurveyContent(Content):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Keeps emails sent from the messaging framework in "Pending" state until SES sets a different status
- If sending of these messages fails on HQ, update the status accordingly. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
