### PR TITLE
Adapt AWC report tests to Django 2.2

### DIFF
--- a/custom/icds_reports/tests/agg_tests/reports/test_awc_reports.py
+++ b/custom/icds_reports/tests/agg_tests/reports/test_awc_reports.py
@@ -1,7 +1,9 @@
 import json
 import datetime
-
 from datetime import date
+from decimal import Decimal as Decimal_
+
+import django
 from django.core.serializers.json import DjangoJSONEncoder
 from django.test import TestCase
 from mock import mock
@@ -18,6 +20,9 @@ from custom.icds_reports.messages import new_born_with_low_weight_help_text, was
     percent_aadhaar_seeded_beneficiaries_help_text, percent_children_enrolled_help_text, \
     percent_pregnant_women_enrolled_help_text, percent_lactating_women_enrolled_help_text, \
     percent_adolescent_girls_enrolled_help_text_v2
+
+# TODO remove when Django 1 is no longer supported
+Decimal = Decimal_ if django.__version__ >= "2.2" else float
 
 
 class FirstDayOfMay(date):
@@ -278,39 +283,39 @@ class TestAWCReport(TestCase):
                     "values": [
                         [
                             1491523200000,
-                            0.65625
+                            Decimal('0.65625000000000000000')
                         ],
                         [
                             1491609600000,
-                            0.64516129
+                            Decimal('0.64516129000000000000')
                         ],
                         [
                             1491782400000,
-                            0.677419355
+                            Decimal('0.67741935500000000000')
                         ],
                         [
                             1491955200000,
-                            0.612903226
+                            Decimal('0.61290322600000000000')
                         ],
                         [
                             1492473600000,
-                            0.612903226
+                            Decimal('0.61290322600000000000')
                         ],
                         [
                             1492732800000,
-                            0.64516129
+                            Decimal('0.64516129000000000000')
                         ],
                         [
                             1492992000000,
-                            0.64516129
+                            Decimal('0.64516129000000000000')
                         ],
                         [
                             1493078400000,
-                            0.64516129
+                            Decimal('0.64516129000000000000')
                         ],
                         [
                             1493251200000,
-                            0.64516129
+                            Decimal('0.64516129000000000000')
                         ]
                     ],
                     "key": "PSE- Average Weekly Attendance"
@@ -828,25 +833,25 @@ class TestAWCReport(TestCase):
                             "eligible": 0
                         },
                         {
-                            "y": 0.741935484,
+                            "y": Decimal('0.74193548400000000000'),
                             "x": 1493683200000,
                             "attended": 23,
                             "eligible": 31
                         },
                         {
-                            "y": 0.806451613,
+                            "y": Decimal('0.80645161300000000000'),
                             "x": 1493769600000,
                             "attended": 25,
                             "eligible": 31
                         },
                         {
-                            "y": 0.8,
+                            "y": Decimal('0.80000000000000000000'),
                             "x": 1493856000000,
                             "attended": 24,
                             "eligible": 30
                         },
                         {
-                            "y": 0.8,
+                            "y": Decimal('0.80000000000000000000'),
                             "x": 1493942400000,
                             "attended": 24,
                             "eligible": 30
@@ -870,7 +875,7 @@ class TestAWCReport(TestCase):
                             "eligible": 0
                         },
                         {
-                            "y": 0.8,
+                            "y": Decimal('0.80000000000000000000'),
                             "x": 1494288000000,
                             "attended": 24,
                             "eligible": 30
@@ -906,37 +911,37 @@ class TestAWCReport(TestCase):
                             "eligible": 0
                         },
                         {
-                            "y": 1.0,
+                            "y": Decimal('1.00000000000000000000'),
                             "x": 1494806400000,
                             "attended": 30,
                             "eligible": 30
                         },
                         {
-                            "y": 0.666666667,
+                            "y": Decimal('0.66666666700000000000'),
                             "x": 1494892800000,
                             "attended": 20,
                             "eligible": 30
                         },
                         {
-                            "y": 0.733333333,
+                            "y": Decimal('0.73333333300000000000'),
                             "x": 1494979200000,
                             "attended": 22,
                             "eligible": 30
                         },
                         {
-                            "y": 0.766666667,
+                            "y": Decimal('0.76666666700000000000'),
                             "x": 1495065600000,
                             "attended": 23,
                             "eligible": 30
                         },
                         {
-                            "y": 0.666666667,
+                            "y": Decimal('0.66666666700000000000'),
                             "x": 1495152000000,
                             "attended": 20,
                             "eligible": 30
                         },
                         {
-                            "y": 0.633333333,
+                            "y": Decimal('0.63333333300000000000'),
                             "x": 1495238400000,
                             "attended": 19,
                             "eligible": 30
@@ -948,7 +953,7 @@ class TestAWCReport(TestCase):
                             "eligible": 0
                         },
                         {
-                            "y": 0.666666667,
+                            "y": Decimal('0.66666666700000000000'),
                             "x": 1495411200000,
                             "attended": 20,
                             "eligible": 30
@@ -960,25 +965,25 @@ class TestAWCReport(TestCase):
                             "eligible": 0
                         },
                         {
-                            "y": 0.666666667,
+                            "y": Decimal('0.66666666700000000000'),
                             "x": 1495584000000,
                             "attended": 20,
                             "eligible": 30
                         },
                         {
-                            "y": 0.666666667,
+                            "y": Decimal('0.66666666700000000000'),
                             "x": 1495670400000,
                             "attended": 20,
                             "eligible": 30
                         },
                         {
-                            "y": 0.666666667,
+                            "y": Decimal('0.66666666700000000000'),
                             "x": 1495756800000,
                             "attended": 20,
                             "eligible": 30
                         },
                         {
-                            "y": 0.666666667,
+                            "y": Decimal('0.66666666700000000000'),
                             "x": 1495843200000,
                             "attended": 20,
                             "eligible": 30
@@ -990,13 +995,13 @@ class TestAWCReport(TestCase):
                             "eligible": 0
                         },
                         {
-                            "y": 0.655172414,
+                            "y": Decimal('0.65517241400000000000'),
                             "x": 1496016000000,
                             "attended": 19,
                             "eligible": 29
                         },
                         {
-                            "y": 1.0,
+                            "y": Decimal('1.00000000000000000000'),
                             "x": 1496102400000,
                             "attended": 29,
                             "eligible": 29


### PR DESCRIPTION
The `Avg`, `StdDev`, and `Variance` aggregate functions now return a `Decimal` instead of a `float` when the input is Decimal.

https://docs.djangoproject.com/en/3.0/releases/2.2/#miscellaneous

Supersedes https://github.com/dimagi/commcare-hq/pull/28117