### PR TITLE
New approach to location-safe HQ reports

### DIFF
--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -251,6 +251,10 @@ def is_location_safe(view_fn, request, view_args, view_kwargs):
         view_fn = report_class
 
     if getattr(view_fn, 'is_location_safe', False):
+        if isinstance(view_fn, type):
+            return _has_own_location_safe_attribute(view_fn)
+        if hasattr(view_fn, "view_class"):
+            return _has_own_location_safe_attribute(view_fn.view_class)
         return True
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
@@ -258,6 +262,10 @@ def is_location_safe(view_fn, request, view_args, view_kwargs):
         return view_fn._conditionally_location_safe_function(view_fn, request, *view_args, **view_kwargs)
 
     return False
+
+
+def _has_own_location_safe_attribute(class_):
+    return 'is_location_safe' in getattr(class_, "__dict__", {})
 
 
 def report_class_is_location_safe(report_class):

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -230,9 +230,9 @@ def location_restricted_exception(request):
 
 
 def _view_obj_is_safe(obj, request, *view_args, **view_kwargs):
-    if _get_own_property(obj, 'is_location_safe'):
+    if getattr(obj, 'is_location_safe', False):
         return True
-    conditional_fn = _get_own_property(obj, '_conditionally_location_safe_function')
+    conditional_fn = getattr(obj, '_conditionally_location_safe_function', None)
     if conditional_fn:
         return conditional_fn(obj, request, *view_args, **view_kwargs)
     return False
@@ -257,10 +257,6 @@ def is_location_safe(view_fn, request, view_args, view_kwargs):
         return _view_obj_is_safe(view_fn.view_class, request, *view_args, **view_kwargs)
 
     return _view_obj_is_safe(view_fn, request, *view_args, **view_kwargs)
-
-
-def _get_own_property(view_fn, prop_name):
-    return view_fn.__dict__.get(prop_name, None)
 
 
 def report_class_is_location_safe(report_class):

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -197,15 +197,9 @@ def location_safe(view):
     """
     view.is_location_safe = True
 
-    if isinstance(view, type):  # it's a class
-
-        # Django class-based views
-        if issubclass(view, View):
-            view = method_decorator(location_safe, 'dispatch')(view)
-
-        # tastypie resources
-        if issubclass(view, Resource):
-            LOCATION_SAFE_TASTYPIE_RESOURCES.add(view.Meta.resource_name)
+    # tastypie resources
+    if isinstance(view, type) and issubclass(view, Resource):
+        LOCATION_SAFE_TASTYPIE_RESOURCES.add(view.Meta.resource_name)
 
     return view
 

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -131,9 +131,6 @@ LOCATION_ACCESS_DENIED = mark_safe(ugettext_lazy(
 
 LOCATION_SAFE_TASTYPIE_RESOURCES = set()
 
-LOCATION_SAFE_HQ_REPORTS = set()
-CONDITIONALLY_LOCATION_SAFE_HQ_REPORTS = dict()
-
 NOTIFY_EXCEPTION_MSG = (
     "Someone was just denied access to a page due to location-based "
     "access restrictions. If this happens a lot, we should investigate."
@@ -198,7 +195,6 @@ def location_safe(view):
     Supports view functions, class-based views, tastypie resources, and HQ reports.
     For classes, decorate the class, not the dispatch method.
     """
-    # view functions
     view.is_location_safe = True
 
     if isinstance(view, type):  # it's a class
@@ -211,10 +207,6 @@ def location_safe(view):
         if issubclass(view, Resource):
             LOCATION_SAFE_TASTYPIE_RESOURCES.add(view.Meta.resource_name)
 
-        # HQ report classes
-        if issubclass(view, GenericReportView):
-            LOCATION_SAFE_HQ_REPORTS.add(view.slug)
-
     return view
 
 
@@ -226,16 +218,9 @@ def conditionally_location_safe(conditional_function):
     Note - for the page to show up in the menus, the function should not rely on `request`.
     """
     def _inner(view_fn):
-        if isinstance(view_fn, type):
-
-            # Django class-based views
-            if issubclass(view_fn, View):
-                view_fn = method_decorator(_inner, 'dispatch')(view_fn)
-
-            # HQ report classes
-            if issubclass(view_fn, GenericReportView):
-                CONDITIONALLY_LOCATION_SAFE_HQ_REPORTS[view_fn.slug] = conditional_function
-
+        # Django class-based views
+        if isinstance(view_fn, type) and issubclass(view_fn, View):
+            view_fn = method_decorator(_inner, 'dispatch')(view_fn)
         else:
             view_fn._conditionally_location_safe_function = conditional_function
         return view_fn
@@ -260,25 +245,24 @@ def is_location_safe(view_fn, request, view_args, view_kwargs):
     request, view_args and kwargs are also needed because view_fn alone doesn't always
     contain enough information
     """
