### PR TITLE
Remove non-existent --list parameter

### DIFF
--- a/corehq/sql_db/management/commands/migrate_multi.py
+++ b/corehq/sql_db/management/commands/migrate_multi.py
@@ -25,8 +25,6 @@ class Command(BaseCommand):
             help='Tells Django to NOT prompt the user for input of any kind.')
         parser.add_argument('--fake', action='store_true', dest='fake', default=False,
             help='Mark migrations as run without actually running them.')
-        parser.add_argument('--list', '-l', action='store_true', dest='list', default=False,
-            help='Show a list of all known migrations and which are applied.')
 
     def handle(self, app_label, migration_name, **options):
         args = []
@@ -40,11 +38,7 @@ class Command(BaseCommand):
         def migrate_db(db_alias, options=options):
             call_options = copy(options)
             call_options['database'] = db_alias
-            call_command(
-                'migrate',
-                *args,
-                **call_options
-            )
+            call_command('migrate', *args, **call_options)
 
         dbs_to_migrate = [
             db_alias


### PR DESCRIPTION
Neither Django 1.11 or Django 2.2 support `migrate --list` out of the
box. Not sure when this was ever supported, or if its part of some
third-party extension.