### PR TITLE
Kill NO_VELLUM feature flag

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1071,6 +1071,10 @@ class FormBase(DocumentSchema):
             or self.form_type == 'advanced_form'
         )
 
+    @property
+    def can_edit_in_vellum(self):
+        return self.form_type != 'shadow_form'
+
     @case_references.setter
     def case_references(self, case_references):
         self.case_references_data = case_references

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1001,7 +1001,6 @@ class FormBase(DocumentSchema):
         default=None,
     )
     auto_gps_capture = BooleanProperty(default=False)
-    no_vellum = BooleanProperty(default=False)
     form_links = SchemaListProperty(FormLink)
     schedule_form_id = StringProperty()
     custom_assertions = SchemaListProperty(CustomAssertion)
@@ -2933,7 +2932,6 @@ class AdvancedModule(ModuleBase):
         name = name if name else _("Untitled Form")
         form = ShadowForm(
             name={lang: name},
-            no_vellum=True,
         )
         form.schedule = FormSchedule(enabled=False)
 

--- a/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/forms/form_view.js
@@ -126,10 +126,6 @@ hqDefine("app_manager/js/forms/form_view", function () {
             $shadowParent.koApplyBindings({
                 shadow_parent: ko.observable(initialPageData('shadow_parent_form_id')),
             });
-        } else if (hqImport('hqwebapp/js/toggles').toggleEnabled('NO_VELLUM')) {
-            $('#no-vellum').koApplyBindings({
-                no_vellum: ko.observable(initialPageData('no_vellum')),
-            });
         }
 
         if (hqImport('hqwebapp/js/toggles').toggleEnabled('CUSTOM_INSTANCES')) {

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -142,7 +142,6 @@
   {% initial_page_data 'multimedia_object_map' multimedia.object_map %}
   {% initial_page_data 'multimedia_upload_managers' multimedia.upload_managers_js %}
   {% initial_page_data 'nav_menu_media_specifics' nav_menu_media_specifics %}
-  {% initial_page_data 'no_vellum' form.no_vellum %}
   {% initial_page_data 'root_requires_same_case' root_requires_same_case %}
   {% initial_page_data 'put_in_root' module.put_in_root %}
   {% initial_page_data 'sessionid' request.COOKIES.sessionid %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/forms/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/forms/form_tab_settings.html
@@ -71,24 +71,6 @@
             {% include "app_manager/partials/forms/shadow_parent_select.html" %}
           {% endif %}
 
-          {% if request|toggle_enabled:'NO_VELLUM' and form.form_type != "shadow_form"%}
-            <div class="form-group">
-              <label class="control-label col-sm-2">
-                {% trans "Disallow editing form in Form Builder" %}
-                <span class="hq-help-template"
-                      data-title="{% trans "Disallow editing form in Form Builder" %}"
-                      data-content="{% blocktrans %}For custom forms that the Form Builder breaks,
-                                                    use this option to disallow editing in the Form Builder.{% endblocktrans %}"
-                ></span>
-              </label>
-              <div class="col-sm-4" id="no-vellum">
-                <input type="checkbox" value="true"
-                       data-bind="checked: no_vellum"/>
-                <input type="hidden" name="no_vellum" data-bind="value: no_vellum"/>
-              </div>
-            </div>
-          {% endif %}
-
           {% if request|toggle_enabled:'CUSTOM_INSTANCES' %}
             {% include "app_manager/partials/forms/custom_instances.html" %}
           {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/form_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/form_link.html
@@ -11,7 +11,7 @@
     </a>
 
     <a id="view_form_{{ module.unique_id }}_{{ form.unique_id }}_sidebar"
-       {% if form.no_vellum %}
+       {% if form.form_type == 'shadow_form' %}
        href="{% url "view_form" domain app.id form.unique_id %}"
        {% else %}
        href="{% url "form_source" domain app.id form.unique_id %}"
@@ -23,7 +23,7 @@
        data-label="Edit Pen"
        class="appnav-title
               track-usage-link
-              {% if not form.no_vellum %}appnav-title-secondary {% endif %}
+              {% if form.form_type != 'shadow_form' %}appnav-title-secondary {% endif %}
               appnav-responsive">
             <i class="drag_handle appnav-drag-icon"></i>
         <i
@@ -50,7 +50,7 @@
         </span>
     </a>
 
-    {% if not form.no_vellum %}
+    {% if form.form_type != 'shadow_form' %}
     <a href="{% url "view_form" domain app.id form.unique_id %}"
        data-moduleid="{{ module.id }}"
        data-formid="{{ form.id }}"

--- a/corehq/apps/app_manager/templates/app_manager/partials/menu/form_link.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/menu/form_link.html
@@ -11,10 +11,10 @@
     </a>
 
     <a id="view_form_{{ module.unique_id }}_{{ form.unique_id }}_sidebar"
-       {% if form.form_type == 'shadow_form' %}
-       href="{% url "view_form" domain app.id form.unique_id %}"
+       {% if form.can_edit_in_vellum %}
+         href="{% url "form_source" domain app.id form.unique_id %}"
        {% else %}
-       href="{% url "form_source" domain app.id form.unique_id %}"
+         href="{% url "view_form" domain app.id form.unique_id %}"
        {% endif %}
        data-moduleid="{{ module.id }}"
        data-formid="{{ form.id }}"
@@ -23,7 +23,7 @@
        data-label="Edit Pen"
        class="appnav-title
               track-usage-link
-              {% if form.form_type != 'shadow_form' %}appnav-title-secondary {% endif %}
+              {% if form.can_edit_in_vellum %}appnav-title-secondary {% endif %}
               appnav-responsive">
             <i class="drag_handle appnav-drag-icon"></i>
         <i
@@ -50,7 +50,7 @@
         </span>
     </a>
 
-    {% if form.form_type != 'shadow_form' %}
+    {% if form.can_edit_in_vellum %}
     <a href="{% url "view_form" domain app.id form.unique_id %}"
        data-moduleid="{{ module.id }}"
        data-formid="{{ form.id }}"

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -112,7 +112,7 @@ def _get_form_designer_view(request, domain, app, module, form):
         ))
         return back_to_main(request, domain, app_id=app.id)
 
-    if form.no_vellum:
+    if form.form_type == "shadow_form":
         messages.warning(request, _(
             "You tried to edit this form in the Form Builder. "
             "However, your administrator has locked this form against editing "

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -112,7 +112,7 @@ def _get_form_designer_view(request, domain, app, module, form):
         ))
         return back_to_main(request, domain, app_id=app.id)
 
-    if form.form_type == "shadow_form":
+    if not form.can_edit_in_vellum:
         messages.warning(request, _(
             "You tried to edit this form in the Form Builder. "
             "However, your administrator has locked this form against editing "

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -352,8 +352,6 @@ def _edit_form_attr(request, domain, app_id, form_unique_id, attr):
                     "a release notes form <TODO messaging>")},
                 status_code=400
             )
-    if should_edit('no_vellum'):
-        form.no_vellum = request.POST['no_vellum'] == 'true'
     if (should_edit("form_links_xpath_expressions") and
             should_edit("form_links_form_ids") and
             toggles.FORM_LINK_WORKFLOW.enabled(domain)):

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -87,7 +87,7 @@ def back_to_main(request, domain, app_id, module_id=None, form_id=None,
             raise Http404()
 
     if form is not None:
-        view_name = 'view_form' if form.no_vellum else 'form_source'
+        view_name = 'view_form' if form.form_type == 'shadow_form' else 'form_source'
         args.append(form.unique_id)
     elif module is not None:
         view_name = 'view_module'

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -87,7 +87,7 @@ def back_to_main(request, domain, app_id, module_id=None, form_id=None,
             raise Http404()
 
     if form is not None:
-        view_name = 'view_form' if form.form_type == 'shadow_form' else 'form_source'
+        view_name = 'form_source' if form.can_edit_in_vellum else 'view_form'
         args.append(form.unique_id)
     elif module is not None:
         view_name = 'view_module'

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -741,14 +741,6 @@ LIVEQUERY_SYNC = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-NO_VELLUM = StaticToggle(
-    'no_vellum',
-    'Allow disabling Form Builder per form '
-    '(for custom forms that Vellum breaks)',
-    TAG_INTERNAL,
-    [NAMESPACE_DOMAIN, NAMESPACE_USER]
-)
-
 HIPAA_COMPLIANCE_CHECKBOX = StaticToggle(
     'hipaa_compliance_checkbox',
     'Show HIPAA compliance checkbox',


### PR DESCRIPTION
##### SUMMARY
Checked all servers, and no real projects are using this. Noticed it while looking at permissions in app manager.

Because there was a `no_vellum` attribute stored on the form, it's possible that a project had this turned on, marked some forms, and then turned it off. I think it's reasonable to say that if the flag is off, you no longer need access to the feature. @dimagi/product let me know if you disagree.

##### FEATURE FLAG
Allow disabling Form Builder per form (for custom forms that Vellum breaks)

##### RISK ASSESSMENT / QA PLAN
Small code removal, no QA.