### PR TITLE
Extended year range in calendar

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -574,8 +574,8 @@ function DateTimeEntryBase(question, options) {
             value: self.answer() ? self.convertServerToClientFormat(self.answer()) : self.answer(),
             maxDate: maxDate,
             minDate: minDate,
-            yearStart: thisYear - 120,
-            yearEnd: thisYear + 30,
+            yearStart: thisYear - 100,
+            yearEnd: thisYear + 10,
             scrollInput: false,
             onChangeDateTime: function (newDate) {
                 if (!newDate) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -574,8 +574,8 @@ function DateTimeEntryBase(question, options) {
             value: self.answer() ? self.convertServerToClientFormat(self.answer()) : self.answer(),
             maxDate: maxDate,
             minDate: minDate,
-            yearStart: thisYear-120,
-            yearEnd: thisYear+30,
+            yearStart: thisYear - 120,
+            yearEnd: thisYear + 30,
             scrollInput: false,
             onChangeDateTime: function (newDate) {
                 if (!newDate) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -558,10 +558,14 @@ function DateTimeEntryBase(question, options) {
         isPhoneMode = ko.utils.unwrapObservable(displayOpts.phoneMode);
 
     EntrySingleAnswer.call(self, question, options);
+
+    // Set year ranges
+    yearEnd = thisYear + 10
+    yearStart = thisYear - 100
     // Set max date to 10 years in the future
-    maxDate = moment(thisYear + 10, 'YYYY').toDate();
+    maxDate = moment(yearEnd, 'YYYY').toDate();
     // Set min date to 100 years in the past
-    minDate = moment(thisYear - 100, 'YYYY').toDate();
+    minDate = moment(yearStart, 'YYYY').toDate();
 
     self.afterRender = function () {
         self.$picker = $('#' + self.entryId);
@@ -574,8 +578,8 @@ function DateTimeEntryBase(question, options) {
             value: self.answer() ? self.convertServerToClientFormat(self.answer()) : self.answer(),
             maxDate: maxDate,
             minDate: minDate,
-            yearStart: thisYear - 100,
-            yearEnd: thisYear + 10,
+            yearEnd: yearEnd,
+            yearStart: yearStart,
             scrollInput: false,
             onChangeDateTime: function (newDate) {
                 if (!newDate) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -574,6 +574,8 @@ function DateTimeEntryBase(question, options) {
             value: self.answer() ? self.convertServerToClientFormat(self.answer()) : self.answer(),
             maxDate: maxDate,
             minDate: minDate,
+            yearStart: thisYear-120,
+            yearEnd: thisYear+30,
             scrollInput: false,
             onChangeDateTime: function (newDate) {
                 if (!newDate) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -554,6 +554,8 @@ function DateTimeEntryBase(question, options) {
         thisYear = new Date().getFullYear(),
         minDate,
         maxDate,
+        yearEnd,
+        yearStart,
         displayOpts = _getDisplayOptions(question),
         isPhoneMode = ko.utils.unwrapObservable(displayOpts.phoneMode);
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -560,8 +560,8 @@ function DateTimeEntryBase(question, options) {
     EntrySingleAnswer.call(self, question, options);
 
     // Set year ranges
-    yearEnd = thisYear + 10
-    yearStart = thisYear - 100
+    yearEnd = thisYear + 10;
+    yearStart = thisYear - 100;
     // Set max date to 10 years in the future
     maxDate = moment(yearEnd, 'YYYY').toDate();
     // Set min date to 100 years in the past


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10975

##### SUMMARY
Users could not select a year prior to 1950 in the calendar year dropdown. 
Updated year dropdown to 100 years before the current year and 10 years after the current year for a wider range.

##### FEATURE FLAG
N/A

##### RISK ASSESSMENT / QA PLAN
N/A

##### PRODUCT DESCRIPTION
Users can see a wider year range in the calendar year dropdown menu.