### PR TITLE
log as error

### DIFF
--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -1,4 +1,5 @@
 import pytz
+import sys
 import uuid
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.groups.models import Group

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -329,10 +329,11 @@ class ScheduleInstance(PartitionedModel):
             if lock.acquire(blocking=False):
                 try:
                     content.send(recipient, logged_event)
-                except:
+                except Exception as e:
                     # Release the lock if an error happened so that we can try sending
                     # to this recipient again later.
                     lock.release()
+                    logged_event.error(MessagingEvent.ERROR_INTERNAL_SERVER_ERROR, additional_error_text=str(e))
                     raise
 
         # Update the MessagingEvent for reporting

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -329,11 +329,15 @@ class ScheduleInstance(PartitionedModel):
             if lock.acquire(blocking=False):
                 try:
                     content.send(recipient, logged_event)
-                except Exception as e:
+                except:
+                    error = sys.exc_info()[1]
                     # Release the lock if an error happened so that we can try sending
                     # to this recipient again later.
                     lock.release()
-                    logged_event.error(MessagingEvent.ERROR_INTERNAL_SERVER_ERROR, additional_error_text=str(e))
+                    logged_event.error(
+                        MessagingEvent.ERROR_INTERNAL_SERVER_ERROR,
+                        additional_error_text=str(error),
+                    )
                     raise
 
         # Update the MessagingEvent for reporting


### PR DESCRIPTION
While debugging for another ticket, stumbled upon this place which leaves the "MessagingEvent" and "MessagingSubEvent" in progress status in case of an error, so now am looking at around 26 MessagingEvent per case and their respective SubEvents in progress state, which is incorrect because the attempt errored out due to an [exception](https://sentry.io/organizations/dimagi/issues/1701425574/?environment=icds&project=1545828&query=is%3Aunresolved+static-icds-cas-static-ls_thr_30_days&statsPeriod=14d)

Each time the instance is tried, a new MessagingEvent is made, so this change just updates the event to reflect the correct outcome of the attempt and does not block a re-attempt.

if this is the correct change here, I don't think we can fix the historic data but at least from now on we should have the correct status.

Using inspiration from other places where we do this as well but on subevent
https://github.com/dimagi/commcare-hq/blob/bd47bd9fabb0b270f255225a4eab64f310980038/corehq/apps/sms/api.py#L158-L163

And we do put an error in case we are not able to get the content for an email
https://github.com/dimagi/commcare-hq/blob/5bb564fb5408a9515e97e4c8f45de9a0077e88e3/corehq/messaging/scheduling/models/content.py#L123-L127

but we dont do so for SMSes
https://github.com/dimagi/commcare-hq/blob/5bb564fb5408a9515e97e4c8f45de9a0077e88e3/corehq/messaging/scheduling/models/content.py#L70-L78

So we possibly should update both subevevnts and events, but this still looks like this is better than leaving things in progress.