### PR TITLE
Bump statici18n to version supporting Django 2.2

### DIFF
--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -60,7 +60,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -185,7 +185,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
 sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -51,7 +51,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -157,7 +157,7 @@ setproctitle==1.1.9       # via -r requirements/prod-requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.2            # via -r requirements/requirements.in

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -49,7 +49,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -141,7 +141,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.2            # via -r requirements/requirements.in

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -54,7 +54,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -154,7 +154,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -60,7 +60,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -185,7 +185,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-extensions, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, fixture, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, packaging, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, traitlets, transifex-client, twilio, unittest2
 smartypants==2.0.1        # via pycco
 sniffer==0.4.0            # via -r requirements/dev-requirements.in
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -51,7 +51,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -157,7 +157,7 @@ setproctitle==1.1.9       # via -r requirements/prod-requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
+six==1.13.0               # via -r requirements/requirements.in, cryptography, django-appconf, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, errand-boy, ethiopian-date-converter, eulxml, eventlet, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pyopenssl, python-dateutil, pyzxcvbn, qrcode, quickcache, traitlets, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.2            # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -87,7 +87,7 @@ django-redis-sessions==0.6.1
 SQLAlchemy~=1.3.0
 alembic==0.8.6
 pyzxcvbn==0.8.0
-django-statici18n==1.3.0
+django-statici18n==1.9.0
 django-simple-captcha==0.5.9
 httpagentparser~=1.7
 boto3~=1.9

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -49,7 +49,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -141,7 +141,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, python-dateutil, pyzxcvbn, qrcode, quickcache, twilio
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 sqlagg==0.16.2            # via -r requirements/requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -54,7 +54,7 @@ django-ranged-response==0.2.0  # via django-simple-captcha
 django-redis-sessions==0.6.1  # via -r requirements/requirements.in
 django-redis==4.10.0      # via -r requirements/requirements.in
 django-simple-captcha==0.5.9  # via -r requirements/requirements.in
-django-statici18n==1.3.0  # via -r requirements/requirements.in
+django-statici18n==1.9.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
@@ -154,7 +154,7 @@ sentry-sdk==0.14.4        # via -r requirements/requirements.in
 sh==1.09                  # via -r requirements/requirements.in
 simpleeval==0.9.8         # via -r requirements/requirements.in
 simplejson==3.16.0        # via -r requirements/requirements.in, datadog, django-prbac
-six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
+six==1.13.0               # via -r requirements/requirements.in, django-appconf, django-prbac, django-simple-captcha, django-statici18n, django-transfer, django-websocket-redis, dropbox, ethiopian-date-converter, eulxml, faker, freezegun, ghdiff, html5lib, jsonfield, jsonobject, jsonobject-couchdbkit, jsonpath-rw, mock, pip-tools, python-dateutil, pyzxcvbn, qrcode, quickcache, requests-mock, sqlalchemy-postgres-copy, twilio, unittest2
 smartypants==2.0.1        # via pycco
 socketpool==0.5.3         # via -r requirements/requirements.in
 soupsieve==1.9.5          # via beautifulsoup4

--- a/settings.py
+++ b/settings.py
@@ -64,6 +64,8 @@ LANGUAGES = (
     ('sw', 'Swahili'),
 )
 
+STATICI18N_FILENAME_FUNCTION = 'statici18n.utils.legacy_filename'
+
 SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not


### PR DESCRIPTION
Change log: https://django-statici18n.readthedocs.io/en/latest/changelog.html

Review by commit (second commit is all automated changes).