### PR TITLE
add back SMS repports

### DIFF
--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -309,10 +309,6 @@ class MessageLogReport(BaseCommConnectLogReport):
 
     exportable = True
 
-    @classmethod
-    def show_in_navigation(cls, domain=None, project=None, user=None):
-        return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
-
     def get_message_type_filter(self):
         filtered_types = MessageTypeFilter.get_value(self.request, self.domain)
         if filtered_types:
@@ -638,10 +634,6 @@ class MessagingEventsReport(BaseMessagingEventReport):
         PhoneNumberOrEmailFilter,
     ]
     ajax_pagination = True
-
-    @classmethod
-    def show_in_navigation(cls, domain=None, project=None, user=None):
-        return settings.SERVER_ENVIRONMENT not in settings.ICDS_ENVS
 
     @property
     def headers(self):


### PR DESCRIPTION
reverts https://github.com/dimagi/commcare-hq/pull/20374 partially to add back 
1. Messaging History
2. Message Log

##### SUMMARY
these two reports are now added under whitelisted reports for ICDS, so should be fine to add the links back
In terms of user visibility, they would not be available to external users since we control that via roles so would be visible only to internal users for debugging puposes

##### RISK ASSESSMENT / QA PLAN
Check with Kishan from data security perspective and also from App team who knew about the links and were accessing it directly but other members were not able to find the reports.

Additionally I would also like to whitelist "SMS Usage" using [management command](https://github.com/dimagi/commcare-hq/blob/579b52f1037d30c8e9184214f7278bb1d6a8b9d2/corehq/apps/reports/management/commands/edit_report_whitelist.py). Confirmed about this along with other two.

Currently whitelisted report slugs
```
'worker_activity',
 'app_status',
 'case_list',
 'submissions_by_form',
 'submit_history',
 'log_details',
 'submit_errors',
 'aggregate_user_status',
 'message_log',
 'messaging_events',
 'message_event_detail',
 'survey_detail',
 'scheduled_messaging_events',
 'completion_vs_submission'
```