### PR TITLE
Updated custom_data_fields.js to match standards

### DIFF
--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -2,6 +2,7 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
     'jquery',
     'knockout',
     'underscore',
+    'hqwebapp/js/assert_properties',
     'hqwebapp/js/initial_page_data',
     'hqwebapp/js/toggles',
     'hqwebapp/js/knockout_bindings.ko',     // needed for sortable binding
@@ -9,23 +10,35 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
     $,
     ko,
     _,
+    assertProperties,
     initialPageData,
     toggles
 ) {
     function Choice(choice) {
-        var self = this;
+        var self = {};
         self.value = ko.observable(choice);
+        return self;
     }
 
-    function Field() {
+    function Field(options) {
+        assertProperties.assertRequired(options, [
+            'slug',
+            'label',
+            'is_required',
+            'choices',
+            'regex',
+            'regex_msg',
+        ]);
         var self = {};
-        self.slug = ko.observable();
-        self.label = ko.observable();
-        self.is_required = ko.observable();
-        self.choices = ko.observableArray();
-        self.validationMode = ko.observable(); // 'choice' or 'regex'
-        self.regex = ko.observable();
-        self.regex_msg = ko.observable();
+        self.slug = ko.observable(options.slug);
+        self.label = ko.observable(options.label);
+        self.is_required = ko.observable(options.is_required);
+        self.choices = ko.observableArray(options.choices.map(function (choice) {
+            return Choice(choice);
+        }));
+        self.validationMode = ko.observable(options.choices.length ? 'choice' : 'regex');
+        self.regex = ko.observable(options.regex);
+        self.regex_msg = ko.observable(options.regex_msg);
 
         if (!toggles.toggleEnabled('REGEX_FIELD_VALIDATION')) {
             // if toggle isn't enabled - always show "choice" option
@@ -33,27 +46,11 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
         }
 
         self.addChoice = function () {
-            self.choices.unshift(new Choice());
+            self.choices.unshift(Choice());
         };
 
         self.removeChoice = function (choice) {
             self.choices.remove(choice);
-        };
-
-        self.init = function (field) {
-            self.slug(field.slug);
-            self.label(field.label);
-            self.is_required(field.is_required);
-            if (field.choices.length > 0) {
-                self.validationMode('choice');
-                self.choices(field.choices.map(function (choice) {
-                    return new Choice(choice);
-                }));
-            } else if (field.regex) {
-                self.validationMode('regex');
-                self.regex(field.regex);
-                self.regex_msg(field.regex_msg);
-            }
         };
 
         self.serialize = function () {
@@ -90,15 +87,24 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
         return self;
     }
 
-    function CustomDataFieldsModel() {
-        var self = this;
+    function CustomDataFieldsModel(options) {
+        assertProperties.assertRequired(options, ['custom_fields']);
+
+        var self = {};
         self.data_fields = ko.observableArray();
         self.purge_existing = ko.observable(false);
         // The data field that the "remove field modal" currently refers to.
         self.modalField = ko.observable();
 
         self.addField = function () {
-            self.data_fields.push(Field());
+            self.data_fields.push(Field({
+                slug: '',
+                label: '',
+                is_required: false,
+                choices: [],
+                regex: '',
+                regex_msg: '',
+            }));
         };
 
         self.removeField = function (field) {
@@ -112,17 +118,6 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
         self.confirmRemoveField = function () {
             // Remove the field that the "remove field modal" currently refers to.
             self.removeField(self.modalField());
-        };
-
-        self.init = function (initialFields) {
-            _.each(initialFields, function (field) {
-                var customField = Field();
-                customField.init(field);
-                self.data_fields.push(customField);
-                customField.choices.subscribe(function () {
-                    $("#save-custom-fields").prop("disabled", false);
-                });
-            });
         };
 
         self.serialize = function () {
@@ -165,11 +160,23 @@ hqDefine('custom_data_fields/js/custom_data_fields', [
             customDataFieldsForm.appendTo("body");
             customDataFieldsForm.submit();
         };
+
+        // Initialize
+        _.each(options.custom_fields, function (field) {
+            var customField = Field(field);
+            self.data_fields.push(customField);
+            customField.choices.subscribe(function () {
+                $("#save-custom-fields").prop("disabled", false);
+            });
+        });
+
+        return self;
     }
 
     $(function () {
-        var customDataFieldsModel = new CustomDataFieldsModel();
-        customDataFieldsModel.init(initialPageData.get('custom_fields'));
+        var customDataFieldsModel = CustomDataFieldsModel({
+            custom_fields: initialPageData.get('custom_fields'),
+        });
         customDataFieldsModel.data_fields.subscribe(function () {
             $("#save-custom-fields").prop("disabled", false);
         });


### PR DESCRIPTION
##### SUMMARY
Cherry-picked from user data profile work. Cleans up existing code:
- Switch to functional inheritance
- Use `assert_properties`
- Get rid of init methods. This isn't an official standard, I just find them annoying and I think they're used in a minority of HQ's javascript.

##### RISK ASSESSMENT / QA PLAN
Minor, tested locally.