### PR TITLE
Updates in ICDS staging deploy process

### DIFF
--- a/scripts/commit-icds-staging
+++ b/scripts/commit-icds-staging
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+commit_command="scripts/commit-staging-util icds-staging.yaml $*"
+$(echo $commit_command)

--- a/scripts/commit-icds-staging
+++ b/scripts/commit-icds-staging
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+function get_branch() {
+    git branch | grep '^\*' | sed 's/* //'
+}
+
+function abort () {
+    echo $1
+    echo "Aborting."
+    exit 1
+}
+
+filename=scripts/icds-staging.yaml
+branch=$(get_branch)
+COMMIT_MESSAGE='update icds-staging.yaml'
+
+if [[ $branch != 'master' ]]
+then
+    abort "You may only commit icds-staging.yaml changes to master."
+fi
+
+# add icds-staging.yaml if the user hasn't
+git add $filename
+
+
+# make sure the only thing about to be committed is scripts/icds-staging.yaml
+staged_files=$(git diff --staged --stat | grep '|' | cut -d '|' -f1 | cut -d ' ' -f2)
+if [[ 'scripts/icds-staging.yaml' != $staged_files ]]
+then
+    if [[ '' = $staged_files ]]
+    then
+        abort "You have no changes to commit."
+    else
+        abort "You have staged changes to more files than just $filename."
+    fi
+fi
+
+
+# make sure icds-staging.yaml parses as yaml
+python scripts/checkyaml.py $filename
+if [[ $? -ne 0 ]]
+then
+    abort "Fix staging.yml and try again"
+fi
+
+# make sure local is not ahead of origin
+git fetch
+if [[ -n $(git log --max-count=1 origin/$branch..$branch) ]]
+then
+    abort "Your local $branch is ahead of origin/$branch."
+fi
+
+# have the commit follow a certain template
+git commit --edit --message="$COMMIT_MESSAGE" --message "[ci skip]"
+
+# push if using --push option
+if [[ $1 = '--push' ]]
+then
+    git push origin $branch
+fi

--- a/scripts/commit-staging-util
+++ b/scripts/commit-staging-util
@@ -10,37 +10,41 @@ function abort () {
     exit 1
 }
 
-filename=scripts/icds-staging.yaml
+filename=$1
+
+if [[ '' = $filename ]]
+then
+    abort "No config file specified."
+fi
+
 branch=$(get_branch)
-COMMIT_MESSAGE='update icds-staging.yaml'
+COMMIT_MESSAGE="update $filename"
 
 if [[ $branch != 'master' ]]
 then
-    abort "You may only commit icds-staging.yaml changes to master."
+    abort "You may only commit staging.yaml or icds-staging.yaml changes to master."
 fi
 
-# add icds-staging.yaml if the user hasn't
+# add staging config file if the user hasn't
 git add $filename
 
 
-# make sure the only thing about to be committed is scripts/icds-staging.yaml
+# make sure the only thing about to be committed is scripts/<config_file>.yaml
 staged_files=$(git diff --staged --stat | grep '|' | cut -d '|' -f1 | cut -d ' ' -f2)
-if [[ 'scripts/icds-staging.yaml' != $staged_files ]]
+if [[ '' = $staged_files ]]
 then
-    if [[ '' = $staged_files ]]
-    then
-        abort "You have no changes to commit."
-    else
-        abort "You have staged changes to more files than just $filename."
-    fi
+    abort "You have no changes to commit."
+elif [[ $(basename $filename) != $(basename $staged_files) ]]
+then
+    abort "You have staged changes to more files than just $filename."
 fi
 
 
-# make sure icds-staging.yaml parses as yaml
+# make sure config file parses as yaml
 python scripts/checkyaml.py $filename
 if [[ $? -ne 0 ]]
 then
-    abort "Fix staging.yml and try again"
+    abort "Fix $filename and try again"
 fi
 
 # make sure local is not ahead of origin
@@ -54,7 +58,7 @@ fi
 git commit --edit --message="$COMMIT_MESSAGE" --message "[ci skip]"
 
 # push if using --push option
-if [[ $1 = '--push' ]]
+if [[ $2 = '--push' ]]
 then
     git push origin $branch
 fi

--- a/scripts/commit-staging-util
+++ b/scripts/commit-staging-util
@@ -10,15 +10,16 @@ function abort () {
     exit 1
 }
 
-filename=$1
+staging_file=$1
 
-if [[ '' = $filename ]]
+if [[ '' = $staging_file ]]
 then
     abort "No config file specified."
 fi
 
