### PR TITLE
Make Volatility Warnings Persistent

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -45,7 +45,7 @@ hqDefine('cloudcare/js/util', function () {
         if (message === undefined) {
             return;
         }
-        _show(message, $el, 30000, "alert alert-warning");
+        _show(message, $el, null, "alert alert-danger");
     };
 
     var showHTMLError = function (message, $el, autoHideTime) {


### PR DESCRIPTION
Changes Volatility warnings from transient (expire after 30 seconds) to persistent, and moves color to red

![image](https://user-images.githubusercontent.com/155066/86970752-e5282280-c13d-11ea-901e-1dafc78f8733.png)

