### PR TITLE
Ce/rev logging

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -233,11 +233,14 @@ class ConfigurableReportTableManagerMixin(object):
             self.migrate_tables(engine, diffs, tables_to_act_on.migrate, table_map)
 
     def migrate_tables(self, engine, diffs, table_names, adapters_by_table):
-        pillow_logging.debug("[rebuild] Application migrations to tables: %s", table_names)
         migration_diffs = [diff for diff in diffs if diff.table_name in table_names]
         changes = migrate_tables(engine, migration_diffs)
         for table, diffs in changes.items():
             adapter = adapters_by_table[table]
+            pillow_logging.info(
+                "[rebuild] Migrating table: %s, from config %s at rev %s",
+                (table, adapter.config._id, adapter.config._rev)
+            )
             adapter.log_table_migrate(source='pillowtop', diffs=diffs)
 
     def rebuild_table(self, adapter, diffs=None):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -216,8 +216,11 @@ class ConfigurableReportTableManagerMixin(object):
 
             tables_to_act_on = get_tables_rebuild_migrate(diffs)
             for table_name in tables_to_act_on.rebuild:
-                pillow_logging.info("[rebuild] Rebuilding table: %s", table_name)
                 sql_adapter = table_map[table_name]
+                pillow_logging.info(
+                    "[rebuild] Rebuilding table: %s, from config %s at rev %s",
+                    (table_name, sql_adapter.config._id, sql_adapter.config._rev)
+                )
                 table_diffs = [diff for diff in diffs if diff.table_name == table_name]
                 if not sql_adapter.config.is_static:
                     try:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds config id and rev info to our rebuild logging and does it for migrations as well. This will hopefully help us get to the bottom of pillows using stale configs.