### PR TITLE
Fixed couch to sql migration for CustomDataFieldDefinition

### DIFF
--- a/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
+++ b/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
@@ -39,5 +39,5 @@ class Command(PopulateSQLCommand):
             )
             for field in doc['fields']
         ])
-        model.save(sync_to_couch=False)
+        model.save()
         return (model, created)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11059

Introduced in https://github.com/dimagi/commcare-hq/pull/27276/

I added `sync_to_couch=False` to this save call in a late commit as a performance improvement: since the migration's purpose is to copy all couch data to sql, there's no reason to re-sync the couch documents. However, the `update_or_create` call at the beginning of the function also calls save on the sql object, which syncs the couch doc. At this point, the new sql object hasn't had fields added yet, so this sync causes the fields to be removed from the couch doc. The rest of the function then adds the fields from the couch doc that's still in memory and saves the sql object, but on this save it doesn't sync couch. That leaves us with a correct sql object but a couch doc without any fields.

If you run the migration again, the `update_or_create` call now fetches and updates the existing sql object, again calling save, which again syncs the couch doc but this time with a complete sql object, which restores the fields. @esoergel I believe this is why there were ~200 couch docs on india that were correct: I ran this migration twice on each server, because each of them failed the first time due to duplicates (see [this comment](https://github.com/dimagi/commcare-hq/pull/27277/#pullrequestreview-403008355)). So a handful of documents had the migration run on them twice, which fixed them.

I could just re-run the migration now to restore the couch data, but I'm going to wait until this is merged.

TODO once this is merged:

- [x] Update the currently-open CommtrackConfig migration: https://github.com/dimagi/commcare-hq/pull/27597/ : done in a02f95f99dd
- [x] Re-run the migration on prod, india, icds, and swiss
- [x] Update [commit_adding_migration](https://github.com/dimagi/commcare-hq/blob/71b8fe5755114532094a2c007828994fb8203b55/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py#L20-L21) with the merge commit hash: done in https://github.com/dimagi/commcare-hq/pull/28028