### PR TITLE
Make high frequency table ids bigint

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1060,6 +1060,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
         ERROR_EMAIL_GATEWAY: ugettext_noop("Email Gateway Error"),
     }
 
+    id = models.BigAutoField(primary_key=True)
     domain = models.CharField(max_length=126, null=False, db_index=True)
     date = models.DateTimeField(null=False, db_index=True)
     source = models.CharField(max_length=3, null=False)
@@ -1480,6 +1481,7 @@ class MessagingSubEvent(models.Model, MessagingStatusMixin):
         (MessagingEvent.RECIPIENT_WEB_USER, ugettext_noop('Web User')),
     )
 
+    id = models.BigAutoField(primary_key=True)
     parent = models.ForeignKey('MessagingEvent', on_delete=models.CASCADE)
     date = models.DateTimeField(null=False, db_index=True)
     recipient_type = models.CharField(max_length=3, choices=RECIPIENT_CHOICES, null=False)

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -1134,6 +1134,7 @@ class AsyncIndicator(models.Model):
 
 
 class InvalidUCRData(models.Model):
+    id = models.BigAutoField(primary_key=True)
     doc_id = models.CharField(max_length=255, null=False)
     doc_type = models.CharField(max_length=126, null=False, db_index=True)
     domain = models.CharField(max_length=126, null=False, db_index=True)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2785,6 +2785,7 @@ class AnonymousCouchUser(object):
 
 
 class UserReportingMetadataStaging(models.Model):
+    id = models.BigAutoField(primary_key=True)
     domain = models.TextField()
     user_id = models.TextField()
     app_id = models.TextField(null=True)  # not all form submissions include an app_id

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -1277,6 +1277,8 @@ class CaseTransaction(PartitionedModel, SaveStateMixin, models.Model):
         TYPE_CASE_ATTACHMENT,
         TYPE_LEDGER,
     )
+
+    id = models.BigAutoField(primary_key=True)
     case = models.ForeignKey(
         'CommCareCaseSQL', to_field='case_id', db_index=False,
         related_name="transaction_set", related_query_name="transaction",


### PR DESCRIPTION
These models are getting closer to their max values on ICDS, so making them bigints.

This is found by running management command https://github.com/dimagi/commcare-hq/blob/master/corehq/sql_db/management/commands/print_max_id_of_pg_tables.py

Here is the result https://docs.google.com/spreadsheets/d/1cFt760sUpBWAoGKkmHm43vVoxW5cKOGekJbvE0W-Qig/edit#gid=1993443052