### PR TITLE
Improve Trumpia SMS gateway error handling

### DIFF
--- a/corehq/messaging/smsbackends/trumpia/models.py
+++ b/corehq/messaging/smsbackends/trumpia/models.py
@@ -67,8 +67,10 @@ class TrumpiaBackend(SQLSMSBackend):
             if data.get("message") == "In progress":
                 msg.set_status_pending()
                 return
-            if "statuscode" in data:
-                message = f"status {data['statuscode']}: {data.get('message')}"
+            if "errorcode" in data and "errormessage" in data:
+                message = f"error {data['errorcode']}: {data['errormessage']}"
+            elif "statuscode" in data and "message" in data:
+                message = f"status {data['statuscode']}: {data['message']}"
             else:
                 message = repr(data)
         else:

--- a/corehq/messaging/smsbackends/trumpia/tests/test_outgoing.py
+++ b/corehq/messaging/smsbackends/trumpia/tests/test_outgoing.py
@@ -81,6 +81,30 @@ class TestTrumpiaBackend(SimpleTestCase):
             "Gateway error: status MRME0201: Internal Error.")
         self.assertTrue(msg.error)
 
+    def test_errorcode_16(self):
+        msg = self.mock_send(
+            response={"requestID": "1234561234567asdf123"},
+            report={
+                "statuscode": "0",
+                "errorcode": "16",
+                "errormessage": "Blocked Number : 15554443333",
+            },
+        )
+        self.assertEqual(msg.backend_message_id, "1234561234567asdf123")
+        self.assertEqual(msg.system_error_message,
+            "Gateway error: error 16: Blocked Number : 15554443333")
+        self.assertTrue(msg.error)
+
+    def test_status_without_message(self):
+        msg = self.mock_send(
+            response={"requestID": "1234561234567asdf123"},
+            report={"statuscode": "?", "something": "else"},
+        )
+        self.assertEqual(msg.backend_message_id, "1234561234567asdf123")
+        self.assertEqual(msg.system_error_message,
+            "Gateway error: {'statuscode': '?', 'something': 'else'}")
+        self.assertTrue(msg.error)
+
     def test_405(self):
         msg = self.mock_send(status_code=405)
         self.assertEqual(msg.system_error_message, "Gateway error: 405")


### PR DESCRIPTION
Improve message status in Survey Detail.

Old error: _Gateway error: status 0: None_
New error: _Gateway error: error 16: Blocked Number : 15554443333_