### PR TITLE
sms email use logged_subevent recipient

### DIFF
--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -145,8 +145,8 @@ class EmailContent(Content):
         email = Email(
             domain=logged_event.domain,
             date=datetime.utcnow(),
-            couch_recipient_doc_type=logged_event.recipient_type,
-            couch_recipient=logged_event.recipient_id,
+            couch_recipient_doc_type=logged_subevent.recipient_type,
+            couch_recipient=logged_subevent.recipient_id,
             messaging_subevent_id=logged_subevent.pk,
             recipient_address=email_address,
             subject=subject,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I assumed the `logged_event` recipient was the same as the `logged_subevent` recipient. This uses the subevent recipient.

