### PR TITLE
Track user modifications

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2,6 +2,7 @@ import hmac
 import json
 import logging
 import re
+from auditcare.decorators.models import store_original_doc
 from datetime import datetime
 from hashlib import sha1
 from uuid import uuid4
@@ -1052,6 +1053,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         if should_save:
             couch_user.save()
 
+        # keep copy of original doc for TrackModelUpdates on save
+        if not hasattr(couch_user, '_original'):
+            couch_user._original = deepcopy(couch_user._doc)
         return couch_user
 
     class AccountTypeError(Exception):
@@ -1396,6 +1400,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         }[doc_type].wrap(source)
 
     @classmethod
+    @store_original_doc()
     @quickcache(['username'], skip_arg="strict")
     def get_by_username(cls, username, strict=False):
         if not username:
@@ -1442,6 +1447,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         get_mirror_domain_links_for_dropdown.clear(self)
 
     @classmethod
+    @store_original_doc()
     @quickcache(['userID', 'domain'])
     def get_by_user_id(cls, userID, domain=None):
         """

--- a/corehq/ex-submodules/auditcare/decorators/models.py
+++ b/corehq/ex-submodules/auditcare/decorators/models.py
@@ -1,0 +1,13 @@
+from copy import deepcopy
+from functools import wraps
+
+
+def store_original_doc():
+    def decorator(fn):
+        @wraps(fn)
+        def _inner(self, *args, **kwargs):
+            model_object = fn(self, *args, **kwargs)
+            model_object._original = deepcopy(model_object._doc)
+            return model_object
+        return _inner
+    return decorator

--- a/corehq/ex-submodules/auditcare/utils/models.py
+++ b/corehq/ex-submodules/auditcare/utils/models.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+
+from corehq.util.model_log import log_model_change
 from corehq.util.soft_assert import soft_assert
 from corehq.util.view_utils import get_request
 
@@ -31,6 +34,20 @@ class TrackModelUpdates(object):
     def save(self):
         if not self._can_track():
             return False
-        else:
-            # track
-            pass
+        changes = defaultdict(dict)
+        for attr_to_check in self.model_object.track_updates_for:
+            new_value = self.model_object._doc.get(attr_to_check)
+            old_value = self.model_object._original.get(attr_to_check)
+            if old_value and not new_value:
+                changes[attr_to_check]['delete'] = old_value
+            elif new_value and not old_value:
+                changes[attr_to_check]['create'] = new_value
+            else:
+                if hasattr(self.model_object, f"compare_{attr_to_check}"):
+                    attr_changes = getattr(self.model_object, f"compare_{attr_to_check}")(self.model_object._original)
+                    if attr_changes:
+                        changes[attr_to_check] = attr_changes
+        if changes:
+            log_model_change(user=self.by_user, model_object=self.model_object.get_django_user(),
+                             message=dict(changes))
+        return True

--- a/corehq/ex-submodules/auditcare/utils/models.py
+++ b/corehq/ex-submodules/auditcare/utils/models.py
@@ -1,0 +1,36 @@
+from corehq.util.soft_assert import soft_assert
+from corehq.util.view_utils import get_request
+
+
+class TrackModelUpdates(object):
+    def __init__(self, model_object, by_user=None):
+        self.model_object = model_object
+        self.by_user = by_user
+
+    def _can_track(self):
+        if not hasattr(self.model_object, 'track_updates_for') or not self.model_object.track_updates_for:
+            return False
+        if not hasattr(self.model_object, '_original'):
+            soft_assert(to=["mkangia@dimagi.com"], notify_admins=False, exponential_backoff=True)(
+                False, "Model called without original doc"
+            )
+            return False
+        if not self.by_user:
+            request = get_request()
+            try:
+                django_user = request.user
+            except:
+                soft_assert(to=["mkangia@dimagi.com"], notify_admins=False, exponential_backoff=True)(
+                    False, "Could not get user for request"
+                )
+                return False
+            else:
+                self.by_user = django_user
+        return True
+
+    def save(self):
+        if not self._can_track():
+            return False
+        else:
+            # track
+            pass


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1505

##### SUMMARY
There is a need to audit changes done to a user.
[Creation](https://github.com/dimagi/commcare-hq/pull/27755) and [Deletion](https://github.com/dimagi/commcare-hq/pull/27835)(soft/permanent) has already been covered.

Tracking updates can get challenging and heavy, so this PR just sets up the structure to track updates to user models for the attributes we want to track.

The ticket currently specifies role assignments to track so this PR focusses on domain membership(s). 

- [x] find a way to keep original doc version
- [x] add log entries on save
- [ ] pass user making the change in case of async tasks
- [ ] update/skip existing tests to avoid overhead
- [ ] add test

The log entries will look something like
<img width="1206" alt="Screenshot 2020-07-07 at 6 59 18 PM" src="https://user-images.githubusercontent.com/3864163/86788658-09bfc400-c084-11ea-995f-2dfcaaf33177.png">

