### PR TITLE
Fix Subscription Renewal Workflow

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -154,6 +154,11 @@ class SoftwarePlanEdition(object):
         PRO,
         ADVANCED,
     ]
+    SELF_RENEWABLE_EDITIONS = [
+        ADVANCED,
+        PRO,
+        STANDARD,
+    ]
 
 
 class SoftwarePlanVisibility(object):

--- a/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
+++ b/corehq/apps/accounting/templates/accounting/partials/confirm_plan_summary.html
@@ -1,10 +1,12 @@
 {% load i18n %}
 
+{% if not is_renewal_page %}
 <p class="lead text-center">
   {% blocktrans with plan.name as p %}
     You have selected the <strong>{{ p }} Edition</strong> subscription.
   {% endblocktrans %}
 </p>
+{% endif %}
 <div class="confirm-plan-summary">
   <div class="tile {{ tile_css }}">
     <h3>

--- a/corehq/apps/domain/templates/domain/base_change_plan.html
+++ b/corehq/apps/domain/templates/domain/base_change_plan.html
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block page_content %}
+  {% block plan_breadcrumbs %}
   <ol class="breadcrumb">
     {% for step in steps %}
       <li>
@@ -20,6 +21,7 @@
       </li>
     {% endfor %}
   </ol>
+  {% endblock %}
   <div class="select-plan-header">
     <h2>{{ step_title }}</h2>
   </div>

--- a/corehq/apps/domain/templates/domain/confirm_subscription_renewal.html
+++ b/corehq/apps/domain/templates/domain/confirm_subscription_renewal.html
@@ -1,45 +1,37 @@
-{% extends 'domain/confirm_billing_info.html' %}
+{% extends "domain/base_change_plan.html" %}
 {% load crispy_forms_tags %}
 {% load hq_shared_tags %}
 {% load i18n %}
 
-{% block page_content %}
-  <h2>{% trans "Renew Plan" %}</h2>
-  <p class="lead">
+{% block js %}
+  <script src="{% static 'accounting/js/widgets.js' %}"></script>
+{% endblock %}
+{% block plan_breadcrumbs %}{% endblock %}
+
+{% block form_content %}
+  <p class="lead text-center">
     {% blocktrans with next_plan.name as p_name%}
-      You are renewing your plan to the <strong>{{ p_name }}</strong> plan
+      You are renewing your plan to the <strong>{{ p_name }}</strong>.
     {% endblocktrans %}
     {% if next_plan.name == plan.name %}
       {% trans "— which matches your current feature usage." %}
     {% endif %}
+    <br />
+    {% blocktrans with subscription.date_end as start_date %}
+      It will be renewed automatically on <strong>{{ start_date }}</strong>.
+    {% endblocktrans %}
   </p>
-  <dl class="dl-horizontal">
-    <dt>{% trans 'Monthly Fee' %}</dt>
-    <dd>{{ next_plan.monthly_fee }}</dd>
-  </dl>
-  <dl class="dl-horizontal">
-    <dt>{% trans 'Start Date' %}</dt>
-    <dd>{{ subscription.date_end }}</dd>
-  </dl>
-  <h4>{% trans 'Included each month' %}</h4>
-  <div class="well well-sm">
-    <dl class="dl-horizontal" style="margin-bottom: 0;">
-      {% for rate in plan.rates %}
-        <dt>{{ rate.name }}</dt>
-        <dd>{{ rate.included }}</dd>
-      {% endfor %}
-    </dl>
-  </div>
-  <p>{{ next_plan.description }}</p>
   {% if next_plan.name != plan.name %}
-    <div class="alert alert-warning">
+    <div class="alert alert-warning alert-subscription">
       {% blocktrans with next_plan.monthly_fee as monthly_fee and subscription.date_end as start_date %}
         <h4>Note: You are renewing to a different plan</h4>
         <p>The new plan will take effect on <strong>{{ start_date }}</strong> and will cost <strong>{{ monthly_fee }}</strong>/month.</p>
       {% endblocktrans %}
     </div>
   {% endif %}
