### PR TITLE
Convert messages to strings

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -271,7 +271,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
                 pass
             else:
                 django_user.delete()
-                log_model_change(request.user, django_user, message={'deleted_via': USER_CHANGE_VIA_API},
+                log_model_change(request.user, django_user, message=f"deleted_via: {USER_CHANGE_VIA_API}",
                                  action=ModelAction.DELETE)
         return bundle
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1648,7 +1648,6 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             created_by,
             self_django_user,
             message=f"created_via: {created_via}",
-            fields_changed=None,
             action=ModelAction.CREATE
         )
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1210,7 +1210,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
             user = self.get_django_user()
             user.delete()
             if deleted_by:
-                log_model_change(user, deleted_by, message={'deleted_via': deleted_via}, action=ModelAction.DELETE)
+                log_model_change(user, deleted_by, message=f"deleted_via: {deleted_via}",
+                                 action=ModelAction.DELETE)
         except User.DoesNotExist:
             pass
         super(CouchUser, self).delete()  # Call the "real" delete() method.
@@ -1646,7 +1647,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         log_model_change(
             created_by,
             self_django_user,
-            message={'created_via': created_via},
+            message=f"created_via: {created_via}",
             fields_changed=None,
             action=ModelAction.CREATE
         )
@@ -1842,7 +1843,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             log_model_change(
                 unretired_by,
                 self.get_django_user(use_primary_db=True),
-                message={'unretired_via': unretired_via},
+                message=f"unretired_via': {unretired_via}",
             )
         return True, None
 
@@ -1881,7 +1882,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         else:
             django_user.delete()
             if deleted_by:
-                log_model_change(deleted_by, django_user, message={'deleted_via': deleted_via},
+                log_model_change(deleted_by, django_user, message=f"deleted_via: {deleted_via}",
                                  action=ModelAction.DELETE)
         self.save()
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1842,7 +1842,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             log_model_change(
                 unretired_by,
                 self.get_django_user(use_primary_db=True),
-                message=f"unretired_via': {unretired_via}",
+                message=f"unretired_via: {unretired_via}",
             )
         return True, None
 

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -72,7 +72,7 @@ class RetireUserTestCase(TestCase):
         self.commcare_user.retire(deleted_by=other_django_user, deleted_via=deleted_via)
         log_entry = LogEntry.objects.get(user_id=other_django_user.pk, action_flag=ModelAction.DELETE.value)
         self.assertEqual(log_entry.object_repr, force_text(django_user))
-        self.assertEqual(log_entry.change_message, str({'deleted_via': deleted_via}))
+        self.assertEqual(log_entry.change_message, f"deleted_via: {deleted_via}")
 
     @run_with_all_backends
     def test_unretire_user(self):

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -106,7 +106,7 @@ class RetireUserTestCase(TestCase):
 
         log_entry = LogEntry.objects.get(user_id=other_django_user.pk, action_flag=ModelAction.UPDATE.value)
         self.assertEqual(log_entry.object_repr, force_text(self.commcare_user.get_django_user()))
-        self.assertEqual(log_entry.change_message, str({'unretired_via': "Test"}))
+        self.assertEqual(log_entry.change_message, f"unretired_via: Test")
 
         cases = CaseAccessors(self.domain).get_cases(case_ids)
         self.assertFalse(all([c.is_deleted for c in cases]))

--- a/corehq/util/model_log.py
+++ b/corehq/util/model_log.py
@@ -33,7 +33,7 @@ def log_model_change(user, model_object, message=None, fields_changed=None, acti
         if not fields_changed:
             raise ValueError("'fields_changed' must not be empty")
 
-        message = {'changed': {'fields': fields_changed}}
+        message = [{'changed': {'fields': fields_changed}}]
 
     return LogEntry.objects.log_action(
         user_id=user.pk,


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/28150#discussion_r457543001


##### SUMMARY
Fix audit messages to be strings and not dictionaries saved as strings
Also fix bug that saves messages as dictionary when logging change for model