### PR TITLE
Backward-compatible Django 2.2 updates (part 4)

### DIFF
--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from couchdbkit import ResourceNotFound
 from django.conf import settings
 from django.db import transaction
+from django.test import TestCase
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr
 from nose.tools import nottest
@@ -210,6 +211,52 @@ def use_sql_backend(cls):
     return partitioned(override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)(cls))
 
 
+def patch_testcase_transactions():
+    TestCase.transaction_exempt_databases = frozenset()
+
+    @classmethod
+    def _enter_atomics(cls):
+        atomics = {}
+        exempt = cls.transaction_exempt_databases
+        for db_name in cls._databases_names():
+            if db_name in exempt:
+                continue
+            atomics[db_name] = transaction.atomic(using=db_name)
+            atomics[db_name].__enter__()
+        return atomics
+    TestCase._enter_atomics = _enter_atomics
+
+    @classmethod
+    def _rollback_atomics(cls, atomics):
+        """Rollback atomic blocks opened by the previous method."""
+        exempt = cls.transaction_exempt_databases
+        for db_name in reversed(cls._databases_names()):
+            if db_name in exempt:
+                continue
+            transaction.set_rollback(True, using=db_name)
+            atomics[db_name].__exit__(None, None, None)
+    TestCase._rollback_atomics = _rollback_atomics
+
+    def _should_check_constraints(self, connection):
+        # Prevent intermittent error:
+        # Traceback (most recent call last):
+        #   File "django/test/testcases.py", line 274, in __call__
+        #     self._post_teardown()
+        #   File "django/test/testcases.py", line 1009, in _post_teardown
+        #     self._fixture_teardown()
+        #   File "django/test/testcases.py", line 1176, in _fixture_teardown
+        #     if self._should_check_constraints(connections[db_name]):
+        #   File "django/test/testcases.py", line 1184, in _should_check_constraints
+        #     not connection.needs_rollback and connection.is_usable()
+        #   File "django/db/backends/postgresql/base.py", line 252, in is_usable
+        #     self.connection.cursor().execute("SELECT 1")
+        # AttributeError: 'NoneType' object has no attribute 'cursor'
+        return (connection.connection is not None
+            and super_should_check_constraints(self, connection))
+    super_should_check_constraints = TestCase._should_check_constraints
+    TestCase._should_check_constraints = _should_check_constraints
+
+
 def patch_shard_db_transactions(cls):
     """Patch shard db transaction management on test class
 
@@ -220,36 +267,15 @@ def patch_shard_db_transactions(cls):
 
     :param cls: A test class.
     """
-    from django.test import TestCase
     if not issubclass(cls, TestCase):
         return cls
     assert hasattr(cls, "_enter_atomics") and hasattr(cls, "_rollback_atomics"), cls
     shard_dbs = {k for k, v in settings.DATABASES.items() if "PLPROXY" in v}
-    print("shard dbs:", shard_dbs)
-    if not shard_dbs:
-        return cls
-
-    @classmethod
-    def _enter_atomics(cls):
-        atomics = {}
-        for db_name in cls._databases_names():
-            if db_name in shard_dbs:
-                continue
-            atomics[db_name] = transaction.atomic(using=db_name)
-            atomics[db_name].__enter__()
-        return atomics
-    cls._enter_atomics = _enter_atomics
-
-    @classmethod
-    def _rollback_atomics(cls, atomics):
-        """Rollback atomic blocks opened by the previous method."""
-        for db_name in reversed(cls._databases_names()):
-            if db_name in shard_dbs:
-                continue
-            transaction.set_rollback(True, using=db_name)
-            atomics[db_name].__exit__(None, None, None)
-    cls._rollback_atomics = _rollback_atomics
-
+    if shard_dbs:
+        # Reassign attribute to prevent leaking this change to other
+        # classes that share the same class attribute.
+        pre_exempt = cls.transaction_exempt_databases
+        cls.transaction_exempt_databases = frozenset(pre_exempt) | shard_dbs
     return cls
 
 

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -224,10 +224,10 @@ def patch_shard_db_transactions(cls):
     if not issubclass(cls, TestCase):
         return cls
     assert hasattr(cls, "_enter_atomics") and hasattr(cls, "_rollback_atomics"), cls
-    shard_cfg = getattr(settings, "PARTITION_DATABASE_CONFIG", None)
-    if not shard_cfg:
+    shard_dbs = {k for k, v in settings.DATABASES.items() if "PLPROXY" in v}
+    print("shard dbs:", shard_dbs)
+    if not shard_dbs:
         return cls
-    shard_dbs = {"proxy"} | set(shard_cfg["shards"])
 
     @classmethod
     def _enter_atomics(cls):

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -7,6 +7,7 @@ from couchdbkit import ResourceNotFound
 from django.conf import settings
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
+from django.utils.decorators import classproperty
 from nose.plugins.attrib import attr
 from nose.tools import nottest
 from unittest2 import skipIf, skipUnless
