### PR TITLE
Support making HQ an oauth2 provider for APIs

### DIFF
--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -16,7 +16,7 @@ from corehq.apps.domain.decorators import (
     login_or_api_key,
     login_or_basic,
     login_or_digest,
-)
+    login_or_oauth2, oauth2_auth)
 from corehq.apps.users.decorators import (
     require_permission,
     require_permission_raw,
@@ -53,12 +53,14 @@ class LoginAndDomainAuthentication(Authentication):
                 'digest': login_or_digest,
                 'basic': login_or_basic,
                 'api_key': login_or_api_key,
+                'oauth2': login_or_oauth2,
             }
         else:
             self.decorator_map = {
                 'digest': digest_auth,
                 'basic': basic_auth,
                 'api_key': api_key_auth,
+                'oauth2': oauth2_auth,
             }
 
     def is_authenticated(self, request, **kwargs):

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -27,6 +27,7 @@ BASIC = 'basic'
 DIGEST = 'digest'
 NOAUTH = 'noauth'
 API_KEY = 'api_key'
+OAUTH2 = 'oauth2'
 FORMPLAYER = 'formplayer'
 
 
@@ -64,6 +65,9 @@ def determine_authtype_from_header(request, default=DIGEST):
     elif auth_header.startswith('digest '):
         # Note: this will not identify initial, uncredentialed digest requests
         return DIGEST
+    elif auth_header.startswith('bearer '):
+        # Note: this will not identify initial, uncredentialed digest requests
+        return OAUTH2
     elif _is_api_key_authentication(request):
         return API_KEY
 

--- a/corehq/apps/domain/auth.py
+++ b/corehq/apps/domain/auth.py
@@ -66,7 +66,6 @@ def determine_authtype_from_header(request, default=DIGEST):
         # Note: this will not identify initial, uncredentialed digest requests
         return DIGEST
     elif auth_header.startswith('bearer '):
-        # Note: this will not identify initial, uncredentialed digest requests
         return OAUTH2
     elif _is_api_key_authentication(request):
         return API_KEY

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -196,8 +196,8 @@ def api_key():
 def oauth2_check():
     def auth_check(request):
         oauthlib_core = get_oauthlib_core()
-        # todo: do we need to set scopes here? If so, how do we do that?
-        valid, r = oauthlib_core.verify_request(request, scopes=[])
+        # as of now, this is only used in our APIs, so explictly check that particular scope
+        valid, r = oauthlib_core.verify_request(request, scopes=['access_apis'])
         if valid:
             request.user = r.user
             return True

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -193,7 +193,7 @@ def api_key():
     return real_decorator
 
 
-def oauth2_check():
+def _oauth2_check():
     def auth_check(request):
         oauthlib_core = get_oauthlib_core()
         # as of now, this is only used in our APIs, so explictly check that particular scope
