### PR TITLE
allow session auth and check permissions on report API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -752,6 +752,7 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
         return uri
 
     class Meta(CustomResourceMeta):
+        authentication = RequirePermissionAuthentication(Permissions.view_reports, allow_session_auth=True)
         list_allowed_methods = []
         detail_allowed_methods = ["get"]
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Previously there were no permission checks on [this endpoint](https://confluence.dimagi.com/display/commcarepublic/Download+Report+Data), but it now requires `view_report` permissions.

Also enables session auth, so that these APIs can be used programmatically in CommCare, and also debugged without re-entering login details.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Not worth announcing
