### PR TITLE
Migrated KeyValList and InputMap to RequireJS

### DIFF
--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -384,6 +384,6 @@
     </div>
     {% endif %}
 
-    <div id="hq-modal-home"></div>
+    <div id="hq-content"></div>
   {% endif %}
 {% endblock modals %}

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-input-map.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-input-map.js
@@ -1,12 +1,16 @@
-/* globals hqDefine, hqImport, $, django */
-
-hqDefine('hqwebapp/js/ui_elements/ui-element-input-map', function () {
+hqDefine('hqwebapp/js/ui_elements/ui-element-input-map', [
+    'jquery',
+    'hqwebapp/js/main',
+], function (
+    $,
+    hqMain
+) {
     'use strict';
     var module = {};
 
     var InputMap = function (show_del_button) {
         var that = this;
-        hqImport("hqwebapp/js/main").eventize(this);
+        hqMain.eventize(this);
         this.ui = $('<div class="form-group hq-input-map" />');
         this.value = {
             key: "",

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
@@ -1,12 +1,20 @@
-/* globals hqDefine, hqImport, $, _, django */
-
-hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', function () {
+hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
+    'jquery',
+    'underscore',
+    'hqwebapp/js/main',
+    'hqwebapp/js/ui_elements/ui-element-input-map',
+], function (
+    $,
+    _,
+    hqMain,
+    uiInputMap
+) {
     'use strict';
     var module = {};
 
     var KeyValList = function (guid, modal_title) {
         var that = this;
-        hqImport("hqwebapp/js/main").eventize(this);
+        hqMain.eventize(this);
         this.ui = $('<div class="enum-pairs" />');
         this.value = {};
         this.translated_value = {};
@@ -59,7 +67,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', function () {
 
         $('#' + this.modal_id + ' a').click(function () {
             if ($(this).attr('data-enum-action') === 'add') {
-                $(this).parent().parent().find('fieldset').append(hqImport('hqwebapp/js/ui-element').input_map(true).ui);
+                $(this).parent().parent().find('fieldset').append(uiInputMap.new(true).ui);
                 $(this).parent().parent().find('fieldset input.enum-key').last().focus();
             }
             if (!$(this).attr('data-dismiss'))
@@ -87,8 +95,8 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', function () {
                     this.$edit_view.text('');
                 }
                 for (var key in this.value) {
-                    $modal_fields.append(hqImport('hqwebapp/js/ui-element').input_map(true).val(key, this.value[key], this.translated_value[key]).ui);
-                    this.$edit_view.append(hqImport('hqwebapp/js/ui-element').input_map(true).val(key, this.value[key], this.translated_value[key]).setEdit(false).$noedit_view);
+                    $modal_fields.append(uiInputMap.new(true).val(key, this.value[key], this.translated_value[key]).ui);
+                    this.$edit_view.append(uiInputMap.new(true).val(key, this.value[key], this.translated_value[key]).setEdit(false).$noedit_view);
                 }
             }
 

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/ui_elements/ui-element-key-val-list.js
@@ -49,7 +49,7 @@ hqDefine('hqwebapp/js/ui_elements/ui-element-key-val-list', [
         $enumModal.append($modalDialog);
 
 
-        $('#hq-modal-home').append($enumModal);
+        $('#hq-content').append($enumModal);
 
         $('#' + this.modal_id).on('hide.bs.modal', function () {
             var $inputMap = $(this).find('form .hq-input-map'),


### PR DESCRIPTION
##### SUMMARY
Cherry picked from user data profile work, which is going to add a `KeyValList` to the custom data fields page. Because the custom data fields UI is RequireJS-compatible, all of its dependencies also need to be compatible.

It's not ideal to have some uiElements migrated and others not, but migrating all of them is fairly large scope because ui-element-key-val-mapping depends on app manager media modules.

##### RISK ASSESSMENT / QA PLAN
Minor. Tested locally, will do a quick sanity test on staging before merging.