### PR TITLE
Ce/lxml restore

### DIFF
--- a/corehq/apps/users/fixturegenerators.py
+++ b/corehq/apps/users/fixturegenerators.py
@@ -1,4 +1,4 @@
-from xml.etree import cElementTree as ElementTree
+from lxml import etree as ElementTree
 
 from casexml.apps.phone.fixtures import FixtureProvider
 from casexml.apps.phone.xml import get_data_element

--- a/corehq/ex-submodules/casexml/apps/case/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/fixtures.py
@@ -28,7 +28,7 @@ class CaseDBFixture(object):
                 <date_opened/>
                 <last_modified/>
                 <case_property />
-                <index>corehq/ex-submodules/casexml/apps/case/fixtures.py
+                <index>
                     <a12345 case_type="" relationship="" />
                 </index>
                 <attachment>

--- a/corehq/ex-submodules/casexml/apps/case/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/fixtures.py
@@ -28,7 +28,7 @@ class CaseDBFixture(object):
                 <date_opened/>
                 <last_modified/>
                 <case_property />
-                <index>
+                <index>corehq/ex-submodules/casexml/apps/case/fixtures.py
                     <a12345 case_type="" relationship="" />
                 </index>
                 <attachment>
@@ -44,7 +44,7 @@ class CaseDBFixture(object):
         https://github.com/dimagi/commcare/wiki/fixtures
         """
         element = safe_element("results")
-        element.attrib = {'id': self.id}
+        element.set('id', self.id)
 
         for case in self.cases:
             element.append(get_casedb_element(case))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -259,7 +259,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
         self.assertEqual(len(restore_attachments), len(attaches))
 
         for attach in attaches:
-            url = list(attach.values())[1]
+            url = attach.get('src')
             case_id = url.split('/')[-2]
             attach_key_from_url = url.split('/')[-1]
             tag = attach.tag

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -154,7 +154,7 @@ class Version2CaseParsingTest(TestCase):
         # quick test for ota restore
         v2response = xml.get_case_xml(case, [const.CASE_ACTION_CREATE, const.CASE_ACTION_UPDATE], V2)
         expected_v2_response = """
-        <case case_id="foo-case-id" date_modified="2011-12-07T13:42:50.000000Z" user_id="bar-user-id" xmlns="http://commcarehq.org/case/transaction/v2">
+        <case case_id="foo-case-id" user_id="bar-user-id" date_modified="2011-12-07T13:42:50.000000Z" xmlns="http://commcarehq.org/case/transaction/v2">
                 <create>
                     <case_type>v2_case_type</case_type>
                     <case_name>test case name</case_name>

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -2,7 +2,7 @@ from __future__ import generator_stop
 from collections import defaultdict, namedtuple
 import uuid
 
-from lxml import etree as ElementTree
+from xml.etree import cElementTree as ElementTree
 import datetime
 
 from django.conf import settings

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -2,7 +2,7 @@ from __future__ import generator_stop
 from collections import defaultdict, namedtuple
 import uuid
 
-from xml.etree import cElementTree as ElementTree
+from lxml import etree as ElementTree
 import datetime
 
 from django.conf import settings

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -84,7 +84,7 @@ class CaseXMLGeneratorBase(object):
 
     def get_index_element(self, index):
         elem = safe_element(index.identifier, index.referenced_id)
-        elem.attrib.set("case_type", index.referenced_type)
+        elem.set("case_type", index.referenced_type)
         if getattr(index, 'relationship') and index.relationship == "extension":
             elem.attrib.update({"relationship": index.relationship})
         return elem
@@ -162,7 +162,7 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
             "user_id": self.case.user_id or '',
         })
         if self.case.modified_on:
-            root.attrib.set("date_modified", datetime_to_xml_string(self.case.modified_on))
+            root.set("date_modified", datetime_to_xml_string(self.case.modified_on))
         return root
 
     def get_case_type_element(self):

--- a/corehq/ex-submodules/casexml/apps/phone/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/fixtures.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 
-from xml.etree import cElementTree as ElementTree
 from casexml.apps.phone.models import OTARestoreUser
 from casexml.apps.case.xml import V1, V2
 from django.conf import settings

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -124,7 +124,7 @@ class RestoreContent(object):
             self.num_items += num - 1
             self.response_body.write(xml_element)
         else:
-            self.response_body.write(xml_util.tostring(xml_element))
+            self.response_body.write(ElementTree.tostring(xml_element, encoding='utf-8'))
 
     def extend(self, iterable):
         for element in iterable:

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -55,7 +55,7 @@ class SimpleOtaRestoreTest(TestCase):
 
         def assertRegistrationData(key, val):
             if val is None:
