### PR TITLE
recreate Table object

### DIFF
--- a/corehq/apps/aggregate_ucrs/ingestion.py
+++ b/corehq/apps/aggregate_ucrs/ingestion.py
@@ -118,7 +118,7 @@ def populate_aggregate_table_data_for_time_period(aggregate_table_adapter, windo
     all_query_columns = [
         pca.to_sqlalchemy_query_column(primary_table, aggregation_params) for pca in primary_column_adapters
     ]
-    for secondary_table in aggregate_table_adapter.config.secondary_tables.all():
+    for secondary_table in aggregate_table_adapter.config.get_secondary_tables():
         sqlalchemy_secondary_table = get_indicator_adapter(secondary_table.data_source).get_table()
         for column_adapter in secondary_table.get_column_adapters():
             all_query_columns.append(
@@ -131,7 +131,7 @@ def populate_aggregate_table_data_for_time_period(aggregate_table_adapter, windo
 
     # now construct join
     select_table = primary_table
-    for secondary_table in aggregate_table_adapter.config.secondary_tables.all():
+    for secondary_table in aggregate_table_adapter.config.get_secondary_tables():
         sqlalchemy_secondary_table = get_indicator_adapter(secondary_table.data_source).get_table()
         # apply join filters along with period start/end filters (if necessary) for related model
         join_conditions = [
@@ -186,5 +186,6 @@ def populate_aggregate_table_data_for_time_period(aggregate_table_adapter, windo
         }
 
     )
+
     with aggregate_table_adapter.session_helper.session_context() as session:
         session.execute(insert_statement)

--- a/corehq/apps/aggregate_ucrs/ingestion.py
+++ b/corehq/apps/aggregate_ucrs/ingestion.py
@@ -118,8 +118,7 @@ def populate_aggregate_table_data_for_time_period(aggregate_table_adapter, windo
     all_query_columns = [
         pca.to_sqlalchemy_query_column(primary_table, aggregation_params) for pca in primary_column_adapters
     ]
-    for secondary_table in aggregate_table_adapter.config.get_secondary_tables():
-        sqlalchemy_secondary_table = get_indicator_adapter(secondary_table.data_source).get_table()
+    for secondary_table, sqlalchemy_secondary_table in aggregate_table_adapter.config.get_secondary_tables():
         for column_adapter in secondary_table.get_column_adapters():
             all_query_columns.append(
                 column_adapter.to_sqlalchemy_query_column(sqlalchemy_secondary_table, aggregation_params)
@@ -131,8 +130,7 @@ def populate_aggregate_table_data_for_time_period(aggregate_table_adapter, windo
 
     # now construct join
     select_table = primary_table
-    for secondary_table in aggregate_table_adapter.config.get_secondary_tables():
-        sqlalchemy_secondary_table = get_indicator_adapter(secondary_table.data_source).get_table()
+    for secondary_table, sqlalchemy_secondary_table in aggregate_table_adapter.config.get_secondary_tables():
         # apply join filters along with period start/end filters (if necessary) for related model
         join_conditions = [
             (primary_table.c[secondary_table.join_column_primary] ==

--- a/corehq/apps/aggregate_ucrs/ingestion.py
+++ b/corehq/apps/aggregate_ucrs/ingestion.py
@@ -118,7 +118,7 @@ def populate_aggregate_table_data_for_time_period(aggregate_table_adapter, windo
     all_query_columns = [
         pca.to_sqlalchemy_query_column(primary_table, aggregation_params) for pca in primary_column_adapters
     ]
-    for secondary_table, sqlalchemy_secondary_table in aggregate_table_adapter.config.get_secondary_tables():
+    for secondary_table, sqlalchemy_secondary_table in aggregate_table_adapter.config.get_secondary_tables_and_adapters():
         for column_adapter in secondary_table.get_column_adapters():
             all_query_columns.append(
                 column_adapter.to_sqlalchemy_query_column(sqlalchemy_secondary_table, aggregation_params)
@@ -130,7 +130,7 @@ def populate_aggregate_table_data_for_time_period(aggregate_table_adapter, windo
 
     # now construct join
     select_table = primary_table
-    for secondary_table, sqlalchemy_secondary_table in aggregate_table_adapter.config.get_secondary_tables():
+    for secondary_table, sqlalchemy_secondary_table in aggregate_table_adapter.config.get_secondary_tables_and_adapters():
         # apply join filters along with period start/end filters (if necessary) for related model
         join_conditions = [
             (primary_table.c[secondary_table.join_column_primary] ==

--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -138,7 +138,7 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
         return columns
 
     @memoized
-    def get_secondary_tables(self):
+    def get_secondary_tables_and_adapters(self):
         return [
             (table, get_indicator_adapter(table.data_source).get_table())
             for table in self.secondary_tables.all()

--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -139,7 +139,10 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
 
     @memoized
     def get_secondary_tables(self):
-        return [(table, get_indicator_adapter(table.data_source).get_table()) for table in self.secondary_tables.all()]
+        return [
+            (table, get_indicator_adapter(table.data_source).get_table())
+            for table in self.secondary_tables.all()
+        ]
 
 
 class PrimaryColumn(models.Model):

--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -136,6 +136,10 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
                 columns.append(column_name)
         return columns
 
+    @memoized
+    def get_secondary_tables(self):
+        return self.secondary_tables.all()
+
 
 class PrimaryColumn(models.Model):
     """

--- a/corehq/apps/aggregate_ucrs/models.py
+++ b/corehq/apps/aggregate_ucrs/models.py
@@ -23,6 +23,7 @@ from corehq.apps.userreports.models import (
     get_datasource_config,
 )
 from corehq.apps.userreports.sql.util import decode_column_name
+from corehq.apps.userreports.util import get_indicator_adapter
 from corehq.sql_db.connections import UCR_ENGINE_ID
 
 MAX_COLUMN_NAME_LENGTH = MAX_TABLE_NAME_LENGTH = 63
@@ -138,7 +139,7 @@ class AggregateTableDefinition(models.Model, AbstractUCRDataSource):
 
     @memoized
     def get_secondary_tables(self):
-        return self.secondary_tables.all()
+        return [(table, get_indicator_adapter(table.data_source).get_table()) for table in self.secondary_tables.all()]
 
 
 class PrimaryColumn(models.Model):

--- a/corehq/apps/callcenter/queries.py
+++ b/corehq/apps/callcenter/queries.py
@@ -1,5 +1,7 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 
+from memoized import memoized
+
 from sqlalchemy import distinct, func
 from sqlalchemy.sql import and_, label, operators, or_, select
 
@@ -12,6 +14,7 @@ class BaseQuery(metaclass=ABCMeta):
         raise NotImplementedError
 
     @property
+    @memoized
     def sql_table(self):
         return self.sql_adapter.get_table()
 
@@ -192,7 +195,6 @@ class CaseQueryTotalLegacy(BaseQuery):
         )).group_by(
             self.sql_table.c.owner_id
         )
-
         return self._run_query(query)
 
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -452,7 +452,7 @@ def get_indicator_table(indicator_config, metadata, override_table_name=None):
             logger.error(f"Invalid index specified on {table_name} ({index.column_ids})")
     constraints = [PrimaryKeyConstraint(*indicator_config.pk_columns)]
     columns_and_indices = sql_columns + extra_indices + constraints
-    current_table = metadata.tables[table_name]
+    current_table = metadata.tables.get(table_name)
     if current_table:
         metadata.remove(current_table)
     return sqlalchemy.Table(

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -453,7 +453,7 @@ def get_indicator_table(indicator_config, metadata, override_table_name=None):
     constraints = [PrimaryKeyConstraint(*indicator_config.pk_columns)]
     columns_and_indices = sql_columns + extra_indices + constraints
     current_table = metadata.tables.get(table_name)
-    if current_table:
+    if current_table is not None:
         metadata.remove(current_table)
     return sqlalchemy.Table(
         table_name,

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -452,12 +452,12 @@ def get_indicator_table(indicator_config, metadata, override_table_name=None):
             logger.error(f"Invalid index specified on {table_name} ({index.column_ids})")
     constraints = [PrimaryKeyConstraint(*indicator_config.pk_columns)]
     columns_and_indices = sql_columns + extra_indices + constraints
-    # todo: needed to add extend_existing=True to support multiple calls to this function for the same table.
-    # is that valid?
+    current_table = metadata.tables[table_name]
+    if current_table:
+        metadata.remove(current_table)
     return sqlalchemy.Table(
         table_name,
         metadata,
-        extend_existing=True,
         *columns_and_indices
     )
 

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -1,6 +1,8 @@
 import collections
 import hashlib
 
+from memoized import memoized
+
 from django_prbac.utils import has_privilege
 
 from corehq import privileges, toggles
@@ -133,6 +135,7 @@ def number_of_ucr_reports(domain):
     return len(ucr_reports)
 
 
+@memoized
 def get_indicator_adapter(config, raise_errors=False, load_source="unknown"):
     from corehq.apps.userreports.sql.adapter import IndicatorSqlAdapter, ErrorRaisingIndicatorSqlAdapter, \
         MultiDBSqlAdapter, ErrorRaisingMultiDBAdapter

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -1,8 +1,6 @@
 import collections
 import hashlib
 
-from memoized import memoized
-
 from django_prbac.utils import has_privilege
 
 from corehq import privileges, toggles

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -135,7 +135,6 @@ def number_of_ucr_reports(domain):
     return len(ucr_reports)
 
 
-@memoized
 def get_indicator_adapter(config, raise_errors=False, load_source="unknown"):
     from corehq.apps.userreports.sql.adapter import IndicatorSqlAdapter, ErrorRaisingIndicatorSqlAdapter, \
         MultiDBSqlAdapter, ErrorRaisingMultiDBAdapter


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I believe this is the fix for https://dimagi-dev.atlassian.net/browse/COV-10, mysterious rebuilds being kicked off for user data sources

`extend_existing` causes the `Table` object to add new columns to the existing definition rather than replace the old one, meaning old columns stuck around for the life of the pillow process in our model of what the table should have.

I believe the sequence of events looked something like this
1) user would remove column in report builder
2) celery rebuild kicked off by report builder would remove those columns because its a fresh process
3) some time later (every 3 hours) pillow would rebootstrap and its `sqlalchemy.MetaData` object would still have the old columns, but reflection on the table would not, so it would readd them (causing a migrate not rebuild)
4) on the next pillow restart, the fresh `MetaData` would be correct so it would trigger a rebuild and remove the columns

That is also why its possible that in the original instance of this, I could not find a version of the data source where the columns all existed at the same time. they only had to exist within the span of 1 pillow lifetime, not in the same data source version

I believe there is still a caching bug causing us to unnecessarily rebuild deleted data sources, but since that has no user facing effects, I am putting this PR up first, while I figure out how to fix the other one.