### PR TITLE
Allow docker tests to be run more than once

### DIFF
--- a/CITUSDB_SETUP.md
+++ b/CITUSDB_SETUP.md
@@ -6,18 +6,16 @@
 1. Citus containers added directly to the hq-compose.yml file
    to make the setup simpler rather than having separate compose files
    and having to join the networks or use host networking
-2. We use the `commcare_ucr_citus` database instead of `test_commcare_ucr_citus`
-   since that is already set up for CitusDB by the docker containers.
-   We could have docker use a different DB name
-   but Django tries to connect to the `postgres` database anyway in order to
-   create test databases.
-   Having Django setup the test database requires doing it in Django migrations
-   (see below). Although this works it adds a lot of time to the test setup
-   since Django needs to run migrations on the worker nodes. To keep the setup
-   time lower we skip this.
-3. Since there is only a single DB in the Citus cluster (the `postgres` database
-   does not exist) Django is unable to tear down the database. To get around this
-   we use `REUSE_DB=True` which skips database teardown.
+2. Since there is only a single DB in the Citus cluster (the `postgres` database
+   does not exist) Django is unable to setup or tear down the database. To get
+   around this we use `REUSE_DB=True` which skips database setup and teardown
+   for existing databases. Other databases that do not exist will be setup, but
+   teardown will be skipped.
+
+   Having Django setup the test database requires doing it in Django migrations.
+   Although this works it adds a lot of time to the test setup since Django
+   needs to run migrations on the worker nodes. To keep the setup time lower we
+   skip it.
 
 ## Running CitusDB
 To run CitusDB in docker execute the following command:

--- a/docker/hq-compose-citus.yml
+++ b/docker/hq-compose-citus.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}citus_master:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_manager:
@@ -17,7 +17,7 @@ services:
     depends_on: { citus_master: { condition: service_healthy } }
     environment:
       CITUS_HOST: citus_master
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_worker1:
@@ -28,7 +28,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}citus_worker1:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
   citus_worker2:
     image: 'citusdata/citus:8.1.1'
@@ -38,5 +38,5 @@ services:
     volumes:
       - ${VOLUME_PREFIX}citus_worker2:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq

--- a/docker/hq-compose-citus.yml
+++ b/docker/hq-compose-citus.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}citus_master:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_manager:
@@ -17,7 +17,7 @@ services:
     depends_on: { citus_master: { condition: service_healthy } }
     environment:
       CITUS_HOST: citus_master
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_worker1:
@@ -28,7 +28,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}citus_worker1:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
   citus_worker2:
     image: 'citusdata/citus:8.1.1'
@@ -38,5 +38,5 @@ services:
     volumes:
       - ${VOLUME_PREFIX}citus_worker2:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -119,7 +119,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_master:}/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_manager:
@@ -128,7 +128,7 @@ services:
     depends_on: { citus_master: { condition: service_healthy } }
     environment:
       CITUS_HOST: citus_master
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_worker1:
@@ -138,7 +138,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_worker1:}/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
   citus_worker2:
     image: 'citusdata/citus:8.1.1'
@@ -147,5 +147,5 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_worker2:}/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
+      POSTGRES_DB: "${UCR_CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq

--- a/docker/hq-compose.yml
+++ b/docker/hq-compose.yml
@@ -119,7 +119,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_master:}/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_manager:
@@ -128,7 +128,7 @@ services:
     depends_on: { citus_master: { condition: service_healthy } }
     environment:
       CITUS_HOST: citus_master
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
       POSTGRES_PASSWORD: commcarehq
   citus_worker1:
@@ -138,7 +138,7 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_worker1:}/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq
   citus_worker2:
     image: 'citusdata/citus:8.1.1'
@@ -147,5 +147,5 @@ services:
     volumes:
       - ${VOLUME_PREFIX}${BLANK_IF_TESTS-citus_worker2:}/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: commcare_ucr_citus
