### PR TITLE
Fix sorting for FCT count column

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1067,7 +1067,7 @@ class FormCompletionTimeReport(WorkerMonitoringFormReportTableBase, DatespanMixi
                 _fmt_ts(stats.get('std_deviation')),
                 _fmt_ts(stats.get('min')),
                 _fmt_ts(stats.get('max')),
-                stats.get('count', 0),
+                self.table_cell(stats.get('count', 0)),
             ])
 
         total_data = get_form_duration_stats_for_users(
@@ -1079,12 +1079,14 @@ class FormCompletionTimeReport(WorkerMonitoringFormReportTableBase, DatespanMixi
             self.datespan.enddate_utc,
             by_submission_time=self.by_submission_time,
         )
-        self.total_row = ["All Users",
-                          _fmt_ts(total_data.get('avg')),
-                          _fmt_ts(total_data.get('std_deviation')),
-                          _fmt_ts(total_data.get('min')),
-                          _fmt_ts(total_data.get('max')),
-                          total_data.get('count', 0)]
+        self.total_row = [
+            "All Users",
+            _fmt_ts(total_data.get('avg')),
+            _fmt_ts(total_data.get('std_deviation')),
+            _fmt_ts(total_data.get('min')),
+            _fmt_ts(total_data.get('max')),
+            self.table_cell(total_data.get('count', 0)),
+        ]
         return rows
 
 


### PR DESCRIPTION
If a cell value is a singleton, then the sort_key is blank.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
nah

##### PRODUCT DESCRIPTION
This change fixes the sorting on the "No. of Forms" column in the Form Completion Time report
