### PR TITLE
It's a BytesWarning in Py3

### DIFF
--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -45,7 +45,7 @@ class GetFormQuestionValuesTests(SimpleTestCase):
 
     def test_utf8_question(self):
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UnicodeWarning)
+            warnings.simplefilter("ignore", BytesWarning)
             value = get_form_question_values({'form': {'foo': {b'b\xc4\x85r': 'baz'}}})
         self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
 

--- a/corehq/motech/tests/test_value_source.py
+++ b/corehq/motech/tests/test_value_source.py
@@ -35,18 +35,8 @@ class GetFormQuestionValuesTests(SimpleTestCase):
         value = get_form_question_values({'form': {'foo': {'bar': 'b\u0105z'}}})
         self.assertEqual(value, {'/data/foo/bar': 'b\u0105z'})
 
-    def test_utf8_answer(self):
-        value = get_form_question_values({'form': {'foo': {'bar': b'b\xc4\x85z'}}})
-        self.assertEqual(value, {'/data/foo/bar': b'b\xc4\x85z'})
-
     def test_unicode_question(self):
         value = get_form_question_values({'form': {'foo': {'b\u0105r': 'baz'}}})
-        self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
-
-    def test_utf8_question(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BytesWarning)
-            value = get_form_question_values({'form': {'foo': {b'b\xc4\x85r': 'baz'}}})
         self.assertEqual(value, {'/data/foo/b\u0105r': 'baz'})
 
     def test_received_on(self):


### PR DESCRIPTION
##### BEFORE

```
$ python -bb manage.py test corehq.motech.tests.test_value_source:GetFormQuestionValuesTests.test_utf8_question -vvv

corehq.motech.tests.test_value_source:GetFormQuestionValuesTests.test_utf8_question ... /srv/share/src/dimagi/commcare-hq/corehq/motech/value_source.py:502: BytesWarning: Comparison between bytes and string
  if key in _reserved_keys:
ok
```

##### AFTER

```
$ python -bb manage.py test corehq.motech.tests.test_value_source:GetFormQuestionValuesTests.test_utf8_question -vvv
...
corehq.motech.tests.test_value_source:GetFormQuestionValuesTests.test_utf8_question ... ok
```
