### PR TITLE
Improve Trumpia message status

### DIFF
--- a/corehq/apps/reports/standard/message_event_display.py
+++ b/corehq/apps/reports/standard/message_event_display.py
@@ -88,11 +88,15 @@ def get_sms_status_display(sms):
         return _('Queued')
     if sms.direction == INCOMING:
         return _('Received')
+    if sms.is_status_pending():
+        detail = " " + _("message ID: {id}").format(id=sms.backend_message_id)
+    else:
+        detail = ""
     if sms.direction == OUTGOING:
         if sms.workflow == WORKFLOW_FORWARD:
-            return _('Forwarded')
-        return _('Sent')
-    return _('Unknown')
+            return _('Forwarded') + detail
+        return _('Sent') + detail
+    return _('Unknown') + detail
 
 
 def _get_keyword_display(keyword_id, content_cache):

--- a/corehq/apps/reports/standard/message_event_display.py
+++ b/corehq/apps/reports/standard/message_event_display.py
@@ -83,20 +83,16 @@ def get_sms_status_display(sms):
         if error:
             error_message = SMS.ERROR_MESSAGES.get(error, error)
             return '%s - %s' % (_('Error'), _(error_message))
-        else:
-            return _('Error')
-    elif not sms.processed:
+        return _('Error')
+    if not sms.processed:
         return _('Queued')
-    else:
-        if sms.direction == INCOMING:
-            return _('Received')
-        elif sms.direction == OUTGOING:
-            if sms.workflow == WORKFLOW_FORWARD:
-                return _('Forwarded')
-            else:
-                return _('Sent')
-        else:
-            return _('Unknown')
+    if sms.direction == INCOMING:
+        return _('Received')
+    if sms.direction == OUTGOING:
+        if sms.workflow == WORKFLOW_FORWARD:
+            return _('Forwarded')
+        return _('Sent')
+    return _('Unknown')
 
 
 def _get_keyword_display(keyword_id, content_cache):

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -189,6 +189,7 @@ class SMSBase(UUIDGeneratorMixin, Log):
     ERROR_CONTACT_IS_INACTIVE = 'CONTACT_IS_INACTIVE'
     ERROR_TRIAL_SMS_EXCEEDED = 'TRIAL_SMS_EXCEEDED'
     ERROR_MESSAGE_FORMAT_INVALID = 'MESSAGE_FORMAT_INVALID'
+    STATUS_PENDING = 'STATUS_PENDING'
 
     ERROR_MESSAGES = {
         ERROR_TOO_MANY_UNSUCCESSFUL_ATTEMPTS:
@@ -271,6 +272,15 @@ class SMSBase(UUIDGeneratorMixin, Log):
             smsutil.clean_phone_number(self.phone_number),
             domain=self.domain
         )
+
+    def set_status_pending(self):
+        """Mark message as sent with backend status pending"""
+        self.error = False
+        self.system_error_message = SMSBase.STATUS_PENDING
+        self.save()
+
+    def is_status_pending(self):
+        return not self.error and self.system_error_message == SMSBase.STATUS_PENDING
 
 
 class SMS(SMSBase):

--- a/corehq/messaging/smsbackends/infobip/models.py
+++ b/corehq/messaging/smsbackends/infobip/models.py
@@ -110,9 +110,9 @@ class InfobipBackend(SQLSMSBackend):
         self.handle_response(response, msg)
 
     def handle_response(self, response, msg):
+        if response.status_code == 500:
+            raise InfobipRetry("Gateway 500 error")
         if response.status_code != 200:
-            if response.status_code == 500:
-                raise InfobipRetry("Gateway 500 error")
             msg.set_gateway_error(response.status_code)
             return
         data = json.loads(response.content)

--- a/corehq/messaging/smsbackends/trumpia/models.py
+++ b/corehq/messaging/smsbackends/trumpia/models.py
@@ -53,9 +53,9 @@ class TrumpiaBackend(SQLSMSBackend):
         self.handle_response(response, msg)
 
     def handle_response(self, response, msg):
+        if response.status_code == 500:
+            raise TrumpiaRetry("Gateway 500 error")
         if response.status_code != 200:
-            if response.status_code == 500:
-                raise TrumpiaRetry("Gateway 500 error")
             msg.set_gateway_error(response.status_code)
             return
         data = response.json()


### PR DESCRIPTION
Fix for https://dimagi-dev.atlassian.net/browse/SAAS-11006

Display messages for which Trumpia responded with "In progress" after the message was sent as "Sent" with the message ID. The message ID can be used to lookup message statuses on an as-needed basis.

The first two commits are cleanup.

Review by commit :blowfish: 

Affects all projects with a Trumpia gateway. No need to announce as this is more of a bugfix than a new feature.