### PR TITLE
Remove m4change custom reports from settings.py

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -358,7 +358,6 @@ HQ_APPS = (
 
     'custom.reports.mc',
     'custom.apps.crs_reports',
-    'custom.m4change',
     'custom.succeed',
     'custom.ucla',
 
@@ -520,8 +519,6 @@ FIXTURE_GENERATORS = [
     "corehq.apps.locations.fixtures.location_fixture_generator",
     "corehq.apps.locations.fixtures.flat_location_fixture_generator",
     "corehq.apps.locations.fixtures.related_locations_fixture_generator",
-    "custom.m4change.fixtures.report_fixtures.generator",
-    "custom.m4change.fixtures.location_fixtures.generator",
 ]
 
 ### Shared drive settings ###
@@ -1482,7 +1479,7 @@ COUCHDB_APPS = [
     # needed to make couchdbkit happy
     ('fluff', 'fluff-bihar'),
     ('mc', 'fluff-mc'),
-    ('m4change', 'm4change'),
+    ('m4change', 'm4change'),  # todo: remove once code that uses is removed
     ('export', META_DB),
     ('callcenter', META_DB),
 
@@ -1975,9 +1972,7 @@ DOMAIN_MODULE_MAP = {
 
     'crs-remind': 'custom.apps.crs_reports',
 
-    'm4change': 'custom.m4change',
     'succeed': 'custom.succeed',
-    'test-pathfinder': 'custom.m4change',
     'champ-cameroon': 'custom.champ',
 
     # From DOMAIN_MODULE_CONFIG on production


### PR DESCRIPTION
part of https://dimagi-dev.atlassian.net/browse/SAAS-10957

##### SUMMARY
Removes m4change custom reports, without actually deleting the code yet. (We want to delete the code and disconnecting it is a first step.)

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
