### PR TITLE
[Admin API  Quick Fix] Don't fail on the API throttle identifier if domain is not part of request

### DIFF
--- a/corehq/apps/api/resources/auth.py
+++ b/corehq/apps/api/resources/auth.py
@@ -100,7 +100,7 @@ class LoginAndDomainAuthentication(Authentication):
 
     def get_identifier(self, request):
         username = request.couch_user.username
-        if API_THROTTLE_WHITELIST.enabled(username):
+        if API_THROTTLE_WHITELIST.enabled(username) or not hasattr(request, 'domain'):
             return username
         return f"{request.domain}_{username}"
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11149

##### SUMMARY
Fixes the `AttributeError` on the salesforce APIs as `domain` is not present in those requests. I know @czue has a nicer PR in the works (https://github.com/dimagi/commcare-hq/pull/28201), but this is needed as a bandaid to unblock Krishna. Hopefully, it's the only issue with the admin APIs...

##### RISK ASSESSMENT / QA PLAN
I chatted with @proteusvacuum and since this is only the throttle identifier, this doesn't introduce a security risk. 
