### PR TITLE
Revert "use processed_timestamp"

### DIFF
--- a/custom/icds/management/commands/get_icds_sms_usage.py
+++ b/custom/icds/management/commands/get_icds_sms_usage.py
@@ -12,7 +12,7 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    help = "Reports of SMSes sent to gateway in a date range"
+    help = ""
 
     def add_arguments(self, parser):
         parser.add_argument('domain')
@@ -126,8 +126,8 @@ class Command(BaseCommand):
 
         for sms in SMS.objects.filter(
             domain=domain,
-            processed_timestamp__gt=start_timestamp,
-            processed_timestamp__lte=end_timestamp,
+            date__gt=start_timestamp,
+            date__lte=end_timestamp,
             backend_api=AirtelTCLBackend.get_api_id(),
             direction='O',
             processed=True,


### PR DESCRIPTION
Reverts dimagi/commcare-hq#27921

Getting consistent build failures like:
```
======================================================================
FAIL: custom.icds.tests.test_get_icds_sms_usage:GetICDSSmsUsageTest.test_values_by_district
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/commcare-hq-ro/custom/icds/tests/test_get_icds_sms_usage.py", line 163, in test_values_by_district
    self.assertEqual(sheet.max_row, 4)
AssertionError: 1 != 4
----------------------------------------------------------------------
```
Looks like the original PR skipped the build, though this is tested (albeit in a very roundabout fashion)