### PR TITLE
Marked ADD_USERS_FROM_LOCATION deprecated

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -544,7 +544,7 @@ BIOMETRIC_INTEGRATION = StaticToggle(
 ADD_USERS_FROM_LOCATION = StaticToggle(
     'add_users_from_location',
     "Allow users to add new mobile workers from the locations page",
-    TAG_SOLUTIONS_CONDITIONAL,
+    TAG_DEPRECATED,
     [NAMESPACE_DOMAIN]
 )
 


### PR DESCRIPTION
This was originally an ilsgateway/ewsghana flag, which are now finished. It has become a maintenance burden when making changes to the user creation workflow.

I don't have enough data yet to justify removing it altogether - a few other real domains are using it - but I'd like to stop any additional domains from using it.

@esoergel I think you'll be fine with this, let's offline if you have objections.