+filename="scripts/$staging_file"
 branch=$(get_branch)
-COMMIT_MESSAGE="update $filename"
+COMMIT_MESSAGE="update $staging_file"
 
 if [[ $branch != 'master' ]]
 then

--- a/scripts/icds-staging.yaml
+++ b/scripts/icds-staging.yaml
@@ -51,6 +51,7 @@
 
 trunk: master
 name: icds-autostaging
+deploy_env: icds-staging
 branches:
   - ap/restrict-unauthorized-users
 

--- a/scripts/icds-staging.yaml
+++ b/scripts/icds-staging.yaml
@@ -7,11 +7,11 @@
 #     $ git checkout master
 # Update scripts/icds-staging.yaml and add your branch that you want to deploy
 # Push the updates of icds-staging.yaml to master by using
-#     $ scripts/commit-icds-staging
+#     $ scripts/commit-staging-util ./scripts/icds-staging.yaml --push
 # To check if your branch causes any conflicts before rebuilding
-#     $ scripts/rebuild-icds-staging --no-push
+#     $ scripts/rebuildstaging-util ./scripts/icds-staging.yaml --no-push
 # To rebuild from your new spec and deploy
-#     $ scripts/rebuild-icds-staging
+#     $ scripts/rebuildstaging-util ./scripts/icds-staging.yaml
 #     $ commcare-cloud icds-staging deploy --commcare-rev icds-autostaging
 # We will be removing --commcare-rev once we add default branch for icds-staging
 # on commcare-cloud

--- a/scripts/icds-staging.yaml
+++ b/scripts/icds-staging.yaml
@@ -7,11 +7,11 @@
 #     $ git checkout master
 # Update scripts/icds-staging.yaml and add your branch that you want to deploy
 # Push the updates of icds-staging.yaml to master by using
-#     $ scripts/commit-staging-util ./scripts/icds-staging.yaml --push
+#     $ scripts/commit-staging-util icds-staging.yaml --push
 # To check if your branch causes any conflicts before rebuilding
-#     $ scripts/rebuildstaging-util ./scripts/icds-staging.yaml --no-push
+#     $ scripts/rebuildstaging-util icds-staging.yaml --no-push
 # To rebuild from your new spec and deploy
-#     $ scripts/rebuildstaging-util ./scripts/icds-staging.yaml
+#     $ scripts/rebuildstaging-util icds-staging.yaml
 #     $ commcare-cloud icds-staging deploy --commcare-rev icds-autostaging
 # We will be removing --commcare-rev once we add default branch for icds-staging
 # on commcare-cloud

--- a/scripts/icds-staging.yaml
+++ b/scripts/icds-staging.yaml
@@ -7,11 +7,11 @@
 #     $ git checkout master
 # Update scripts/icds-staging.yaml and add your branch that you want to deploy
 # Push the updates of icds-staging.yaml to master by using
-#     $ scripts/commit-staging-util icds-staging.yaml --push
+#     $ scripts/commit-icds-staging --push
 # To check if your branch causes any conflicts before rebuilding
-#     $ scripts/rebuildstaging-util icds-staging.yaml --no-push
+#     $ scripts/rebuild-icds-staging --no-push
 # To rebuild from your new spec and deploy
-#     $ scripts/rebuildstaging-util icds-staging.yaml
+#     $ scripts/rebuild-icds-staging
 #     $ commcare-cloud icds-staging deploy --commcare-rev icds-autostaging
 # We will be removing --commcare-rev once we add default branch for icds-staging
 # on commcare-cloud

--- a/scripts/rebuild-icds-staging
+++ b/scripts/rebuild-icds-staging
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rebuild_command="scripts/rebuildstaging-util icds-staging.yaml $*"
+$(echo $rebuild_command)

