### PR TITLE
Removed unused context variables

### DIFF
--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -764,7 +764,6 @@ def get_form_view_context_and_template(request, domain, form, langs, current_lan
             {'test': assertion.test, 'text': assertion.text.get(current_lang)}
             for assertion in form.custom_assertions
         ],
-        'can_preview_form': request.couch_user.has_permission(domain, 'edit_data'),
         'form_icon': None,
     }
 

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -305,7 +305,6 @@ def view_generic(request, domain, app_id, module_id=None, form_id=None,
             app,
             request.couch_user.username
         ),
-        'can_preview_form': request.couch_user.has_permission(domain, 'edit_data')
     })
 
     confirm = request.session.pop('CONFIRM', False)


### PR DESCRIPTION
Trivial. These are leftover from an old version of web apps (see https://github.com/dimagi/commcare-hq/pull/14457)