### PR TITLE
Bump sqlagg version to 0.16.2

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -198,7 +198,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 sqlparse==0.3.0           # via django-debug-toolbar

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -158,7 +158,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -144,7 +144,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -158,7 +158,7 @@ six==1.13.0               # via -r requirements/requirements.in, django-appconf,
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 stripe==1.67.0            # via -r requirements/requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -198,7 +198,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 sqlparse==0.3.0           # via django-debug-toolbar

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -158,7 +158,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -59,7 +59,7 @@ openpyxl~=2.6
 six~=1.11
 socketpool==0.5.3
 markdown==2.2.1
-sqlagg==0.16.1
+sqlagg==0.16.2
 django-redis~=4.9
 redis==2.10.6
 redis-py-cluster==1.3.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -144,7 +144,7 @@ simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django
 six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg
 stripe==1.67.0            # via -r requirements/requirements.in
 suds-jurko==0.6           # via -r requirements/requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -158,7 +158,7 @@ six==1.13.0               # via -r requirements/requirements.in, django-appconf,
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4
-sqlagg==0.16.1            # via -r requirements/requirements.in
+sqlagg==0.16.2            # via -r requirements/requirements.in
 sqlalchemy-postgres-copy==0.5.0  # via -r requirements/test-requirements.in
 sqlalchemy==1.3.10        # via -r requirements/requirements.in, alembic, sqlagg, sqlalchemy-postgres-copy
 stripe==1.67.0            # via -r requirements/requirements.in


### PR DESCRIPTION
Replaces https://github.com/dimagi/commcare-hq/pull/27863 for solving https://dimagi-dev.atlassian.net/browse/SAAS-11003

##### SUMMARY

This gets https://github.com/dimagi/sql-agg/pull/69 and https://github.com/dimagi/sql-agg/pull/70 backported to the 0.16 line.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
