### PR TITLE
log the correct adapter

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -221,9 +221,9 @@ class ConfigurableReportTableManagerMixin(object):
                     "[rebuild] Rebuilding table: %s, from config %s at rev %s",
                     table_name, sql_adapter.config._id, sql_adapter.config._rev
                 )
-                pillow_logging.info("[rebuild] Using config: %r", adapter.config)
+                pillow_logging.info("[rebuild] Using config: %r", sql_adapter.config)
                 pillow_logging.info("[rebuild] sqlalchemy metadata: %r", get_metadata(engine_id).tables[table_name])
-                pillow_logging.info("[rebuild] sqlalchemy table: %r", adapter.get_table())
+                pillow_logging.info("[rebuild] sqlalchemy table: %r", sql_adapter.get_table())
                 table_diffs = [diff for diff in diffs if diff.table_name == table_name]
                 if not sql_adapter.config.is_static:
                     try:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Because it wouldnt be fun if logging worked the first time you deployed it, or the second, or the third.