### PR TITLE
condition check for default fallback if user lang is None

### DIFF
--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -443,6 +443,12 @@ class Content(models.Model):
         :param message_dict: a dictionary of {language code: message}
         :param preferred_language_code: the language code of the user's preferred language
         """
+
+        # If: message_dict contains no translations i.e. only contains * ;
+        # Then: treat it as an alert and send the message.
+        if {'*'} == message_dict.keys():
+            return Content.get_cleaned_message(message_dict, '*')
+
         result = Content.get_cleaned_message(message_dict, preferred_language_code)
 
         if domain_obj.sms_language_fallback == LANGUAGE_FALLBACK_NONE:

--- a/corehq/messaging/scheduling/models/abstract.py
+++ b/corehq/messaging/scheduling/models/abstract.py
@@ -444,8 +444,7 @@ class Content(models.Model):
         :param preferred_language_code: the language code of the user's preferred language
         """
 
-        # If: message_dict contains no translations i.e. only contains * ;
-        # Then: treat it as an alert and send the message.
+        # return untranslated content, if no translations set
         if {'*'} == message_dict.keys():
             return Content.get_cleaned_message(message_dict, '*')
 

--- a/corehq/messaging/scheduling/tests/test_content.py
+++ b/corehq/messaging/scheduling/tests/test_content.py
@@ -150,6 +150,7 @@ class TestContent(TestCase):
             'en': 'english message',            # project default
             'hin': 'hindi message',             # schedule default
             'es': 'spanish message',            # user's preferred language
+            'kan': 'kannada message',           # arbitrary language to test untranslated case
         }
         user_lang = self.user.get_language_code()
         content = Content()
@@ -195,6 +196,7 @@ class TestContent(TestCase):
             content.get_translation_from_message_dict(self.domain_obj, message_dict, user_lang),
             message_dict['*']
         )
+        message_dict.pop('kan')
 
         # Default: same as LANGUAGE_FALLBACK_UNTRANSLATED
         self.domain_obj.sms_language_fallback = None


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/projects/ICDS/issues/ICDS-1539

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For ICDS,
Users with no preferred language set are not able to receive the helpdesk alerts which aren't meant to have translations, because of the set fallback on ICDS to be none (which means don't send sms, if it's not available in the language set for the user). 
This PR tries to fix it, by sending the untranslated message itself, even before checking for the fallback set, which is better than not sending any message.

For product,
In case there are no translations specified for a conditional alert, send the untranslated text without checking on fallbacks and languages set on user/alert/domain.
Only ICDS currently uses the fallback configuration. For product otherwise there is no real change.
