### PR TITLE
Move deploy history report to standalone page

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -282,13 +282,13 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
 
     emailable = False
     exportable = False
-    ajax_pagination = True
+    ajax_pagination = False
     default_rows = 10
 
     @property
     def headers(self):
         return DataTablesHeader(
-            DataTablesColumn(_("Date"), sortable=False),
+            DataTablesColumn(_("Date")),
             DataTablesColumn(_("User"), sortable=False),
             DataTablesColumn(_("Diff URL"), sortable=False),
         )
@@ -308,20 +308,20 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
         return reverse('web_deploy_lookup')
 
     def _format_date(self, date):
-        raw_time_since_deploy = dt.now() - date
-        delta_dict = self._strfdelta(raw_time_since_deploy)
-
-        if delta_dict['days'] != 0:
-            delta_str = "{days} day(s), {hours} hour(s) ago".format(**delta_dict)
-        elif delta_dict['hours'] != 0:
-            delta_str = "{hours} hour(s), {minutes} minute(s) ago".format(
-                **delta_dict)
-        else:
-            delta_str = "{minutes} minute(s), {seconds} second(s) ago".format(
-                **delta_dict)
-
-        ret_str = '<div>{delta}</div><div>{actual_date}</div>'
         if date:
+            raw_time_since_deploy = dt.now() - date
+            delta_dict = self._strfdelta(raw_time_since_deploy)
+
+            if delta_dict['days'] != 0:
+                delta_str = "{days} day(s), {hours} hour(s) ago".format(**delta_dict)
+            elif delta_dict['hours'] != 0:
+                delta_str = "{hours} hour(s), {minutes} minute(s) ago".format(
+                    **delta_dict)
+            else:
+                delta_str = "{minutes} minute(s), {seconds} second(s) ago".format(
+                    **delta_dict)
+
+            ret_str = '<div>{delta}</div><div>{actual_date}</div>'
             return ret_str.format(delta=delta_str, actual_date=date.strftime(SERVER_DATETIME_FORMAT))
         return "---"
 
@@ -334,6 +334,4 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
         return relative_time_formatted
 
     def _hyperlink_diff_url(self, diff_url):
-        hyperlink_diff_url = '<a href="{link}">Diff with previous</a>'
-        hyperlink_diff_url = hyperlink_diff_url.format(link=diff_url)
-        return hyperlink_diff_url
+        return '<a href="{link}">Diff with previous</a>'.format(link=diff_url)

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -274,7 +274,7 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
 
     slug = 'deploy_history_report'
     name = ugettext_lazy("Deploy History Report")
-    
+
     # search should accept git ref and show the deploy that contains that ref. More involved than simpleSearch
 
     emailable = False
@@ -299,10 +299,6 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
                 deploy.user,
                 deploy.diff_url,
             ]
-
-    @property
-    def total_records(self):
-        return self.default_rows
 
     @cached_property
     def _user_lookup_url(self):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -274,12 +274,9 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
 
     slug = 'deploy_history_report'
     name = ugettext_lazy("Deploy History Report")
-
-    # can remove simple search in seperate commit
+    
     # search should accept git ref and show the deploy that contains that ref. More involved than simpleSearch
-    fields = [
-        'corehq.apps.reports.filters.simple.SimpleSearch',
-    ]
+
     emailable = False
     exportable = False
     ajax_pagination = True

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -275,6 +275,8 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
     slug = 'deploy_history_report'
     name = ugettext_lazy("Deploy History Report")
 
+    # can remove simple search in seperate commit
+    # search should accept git ref and show the deploy that contains that ref. More involved than simpleSearch
     fields = [
         'corehq.apps.reports.filters.simple.SimpleSearch',
     ]
@@ -296,7 +298,7 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
         deploy_list = HqDeploy.objects.filter()[:10]
         for deploy in deploy_list:
             yield [
-                deploy.date,
+                self._format_date(deploy.date),
                 deploy.user,
                 deploy.diff_url,
             ]
@@ -308,3 +310,10 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
     @cached_property
     def _user_lookup_url(self):
         return reverse('web_deploy_lookup')
+
+    @staticmethod
+    def _format_date(date):
+        #find time relative to now -> last_deploy.date|naturaltime
+        if date:
+            return date.strftime(SERVER_DATETIME_FORMAT)
+        return "---"

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -4,7 +4,6 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 from django.contrib.humanize.templatetags.humanize import naturaltime
 
-from datetime import datetime as dt
 from dateutil.parser import parse
 from memoized import memoized
 

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -292,12 +292,12 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
 
     @property
     def rows(self):
-        deploy_list = HqDeploy.objects.filter()[:10]
+        deploy_list = HqDeploy.objects.filter()
         for deploy in deploy_list:
             yield [
                 self._format_date(deploy.date),
                 deploy.user,
-                deploy.diff_url,
+                self._hyperlink_diff_url(deploy.diff_url),
             ]
 
     @cached_property
@@ -310,3 +310,9 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
         if date:
             return date.strftime(SERVER_DATETIME_FORMAT)
         return "---"
+
+    def _hyperlink_diff_url(self, diff_url):
+        hyperlink_diff_url = '<a href="{link}">Diff with previous</a>'
+        hyperlink_diff_url = hyperlink_diff_url.format(link=diff_url)
+        return hyperlink_diff_url
+

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
+from django.contrib.humanize.templatetags.humanize import naturaltime
 
 from datetime import datetime as dt
 from dateutil.parser import parse
@@ -310,36 +311,10 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
     def total_records(self):
         return HqDeploy.objects.count()
 
