### PR TITLE
Ignore Formplayer settings filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ python_env-3.6
 services
 KEEP_UNTIL__*
 formplayer.properties
+application.properties
 formplayer.jar
 .vscode/*
 


### PR DESCRIPTION
#### CONTEXT
Formplayer settings filename has changed from **formplayer.properties** to **application.properties** in line with production environments.
* Slack `#formplayer`
* [DEV_SETUP.md](https://github.com/dimagi/commcare-hq/blob/master/DEV_SETUP.md#formplayer)

#### SUMMARY
Ignore the new filename. (And continue to ignore the filename currently in use.)
