### PR TITLE
Have sentry thread cloudcare errors better

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -566,4 +566,4 @@ def _message_to_sentry_thread_topic(message):
     ... 'If this error persists please report a bug to CommCareHQ.')
     'EntityScreen EntityScreen [Detail=org.commcare.suite.model.Detail@[...], selection=null] could not select case [...]. If this error persists please report a bug to CommCareHQ.'
     """
-    return re.sub(r'[a-f-0-9]{8,}', '[...]', message)
+    return re.sub(r'[a-f0-9-]{8,}', '[...]', message)

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -513,15 +513,17 @@ def report_formplayer_error(request, domain):
             'cloudcare_env': data.get('cloudcareEnv'),
         })
         message = data.get("readableErrorMessage") or "request failure in web form session"
-        notify_error(message=f'[Cloudcare] {message}', details=data)
+        thread_topic = _message_to_sentry_thread_topic(message)
+        notify_error(message=f'[Cloudcare] {thread_topic}', details=data)
     elif error_type == 'show_error_notification':
         message = data.get('message')
+        thread_topic = _message_to_sentry_thread_topic(message)
         metrics_counter('commcare.formplayer.show_error_notification', tags={
             'message': _message_to_tag_value(message or 'no_message'),
             'domain': domain,
             'cloudcare_env': data.get('cloudcareEnv'),
         })
-        notify_error(message=f'[Cloudcare] {message}', details=data)
+        notify_error(message=f'[Cloudcare] {thread_topic}', details=data)
     else:
         metrics_counter('commcare.formplayer.unknown_error_type', tags={
             'domain': domain,
@@ -554,3 +556,14 @@ def _message_to_tag_value(message, allowed_chars=string.ascii_lowercase + string
     message_tag = ''.join((c if c in allowed_chars else ' ') for c in message_tag.lower())
     message_tag = '_'.join(re.split(r' +', message_tag)[:4])
     return message_tag[:59]
+
+
+def _message_to_sentry_thread_topic(message):
+    """
+    >>> _message_to_sentry_thread_topic(
+    ... 'EntityScreen EntityScreen [Detail=org.commcare.suite.model.Detail@1f984e3c, '
+    ... 'selection=null] could not select case 8854f3583f6f46e69af59fddc9f9428d. '
+    ... 'If this error persists please report a bug to CommCareHQ.')
+    'EntityScreen EntityScreen [Detail=org.commcare.suite.model.Detail@[...], selection=null] could not select case [...]. If this error persists please report a bug to CommCareHQ.'
+    """
+    return re.sub(r'[a-f-0-9]{8,}', '[...]', message)


### PR DESCRIPTION
These are just totally spamming us because they're coming in one error, one thread. This attempts to remove ids from thread topics so that similar errors have the same topic.