### PR TITLE
added or recevier appearance to combobox

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -699,8 +699,10 @@ ComboboxEntry.prototype.receiveMessage = function (message, field) {
     var self = this;
     var options = self.options();
     var fieldsByPriority = field.split("||");
-    for (var fieldByPriority of fieldsByPriority) {
-        for (var option of options) {
+    for (var i = 0; i < fieldsByPriority.length; i++) {
+        var fieldByPriority = fieldsByPriority[i];
+        for (var j = 0; j < options.length; j++) {
+            var option = options[j];
             if (option.name === message[fieldByPriority]) {
                 self.rawAnswer(option.name);
                 return;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -129,7 +129,7 @@ EntrySingleAnswer.prototype.enableReceiver = function (question, options) {
             question.parentPubSub.subscribe(function (message) {
                 if (message === Formplayer.Const.NO_ANSWER) {
                     self.rawAnswer(Formplayer.Const.NO_ANSWER);
-                } else if (message, receiveTopicField) {
+                } else if (message) {
                     self.receiveMessage(message, receiveTopicField);
                 }
             }, null, receiveTopic);
@@ -695,7 +695,7 @@ ComboboxEntry.prototype.receiveMessage = function (message, field) {
     // Iterates through options and selects an option that matches message[field].
     // Registers a no answer if message[field] is not in options.
     // Also accepts fields in format `field1||field2||...||fieldn` it will find the
-    // first message[fieldi] that matches an option.
+    // first message[field] that matches an option.
     var self = this;
     var options = self.options();
     var fieldsByPriority = field.split("||");


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/UbRRmNaF/101-add-new-address-geocoder-question-type

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Modifies some address field names according to [doc](https://docs.google.com/document/d/1M2alDemPuWRaJptTH_XPO-JE9lh49McCpPSjaiI-k54/edit?ts=5f22f0bc#heading=h.2urpcnxz4a5n)
  a. `state_long` to be deprecated in favor of `us_state`
  b.  `state_short` to be deprecated in favor of  `us_state_short`
  c. adds `country`, `country_short`, `region`
2. Adds support in combobox for multiple fields in the format `receive-<topic>-<field1>||<field2>||<fieldi>||...` and match on the first field that matches the options. Thus, if `field1` does not exist or match an option, it continue looking at the next fields until a match is found, or report a no_answer if none found. @ctsims to verify that `||` is what we want to use, or is there another delimiter that is more consistent with our syntax (and `|` can be mistaken for the letter `I`). 

State Priority
<img width="1206" alt="Screen Shot 2020-07-30 at 4 33 35 PM" src="https://user-images.githubusercontent.com/615126/88971805-8e1bf600-d282-11ea-9805-e5f5f1bb9df3.png">

And country fallback
<img width="1188" alt="Screen Shot 2020-07-30 at 4 34 08 PM" src="https://user-images.githubusercontent.com/615126/88971820-93794080-d282-11ea-9ccd-4ac9c640eedf.png">


Here we see the prioritization where `Massachusetts` is not an option but `United States of America is`, so it falls back to country.

<img width="1204" alt="Screen Shot 2020-07-30 at 4 36 23 PM" src="https://user-images.githubusercontent.com/615126/88972043-f7036e00-d282-11ea-9e28-3e181739774e.png">


