### PR TITLE
remove ICDS UCRs from 'india' env

### DIFF
--- a/custom/icds_reports/ucr/data_sources/adolescent_girl_register_form_ucr.json
+++ b/custom/icds_reports/ucr/data_sources/adolescent_girl_register_form_ucr.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/ag_care_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ag_care_cases.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/ag_care_cases_monthly.json
+++ b/custom/icds_reports/ucr/data_sources/ag_care_cases_monthly.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/awc_locations.json
+++ b/custom/icds_reports/ucr/data_sources/awc_locations.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
+++ b/custom/icds_reports/ucr/data_sources/awc_mgt_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/cbe_form.json
+++ b/custom/icds_reports/ucr/data_sources/cbe_form.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/ccs_record_cases_monthly_v2.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
+++ b/custom/icds_reports/ucr/data_sources/child_cases_monthly_v2.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/child_delivery_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/child_health_cases.json
+++ b/custom/icds_reports/ucr/data_sources/child_health_cases.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/daily_feeding_forms.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/add_pregnancy_form.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/add_pregnancy_form.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/availing_service_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/availing_service_forms.json
@@ -21,7 +21,6 @@
     "cas-lab"
 	],
 	"server_environment": [
-		"india",
     "icds",
     "icds-staging"
 	],

--- a/custom/icds_reports/ucr/data_sources/dashboard/birth_preparedness_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/birth_preparedness_forms.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/child_tasks.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/commcare_user_cases.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/commcare_user_cases.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/complementary_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/complementary_feeding_forms.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/daily_feeding_forms.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/dashboard_growth_monitoring.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/delivery_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/delivery_forms.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/migrations_form.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/migrations_form.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/postnatal_care_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/postnatal_care_forms.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/pregnant_tasks.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/dashboard/thr_forms.json
+++ b/custom/icds_reports/ucr/data_sources/dashboard/thr_forms.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/gm_forms.json
+++ b/custom/icds_reports/ucr/data_sources/gm_forms.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/hardware_cases.json
+++ b/custom/icds_reports/ucr/data_sources/hardware_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/home_visit_forms.json
+++ b/custom/icds_reports/ucr/data_sources/home_visit_forms.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/household_cases.json
+++ b/custom/icds_reports/ucr/data_sources/household_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/infrastructure_form_v2.json
+++ b/custom/icds_reports/ucr/data_sources/infrastructure_form_v2.json
@@ -20,7 +20,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/it_report_follow_issue.json
+++ b/custom/icds_reports/ucr/data_sources/it_report_follow_issue.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/ls_app_usage_forms.json
+++ b/custom/icds_reports/ucr/data_sources/ls_app_usage_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
+++ b/custom/icds_reports/ucr/data_sources/ls_home_visit_forms_filled.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/ls_vhnd_form.json
+++ b/custom/icds_reports/ucr/data_sources/ls_vhnd_form.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/person_cases_v3.json
+++ b/custom/icds_reports/ucr/data_sources/person_cases_v3.json
@@ -24,7 +24,6 @@
     "zohaib-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/primary_private_school_form_ucr.json
+++ b/custom/icds_reports/ucr/data_sources/primary_private_school_form_ucr.json
@@ -19,7 +19,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/tasks_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tasks_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
+++ b/custom/icds_reports/ucr/data_sources/tech_issue_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
+++ b/custom/icds_reports/ucr/data_sources/thr_forms_v2.json
@@ -20,7 +20,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/usage_forms.json
+++ b/custom/icds_reports/ucr/data_sources/usage_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/vhnd_form.json
+++ b/custom/icds_reports/ucr/data_sources/vhnd_form.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
+++ b/custom/icds_reports/ucr/data_sources/visitorbook_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/asr/asr_2_3_person_cases.json
+++ b/custom/icds_reports/ucr/reports/asr/asr_2_3_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/asr/asr_2_household_cases.json
+++ b/custom/icds_reports/ucr/reports/asr/asr_2_household_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/asr/asr_2_lactating.json
+++ b/custom/icds_reports/ucr/reports/asr/asr_2_lactating.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/asr/asr_2_pregnancies.json
+++ b/custom/icds_reports/ucr/reports/asr/asr_2_pregnancies.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/asr/asr_4_6_infrastructure.json
+++ b/custom/icds_reports/ucr/reports/asr/asr_4_6_infrastructure.json
@@ -20,7 +20,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
+++ b/custom/icds_reports/ucr/reports/asr/ucr_v2/asr_2_3_beneficiaries.json
@@ -20,7 +20,6 @@
     "reach-test"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/dashboard/asr_2_3_person_cases.json
