### PR TITLE
Users can no longer start role name with whitespace character

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -78,12 +78,6 @@ hqDefine('users/js/roles',[
                 var data = ko.mapping.toJS(self);
 
                 if (data.name) {
-                    // some older browsers don't use the String.prototype.trim() function. Explicity declare it in this case:
-                    if (!String.prototype.trim) {
-                        String.prototype.trim = function () {
-                            return this.replace(/^\s+|\s+$/g,'');
-                        };
-                    }
                     data.name = data.name.trim();
                 }
 

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -77,6 +77,16 @@ hqDefine('users/js/roles',[
             unwrap: function (self) {
                 var data = ko.mapping.toJS(self);
 
+                if (data.name) {
+                    // some older browsers don't use the String.prototype.trim() function. Explicity declare it in this case:
+                    if (!String.prototype.trim) {
+                        String.prototype.trim = function () {
+                            return this.replace(/^\s+|\s+$/g,'');
+                        }
+                    }
+                    data.name = data.name.trim();
+                }
+
                 data.permissions.view_report_list = ko.utils.arrayMap(ko.utils.arrayFilter(data.reportPermissions.specific, function (report) {
                     return report.value;
                 }), function (report) {

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -82,7 +82,7 @@ hqDefine('users/js/roles',[
                     if (!String.prototype.trim) {
                         String.prototype.trim = function () {
                             return this.replace(/^\s+|\s+$/g,'');
-                        }
+                        };
                     }
                     data.name = data.name.trim();
                 }

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -26,7 +26,7 @@
                        id="role-name"
                        class="form-control"
                        pattern="\S.*"
-                       title="The name must start with a valid character."
+                       title='{% trans_html_attr "The name must start with a valid character." %}'
                        required />
               </div>
             </div>

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -25,6 +25,8 @@
                        type="text"
                        id="role-name"
                        class="form-control"
+                       pattern="\S.*"
+                       title="The name must start with a valid character."
                        required />
               </div>
             </div>


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10974?focusedCommentId=60786

##### SUMMARY
Fixed a bug where users could submit a whitespace character " " as their role name. Role names can no longer begin with a whitespace character.
##### FEATURE FLAG
NA
##### RISK ASSESSMENT / QA PLAN
NA
##### PRODUCT DESCRIPTION
Users will be unable to submit roles names that begin with whitespace characters.