--- a/scripts/rebuild-icds-staging
+++ b/scripts/rebuild-icds-staging
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+function usage() {
+    cat << EOF
+usage: $0 [-h|--help] [-v|--verbose] [--deploy|--no-push] [--skip-fetch]
+
+rebuild staging from yaml configuration (scripts/icds-staging.yaml)
+
+    -h --help       print this help text
+    -v --verbose    display debugging output
+    --deploy        deploy after rebuild is complete
+    --no-push       do not push changes (cannot be used with --deploy)
+    --skip-fetch    assume local copy is already update date with remote
+    --enterprise    rebuild the enterprise branch
+EOF
+}
+
+while [[ $# > 0 ]]
+do
+    key="$1"
+    shift
+
+    case $key in
+      --deploy)
+        deploy=y
+        ;;
+      -h|--help)
+        usage
+        exit
+        ;;
+      -v|--verbose)
+        verbose=y
+        ;;
+      --skip-fetch)
+        skip_fetch=y
+        echo skip-fetch
+        ;;
+      --no-push)
+        no_push=y
+        echo no-push
+        ;;
+      --enterprise)
+        enterprise=y
+        echo enterprise
+        ;;
+      *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+function rebuildstaging() {
+    echo "rebuilding staging branch, this might take a while..."
+    python scripts/rebuildstaging.py scripts/icds-staging.yaml "$@"
+}
+
+args=''
+
+[[ $verbose = 'y' ]] && args="$args -v"
+[[ $no_push = 'y' ]] && args="$args --no-push"
+
+[[ $skip_fetch = 'y' ]] && args="$args sync rebuild"
+
+# if icds-staging.yaml isn't up-to-date, warn and quit
+git fetch origin master
+if [[ -n $(git diff origin/master -- scripts/icds-staging.yaml) && $no_push != 'y' ]]
+then
+    echo "scripts/icds-staging.yaml on this branch different from the one on master"
+    echo "Aborting."
+    exit 1
+fi
+
+if [[ $deploy = 'y' && $no_push != 'y' && $enterprise != 'y' ]]
+then
+    rebuildstaging $args && {
+        which commcare-cloud \
+        && commcare-cloud icds-staging deploy --quiet \
+        || echo 'Could not auto-deploy for you. Run `commcare-cloud icds-staging deploy` to deploy.'
+    }
+else
+    rebuildstaging $args
+fi

--- a/scripts/rebuildstaging-util
+++ b/scripts/rebuildstaging-util
@@ -18,12 +18,18 @@ rebuild staging from yaml configuration
 EOF
 }
 
-filename=$1
-if [[ '' = $filename ]]
-then
-    echo "No config file specified."
+function abort () {
+    echo $1
+    echo "Aborting."
     exit 1
+}
+
+staging_file=$1
+if [[ '' = $staging_file ]]
+then
+    abort "No config file specified."
 fi
