### PR TITLE
Only dump messaging backend mappings that have domain backends

### DIFF
--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -8,8 +8,8 @@ from django.db import router
 from corehq.apps.dump_reload.exceptions import DomainDumpError
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
-    DomainOrNullFilter,
     FilteredModelIteratorBuilder,
+    ManyFilters,
     SimpleFilter,
     UniqueFilteredModelIteratorBuilder,
     UserIDFilter,
@@ -116,8 +116,8 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('sms.KeywordAction', SimpleFilter('keyword__domain')),
     FilteredModelIteratorBuilder('sms.QueuedSMS', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('sms.SelfRegistrationInvitation', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('sms.SQLMobileBackend', DomainOrNullFilter('domain')),
-    FilteredModelIteratorBuilder('sms.SQLMobileBackendMapping', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('sms.SQLMobileBackend', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('sms.SQLMobileBackendMapping', ManyFilters('domain', 'backend__domain')),
     FilteredModelIteratorBuilder('cloudcare.ApplicationAccess', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('cloudcare.SQLAppGroup', SimpleFilter('application_access__domain')),
     FilteredModelIteratorBuilder('linked_domain.DomainLink', SimpleFilter('linked_domain')),

--- a/corehq/apps/dump_reload/sql/dump.py
+++ b/corehq/apps/dump_reload/sql/dump.py
@@ -8,14 +8,15 @@ from django.db import router
 from corehq.apps.dump_reload.exceptions import DomainDumpError
 from corehq.apps.dump_reload.interface import DataDumper
 from corehq.apps.dump_reload.sql.filters import (
+    DomainOrNullFilter,
     FilteredModelIteratorBuilder,
     SimpleFilter,
     UniqueFilteredModelIteratorBuilder,
     UserIDFilter,
-    UsernameFilter
+    UsernameFilter,
 )
 from corehq.apps.dump_reload.sql.serialization import JsonLinesSerializer
-from corehq.apps.dump_reload.util import get_model_label, get_model_class
+from corehq.apps.dump_reload.util import get_model_class, get_model_label
 from corehq.sql_db.config import plproxy_config
 
 APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
@@ -115,7 +116,7 @@ APP_LABELS_WITH_FILTER_KWARGS_TO_DUMP = defaultdict(list)
     FilteredModelIteratorBuilder('sms.KeywordAction', SimpleFilter('keyword__domain')),
     FilteredModelIteratorBuilder('sms.QueuedSMS', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('sms.SelfRegistrationInvitation', SimpleFilter('domain')),
-    FilteredModelIteratorBuilder('sms.SQLMobileBackend', SimpleFilter('domain')),
+    FilteredModelIteratorBuilder('sms.SQLMobileBackend', DomainOrNullFilter('domain')),
     FilteredModelIteratorBuilder('sms.SQLMobileBackendMapping', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('cloudcare.ApplicationAccess', SimpleFilter('domain')),
     FilteredModelIteratorBuilder('cloudcare.SQLAppGroup', SimpleFilter('application_access__domain')),

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -21,6 +21,15 @@ class SimpleFilter(DomainFilter):
         return [Q(**{self.filter_kwarg: domain_name})]
 
 
+class DomainOrNullFilter(SimpleFilter):
+    def get_filters(self, domain_name):
+        """
+        Returns a queryset filtered by domain name or when domain is NULL
+        """
+        return [Q(**{self.filter_kwarg: domain_name})
+                | Q(**{f'{self.filter_kwarg}__isnull': True})]
+
+
 class UsernameFilter(DomainFilter):
     def get_filters(self, domain_name):
         """

--- a/corehq/apps/dump_reload/sql/filters.py
+++ b/corehq/apps/dump_reload/sql/filters.py
@@ -21,13 +21,19 @@ class SimpleFilter(DomainFilter):
         return [Q(**{self.filter_kwarg: domain_name})]
 
 
-class DomainOrNullFilter(SimpleFilter):
+class ManyFilters(DomainFilter):
+    """
+    Filter by multiple filter kwargs. Filters are ANDed
+    """
+    def __init__(self, *filter_kwargs):
+        assert filter_kwargs, 'Please set one of more filter_kwargs'
+        self.filter_kwargs = filter_kwargs
+
     def get_filters(self, domain_name):
-        """
-        Returns a queryset filtered by domain name or when domain is NULL
-        """
-        return [Q(**{self.filter_kwarg: domain_name})
-                | Q(**{f'{self.filter_kwarg}__isnull': True})]
+        filter_ = Q(**{self.filter_kwargs[0]: domain_name})
+        for filter_kwarg in self.filter_kwargs[1:]:
+            filter_ &= Q(**{filter_kwarg: domain_name})
+        return [filter_]
 
 
 class UsernameFilter(DomainFilter):

--- a/corehq/apps/dump_reload/sql/load.py
+++ b/corehq/apps/dump_reload/sql/load.py
@@ -129,16 +129,25 @@ def load_data_for_db(db_alias, objects):
     with connection.constraint_checks_disabled():
         for obj in PythonDeserializer(objects, using=db_alias):
             if router.allow_migrate_model(db_alias, obj.object.__class__):
+                app = obj.object._meta.app_label,
+                name = obj.object._meta.object_name,
+                pk = obj.object.pk,
                 model_counter.update([obj.object.__class__])
+
+                # DomainOrNullFilter will mean that the dump can
+                # include existing records. We'll need to skip those.
+                Model = type(obj.object)
+                queryset = Model.objects.using(db_alias)
+                if queryset.filter(pk=obj.object.pk).exists():
+                    # We expect this to be very rare, so OK to print.
+                    # (And if it's not rare, it's probably a problem.)
+                    print(f'{app}.{name}(pk={pk}) already exists: Skipped')
+                    continue
+
                 try:
                     obj.save(using=db_alias)
                 except (DatabaseError, IntegrityError) as e:
-                    e.args = ("Could not load %(app_label)s.%(object_name)s(pk=%(pk)s): %(error_msg)s" % {
-                        'app_label': obj.object._meta.app_label,
-                        'object_name': obj.object._meta.object_name,
-                        'pk': obj.object.pk,
-                        'error_msg': force_text(e)
-                    },)
+                    e.args = (f"Could not load {app}.{name}(pk={pk}): {e}",)
                     raise
 
     # Since we disabled constraint checks, we must manually check for

--- a/corehq/apps/dump_reload/sql/load.py
+++ b/corehq/apps/dump_reload/sql/load.py
@@ -129,24 +129,13 @@ def load_data_for_db(db_alias, objects):
     with connection.constraint_checks_disabled():
         for obj in PythonDeserializer(objects, using=db_alias):
             if router.allow_migrate_model(db_alias, obj.object.__class__):
-                app = obj.object._meta.app_label,
-                name = obj.object._meta.object_name,
-                pk = obj.object.pk,
                 model_counter.update([obj.object.__class__])
-
-                # DomainOrNullFilter will mean that the dump can
-                # include existing records. We'll need to skip those.
-                Model = type(obj.object)
-                queryset = Model.objects.using(db_alias)
-                if queryset.filter(pk=obj.object.pk).exists():
-                    # We expect this to be very rare, so OK to print.
-                    # (And if it's not rare, it's probably a problem.)
-                    print(f'{app}.{name}(pk={pk}) already exists: Skipped')
-                    continue
-
                 try:
                     obj.save(using=db_alias)
                 except (DatabaseError, IntegrityError) as e:
+                    app = obj.object._meta.app_label,
+                    name = obj.object._meta.object_name,
+                    pk = obj.object.pk,
                     e.args = (f"Could not load {app}.{name}(pk={pk}): {e}",)
                     raise
 

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -529,6 +529,60 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
         ).save()
         self._dump_and_load({AlertScheduleInstance: 1})
 
+    def test_domain_mobile_backend(self):
+        from corehq.apps.sms.models import (
+            SQLMobileBackend,
+            SQLMobileBackendMapping,
+        )
+
+        backend = SQLMobileBackend.objects.create(
+            domain=self.domain_name,
+            name='test-mobile-backend',
+            display_name='Test Mobile Backend',
+            hq_api_id='TMB',
+            inbound_api_key='test-mobile-backend-inbound-api-key',
+            supported_countries=["*"],
+            backend_type=SQLMobileBackend.SMS,
+            is_global=False,
+        )
+        SQLMobileBackendMapping.objects.create(
+            domain=self.domain_name,
+            backend=backend,
+            backend_type=SQLMobileBackend.SMS,
+            prefix='*',
+        )
+        self._dump_and_load({
+            SQLMobileBackendMapping: 1,
+            SQLMobileBackend: 1,
+        })
+
+    def test_global_mobile_backend(self):
+        from corehq.apps.sms.models import (
+            SQLMobileBackend,
+            SQLMobileBackendMapping,
+        )
+
+        backend = SQLMobileBackend.objects.create(
+            domain=None,
+            name='test-mobile-backend',
+            display_name='Test Mobile Backend',
+            hq_api_id='TMB',
+            inbound_api_key='test-mobile-backend-inbound-api-key',
+            supported_countries=["*"],
+            backend_type=SQLMobileBackend.SMS,
+            is_global=True,
+        )
+        SQLMobileBackendMapping.objects.create(
+            domain=self.domain_name,
+            backend=backend,
+            backend_type=SQLMobileBackend.SMS,
+            prefix='*',
+        )
+        self._dump_and_load({
+            SQLMobileBackendMapping: 1,
+            SQLMobileBackend: 1,
+        })
+
     def test_case_importer(self):
         from corehq.apps.case_importer.tracking.models import (
             CaseUploadFileMeta,

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -529,52 +529,42 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
         ).save()
         self._dump_and_load({AlertScheduleInstance: 1})
 
-    def test_domain_mobile_backend(self):
+    def test_mobile_backend(self):
         from corehq.apps.sms.models import (
             SQLMobileBackend,
             SQLMobileBackendMapping,
         )
 
-        backend = SQLMobileBackend.objects.create(
+        domain_backend = SQLMobileBackend.objects.create(
             domain=self.domain_name,
-            name='test-mobile-backend',
-            display_name='Test Mobile Backend',
-            hq_api_id='TMB',
-            inbound_api_key='test-mobile-backend-inbound-api-key',
+            name='test-domain-mobile-backend',
+            display_name='Test Domain Mobile Backend',
+            hq_api_id='TDMB',
+            inbound_api_key='test-domain-mobile-backend-inbound-api-key',
             supported_countries=["*"],
             backend_type=SQLMobileBackend.SMS,
             is_global=False,
         )
         SQLMobileBackendMapping.objects.create(
             domain=self.domain_name,
-            backend=backend,
+            backend=domain_backend,
             backend_type=SQLMobileBackend.SMS,
-            prefix='*',
-        )
-        self._dump_and_load({
-            SQLMobileBackendMapping: 1,
-            SQLMobileBackend: 1,
-        })
-
-    def test_global_mobile_backend(self):
-        from corehq.apps.sms.models import (
-            SQLMobileBackend,
-            SQLMobileBackendMapping,
+            prefix='123',
         )
 
-        backend = SQLMobileBackend.objects.create(
+        global_backend = SQLMobileBackend.objects.create(
             domain=None,
-            name='test-mobile-backend',
-            display_name='Test Mobile Backend',
-            hq_api_id='TMB',
-            inbound_api_key='test-mobile-backend-inbound-api-key',
+            name='test-global-mobile-backend',
+            display_name='Test Global Mobile Backend',
+            hq_api_id='TGMB',
+            inbound_api_key='test-global-mobile-backend-inbound-api-key',
             supported_countries=["*"],
             backend_type=SQLMobileBackend.SMS,
             is_global=True,
         )
         SQLMobileBackendMapping.objects.create(
             domain=self.domain_name,
-            backend=backend,
+            backend=global_backend,
             backend_type=SQLMobileBackend.SMS,
             prefix='*',
         )
@@ -582,6 +572,10 @@ class TestSQLDumpLoad(BaseDumpLoadTest):
             SQLMobileBackendMapping: 1,
             SQLMobileBackend: 1,
         })
+        self.assertEqual(SQLMobileBackend.objects.first().domain,
+                         self.domain_name)
+        self.assertEqual(SQLMobileBackendMapping.objects.first().domain,
+                         self.domain_name)
 
     def test_case_importer(self):
         from corehq.apps.case_importer.tracking.models import (


### PR DESCRIPTION
Jira: [SC-735](https://dimagi-dev.atlassian.net/browse/SC-735)

##### SUMMARY

[Edited]

Currently the **dump_domain_data** management command dumps SQLMobileBackend instances owned by the domain, and SQLMobileBackendMapping instances that map to both domain backends and global backends. This breaks foreign key constraints.

This change stops dumping SQLMobileBackendMapping instances that aren't linked to a SQLMobileBackend instance owned by the domain. New global backends will need to be added manually.
