### PR TITLE
install chrome headless outside of puppeteer build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,28 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
 
-RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jdk
+RUN apt-get update \
+  && apt-get install -y \
+  openjdk-7-jdk \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  gnupg \
+  --no-install-recommends \
+  && curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+  && apt-get update && apt-get install -y \
+  google-chrome-beta \
+  fontconfig \
+  fonts-ipafont-gothic \
+  fonts-wqy-zenhei \
+  fonts-thai-tlwg \
+  fonts-kacst \
+  fonts-noto \
+  fonts-freefont-ttf \
+  --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
 
 COPY requirements/test-requirements.txt package.json /vendor/
 
@@ -26,6 +47,9 @@ RUN npm -g install \
     bower \
     grunt-cli \
     uglify-js \
+ && export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false \
+ && npm -g install \
+    puppeteer \
     mocha-headless-chrome \
  && echo '{ "allow_root": true }' > /root/.bowerrc \
  && cd /vendor \


### PR DESCRIPTION
##### SUMMARY
the dockerhub build is failing on an async install of chrome headless during the npm install of `mocha-chrome-headless` with `puppeteer`. this fixes that build