### PR TITLE
Ce/enterprise invited

### DIFF
--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -195,7 +195,7 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
     def headers(self):
         headers = super(EnterpriseMobileWorkerReport, self).headers
         return [_('Username'), _('Name'), _('Email Address'), _('Created Date [UTC]'), _('Last Sync [UTC]'),
-                _('Last Submission [UTC]'), _('CommCare Version')] + headers
+                _('Last Submission [UTC]'), _('CommCare Version'), _('User ID')] + headers
 
     def rows_for_domain(self, domain_obj):
         rows = []
@@ -210,6 +210,7 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
                 self.format_date(user.reporting_metadata.last_sync_for_user.sync_date),
                 self.format_date(user.reporting_metadata.last_submission_for_user.submission_date),
                 user.reporting_metadata.last_submission_for_user.commcare_version or '',
+                user.user_id
             ] + self.domain_properties(domain_obj))
         return rows
 

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -178,7 +178,7 @@ class EnterpriseWebUserReport(EnterpriseReport):
                     'N/A',
                     _('Invited')
                 ]
-            )
+                + self.domain_properties(domain_obj))
         return rows
 
     def total_for_domain(self, domain_obj):

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -22,7 +22,7 @@ from corehq.apps.users.dbaccessors.all_commcare_users import (
     get_mobile_user_count,
     get_web_user_count,
 )
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.models import CouchUser, Invitation
 from corehq.util.quickcache import quickcache
 
 
@@ -137,9 +137,19 @@ class EnterpriseWebUserReport(EnterpriseReport):
     def headers(self):
         headers = super(EnterpriseWebUserReport, self).headers
         return [_('Name'), _('Email Address'), _('Role'), _('Last Login [UTC]'),
-                _('Last Access Date [UTC]')] + headers
+                _('Last Access Date [UTC]'), _('Status')] + headers
 
     def rows_for_domain(self, domain_obj):
+
+        def _get_role_name(role):
+            if role:
+                if role == 'admin':
+                    return role
+                else:
+                    role_id = role[len('user-role:'):]
+                    return UserRole.get(role_id).name
+            else:
+                return 'N/A'
         rows = []
         for user in get_all_user_rows(domain_obj.name, include_web_users=True, include_mobile_users=False,
                                       include_inactive=False, include_docs=True):
@@ -150,13 +160,25 @@ class EnterpriseWebUserReport(EnterpriseReport):
                 last_accessed_domain = domain_membership.last_accessed
             rows.append(
                 [
-                    user.full_name,
                     user.username,
+                    user.full_name,
                     user.role_label(domain_obj.name),
                     self.format_date(user.last_login),
-                    last_accessed_domain
+                    last_accessed_domain,
+                    _('Active User')
                 ]
                 + self.domain_properties(domain_obj))
+        for invite in Invitation.by_domain(domain_obj.name):
+            rows.append(
+                [
+                    invite.email,
+                    'N/A',
+                    _get_role_name(invite.role),
+                    'N/A',
+                    'N/A',
+                    _('Invited')
+                ]
+            )
         return rows
 
     def total_for_domain(self, domain_obj):

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -22,7 +22,7 @@ from corehq.apps.users.dbaccessors.all_commcare_users import (
     get_mobile_user_count,
     get_web_user_count,
 )
-from corehq.apps.users.models import CouchUser, Invitation
+from corehq.apps.users.models import CouchUser, Invitation, UserRole
 from corehq.util.quickcache import quickcache
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://trello.com/c/L9bxEZdW/98-add-pending-invites-to-enterprise-web-user-report

This adds invited users to the web user enterprise report. To make that more usable, given that most columns are blank for these users, I also moved the username to the first column since all rows are guaranteed to have that, and it's probably more meaningful than the name anyway.

I also made a small change to the mobile user report, adding the user id, since it will be increasingly important for that to be accessible as cross domain mobile worker uploads become a thing. Otherwise, users will have to do mobile worker downloads in each domain in order to edit workers across domains.

I chatted with Dev about the two changes not explicitly mentioned in the card and he approved both (column reorder, mobile user id)