### PR TITLE
Have Web Apps always refresh answers right before submitting a form

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -486,28 +486,36 @@ WebFormSession.prototype.switchLanguage = function (lang) {
 
 WebFormSession.prototype.submitForm = function (form) {
     var self = this,
-        answers = {},
+        answers,
         accumulate_answers,
         prevalidated = true;
 
     accumulate_answers = function (o) {
-        if (ko.utils.unwrapObservable(o.type) !== 'question') {
-            if (o.hasOwnProperty("children")) {
-                $.each(o.children(), function (i, val) {
-                    accumulate_answers(val);
-                });
-            }
-        } else {
-            if (o.isValid()) {
-                if (ko.utils.unwrapObservable(o.datatype) !== "info") {
-                    answers[getIx(o)] = ko.utils.unwrapObservable(o.answer);
+        var _answers = {},
+            _accumulate_answers;
+
+        _accumulate_answers = function (o) {
+            if (ko.utils.unwrapObservable(o.type) !== 'question') {
+                if (o.hasOwnProperty("children")) {
+                    $.each(o.children(), function (i, val) {
+                        _accumulate_answers(val);
+                    });
                 }
             } else {
-                prevalidated = false;
+                if (o.isValid()) {
+                    if (ko.utils.unwrapObservable(o.datatype) !== "info") {
+                        _answers[getIx(o)] = ko.utils.unwrapObservable(o.answer);
+                    }
+                } else {
+                    prevalidated = false;
+                }
             }
-        }
+        };
+        _accumulate_answers(o);
+        return _answers;
     };
-    accumulate_answers(form);
+    answers = accumulate_answers(form);
+
     form.isSubmitting(true);
     var submitAttempts = 0,
         timer = setInterval(function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -486,7 +486,6 @@ WebFormSession.prototype.switchLanguage = function (lang) {
 
 WebFormSession.prototype.submitForm = function (form) {
     var self = this,
-        answers,
         accumulate_answers,
         prevalidated = true;
 
@@ -514,17 +513,18 @@ WebFormSession.prototype.submitForm = function (form) {
         _accumulate_answers(o);
         return _answers;
     };
-    answers = accumulate_answers(form);
 
     form.isSubmitting(true);
     var submitAttempts = 0,
         timer = setInterval(function () {
+            var answers;
             if (form.blockSubmit() && submitAttempts < 10) {
                 submitAttempts++;
                 return;
             }
             clearInterval(timer);
 
+            answers = accumulate_answers(form);
             self.serverRequest(
                 {
                     'action': Formplayer.Const.SUBMIT,


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11035

##### SUMMARY
The issue here seems to be that we were collecting the form to submit when the Submit button is _first clicked_, not after the models have been updated with the results of pending answers.
