### PR TITLE
filter UCR datasources from pillow if they are not valid

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -104,6 +104,18 @@ def _filter_missing_domains(configs):
     ]
 
 
+def _filter_invalid_config(configs):
+    """Return a list of configs that have been validated"""
+    valid_configs = []
+    for config in configs:
+        try:
+            config.validate()
+            valid_configs.append(config)
+        except Exception:
+            pillow_logging.warning("Invalid config found during bootstrap: %s", config._id)
+    return valid_configs
+
+
 class ConfigurableReportTableManagerMixin(object):
 
     def __init__(self, data_source_providers, ucr_division=None,
@@ -151,6 +163,7 @@ class ConfigurableReportTableManagerMixin(object):
             configs = _filter_by_hash(configs, self.ucr_division)
 
         configs = _filter_missing_domains(configs)
+        configs = _filter_invalid_config(configs)
 
         return configs
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -183,7 +183,7 @@ class ConfigurableReportTableManagerDbTest(TestCase):
             "column_id": "date",
             "type": "expression",
             "expression": {
-              "type": "missing_expression",
+                "type": "missing_expression",
             },
             "datatype": "datetime"
         }


### PR DESCRIPTION
Removing ICDS code from environments results in UCR datasources that reference expressions which no longer exist. 

##### SUMMARY
Filter out UCR data source configurations in the pillows if they fail to validate.

##### RISK ASSESSMENT / QA PLAN
Any configs that fail to validate now would cause errors so filtering them out should not create be a problem. The only issue may be that doing this may prevent anyone from noticing if there are issues. This code does add logging but that would require a developer to check the logs.

Should this raise a soft assert for any configs that are found to be invalid?