@@ -279,7 +279,7 @@ def login_or_api_key_ex(allow_cc_users=False, allow_sessions=True):
 
 def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True):
     return _login_or_challenge(
-        oauth2_check(),
+        _oauth2_check(),
         allow_cc_users=allow_cc_users,
         api_key=True,
         allow_sessions=allow_sessions

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -20,6 +20,8 @@ from django.views import View
 
 from django_otp import match_token
 from django_prbac.utils import has_privilege
+from oauth2_provider.oauth2_backends import get_oauthlib_core
+
 from corehq.apps.domain.auth import HQApiKeyAuthentication
 from tastypie.http import HttpUnauthorized
 
@@ -191,6 +193,27 @@ def api_key():
     return real_decorator
 
 
+def oauth2_check():
+    def auth_check(request):
+        oauthlib_core = get_oauthlib_core()
+        # todo: do we need to set scopes here? If so, how do we do that?
+        valid, r = oauthlib_core.verify_request(request, scopes=[])
+        if valid:
+            request.user = r.user
+            return True
+
+    def real_decorator(view):
+        def wrapper(request, *args, **kwargs):
+            auth = auth_check(request)
+            if auth:
+                return view(request, *args, **kwargs)
+
+            response = HttpUnauthorized()
+            return response
+        return wrapper
+    return real_decorator
+
+
 def _login_or_challenge(challenge_fn, allow_cc_users=False, api_key=False, allow_sessions=True):
     """
     kwargs:
@@ -248,6 +271,15 @@ def login_or_formplayer_ex(allow_cc_users=False, allow_sessions=True):
 def login_or_api_key_ex(allow_cc_users=False, allow_sessions=True):
     return _login_or_challenge(
         api_key(),
+        allow_cc_users=allow_cc_users,
+        api_key=True,
+        allow_sessions=allow_sessions
+    )
+
+
+def login_or_oauth2_ex(allow_cc_users=False, allow_sessions=True):
+    return _login_or_challenge(
+        oauth2_check(),
         allow_cc_users=allow_cc_users,
         api_key=True,
         allow_sessions=allow_sessions
@@ -315,11 +347,13 @@ api_auth = _get_multi_auth_decorator(default=DIGEST)
 login_or_digest = login_or_digest_ex()
 login_or_basic = login_or_basic_ex()
 login_or_api_key = login_or_api_key_ex()
+login_or_oauth2 = login_or_oauth2_ex()
 
 # Use these decorators on views to exclusively allow any one authorization method and not session based auth
 digest_auth = login_or_digest_ex(allow_sessions=False)
 basic_auth = login_or_basic_ex(allow_sessions=False)
 api_key_auth = login_or_api_key_ex(allow_sessions=False)
+oauth2_auth = login_or_oauth2_ex(allow_sessions=False)
 
 basic_auth_or_try_api_key_auth = login_or_basic_or_api_key_ex(allow_sessions=False)
 

--- a/custom/_legacy/pact/signals.py
+++ b/custom/_legacy/pact/signals.py
@@ -1,6 +1,5 @@
 from corehq.apps.users.models import CouchUser
 from dimagi.utils.logging import notify_exception
-from pact.utils import get_case_id
 from couchforms.signals import successful_form_received
 import traceback
 
@@ -10,6 +9,7 @@ BLOCKING = True
 
 def process_dots_submission(sender, xform, **kwargs):
     from pact.tasks import recalculate_dots_data, eval_dots_block
+    from pact.utils import get_case_id
     try:
         if xform.xmlns != "http://dev.commcarehq.org/pact/dots_form":
             return

--- a/requirements-python3/dev-requirements.txt
+++ b/requirements-python3/dev-requirements.txt
@@ -52,6 +52,7 @@ django-extensions==2.2.5  # via -r requirements/dev-requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -66,7 +67,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via -r requirements/dev-requirements.in, botocore, recommonmark, sphinx
@@ -125,7 +126,7 @@ modernize==0.7            # via -r requirements/dev-requirements.in
 msgpack-python==0.5.6     # via ddtrace
 nose-exclude==0.5.0       # via -r requirements/test-requirements.in
 nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude, sniffer
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 packaging==19.2           # via sphinx
 parso==0.7.0              # via jedi
@@ -177,7 +178,7 @@ redis==2.10.6             # via -r requirements/requirements.in, django-redis, d
 reportlab==3.0            # via -r requirements/requirements.in
 requests-mock==1.7.0      # via -r requirements/test-requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, jenkinsapi, requests-mock, requests-oauthlib, sphinx, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, jenkinsapi, requests-mock, requests-oauthlib, sphinx, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/requirements-python3/prod-requirements.txt
+++ b/requirements-python3/prod-requirements.txt
@@ -43,6 +43,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -57,7 +58,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator, eventlet
 docutils==0.15.2          # via botocore
@@ -103,7 +104,7 @@ markupsafe==1.1.1         # via jinja2, mako
 mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
 ndg-httpsclient==0.5.1    # via -r requirements/prod-requirements.in
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 parso==0.7.0              # via jedi
 pbr==5.4.3                # via mock
@@ -148,7 +149,7 @@ redis-py-cluster==1.3.6   # via -r requirements/requirements.in
 redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
 reportlab==3.0            # via -r requirements/requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-oauthlib, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-oauthlib, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/requirements-python3/requirements.txt
+++ b/requirements-python3/requirements.txt
@@ -41,6 +41,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -55,7 +56,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
@@ -95,7 +96,7 @@ markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
 mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
@@ -133,7 +134,7 @@ redis-py-cluster==1.3.6   # via -r requirements/requirements.in
 redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
 reportlab==3.0            # via -r requirements/requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-oauthlib, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-oauthlib, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/requirements-python3/test-requirements.txt
+++ b/requirements-python3/test-requirements.txt
@@ -46,6 +46,7 @@ django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -60,7 +61,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
@@ -106,7 +107,7 @@ mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
 nose-exclude==0.5.0       # via -r requirements/test-requirements.in
 nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
@@ -146,7 +147,7 @@ redis==2.10.6             # via -r requirements/requirements.in, django-redis, d
 reportlab==3.0            # via -r requirements/requirements.in
 requests-mock==1.7.0      # via -r requirements/test-requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-mock, requests-oauthlib, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-mock, requests-oauthlib, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -52,6 +52,7 @@ django-extensions==2.2.5  # via -r requirements/dev-requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -66,7 +67,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via -r requirements/dev-requirements.in, botocore, recommonmark, sphinx
@@ -125,7 +126,7 @@ modernize==0.7            # via -r requirements/dev-requirements.in
 msgpack-python==0.5.6     # via ddtrace
 nose-exclude==0.5.0       # via -r requirements/test-requirements.in
 nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude, sniffer
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 packaging==19.2           # via sphinx
 parso==0.7.0              # via jedi
@@ -177,7 +178,7 @@ redis==2.10.6             # via -r requirements/requirements.in, django-redis, d
 reportlab==3.0            # via -r requirements/requirements.in
 requests-mock==1.7.0      # via -r requirements/test-requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, jenkinsapi, requests-mock, requests-oauthlib, sphinx, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, jenkinsapi, requests-mock, requests-oauthlib, sphinx, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -43,6 +43,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -57,7 +58,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator, eventlet
 docutils==0.15.2          # via botocore
@@ -103,7 +104,7 @@ markupsafe==1.1.1         # via jinja2, mako
 mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
 ndg-httpsclient==0.5.1    # via -r requirements/prod-requirements.in
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 parso==0.7.0              # via jedi
 pbr==5.4.3                # via mock
@@ -148,7 +149,7 @@ redis-py-cluster==1.3.6   # via -r requirements/requirements.in
 redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
 reportlab==3.0            # via -r requirements/requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-oauthlib, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-oauthlib, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -117,3 +117,4 @@ architect==0.5.6
 prometheus-client==0.7.1
 turn-python==0.0.1
 django-logentry-admin==1.0.6
+django-oauth-toolkit==1.3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,6 +41,7 @@ django-crispy-forms==1.7.0  # via -r requirements/requirements.in
 django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -55,7 +56,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
@@ -95,7 +96,7 @@ markdown==2.2.1           # via -r requirements/requirements.in, pycco
 markupsafe==1.1.1         # via jinja2, mako
 mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
@@ -133,7 +134,7 @@ redis-py-cluster==1.3.6   # via -r requirements/requirements.in
 redis==2.10.6             # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis, redis-py-cluster
 reportlab==3.0            # via -r requirements/requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-oauthlib, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-oauthlib, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -46,6 +46,7 @@ django-cte==1.1.4         # via -r requirements/requirements.in
 django-formtools==2.1     # via -r requirements/requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements/requirements.in
 git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r requirements/test-requirements.in
+django-oauth-toolkit==1.3.2  # via -r requirements/requirements.in
 django-otp==0.9.3         # via -r requirements/requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements/requirements.in
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -60,7 +61,7 @@ django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
 django-websocket-redis==0.5.2  # via -r requirements/requirements.in
-django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
+django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator
 docutils==0.15.2          # via botocore
@@ -106,7 +107,7 @@ mock==2.0.0               # via -r requirements/requirements.in
 msgpack-python==0.5.6     # via ddtrace
 nose-exclude==0.5.0       # via -r requirements/test-requirements.in
 nose==1.3.7               # via -r requirements/test-requirements.in, django-nose, nose-exclude
-oauthlib==3.1.0           # via requests-oauthlib
+oauthlib==3.1.0           # via django-oauth-toolkit, requests-oauthlib
 openpyxl==2.6.4           # via -r requirements/requirements.in, commcaretranslationchecker
 pbr==5.4.3                # via mock
 pdfrw==0.4                # via weasyprint
@@ -146,7 +147,7 @@ redis==2.10.6             # via -r requirements/requirements.in, django-redis, d
 reportlab==3.0            # via -r requirements/requirements.in
 requests-mock==1.7.0      # via -r requirements/test-requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
-requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, dropbox, requests-mock, requests-oauthlib, stripe, tinys3, twilio
+requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-mock, requests-oauthlib, stripe, tinys3, twilio
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.2.1         # via boto3
 schema==0.7.1             # via -r requirements/requirements.in

--- a/settings.py
+++ b/settings.py
@@ -813,6 +813,13 @@ ES_SEARCH_TIMEOUT = 30
 
 BITLY_OAUTH_TOKEN = None
 
+OAUTH2_PROVIDER = {
+    'SCOPES': {
+        'view_reports': 'View Report Data on All Domains',
+    },
+}
+
+
 # this should be overridden in localsettings
 INTERNAL_DATA = defaultdict(list)
 

--- a/settings.py
+++ b/settings.py
@@ -214,6 +214,7 @@ DEFAULT_APPS = (
     'statici18n',
     'django_user_agents',
     'logentry_admin',
+    'oauth2_provider',
 )
 
 CAPTCHA_FIELD_TEMPLATE = 'hq-captcha-field.html'

--- a/settings.py
+++ b/settings.py
@@ -815,7 +815,7 @@ BITLY_OAUTH_TOKEN = None
 
 OAUTH2_PROVIDER = {
     'SCOPES': {
-        'view_reports': 'View Report Data on All Domains',
+        'access_apis': 'Access API data on all your CommCare projects',
     },
 }
 

--- a/urls.py
+++ b/urls.py
@@ -102,6 +102,7 @@ urlpatterns = [
     url(r'^register/', include('corehq.apps.registration.urls')),
     url(r'^a/(?P<domain>%s)/' % legacy_domain_re, include(domain_specific)),
     url(r'^account/', include('corehq.apps.settings.urls')),
+    url(r'^oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     url(r'', include('corehq.apps.hqwebapp.urls')),
     url(r'', include('corehq.apps.domain.urls')),
     url(r'^hq/accounting/', include('corehq.apps.accounting.urls')),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Initial implementation of https://github.com/dimagi/commcare-hq/issues/28140

Probably easiest to review all at once. I'll do a self-review now looking for any gotchas.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The CEP has most of the context for this change.

The details of this implementation (which is definitely the simplest possible way of implementing this to do what I needed):

- Client applications are managed via the built in `django-oauth-toolkit` views which are only accessible to superusers. So Dimagi / HQ admins are the only ones who will be able to manage applications for now.
- I bundled everything into a single global scope which gives you API access to all your domains. Mostly because this was the easiest thing to do. To manage it more specifically (both in terms of scopes as well as differentiating scopes based on the domain) would require substantially more work - and in the latter case almost certainly a new data model which I was hoping to avoid for now.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

n/a

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

I'm going to do some QA on staging and also hopefully build a demo app that's public. Because it's a security thing it's always good to be cautious, but I think will be very difficult to test any security implications so we should rely on careful code review to ensure there aren't any concerns.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

I've tagged this "custom" for now, since I think this will only be used / enabled for custom report / data projects to start. There is something "general" in here - but it's mostly for CommCare *server* maintainers, not product users.
