### PR TITLE
Silence "ResizeObserver loop limit exceeded" jserror

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -42,7 +42,11 @@ hqDefine("hqwebapp/js/hq.helpers", [
 
     window.onerror = function (message, file, line, col, error) {
         var stack = error ? error.stack : null;
-        if (!stack && (message === 'Script error' || message === 'Script error.')) {
+        if (!stack && (
+                message === 'Script error'
+                || message === 'Script error.'
+                || message === 'ResizeObserver loop limit exceeded'
+        )) {
             return false;
         }
         $.post('/jserror/', {

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hq.helpers.js
@@ -43,9 +43,9 @@ hqDefine("hqwebapp/js/hq.helpers", [
     window.onerror = function (message, file, line, col, error) {
         var stack = error ? error.stack : null;
         if (!stack && (
-                message === 'Script error'
-                || message === 'Script error.'
-                || message === 'ResizeObserver loop limit exceeded'
+            message === 'Script error'
+            || message === 'Script error.'
+            || message === 'ResizeObserver loop limit exceeded'
         )) {
             return false;
         }


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1743454866/?environment=production&project=136860&query=is%3Aunresolved&statsPeriod=14d
##### SUMMARY
According to https://stackoverflow.com/a/50387233
this happens when resize events are throttled by the browser
is safe to ignore.

