### PR TITLE
rebuild the data too

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -249,10 +249,7 @@ class ConfigurableReportTableManagerMixin(object):
             adapter.log_table_rebuild_skipped(source='pillowtop', diffs=diff_dicts)
             return
 
-        if config.is_static:
-            rebuild_indicators.delay(adapter.config.get_id, source='pillowtop', engine_id=adapter.engine_id)
-        else:
-            adapter.rebuild_table(source='pillowtop')
+        rebuild_indicators.delay(adapter.config.get_id, source='pillowtop', engine_id=adapter.engine_id)
 
     def _pull_in_new_and_modified_data_sources(self):
         """


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We want to fill in the data too, not just change the table

This is in response to a P1 where some covid domains had their report builder reports "rebuilt" in this way, and therefore had no data. It is not meant to be a long term fix, since we probably don't want to actually backfill all these data sources, but until we can be smarter about that, it is better than just truncating their data when things go wrong.