### PR TITLE
Added account name filter to SMS Billing Report

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -459,7 +459,6 @@ class BillingAccount(ValidateModelMixin, models.Model):
         ), True
 
     @classmethod
-    @quickcache(['domain'])
     def get_account_by_domain(cls, domain):
         current_subscription = Subscription.get_active_subscription_by_domain(domain)
         if current_subscription is not None:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -459,6 +459,7 @@ class BillingAccount(ValidateModelMixin, models.Model):
         ), True
 
     @classmethod
+    @quickcache(['domain'])
     def get_account_by_domain(cls, domain):
         current_subscription = Subscription.get_active_subscription_by_domain(domain)
         if current_subscription is not None:

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/select2s.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/select2s.less
@@ -73,3 +73,7 @@
 .select2-container.select2-container-active > .select2-choice {
   .box-shadow(0 0 10px @cc-brand-mid);
 }
+
+.select2-selection__placeholder {
+  color: @gray-base !important;
+}

--- a/corehq/apps/reports/static/reports/js/filters/select2s.js
+++ b/corehq/apps/reports/static/reports/js/filters/select2s.js
@@ -50,7 +50,7 @@ hqDefine("reports/js/filters/select2s", [
                 width: '100%',
             },
             allowClear: true,
-            placeholder: $filter.data('placeholder')
+            placeholder: $filter.data('placeholder'),
         });
         var initial = $filter.data("selected");
         if (initial) {

--- a/corehq/apps/reports/static/reports/js/filters/select2s.js
+++ b/corehq/apps/reports/static/reports/js/filters/select2s.js
@@ -50,7 +50,7 @@ hqDefine("reports/js/filters/select2s", [
                 width: '100%',
             },
             allowClear: true,
-            placeholder: $filter.data('placeholder'),
+            placeholder: $filter.data("placeholder") || ' ',
         });
         var initial = $filter.data("selected");
         if (initial) {

--- a/corehq/apps/reports/static/reports/js/filters/select2s.js
+++ b/corehq/apps/reports/static/reports/js/filters/select2s.js
@@ -50,7 +50,7 @@ hqDefine("reports/js/filters/select2s", [
                 width: '100%',
             },
             allowClear: true,
-            placeholder: " ",
+            placeholder: $filter.data('placeholder')
         });
         var initial = $filter.data("selected");
         if (initial) {

--- a/corehq/apps/reports/templates/reports/filters/single_option.html
+++ b/corehq/apps/reports/templates/reports/filters/single_option.html
@@ -8,7 +8,7 @@
             data-url="{{ pagination.url }}"
             data-action="{{ pagination.action }}"
             style="width: 100%"
-            placeholder="{{ select.default_text }}"
+            data-placeholder="{{ select.default_text }}"
             data-selected="{{ select.selected|default:'' }}"
             name="{{ slug }}"></select>
   {% else %}

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -100,8 +100,8 @@ class SMSBillablesInterface(GenericTabularReport):
                     'value': ShowBillablesFilter.get_value(self.request, self.domain)
                 },
                 {
-                   'name': NameFilter.slug,
-                   'value': NameFilter.get_value(self.request, self.domain)
+                    'name': NameFilter.slug,
+                    'value': NameFilter.get_value(self.request, self.domain)
                 },
                 {
                     'name': DomainFilter.slug,


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11011

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
An account name filter was added to shorten the time it takes to generate a SMS billing report. 
I used the NameFilter from accounting for similar use in smsbillables. 
  

##### FEATURE FLAG
N/A

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
Requires QA before merge: https://dimagi-dev.atlassian.net/jira/software/projects/QA/boards/3/backlog

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
Users are able to filter SMS billables by account name. 