### PR TITLE
Fixed linked project history for lookup tables

### DIFF
--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -374,7 +374,7 @@ def update_linked_app(app, master_app_id_or_build, user_id):
         app.reapply_overrides()
         app.save()
 
-    app.domain_link.update_last_pull('app', user_id, model_details=AppLinkDetail(app_id=app._id).to_json())
+    app.domain_link.update_last_pull('app', user_id, model_detail=AppLinkDetail(app_id=app._id).to_json())
     return app
 
 

--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -60,12 +60,12 @@ class DomainLink(models.Model):
         return bool(self.remote_base_url) or 'http' in self.linked_domain
 
     @atomic
-    def update_last_pull(self, model, user_id, date=None, model_details=None):
+    def update_last_pull(self, model, user_id, date=None, model_detail=None):
         self.last_pull = date or datetime.utcnow()
         self.save()
         history = DomainLinkHistory(link=self, date=self.last_pull, user_id=user_id, model=model)
-        if model_details:
-            history.model_detail = model_details
+        if model_detail:
+            history.model_detail = model_detail
         history.save()
 
     def save(self, *args, **kwargs):

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -164,4 +164,4 @@ The following linked project spaces received content:
 
     def _release_model(self, domain_link, model, user):
         update_model_type(domain_link, model['type'], model_detail=model['detail'])
-        domain_link.update_last_pull(model['type'], user._id)
+        domain_link.update_last_pull(model['type'], user._id, model_details=model['detail'])

--- a/corehq/apps/linked_domain/tasks.py
+++ b/corehq/apps/linked_domain/tasks.py
@@ -164,4 +164,4 @@ The following linked project spaces received content:
 
     def _release_model(self, domain_link, model, user):
         update_model_type(domain_link, model['type'], model_detail=model['detail'])
-        domain_link.update_last_pull(model['type'], user._id, model_details=model['detail'])
+        domain_link.update_last_pull(model['type'], user._id, model_detail=model['detail'])

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -363,14 +363,20 @@ class DomainLinkView(BaseAdminProjectSettingsView):
                 update['name'] = '{} ({})'.format(name, app_name)
             model_status.append(update)
             if action.model == 'fixture':
-                tag = action.wrapped_detail.tag
-                try:
-                    fixture = fixtures.get(tag)
-                    del fixtures[tag]
-                except KeyError:
-                    fixture = get_fixture_data_type_by_tag(self.domain, tag)
-                update['name'] = f'{name} ({fixture.tag})'
-                update['can_update'] = fixture.is_global
+                tag_name = ugettext('Unknown Table')
+                can_update = False
+                if action.model_detail:
+                    detail = action.wrapped_detail
+                    tag = action.wrapped_detail.tag
+                    try:
+                        fixture = fixtures.get(tag)
+                        del fixtures[tag]
+                    except KeyError:
+                        fixture = get_fixture_data_type_by_tag(self.domain, tag)
+                    tag_name = fixture.tag
+                    can_update = fixture.is_global
+                update['name'] = f'{name} ({tag_name})'
+                update['can_update'] = can_update
             if action.model == 'report':
                 report_id = action.wrapped_detail.report_id
                 try:

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -407,7 +407,7 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         error = ""
         try:
             update_model_type(master_link, type_, detail_obj)
-            master_link.update_last_pull(type_, self.request.couch_user._id, model_details=detail_obj.to_json())
+            master_link.update_last_pull(type_, self.request.couch_user._id, model_detail=detail_obj.to_json())
         except UnsupportedActionError as e:
             error = str(e)
 

--- a/corehq/apps/linked_domain/views.py
+++ b/corehq/apps/linked_domain/views.py
@@ -407,7 +407,8 @@ class DomainLinkRMIView(JSONResponseMixin, View, DomainViewMixin):
         error = ""
         try:
             update_model_type(master_link, type_, detail_obj)
-            master_link.update_last_pull(type_, self.request.couch_user._id, model_detail=detail_obj.to_json())
+            model_detail = detail_obj.to_json() if detail_obj else None
+            master_link.update_last_pull(type_, self.request.couch_user._id, model_detail=model_detail)
         except UnsupportedActionError as e:
             error = str(e)
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1569,7 +1569,7 @@ def copy_report(request, domain):
             domain_link.update_last_pull(
                 'report',
                 request.couch_user._id,
-                model_details=ReportLinkDetail(report_id=link_info.report.get_id).to_json(),
+                model_detail=ReportLinkDetail(report_id=link_info.report.get_id).to_json(),
             )
             successes.append(to_domain)
         except Exception as err:


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/COV-12

Model details (the tag of the lookup table) weren't being saved when using Enterprise Release Management to "push" changes. This PR fixes that, and it makes the linked domain views able to handle legacy lookup table history entries that are missing the tag.

##### FEATURE FLAG
Linked project spaces

##### RISK ASSESSMENT / QA PLAN
Tested locally, no formal QA.

##### PRODUCT DESCRIPTION
Fixes 500 on domains that were early adopters of lookup tables for linked project spaces.
