### PR TITLE
remove name from case details title

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_data.html
@@ -5,8 +5,6 @@
 {% load proptable_tags %}
 {% load timezone_tags %}
 
-{% block title %}Case: {{ case.name }}{% endblock %}
-
 {% block head %} {{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static "hqwebapp/css/proptable.css" %}">
 {% endblock %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove case name from title of case details report. This now falls back to the `page_title` attribute of the view defined in https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/views.py#L955