### PR TITLE
Fix progress bar for messaging rules

### DIFF
--- a/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
+++ b/corehq/apps/data_interfaces/tests/test_scheduling_integration.py
@@ -1069,7 +1069,8 @@ class CaseRuleSchedulingIntegrationTest(TestCase):
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     @patch('corehq.messaging.tasks.sync_case_for_messaging_rule.delay')
-    def test_run_messaging_rule(self, task_patch):
+    @patch('corehq.apps.es.es_query.ESQuery.count', return_value=10)
+    def test_run_messaging_rule(self, es_patch, task_patch):
         rule_id = self._setup_rule()
         with create_case(self.domain, 'person') as case1, create_case(self.domain, 'person') as case2:
             run_messaging_rule(self.domain, rule_id)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -193,6 +193,7 @@ def run_messaging_rule_for_shard(domain, rule_id, db_alias):
     if not progress_helper.is_canceled():
         for case_id_chunk in chunked(paginated_case_ids(domain, rule.case_type, db_alias), chunk_size):
             sync_case_chunk_for_messaging_rule.delay(domain, case_id_chunk, rule_id)
+            progress_helper.update_total_key_expiry()
             if progress_helper.is_canceled():
                 break
     all_shards_complete = progress_helper.mark_shard_complete(db_alias)

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -152,11 +152,15 @@ def run_messaging_rule(domain, rule_id):
     progress_helper.set_total_cases_to_be_processed(total_cases_count)
 
     def _run_rule_sequentially():
+        incr = 0
         progress_helper.set_initial_progress()
         for case_id in get_case_ids_for_messaging_rule(domain, rule.case_type):
             sync_case_for_messaging_rule.delay(domain, case_id, rule_id)
-            if progress_helper.is_canceled():
-                break
+            incr += 1
+            if incr >= 1000:
+                incr = 0
+                if progress_helper.is_canceled():
+                    break
 
         # By putting this task last in the queue, the rule should be marked
         # complete at about the time that the last tasks are finishing up.

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -159,6 +159,7 @@ def run_messaging_rule(domain, rule_id):
             incr += 1
             if incr >= 1000:
                 incr = 0
+                progress_helper.update_total_key_expiry()
                 if progress_helper.is_canceled():
                     break
 

--- a/corehq/messaging/tasks.py
+++ b/corehq/messaging/tasks.py
@@ -1,4 +1,3 @@
-from corehq import toggles
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.sms import tasks as sms_tasks
 from corehq.apps.es import CaseES
@@ -158,7 +157,6 @@ def run_messaging_rule(domain, rule_id):
             sync_case_for_messaging_rule.delay(domain, case_id, rule_id)
             if progress_helper.is_canceled():
                 break
-
 
         # By putting this task last in the queue, the rule should be marked
         # complete at about the time that the last tasks are finishing up.

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -87,7 +87,7 @@ class MessagingRuleProgressHelper(object):
             if fail_hard:
                 raise
 
-    def update_total_key_expiry(self, value):
+    def update_total_key_expiry(self):
         self.client.expire(self.total_key, self.key_expiry)
 
     def cancel(self):

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -87,8 +87,7 @@ class MessagingRuleProgressHelper(object):
             if fail_hard:
                 raise
 
-    def increase_total_case_count(self, value):
-        self.client.incr(self.total_key, delta=value)
+    def update_total_key_expiry(self, value):
         self.client.expire(self.total_key, self.key_expiry)
 
     def cancel(self):

--- a/corehq/messaging/util.py
+++ b/corehq/messaging/util.py
@@ -52,13 +52,15 @@ class MessagingRuleProgressHelper(object):
     def set_initial_progress(self, shard_count=0):
         # shard_count is passed when tasks are run per each shard
         self.client.set(self.current_key, 0)
-        self.client.set(self.total_key, 0)
         if shard_count:
             self.client.set(self.shard_count_key, shard_count)
         for key in [self.current_key, self.total_key, self.shard_count_key, self.completed_shards_key]:
             self.client.expire(key, self.key_expiry)
         self.client.delete(self.rule_cancellation_key)
         self.set_rule_initiation_key()
+
+    def set_total_cases_to_be_processed(self, total_cases):
+        self.client.set(self.total_key, total_cases)
 
     def mark_shard_complete(self, db_alias):
         """Mark shard complete


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/ICDS-1437
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On activating conditional alerts the progress bar of the cases processed was giving not so accurate values.
The changes fix the bar by taking a total count of cases from ES which was estimated before on the basis of batches processed.
