### PR TITLE
fix syntax error

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
+++ b/corehq/apps/app_manager/static/app_manager/js/details/case_claim.js
@@ -53,7 +53,7 @@ hqDefine("app_manager/js/details/case_claim", function () {
                 self.searchProperties.push(searchProperty(
                     searchProperties[i].name,
                     label,
-                    searchProperties[i].appearance,
+                    searchProperties[i].appearance
                 ));
             }
         } else {


### PR DESCRIPTION
Fixes the syntax error:

```
[100.71.188.147] Executing task 'compress'
[100.71.188.147] sudo: /home/cchq/www/icds-staging/releases/2020-06-25_02.37/python_env-3.6/bin/python manage.py compress --force -v 0
[100.71.188.147] out: CommandError: An error occurred during rendering /home/cchq/www/icds-staging/releases/2020-06-25_02.37/corehq/apps/app_manager/templates/app_manager/module_view_advanced.html: (b'', b'Parse error at app_manager/js/details/case_claim.js:57,16\n                ));\n                ^\nSyntaxError: Unexpected token: punc ())\n    at JS_Parse_Error.get (eval at <anonymous> (/home/cchq/www/icds-staging/releases/2020-06-25_02.37/node_modules/uglify-js/tools/node.js:27:1), <anonymous>:84:23)\n    at /home/cchq/www/icds-staging/releases/2020-06-25_02.37/node_modules/uglify-js/bin/uglifyjs:384:40\n    at time_it (/home/cchq/www/icds-staging/releases/2020-06-25_02.37/node_modules/uglify-js/bin/uglifyjs:620:15)\n    at /home/cchq/www/icds-staging/releases/2020-06-25_02.37/node_modules/uglify-js/bin/uglifyjs:345:9\n    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:63:3)\n')
[100.71.188.147] out: Compressing...
Fatal error: sudo() received nonzero return code 1 while executing!
Requested: /home/cchq/www/icds-staging/releases/2020-06-25_02.37/python_env-3.6/bin/python manage.py compress --force -v 0
Executed: sudo -S -p 'sudo password:' -H  -u "cchq"  /bin/bash -l -c "cd /home/cchq/www/icds-staging/releases/2020-06-25_02.37 >/dev/null && /home/cchq/www/icds-staging/releases/2020-06-25_02.37/python_env-3.6/bin/python manage.py compress --force -v 0"
```

Looks like raised here: https://github.com/dimagi/commcare-hq/pull/27873



Though, its weird to see that trailing comma causing an error in function calls. I see my editor flagging the error too. But its weird browser console runs it fine. Could it be the JS version issue?