### PR TITLE
Revert "Moved last_visited_domain from request to cache"

### DIFF
--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -1,9 +1,11 @@
+# Use modern Python
+
 from django.template.response import TemplateResponse
+# External imports
 from django.utils.deprecation import MiddlewareMixin
 
-from dimagi.utils.couch.cache import cache_core
-
 from corehq.apps.accounting.models import DefaultProductPlan, Subscription
+from corehq.apps.domain.models import DomainAuditRecordEntry
 from corehq.toggles import DATA_MIGRATION
 
 
@@ -50,28 +52,13 @@ class DomainHistoryMiddleware(MiddlewareMixin):
             return response
 
         if hasattr(request, 'domain') and getattr(response, '_remember_domain', True):
-            self.remember_domain_visit(request)
+            self.remember_domain_visit(request, response)
         return response
 
-    def remember_domain_visit(self, request):
-        if hasattr(request, 'couch_user') and request.couch_user:
-            set_last_visited_domain(request.couch_user, request.domain)
-
-
-def get_last_visited_domain(couch_user):
-    client = cache_core.get_redis_client()
-    return client.get(_last_visited_domain_cache_key(couch_user))
-
-
-def set_last_visited_domain(couch_user, domain):
-    client = cache_core.get_redis_client()
-    cache_expiration = 60 * 60 * 24 * 7
-    cache_key = _last_visited_domain_cache_key(couch_user)
-    client.set(cache_key, domain, timeout=cache_expiration)
-
-
-def _last_visited_domain_cache_key(couch_user):
-    return 'last-visited-domain-%s' % couch_user.username
+    def remember_domain_visit(self, request, response):
+        last_visited_domain = request.session.get('last_visited_domain')
+        if last_visited_domain != request.domain:
+            request.session['last_visited_domain'] = request.domain
 
 
 class DomainMigrationMiddleware(MiddlewareMixin):

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -27,24 +27,35 @@
       </h3>
     </div>
     <div class="panel-body">
-      <ul class="list-unstyled" data-bind="foreach: invitationLinks">
-        <li style="padding-bottom: 6px;">
-          <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
-            <i class='fa fa-envelope'>
-            </i>
-            {% trans "Accept" %}
-          </a>
-          <!-- ko text: display_name -->
-          <!-- /ko -->
-        </li>
-      </ul>
+      <table class="table table-striped table-responsive">
+        <thead>
+          <tr>
+            <th>{% trans 'Project Name' %}
+            </th>
+          </tr>
+        </thead>
+        <tbody data-bind="foreach: invitationLinks">
+          <tr>
+            <td>
+              
+              <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
+                <i class='fa fa-envelope'>
+                </i>
+                {% trans "Accept" %}
+              </a>
+              <!-- ko text: display_name -->
+              <!-- /ko -->
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
   <div class="panel panel-default">
     <div class="panel-heading ">
       <div class="row">
         <div class="col-sm-6">
-          <h3 class="panel-title" style="padding-top: 7px;">
+          <h3 class="panel-title">
             {% trans 'My Projects' %}
           </h3>
         </div>
@@ -59,11 +70,23 @@
       </div>
     </div>
     <div class="panel-body">
-      <ul class="nav nav-pills nav-stacked" data-bind="foreach: domainLinks">
-        <li>
-          <a data-bind="attr: {href: url}, text: display_name"></a>
-        </li>
-      </ul>
+      <table class="table table-striped table-responsive">
+        <thead>
+          <tr>
+            <th>{% trans 'Project Name' %}
+            </th>
+          </tr>
+        </thead>
+        <tbody data-bind="foreach: domainLinks">
+          <tr>
+            <td>
+              <a data-bind="attr: {href: url}, text: display_name">
+              </a>
+            </td>
+          </tr>
+        </tbody>
+        
+      </table>
     </div>
   </div>
 </div>

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -27,35 +27,24 @@
       </h3>
     </div>
     <div class="panel-body">
-      <table class="table table-striped table-responsive">
-        <thead>
-          <tr>
-            <th>{% trans 'Project Name' %}
-            </th>
-          </tr>
-        </thead>
-        <tbody data-bind="foreach: invitationLinks">
-          <tr>
-            <td>
-              
-              <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
-                <i class='fa fa-envelope'>
-                </i>
-                {% trans "Accept" %}
-              </a>
-              <!-- ko text: display_name -->
-              <!-- /ko -->
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <ul class="list-unstyled" data-bind="foreach: invitationLinks">
+        <li style="padding-bottom: 6px;">
+          <a data-bind="attr: {href: url}" class="btn btn-default btn-xs">
+            <i class='fa fa-envelope'>
+            </i>
+            {% trans "Accept" %}
+          </a>
+          <!-- ko text: display_name -->
+          <!-- /ko -->
+        </li>
+      </ul>
     </div>
   </div>
   <div class="panel panel-default">
     <div class="panel-heading ">
       <div class="row">
         <div class="col-sm-6">
-          <h3 class="panel-title">
+          <h3 class="panel-title" style="padding-top: 7px;">
             {% trans 'My Projects' %}
           </h3>
         </div>
@@ -70,23 +59,11 @@
       </div>
     </div>
     <div class="panel-body">
-      <table class="table table-striped table-responsive">
-        <thead>
-          <tr>
-            <th>{% trans 'Project Name' %}
-            </th>
-          </tr>
-        </thead>
-        <tbody data-bind="foreach: domainLinks">
-          <tr>
-            <td>
-              <a data-bind="attr: {href: url}, text: display_name">
-              </a>
-            </td>
-          </tr>
-        </tbody>
-        
-      </table>
+      <ul class="nav nav-pills nav-stacked" data-bind="foreach: domainLinks">
+        <li>
+          <a data-bind="attr: {href: url}, text: display_name"></a>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -18,7 +18,6 @@ from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.utils import send_confirmation_email
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq.apps.users.models import Invitation
-from corehq.apps.domain.middleware import get_last_visited_domain, set_last_visited_domain
 from corehq.util.quickcache import quickcache
 
 
@@ -57,7 +56,7 @@ def select(request, do_not_redirect=False, next_view=None):
     }
 
     domain_select_template = "domain/select.html"
-    last_visited_domain = get_last_visited_domain(request.couch_user)
+    last_visited_domain = request.session.get('last_visited_domain')
     if open_invitations \
        or do_not_redirect \
        or not last_visited_domain:
@@ -77,7 +76,7 @@ def select(request, do_not_redirect=False, next_view=None):
                 except Http404:
                     pass
 
-        set_last_visited_domain(request.couch_user, None)
+        del request.session['last_visited_domain']
         return render(request, domain_select_template, additional_context)
 
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/COV-11

Reverts dimagi/commcare-hq#27779 and re-applies the UI-only changes. Ideal redirect behavior is still being discussed, so to take time pressure off, I'm just reverting to previous behavior.

Product changes: this makes it so that HQ no longer redirects you to your last visited domain when you log out and back in.