### PR TITLE
Patch user to ES signal

### DIFF
--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -19,6 +19,7 @@ from corehq.apps.users.models import (
 from corehq.elastic import send_to_elasticsearch
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
 from corehq.util.elastic import reset_es_index
+from corehq.util.es.testing import sync_users_to_es
 
 from .utils import APIResourceTest
 
@@ -35,8 +36,8 @@ class TestCommCareUserResource(APIResourceTest):
         reset_es_index(USER_INDEX_INFO)
         super().setUpClass()
 
-    @patch('corehq.apps.users.signals._should_sync_to_es', return_value=True)
-    def test_get_list(self, patch):
+    @sync_users_to_es()
+    def test_get_list(self):
 
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****',
                                             created_by=None, created_via=None)

--- a/corehq/apps/users/signals.py
+++ b/corehq/apps/users/signals.py
@@ -42,9 +42,11 @@ def update_user_in_es(sender, couch_user, **kwargs):
     Automatically sync the user to elastic directly on save or delete
     """
     from corehq.pillows.user import transform_user_for_elasticsearch
-    if _should_sync_to_es():
-        send_to_elasticsearch("users", transform_user_for_elasticsearch(couch_user.to_json()),
-                              delete=couch_user.to_be_deleted())
+    send_to_elasticsearch(
+        "users",
+        transform_user_for_elasticsearch(couch_user.to_json()),
+        delete=couch_user.to_be_deleted()
+    )
 
 
 def sync_user_phone_numbers(sender, couch_user, **kwargs):

--- a/corehq/apps/users/tests/test_location_assignment.py
+++ b/corehq/apps/users/tests/test_location_assignment.py
@@ -10,6 +10,7 @@ from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.users.management.commands import add_multi_location_property
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.elastic import refresh_elasticsearch_index
+from corehq.util.es.testing import sync_users_to_es
 from corehq.util.test_utils import generate_cases
 
 
@@ -100,8 +101,8 @@ class CCUserLocationAssignmentTest(TestCase):
         self.user.unset_location_by_id(self.loc1.location_id, fall_back_to_next=True)
         self.assertAssignedLocations([])
 
-    @patch('corehq.apps.users.signals._should_sync_to_es', return_value=True)
-    def test_deleting_location_updates_user(self, mock):
+    @sync_users_to_es()
+    def test_deleting_location_updates_user(self):
         self.user.reset_locations(self.loc_ids)
         refresh_elasticsearch_index('users')
         self.loc1.sql_location.full_delete()

--- a/corehq/apps/users/tests/test_signals.py
+++ b/corehq/apps/users/tests/test_signals.py
@@ -2,7 +2,6 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from corehq.util.es.elasticsearch import ConnectionError
 from mock import MagicMock, patch
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
@@ -13,6 +12,8 @@ from pillowtop.es_utils import initialize_index_and_mapping
 from corehq.apps.reports.analytics.esaccessors import get_user_stubs
 from corehq.elastic import doc_exists_in_es, get_es_new
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
+from corehq.util.es.elasticsearch import ConnectionError
+from corehq.util.es.testing import sync_users_to_es
 from corehq.util.test_utils import mock_out_couch, trap_extra_setup
 
 from ..models import CommCareUser, WebUser
@@ -73,6 +74,7 @@ class TestUserSyncToEs(SimpleTestCase):
         with trap_extra_setup(ConnectionError):
             initialize_index_and_mapping(cls.es, USER_INDEX_INFO)
 
+    @sync_users_to_es()
     def test_sync_to_es_create_update_delete(self, *mocks):
         domain = 'user_es_domain'
         user = CommCareUser(

--- a/corehq/tests/noseplugins/patches.py
+++ b/corehq/tests/noseplugins/patches.py
@@ -1,5 +1,7 @@
 from nose.plugins import Plugin
 
+from corehq.util.es.testing import patch_es_user_signals
+
 
 class PatchesPlugin(Plugin):
     """Patches various things before tests are run"""
@@ -12,6 +14,7 @@ class PatchesPlugin(Plugin):
     def begin(self):
         patch_assertItemsEqual()
         fix_freezegun_bugs()
+        patch_es_user_signals()
 
 
 def patch_assertItemsEqual():

--- a/corehq/util/es/testing.py
+++ b/corehq/util/es/testing.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+from mock import patch
+
+from django.conf import settings
+
+_sync_user_to_es_patch = patch('corehq.apps.users.signals.send_to_elasticsearch')
+
+
+def patch_es_user_signals():
+    assert settings.UNIT_TESTING
+    _sync_user_to_es_patch.start()
+
+
+@contextmanager
+def sync_users_to_es():
+    """Contextmanager/decorator to enable sync users to ES
+
+    Usage as decorator:
+
+        @sync_users_to_es()
+        def test_something():
+            ...  # do thing with users in ES
+
+    Usage as context manager:
+
+        with sync_users_to_es():
+            ...  # do thing with users in ES
+    """
+    assert settings.UNIT_TESTING
+    _sync_user_to_es_patch.stop()
+    try:
+        yield
+    finally:
+        _sync_user_to_es_patch.start()


### PR DESCRIPTION
Tests that want to sync users to ES should use `@sync_users_to_es()` decorator/context manager.

Based on https://github.com/dimagi/commcare-hq/pull/27876