-    @cached_property
-    def _user_lookup_url(self):
-        return reverse('web_deploy_lookup')
-
     def _format_date(self, date):
         if date:
-            raw_time_since_deploy = dt.now() - date
-            delta_dict = self._strfdelta(raw_time_since_deploy)
-
-            if delta_dict['days'] != 0:
-                delta_str = "{days} day(s), {hours} hour(s) ago".format(
-                    **delta_dict)
-            elif delta_dict['hours'] != 0:
-                delta_str = "{hours} hour(s), {minutes} minute(s) ago".format(
-                    **delta_dict)
-            else:
-                delta_str = "{minutes} minute(s), {seconds} second(s) ago".format(
-                    **delta_dict)
-
-            ret_str = '<div>{delta}</div><div>{actual_date}</div>'
-            return ret_str.format(delta=delta_str, actual_date=date.strftime(SERVER_DATETIME_FORMAT))
+            return f'<div>{naturaltime(date)}</div><div>{date.strftime(SERVER_DATETIME_FORMAT)}</div>'
         return "---"
 
-    def _strfdelta(self, tdelta):
-        # datetime.timedelta object cannot use 'strftime', use custom fn:
-        relative_time_formatted = {"days": tdelta.days}
-        relative_time_formatted["hours"], rem = divmod(tdelta.seconds, 3600)
-        relative_time_formatted["minutes"], relative_time_formatted[
-            "seconds"] = divmod(rem, 60)
-        return relative_time_formatted
-
     def _hyperlink_diff_url(self, diff_url):
-        return '<a href="{link}">Diff with previous</a>'.format(link=diff_url)
+        return f'<a href="{diff_url}">Diff with previous</a>'

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -73,7 +73,8 @@ class DeviceLogSoftAssertReport(BaseDeviceLogReport, AdminReport):
         logs = self._filter_logs()
         rows = self._create_rows(
             logs,
-            range=slice(self.pagination.start, self.pagination.start + self.pagination.count)
+            range=slice(self.pagination.start,
+                        self.pagination.start + self.pagination.count)
         )
         return rows
 
@@ -282,26 +283,32 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
 
     emailable = False
     exportable = False
-    ajax_pagination = False
+    ajax_pagination = True
     default_rows = 10
 
     @property
     def headers(self):
         return DataTablesHeader(
-            DataTablesColumn(_("Date")),
+            DataTablesColumn(_("Date"), sortable=False),
             DataTablesColumn(_("User"), sortable=False),
             DataTablesColumn(_("Diff URL"), sortable=False),
         )
 
     @property
     def rows(self):
-        deploy_list = HqDeploy.objects.filter()
-        for deploy in deploy_list:
+        deploy_list = HqDeploy.objects.all()
+        start = self.pagination.start
+        end = self.pagination.start + self.pagination.count
+        for deploy in deploy_list[start:end]:
             yield [
                 self._format_date(deploy.date),
                 deploy.user,
                 self._hyperlink_diff_url(deploy.diff_url),
             ]
+
+    @property
+    def total_records(self):
+        return HqDeploy.objects.count()
 
     @cached_property
     def _user_lookup_url(self):
@@ -313,7 +320,8 @@ class DeployHistoryReport(GetParamsMixin, AdminReport):
             delta_dict = self._strfdelta(raw_time_since_deploy)
 
             if delta_dict['days'] != 0:
-                delta_str = "{days} day(s), {hours} hour(s) ago".format(**delta_dict)
+                delta_str = "{days} day(s), {hours} hour(s) ago".format(
+                    **delta_dict)
             elif delta_dict['hours'] != 0:
                 delta_str = "{hours} hour(s), {minutes} minute(s) ago".format(
                     **delta_dict)

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -10,6 +10,7 @@ from corehq.apps.hqadmin.reports import (
     DeviceLogSoftAssertReport,
     UserAuditReport,
     UserListReport,
+    DeployHistoryReport,
 )
 from corehq.apps.linked_domain.views import DomainLinkHistoryReport
 from corehq.apps.reports.standard import (
@@ -339,6 +340,7 @@ ADMIN_REPORTS = (
         DeviceLogSoftAssertReport,
         AdminPhoneNumberReport,
         UserAuditReport,
+        DeployHistoryReport,
     )),
 )
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -37,6 +37,7 @@ from corehq.apps.hqadmin.reports import (
     DeviceLogSoftAssertReport,
     UserAuditReport,
     UserListReport,
+    DeployHistoryReport,
 )
 from corehq.apps.hqadmin.views.system import GlobalThresholds
 from corehq.apps.hqwebapp.models import GaTracker
@@ -2213,6 +2214,8 @@ class AdminTab(UITab):
             (_('Administrative Reports'), [
                 {'title': _('User List'),
                  'url': UserListReport.get_url()},
+                {'title': _('Deploy History'),
+                 'url': DeployHistoryReport.get_url()},
                 {'title': _('Download Malt table'),
                  'url': reverse('download_malt')},
                 {'title': _('Download Global Impact Report'),


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/issues/27839
One feature of the above CEP.

Please note this is re-upload of another PR (https://github.com/dimagi/commcare-hq/pull/28133), in which I messed up a rebase. Please look there for the original comments on my PR.

##### SUMMARY
Moved the Deploy History Report previously found on the 'System Info' admin page to its own standalone page. Part of a larger process of adding a commit field to the deploy history as explained in the above issue.

##### PRODUCT DESCRIPTION
Users will now be able to access the 'deploy history report' on its own standalone page.