### PR TITLE
Retry exceptions when submitting partially complete SMS surveys

### DIFF
--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -120,6 +120,8 @@ def submit_unfinished_form(session):
     # Get and clean the raw xml
     try:
         response = FormplayerInterface(session.session_id, session.domain).get_raw_instance()
+        # Formplayer's ExceptionResponseBean includes the exception message,
+        # stautus ("error"), url, and type ("text")
         if response.get('status') == 'error':
             raise TouchformsError(response.get('exception'))
         xml = response['output']

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -120,6 +120,8 @@ def submit_unfinished_form(session):
     # Get and clean the raw xml
     try:
         response = FormplayerInterface(session.session_id, session.domain).get_raw_instance()
+        if response.get('status') == 'error':
+            raise TouchformsError(response.get('exception'))
         xml = response['output']
     except InvalidSessionIdException:
         return

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -11,6 +11,7 @@ from django.utils.translation import ugettext_noop
 from couchdbkit import MultipleResultsFound
 
 from corehq import toggles
+from corehq.apps.formplayer_api.smsforms.api import TouchformsError
 from corehq.apps.sms.mixin import BadSMSConfigException
 from corehq.apps.sms.models import PhoneNumber
 from corehq.apps.sms.util import strip_plus
@@ -105,14 +106,19 @@ class SQLXFormsSession(models.Model):
     def _id(self):
         return self.couch_id
 
-    def close(self):
+    def close(self, force=True):
         from corehq.apps.smsforms.app import submit_unfinished_form
 
         if not self.session_is_open:
             return
 
         if self.submit_partially_completed_forms:
-            submit_unfinished_form(self)
+            try:
+                submit_unfinished_form(self)
+            except TouchformsError as e:
+                if not force:
+                    # Allow caller to handle and potentially retry
+                    raise e
 
         self.mark_completed(False)
 

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -111,13 +111,10 @@ class SQLXFormsSession(models.Model):
         if not self.session_is_open:
             return
 
-        try:
-            if self.submit_partially_completed_forms:
-                submit_unfinished_form(self)
-        finally:
-            # this needs to be called after the submission, but regardless of whether it succeeded
-            # thus the try/finally
-            self.mark_completed(False)
+        if self.submit_partially_completed_forms:
+            submit_unfinished_form(self)
+
+        self.mark_completed(False)
 
     def mark_completed(self, completed):
         self.session_is_open = False

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -1,4 +1,3 @@
-from celery.exceptions import MaxRetriesExceededError
 from celery.task import task
 from datetime import timedelta
 

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -80,7 +80,7 @@ def send_first_message(domain, recipient, phone_entry_or_number, session, respon
 
 
 @no_result_task(serializer='pickle', queue='reminder_queue')
-def handle_due_survey_action(self, domain, contact_id, session_id):
+def handle_due_survey_action(domain, contact_id, session_id):
     with critical_section_for_smsforms_sessions(contact_id):
         session = SQLXFormsSession.by_session_id(session_id)
         if (

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -80,7 +80,7 @@ def send_first_message(domain, recipient, phone_entry_or_number, session, respon
     logged_subevent.completed()
 
 
-@task(serializer='pickle', queue='reminder_queue', bind=True, max_retries=3, default_retry_delay=15 * 60)
+@no_result_task(serializer='pickle', queue='reminder_queue')
 def handle_due_survey_action(self, domain, contact_id, session_id):
     with critical_section_for_smsforms_sessions(contact_id):
         session = SQLXFormsSession.by_session_id(session_id)
@@ -127,15 +127,26 @@ def handle_due_survey_action(self, domain, contact_id, session_id):
             session.move_to_next_action()
             session.save()
         else:
+            close_session.delay(contact_id, session_id)
+
+
+@task(serializer='pickle', queue='reminder_queue', bind=True, max_retries=3, default_retry_delay=15 * 60)
+def close_session(self, contact_id, session_id):
+    with critical_section_for_smsforms_sessions(contact_id):
+        session = SQLXFormsSession.by_session_id(session_id)
+        try:
+            session.close(force=False)
+        except TouchformsError as e:
             try:
-                session.close()
+                self.retry(exc=e)
             except TouchformsError as e:
-                try:
-                    self.retry(exc=e)
-                except MaxRetriesExceededError:
-                    # Eventually the session needs to get closed
-                    session.mark_completed(False)
-            session.save()
+                raise e
+            finally:
+                # Eventually the session needs to get closed
+                session.mark_completed(False)
+                session.save()
+                return
+        session.save()
 
 
 def session_is_stale(session):

--- a/corehq/apps/smsforms/tasks.py
+++ b/corehq/apps/smsforms/tasks.py
@@ -80,7 +80,7 @@ def send_first_message(domain, recipient, phone_entry_or_number, session, respon
     logged_subevent.completed()
 
 
-@task(serializer='pickle', queue='reminder_queue', max_retries=3, default_retry_delay=15 * 60)
+@task(serializer='pickle', queue='reminder_queue', bind=True, max_retries=3, default_retry_delay=15 * 60)
 def handle_due_survey_action(self, domain, contact_id, session_id):
     with critical_section_for_smsforms_sessions(contact_id):
         session = SQLXFormsSession.by_session_id(session_id)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/COV-17

Adjustment to https://github.com/dimagi/commcare-hq/commit/665a6525e56fa6d7f01cfb291c7ba060daf294d6

Errors encountered in `submit_unfinished_form` currently fail hard without a retry mechanism. This captures them and retries them at 15-minute intervals, at most 3 times.

I don't think there's a good way to test this and I don't do a ton with celery, so I'm very interested in incisive feedback from both of you, @dannyroberts @calellowitz 