+    if getattr(view_fn, 'is_hq_report', False):
+        dispatcher = view_fn.view_class
+        report_class = dispatcher.get_report(view_kwargs['domain'], view_kwargs['report_slug'])
+        view_fn = report_class
+
     if getattr(view_fn, 'is_location_safe', False):
         return True
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
     if getattr(view_fn, '_conditionally_location_safe_function', False):
         return view_fn._conditionally_location_safe_function(view_fn, request, *view_args, **view_kwargs)
-    if getattr(view_fn, 'is_hq_report', False):
-        if view_kwargs['report_slug'] in CONDITIONALLY_LOCATION_SAFE_HQ_REPORTS:
-            return CONDITIONALLY_LOCATION_SAFE_HQ_REPORTS[view_kwargs['report_slug']](
-                view_fn, request, *view_args, **view_kwargs
-            )
-        else:
-            return view_kwargs['report_slug'] in LOCATION_SAFE_HQ_REPORTS
+
     return False
 
 
 def report_class_is_location_safe(report_class):
     cls = to_function(report_class)
-    return cls and getattr(cls, 'slug', None) in LOCATION_SAFE_HQ_REPORTS
+    return cls and getattr(cls, 'is_location_safe', False)
 
 
 def user_can_access_location_id(domain, user, location_id):

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -1,0 +1,46 @@
+from django.views.generic.base import View
+
+from mock import MagicMock
+
+from ..permissions import is_location_safe, location_safe
+
+
+@location_safe
+def safe_fn_view(request, domain):
+    return "hello"
+
+
+def unsafe_fn_view(request, domain):
+    return "hello"
+
+
+@location_safe
+class SafeClsView(View):
+    pass
+
+
+class UnsafeClsView(View):
+    pass
+
+
+class UnSafeChildOfSafeClsView(SafeClsView):
+    """This inherits its parent class's safety"""  # TODO change this behavior
+
+
+@location_safe
+class SafeChildofUnsafeClsView(UnsafeClsView):
+    """This shouldn't hoist its safety up to the parent class"""
+
+
+def test_view_safety():
+    def _assert(view_fn, is_safe):
+        assert is_location_safe(view_fn, MagicMock(), (), {}) == is_safe, \
+            f"{view_fn} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
+
+    for view, is_safe in [
+            (safe_fn_view, True),
+            (unsafe_fn_view, False),
+            (SafeClsView, True),
+            (UnsafeClsView, False),
+    ]:
+        yield _assert, view, is_safe

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -40,7 +40,9 @@ def test_view_safety():
     for view, is_safe in [
             (safe_fn_view, True),
             (unsafe_fn_view, False),
-            (SafeClsView, True),
-            (UnsafeClsView, False),
+            (SafeClsView.as_view(), True),
+            (UnsafeClsView.as_view(), False),
+            (UnSafeChildOfSafeClsView.as_view(), True),
+            (SafeChildofUnsafeClsView.as_view(), True),
     ]:
         yield _assert, view, is_safe

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -27,7 +27,7 @@ class UnsafeClsView(View):
 
 
 class UnSafeChildOfSafeClsView(SafeClsView):
-    """This inherits its parent class's safety"""  # TODO change this behavior
+    """This DOES NOT inherit its parent class's safety"""
 
 
 @location_safe
@@ -45,7 +45,7 @@ def test_django_view_safety():
             (unsafe_fn_view, False),
             (SafeClsView.as_view(), True),
             (UnsafeClsView.as_view(), False),
-            (UnSafeChildOfSafeClsView.as_view(), True),
+            (UnSafeChildOfSafeClsView.as_view(), False),
             (SafeChildofUnsafeClsView.as_view(), True),
     ]:
         yield _assert, view, is_safe
@@ -107,7 +107,7 @@ class UnsafeHQReport(BaseReport):
 
 
 class UnsafeChildOfSafeHQReport(SafeHQReport):
