### PR TITLE
update nodejs version in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Dimagi <devops@dimagi.com>
 ENV PYTHONUNBUFFERED=1 \
     PYTHONUSERBASE=/vendor \
     PATH=/vendor/bin:$PATH \
-    NODE_VERSION=13.12.0
+    NODE_VERSION=12.18.1
 
 RUN mkdir /vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Dimagi <devops@dimagi.com>
 ENV PYTHONUNBUFFERED=1 \
     PYTHONUSERBASE=/vendor \
     PATH=/vendor/bin:$PATH \
-    NODE_VERSION=5.12.0
+    NODE_VERSION=13.12.0
 
 RUN mkdir /vendor
 


### PR DESCRIPTION
##### SUMMARY
A newer version of nodejs is needed in order to download packages necessary to run the new js tests from https://github.com/dimagi/commcare-hq/pull/27815. This has to be merged into master so that dockerhub registers it and builds the container
