### PR TITLE
add phantomjs-prebuilt with yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,5 @@ RUN npm -g install \
  && echo '{ "allow_root": true }' > /root/.bowerrc \
  && cd /vendor \
  && npm shrinkwrap \
+ && yarn global add phantomjs-prebuilt \
  && npm -g install


### PR DESCRIPTION
##### SUMMARY
for dependencies that still want `phantomjs` in their devDependencies (like `xpath`)...otherwise, `yarn install` fails due to proxy errors

killing build on purpose