-    """Unfortunately this DOES inherit safety from its parent"""  # TODO change this behavior
+    """This DOES NOT inherit safety from its parent"""
     slug = 'unsafe_child_of_safe_hq_report'
 
 
@@ -131,7 +131,7 @@ def test_hq_report_safety():
     for report, request, is_safe in [
             (SafeHQReport, MagicMock(), True),
             (UnsafeHQReport, MagicMock(), False),
-            (UnsafeChildOfSafeHQReport, MagicMock(), True),
+            (UnsafeChildOfSafeHQReport, MagicMock(), False),
             (SafeChildOfUnsafeHQReport, MagicMock(), True),
             (ConditionallySafeHQReport, MagicMock(this_is_safe=True), True),
             (ConditionallySafeHQReport, MagicMock(this_is_safe=False), False),

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -65,6 +65,10 @@ class ConditionallySafeClsView(View):
     pass
 
 
+class UnsafeChildOfConditionallySafeClsView(ConditionallySafeClsView):
+    pass
+
+
 def test_conditionally_safe_django_views():
     safe_request = MagicMock(this_is_safe=True)
     unsafe_request = MagicMock(this_is_safe=False)
@@ -79,6 +83,11 @@ def test_conditionally_safe_django_views():
     ]:
         yield _assert, view, safe_request, True
         yield _assert, view, unsafe_request, False
+
+    # conditionally safe views shouldn't inherit safety
+    view = UnsafeChildOfConditionallySafeClsView.as_view()
+    yield _assert, view, safe_request, False
+    yield _assert, view, unsafe_request, False
 
 
 class ExampleReportDispatcher(ReportDispatcher):

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -107,6 +107,7 @@ class UnsafeHQReport(BaseReport):
 
 
 class UnsafeChildOfSafeHQReport(SafeHQReport):
+    """Unfortunately this DOES inherit safety from its parent"""  # TODO change this behavior
     slug = 'unsafe_child_of_safe_hq_report'
 
 
@@ -130,7 +131,7 @@ def test_hq_report_safety():
     for report, request, is_safe in [
             (SafeHQReport, MagicMock(), True),
             (UnsafeHQReport, MagicMock(), False),
-            (UnsafeChildOfSafeHQReport, MagicMock(), False),
+            (UnsafeChildOfSafeHQReport, MagicMock(), True),
             (SafeChildOfUnsafeHQReport, MagicMock(), True),
             (ConditionallySafeHQReport, MagicMock(this_is_safe=True), True),
             (ConditionallySafeHQReport, MagicMock(this_is_safe=False), False),

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -2,6 +2,9 @@ from django.views.generic.base import View
 
 from mock import MagicMock
 
+from corehq.apps.reports.dispatcher import ReportDispatcher
+from corehq.apps.reports.generic import GenericReportView
+
 from ..permissions import is_location_safe, location_safe
 
 
@@ -32,7 +35,7 @@ class SafeChildofUnsafeClsView(UnsafeClsView):
     """This shouldn't hoist its safety up to the parent class"""
 
 
-def test_view_safety():
+def test_django_view_safety():
     def _assert(view_fn, is_safe):
         assert is_location_safe(view_fn, MagicMock(), (), {}) == is_safe, \
             f"{view_fn} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
@@ -46,3 +49,50 @@ def test_view_safety():
             (SafeChildofUnsafeClsView.as_view(), True),
     ]:
         yield _assert, view, is_safe
+
+
+class ExampleReportDispatcher(ReportDispatcher):
+    @classmethod
+    def get_reports(cls, domain):
+        return [('All Reports', [r for r, is_safe in EXAMPLE_REPORTS])]
+
+
+class BaseReport(GenericReportView):
+    dispatcher = ExampleReportDispatcher
+
+
+@location_safe
+class SafeHQReport(BaseReport):
+    slug = 'safe_hq_report'
+
+
+class UnsafeHQReport(BaseReport):
+    slug = 'unsafe_hq_report'
+
+
+class UnsafeChildOfSafeHQReport(SafeHQReport):
+    slug = 'unsafe_child_of_safe_hq_report'
+
+
+@location_safe
+class SafeChildOfUnsafeHQReport(UnsafeHQReport):
+    slug = 'safe_child_of_unsafe_hq_report'
+
+
+EXAMPLE_REPORTS = [
+    (SafeHQReport, True),
+    (UnsafeHQReport, False),
+    (UnsafeChildOfSafeHQReport, False),
+    (SafeChildOfUnsafeHQReport, True),
+]
+
+
+def test_hq_report_safety():
+    for report, is_safe in EXAMPLE_REPORTS:
+        def _assert(report, is_safe):
+            view_fn = report.dispatcher.as_view()
+            view_kwargs = {'domain': 'foo', 'report_slug': report.slug}
+            assert is_location_safe(view_fn, MagicMock(), (), view_kwargs) == is_safe, \
+                f"{report} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
+
+        yield _assert, report, is_safe

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -68,6 +68,7 @@ class ConditionallySafeClsView(View):
 def test_conditionally_safe_django_views():
     safe_request = MagicMock(this_is_safe=True)
     unsafe_request = MagicMock(this_is_safe=False)