+      POSTGRES_DB: "${CITUS_DB:-commcare_ucr_citus}"
       POSTGRES_USER: commcarehq

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -76,8 +76,6 @@ DATABASES.update({
         'HOST': 'citus_master',
         'PORT': '5432',
         'TEST': {
-            # use the same DB for tests to skip expensive setup time in Travs
-            'NAME': 'commcare_ucr_citus',
             'SERIALIZE': False,
         },
     },

--- a/scripts/docker
+++ b/scripts/docker
@@ -143,6 +143,7 @@ if [ "$CMD" == "test" -o "$CMD" == "hqtest" -o "$CMD" == "py3test" ]; then
     fi
     export COMPOSE_FILE=docker/hq-compose.yml
     export COMPOSE_PROJECT_NAME=hqtest
+    export CITUS_DB="${CITUS_DB:-test_commcare_ucr_citus}"
     if [ -n "$TRAVIS_BUILD_DIR" ]; then
         export VOLUME_PREFIX="$TRAVIS_BUILD_DIR/docker-volumes/"
     else
@@ -222,6 +223,7 @@ export TRAVIS_BUILD_NUMBER="$TRAVIS_BUILD_NUMBER"
 export TRAVIS_HQ_USERNAME="$TRAVIS_HQ_USERNAME"
 export TRAVIS_HQ_PASSWORD="$TRAVIS_HQ_PASSWORD"
 export DATADOG_API_KEY="$DATADOG_API_KEY"
+export CITUS_DB="${CITUS_DB:-commcare_ucr_citus}"
 
 if [ "$TRAVIS" == "true" -o "$DOCKER_HQ_OVERLAY" == "none" ]; then
     # don't mount /mnt/commcare-hq-ro volume read-only on travis

--- a/scripts/docker
+++ b/scripts/docker
@@ -143,7 +143,7 @@ if [ "$CMD" == "test" -o "$CMD" == "hqtest" -o "$CMD" == "py3test" ]; then
     fi
     export COMPOSE_FILE=docker/hq-compose.yml
     export COMPOSE_PROJECT_NAME=hqtest
-    export CITUS_DB="${CITUS_DB:-test_commcare_ucr_citus}"
+    export UCR_CITUS_DB="${UCR_CITUS_DB:-test_commcare_ucr_citus}"
     if [ -n "$TRAVIS_BUILD_DIR" ]; then
         export VOLUME_PREFIX="$TRAVIS_BUILD_DIR/docker-volumes/"
     else
@@ -223,7 +223,7 @@ export TRAVIS_BUILD_NUMBER="$TRAVIS_BUILD_NUMBER"
 export TRAVIS_HQ_USERNAME="$TRAVIS_HQ_USERNAME"
 export TRAVIS_HQ_PASSWORD="$TRAVIS_HQ_PASSWORD"
 export DATADOG_API_KEY="$DATADOG_API_KEY"
-export CITUS_DB="${CITUS_DB:-commcare_ucr_citus}"
+export UCR_CITUS_DB="${UCR_CITUS_DB:-commcare_ucr_citus}"
 
 if [ "$TRAVIS" == "true" -o "$DOCKER_HQ_OVERLAY" == "none" ]; then
     # don't mount /mnt/commcare-hq-ro volume read-only on travis


### PR DESCRIPTION
Previously it was not possible to run tests in docker (./scripts/docker test ...) more than once without completely destroying test containers and volumes because subsequent test runs invoke a db name check during setup, which does not allow databases with names that do not start with "test_". This check was previously violated by the "commcare_ucr_citus" db. It is unclear how the first test run avoids that check. Maybe that should be fixed?

Error seen on second and subsequent docker test runs:

```
ERROR: test suite for <corehq.tests.nose.HqdbContext object at 0x7fa191a3db38>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vendor/lib/python3.6/site-packages/nose/suite.py", line 210, in run
    self.setUp()
  File "/vendor/lib/python3.6/site-packages/nose/suite.py", line 297, in setUp
    self.setupContext(context)
  File "/vendor/lib/python3.6/site-packages/nose/suite.py", line 316, in setupContext
    try_run(context, names)
  File "/vendor/lib/python3.6/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/mnt/commcare-hq/corehq/util/test_utils.py", line 415, in time_limit
    rval = func(*args, **kw)
  File "/mnt/commcare-hq/corehq/tests/nose.py", line 207, in setup
    if self.skip_setup_for_reuse_db and self._databases_ok():
  File "/mnt/commcare-hq/corehq/tests/nose.py", line 241, in _databases_ok
    assert db["NAME"].startswith(TEST_DATABASE_PREFIX), db["NAME"]
AssertionError: commcare_ucr_citus
```