-  <hr />
-  <h3>{% trans 'Confirm Billing Information' %}</h3>
-  {% crispy confirm_form %}
+  <div class="panel panel-modern-gray panel-form-only" id="billing-info">
+    <div class="panel-body">
+      {% crispy confirm_form %}
+    </div>
+  </div>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/renew_plan.html
+++ b/corehq/apps/domain/templates/domain/renew_plan.html
@@ -4,6 +4,7 @@
 {% load compress %}
 {% load menu_tags %}
 
+{% block plan_breadcrumbs %}{% endblock %}
 
 {% block form_content %}
   <p class="lead text-center">
@@ -11,35 +12,7 @@
       You are renewing your <strong>{{ p }} Edition</strong> subscription.
     {% endblocktrans %}
   </p>
-  <div class="confirm-plan-summary">
-    <div class="tile {{ tile_css }}">
-      <h3>
-        {{ plan.name }}
-      </h3>
-      <p class="plan-price">
-        {{ plan.monthly_fee }}
-      </p>
-      <p class="plan-monthly-label">
-        <strong>
-          {% trans "Monthly Fee" %}
-        </strong>
-      </p>
-      <h4>
-        {% trans 'Included each month' %}
-      </h4>
-      <div class="plan-included well well-sm">
-        <dl class="dl-horizontal">
-          {% for rate in plan.rates %}
-            <dt>{{ rate.name }}</dt>
-            <dd>{{ rate.included }}</dd>
-          {% endfor %}
-        </dl>
-      </div>
-      <p class="plan-desc">
-        {{ plan.description }}
-      </p>
-    </div>
-  </div>
+  {% include 'accounting/partials/confirm_plan_summary.html' %}
 
   <form class="form"
         method="post"

--- a/corehq/apps/domain/templates/domain/renew_plan.html
+++ b/corehq/apps/domain/templates/domain/renew_plan.html
@@ -6,11 +6,40 @@
 
 
 {% block form_content %}
-  <p>
-    {% blocktrans %}
-      You are renewing your CommCare {{ plan_edition }} plan.
+  <p class="lead text-center">
+    {% blocktrans with plan.name as p %}
+      You are renewing your <strong>{{ p }} Edition</strong> subscription.
     {% endblocktrans %}
   </p>
+  <div class="confirm-plan-summary">
+    <div class="tile {{ tile_css }}">
+      <h3>
+        {{ plan.name }}
+      </h3>
+      <p class="plan-price">
+        {{ plan.monthly_fee }}
+      </p>
+      <p class="plan-monthly-label">
+        <strong>
+          {% trans "Monthly Fee" %}
+        </strong>
+      </p>
+      <h4>
+        {% trans 'Included each month' %}
+      </h4>
+      <div class="plan-included well well-sm">
+        <dl class="dl-horizontal">
+          {% for rate in plan.rates %}
+            <dt>{{ rate.name }}</dt>
+            <dd>{{ rate.included }}</dd>
+          {% endfor %}
+        </dl>
+      </div>
+      <p class="plan-desc">
+        {{ plan.description }}
+      </p>
+    </div>
+  </div>
 
   <form class="form"
         method="post"
@@ -18,15 +47,13 @@
     {% csrf_token %}
 
     <input type="hidden" name="from_plan_page" value="true" />
-    <input type="hidden" name="plan_edition" data-bind="{{ plan_edition }}">
+    <input type="hidden" name="plan_edition" value="{{ current_edition }}">
 
-    <div class="form-actions">
-      <div class="col-xs-offset-2">
-        <button type="submit"
-                class="btn btn-primary btn-lg">
-          {% trans 'Next' %}
-        </button>
-      </div>
+    <div class="text-center plan-next">
+      <button type="submit"
+              class="btn btn-primary btn-lg">
+        {% trans 'Next' %}
+      </button>
     </div>
   </form>
 {% endblock %}

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1521,7 +1521,7 @@ class SubscriptionMixin(object):
 class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
     urlname = "domain_subscription_renewal"
     page_title = ugettext_lazy("Renew Plan")
-    step_title = ugettext_lazy("Renew or Change Plan")
+    step_title = ugettext_lazy("Renew Plan")
     template_name = "domain/renew_plan.html"
 
     @property
