### PR TITLE
Add Vectorlink reports for Côte d'Ivoire

### DIFF
--- a/custom/abt/reports/data_sources/late_pmt.json
+++ b/custom/abt/reports/data_sources/late_pmt.json
@@ -16,6 +16,7 @@
     "vectorlink-burkina-faso",
     "vectorlink-ethiopia",
     "vectorlink-ghana",
+    "vectorlink-ivorycoast",
     "vectorlink-kenya",
     "vectorlink-madagascar",
     "vectorlink-malawi",

--- a/custom/abt/reports/data_sources/sms_case.json
+++ b/custom/abt/reports/data_sources/sms_case.json
@@ -16,6 +16,7 @@
     "vectorlink-burkina-faso",
     "vectorlink-ethiopia",
     "vectorlink-ghana",
+    "vectorlink-ivorycoast",
     "vectorlink-kenya",
     "vectorlink-madagascar",
     "vectorlink-malawi",

--- a/custom/abt/reports/data_sources/supervisory_v2019.json
+++ b/custom/abt/reports/data_sources/supervisory_v2019.json
@@ -17,6 +17,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/custom/abt/reports/sms_indicator_report.json
+++ b/custom/abt/reports/sms_indicator_report.json
@@ -16,6 +16,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/custom/abt/reports/spray_progress_country.json
+++ b/custom/abt/reports/spray_progress_country.json
@@ -16,6 +16,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/custom/abt/reports/spray_progress_level_1.json
+++ b/custom/abt/reports/spray_progress_level_1.json
@@ -16,6 +16,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/custom/abt/reports/spray_progress_level_2.json
+++ b/custom/abt/reports/spray_progress_level_2.json
@@ -16,6 +16,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/custom/abt/reports/spray_progress_level_3.json
+++ b/custom/abt/reports/spray_progress_level_3.json
@@ -15,6 +15,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/custom/abt/reports/spray_progress_level_4.json
+++ b/custom/abt/reports/spray_progress_level_4.json
@@ -15,6 +15,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/custom/abt/reports/supervisory_report_v2019.json
+++ b/custom/abt/reports/supervisory_report_v2019.json
@@ -17,6 +17,7 @@
         "vectorlink-burkina-faso",
         "vectorlink-ethiopia",
         "vectorlink-ghana",
+        "vectorlink-ivorycoast",
         "vectorlink-kenya",
         "vectorlink-madagascar",
         "vectorlink-malawi",

--- a/settings.py
+++ b/settings.py
@@ -2000,6 +2000,7 @@ DOMAIN_MODULE_MAP = {
     'vectorlink-burkina-faso': 'custom.abt',
     'vectorlink-ethiopia': 'custom.abt',
     'vectorlink-ghana': 'custom.abt',
+    'vectorlink-ivorycoast': 'custom.abt',
     'vectorlink-kenya': 'custom.abt',
     'vectorlink-madagascar': 'custom.abt',
     'vectorlink-malawi': 'custom.abt',


### PR DESCRIPTION
Adds all recent versions of Vectorlink static reports and data sources for Côte d'Ivoire. 
