### PR TITLE
Removed polling from messaging dashboard

### DIFF
--- a/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
+++ b/corehq/messaging/scheduling/static/scheduling/js/dashboard.js
@@ -106,25 +106,17 @@ hqDefine("scheduling/js/dashboard",[
     var dashboardViewModel = new DashboardViewModel();
     dashboardViewModel.init();
 
-    var updateDashboard = function () {
-        $.getJSON(dashboardUrl, {action: 'raw'})
-            .done(function (json) {
+    $(function () {
+        $.ajax({
+            url: dashboardUrl,
+            data: {action: 'raw'},
+            success: function (json) {
                 dashboardViewModel.update(json);
-                if (!dashboardViewModel.bindingApplied()) {
-                    // We have to do this on the async ajax thread otherwise there
-                    // still might be a flicker on the page.
-                    $('#messaging_dashboard').koApplyBindings(dashboardViewModel);
-                    dashboardViewModel.bindingApplied(true);
-                }
+                $('#messaging_dashboard').koApplyBindings(dashboardViewModel);
+                dashboardViewModel.bindingApplied(true);
                 // updating charts must be done when everything is visible
                 dashboardViewModel.update_charts(json);
-            })
-            .always(function () {
-                setTimeout(updateDashboard, 30000);
-            });
-    };
-
-    $(function () {
-        updateDashboard();
+            },
+        });
     });
 });


### PR DESCRIPTION
##### SUMMARY

This will address https://dimagi-dev.atlassian.net/browse/SAAS-11075 (auto-logout not working on this page) and also  https://dimagi-dev.atlassian.net/browse/SAAS-10952 (2FA login loop). I don't think this polling is adding enough value to keep it. HQ typically doesn't behave like this; it's normal for users to refresh a page to get new data.

Hold off on merge until @dimagi/product confirms this is okay.

##### RISK ASSESSMENT / QA PLAN
Low risk, tested locally, no formal QA.

##### PRODUCT DESCRIPTION
This stops the messaging dashboard from auto-updating every 30 seconds.
