### PR TITLE
Fixed submenu link

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_view_settings.html
@@ -59,7 +59,7 @@
                         data-title="{% trans "Parent Menu" %}"
                         data-content="{% blocktrans %}
                                Nest this menu under another for easier application navigation.
-                               <a href='https://confluence.dimagi.com/display/ccinternal/Sub-menus'>(More Information)</span>
+                               <a href='https://confluence.dimagi.com/display/commcarepublic/Sub+Menus'>(More Information)</span>
                                {% endblocktrans %}">
                   </span>
                 </label>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8919,7 +8919,7 @@ msgid ""
 "                               Nest this menu under another for easier "
 "application navigation.\n"
 "                               <a href='https://confluence.dimagi.com/"
-"display/ccinternal/Sub-menus'>(More Information)</span>\n"
+"display/commcarepublic/Sub+Menus'>(More Information)</span>\n"
 "                               "
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -9172,7 +9172,7 @@ msgid ""
 "                               Nest this menu under another for easier "
 "application navigation.\n"
 "                               <a href='https://confluence.dimagi.com/"
-"display/ccinternal/Sub-menus'>(More Information)</span>\n"
+"display/commcarepublic/Sub+Menus'>(More Information)</span>\n"
 "                               "
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8604,7 +8604,7 @@ msgid ""
 "                               Nest this menu under another for easier "
 "application navigation.\n"
 "                               <a href='https://confluence.dimagi.com/"
-"display/ccinternal/Sub-menus'>(More Information)</span>\n"
+"display/commcarepublic/Sub+Menus'>(More Information)</span>\n"
 "                               "
 msgstr ""
 

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -9043,7 +9043,7 @@ msgid ""
 "                               Nest this menu under another for easier "
 "application navigation.\n"
 "                               <a href='https://confluence.dimagi.com/"
-"display/ccinternal/Sub-menus'>(More Information)</span>\n"
+"display/commcarepublic/Sub+Menus'>(More Information)</span>\n"
 "                               "
 msgstr ""
 

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -8617,7 +8617,7 @@ msgid ""
 "                               Nest this menu under another for easier "
 "application navigation.\n"
 "                               <a href='https://confluence.dimagi.com/"
-"display/ccinternal/Sub-menus'>(More Information)</span>\n"
+"display/commcarepublic/Sub+Menus'>(More Information)</span>\n"
 "                               "
 msgstr ""
 

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -8641,7 +8641,7 @@ msgid ""
 "                               Nest this menu under another for easier "
 "application navigation.\n"
 "                               <a href='https://confluence.dimagi.com/"
-"display/ccinternal/Sub-menus'>(More Information)</span>\n"
+"display/commcarepublic/Sub+Menus'>(More Information)</span>\n"
 "                               "
 msgstr ""
 

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -8608,7 +8608,7 @@ msgid ""
 "                               Nest this menu under another for easier "
 "application navigation.\n"
 "                               <a href='https://confluence.dimagi.com/"
-"display/ccinternal/Sub-menus'>(More Information)</span>\n"
+"display/commcarepublic/Sub+Menus'>(More Information)</span>\n"
 "                               "
 msgstr ""
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10677

##### SUMMARY
Since sub-menus are a public feature, the help text should link to the public help documents.

##### FEATURE FLAG
N/A

##### RISK ASSESSMENT / QA PLAN
N/A

##### PRODUCT DESCRIPTION
Users will be directed to the sub-menus help page if they click on the help text. 