### PR TITLE
don't crash on UCR report API if there are prefilters

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -667,7 +667,7 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
             return ""
 
     def _get_report_data(self, report_config, domain, start, limit, get_params):
-        report = ConfigurableReportDataSource.from_spec(report_config)
+        report = ConfigurableReportDataSource.from_spec(report_config, include_prefilters=True)
 
         string_type_params = [
             filter.name


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Sentry Issue](https://sentry.io/organizations/dimagi/issues/1783971336/?environment=production&project=136860&query=is%3Aunresolved+configurablereportdata&statsPeriod=14d)

We need to initialize the data source the same way we do [in the view](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/reports/view.py#L224)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Not worth announcing.