### PR TITLE
CouchDataLoader.__init__() missing param

### DIFF
--- a/corehq/apps/dump_reload/couch/load.py
+++ b/corehq/apps/dump_reload/couch/load.py
@@ -23,8 +23,8 @@ def drop_suffix(doc_type):
 class CouchDataLoader(DataLoader):
     slug = 'couch'
 
-    def __init__(self, stdout=None, stderr=None):
-        super(CouchDataLoader, self).__init__(stdout, stderr)
+    def __init__(self, object_filter=None, stdout=None, stderr=None):
+        super().__init__(object_filter, stdout, stderr)
         self._dbs = {}
         self.success_counter = Counter()
 


### PR DESCRIPTION

##### SUMMARY
`CouchDataLoader.__init__()` should take `object_filter` param, and should pass it to `super().__init__()`
