### PR TITLE
Allows searching and viewing the date a case was closed in CLE

### DIFF
--- a/corehq/apps/case_search/const.py
+++ b/corehq/apps/case_search/const.py
@@ -40,6 +40,7 @@ SPECIAL_CASE_PROPERTIES_MAP = {
     'external_id': SpecialCaseProperty('external_id', lambda doc: doc.get('external_id', ''), 'external_id'),
 
     'date_opened': SpecialCaseProperty('date_opened', lambda doc: doc.get('opened_on'), 'opened_on'),
+    'closed_on': SpecialCaseProperty('closed_on', lambda doc: doc.get('closed_on'), 'closed_on'),
     'last_modified': SpecialCaseProperty('last_modified', lambda doc: doc.get('modified_on'), 'modified_on'),
 }
 SPECIAL_CASE_PROPERTIES = list(SPECIAL_CASE_PROPERTIES_MAP.keys())


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
A few people have asked this on Field/Dev

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds `closed_on` as a property to the CLE so you can search / add it as a column

![Screenshot from 2020-07-01 09-49-31](https://user-images.githubusercontent.com/146896/86251674-2d64a500-bb80-11ea-8694-820c545912a4.png)

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
case list explorer

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
