### PR TITLE
address fix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -267,7 +267,7 @@ function AddressEntry(question, options) {
 
     // geocoder function called when user presses 'x', broadcast a no answer to subscribers.
     self.geocoderOnClearCallback = function () {
-        self.answer(Formplayer.Const.NO_ANSWER);
+        self.rawAnswer(Formplayer.Const.NO_ANSWER);
         self.editing = true;
         self.broadcastTopics.forEach(function (broadcastTopic) {
             question.parentPubSub.notifySubscribers(Formplayer.Const.NO_ANSWER, broadcastTopic);
@@ -933,13 +933,15 @@ function getEntry(question) {
         case Formplayer.Const.STRING:
             // Barcode uses text box for CloudCare so it's possible to still enter a barcode field
         case Formplayer.Const.BARCODE:
-            options = {
-                enableAutoUpdate: isPhoneMode,
-                receiveStyle: receiveStyle,
-            };
+            // If it's a receiver, it cannot autoupdate because updates will come quickly which messes with the
+            // autoupdate rate limiting.
+            if (receiveStyle) {
+                options.receiveStyle = receiveStyle;
+            } else {
+                options.enableAutoUpdate = isPhoneMode;
+            }
             if (question.stylesContains(Formplayer.Const.ADDRESS)) {
                 entry = new AddressEntry(question, {
-                    enableAutoUpdate: isPhoneMode,
                     broadcastStyles: question.stylesContaining(/broadcast-*/),
                 });
             } else if (question.stylesContains(Formplayer.Const.NUMERIC)) {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/UbRRmNaF/101-add-new-address-geocoder-question-type

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The other [fix](https://github.com/dimagi/commcare-hq/pull/28223) did not do the job on prod, the timing issues are just too unpredictable in different environments.  This disables autoupdating when a receiver is requested--which makes sense because in most cases it will receive a value. If the user wants to change the answer after it is received, they can change it but the answer will be registered once after they leave the field, not after keystrokes. 

 

