### PR TITLE
Added backup token display to edit mobile worker page

### DIFF
--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -26,8 +26,8 @@
     {% if commtrack_enabled or uses_locations %}
       <li><a href="#commtrack-data" data-toggle="tab">{% trans "Locations" %}</a></li>
     {% endif %}
-    {% if not request.is_view_only %}
-      <li><a href="#user-password" data-toggle="tab">{% trans "Password" %}</a></li>
+    {% if not request.is_view_only or token %}
+      <li><a href="#user-password" data-toggle="tab">{% trans "Security" %}</a></li>
     {% endif %}
     {% if not is_currently_logged_in_user and not request.is_view_only %}
       <li><a href="#user-permanent" data-toggle="tab">{% trans "Actions" %}</a></li>
@@ -57,13 +57,29 @@
         </div>
       </div>
     {% endif %}
-    {% if not request.is_view_only %}
-      <div class="tab-pane" id="user-password">
-        <div class="panel-body">
+    <div class="tab-pane" id="user-password">
+      <div class="panel-body">
+        {% if not request.is_view_only %}
           {% include 'users/partials/reset_password.html' %}
-        </div>
+          <div class="spacer"></div>
+        {% endif %}
+        {% if token %}
+          <fieldset>
+            <legend>{% trans 'Two Factor Authentication' %}</legend>
+            <div class="form form-horizontal">
+              <div class="form-group">
+                <label class="control-label col-sm-3 col-md-2">
+                  {% trans "Backup Token" %}
+                </label>
+                <div class="controls col-sm-9 col-md-8 col-lg-6">
+                  <input type="text" class="form-control" disabled value="{{ token }}" />
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        {% endif %}
       </div>
-    {% endif %}
+    </div>
     {% if not is_currently_logged_in_user and not request.is_view_only %}
       <div class="tab-pane" id="user-permanent">
         <div class="panel-body">

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -180,6 +180,7 @@ class EditCommCareUserView(BaseEditUserView):
             'strong_mobile_passwords': self.request.project.strong_mobile_passwords,
             'implement_password_obfuscation': settings.OBFUSCATE_PASSWORD_FOR_NIC_COMPLIANCE,
             'has_any_sync_logs': self.has_any_sync_logs,
+            'token': self.backup_token,
         })
         return context
 


### PR DESCRIPTION
##### SUMMARY
https://trello.com/c/98HFSFZU/79-show-backup-2fa-tokens-for-mobile-workers

Only shows if the domain requires 2FA, which is the same way it works on the web user edit page.

##### RISK ASSESSMENT / QA PLAN
Minor, no QA.

##### PRODUCT DESCRIPTION
![Screen Shot 2020-06-18 at 9 45 21 PM](https://user-images.githubusercontent.com/1486591/85088353-e7860500-b1ad-11ea-8fc1-81dbbf713285.png)

fyi @dimagi/product 
