### PR TITLE
Update Web App Icons to Natural Boxing

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -115,7 +115,7 @@
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
         <% } %>
-        <% if (imageUrl) { %>
+        <% else { %>
           <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
         <% } %>
         <div class="appicon-title">
@@ -132,7 +132,7 @@
     <% if (!imageUrl) { %>
       <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
     <% } %>
-    <% if (imageUrl) { %>
+    <% else { %>
       <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
     <% } %>
     <div class="appicon-title">

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -114,7 +114,7 @@
       <div class="appicon appicon-default js-start-app">
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
-	<% } else { %>
+        <% } else { %>
           <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
         <% } %>
         <div class="appicon-title">

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -111,9 +111,12 @@
   <div class="container">
     <div class="spacer"></div>
     <div class="col-xs-6 col-sm-4 col-xs-offset-3 col-sm-offset-4">
-      <div class="appicon appicon-default js-start-app" <% if (imageUrl) { %>style="background-image: url('<%= imageUrl %>');"<% } %>>
+      <div class="appicon appicon-default js-start-app">
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
+        <% } %>
+        <% if (imageUrl) { %>
+          <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
         <% } %>
         <div class="appicon-title">
           <h3><%= appName %></h3>
@@ -125,9 +128,12 @@
 </script>
 
 <script id="row-template" type="text/template">
-  <div class="appicon appicon-default" <% if (imageUrl) { %>style="background-image: url('<%= imageUrl %>');"<% } %>>
+  <div class="appicon appicon-default">
     <% if (!imageUrl) { %>
       <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
+    <% } %>
+    <% if (imageUrl) { %>
+      <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
     <% } %>
     <div class="appicon-title">
       <h3><%- name %></h3>

--- a/corehq/apps/cloudcare/templates/formplayer/grid_view.html
+++ b/corehq/apps/cloudcare/templates/formplayer/grid_view.html
@@ -114,8 +114,7 @@
       <div class="appicon appicon-default js-start-app">
         <% if (!imageUrl) { %>
           <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
-        <% } %>
-        <% else { %>
+	<% } else { %>
           <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
         <% } %>
         <div class="appicon-title">
@@ -131,8 +130,7 @@
   <div class="appicon appicon-default">
     <% if (!imageUrl) { %>
       <i class="fcc fcc-flower appicon-icon" aria-hidden="true"></i>
-    <% } %>
-    <% else { %>
+    <% } else { %>
       <i class="fcc appicon-custom appicon-icon" style="background-image: url('<%= imageUrl %>');" aria-hidden="true"></i>
     <% } %>
     <div class="appicon-title">

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
@@ -23,8 +23,8 @@
       font-size: @icon-height;
     }
     .appicon-custom {
-      top: 0.05*@icon-height + 8;
-      height: @icon-height - 8;
+      top: 0.05*@icon-height + 10;
+      height: @icon-height - 10;
     }
   }
   .appicon-default .appicon-icon {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
@@ -83,7 +83,7 @@
   .appicon-custom {
     background-size: contain;
     background-repeat: no-repeat;
-    background-position: center top;
+    background-position: center;
   }
 
   .appicon-icon, .gridicon-icon {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
@@ -22,6 +22,10 @@
       line-height: @icon-height;
       font-size: @icon-height;
     }
+    .appicon-custom {
+      top: 0.05*@icon-height + 8;
+      height: @icon-height - 8;
+    }
   }
   .appicon-default .appicon-icon {
     font-size: @icon-height * .9;
@@ -52,8 +56,6 @@
 
 .appicon, .gridicon {
   background-color: @cc-neutral-mid;
-  background-repeat: no-repeat;
-  background-position: center top;
   text-align: center;
   color: white;
   position: relative;
@@ -76,6 +78,12 @@
       overflow: hidden;
       font-weight: 300;
     }
+  }
+
+  .appicon-custom {
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center top;
   }
 
   .appicon-icon, .gridicon-icon {

--- a/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
+++ b/corehq/apps/hqwebapp/static/cloudcare/less/formplayer-common/appicon.less
@@ -23,6 +23,8 @@
       font-size: @icon-height;
     }
     .appicon-custom {
+      // the default icons have internal padding in the image itself.
+      // this prevents users from needing to replicate that
       top: 0.05*@icon-height + 10;
       height: @icon-height - 10;
     }


### PR DESCRIPTION
Since the web app icon tiles naturally resize, their [layout was very hard to make consistent](https://github.com/dimagi/commcare-hq/pull/27825#issuecomment-650232968), and it was difficult to figure out exactly the right margins for the layout.

This updates the web icons to be boxed naturally with the same margins and padding as the default flower icons, which means an uploader can upload an icon that fills a box and have it look natural without guessing at the margins.

Here's the result of naively laid out images which were resized by the layout engine. The only clear tradeoff remaining is if a user uploads an image that is < 150px in either dimension (the blurry first image which gets upsampled) which I'm fine forcing the burden downward to add manual margins
![image](https://user-images.githubusercontent.com/155066/85882486-5a464000-b7ad-11ea-8f32-1b6d547591d0.png)

(old behavior for reference with these same icons)
![image](https://user-images.githubusercontent.com/155066/85882899-1b64ba00-b7ae-11ea-9a05-7f4eac958e7d.png)