@@ -1545,14 +1545,16 @@ class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
             'current_edition': current_edition,
             'plan': self.subscription.plan_version.user_facing_description,
             'tile_css': 'tile-{}'.format(current_edition.lower()),
+            'is_renewal_page': True,
         })
         return context
 
 
-class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin, SubscriptionMixin):
+class ConfirmSubscriptionRenewalView(SelectPlanView, DomainAccountingSettings, AsyncHandlerMixin, SubscriptionMixin):
     template_name = 'domain/confirm_subscription_renewal.html'
     urlname = 'domain_subscription_renewal_confirmation'
-    page_title = ugettext_lazy("Renew Plan")
+    page_title = ugettext_lazy("Confirm Billing Information")
+    step_title = ugettext_lazy("Confirm Billing Information")
     async_handlers = [
         Select2BillingInfoHandler,
     ]
@@ -1599,6 +1601,7 @@ class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin
             'plan': self.subscription.plan_version.user_facing_description,
             'confirm_form': self.confirm_form,
             'next_plan': self.next_plan_version.user_facing_description,
+            'is_renewal_page': True,
         }
 
     @property

--- a/corehq/apps/domain/views/accounting.py
+++ b/corehq/apps/domain/views/accounting.py
@@ -1533,22 +1533,19 @@ class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
     def page_context(self):
         context = super(SubscriptionRenewalView, self).page_context
 
-        current_privs = get_privileges(self.subscription.plan_version)
-        plan = DefaultProductPlan.get_lowest_edition(
-            current_privs, return_plan=False,
-        ).lower()
+        current_edition = self.subscription.plan_version.plan.edition
 
-        current_edition = (plan
-                           if self.current_subscription is not None
-                           and not self.current_subscription.is_trial
-                           else "")
+        if current_edition in [
+            SoftwarePlanEdition.COMMUNITY,
+            SoftwarePlanEdition.PAUSED,
+        ]:
+            raise Http404()
 
-        # never allow renewal into community
-        if current_edition == SoftwarePlanEdition.COMMUNITY:
-            raise Http404
-
-        context['current_edition'] = current_edition
-
+        context.update({
+            'current_edition': current_edition,
+            'plan': self.subscription.plan_version.user_facing_description,
+            'tile_css': 'tile-{}'.format(current_edition.lower()),
+        })
         return context
 
 

--- a/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
+++ b/corehq/apps/hqwebapp/static/accounting/less/pricing-main.less
@@ -185,7 +185,7 @@ input:checked + .slider:before {
 
 ._make-color-tile(@_color-tile) {
   width: 230px;
-  height: 350px;
+  height: 370px;
   position: relative;
 
   &:not(.tile-paused) {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10982

##### SUMMARY
Well, our subscription renewal button/workflow hasn't worked for a while, and basically ensured that anytime it was clicked and filled out the domain would be only ever renewed to community (!!!!) yikes.

![Screen Shot 2020-07-14 at 7 27 12 PM](https://user-images.githubusercontent.com/716573/87489560-f8893100-c608-11ea-83f9-5c895c8bcc89.png)

##### THE BEFORE LOOK
![Screen Shot 2020-07-14 at 7 27 56 PM](https://user-images.githubusercontent.com/716573/87489577-fe7f1200-c608-11ea-94f1-033fd4ab8421.png)
![Screen Shot 2020-07-14 at 7 28 08 PM](https://user-images.githubusercontent.com/716573/87489581-0343c600-c609-11ea-90d3-c503138ce228.png)

##### THE AFTER LOOK
![Screen Shot 2020-07-14 at 7 29 21 PM](https://user-images.githubusercontent.com/716573/87489608-122a7880-c609-11ea-863b-8d68495fef87.png)
![Screen Shot 2020-07-14 at 7 29 39 PM](https://user-images.githubusercontent.com/716573/87489615-1787c300-c609-11ea-950e-cd250b6f5d33.png)


##### RISK ASSESSMENT / QA PLAN
I think the feature as it right now does not work. I verified locally that this does not affect the current subscription change workflow, so I think it's safe to do a quick QA after deploy?
