### PR TITLE
remove ga for hipaa domains

### DIFF
--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -114,11 +114,14 @@ def current_url_name(request):
 def js_api_keys(request):
     if hasattr(request, 'couch_user') and request.couch_user and not request.couch_user.analytics_enabled:
         return {}  # disable js analytics
-    return {
+    api_keys = {
         'ANALYTICS_IDS': settings.ANALYTICS_IDS,
         'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG,
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
     }
+    if hasattr(request, 'project') and request.project.hipaa_compliant:
+        del api_keys['ANALYTICS_IDS']['GOOGLE_ANALYTICS_API_ID']
+    return api_keys
 
 
 def js_toggles(request):

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -112,14 +112,14 @@ def current_url_name(request):
 
 
 def js_api_keys(request):
-    if hasattr(request, 'couch_user') and request.couch_user and not request.couch_user.analytics_enabled:
+    if getattr(request, 'couch_user', None) and not request.couch_user.analytics_enabled:
         return {}  # disable js analytics
     api_keys = {
         'ANALYTICS_IDS': settings.ANALYTICS_IDS,
         'ANALYTICS_CONFIG': settings.ANALYTICS_CONFIG,
         'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
     }
-    if hasattr(request, 'project') and request.project.hipaa_compliant:
+    if getattr(request, 'project', None) and request.project.hipaa_compliant and api_keys['ANALYTICS_IDS'].get('GOOGLE_ANALYTICS_API_ID'):
         del api_keys['ANALYTICS_IDS']['GOOGLE_ANALYTICS_API_ID']
     return api_keys
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Turns off google analytics for hipaa domains by removing the key in requests from those domains (same principle we use for our generic analytics opt out).

FYI @djmore9 