+filename="scripts/$1"
 shift
 while [[ $# > 0 ]]
 do
@@ -87,13 +93,11 @@ args=''
 
 [[ $skip_fetch = 'y' ]] && args="$args sync rebuild"
 
-# if icds-staging.yaml isn't up-to-date, warn and quit
+# if staging file isn't up-to-date, warn and quit
 git fetch origin master
 if [[ -n $(git diff origin/master -- "$filename") && $no_push != 'y' ]]
 then
-    echo "$filename on this branch different from the one on master"
-    echo "Aborting."
-    exit 1
+    abort "$filename on this branch different from the one on master"
 fi
 
 

--- a/scripts/rebuildstaging-util
+++ b/scripts/rebuildstaging-util
@@ -71,21 +71,6 @@ function rebuildstaging() {
     python scripts/rebuildstaging.py "$filename" "$@"
 }
 
-function get_deploy_env() {
-  if [[ $(basename $filename) == 'icds-staging.yaml' ]]
-  then
-    echo "icds-staging"
-  elif [[ $(basename $filename) == 'staging.yaml' ]]
-  then
-    echo "staging"
-  else
-    echo "Unknown config file."
-    echo "Aborting"
-    exit 1
-  fi
-}
-
-
 args=''
 
 [[ $verbose = 'y' ]] && args="$args -v"
@@ -104,8 +89,12 @@ fi
 rebuildstaging $args
 if [[ $deploy = 'y' && $no_push != 'y' && $enterprise != 'y' ]]
 then
-    deploy_env=$(get_deploy_env $filename)
+    deploy_env=$(grep deploy_env $filename | sed -E 's/deploy_env:[[:space:]]+//')
+    if [[ '' = $staging_file ]]
+    then
+        abort "Key 'deploy_env' not present in $filename."
+    fi
     which commcare-cloud \
     && commcare-cloud $deploy_env deploy --quiet \
-    || echo 'Could not auto-deploy for you. Run `commcare-cloud icds-staging deploy` to deploy.'
+    || echo "Could not auto-deploy for you. Run `commcare-cloud $deploy_env deploy` to deploy."
 fi

--- a/scripts/rebuildstaging-util
+++ b/scripts/rebuildstaging-util
@@ -2,9 +2,12 @@
 
 function usage() {
     cat << EOF
-usage: $0 [-h|--help] [-v|--verbose] [--deploy|--no-push] [--skip-fetch]
+usage: $0 <staging-config-file>.yaml [-h|--help] [-v|--verbose] [--deploy|--no-push] [--skip-fetch]
 
-rebuild staging from yaml configuration (scripts/icds-staging.yaml)
+rebuild staging from yaml configuration
+
+  For ICDS-Staging env = scripts/icds-staging.yaml
+  For Staging env = scripts/staging.yaml
 
     -h --help       print this help text
     -v --verbose    display debugging output
@@ -15,6 +18,13 @@ rebuild staging from yaml configuration (scripts/icds-staging.yaml)
 EOF
 }
 
+filename=$1
+if [[ '' = $filename ]]
+then
+    echo "No config file specified."
+    exit 1
+fi
+shift
 while [[ $# > 0 ]]
 do
     key="$1"
@@ -52,8 +62,23 @@ done
 
 function rebuildstaging() {
     echo "rebuilding staging branch, this might take a while..."
-    python scripts/rebuildstaging.py scripts/icds-staging.yaml "$@"
+    python scripts/rebuildstaging.py "$filename" "$@"
 }
+
+function get_deploy_env() {
+  if [[ $(basename $filename) == 'icds-staging.yaml' ]]
+  then
+    echo "icds-staging"
+  elif [[ $(basename $filename) == 'staging.yaml' ]]
+  then
+    echo "staging"
+  else
+    echo "Unknown config file."
+    echo "Aborting"
+    exit 1
+  fi
+}
+
 
 args=''
 
@@ -64,20 +89,19 @@ args=''
 
 # if icds-staging.yaml isn't up-to-date, warn and quit
 git fetch origin master
-if [[ -n $(git diff origin/master -- scripts/icds-staging.yaml) && $no_push != 'y' ]]
+if [[ -n $(git diff origin/master -- "$filename") && $no_push != 'y' ]]
 then
-    echo "scripts/icds-staging.yaml on this branch different from the one on master"
+    echo "$filename on this branch different from the one on master"
     echo "Aborting."
     exit 1
 fi
 
+
+rebuildstaging $args
 if [[ $deploy = 'y' && $no_push != 'y' && $enterprise != 'y' ]]
 then
-    rebuildstaging $args && {
-        which commcare-cloud \
-        && commcare-cloud icds-staging deploy --quiet \
-        || echo 'Could not auto-deploy for you. Run `commcare-cloud icds-staging deploy` to deploy.'
-    }
-else
-    rebuildstaging $args
+    deploy_env=$(get_deploy_env $filename)
+    which commcare-cloud \
+    && commcare-cloud $deploy_env deploy --quiet \
+    || echo 'Could not auto-deploy for you. Run `commcare-cloud icds-staging deploy` to deploy.'
 fi

--- a/scripts/staging.yaml
+++ b/scripts/staging.yaml
@@ -48,6 +48,7 @@
 
 trunk: master
 name: autostaging
+deploy_env: staging
 branches:
   - vellum-staging  # DO NOT REMOVE this is similar to "autostaging", but for vellum
   - jls/sync-mixins-hard-fail # Jenny May 24


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This is the follow up PR of https://github.com/dimagi/commcare-hq/pull/27980
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I have added two new scripts files `scripts/commit-icds-staging` and `scripts/rebuild-icds-staging` which are similar to `scripts/commit-staging` and `scripts/rebuildstaging`, just that they deal with the `icds-staging.yml`.

The task could have been achieved by updating `scripts/rebuildstaging` and `scripts/commit-staging` as well. By enabling them to take on an extra parameter like `env` or `filename`, but I felt that would not be suited for the following reasons - 
1) I think it would be prone to errors as it is very easy to forget a parameter while running a command whereas the command without parameter does a totally different thing.
2) It made the process more intuitive like
```sh
$ scripts/commit-icds-staging
$ scripts/rebuild-icds-staging
```
would be more intuitive than
```sh
$ scripts/commit-staging ./scripts/icds-staging.yml
$ scripts/rebuildstaging ./scripts/icds-staging.yml
``` 
3) There would be some branching introduced if we take in parameter, we will have to check at various places about the file passed or the environment.


I have successfully deployed using the following process in ICDS-staging.

```
$ scripts/commit-icds-staging --push
$ scripts/rebuild-icds-staging
$ commcare-cloud icds-staging deploy --commcare-rev icds-autostaging
```

I am looking for suggestions/feedback on the process and approach to how it can be improved.
