### PR TITLE
Couch to SQL migration verification

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import traceback
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
 from django.db import transaction
 
@@ -141,6 +141,9 @@ class PopulateSQLCommand(BaseCommand):
     def handle(self, **options):
         verify_only = options.get("verify_only", False)
         skip_verify = options.get("skip_verify", False)
+
+        if verify_only and skip_verify:
+            raise CommandError("verify_only and skip_verify are mutually exclusive")
 
         self.doc_count = get_doc_count_by_type(self.couch_db(), self.couch_doc_type())
         self.diff_count = 0

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -118,9 +118,9 @@ class PopulateSQLCommand(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--verify',
+            '--verify-only',
             action='store_true',
-            dest='verify',
+            dest='verify_only',
             default=False,
             help="""
                 Don't migrate anything, instead check if couch and sql data is identical.
@@ -129,7 +129,7 @@ class PopulateSQLCommand(BaseCommand):
         )
 
     def handle(self, **options):
-        verify = options.get("verify", False)
+        verify_only = options.get("verify_only", False)
 
         doc_count = get_doc_count_by_type(self.couch_db(), self.couch_doc_type())
         logger.info("Found {} {} docs and {} {} models".format(
@@ -142,7 +142,7 @@ class PopulateSQLCommand(BaseCommand):
         doc_index = 0
         for doc in get_all_docs_with_doc_types(self.couch_db(), [self.couch_doc_type()]):
             doc_index += 1
-            if verify:
+            if verify_only:
                 try:
                     obj = self.sql_class().objects.get(couch_id=doc["_id"])
                     diff = self.diff_couch_and_sql(doc, obj)
@@ -163,7 +163,7 @@ class PopulateSQLCommand(BaseCommand):
                     action = "Creating" if created else "Updated"
                     logger.info("{} model for doc with id {}".format(action, doc["_id"]))
 
-        if verify:
+        if verify_only:
             logger.info(f"Found {diff_count} differences")
         else:
             logger.info(f"Processed {doc_index} documents")

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -154,10 +154,10 @@ class PopulateSQLCommand(BaseCommand):
         ))
         for doc in get_all_docs_with_doc_types(self.couch_db(), [self.couch_doc_type()]):
             self.doc_index += 1
-            if not skip_verify:
-                self._verify_doc(doc)
             if not verify_only:
                 self._migrate_doc(doc)
+            if not skip_verify:
+                self._verify_doc(doc)
 
         logger.info(f"Processed {self.doc_index} documents")
         if not skip_verify:

--- a/corehq/apps/cleanup/tests/test_couch_to_sql_custom_data_fields.py
+++ b/corehq/apps/cleanup/tests/test_couch_to_sql_custom_data_fields.py
@@ -1,0 +1,80 @@
+from django.test import TestCase
+
+from corehq.apps.custom_data_fields.management.commands.populate_custom_data_fields import Command
+from corehq.apps.custom_data_fields.models import (
+    CustomDataField,
+    CustomDataFieldsDefinition,
+    SQLCustomDataFieldsDefinition,
+    SQLField,
+)
+from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
+
+
+class TestCouchToSQL(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.db = CustomDataFieldsDefinition.get_db()
+
+    def tearDown(self):
+        SQLCustomDataFieldsDefinition.objects.all().delete()
+        for doc in get_all_docs_with_doc_types(self.db, ['CustomDataFieldsDefinition']):
+            CustomDataFieldsDefinition.wrap(doc).delete()
+        super().tearDown()
+
+    def test_diff(self):
+        # Start with identical data
+        def_args = {'domain': 'some-domain', 'field_type': 'ProductFields'}
+        field1_args = {'slug': 'texture', 'is_required': True, 'label': 'Texture', 'choices': ['soft', 'spiky']}
+        obj = SQLCustomDataFieldsDefinition(**def_args)
+        obj.save()
+        obj.set_fields([SQLField(**field1_args)])
+        doc = CustomDataFieldsDefinition(
+            fields=[CustomDataField(**field1_args)],
+            **def_args,
+        ).to_json()
+        self.assertIsNone(Command.diff_couch_and_sql(doc, obj))
+
+        # Difference in top-level attribute
+        doc['domain'] = 'other-domain'
+        self.assertEqual(
+            Command.diff_couch_and_sql(doc, obj),
+            "domain: couch value 'other-domain' != sql value 'some-domain'"
+        )
+
+        # Difference in numer of sub-models
+        doc['domain'] = 'some-domain'
+        field2_args = {'slug': 'temp', 'is_required': False, 'label': 'F', 'choices': ['32', '212']}
+        doc['fields'] = [CustomDataField(**field1_args).to_json(), CustomDataField(**field2_args).to_json()]
+        self.assertEqual(
+            Command.diff_couch_and_sql(doc, obj),
+            "fields: 2 in couch != 1 in sql"
+        )
+
+        # Different in sub-model attribute
+        field2_args['label'] = 'C'
+        obj.set_fields([SQLField(**field1_args), SQLField(**field2_args)])
+        self.assertEqual(
+            Command.diff_couch_and_sql(doc, obj),
+            "label: couch value 'F' != sql value 'C'"
+        )
+
+        # Difference in sub-model ordering
+        field2_args['label'] = 'F'
+        obj.set_fields([SQLField(**field2_args), SQLField(**field1_args)])
+        self.assertEqual(
+            Command.diff_couch_and_sql(doc, obj).split("\n"), [
+                "slug: couch value 'texture' != sql value 'temp'",
+                "is_required: couch value 'True' != sql value 'False'",
+                "label: couch value 'Texture' != sql value 'F'",
+                "choices: couch value '['soft', 'spiky']' != sql value '['32', '212']'",
+                "slug: couch value 'temp' != sql value 'texture'",
+                "is_required: couch value 'False' != sql value 'True'",
+                "label: couch value 'F' != sql value 'Texture'",
+                "choices: couch value '['32', '212']' != sql value '['soft', 'spiky']'",
+            ]
+        )
+
+        # Identical data
+        obj.set_fields([SQLField(**field1_args), SQLField(**field2_args)])
+        self.assertIsNone(Command.diff_couch_and_sql(doc, obj))

--- a/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
+++ b/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
@@ -20,6 +20,29 @@ class Command(PopulateSQLCommand):
     def commit_adding_migration(cls):
         return "bb82e5c3d2840d6e3e3a6f5ebf1a0c7e817f4613"
 
+    @classmethod
+    def diff_attr(cls, name, doc, obj):
+        couch = doc.get(name, None)
+        sql = getattr(obj, name, None)
+        if couch != sql:
+            return f"{name}: couch value '{couch}' != sql value '{sql}'"
+
+    @classmethod
+    def diff_couch_and_sql(cls, doc, obj):
+        diffs = []
+        for attr in ('field_type', 'domain'):
+            diffs.append(cls.diff_attr(attr, doc, obj))
+        couch_fields = doc.get('fields', [])
+        sql_fields = obj.get_fields()
+        if len(couch_fields) != len(sql_fields):
+            diffs.append(f"fields: {len(couch_fields)} in couch != {len(sql_fields)} in sql")
+        else:
+            for couch_field, sql_field in list(zip(couch_fields, sql_fields)):
+                for attr in ('slug', 'is_required', 'label', 'choices', 'regex', 'regex_msg'):
+                    diffs.append(cls.diff_attr(attr, couch_field, sql_field))
+        diffs = [d for d in diffs if d]
+        return "\n".join(diffs) if diffs else None
+
     def update_or_create_sql_object(self, doc):
         model, created = self.sql_class().objects.update_or_create(
             couch_id=doc['_id'],

--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -211,6 +211,8 @@ class CustomDataFieldsDefinition(SyncCouchToSQLMixin, QuickCachedDocumentMixin, 
         for field_name in self._migration_get_fields():
             value = getattr(self, field_name)
             setattr(sql_object, field_name, value)
+        if not sql_object.id:
+            sql_object.save(sync_to_couch=False)
         sql_object.set_fields([
             SQLField(
                 slug=field.slug,

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 
+from django.conf import settings
+
 from dimagi.utils.logging import notify_exception
 
 SubModelSpec = namedtuple('SubModelSpec', [
@@ -126,7 +128,9 @@ class SyncCouchToSQLMixin(object):
         if sync_to_sql:
             try:
                 self._migration_do_sync()
-            except:
+            except Exception as e:
+                if settings.UNIT_TESTING:
+                    raise e
                 sql_class_name = self._migration_get_sql_model_class().__name__
                 couch_class_name = self.__class__.__name__
                 notify_exception(None,
@@ -222,7 +226,9 @@ class SyncSQLToCouchMixin(object):
         if sync_to_couch:
             try:
                 self._migration_do_sync()
-            except:
+            except Exception as e:
+                if settings.UNIT_TESTING:
+                    raise e
                 couch_class_name = self._migration_get_couch_model_class().__name__
                 sql_class_name = self.__class__.__name__
                 notify_exception(None,


### PR DESCRIPTION
##### SUMMARY
Followup for last week's CustomDataFieldDefinition P1s. Adds a `--verify` option to the migration command that verifies couch and sql contain the same data. Also adds tests for CustomDataFieldDefinition syncing.

##### RISK ASSESSMENT / QA PLAN
No QA. This is mostly tests.
