### PR TITLE
View apps permission

### DIFF
--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -80,6 +80,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
             self.domain.name,
             Permissions(
                 edit_apps=True,
+                view_apps=True,
                 edit_web_users=True,
                 view_web_users=True,
                 view_roles=True,
@@ -178,6 +179,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
                 edit_locations=True,
                 view_locations=True,
                 edit_apps=True,
+                view_apps=True,
                 edit_data=True,
                 edit_reports=True
             )

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -193,6 +193,7 @@ class TestWebUserResource(APIResourceTest):
         "last_name": "Admin",
         "permissions": {
             "edit_apps": True,
+            "view_apps": True,
             "edit_commcare_users": True,
             "view_commcare_users": True,
             "edit_groups": True,
@@ -232,6 +233,7 @@ class TestWebUserResource(APIResourceTest):
             'edit_users_in_locations',
             'edit_data',
             'edit_apps',
+            'view_apps',
             'edit_reports',
             'view_reports',
         ]:
@@ -319,7 +321,9 @@ class TestWebUserResource(APIResourceTest):
 
     def test_create_with_custom_role(self):
         new_user_role = UserRole.get_or_create_with_permissions(
-            self.domain.name, Permissions(edit_apps=True, view_reports=True), 'awesomeness')
+            self.domain.name,
+            Permissions(edit_apps=True, view_apps=True, view_reports=True),
+            'awesomeness')
         user_json = deepcopy(self.default_user_json)
         user_json["role"] = new_user_role.name
         user_json["is_admin"] = False

--- a/corehq/apps/app_manager/decorators.py
+++ b/corehq/apps/app_manager/decorators.py
@@ -190,4 +190,7 @@ def _build_request_in_progress(domain, app_id):
 
 
 require_can_edit_apps = require_permission(Permissions.edit_apps)
+require_can_edit_or_view_apps = require_permission(
+    'edit_apps', view_only_permission='view_apps'
+)
 require_deploy_apps = login_and_domain_required  # todo: can fix this when it is better supported

--- a/corehq/apps/dashboard/models.py
+++ b/corehq/apps/dashboard/models.py
@@ -177,7 +177,7 @@ class AppsPaginator(TilePaginator):
         def _get_app_url(app):
             return (
                 _get_view_app_url(app)
-                if self.request.couch_user.can_edit_apps()
+                if self.request.couch_user.can_view_apps()
                 else _get_release_manager_url(app)
             )
 

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -113,14 +113,11 @@ class DomainDashboardView(LoginAndDomainMixin, BillingModalsMixin, BasePageView,
 
 
 def _get_default_tiles(request):
-    can_edit_apps = lambda request: (request.couch_user.is_web_user()
-                                     or request.couch_user.can_edit_apps())
     can_edit_users = lambda request: (request.couch_user.can_edit_commcare_users()
                                       or request.couch_user.can_edit_web_users())
 
     def can_view_apps(request):
-        return can_edit_apps(request) and has_privilege(request,
-                                                        privileges.PROJECT_ACCESS)
+        return request.couch_user.can_view_apps() and has_privilege(request, privileges.PROJECT_ACCESS)
 
     def can_view_users(request):
         can_do_something = (

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -24,7 +24,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
         cls.other_domain = Domain.get_or_create_with_name(name='other-domain')
 
-        permissions = Permissions(edit_apps=True, view_reports=True)
+        permissions = Permissions(edit_apps=True, view_apps=True, view_reports=True)
         cls.role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'edit-apps')
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()

--- a/corehq/apps/users/migrations/0021_add_view_apps_permission.py
+++ b/corehq/apps/users/migrations/0021_add_view_apps_permission.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+from dimagi.utils.couch.database import iter_docs
+
+from corehq.apps.users.models import UserRole
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def _migrate_view_apps_permission(apps, schema_editor):
+    roles = UserRole.view(
+        'users/roles_by_domain',
+        include_docs=False,
+        reduce=False
+    ).all()
+    for role_doc in iter_docs(UserRole.get_db(), [r['id'] for r in roles]):
+        role = UserRole.wrap(role_doc)
+
+        if role.permissions.edit_apps:
+            role.permissions.view_apps = True
+            role.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0020_user_staging_pk_to_bigint'),
+    ]
+
+    operations = [
+        migrations.RunPython(_migrate_view_apps_permission,
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True)
+    ]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -130,6 +130,7 @@ class Permissions(DocumentSchema):
     edit_motech = BooleanProperty(default=False)
     edit_data = BooleanProperty(default=False)
     edit_apps = BooleanProperty(default=False)
+    view_apps = BooleanProperty(default=False)
     edit_shared_exports = BooleanProperty(default=False)
     access_all_locations = BooleanProperty(default=True)
     access_api = BooleanProperty(default=True)
@@ -242,6 +243,7 @@ class Permissions(DocumentSchema):
             edit_motech=True,
             edit_data=True,
             edit_apps=True,
+            view_apps=True,
             edit_reports=True,
             view_reports=True,
             edit_billing=True,
@@ -284,7 +286,7 @@ class UserRolePresets(object):
                                                        view_locations=True,
                                                        edit_shared_exports=True,
                                                        view_reports=True),
