### PR TITLE
Pin to sqlagg pre-release commit

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -198,7 +198,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 sqlparse==0.3.0           # via django-debug-toolbar

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -158,7 +158,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -144,7 +144,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -158,7 +158,7 @@ six==1.13.0               # via -r requirements/requirements.in, django-appconf,
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 stripe==1.67.0            # via -r requirements/requirements.in

--- a/requirements-python3/uninstall-requirements.txt
+++ b/requirements-python3/uninstall-requirements.txt
@@ -15,3 +15,4 @@ celery  # Remove once we are back to regular celery releases
 subprocess32
 eventlet
 contextlib2
+sqlagg  # Remove once we are back to regular sqlagg releases

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -198,7 +198,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 sqlparse==0.3.0           # via django-debug-toolbar

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -158,7 +158,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -59,7 +59,8 @@ openpyxl~=2.6
 six~=1.11
 socketpool==0.5.3
 markdown==2.2.1
-sqlagg==0.16.1
+# sqlagg==0.16.1
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg
 django-redis~=4.9
 redis==2.10.6
 redis-py-cluster==1.3.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -144,7 +144,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -158,7 +158,7 @@ six==1.13.0               # via -r requirements/requirements.in, django-appconf,
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.16.1            # via -r requirements/requirements.in
+git+git://github.com/dimagi/sql-agg@e483351a6de31eabc9da21ecfb3d46d4930459a6#egg=sqlagg  # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 stripe==1.67.0            # via -r requirements/requirements.in

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -15,3 +15,4 @@ celery  # Remove once we are back to regular celery releases
 subprocess32
 eventlet
 contextlib2
+sqlagg  # Remove once we are back to regular sqlagg releases


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11003

##### SUMMARY

I think we want to do this "right" tomorrow and make a sqlagg release that we pin to instead, but we decided it was important to get this out quick, and I didn't want to have that process be a potential blocker.

This fixes UCR's total counts (used in the paginated report table), which were previously being incorrectly estimated under some condition that included a column having null values