### PR TITLE
Override support email on mobile for non-Dimagi envs

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4888,6 +4888,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             'locale': locale,
             'apk_heartbeat_url': apk_heartbeat_url,
             'target_package_id': target_package_id,
+            'support_email': settings.SUPPORT_EMAIL if not settings.IS_DIMAGI_ENVIRONMENT else None,
         }).encode('utf-8')
 
     @property

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4816,7 +4816,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
 
     @time_method()
     def create_profile(self, is_odk=False, with_media=False,
-                       template='app_manager/profile.xml', build_profile_id=None, commcare_flavor=None):
+                       build_profile_id=None, commcare_flavor=None):
         self__profile = self.profile
         app_profile = defaultdict(dict)
 
@@ -4874,7 +4874,7 @@ class Application(ApplicationBase, ApplicationMediaMixin, ApplicationIntegration
             TARGET_COMMCARE: 'org.commcare.dalvik',
             TARGET_COMMCARE_LTS: 'org.commcare.lts',
         }.get(commcare_flavor)
-        return render_to_string(template, {
+        return render_to_string('app_manager/profile.xml', {
             'is_odk': is_odk,
             'app': self,
             'profile_url': profile_url,

--- a/corehq/apps/app_manager/templates/app_manager/profile.xml
+++ b/corehq/apps/app_manager/templates/app_manager/profile.xml
@@ -24,6 +24,9 @@
     {% if target_package_id %}
     <property key="target-package-id" value="{{ target_package_id }}" force="true"/>
     {% endif %}
+    {% if support_email %}
+    <property key="support-email-address" value="{{ support_email }}" force="true"/>
+    {% endif %}
 
     <!-- Properties configured on CommCare HQ 1.0 -->
     {% for key, value in app_profile.properties.items %}{% if value != None %}

--- a/corehq/apps/app_manager/tests/test_profile.py
+++ b/corehq/apps/app_manager/tests/test_profile.py
@@ -1,9 +1,8 @@
 import uuid
 import xml.etree.cElementTree as ET
 
-from django.test import SimpleTestCase
-
-import mock
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
 
 from corehq.apps.app_manager.commcare_settings import (
     get_commcare_settings_lookup,
@@ -128,5 +127,15 @@ class ProfileTest(SimpleTestCase, TestXmlMixin):
             ET.fromstring(profile),
             key='recovery-measures-url',
             value=self.app.recovery_measures_url,
+            setting={'force': True},
+        )
+
+    @override_settings(IS_DIMAGI_ENVIRONMENT=False)
+    def test_support_email_setting(self):
+        profile = self.app.create_profile()
+        self._test_property(
+            ET.fromstring(profile),
+            key='support-email-address',
+            value=settings.SUPPORT_EMAIL,
             setting={'force': True},
         )


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-663
(discussed here: https://dimagi-dev.atlassian.net/browse/SUPPORT-1245)

##### SUMMARY
CommCare Android has Dimagi's support email [hardcoded](https://github.com/dimagi/commcare-android/blob/master/app/res/values/strings.xml#L13), which means that all issues reported via mobile come to Dimagi, even if their remote environment is third party.  This overrides that.  I'm a bit tempted to do this also for Dimagi environments, in the hopes that mobile would eventually be able to remove that line of code, but I suppose that's a bit unrealistic.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