-                template = '<data key="{prefix}_{key}" />'
+                template = '<data key="{prefix}_{key}"/>'
             else:
                 template = '<data key="{prefix}_{key}">{val}</data>'
             self.assertIn(
@@ -177,7 +177,7 @@ class OtaRestoreTest(BaseOtaRestoreTest):
 
         # check v2
         expected_v2_case_block = """
-        <case case_id="asdf" date_modified="2010-06-29T13:42:50.000000Z" user_id="{user_id}" xmlns="http://commcarehq.org/case/transaction/v2" >
+        <case case_id="asdf" user_id="{user_id}" date_modified="2010-06-29T13:42:50.000000Z" xmlns="http://commcarehq.org/case/transaction/v2" >
             <create>
                 <case_type>test_case_type</case_type>
                 <case_name>test case name</case_name>

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -1,6 +1,6 @@
 import logging
 from xml.sax import saxutils
-from xml.etree import cElementTree as ElementTree
+from lxml import etree as ElementTree
 from casexml.apps.case import const
 from casexml.apps.case.xml import check_version, V1
 from casexml.apps.case.xml.generator import get_generator, date_to_xml_string,\
@@ -27,7 +27,7 @@ def tostring(element):
 
 def get_sync_element(restore_id=None):
     elem = safe_element("Sync")
-    elem.attrib = {"xmlns": SYNC_XMLNS}
+    elem.set("xmlns", SYNC_XMLNS)
     if restore_id is not None:
         elem.append(safe_element("restore_id", restore_id))
     return elem
@@ -110,7 +110,7 @@ def get_casedb_element(case):
 
 def get_registration_element(restore_user):
     root = safe_element("Registration")
-    root.attrib = {"xmlns": USER_REGISTRATION_XMLNS}
+    root.set("xmlns", USER_REGISTRATION_XMLNS)
     root.append(safe_element("username", restore_user.username))
     root.append(safe_element("password", restore_user.password))
     root.append(safe_element("uuid", restore_user.user_id))
@@ -122,7 +122,7 @@ def get_registration_element(restore_user):
 # Case registration blocks do not have a password
 def get_registration_element_for_case(case):
     root = safe_element("Registration")
-    root.attrib = {"xmlns": USER_REGISTRATION_XMLNS}
+    root.set("xmlns", USER_REGISTRATION_XMLNS)
     root.append(safe_element("username", case.name))
     root.append(safe_element("password", ""))
     root.append(safe_element("uuid", case.case_id))
@@ -136,7 +136,7 @@ def get_data_element(name, dict):
     # sorted for deterministic unit tests
     for k, v in sorted(dict.items()):
         sub_el = safe_element("data", v)
-        sub_el.attrib = {"key": k}
+        sub_el.set("key", k)
         elem.append(sub_el)
     return elem
 

--- a/corehq/ex-submodules/couchforms/openrosa_response.py
+++ b/corehq/ex-submodules/couchforms/openrosa_response.py
@@ -1,4 +1,4 @@
-from xml.etree import cElementTree as ElementTree
+from lxml import etree as ElementTree
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 import six
@@ -47,10 +47,10 @@ class OpenRosaResponse(object):
 
     def etree(self):
         elem = ElementTree.Element('OpenRosaResponse')
-        elem.attrib = {'xmlns': RESPONSE_XMLNS}
+        elem.set('xmlns', RESPONSE_XMLNS)
         msg_elem = ElementTree.Element('message')
         if self.nature:
-            msg_elem.attrib = {'nature': self.nature}
+            msg_elem.set('nature', self.nature)
         msg_elem.text = six.text_type(self.message)
         elem.append(msg_elem)
         return elem

--- a/corehq/form_processor/abstract_models.py
+++ b/corehq/form_processor/abstract_models.py
@@ -139,7 +139,7 @@ def get_index_map(indices):
 
 class CaseToXMLMixin(object):
     def to_xml(self, version, include_case_on_closed=False):
-        from xml.etree import cElementTree as ElementTree
+        from lxml import etree as ElementTree
         from casexml.apps.phone.xml import get_case_element
         if self.closed:
             if include_case_on_closed:
@@ -293,7 +293,7 @@ class AbstractCommCareCase(CaseToXMLMixin):
         }
 
     def to_xml(self, version, include_case_on_closed=False):
-        from xml.etree import cElementTree as ElementTree
+        from lxml import etree as ElementTree
         from casexml.apps.phone.xml import get_case_element
         if self.closed:
             if include_case_on_closed:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This swaps out python core `ElementTree` for `lxml` in restore case and fixture generators. In my profiling of large restores, nearly half the time was spent converting case nodes to a string (one at a time), this cut the time spent doing that by nearly 90%.

The other changes are due to slight differences in their APIs. In lxml, `attrib` is a property and not assignable.