### PR TITLE
Allow specification of alternative charset in sislog gateway

### DIFF
--- a/corehq/messaging/smsbackends/http/models.py
+++ b/corehq/messaging/smsbackends/http/models.py
@@ -163,9 +163,7 @@ class SQLHttpBackend(SQLSMSBackend):
 
     @staticmethod
     def _encode_http_message(text, charset=None):
-        if charset:
-            return text.encode(charset)
         try:
-            return text.encode("iso-8859-1")
+            return text.encode(charset if charset else "iso-8859-1")
         except UnicodeEncodeError:
             return text.encode("utf-8")

--- a/corehq/messaging/smsbackends/http/models.py
+++ b/corehq/messaging/smsbackends/http/models.py
@@ -137,11 +137,8 @@ class SQLHttpBackend(SQLSMSBackend):
         else:
             phone_number = strip_plus(phone_number)
 
-        try:
-            text = msg.text.encode("iso-8859-1")
-        except UnicodeEncodeError:
-            text = msg.text.encode("utf-8")
-        params[config.message_param] = text
+        charset = config.additional_params.get("_charset_")
+        params[config.message_param] = self._encode_http_message(msg.text, charset)
         params[config.number_param] = phone_number
 
         url_params = urlencode(params)
@@ -163,3 +160,12 @@ class SQLHttpBackend(SQLSMSBackend):
         except Exception as e:
             msg = "Error sending message from backend: '{}'\n\n{}".format(self.pk, str(e))
             six.reraise(BackendProcessingException, BackendProcessingException(msg), sys.exc_info()[2])
+
+    @staticmethod
+    def _encode_http_message(text, charset=None):
+        if charset:
+            return text.encode(charset)
+        try:
+            return text.encode("iso-8859-1")
+        except UnicodeEncodeError:
+            return text.encode("utf-8")


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11133

We recently made a change to this gateway's configuration to address a character encoding issue.  As @dannyroberts [wrote]( https://dimagi-dev.atlassian.net/browse/SAAS-10966?focusedCommentId=63623):

> the issue was that we were encoding in `iso-8859-1` here, but Sislog uses the sensible default of `utf-8`. The quick fix here was to change the gateway config in the UI to add a parameter `_charset_=iso-8859-1`

More recently, there have been reports of an odd character appearing where long messages break into multiple lines, which used to work well.  I suspect the issue is a downside of using that strange charset, so my hope is by encoding as utf-8 (and telling sislog we're doing so), we'll both resolve this issue and prevent a recurrence of the previous issue.

I've implemented the switch based on the [provided configuration](https://www.commcarehq.org/hq/sms/edit_global_gateway/SISLOG/7/).  This will let me test out a change to the sislog gateway and revert if needed without a deploy If all goes well, I expect to make this change more permanent (and not dependent on the config).

<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
Shouldn't take any effect on its own.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
