### PR TITLE
Upgrade jsonfield to Django 1.11/2.2 compatible version

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -104,7 +104,7 @@ jenkinsapi==0.2.28        # via -r requirements/dev-requirements.in
 jinja2==2.10.3            # via -r requirements/requirements.in, sphinx
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -182,7 +182,7 @@ sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
 sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -86,7 +86,7 @@ jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -154,7 +154,7 @@ sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.1            # via -r requirements/requirements.in

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -81,7 +81,7 @@ jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -140,7 +140,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.1            # via -r requirements/requirements.in

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -89,7 +89,7 @@ jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -153,7 +153,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -104,7 +104,7 @@ jenkinsapi==0.2.28        # via -r requirements/dev-requirements.in
 jinja2==2.10.3            # via -r requirements/requirements.in, sphinx
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -182,7 +182,7 @@ sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
 sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -86,7 +86,7 @@ jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -154,7 +154,7 @@ sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.1            # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,7 +12,7 @@ django>=1.11.29,<2  # https://github.com/advisories/GHSA-hmr4-m2h5-33qx
 django-braces==1.13.0
 django-celery-results~=1.0.0
 django-crispy-forms==1.7.0
-jsonfield==1.0.3
+jsonfield==2.1.1
 dropbox==9.3.0
 defusedxml==0.5.0
 diff-match-patch==20120106

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -81,7 +81,7 @@ jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -140,7 +140,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.1            # via -r requirements/requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -89,7 +89,7 @@ jdcal==1.4.1              # via openpyxl
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
-jsonfield==1.0.3          # via -r requirements/requirements.in, django-prbac
+jsonfield==2.1.1          # via -r requirements/requirements.in, django-prbac
 jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
@@ -153,7 +153,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4


### PR DESCRIPTION
jsonfield 2.1.x version notes are missing from more recent change logs. For 2.1.x changes, see https://github.com/rpkilby/jsonfield/blob/2.1.1/CHANGES.rst

I reviewed all commits from jsonfield 1.0.3 to 2.1.1 to verify that no major/breaking changes occurred. If tests pass I think this is good to merge.

Supersedes #27128 