### PR TITLE
skip remember domain for views where we also bypass the session

### DIFF
--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -46,6 +46,9 @@ class CCHQPRBACMiddleware(MiddlewareMixin):
 class DomainHistoryMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
+        if getattr(request, '_bypass_sessions', False):
+            return response
+
         if hasattr(request, 'domain') and getattr(response, '_remember_domain', True):
             self.remember_domain_visit(request)
         return response


### PR DESCRIPTION
##### SUMMARY
For URLs that skip the session middleware we should also skip this.

It is suspected that this may be related to increased load on CouchDB on ICDS.

Change from: https://github.com/dimagi/commcare-hq/pull/27779