### PR TITLE
Remove link from usernames when user don't have form view permissions

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -95,8 +95,17 @@ class WorkerMonitoringReportTableBase(GenericTabularReport, ProjectReport, Proje
     exportable = True
 
     def get_user_link(self, user):
-        user_link = self.get_raw_user_link(user)
-        return self.table_cell(user.raw_username, user_link)
+        if(self._has_form_view_permission()):
+            user_link = self.get_raw_user_link(user)
+            return self.table_cell(user.raw_username, user_link)
+        return self.table_cell(user.raw_username)
+
+    def _has_form_view_permission(self):
+        return self.request.couch_user.has_permission(
+            self.request.domain,
+            'view_report',
+            data='corehq.apps.reports.standard.inspect.SubmitHistory'
+        )
 
     def get_raw_user_link(self, user):
         raise NotImplementedError

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -95,7 +95,7 @@ class WorkerMonitoringReportTableBase(GenericTabularReport, ProjectReport, Proje
     exportable = True
 
     def get_user_link(self, user):
-        if(self._has_form_view_permission()):
+        if self._has_form_view_permission():
             user_link = self.get_raw_user_link(user)
             return self.table_cell(user.raw_username, user_link)
         return self.table_cell(user.raw_username)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1606
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Users who have access to "Submissions by Form" report used to get link attached to username which used to point to Submit History Report of that user who have submitted that form.
We were not checking if that specific user has access to view the Submit History report. 
In this PR we have disabled the link for the users who don't have access to view Submit History Report.
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