+++ b/custom/icds_reports/ucr/reports/dashboard/asr_2_3_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/dashboard/asr_4a_6.pse.json
+++ b/custom/icds_reports/ucr/reports/dashboard/asr_4a_6.pse.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_above_6mo_nutrition.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_above_6mo_nutrition.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_awc_days_open.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_awc_days_open.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_awc_locations.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_awc_locations.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_awc_mgmt_forms.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_awc_mgmt_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_beneficiary_feedback.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_beneficiary_feedback.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_born_last_30_days.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_born_last_30_days.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_ccs_record_cases.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_ccs_record_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_child_nutrition_status.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_child_nutrition_status.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_children_weighed.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_children_weighed.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_comp_feeding.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_comp_feeding.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_ebf.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_ebf.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_handwashing.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_handwashing.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_ifa_consumption.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_ifa_consumption.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_immun_complete.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_immun_complete.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_report_child_names.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_child_names.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_report_child_nutrition_status.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_child_nutrition_status.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_report_lbw_pre_term.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_lbw_pre_term.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_report_pregnant_women_names.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_report_pregnant_women_names.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_thr_30_days.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_thr_30_days.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_thr_forms.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_thr_forms.json
@@ -20,7 +20,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_timely_home_visits.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_timely_home_visits.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_above_6mo_nutrition.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_above_6mo_nutrition.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_ag.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_ag.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_ag_monthly.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_ag_monthly.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_awc_days_open.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_awc_days_open.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_born_last_30_days.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_born_last_30_days.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_cbe.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_cbe.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_ccs_record_cases.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_ccs_record_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_child_nutrition_status.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_child_nutrition_status.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_children_weighed.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_children_weighed.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_comp_feeding.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_comp_feeding.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_ebf.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_ebf.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_handwashing.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_handwashing.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_ifa_consumption.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_ifa_consumption.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_report_child_names.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_report_child_names.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_report_child_nutrition_status.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_report_child_nutrition_status.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_report_lactating_women_names.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_report_lactating_women_names.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_report_lbw_pre_term.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_report_lbw_pre_term.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_report_pregnant_women_names.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_report_pregnant_women_names.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_thr_30_days.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_thr_30_days.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/ls/ls_v2_timely_home_visits.json
+++ b/custom/icds_reports/ucr/reports/ls/ls_v2_timely_home_visits.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/dashboard/mpr_10ab_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/dashboard/mpr_10ab_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/dashboard/mpr_4a_6_pse.json
+++ b/custom/icds_reports/ucr/reports/mpr/dashboard/mpr_4a_6_pse.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_10a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_10a_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_10b_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_10b_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_11_visitor_book_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_11_visitor_book_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_1_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_1_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2a_3_child_delivery_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2a_3_child_delivery_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2a_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2bi_preg_delivery_death_list.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2bii_child_death_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2bii_child_death_list.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_2ci_child_birth_list.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_2ci_child_birth_list.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_3i_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_3i_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_3ii_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_3ii_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_4a_6_pse.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_4a_6_pse.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_4b_infra_forms.json
@@ -20,7 +20,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_4b_web_infra.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_4b_web_infra.json
@@ -20,7 +20,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_5_ccs_record_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_5_ccs_record_cases.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_5_ccs_record_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_5_ccs_record_cases_v2.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_5_child_health_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_5_child_health_cases.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_5_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_5_child_health_cases_v2.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_6ac_child_health_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_6ac_child_health_cases.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_6ac_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_6ac_child_health_cases_v2.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_6b_child_health_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_6b_child_health_cases.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_6b_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_6b_child_health_cases_v2.json
@@ -21,7 +21,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_7_growth_monitoring_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_7_growth_monitoring_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_8_tasks_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_8_tasks_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_9_vhnd_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_9_vhnd_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_10a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_10a_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_10b_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_10b_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_11_visitor_book_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_11_visitor_book_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_1_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_1_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_2a_3_child_delivery_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_2a_3_child_delivery_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_2a_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_2a_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_3i_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_3i_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_3ii_person_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_3ii_person_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_4a_6_pse.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_4a_6_pse.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_4b_infra_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_4b_infra_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_5_ccs_record_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_5_ccs_record_cases_v2.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_5_child_health_cases_v2.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_5_child_health_cases_v2.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_6ac_child_health_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_6ac_child_health_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_6b_child_health_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_6b_child_health_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_7_growth_monitoring_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_7_growth_monitoring_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_8_tasks_cases.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_8_tasks_cases.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/mpr/mpr_v2_9_vhnd_forms.json
+++ b/custom/icds_reports/ucr/reports/mpr/mpr_v2_9_vhnd_forms.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/hardware_block.json
+++ b/custom/icds_reports/ucr/reports/other/hardware_block.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/hardware_district.json
+++ b/custom/icds_reports/ucr/reports/other/hardware_district.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/hardware_individual.json
+++ b/custom/icds_reports/ucr/reports/other/hardware_individual.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/it_individual_issues.json
+++ b/custom/icds_reports/ucr/reports/other/it_individual_issues.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/it_issues_activity.json
+++ b/custom/icds_reports/ucr/reports/other/it_issues_activity.json
@@ -1,6 +1,5 @@
 {
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/it_issues_block.json
+++ b/custom/icds_reports/ucr/reports/other/it_issues_block.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/it_issues_by_ticket_level.json
+++ b/custom/icds_reports/ucr/reports/other/it_issues_by_ticket_level.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/it_issues_by_type.json
+++ b/custom/icds_reports/ucr/reports/other/it_issues_by_type.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/it_issues_district.json
+++ b/custom/icds_reports/ucr/reports/other/it_issues_district.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/it_issues_state.json
+++ b/custom/icds_reports/ucr/reports/other/it_issues_state.json
@@ -22,7 +22,6 @@
     "cas-lab"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],

--- a/custom/icds_reports/ucr/reports/other/list_pnc_delivery_complications.json
+++ b/custom/icds_reports/ucr/reports/other/list_pnc_delivery_complications.json
@@ -22,7 +22,6 @@
     "icds-cas-sandbox"
   ],
   "server_environment": [
-    "india",
     "icds",
     "icds-staging"
   ],


### PR DESCRIPTION
We will be removing Citus from 'india' env soon (https://github.com/dimagi/commcare-cloud/pull/3907) so this will avoid creating all these tables in the main UCR DB