### PR TITLE
Make ICDS-staging deploy process similar to that of staging

### DIFF
--- a/scripts/icds-staging.yaml
+++ b/scripts/icds-staging.yaml
@@ -1,0 +1,57 @@
+#############################
+#   ICDS STAGING WORKFLOW   #
+############################
+
+# GENERAL PROCESS
+# From your commcare-hq directory with the virtualenv turned on
+#     $ git checkout master
+# Update scripts/icds-staging.yaml and add your branch that you want to deploy
+# Push the updates of icds-staging.yaml to master
+# To check if your branch causes any conflicts before rebuilding
+#     $ scripts/rebuildstaging scripts/icds-staging.yaml --no-push
+# To rebuild from your new spec and deploy
+#     $ scripts/rebuildstaging scripts/icds-staging.yaml
+#     $ commcare-cloud icds-staging deploy --commcare-rev icds-autostaging
+# We will be removing --commcare-rev once we add default branch for icds-staging
+# on commcare-cloud
+
+# CONFLICT RESOLUTION
+# First, determine where the conflict lies.
+# a). branch `foo` conflicts with `master`
+#       $ git checkout -b foo origin/foo
+#       $ git pull origin master
+#     try to resolve conflict
+#       $ git push origin foo
+# b). branch `foo` conflicts with branch `bar`
+#     you can't just merge foo into bar or vice versa, otherwise the PR
+#     for foo will contain commits from bar.  Instead make a third,
+#     conflict-resolution branch:
+#       $ git checkout -b foo+bar --no-track origin/foo
+#       $ git pull origin bar
+#     try to resolve conflict
+#       $ git push origin foo+bar
+#     add the branch `foo+bar` to icds-staging.yaml and move branches foo and
+#     bar to right below it
+#
+#     Later on branch B gets merged into master and removed from icds-staging.yaml.
+#     Perhaps the person who removes it also notices the A+B and does the
+#     following. Otherwise anyone who comes along and sees A+B but not both
+#     branches can feel free to assume the following need to be done.
+#       * Merge A+B into A. Since B is now gone, you want to merge the
+#         resolution into A, otherwise A will conflict with master.
+#       * Remove A+B from icds-staging.yaml. It's no longer necessary since it's
+#         now a subset of A.
+#
+# If you are unsure of how to resolve a conflict, notify the branch owner.
+
+# FORMPLAYER
+# From the formplayer, repo, call `./scripts/rebuildstaging`
+# This rebuilds the `icds-autostaging` branch of formplayer and runs the formplayer-staging job on jenkins
+
+trunk: master
+name: icds-autostaging
+branches:
+  - vellum-staging  # DO NOT REMOVE this is similar to "icds-autostaging", but for vellum
+  - ap/restrict-unauthorized-users
+
+submodules: {}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On staging environment, we can test out features without necessarily merging them to master. A similar sort of functionality would be good to have for icds-staging.
The deploy process would be 
- Checkout to master
- Add your branch in `scripts/icds-staging.yaml`
- Push the updates of `icds-staging.yaml` to master.
- Test if your branch cause any conflicts before rebuilding
```sh
$ scripts/rebuildstaging scripts/icds-staging.yaml --no-push
```
- To rebuild and deploy
```sh
$ scripts/rebuildstaging scripts/icds-staging.yaml
$ commcare-cloud icds-staging deploy --commcare-rev icds-autostaging
```
We will be removing --commcare-rev once we add `icds-staging` as default branch on commcare-cloud

