### PR TITLE
Drop --force-color arg in ptop_reindexer_v2

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -131,7 +131,14 @@ class Command(SubCommand):
         cleanup = options.pop('cleanup')
         noinput = options.pop('noinput')
 
-        for option in ['settings', 'pythonpath', 'verbosity', 'traceback', 'no_color']:
+        for option in [
+            'settings',
+            'pythonpath',
+            'verbosity',
+            'traceback',
+            'no_color',
+            'force_color',
+        ]:
             options.pop(option, None)
 
         def confirm():


### PR DESCRIPTION
New option [added in Django 2.2](https://docs.djangoproject.com/en/3.0/ref/django-admin/#cmdoption-force-color)