### PR TITLE
Avoid BytesWarning for Django 2 upgrade

### DIFF
--- a/corehq/apps/api/tests/case_resources.py
+++ b/corehq/apps/api/tests/case_resources.py
@@ -176,7 +176,7 @@ class TestCommCareCaseResource(APIResourceTest):
         self.assertEqual(
             response.status_code,
             200,
-            "Status code was not 200. Response content was {}".format(response.content)
+            f"Status code was not 200. Response content was {response.content!r}"
         )
         parent_cases = list(json.loads(response.content)['parent_cases'].values())
 
@@ -190,7 +190,7 @@ class TestCommCareCaseResource(APIResourceTest):
         self.assertEqual(
             response.status_code,
             200,
-            "Status code was not 200. Response content was {}".format(response.content)
+            f"Status code was not 200. Response content was {response.content!r}"
         )
         child_cases = list(json.loads(response.content)['child_cases'].values())
 

--- a/corehq/apps/app_manager/views/utils.py
+++ b/corehq/apps/app_manager/views/utils.py
@@ -115,7 +115,7 @@ def get_langs(request, app):
 
 
 def set_lang_cookie(response, lang):
-    response.set_cookie('lang', encode_if_unicode(lang))
+    response.set_cookie('lang', lang)
 
 
 def bail(request, domain, app_id, not_found=""):
@@ -124,10 +124,6 @@ def bail(request, domain, app_id, not_found=""):
     else:
         messages.error(request, 'Oops! We could not complete your request. Please try again')
     return back_to_main(request, domain, app_id)
-
-
-def encode_if_unicode(s):
-    return s.encode('utf-8') if isinstance(s, str) else s
 
 
 def validate_langs(request, existing_langs):

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -38,7 +38,7 @@ def submit_form_locally(instance, domain, **kwargs):
     if not 200 <= result.response.status_code < 300:
         raise LocalSubmissionError('Error submitting (status code %s): %s' % (
             result.response.status_code,
-            result.response.content,
+            result.response.content.decode('utf-8', errors='backslashreplace'),
         ))
     return result
 

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -30,6 +30,7 @@ from corehq.motech.const import (
     PASSWORD_PLACEHOLDER,
 )
 from corehq.motech.utils import b64_aes_decrypt, b64_aes_encrypt
+from corehq.util import as_text
 
 
 class ConnectionSettings(models.Model):
@@ -219,19 +220,8 @@ class RequestLog(models.Model):
             request_url=log_entry.url,
             request_headers=log_entry.headers,
             request_params=log_entry.params,
-            request_body=_as_text(log_entry.data),
+            request_body=as_text(log_entry.data),
             request_error=log_entry.error,
             response_status=log_entry.response_status,
-            response_body=_as_text(log_entry.response_body),
+            response_body=as_text(log_entry.response_body),
         )
-
-
-def _as_text(value):
-    if isinstance(value, str):
-        return value
-    if isinstance(value, bytes):
-        try:
-            return value.decode("utf8")
-        except UnicodeDecodeError:
-            pass
-    return repr(value)

--- a/corehq/motech/models.py
+++ b/corehq/motech/models.py
@@ -219,8 +219,19 @@ class RequestLog(models.Model):
             request_url=log_entry.url,
             request_headers=log_entry.headers,
             request_params=log_entry.params,
-            request_body=log_entry.data,
+            request_body=_as_text(log_entry.data),
             request_error=log_entry.error,
             response_status=log_entry.response_status,
-            response_body=log_entry.response_body,
+            response_body=_as_text(log_entry.response_body),
         )
+
+
+def _as_text(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf8")
+        except UnicodeDecodeError:
+            pass
+    return repr(value)

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -9,6 +9,7 @@ from mock import Mock, patch
 from corehq.motech.const import ALGO_AES, PASSWORD_PLACEHOLDER
 from corehq.motech.models import ConnectionSettings, RequestLog
 from corehq.motech.requests import get_basic_requests
+from corehq.util import as_text
 
 TEST_API_URL = 'http://localhost:9080/api/'
 TEST_API_USERNAME = 'admin'
@@ -62,13 +63,13 @@ class UnpackRequestArgsTests(SimpleTestCase):
             domain=TEST_DOMAIN,
             log_level=logging.INFO,
             payload_id=None,
-            request_body=request_body,
+            request_body=as_text(request_body),
             request_error=self.error_message,
             request_headers=self.request_headers,
             request_method=self.request_method,
             request_params=request_params,
             request_url='http://localhost:9080/api/person/',
-            response_body=self.content_json,
+            response_body=as_text(self.content_json),
             response_status=self.status_code,
         )
 