@@ -213,6 +214,14 @@ def use_sql_backend(cls):
 def patch_testcase_databases():
     """Lift Django 2.2 restriction on database access in tests
 
+    Allows `TestCase` and `TransactionTestCase` to access all databases
+    except for icds-specific databases by default. This can be
+    overridden by setting `databases` on test case subclasses.
+
+    Similar to pre-Django 2.2, transactions are disabled on all
+    databases except "default". This can be overridden by setting
+    `transaction_exempt_databases` on test case subclasses.
+
     For test performance it may be better to remove this and tag each
     test with the databases it will query.
     """
@@ -225,15 +234,23 @@ def patch_testcase_databases():
     #
     # Similar error reported elsewhere:
     # https://code.djangoproject.com/ticket/30541
-    TransactionTestCase.databases = settings.DATABASES.keys()
-    TransactionTestCase.transaction_exempt_databases = frozenset()
+    databases = frozenset(k for k in settings.DATABASES.keys() if "icds" not in k)
+    TestCase.databases = databases
+    TransactionTestCase.databases = databases
+
+    @classproperty
+    def transaction_exempt_databases(cls):
+        if cls.databases is databases:
+            return frozenset(db for db in databases if db != "default")
+        return frozenset(db for db in databases if db not in cls.databases)
+    TransactionTestCase.transaction_exempt_databases = transaction_exempt_databases
 
     @classmethod
     def _databases_names(cls, include_mirrors=True):
-        names = super_database_names(include_mirrors=include_mirrors)
+        names = super_database_names(cls, include_mirrors=include_mirrors)
         exempt = cls.transaction_exempt_databases
         return [n for n in names if n not in exempt]
-    super_database_names = TransactionTestCase._databases_names
+    super_database_names = TransactionTestCase._databases_names.__func__
     TransactionTestCase._databases_names = _databases_names
 
     def _should_check_constraints(self, connection):

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -218,8 +218,11 @@ def patch_shard_db_transactions(cls):
     This means that changes to shard dbs will not be rolled back at the
     end of each test; test cleanup must be done manually.
 
-    :param cls: A subclass of `django.test.TestCase`
+    :param cls: A test class.
     """
+    from django.test import TestCase
+    if not issubclass(cls, TestCase):
+        return cls
     assert hasattr(cls, "_enter_atomics") and hasattr(cls, "_rollback_atomics"), cls
     shard_cfg = getattr(settings, "PARTITION_DATABASE_CONFIG", None)
     if not shard_cfg:

--- a/corehq/tests/noseplugins/patches.py
+++ b/corehq/tests/noseplugins/patches.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from nose.plugins import Plugin
 
 from corehq.util.es.testing import patch_es_user_signals
@@ -30,7 +31,16 @@ def patch_django_TestCase_databases():
     test with the databases it will query.
     """
     from django.test import TestCase
-    TestCase.databases = "__all__"
+    # According to the docs it should be possible to allow tests to
+    # access all databases with `TestCase.databses = '_all__'`
+    # https://docs.djangoproject.com/en/2.2/topics/testing/tools/#multi-database-support
+    #
+    # Unfortunately support for '__all__' appears to be buggy:
+    # django.db.utils.ConnectionDoesNotExist: The connection _ doesn't exist
+    #
+    # Similar error reported elsewhere:
+    # https://code.djangoproject.com/ticket/30541
+    TestCase.databases = settings.DATABASES.keys()
 
 
 GLOBAL_FREEZEGUN_IGNORE_LIST = ["kafka."]

--- a/corehq/tests/noseplugins/patches.py
+++ b/corehq/tests/noseplugins/patches.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from nose.plugins import Plugin
 
+from corehq.form_processor.tests.utils import patch_testcase_transactions
 from corehq.util.es.testing import patch_es_user_signals
 
 
@@ -41,6 +42,8 @@ def patch_django_TestCase_databases():
     # Similar error reported elsewhere:
     # https://code.djangoproject.com/ticket/30541
     TestCase.databases = settings.DATABASES.keys()
+
+    patch_testcase_transactions()
 
 
 GLOBAL_FREEZEGUN_IGNORE_LIST = ["kafka."]

--- a/corehq/tests/noseplugins/patches.py
+++ b/corehq/tests/noseplugins/patches.py
@@ -13,6 +13,7 @@ class PatchesPlugin(Plugin):
 
     def begin(self):
         patch_assertItemsEqual()
+        patch_django_TestCase_databases()
         fix_freezegun_bugs()
         patch_es_user_signals()
 
@@ -20,6 +21,16 @@ class PatchesPlugin(Plugin):
 def patch_assertItemsEqual():
     import unittest
     unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
+
+
+def patch_django_TestCase_databases():
+    """Lift restriction on database access in tests introduced in Django 2.2
+
+    For test performance it may be better to remove this and tag each
+    test with the databases it will query.
+    """
+    from django.test import TestCase
+    TestCase.databases = "__all__"
 
 
 GLOBAL_FREEZEGUN_IGNORE_LIST = ["kafka."]

