### PR TITLE
Accept status "too-many-requests" on formplayer submit responses

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -526,8 +526,11 @@ WebFormSession.prototype.submitForm = function (form) {
                         $.each(resp.errors, function (ix, error) {
                             self.serverError(getForIx(form, ix), error);
                         });
+                        // todo: mark all these messages for translation
                         if (resp.status === 'too-many-requests') {
-                            alert("Contact your administrator.");
+                            alert("We’re unable to submit this form right now due to high system usage. \n\n" +
+                                "Please keep this window open and try again in a minute, " +
+                                "or come back to this form in Incomplete Forms later.");
                         } else if (resp.notification) {
                             alert("Form submission failed with error: \n\n" +
                                 resp.notification.message + ". \n\n " +

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -520,13 +520,15 @@ WebFormSession.prototype.submitForm = function (form) {
                 },
                 function (resp) {
                     form.isSubmitting(false);
-                    if (resp.status == 'success') {
+                    if (resp.status === 'success') {
                         self.onsubmit(resp);
                     } else {
                         $.each(resp.errors, function (ix, error) {
                             self.serverError(getForIx(form, ix), error);
                         });
-                        if (resp.notification) {
+                        if (resp.status === 'too-many-requests') {
+                            alert("Contact your administrator.");
+                        } else if (resp.notification) {
                             alert("Form submission failed with error: \n\n" +
                                 resp.notification.message + ". \n\n " +
                                 "This must be corrected before the form can be submitted.");

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -164,7 +164,7 @@ FormplayerFrontend.on('startForm', function (data) {
     data.formplayerEnabled = true;
     data.displayOptions = $.extend(true, {}, user.displayOptions);
     data.onerror = function (resp) {
-        var message = resp.human_readable_message || resp.exception;
+        var message = resp.human_readable_message || resp.exception || "Unexpected Error";
         if (resp.is_html) {
             showHTMLError(message, $("#cloudcare-notifications"));
         } else {


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-10754

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
If a submission is rate limited because the domain is over their limit, the user will get the following message when they submit on Web Apps (but with e.g. www.commcarehq.org instead of localhost:8000) <img width="445" alt="Screen Shot 2020-06-25 at 11 50 10 AM" src="https://user-images.githubusercontent.com/137212/85763459-47af0680-b6da-11ea-85fb-7cf06bd8e58b.png">

and they will be able to retry submitting