--- a/corehq/util/__init__.py
+++ b/corehq/util/__init__.py
@@ -1,7 +1,9 @@
+from traceback import format_exception_only
+
 from django.utils.functional import Promise
 
-from .couch import get_document_or_404
-from .view_utils import reverse
+from .couch import get_document_or_404  # noqa: F401
+from .view_utils import reverse  # noqa: F401
 
 
 def flatten_list(elements):
@@ -32,3 +34,15 @@ def cmp(a, b):
     https://stackoverflow.com/a/22490617/10840
     """
     return (a > b) - (a < b)
+
+
+def as_text(value):
+    """Safely convert object to text"""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        return value.decode("utf8", errors="backslashreplace")
+    if isinstance(value, BaseException):
+        lines = format_exception_only(type(value), value)
+        return "\n".join(x.rstrip("\n") for x in lines)
+    return repr(value)

--- a/corehq/util/metrics/metrics.py
+++ b/corehq/util/metrics/metrics.py
@@ -121,6 +121,9 @@ class DebugMetrics:
             return _check
         raise AttributeError(item)
 
+    def push_metrics(self):
+        pass
+
     def create_event(self, title: str, text: str, alert_type: str = ALERT_INFO,
                      tags: Dict[str, str] = None, aggregation_key: str = None):
         _validate_tag_names(tags)
@@ -132,7 +135,7 @@ class DelegatedMetrics:
         self.delegates = delegates
 
     def __getattr__(self, item):
-        if item in ('counter', 'gauge', 'histogram', 'create_event'):
+        if item in ('counter', 'gauge', 'histogram', 'create_event', 'push_metrics'):
             def _record_metric(*args, **kwargs):
                 for delegate in self.delegates:
                     getattr(delegate, item)(*args, **kwargs)

--- a/corehq/util/tests/test_view_utils.py
+++ b/corehq/util/tests/test_view_utils.py
@@ -16,7 +16,7 @@ class NotifyExceptionTest(SimpleTestCase):
             my_view('foo', err)
             notify_exception_patch.assert_called_with(
                 'foo',
-                "JSON exception response: "
+                "JSON exception response: ValueError: "
                 "b'\\xce\\xb2\\xc2\\xaa\\xc4\\x91 \\xe1\\xb9\\xbf\\xc3\\xa5\\xc6\\x9a\\xc5\\xad\\xc4\\x99'"
             )
 

--- a/corehq/util/tests/test_view_utils.py
+++ b/corehq/util/tests/test_view_utils.py
@@ -25,4 +25,7 @@ class NotifyExceptionTest(SimpleTestCase):
         err = ValueError('βªđ ṿåƚŭę')
         with patch('corehq.util.view_utils.notify_exception') as notify_exception_patch:
             my_view('foo', err)
-            notify_exception_patch.assert_called_with('foo', 'JSON exception response: βªđ ṿåƚŭę')
+            notify_exception_patch.assert_called_with(
+                'foo',
+                'JSON exception response: ValueError: βªđ ṿåƚŭę',
+            )

--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.urls import reverse as _reverse
-from django.utils.encoding import smart_text
 from django.utils.http import urlencode
 
 from dimagi.utils.logging import notify_exception
@@ -51,6 +50,7 @@ def json_error(f):
     """
     @wraps(f)
     def inner(request, *args, **kwargs):
+        from . import as_text
         try:
             response = f(request, *args, **kwargs)
 
@@ -71,7 +71,7 @@ def json_error(f):
         except BadRequest as e:
             return _get_json_exception_response(400, request, e)
         except Exception as e:
-            message = 'JSON exception response: {}'.format(smart_text(e))
+            message = f'JSON exception response: {as_text(e)}'
             notify_exception(request, message)
             return _get_json_exception_response(500, request, e)
     return inner


### PR DESCRIPTION
The final commit (https://github.com/dimagi/commcare-hq/commit/b01349161f5f32e1c4930bc7d30106c42f1db3d2) should resolve [QA-1592](https://dimagi-dev.atlassian.net/browse/QA-1592), ~although it may not fix bad cookie values in the wild (depending on how often the cookie value is reset). It may be necessary to clear at least the "lang" cookie in your browser after this is merged and deployed to staging, but before performing further testing to see if the bug has been resolved.~

https://github.com/dimagi/commcare-hq/commit/863a9813e7d40305d13a49eb64b07ab8eca4ae30 is unrelated to BytesWarning, but fixes an issue that was creating annoying tracebacks in test output.

Review by commit :blowfish: 