--- a/corehq/tests/noseplugins/patches.py
+++ b/corehq/tests/noseplugins/patches.py
@@ -1,7 +1,6 @@
-from django.conf import settings
 from nose.plugins import Plugin
 
-from corehq.form_processor.tests.utils import patch_testcase_transactions
+from corehq.form_processor.tests.utils import patch_testcase_databases
 from corehq.util.es.testing import patch_es_user_signals
 
 
@@ -15,7 +14,7 @@ class PatchesPlugin(Plugin):
 
     def begin(self):
         patch_assertItemsEqual()
-        patch_django_TestCase_databases()
+        patch_testcase_databases()
         fix_freezegun_bugs()
         patch_es_user_signals()
 
@@ -23,27 +22,6 @@ class PatchesPlugin(Plugin):
 def patch_assertItemsEqual():
     import unittest
     unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
-
-
-def patch_django_TestCase_databases():
-    """Lift restriction on database access in tests introduced in Django 2.2
-
-    For test performance it may be better to remove this and tag each
-    test with the databases it will query.
-    """
-    from django.test import TestCase
-    # According to the docs it should be possible to allow tests to
-    # access all databases with `TestCase.databses = '_all__'`
-    # https://docs.djangoproject.com/en/2.2/topics/testing/tools/#multi-database-support
-    #
-    # Unfortunately support for '__all__' appears to be buggy:
-    # django.db.utils.ConnectionDoesNotExist: The connection _ doesn't exist
-    #
-    # Similar error reported elsewhere:
-    # https://code.djangoproject.com/ticket/30541
-    TestCase.databases = settings.DATABASES.keys()
-
-    patch_testcase_transactions()
 
 
 GLOBAL_FREEZEGUN_IGNORE_LIST = ["kafka."]

--- a/custom/icds_reports/tests/agg_tests/__init__.py
+++ b/custom/icds_reports/tests/agg_tests/__init__.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 import mock
 
+from nose.tools import nottest
+
 from django.conf import settings
 from django.test.utils import override_settings
 from django.test.testcases import TestCase
@@ -31,6 +33,11 @@ def setUpModule():
         print('============= WARNING: not running test setup because settings.USE_PARTITIONED_DATABASE is True.')
         return
 
+    global _stop_transaction_exemption
+    _stop_transaction_exemption = exempt_from_test_transactions([
+        "icds-ucr",
+        "icds-ucr-citus",
+    ])
     domain = create_domain('icds-cas')
     setup_location_hierarchy(domain.name)
 
@@ -74,6 +81,42 @@ def tearDownModule():
 
     Domain.get_by_name('icds-cas').delete()
     _call_center_domain_mock.stop()
+    _stop_transaction_exemption()
+
+
+@nottest
+def exempt_from_test_transactions(dbnames):
+    """Do not start a transaction per test for the given databases
+
+    AVOID IF POSSIBLE. All new tests should attempt to work with test
+    transactions to facilitate automatic cleanup. Otherwise it is
+    difficult to prevent test state mutations from contaminating other
+    tests.
+
+    TODO remove this and update tests that depend on it.
+
+    Depends on `TestCase.transaction_exempt_databases`, which is a
+    feature added by
+    `corehq.form_processor.tests.utils.patch_testcase_transactions`
+
+    :param dbnames: Sequence of transaction-exempt database names.
+    :returns: A function that stops/removes the exemption.
+    """
+    def stop_exemption():
+        assert new_exempt == TestCase.transaction_exempt_databases, f"""
+            database test transaction exemptions unexpectedly changed
+            during this exemption context.
+            original exempt dbs: {old_exempt}
+            context exempt dbs: {new_exempt}
+            current exempt dbs: {TestCase.transaction_exempt_databases}
+        """
+        TestCase.transaction_exempt_databases = old_exempt
+
+    assert not isinstance(dbnames, str), "expected a sequence, got str"
+    old_exempt = TestCase.transaction_exempt_databases
+    new_exempt = frozenset(old_exempt).union(dbnames)
+    TestCase.transaction_exempt_databases = new_exempt
+    return stop_exemption
 
 
 class CSVTestCase(TestCase):

--- a/custom/icds_reports/tests/agg_tests/__init__.py
+++ b/custom/icds_reports/tests/agg_tests/__init__.py
@@ -97,7 +97,7 @@ def exempt_from_test_transactions(dbnames):
 
     Depends on `TestCase.transaction_exempt_databases`, which is a
     feature added by
-    `corehq.form_processor.tests.utils.patch_testcase_transactions`
+    `corehq.form_processor.tests.utils.patch_testcase_databases`
 
     :param dbnames: Sequence of transaction-exempt database names.
     :returns: A function that stops/removes the exemption.


### PR DESCRIPTION
Cherry-picked from #27911

This PR contains a lot of churn as I fought with the tests attempting to find a way to make them run. Review all at once :office: 