+
     def _assert(view_fn, request, is_safe):
         assert is_location_safe(view_fn, request, (), {}) == is_safe, \
             f"{view_fn} {'IS NOT' if is_safe else 'IS'} marked as location-safe"
@@ -78,7 +79,6 @@ def test_conditionally_safe_django_views():
     ]:
         yield _assert, view, safe_request, True
         yield _assert, view, unsafe_request, False
-
 
 
 class ExampleReportDispatcher(ReportDispatcher):

--- a/corehq/apps/locations/tests/test_location_safety.py
+++ b/corehq/apps/locations/tests/test_location_safety.py
@@ -26,8 +26,8 @@ class UnsafeClsView(View):
     pass
 
 
-class UnSafeChildOfSafeClsView(SafeClsView):
-    """This DOES NOT inherit its parent class's safety"""
+class ImplicitlySafeChildOfSafeClsView(SafeClsView):
+    """This inherits its parent class's safety"""
 
 
 @location_safe
@@ -45,7 +45,7 @@ def test_django_view_safety():
             (unsafe_fn_view, False),
             (SafeClsView.as_view(), True),
             (UnsafeClsView.as_view(), False),
-            (UnSafeChildOfSafeClsView.as_view(), False),
+            (ImplicitlySafeChildOfSafeClsView.as_view(), True),
             (SafeChildofUnsafeClsView.as_view(), True),
     ]:
         yield _assert, view, is_safe
@@ -65,7 +65,7 @@ class ConditionallySafeClsView(View):
     pass
 
 
-class UnsafeChildOfConditionallySafeClsView(ConditionallySafeClsView):
+class ImplicitlySafeChildOfConditionallySafeClsView(ConditionallySafeClsView):
     pass
 
 
@@ -80,14 +80,10 @@ def test_conditionally_safe_django_views():
     for view in [
             conditionally_safe_fn_view,
             ConditionallySafeClsView.as_view(),
+            ImplicitlySafeChildOfConditionallySafeClsView.as_view(),
     ]:
         yield _assert, view, safe_request, True
         yield _assert, view, unsafe_request, False
-
-    # conditionally safe views shouldn't inherit safety
-    view = UnsafeChildOfConditionallySafeClsView.as_view()
-    yield _assert, view, safe_request, False
-    yield _assert, view, unsafe_request, False
 
 
 class ExampleReportDispatcher(ReportDispatcher):
@@ -96,7 +92,7 @@ class ExampleReportDispatcher(ReportDispatcher):
         return [('All Reports', [
             SafeHQReport,
             UnsafeHQReport,
-            UnsafeChildOfSafeHQReport,
+            ImplicitlySafeChildOfSafeHQReport,
             SafeChildOfUnsafeHQReport,
             ConditionallySafeHQReport,
         ])]
@@ -115,9 +111,9 @@ class UnsafeHQReport(BaseReport):
     slug = 'unsafe_hq_report'
 
 
-class UnsafeChildOfSafeHQReport(SafeHQReport):
-    """This DOES NOT inherit safety from its parent"""
-    slug = 'unsafe_child_of_safe_hq_report'
+class ImplicitlySafeChildOfSafeHQReport(SafeHQReport):
+    """This inherits safety from its parent"""
+    slug = 'implicitly_safe_child_of_safe_hq_report'
 
 
 @location_safe
