### PR TITLE
Fixed spacing on download message

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/shared_download_status.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/shared_download_status.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% block results %}
   <div class="alert alert-success">
-    <h3>{{ on_complete_long }}</h3>
+    {% if on_complete_long %}
+      <h3>{{ on_complete_long }}</h3>
+    {% endif %}
     <p>{%  trans "Your download is ready." %} <a href="{% url "retrieve_download" download_id %}?get_file=1">{{ link_text }}</a></p>
   </div>
 {% endblock results %}


### PR DESCRIPTION
This is a tiny thing that bugs me.

![Screen Shot 2020-07-14 at 4 10 28 PM](https://user-images.githubusercontent.com/1486591/87471763-e3060e00-c5ec-11ea-920d-03d4b1ceceb5.png)
