### PR TITLE
Fix scheduled reports encoding

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -865,6 +865,10 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
                            send_only_active=False):
     """
     Renders only notification's main content, which then may be used to generate full notification body.
+
+    :returns: two-tuple `(report_text: str, excel_files: list)`. Both
+    values are empty when there are no applicable report configs.
+    `excel_files` is a list of dicts.
     """
     from dimagi.utils.web import get_url_base
 
@@ -878,7 +882,7 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
 
     # Don't send an email if none of the reports configs have started
     if len(configs) == 0:
-        return False, False
+        return "", []
 
     for config in configs:
         content, excel_file = config.get_report_content(lang, attach_excel=attach_excel)
@@ -938,8 +942,8 @@ def render_full_report_notification(request, content, email=None, report_notific
 
 @login_and_domain_required
 def view_scheduled_report(request, domain, scheduled_report_id):
-    content = get_scheduled_report_response(request.couch_user, domain, scheduled_report_id, email=False)[0]
-    return render_full_report_notification(request, content)
+    report_text = get_scheduled_report_response(request.couch_user, domain, scheduled_report_id, email=False)[0]
+    return render_full_report_notification(request, report_text)
 
 
 def safely_get_case(request, domain, case_id):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -899,7 +899,7 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
             "enddate": date_range.get("enddate") if date_range else "",
         })
 
-    return render(request, "reports/report_email_content.html", {
+    response = render(request, "reports/report_email_content.html", {
         "reports": report_outputs,
         "domain": domain,
         "couch_user": owner_id,
@@ -908,7 +908,8 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
         "email": email,
         "notes": notes,
         "report_type": _("once off report") if once else _("scheduled report"),
-    }).content, excel_attachments
+    })
+    return response.content.decode("utf-8"), excel_attachments
 
 
 def render_full_report_notification(request, content, email=None, report_notification=None):

--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -691,18 +691,18 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
 
             attach_excel = getattr(self, 'attach_excel', False)
             try:
-                content, excel_files = get_scheduled_report_response(
+                report_text, excel_files = get_scheduled_report_response(
                     self.owner, self.domain, self._id, attach_excel=attach_excel,
                     send_only_active=True
                 )
 
-                # Will be False if ALL the ReportConfigs in the ReportNotification
+                # Both are empty if ALL the ReportConfigs in the ReportNotification
                 # have a start_date in the future.
-                if content is False:
+                if not report_text and not excel_files:
                     return
 
                 for email in emails:
-                    body = render_full_report_notification(None, content, email, self).content
+                    body = render_full_report_notification(None, report_text, email, self).content
                     send_html_email_async(
                         title, email, body,
                         email_from=settings.DEFAULT_FROM_EMAIL,

--- a/corehq/apps/saved_reports/tasks.py
+++ b/corehq/apps/saved_reports/tasks.py
@@ -138,11 +138,11 @@ def send_email_report(self, recipient_emails, domain, report_slug, report_type,
     subject = cleaned_data['subject'] or _("Email report from CommCare HQ")
 
     try:
-        content = _render_report_configs(
+        report_text = _render_report_configs(
             mock_request, [config], domain, user_id, couch_user, True, lang=couch_user.language,
             notes=cleaned_data['notes'], once=once
         )[0]
-        body = render_full_report_notification(None, content).content
+        body = render_full_report_notification(None, report_text).content
 
         for recipient in recipient_emails:
             send_HTML_email(subject, recipient,

--- a/corehq/apps/saved_reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/saved_reports/tests/test_scheduled_reports.py
@@ -204,7 +204,7 @@ class ScheduledReportSendingTest(TestCase):
             hour=12, minute=None, day=30, interval='monthly', config_ids=[report_config._id]
         )
         report.save()
-        response = get_scheduled_report_response(
+        report_text = get_scheduled_report_response(
             couch_user=self.user, domain=domain, scheduled_report_id=report._id
         )[0]
-        self.assertTrue(self.user.username in response.decode('utf-8'))
+        self.assertTrue(self.user.username in report_text)


### PR DESCRIPTION
The first commit is the fix, and the second is cleanup to make the code easier to understand.

This is the same type of issue fixed in https://github.com/dimagi/commcare-hq/pull/28157

See also https://docs.djangoproject.com/en/3.0/releases/2.0/#removed-support-for-bytestrings-in-some-places