### PR TITLE
Upgrade IPython from 5.2.2 to 7.15.0

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -11,6 +11,7 @@ architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, sphinx
+backcall==0.2.0           # via ipython
 beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
@@ -98,9 +99,10 @@ idna==2.8                 # via email-validator, requests
 imagesize==1.1.0          # via sphinx
 ipdb==0.11                # via -r requirements/dev-requirements.in
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2            # via -r requirements/dev-requirements.in, ipdb
+ipython==7.15.0           # via -r requirements/dev-requirements.in, ipdb
 iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
+jedi==0.17.1              # via ipython
 jenkinsapi==0.2.28        # via -r requirements/dev-requirements.in
 jinja2==2.10.3            # via -r requirements/requirements.in, sphinx
 jmespath==0.9.4           # via boto3, botocore
@@ -126,6 +128,7 @@ nose==1.3.7               # via -r requirements/test-requirements.in, django-nos
 oauthlib==3.1.0           # via requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 packaging==19.2           # via sphinx
+parso==0.7.0              # via jedi
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
@@ -136,7 +139,7 @@ pip-tools==5.1.0          # via -r requirements/test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0              # via -r requirements/requirements.in
 prometheus-client==0.7.1  # via -r requirements/requirements.in
-prompt-toolkit==1.0.18    # via ipython
+prompt-toolkit==3.0.5     # via ipython
 psutil==5.7.0             # via -r requirements/dev-requirements.in
 psycogreen==1.0.1         # via -r requirements/requirements.in
 psycopg2==2.8.5           # via -r requirements/requirements.in, sqlalchemy-postgres-copy
@@ -181,9 +184,8 @@ schema==0.7.1             # via -r requirements/requirements.in
 sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
-simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
 sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -9,6 +9,7 @@ amqp==2.5.2               # via kombu
 architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, flower
+backcall==0.2.0           # via ipython
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
@@ -81,9 +82,10 @@ html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via -r requirements/prod-requirements.in, email-validator, requests
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2            # via -r requirements/prod-requirements.in
+ipython==7.15.0           # via -r requirements/prod-requirements.in
 iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
+jedi==0.17.1              # via ipython
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
@@ -103,6 +105,7 @@ msgpack-python==0.5.6     # via ddtrace
 ndg-httpsclient==0.5.1    # via -r requirements/prod-requirements.in
 oauthlib==3.1.0           # via requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
+parso==0.7.0              # via jedi
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
@@ -112,7 +115,7 @@ pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, djang
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0              # via -r requirements/requirements.in
 prometheus-client==0.7.1  # via -r requirements/requirements.in
-prompt-toolkit==1.0.18    # via ipython
+prompt-toolkit==3.0.5     # via ipython
 psycogreen==1.0.1         # via -r requirements/requirements.in
 psycopg2==2.8.5           # via -r requirements/requirements.in
 ptyprocess==0.6.0         # via pexpect
@@ -153,9 +156,8 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 setproctitle==1.1.9       # via -r requirements/prod-requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
-simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.2            # via -r requirements/requirements.in

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -6,7 +6,7 @@ fixture==1.5.11
 sniffer==0.4.0
 psutil>5.1.3  # for memory profiling
 django-extensions
-ipython==5.2.2
+ipython==7.15.0
 ipdb==0.11
 wheel==0.29.0
 transifex-client==0.12.4

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -11,6 +11,7 @@ architect==0.5.6          # via -r requirements/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, sphinx
+backcall==0.2.0           # via ipython
 beautifulsoup4==4.8.1     # via -r requirements/test-requirements.in
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
@@ -98,9 +99,10 @@ idna==2.8                 # via email-validator, requests
 imagesize==1.1.0          # via sphinx
 ipdb==0.11                # via -r requirements/dev-requirements.in
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2            # via -r requirements/dev-requirements.in, ipdb
+ipython==7.15.0           # via -r requirements/dev-requirements.in, ipdb
 iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
+jedi==0.17.1              # via ipython
 jenkinsapi==0.2.28        # via -r requirements/dev-requirements.in
 jinja2==2.10.3            # via -r requirements/requirements.in, sphinx
 jmespath==0.9.4           # via boto3, botocore
@@ -126,6 +128,7 @@ nose==1.3.7               # via -r requirements/test-requirements.in, django-nos
 oauthlib==3.1.0           # via requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 packaging==19.2           # via sphinx
+parso==0.7.0              # via jedi
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
@@ -136,7 +139,7 @@ pip-tools==5.1.0          # via -r requirements/test-requirements.in
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0              # via -r requirements/requirements.in
 prometheus-client==0.7.1  # via -r requirements/requirements.in
-prompt-toolkit==1.0.18    # via ipython
+prompt-toolkit==3.0.5     # via ipython
 psutil==5.7.0             # via -r requirements/dev-requirements.in
 psycogreen==1.0.1         # via -r requirements/requirements.in
 psycopg2==2.8.5           # via -r requirements/requirements.in, sqlalchemy-postgres-copy
@@ -181,9 +184,8 @@ schema==0.7.1             # via -r requirements/requirements.in
 sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
-simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, prompt-toolkit, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
 sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements/prod-requirements.in
+++ b/requirements/prod-requirements.in
@@ -7,7 +7,7 @@ tornado<5.0
 errand-boy==0.3.8
 setproctitle==1.1.9
 uWSGI==2.0.18
-ipython==5.2.2
+ipython==7.15.0
 ndg-httpsclient
 pyasn1
 

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -9,6 +9,7 @@ amqp==2.5.2               # via kombu
 architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.7.0              # via django-phonenumber-field, flower
+backcall==0.2.0           # via ipython
 billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.10.14            # via -r requirements/requirements.in
 botocore==1.13.14         # via boto3, s3transfer
@@ -81,9 +82,10 @@ html5lib==1.0.1           # via weasyprint
 httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.8                 # via -r requirements/prod-requirements.in, email-validator, requests
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.2.2            # via -r requirements/prod-requirements.in
+ipython==7.15.0           # via -r requirements/prod-requirements.in
 iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
+jedi==0.17.1              # via ipython
 jinja2==2.10.3            # via -r requirements/requirements.in
 jmespath==0.9.4           # via boto3, botocore
 json-delta==2.0           # via -r requirements/requirements.in
@@ -103,6 +105,7 @@ msgpack-python==0.5.6     # via ddtrace
 ndg-httpsclient==0.5.1    # via -r requirements/prod-requirements.in
 oauthlib==3.1.0           # via requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
+parso==0.7.0              # via jedi
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
 pexpect==4.7.0            # via ipython
@@ -112,7 +115,7 @@ pillow==6.2.2             # via -r requirements/requirements.in, cairosvg, djang
 ply==3.11                 # via eulxml, jsonpath-rw
 polib==1.1.0              # via -r requirements/requirements.in
 prometheus-client==0.7.1  # via -r requirements/requirements.in
-prompt-toolkit==1.0.18    # via ipython
+prompt-toolkit==3.0.5     # via ipython
 psycogreen==1.0.1         # via -r requirements/requirements.in
 psycopg2==2.8.5           # via -r requirements/requirements.in
 ptyprocess==0.6.0         # via pexpect
@@ -153,9 +156,8 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 setproctitle==1.1.9       # via -r requirements/prod-requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
-simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, prompt-toolkit, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.2            # via -r requirements/requirements.in


### PR DESCRIPTION
Required for when we support Python 3.8+

Context: https://github.com/ipython/ipython/issues/11590
