### PR TITLE
Add email address to the enterprise dashboard mobile worker report

### DIFF
--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -172,7 +172,7 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
     @property
     def headers(self):
         headers = super(EnterpriseMobileWorkerReport, self).headers
-        return [_('Username'), _('Name'), _('Created Date [UTC]'), _('Last Sync [UTC]'),
+        return [_('Username'), _('Name'), _('Email Address'), _('Created Date [UTC]'), _('Last Sync [UTC]'),
                 _('Last Submission [UTC]'), _('CommCare Version')] + headers
 
     def rows_for_domain(self, domain_obj):
@@ -183,6 +183,7 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
             rows.append([
                 re.sub(r'@.*', '', user.username),
                 user.full_name,
+                user.email,
                 self.format_date(user.created_on),
                 self.format_date(user.reporting_metadata.last_sync_for_user.sync_date),
                 self.format_date(user.reporting_metadata.last_submission_for_user.submission_date),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/MuAWIkOP/96-update-enterprise-dashboard-mobile-worker-report-to-include-email

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds the mobile worker email address to the enterprise dashboard report

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
Enterprise Dashboard

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
Low risk. I tested this in a report with 2 mobile workers - one with an email address, and one without, and the report sent to me successfully. 

![Screenshot from 2020-07-03 10-37-54](https://user-images.githubusercontent.com/146896/86478986-448aca80-bd19-11ea-8b87-58ac8025abaa.png)


##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
