### PR TITLE
Rate limit per domain per user

### DIFF
--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -97,7 +97,7 @@ class LoginAndDomainAuthentication(Authentication):
             return response
 
     def get_identifier(self, request):
-        return request.couch_user.username
+        return f"{request.domain}_{request.couch_user.username}"
 
 
 class RequirePermissionAuthentication(LoginAndDomainAuthentication):

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -272,3 +272,16 @@ class HQApiKeyAuthentication(ApiKeyAuthentication):
         request.user = user
 
         return True
+
+    def get_identifier(self, request):
+        """Returns {domain}_{api_key} for use in rate limiting api key.
+
+        Each api key can currently be used on multiple domains, and rates
+        are domain specific.
+
+        """
+        try:
+            api_key = self.extract_credentials(request)[1]
+        except ValueError:
+            api_key = ''
+        return f"{request.domain}_{api_key}"


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/bvaWRAvj/56-re-introduce-some-api-rate-limiting

NOTE: the base branch is `fr/multiple-api-keys` from this PR: https://github.com/dimagi/commcare-hq/pull/27679

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This switches rate limiting to use a combination of domain_username so that each user's rate limit is specified per domain. 

I think there might be a place in the future where we want to be more nuanced with this (e.g. you can pay us for a higher limit for a specific API Key, etc.) But this meets the short-term goals. 
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
