### PR TITLE
"zapier" api tweaks

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -864,7 +864,7 @@ class DomainForms(Resource):
 
     class Meta(object):
         resource_name = 'domain_forms'
-        authentication = HQApiKeyAuthentication()
+        authentication = RequirePermissionAuthentication(Permissions.access_api)
         object_class = Form
         include_resource_uri = False
         allowed_methods = ['get']
@@ -875,13 +875,6 @@ class DomainForms(Resource):
         application_id = bundle.request.GET.get('application_id')
         if not application_id:
             raise NotFound('application_id parameter required')
-
-        domain = kwargs['domain']
-        couch_user = CouchUser.from_django_user(bundle.request.user)
-        if not domain_has_privilege(domain, privileges.ZAPIER_INTEGRATION) or not couch_user.is_member_of(domain):
-            raise ImmediateHttpResponse(
-                HttpForbidden('You are not allowed to get list of forms for this domain')
-            )
 
         results = []
         application = Application.get(docid=application_id)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -939,21 +939,14 @@ class DomainUsernames(Resource):
 
     class Meta(object):
         resource_name = 'domain_usernames'
-        authentication = HQApiKeyAuthentication()
+        authentication = RequirePermissionAuthentication(Permissions.view_commcare_users)
         object_class = User
         include_resource_uri = False
         allowed_methods = ['get']
 
     def obj_get_list(self, bundle, **kwargs):
         domain = kwargs['domain']
-
-        couch_user = CouchUser.from_django_user(bundle.request.user)
-        if not domain_has_privilege(domain, privileges.ZAPIER_INTEGRATION) or not couch_user.is_member_of(domain):
-            raise ImmediateHttpResponse(
-                HttpForbidden('You are not allowed to get list of usernames for this domain')
-            )
         user_ids_username_pairs = get_all_user_id_username_pairs_by_domain(domain)
-
         results = [UserInfo(user_id=user_pair[0], user_name=raw_username(user_pair[1]))
                    for user_pair in user_ids_username_pairs]
         return results

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -912,7 +912,7 @@ class DomainCases(Resource):
 
     class Meta(object):
         resource_name = 'domain_cases'
-        authentication = HQApiKeyAuthentication()
+        authentication = RequirePermissionAuthentication(Permissions.access_api)
         object_class = CaseType
         include_resource_uri = False
         allowed_methods = ['get']
@@ -921,12 +921,6 @@ class DomainCases(Resource):
 
     def obj_get_list(self, bundle, **kwargs):
         domain = kwargs['domain']
-        couch_user = CouchUser.from_django_user(bundle.request.user)
-        if not domain_has_privilege(domain, privileges.ZAPIER_INTEGRATION) or not couch_user.is_member_of(domain):
-            raise ImmediateHttpResponse(
-                HttpForbidden('You are not allowed to get list of case types for this domain')
-            )
-
         case_types = get_case_types_for_domain_es(domain)
         results = [CaseType(case_type=case_type) for case_type in case_types]
         return results


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

These three APIs (list case types in a domain, list form types in an app, list usernames in a domain) were created for the Zapier integration but are more generally useful so am opening them up a bit.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- Makes APIs viewable by other means than just API keys (similar to most other APIs) by using a more traditional `authorization` class
- Limits APIs to specific roles in the project
- Removes unnecessary Zapier privilege check to access APIs.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

I think this is safe though it's possible there is some edge case in setting up a zapier integration I haven't thought of that might go wrong. I think the most likely scenario would be an error message in Zapier getting less readable.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Not worth announcing for now.
