### PR TITLE
always include app tag

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -790,9 +790,12 @@ class RestoreConfig(object):
 
         tags['type'] = 'sync' if self.params.sync_log_id else 'restore'
 
-        if settings.ENTERPRISE_MODE and self.params.app and self.params.app.copy_of:
-            app_name = slugify(self.params.app.name)
-            tags['app'] = '{}-{}'.format(app_name, self.params.app.version)
+        if settings.ENTERPRISE_MODE:
+            if self.params.app and self.params.app.copy_of:
+                app_name = slugify(self.params.app.name)
+                tags['app'] = '{}-{}'.format(app_name, self.params.app.version)
+            else:
+                tags['app'] = ''
 
         metrics_counter('commcare.restores.count', tags=tags)
         metrics_histogram(


### PR DESCRIPTION
```
Message: Prometheus metric error
Value: {'error': ValueError('Incorrect label names',), 'metric_name': 'commcare_restores_duration_seconds', 'tags': {'status_code': 200, 'device_type': 'webapps', 'type': 'sync'}, 'expected_tags': ('status_code', 'device_type', 'type', 'app')}
```