### PR TITLE
Silence meaningless "Script error." jserror

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -41,12 +41,16 @@ hqDefine("hqwebapp/js/hq.helpers", [
     }
 
     window.onerror = function (message, file, line, col, error) {
+        var stack = error ? error.stack : null;
+        if (!stack && (message === 'Script error' || message === 'Script error.')) {
+            return false;
+        }
         $.post('/jserror/', {
             message: message,
             page: window.location.href,
             file: file,
             line: line,
-            stack: error ? error.stack : null,
+            stack: stack,
         });
         return false; // let default handler run
     };


### PR DESCRIPTION
##### SUMMARY
As far as I can tell the hundreds of thousands of "Script error." messages we get from people's js browser errors doesn't cause issues and isn't actionable to us. Searching the internet, my best guess is that it could be caused by a plugin that people have installed.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
