### PR TITLE
address kewdown glitch fix

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -268,6 +268,7 @@ function AddressEntry(question, options) {
     // geocoder function called when user presses 'x', broadcast a no answer to subscribers.
     self.geocoderOnClearCallback = function () {
         self.rawAnswer(Formplayer.Const.NO_ANSWER);
+        self.question.error(null);
         self.editing = true;
         self.broadcastTopics.forEach(function (broadcastTopic) {
             question.parentPubSub.notifySubscribers(Formplayer.Const.NO_ANSWER, broadcastTopic);
@@ -304,6 +305,7 @@ function AddressEntry(question, options) {
         // On key down, switch to editing mode so we unregister an answer.
         if (!self.editing && self.rawAnswer() !== event.target.value) {
             self.rawAnswer(Formplayer.Const.NO_ANSWER);
+            self.question.error('Please select an address from the options');
             self.editing = true;
         }
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -300,9 +300,9 @@ function AddressEntry(question, options) {
         inputEl.on('keydown', _.debounce(self._inputOnKeyDown, 200));
     };
 
-    self._inputOnKeyDown = function () {
+    self._inputOnKeyDown = function (event) {
         // On key down, switch to editing mode so we unregister an answer.
-        if (!self.editing) {
+        if (!self.editing && self.rawAnswer() !== event.target.value) {
             self.rawAnswer(Formplayer.Const.NO_ANSWER);
             self.editing = true;
         }


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For the address question, we want to prevent users from modifying the input element after they've selected an address from the dropdown because we only register an official answer from the geocoding api. We do this by switching back to editing mode on a keypress, and also clearing the answer. However, it also clears the answer when we press a key that doesn't change the text, e.g. a directional arrow. 

This fix makes sure that the input element text actually changed from the answer before clearing the answer. 

