### PR TITLE
remove redundant method

### DIFF
--- a/custom/icds/messaging/indicators.py
+++ b/custom/icds/messaging/indicators.py
@@ -403,11 +403,6 @@ class LSAggregatePerformanceIndicator(LSIndicator):
     def get_report_fixture(self, report_id):
         return get_report_fixture_for_user(self.domain, report_id, self.restore_user)
 
-    def clear_caches(self):
-        get_report_configs.clear(self.domain)
-        for report_id in REPORT_IDS:
-            get_report_fixture_for_user.clear(self.domain, report_id, self.restore_user)
-
     @property
     @memoized
     def visits_fixture(self):


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/15357/commits/3b72831b9d6999ff2e7a45e9795d5b4cf44946b2#r105911133

the definition itself was incorrect since it should have been 
`_get_report_fixture_for_user.clear`
and plus the method was not in use.