### PR TITLE
fix UCR tests for new behavior

### DIFF
--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -204,6 +204,7 @@ class ChunkedUCRProcessorTest(TestCase):
         delete_all_cases()
         delete_all_xforms()
         InvalidUCRData.objects.all().delete()
+        self.config = DataSourceConfiguration.get(self.config.data_source_id)
         self.config.validations = []
         self.config.save()
 
@@ -234,6 +235,7 @@ class ChunkedUCRProcessorTest(TestCase):
         return cases
 
     def _create_and_process_changes(self, docs=[]):
+        self.pillow = _get_pillow([self.config], processor_chunk_size=100)
         since = self.pillow.get_change_feed().get_latest_offsets()
         cases = self._create_cases(docs=docs)
         # run pillow and check changes
@@ -284,6 +286,9 @@ class ChunkedUCRProcessorTest(TestCase):
 
     @mock.patch('corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor.process_change')
     def test_invalid_data_bulk_processor(self, process_change):
+        # re-fetch from DB to bust object caches
+        self.config = DataSourceConfiguration.get(self.config.data_source_id)
+
         self.config.validations = [
             Validation.wrap({
                 "name": "impossible_condition",
@@ -311,6 +316,9 @@ class ChunkedUCRProcessorTest(TestCase):
 
     @mock.patch('corehq.apps.userreports.pillow.ConfigurableReportPillowProcessor.process_changes_chunk')
     def test_invalid_data_serial_processor(self, process_changes_chunk):
+        # re-fetch from DB to bust object caches
+        self.config = DataSourceConfiguration.get(self.config.data_source_id)
+
         process_changes_chunk.side_effect = Exception
         self.config.validations = [
             Validation.wrap({
@@ -552,6 +560,7 @@ class ProcessRelatedDocTypePillowTest(TestCase):
         self.pillow.get_change_feed().get_latest_offsets()
 
     def tearDown(self):
+        self.config = DataSourceConfiguration.get(self.config.data_source_id)
         self.config.delete()
         self.adapter.drop_table()
         delete_all_cases()
@@ -720,6 +729,7 @@ class AsyncIndicatorTest(TestCase):
         delete_all_xforms()
         AsyncIndicator.objects.all().delete()
         InvalidUCRData.objects.all().delete()
+        self.config = DataSourceConfiguration.get(self.config.data_source_id)
         self.config.validations = []
         self.config.save()
 
@@ -809,6 +819,9 @@ class AsyncIndicatorTest(TestCase):
         self.assertEqual(indicators.count(), 1)
 
     def test_async_invalid_data(self):
+        # re-fetch from DB to bust object caches
+        self.config = DataSourceConfiguration.get(self.config.data_source_id)
+
         self.config.validations = [
             Validation.wrap({
                 "name": "impossible_condition",

--- a/corehq/apps/userreports/tests/test_rebuild_migrate.py
+++ b/corehq/apps/userreports/tests/test_rebuild_migrate.py
@@ -165,6 +165,9 @@ class RebuildTableTest(TestCase):
             len([c for c in insp.get_columns(table_name) if c['name'] == 'new_date']), 0
         )
 
+        # re-fetch from DB to bust object caches
+        self.config = DataSourceConfiguration.get(self.config.data_source_id)
+
         # add the column to the config
         self.config.configured_indicators.append({
             "column_id": "new_date",
@@ -233,13 +236,12 @@ class RebuildTableTest(TestCase):
             "property_name": "owner_id",
             "is_primary_key": True
         })
+        config.sql_settings.primary_key = ['pk_key', 'doc_id']
         config.save()
+
+        get_case_pillow(ucr_configs=[config])
         adapter = get_indicator_adapter(config)
         engine = adapter.engine
-        config.sql_settings.primary_key = ['pk_key', 'doc_id']
-
-        # rebuild table
-        get_case_pillow(ucr_configs=[config])
         insp = reflection.Inspector.from_engine(engine)
         table_name = get_table_name(self.config.domain, self.config.table_id)
         pk = insp.get_pk_constraint(table_name)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Tagged anyone who I have spoken to about this, or might have any context, but I think this fixes the build.

There are 2 causes of the majority of issues, all from the switch from using `adapter.rebuild_table` to the celery task `rebuild_indicators`
1) The celery task reloads the config from the db so changes to the config need to be saved, some tests were previously relying on the fact that they could change the config in memory and pass the object to the pillow.
2) The celery task saves the config so we were getting a lot of document update conflicts where changes were made in a test, the table was rebuilt, then further changes were made without reloading the config from the db. I made a lot of changes to aggressively reload the config