### PR TITLE
dont block sms session on opt out

### DIFF
--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -237,13 +237,6 @@ class SMSSurveyContent(Content):
             logged_subevent.error(MessagingEvent.ERROR_NO_TWO_WAY_PHONE_NUMBER)
             return
 
-        # The SMS framework already checks if the number has opted out before sending to
-        # it. But for this use case we check for it here because we don't want to start
-        # the survey session if they've opted out.
-        if self.phone_has_opted_out(phone_entry_or_number):
-            logged_subevent.error(MessagingEvent.ERROR_PHONE_OPTED_OUT)
-            return
-
         with self.get_critical_section(recipient):
             # Get the case to submit the form against, if any
             case_id = None


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Spoke briefly with a few people about this approach and I think it's the cleanest way to finish the work for this ticket https://trello.com/c/VORjEVCe/43-include-stop-refusals-as-part-of-sms-opt-out-queue

This has a few side effects when users submit keywords after opting out that I do not love, but seem fine
1) Surveys with no questions will show up as completed in reports, even though no sms was sent (this seems fine since the form is processed, but in theory one step wasn't done)
2) Surveys with questions get stuck "in progress", with no mention that the opt out is preventing completion (this seems worse, but still is not wrong, just mildly misleading)

Both of these occur because the opt out error now occurs on the sms object, not the messaging subevent.
