### PR TITLE
update Dockerhub image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN npm -g install \
     bower \
     grunt-cli \
     uglify-js \
+    mocha-headless-chrome \
  && echo '{ "allow_root": true }' > /root/.bowerrc \
  && cd /vendor \
  && npm shrinkwrap \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,4 @@ RUN npm -g install \
  && echo '{ "allow_root": true }' > /root/.bowerrc \
  && cd /vendor \
  && npm shrinkwrap \
- && npm -g install \
- && npm cache clean
+ && npm -g install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dimagi/commcarehq_base_new:latest
+FROM dimagi/commcarehq_base:latest
 # When changing this file, also update docker/Dockerfile-py3
 
 VOLUME /mnt/commcare-hq-ro /mnt/lib


### PR DESCRIPTION
##### SUMMARY
removes  `npm cache clean` (no longer needed after `npm@5`) and renames the docker image back to `commcarehq_base` instead of `commcarehq_base_new`