### PR TITLE
install yarn in docker image so that tests pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN git config --global url."https://".insteadOf git:// \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 RUN npm -g install \
+    yarn \
     bower \
     grunt-cli \
     uglify-js \


### PR DESCRIPTION

##### SUMMARY
we need to rebuild the docker image so that it has `yarn` installed (keep `bower` for now since `master` still needs it)
otherwise, tests won't pass in https://github.com/dimagi/commcare-hq/pull/28012