### PR TITLE
Update django-two-factor-auth and django-otp

### DIFF
--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -78,7 +78,7 @@ urlpatterns = [
     url(r'^account/two_factor/backup/phone/register/$', TwoFactorPhoneSetupView.as_view(), name=TwoFactorPhoneSetupView.urlname),
     url(r'^account/two_factor/backup/phone/unregister/(?P<pk>\d+)/$', TwoFactorPhoneDeleteView.as_view(),
         name=TwoFactorPhoneDeleteView.urlname),
-    url(r'', include((tf_urls + tf_twilio_urls, 'two_factor'), namespace='two_factor')),
+    url(r'', include((tf_urls[0] + tf_twilio_urls[0], 'two_factor'), namespace='two_factor')),
     url(r'^account/two_factor/reset/$', TwoFactorResetView.as_view(), name=TwoFactorResetView.urlname),
     url(r'^hq/admin/session_details/$', SessionDetailsView.as_view(),
         name=SessionDetailsView.urlname),

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -52,7 +52,7 @@ django-extensions==2.2.5  # via -r requirements/dev-requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -63,7 +63,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -43,7 +43,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -54,7 +54,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -41,7 +41,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -52,7 +52,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -46,7 +46,7 @@ django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -57,7 +57,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -52,7 +52,7 @@ django-extensions==2.2.5  # via -r requirements/dev-requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -63,7 +63,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -43,7 +43,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -54,7 +54,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -78,8 +78,8 @@ Pygments~=2.0
 Jinja2~=2.10
 tinys3==0.1.12
 django-formtools==2.1
-django-otp==0.3.13
-django-two-factor-auth==1.6.2
+django-otp~=0.9.3
+django-two-factor-auth~=1.12
 datadog==0.15.0
 ddtrace==0.14.1
 django-websocket-redis==0.5.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,7 +41,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -52,7 +52,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -46,7 +46,7 @@ django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
-django-otp==0.3.13        # via -r requirements/requirements.in, django-two-factor-auth
+django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-prbac==0.0.8       # via -r requirements/requirements.in
@@ -57,7 +57,7 @@ django-simple-captcha==0.5.9  # via -r requirements/requirements.in
 django-statici18n==1.3.0  # via -r requirements/requirements.in
 django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
-django-two-factor-auth==1.6.2  # via -r requirements/requirements.in
+django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/commit/3b4b73ae43ab4a8a7a2fb95132b73510ec879445 breaks the deploy script, so cannot be deployed to staging. It also [breaks tests](https://travis-ci.org/github/dimagi/commcare-hq/builds/707634562).

Note: this is merging into dm/dj2-fix-tests, not master. dm/dj2-fix-tests is in flux right now, and likely will be rebased or split up into a set of smaller PRs eventually.

~TODO fix the deploy and tests~ Fixed in https://github.com/dimagi/commcare-hq/pull/28095/commits/c6c7abc4085c9d00491ad2a13a86f66f84aa8aeb