### PR TITLE
Pull data monthly in fact sheet

### DIFF
--- a/custom/icds_reports/reports/fact_sheets.py
+++ b/custom/icds_reports/reports/fact_sheets.py
@@ -557,17 +557,6 @@ class FactSheetsReport(object):
         ]
         return fact_sheet_data_config
 
-    def data_sources(self, config):
-        fact_sheet_datasources = dict()
-        for datasource_name, datasource_class in FACT_SHEET_DATASOURCES_NAMES.items():
-            fact_sheet_datasources[datasource_name] = datasource_class(
-                config=config,
-                loc_level=self.loc_level,
-                show_test=self.show_test,
-                beta=self.beta
-            )
-        return fact_sheet_datasources
-
     def _get_collected_sections(self, config_list):
         sections_by_slug = OrderedDict()
         for config in config_list:

--- a/custom/icds_reports/sqldata/agg_awc_monthly.py
+++ b/custom/icds_reports/sqldata/agg_awc_monthly.py
@@ -1,6 +1,6 @@
 from sqlagg.base import AliasColumn
 from sqlagg.columns import SumColumn, SimpleColumn
-from sqlagg.filters import BETWEEN, IN, NOT
+from sqlagg.filters import BETWEEN, IN, NOT, EQ
 from sqlagg.sorting import OrderBy
 
 from corehq.apps.reports.sqlreport import DatabaseColumn, AggregateColumn
@@ -35,7 +35,7 @@ class AggAWCMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
             filters.append(NOT(IN('state_id', get_INFilter_bindparams('excluded_states', self.excluded_states))))
 
         if 'month' in self.config and self.config['month']:
-            filters.append(BETWEEN('month', 'two_before', 'month'))
+            filters.append(EQ('month', 'month'))
         return filters
 
     @property

--- a/custom/icds_reports/sqldata/agg_ccs_record_monthly.py
+++ b/custom/icds_reports/sqldata/agg_ccs_record_monthly.py
@@ -1,6 +1,6 @@
 from sqlagg.base import AliasColumn
 from sqlagg.columns import SumColumn, SimpleColumn, SumWhen
-from sqlagg.filters import BETWEEN, IN, NOT
+from sqlagg.filters import BETWEEN, IN, NOT, EQ
 from sqlagg.sorting import OrderBy
 
 from corehq.apps.reports.sqlreport import DatabaseColumn, AggregateColumn
@@ -39,7 +39,7 @@ class AggCCSRecordMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
         if not self.show_test:
             filters.append(NOT(IN('state_id', get_INFilter_bindparams('excluded_states', self.excluded_states))))
         if 'month' in self.config and self.config['month']:
-            filters.append(BETWEEN('month', 'two_before', 'month'))
+            filters.append(EQ('month', 'month'))
         return filters
 
     @property

--- a/custom/icds_reports/sqldata/agg_child_health_monthly.py
+++ b/custom/icds_reports/sqldata/agg_child_health_monthly.py
@@ -1,6 +1,6 @@
 from sqlagg.base import AliasColumn
 from sqlagg.columns import SumWhen, SumColumn, SimpleColumn
-from sqlagg.filters import BETWEEN, IN, NOT
+from sqlagg.filters import BETWEEN, IN, NOT, EQ
 from sqlagg.sorting import OrderBy
 
 from corehq.apps.reports.sqlreport import DatabaseColumn, AggregateColumn
@@ -50,7 +50,7 @@ class AggChildHealthMonthlyDataSource(ProgressReportMixIn, IcdsSqlData):
         if not self.show_test:
             filters.append(NOT(IN('state_id', get_INFilter_bindparams('excluded_states', self.excluded_states))))
         if 'month' in self.config and self.config['month']:
-            filters.append(BETWEEN('month', 'two_before', 'month'))
+            filters.append(EQ('month', 'month'))
         return filters
 
     @property


### PR DESCRIPTION
This is from the Latest learning that Indexes on month column are not used when we pull multiple months data via `in` or `BETWEEN` or `< and >` queries. They are only used in `=` query. Last we have seen this in the child growth tracker report that pulling month data separately for each month is much faster than pulling all of the months data together because of the index thing mentioned above.

I am positive that this would reduce the load time of Factsheet a lot. I also think that this will prevent the occasional high spikes in the load time which I guess happens because of the super slow queries Will be testing it out before actually merging it. Putting it out as Pr so to get the review before do the limited release.