-            cls.APP_EDITOR: lambda: Permissions(edit_apps=True, view_reports=True),
+            cls.APP_EDITOR: lambda: Permissions(edit_apps=True, view_apps=True, view_reports=True),
             cls.BILLING_ADMIN: lambda: Permissions(edit_billing=True)
         }
 
@@ -427,6 +429,7 @@ PERMISSIONS_PRESETS = {
         'name': 'App Editor',
         'permissions': Permissions(
             edit_apps=True,
+            view_apps=True,
             view_reports=True,
         ),
     },
@@ -2748,6 +2751,9 @@ class AnonymousCouchUser(object):
         return False
 
     def can_edit_apps(self):
+        return False
+
+    def can_view_apps(self):
         return False
 
     def can_edit_reports(self):

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -469,11 +469,34 @@
                   </label>
                 </div>
               </div>
+
               <div class="col-sm-2 controls">
-                <div class="form-check-placeholder">
-                  <label></label>
+                {# PLACEHOLDER checkbox when edit_apps is true #}
+                <div class="form-check" data-bind="visible: permissions.edit_apps()">
+                  <input type="checkbox" checked="checked" disabled="disabled" />
+                  <label>
+                    <span class="sr-only">
+                      {% trans "View-Only Applications" %}
+                    </span>
+                  </label>
                 </div>
+                {# end PLACEHOLDER #}
+
+                {# REAL checkbox that controls view_apps permission #}
+                <div class="form-check" data-bind="visible: !permissions.edit_apps()">
+                  <input type="checkbox"
+                         id="view-apps-checkbox"
+                         data-bind="checked: permissions.view_apps,
+                                    disable: !$root.allowEdit" />
+                  <label for="view-apps-checkbox">
+                    <span class="sr-only">
+                      {% trans "View-Only Applications" %}
+                    </span>
+                  </label>
+                </div>
+                {# END REAL checkbox #}
               </div>
+
               <div class="col-sm-8 control-label">
                 {% blocktrans %}
                   <strong>Applications</strong> &mdash; modify or view the structure

--- a/corehq/apps/users/templates/users/roles_and_permissions.html
+++ b/corehq/apps/users/templates/users/roles_and_permissions.html
@@ -154,7 +154,8 @@
           <td class="text-center">
             <div data-bind="visible: permissions.access_all_locations,
                                             permissionIcon: {
-                                              edit: permissions.edit_apps
+                                              edit: permissions.edit_apps,
+                                              view: permissions.view_apps,
                                             }"></div>
           </td>
           {% if show_integration %}

--- a/corehq/apps/users/tests/permissions.py
+++ b/corehq/apps/users/tests/permissions.py
@@ -26,11 +26,13 @@ class PermissionsTest(TestCase):
         )
         p2 = Permissions(
             edit_apps=True,
+            view_apps=True,
             view_reports=True,
             view_report_list=['report2'],
         )
         self.assertEqual(p1 | p2, Permissions(
             edit_apps=True,
+            view_apps=True,
             edit_web_users=True,
             view_web_users=True,
             view_roles=True,

--- a/corehq/apps/users/tests/test_db_accessors.py
+++ b/corehq/apps/users/tests/test_db_accessors.py
@@ -42,6 +42,7 @@ class AllCommCareUsersTest(TestCase):
             cls.ccdomain.name,
             Permissions(
                 edit_apps=True,
+                view_apps=True,
                 edit_web_users=True,
                 view_web_users=True,
                 view_roles=True,

--- a/corehq/apps/users/tests/test_mirroring.py
+++ b/corehq/apps/users/tests/test_mirroring.py
@@ -54,6 +54,7 @@ class DomainPermissionsMirrorTest(TestCase):
                 view_groups=True,
                 edit_groups=False,
                 edit_apps=True,     # needed for InternalFixtureResource
+                view_apps=True,
             )
         )
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -951,7 +951,7 @@ class ApplicationsTab(UITab):
     def _is_viewable(self):
         couch_user = self.couch_user
         return (self.domain and couch_user
-                and (couch_user.is_web_user() or couch_user.can_edit_apps())
+                and couch_user.can_view_apps()
                 and (couch_user.is_member_of(self.domain, allow_mirroring=True) or couch_user.is_superuser)
                 and has_privilege(self._request, privileges.PROJECT_ACCESS))
 


### PR DESCRIPTION
##### SUMMARY
https://trello.com/c/fAq01fpI/123-applications-tab-displays-for-web-user-role

This adds a new "View Apps" permission and updates the top Applications menu and dashboard to require View Apps permission. These used to be visible to all web users. So this will change behavior for end users, but anyone who loses access to the top nav and should have it can get it back if they're assigned a role with View Apps.

The downside of the new permission is that it's poor UX. Skimming the code, it looks like the major app manager views (releases page, menu settings, etc) are restricted by `require_deploy_apps`, which is equivalent to `login_and_domain_required`, and then the write actions are properly restricted by `edit_apps`. But app manager UIs are not set up to check `request.is_view_only` before displaying save buttons, etc.

All this means view-only users will see what look like fully-functional pages and then will get errors when they try to do anything. The followup work referenced on the Trello card is to improve this experience to be in line with other parts of HQ (e.g., locations).

##### RISK ASSESSMENT / QA PLAN
[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-1702)