@@ -140,7 +136,7 @@ def test_hq_report_safety():
     for report, request, is_safe in [
             (SafeHQReport, MagicMock(), True),
             (UnsafeHQReport, MagicMock(), False),
-            (UnsafeChildOfSafeHQReport, MagicMock(), False),
+            (ImplicitlySafeChildOfSafeHQReport, MagicMock(), True),
             (SafeChildOfUnsafeHQReport, MagicMock(), True),
             (ConditionallySafeHQReport, MagicMock(this_is_safe=True), True),
             (ConditionallySafeHQReport, MagicMock(this_is_safe=False), False),

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -72,8 +72,9 @@ class ReportDispatcher(View):
         """
         return True
 
-    def get_reports(self, domain):
-        attr_name = self.map_name
+    @classmethod
+    def get_reports(cls, domain):
+        attr_name = cls.map_name
         from corehq import reports
         if domain:
             domain_obj = Domain.get_by_name(domain)
@@ -100,12 +101,13 @@ class ReportDispatcher(View):
 
         return corehq_reports + custom_reports
 
-    def get_report(self, domain, report_slug, *args):
+    @classmethod
+    def get_report(cls, domain, report_slug, *args):
         """
         Returns the report class for `report_slug`, or None if no report is
         found.
         """
-        for name, group in self.get_reports(domain):
+        for name, group in cls.get_reports(domain):
             for report in group:
                 if report.slug == report_slug:
                     return report

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -139,6 +139,7 @@ def _ucr_view_is_safe(view_fn, *args, **kwargs):
                                       domain=kwargs.get('domain'))
 
 
+@conditionally_location_safe(_ucr_view_is_safe)
 class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     section_name = ugettext_noop("Reports")
     template_name = 'userreports/configurable_report.html'
@@ -162,7 +163,6 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
     @use_datatables
     @use_nvd3
     @track_domain_request(calculated_prop='cp_n_viewed_ucr_reports')
-    @conditionally_location_safe(_ucr_view_is_safe)
     def dispatch(self, request, *args, **kwargs):
         if self.should_redirect_to_paywall(request):
             from corehq.apps.userreports.views import paywall_home
@@ -614,6 +614,7 @@ class CustomConfigurableReportDispatcher(ReportDispatcher):
         return url(pattern, cls.as_view(), name=cls.slug)
 
 
+@conditionally_location_safe(_ucr_view_is_safe)
 class DownloadUCRStatusView(BaseDomainView):
     urlname = 'download_ucr_status'
     page_title = ugettext_noop('Download UCR Status')
@@ -641,10 +642,6 @@ class DownloadUCRStatusView(BaseDomainView):
             return render(request, 'hqwebapp/soil_status_full.html', context)
         else:
             raise Http403()
-
-    @conditionally_location_safe(_ucr_view_is_safe)
-    def dispatch(self, *args, **kwargs):
-        return super(DownloadUCRStatusView, self).dispatch(*args, **kwargs)
 
     def page_url(self):
         return reverse(self.urlname, args=self.args, kwargs=self.kwargs)

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -599,9 +599,10 @@ class CustomConfigurableReportDispatcher(ReportDispatcher):
             raise Http404
         return report_class.as_view()(request, domain=domain, subreport_slug=report_config_id, **kwargs)
 
-    def get_report(self, domain, slug, config_id):
+    @classmethod
+    def get_report(cls, domain, slug, config_id):
         try:
-            report_class = self._report_class(domain, config_id)
+            report_class = cls._report_class(domain, config_id)
         except BadSpecError:
             return None
         return report_class.get_report(domain, slug, config_id)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-759

The previous approach worked by updating a global when the report class was first loaded, but that wasn't reliable.  Not all report classes are guaranteed to have been loaded.  The major downside of this new approach is that the safety flag is now inherited.  The same behavior exists for Django CBVs though, so it seems a reasonable tradeoff.

I would be interested to hear alternative ideas to get the best of both worlds, however.  What I really want is a way to identify classes that were directly decorated, not their children (or worse, ancestors!).  One idea I had was rather than setting `is_location_safe` to `True`, set it to the name of the class, then compare that.  Still seems messy, but it might work better.  Any ideas?

This also adds tests, which makes it a lot easier to iterate.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
Holding off on merge at the moment, as I want to audit the existing reports for the inheritance problem (I know at least the CaseListReport has to deal with this).

##### PRODUCT DESCRIPTION
Fixes a bug where the Case List Explorer (and possibly others?)  Would sometimes incorrectly give 403 responses to location-restricted users.
