### PR TITLE
Do not remove curl in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,15 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 # Note: this installs the necessary libs to make the bundled version
 # of Chromium that Puppeteer installs, work.
 RUN apt-get update \
-  && apt-get install -y \
-  openjdk-7-jdk \
-  wget \
-  --no-install-recommends \
+  && apt-get install -y --no-install-recommends \
+     openjdk-7-jdk \
+     wget \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /src/*.deb
+  && rm -rf /var/lib/apt/lists/* /src/*.deb
 
 COPY requirements/test-requirements.txt package.json /vendor/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
-  && apt-get purge --auto-remove -y curl \
   && rm -rf /src/*.deb
 
 COPY requirements/test-requirements.txt package.json /vendor/


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/27858 removed curl from the docker image, which broke the curl commands that send travis test metrics to datadog:

https://github.com/dimagi/commcare-hq/blob/e02336dae4901e39f9c7c88d9a70e8ffe6a32c6b/docker/run.sh#L79

Resulting in errors like this in [travis logs](https://api.travis-ci.org/v3/job/699868403/log.txt) (the errors did not cause tests to fail):
```
/mnt/run.sh: line 79: curl: command not found
```
However, they affected [test timings in datadog](https://app.datadoghq.com/dashboard/jmh-4qt-sp8/travis-test-timings?from_ts=1590579204203&live=true&to_ts=1593171204203) from 6/18 util now.

:blowfish: Review by commit. The second commit is cleanup only.

Skipped tests since dockerfile changes do not affect tests until they are pulled by dockerhub.