### PR TITLE
Mk/delay to next slot

### DIFF
--- a/corehq/apps/sms/management/commands/run_sms_queue.py
+++ b/corehq/apps/sms/management/commands/run_sms_queue.py
@@ -1,18 +1,29 @@
+import pytz
+import datetime
 from time import sleep
 
 from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.utils.functional import cached_property
 
 from dimagi.utils.couch import get_redis_lock
 from dimagi.utils.logging import notify_exception
 
+from corehq.apps.app_manager.models import Domain
 from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
+from corehq.apps.sms.api import get_utcnow
 from corehq.apps.sms.models import QueuedSMS
-from corehq.apps.sms.tasks import send_to_sms_queue
+from corehq.apps.sms.tasks import send_to_sms_queue, time_within_windows
 from corehq.sql_db.util import handle_connection_failure
+from corehq.util.timezones.conversions import ServerTime
+from custom.icds.utils.sms import can_send_sms_now
+
+india_timezone = pytz.timezone('Asia/Kolkata')
 
 
 def skip_domain(domain):
-    return any_migrations_in_progress(domain)
+    if any_migrations_in_progress(domain):
+        return True
 
 
 class SMSEnqueuingOperation(BaseCommand):
@@ -43,6 +54,8 @@ class SMSEnqueuingOperation(BaseCommand):
             if queued_sms.domain and skip_domain(queued_sms.domain):
                 continue
 
+            if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS and not can_send_sms_now():
+                break
             self.enqueue(queued_sms)
 
     def enqueue(self, queued_sms):
@@ -53,10 +66,26 @@ class SMSEnqueuingOperation(BaseCommand):
     def handle(self, **options):
         while True:
             try:
-                self.create_tasks()
+                if settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS and not can_send_sms_now():
+                    sleep(self._time_till_next_window())
+                else:
+                    self.create_tasks()
             except:
                 notify_exception(None, message="Could not fetch due survey actions")
             sleep(10)
+
+    def _time_till_next_window(self):
+        # if from time is greater than the start_time, it would give seconds till next day start
+        server_now_time = self._get_server_time()
+        today = datetime.date.today()
+        from_datetime = datetime.datetime.combine(today, server_now_time)
+        to_datetime = datetime.datetime.combine(today, datetime.time(9, 0))
+        return (to_datetime - from_datetime).seconds
+
+    def _get_server_time(self):
+        utcnow = get_utcnow()
+        server_now = ServerTime(utcnow).user_time(india_timezone).done()
+        return server_now.time()
 
 
 class Command(SMSEnqueuingOperation):

--- a/custom/icds/utils/sms.py
+++ b/custom/icds/utils/sms.py
@@ -1,0 +1,23 @@
+import pytz
+from datetime import timedelta
+
+def get_next_available_time(domain_object, domain_now):
+    if domain_object.restricted_sms_times:
+        restricted_sms_time = domain_object.restricted_sms_times[0]
+        next_available_time = None
+        # triggered before the window began on the day
+        if domain_now.time() < restricted_sms_time.start_time:
+            next_available_time = domain_now.replace(
+                hour=restricted_sms_time.start_time.hour,
+                minute=restricted_sms_time.start_time.minute,
+                second=0)
+            next_available_time = next_available_time.astimezone(pytz.utc).replace(tzinfo=None)
+        # triggered after the window finished on the day
+        elif domain_now.time() > restricted_sms_time.end_time:
+            next_available_time = domain_now + timedelta(days=1)
+            next_available_time = next_available_time.replace(
+                hour=restricted_sms_time.start_time.hour,
+                minute=restricted_sms_time.start_time.minute,
+                second=0)
+            next_available_time = next_available_time.astimezone(pytz.utc).replace(tzinfo=None)
+        return next_available_time

--- a/custom/icds/utils/sms.py
+++ b/custom/icds/utils/sms.py
@@ -1,6 +1,10 @@
 import pytz
 from datetime import timedelta
 
+from corehq.apps.sms.api import get_utcnow
+from corehq.util.timezones.conversions import ServerTime
+
+
 def get_next_available_time(domain_object, domain_now):
     if domain_object.restricted_sms_times:
         restricted_sms_time = domain_object.restricted_sms_times[0]
@@ -21,3 +25,11 @@ def get_next_available_time(domain_object, domain_now):
                 second=0)
             next_available_time = next_available_time.astimezone(pytz.utc).replace(tzinfo=None)
         return next_available_time
+
+
+def can_send_sms_now():
+    # from 9am to 9pm IST
+    utcnow = get_utcnow()
+    india_timezone = pytz.timezone('Asia/Kolkata')
+    server_now = ServerTime(utcnow).user_time(india_timezone).done()
+    return 9 <= server_now.hour < 21


### PR DESCRIPTION
##### SUMMARY
On ICDS, we really just want SMSes to trigger from 9am to 9pm and that has been set [on the domain level](https://www.icds-cas.gov.in/a/icds-cas/sms/settings/).
Seeing observation in https://dimagi-dev.atlassian.net/browse/ICDS-1537?focusedCommentId=60885 it appears that SMSes are actually just going from 9am to 11am 
and post that we also reach out limit for the day due to which SMSes are either [delayed by 1 hour](https://github.com/dimagi/commcare-hq/blob/d38e96009f737668a85978af912ac2e4c7cc141b/corehq/apps/sms/tasks.py#L344) or we just keep [removing the stale ones](https://github.com/dimagi/commcare-hq/blob/d38e96009f737668a85978af912ac2e4c7cc141b/corehq/apps/sms/tasks.py#L375)

And from 9pm - 9am it just keeps [delaying SMSes](https://github.com/dimagi/commcare-hq/blob/d38e96009f737668a85978af912ac2e4c7cc141b/corehq/apps/sms/tasks.py#L385) by [after 15 mins](https://github.com/dimagi/commcare-hq/blob/92d64923822c45a60ccb2d80585fa23e16758b8b/settings.py#L637)
So for ICDS between 11am and 9am next day(22 hours), we are just delaying SMSes or clearing stale ones which is not a great use of infra.

My original thought was to just change 15 mins to a higher value say 3 hours or 6 hours but I thought this can be really controlled considering how custom this is.

This is a draft PR to share two approaches, each present in a commit which can be picked eventually.

Approach 1: Still keeps things configured as they are now via SMS framework and delay each SMS to the beginning of next possible time slot if it's triggered outside the window instead of by 15 mins.

Approach 2: Makes restriction within code, and stop even the task from queueing any SMS if it's not in the time window. This can be implemented to use configuration set on the domain, but I implemented it in code to show the advantages it would have where there won't be any need to even fetch the domain object and considering icds-cas is the only domain on ICDS_ENVS, this should be okay.

[DataDog Graph for some reference](https://app.datadoghq.com/dashboard/2z2-9gq-y93/sms?from_ts=1590244653387&fullscreen_end_ts=1592865033753&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1592260233753&fullscreen_widget=5959534267603202&live=true&to_ts=1592836653387&tpl_var_environment=icds)