### PR TITLE
Make sislog gateway permanently utf-8

### DIFF
--- a/corehq/messaging/smsbackends/http/models.py
+++ b/corehq/messaging/smsbackends/http/models.py
@@ -137,8 +137,7 @@ class SQLHttpBackend(SQLSMSBackend):
         else:
             phone_number = strip_plus(phone_number)
 
-        charset = config.additional_params.get("_charset_")
-        params[config.message_param] = self._encode_http_message(msg.text, charset)
+        params[config.message_param] = self._encode_http_message(msg.text)
         params[config.number_param] = phone_number
 
         url_params = urlencode(params)
@@ -162,8 +161,8 @@ class SQLHttpBackend(SQLSMSBackend):
             six.reraise(BackendProcessingException, BackendProcessingException(msg), sys.exc_info()[2])
 
     @staticmethod
-    def _encode_http_message(text, charset=None):
+    def _encode_http_message(text):
         try:
-            return text.encode(charset if charset else "iso-8859-1")
+            return text.encode("iso-8859-1")
         except UnicodeEncodeError:
             return text.encode("utf-8")

--- a/corehq/messaging/smsbackends/sislog/models.py
+++ b/corehq/messaging/smsbackends/sislog/models.py
@@ -14,3 +14,7 @@ class SQLSislogBackend(SQLHttpBackend):
     @classmethod
     def get_generic_name(cls):
         return "Sislog"
+
+    @staticmethod
+    def _encode_http_message(text):
+        return text.encode("utf-8")


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11133
Followup from https://github.com/dimagi/commcare-hq/pull/28243
I applied this change in a temporary fashion to be cautious, and it worked, so now I'd like to codify it, as splitting this between code and the DB is sloppy.

##### PRODUCT DESCRIPTION
Fix issue on sislog gateway where long messages were split up with odd characters inserted in the middle.
