### PR TITLE
move repeaters list to settings and remove icds repeaters

### DIFF
--- a/corehq/motech/repeaters/const.py
+++ b/corehq/motech/repeaters/const.py
@@ -9,21 +9,3 @@ RECORD_PENDING_STATE = 'PENDING'
 RECORD_SUCCESS_STATE = 'SUCCESS'
 RECORD_FAILURE_STATE = 'FAIL'
 RECORD_CANCELLED_STATE = 'CANCELLED'
-
-# Repeaters in the order in which they should appear in "Data Forwarding"
-REPEATER_CLASSES = (
-    'corehq.motech.repeaters.models.FormRepeater',
-    'corehq.motech.repeaters.models.CaseRepeater',
-    'corehq.motech.repeaters.models.CreateCaseRepeater',
-    'corehq.motech.repeaters.models.UpdateCaseRepeater',
-    'corehq.motech.repeaters.models.ReferCaseRepeater',
-    'corehq.motech.repeaters.models.ShortFormRepeater',
-    'corehq.motech.repeaters.models.AppStructureRepeater',
-    'corehq.motech.repeaters.models.UserRepeater',
-    'corehq.motech.repeaters.models.LocationRepeater',
-    'corehq.motech.openmrs.repeaters.OpenmrsRepeater',
-    'corehq.motech.dhis2.repeaters.Dhis2Repeater',
-    'corehq.motech.dhis2.repeaters.Dhis2EntityRepeater',
-    'custom.icds.repeaters.phi.SearchByParamsRepeater',
-    'custom.icds.repeaters.phi.ValidatePHIDRepeater',
-)

--- a/corehq/motech/repeaters/utils.py
+++ b/corehq/motech/repeaters/utils.py
@@ -1,11 +1,12 @@
 from collections import OrderedDict
 
-from dimagi.utils.modules import to_function
+from django.conf import settings
 
-from corehq.motech.repeaters.const import REPEATER_CLASSES
+from dimagi.utils.modules import to_function
 
 
 def get_all_repeater_types():
     return OrderedDict([
-        (to_function(cls, failhard=True).__name__, to_function(cls, failhard=True)) for cls in REPEATER_CLASSES
+        (to_function(cls, failhard=True).__name__, to_function(cls, failhard=True))
+        for cls in settings.REPEATER_CLASSES
     ])

--- a/settings.py
+++ b/settings.py
@@ -797,8 +797,28 @@ RUN_UNKNOWN_USER_PILLOW = True
 # databases.
 CASE_ES_DROP_FORM_FIELDS = False
 
+# Repeaters in the order in which they should appear in "Data Forwarding"
+REPEATER_CLASSES = [
+    'corehq.motech.repeaters.models.FormRepeater',
+    'corehq.motech.repeaters.models.CaseRepeater',
+    'corehq.motech.repeaters.models.CreateCaseRepeater',
+    'corehq.motech.repeaters.models.UpdateCaseRepeater',
+    'corehq.motech.repeaters.models.ReferCaseRepeater',
+    'corehq.motech.repeaters.models.ShortFormRepeater',
+    'corehq.motech.repeaters.models.AppStructureRepeater',
+    'corehq.motech.repeaters.models.UserRepeater',
+    'corehq.motech.repeaters.models.LocationRepeater',
+    'corehq.motech.openmrs.repeaters.OpenmrsRepeater',
+    'corehq.motech.dhis2.repeaters.Dhis2Repeater',
+    'corehq.motech.dhis2.repeaters.Dhis2EntityRepeater',
+]
+
+# Override this in localsettings to add new repeater types
+LOCAL_REPEATER_CLASSES = []
+
 # tuple of fully qualified repeater class names that are enabled.
 # Set to None to enable all or empty tuple to disable all.
+# This will not prevent users from creating
 REPEATERS_WHITELIST = None
 
 # If ENABLE_PRELOGIN_SITE is set to true, redirect to Dimagi.com urls
@@ -1057,6 +1077,8 @@ AVAILABLE_CUSTOM_REMINDER_RECIPIENTS.update(LOCAL_AVAILABLE_CUSTOM_REMINDER_RECI
 AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS.update(LOCAL_AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS)
 AVAILABLE_CUSTOM_RULE_CRITERIA.update(LOCAL_AVAILABLE_CUSTOM_RULE_CRITERIA)
 AVAILABLE_CUSTOM_RULE_ACTIONS.update(LOCAL_AVAILABLE_CUSTOM_RULE_ACTIONS)
+
+REPEATER_CLASSES.extend(LOCAL_REPEATER_CLASSES)
 
 # The defaults above are given as a function of (or rather a closure on) DEBUG,
 # so if not overridden they need to be evaluated after DEBUG is set


### PR DESCRIPTION
##### RISK ASSESSMENT / QA PLAN
* tested the UI locally and any existing repeaters that are of these types are not shown on the UI
* the processing code for repeaters already handles repeater classes that don't exist: 

https://github.com/dimagi/commcare-hq/blob/d30bdee5bd4beff79e327f96677f9e1fecc219b6/corehq/motech/repeaters/models.py#L311-L315

https://github.com/dimagi/commcare-hq/blob/d30bdee5bd4beff79e327f96677f9e1fecc219b6/corehq/motech/repeaters/models.py#L722-L726

*Additional note*
Apart from testing neither of these repeaters have ever been used on a production domain. I have validated that there are no repeaters on any Dimagi env that are using these ICDS types:

```python
from corehq.motech.repeaters.models import Repeater
results = Repeater.get_db().view('repeaters/repeaters',
    include_docs=False,
    reduce=False,
).all()
types = {r["key"][1] for r in results}
print("SearchByParamsRepeater" in types)
print("ValidatePHIDRepeater" in types)
```
