### PR TITLE
Fix stale lock issue with ONE_PHONE_NUMBER_MULTIPLE_CONTACTS flag

### DIFF
--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -296,7 +296,7 @@ class XFormsSessionSynchronization:
         """
         channel = session.get_channel()
         with cls._critical_section(channel):
-            if cls._channel_is_available_for_session(session) or cls._clear_stale_channel_claim(channel):
+            if cls._channel_is_available_for_session(session):
                 cls._set_running_session_info_for_channel(
                     channel,
                     RunningSessionInfo(session.session_id, session.connection_id),

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -296,7 +296,7 @@ class XFormsSessionSynchronization:
         """
         channel = session.get_channel()
         with cls._critical_section(channel):
-            if cls.channel_is_available_for_session(session) or cls._clear_stale_channel_claim(channel):
+            if cls._channel_is_available_for_session(session) or cls._clear_stale_channel_claim(channel):
                 cls._set_running_session_info_for_channel(
                     channel,
                     RunningSessionInfo(session.session_id, session.connection_id),
@@ -321,8 +321,18 @@ class XFormsSessionSynchronization:
         a subsequent call to claim_channel_for_session could still return False
         i.e. if another session claims it first.
         """
-        running_session_info = cls.get_running_session_info_for_channel(session.get_channel())
-        return not running_session_info.session_id or running_session_info.session_id == session.session_id
+        with cls._critical_section(session.get_channel()):
+            return cls._channel_is_available_for_session(session)
+
+    @classmethod
+    def _channel_is_available_for_session(cls, session):
+        channel = session.get_channel()
+        running_session_info = cls.get_running_session_info_for_channel(channel)
+        return (
+            not running_session_info.session_id
+            or cls._clear_stale_channel_claim(channel)
+            or running_session_info.session_id == session.session_id
+        )
 
     @classmethod
     def release_channel_for_session(cls, session):
@@ -335,7 +345,7 @@ class XFormsSessionSynchronization:
         channel = session.get_channel()
         with cls._critical_section(channel):
             running_session_info = cls.get_running_session_info_for_channel(channel)
-            if cls.channel_is_available_for_session(session):
+            if cls._channel_is_available_for_session(session):
                 # Drop the session_id but keep the contact_id
                 # This will let incoming SMS keep affinity with that contact_id until a new session starts
                 running_session_info = running_session_info._replace(session_id=None)

--- a/corehq/apps/smsforms/tests/test_session_synchronization.py
+++ b/corehq/apps/smsforms/tests/test_session_synchronization.py
@@ -66,6 +66,7 @@ def test_auto_clear_stale_session_on_claim():
     # Set the current active session to closed manually, leaving a dangling/stale session claim
     session_a_1.session_is_open = False
     # Claim for the channel now succeeds
+    assert XFormsSessionSynchronization.channel_is_available_for_session(session_a_2)
     assert XFormsSessionSynchronization.claim_channel_for_session(session_a_2)
     # And it is now the active session for the channel
     assert (

--- a/corehq/apps/smsforms/tests/test_session_synchronization.py
+++ b/corehq/apps/smsforms/tests/test_session_synchronization.py
@@ -65,8 +65,14 @@ def test_auto_clear_stale_session_on_claim():
     assert not XFormsSessionSynchronization.claim_channel_for_session(session_a_2)
     # Set the current active session to closed manually, leaving a dangling/stale session claim
     session_a_1.session_is_open = False
-    # Claim for the channel now succeeds
+    # Channel is now available
     assert XFormsSessionSynchronization.channel_is_available_for_session(session_a_2)
+    # And the call above cleared the channel claim but left the contact
+    assert (
+        XFormsSessionSynchronization.get_running_session_info_for_channel(session_a_2.get_channel())
+        == RunningSessionInfo(session_id=None, contact_id='Alpha')
+    )
+    # Claim for the channel now succeeds
     assert XFormsSessionSynchronization.claim_channel_for_session(session_a_2)
     # And it is now the active session for the channel
     assert (

--- a/corehq/apps/smsforms/tests/test_session_synchronization.py
+++ b/corehq/apps/smsforms/tests/test_session_synchronization.py
@@ -47,6 +47,33 @@ def test_session_synchronization():
     assert not XFormsSessionSynchronization.clear_stale_channel_claim(SMSChannel(BACKEND_ID, phone_number_a))
 
 
+@mock.patch.object(SQLXFormsSession, 'by_session_id',
+                   lambda session_id: FakeSession.by_session_id(session_id))
+def test_auto_clear_stale_session_on_claim():
+    phone_number_a = _clean_up_number('15555555555')
+    session_a_1 = FakeSession(session_id=str(uuid4()), phone_number=phone_number_a, connection_id='Alpha')
+    session_a_2 = FakeSession(session_id=str(uuid4()), phone_number=phone_number_a, connection_id='Beta')
+
+    # Nothing set yet, so it can be claimed
+    assert XFormsSessionSynchronization.channel_is_available_for_session(session_a_1)
+    # And so can the other one
+    assert XFormsSessionSynchronization.channel_is_available_for_session(session_a_2)
+    # Claim succeeds
+    assert XFormsSessionSynchronization.claim_channel_for_session(session_a_1)
+    # Claim for same channel fails
+    assert not XFormsSessionSynchronization.channel_is_available_for_session(session_a_2)
+    assert not XFormsSessionSynchronization.claim_channel_for_session(session_a_2)
+    # Set the current active session to closed manually, leaving a dangling/stale session claim
+    session_a_1.session_is_open = False
+    # Claim for the channel now succeeds
+    assert XFormsSessionSynchronization.claim_channel_for_session(session_a_2)
+    # And it is now the active session for the channel
+    assert (
+        XFormsSessionSynchronization.get_running_session_info_for_channel(session_a_2.get_channel()).session_id
+        == session_a_2.session_id
+    )
+
+
 class FakeSession:
     expire_after = 60
     _global_objects = {}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11045

##### SUMMARY
It appears that Keyword SMS Surveys that have a single label and no other questions leave the form session with `session.session_is_open = False` somehow without actually calling `session.close()` (which also releases the channel claim), and so the channel claim is left around. Currently this prevents other things from happening until the channel claim is explicitly cleared with `clear_stale_channel_claim` at a later time, but that call is put in a few places somewhat arbitrarily and I hadn't expected to rely on it. This change makes it call the same log `clear_stale_channel_claim` does every time you claim a channel, thus treating a channel claimed by a stale session the same as a channel not claimed for most purposes.

##### FEATURE FLAG
ONE_PHONE_NUMBER_MULTIPLE_CONTACTS
