### PR TITLE
Fix timezone fallback

### DIFF
--- a/corehq/apps/domain/static/domain/js/my_project_settings.js
+++ b/corehq/apps/domain/static/domain/js/my_project_settings.js
@@ -15,11 +15,7 @@ hqDefine("domain/js/my_project_settings", [
         self.disableUpdateSettings = ko.observable(true);
 
         self.updateForm = function () {
-            if ($('#override_global_tz')[0].checked) {
-                self.disableUpdateSettings(self.no_domain_membership());
-            } else {
-                self.disableUpdateSettings(true);
-            }
+            self.disableUpdateSettings(self.no_domain_membership());
         };
 
         return self;

--- a/corehq/util/timezones/tests/test_utils.py
+++ b/corehq/util/timezones/tests/test_utils.py
@@ -1,0 +1,43 @@
+import pytz
+from mock import patch
+
+from django.test import SimpleTestCase
+
+from corehq.apps.users.models import WebUser, DomainMembership
+from corehq.util.timezones.utils import get_timezone_for_user
+
+DOMAIN_TIMEZONE = pytz.timezone('Asia/Kolkata')
+
+
+@patch('corehq.util.timezones.utils.get_timezone_for_domain', lambda x: DOMAIN_TIMEZONE)
+@patch('corehq.apps.users.models._AuthorizableMixin.get_domain_membership')
+class GetTimezoneForUserTest(SimpleTestCase):
+    def test_no_user(self, _):
+        self.assertEqual(get_timezone_for_user(None, "test"), DOMAIN_TIMEZONE)
+
+    def test_user_with_no_domain_membership(self, domain_membership_mock):
+        couch_user = WebUser()
+        domain_membership_mock.return_value = None
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
+
+    def test_user_with_domain_membership(self, domain_membership_mock):
+        couch_user = WebUser()
+        domain_membership = DomainMembership()
+        domain_membership_mock.return_value = domain_membership
+
+        # use domain timezone if not override_global_tz
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)
+
+        # use default timezone on membership if non set
+        domain_membership.override_global_tz = True
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), pytz.utc)
+
+        domain_membership_timezone = pytz.timezone('America/New_York')
+        domain_membership.timezone = 'America/New_York'
+
+        # use timezone set on membership
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), domain_membership_timezone)
+
+        # do not use timezone set on membership if not override_global_tz
+        domain_membership.override_global_tz = False
+        self.assertEqual(get_timezone_for_user(couch_user, "test"), DOMAIN_TIMEZONE)

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -4,6 +4,7 @@ import pytz
 from functools import reduce
 from memoized import memoized
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from corehq.apps.domain.models import Domain
@@ -63,8 +64,12 @@ def get_timezone_for_user(couch_user_or_id, domain):
 
         if requesting_user:
             domain_membership = requesting_user.get_domain_membership(domain)
-            if domain_membership and domain_membership.override_global_tz:
-                return coerce_timezone_value(domain_membership.timezone)
+            if domain_membership:
+                if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS:
+                    if domain_membership.override_global_tz:
+                        return coerce_timezone_value(domain_membership.timezone)
+                else:
+                    return coerce_timezone_value(domain_membership.timezone)
 
     return get_timezone_for_domain(domain)
 

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -63,7 +63,7 @@ def get_timezone_for_user(couch_user_or_id, domain):
 
         if requesting_user:
             domain_membership = requesting_user.get_domain_membership(domain)
-            if domain_membership:
+            if domain_membership and domain_membership.override_global_tz:
                 return coerce_timezone_value(domain_membership.timezone)
 
     return get_timezone_for_domain(domain)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1562?focusedCommentId=59816
[Detail Doc](https://docs.google.com/document/d/1Vdc-YSffAnvshL-4aSK57VkPi2iA8d43qkIBsf9W8U8/edit)

##### SUMMARY
Looks like when we originally implemented to look for timezone on domain membership it was here
https://github.com/dimagi/commcare-hq/commit/5b2e22735282765311e49d2e94eea0c07a736437

and there was some improvement done in 
https://github.com/dimagi/commcare-hq/commit/0a8320db066ced4306454a61f59045c940b982cc#

The default value set for the timezone on domain membership is the one set on django settings or else "UTC"
`timezone = StringProperty(default=getattr(settings, "TIME_ZONE", "UTC"))`
Same is true for timezone set on a Domain.

The name of the new property on Domain Membership was "override_global_tz" but it refers to [project's timezone in description](https://github.com/dimagi/commcare-hq/blob/b5192db72f35b52d8527690a2a7ee22941aa668a/corehq/apps/domain/forms.py#L144).

So now,
For web user
1. The UI lets user override the projects default setting.
2. But it does not let user unset it (fixed in this PR)
For mobile user
1. there is no link to reach to the page to edit this timezone
2. but they can access the page directly though

So the fallback currently works in order
1. user timezone for the domain set by user
2. environment timezone (is used even if user has not set anything for timezone to be used for project, since we have the default value set on domain membership and we don't check for `override_global_tz`)
3. domain timezone

Assuming here that it actually should be
1. timezone set for the domain set by user
2. domain timezone
3. environment timezone

This PR fixes that by checking for `override_global_tz` to consider the timezone set in domain membership else check for domain timezone which is set to environment timezone by default.

I think a mobile user should be able to set this as well, but not covering that here to keep scope limited.

##### RISK ASSESSMENT / QA PLAN
For users visiting domains, 
if the domain has a timezone set other than the one set on domain membership for the user(both default to the one set on the HQ environment unless changed), 
User would notice a change in the timezone getting used for them on HQ. 
This would reflect for all places that rely on timezone in views and possibly in data exports where timezone is relevant.
I am not sure if this is okay or needs more analysis. Open to suggestions here.

Restricted this to just ICDS environment for now but should be released overall. The google doc linked above does some number analysis for production environment
@dimagi/product 