### PR TITLE
Pull Bounced email info from SNS endpoint (rather than commcarehq-bounces email)

### DIFF
--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -67,6 +67,10 @@ def send_mail_async(self, subject, message, from_email, recipient_list, messagin
         return
 
     headers = {}
+
+    if settings.RETURN_PATH_EMAIL:
+        headers['Return-Path'] = settings.RETURN_PATH_EMAIL
+
     if messaging_event_id is not None:
         headers[COMMCARE_MESSAGE_ID_HEADER] = messaging_event_id
     if settings.SES_CONFIGURATION_SET is not None:

--- a/corehq/apps/hqwebapp/tasks.py
+++ b/corehq/apps/hqwebapp/tasks.py
@@ -183,7 +183,6 @@ def process_bounced_emails():
             with BouncedEmailManager(
                 delete_processed_messages=True
             ) as bounced_manager, metrics_track_errors('process_bounced_emails_task'):
-                bounced_manager.process_aws_notifications()
                 bounced_manager.process_daemon_messages()
         except Exception as e:
             notify_exception(

--- a/corehq/apps/sms/event_handlers.py
+++ b/corehq/apps/sms/event_handlers.py
@@ -1,0 +1,34 @@
+from corehq.apps.sms.models import MessagingSubEvent, MessagingEvent
+
+
+def handle_email_messaging_subevent(message, subevent_id):
+    try:
+        subevent = MessagingSubEvent.objects.get(id=subevent_id)
+    except MessagingSubEvent.DoesNotExist:
+        return
+
+    event_type = message.get('eventType')
+    if event_type == 'Bounce':
+        additional_error_text = ''
+
+        bounce_type = message.get('bounce', {}).get('bounceType')
+        if bounce_type:
+            additional_error_text = f"{bounce_type}."
+        bounced_recipients = message.get('bounce', {}).get('bouncedRecipients',
+                                                           [])
+        recipient_addresses = []
+        for bounced_recipient in bounced_recipients:
+            recipient_addresses.append(bounced_recipient.get('emailAddress'))
+        if recipient_addresses:
+            additional_error_text = f"{additional_error_text} - {', '.join(recipient_addresses)}"
+
+        subevent.error(MessagingEvent.ERROR_EMAIL_BOUNCED,
+                       additional_error_text=additional_error_text)
+    elif event_type == 'Send':
+        subevent.status = MessagingEvent.STATUS_EMAIL_SENT
+    elif event_type == 'Delivery':
+        subevent.status = MessagingEvent.STATUS_EMAIL_DELIVERED
+        subevent.additional_error_text = message.get('delivery', {}).get(
+            'timestamp')
+
+    subevent.save()

--- a/corehq/util/email_event_utils.py
+++ b/corehq/util/email_event_utils.py
@@ -1,0 +1,126 @@
+from django.utils.dateparse import parse_datetime
+
+from corehq.util.metrics import metrics_counter
+from corehq.util.models import (
+    NotificationType,
+    AwsMeta,
+    BounceType,
+    BouncedEmail,
+    PermanentBounceMeta,
+    ComplaintBounceMeta,
+    TransientBounceEmail,
+)
+
+
+def handle_email_sns_event(message):
+    """
+    This expects message to be the "Message" portion of an AWS SNS Notification as
+    sent by Amazon SNS, as described here:
+    https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-retrieving-sns-examples.html
+    :param message:
+    :return:
+    """
+    for aws_meta in get_relevant_aws_meta(message):
+        if aws_meta.notification_type == NotificationType.BOUNCE:
+            if aws_meta.main_type == BounceType.PERMANENT:
+                record_permanent_bounce(aws_meta)
+                metrics_counter('commcare.email_sns_event.permanent_bounce_recorded')
+            elif aws_meta.main_type == BounceType.TRANSIENT:
+                record_transient_bounce(aws_meta)
+                metrics_counter('commcare.email_sns_event.transient_bounce_recorded')
+            elif aws_meta.main_type == BounceType.UNDETERMINED:
+                record_permanent_bounce(aws_meta)
+                metrics_counter('commcare.email_sns_event.undetermined_bounce_received')
+        elif aws_meta.notification_type == NotificationType.COMPLAINT:
+            record_complaint(aws_meta)
+            metrics_counter('commcare.email_sns_event.complaint_recorded')
+
+
+def record_permanent_bounce(aws_meta):
+    bounced_email, _ = BouncedEmail.objects.update_or_create(
+        email=aws_meta.email,
+    )
+    exists = PermanentBounceMeta.objects.filter(
+        bounced_email=bounced_email,
+        timestamp=aws_meta.timestamp,
+        sub_type=aws_meta.sub_type,
+    ).exists()
+    if not exists:
+        PermanentBounceMeta.objects.create(
+            bounced_email=bounced_email,
+            timestamp=aws_meta.timestamp,
+            sub_type=aws_meta.sub_type,
+            headers=aws_meta.headers,
+            reason=aws_meta.reason,
+            destination=aws_meta.destination,
+        )
+
+
+def record_complaint(aws_meta):
+    bounced_email, _ = BouncedEmail.objects.update_or_create(
+        email=aws_meta.email,
+    )
+    exists = ComplaintBounceMeta.objects.filter(
+        bounced_email=bounced_email,
+        timestamp=aws_meta.timestamp,
+    ).exists()
+    if not exists:
+        ComplaintBounceMeta.objects.create(
+            bounced_email=bounced_email,
+            timestamp=aws_meta.timestamp,
+            headers=aws_meta.headers,
+            feedback_type=aws_meta.main_type,
+            sub_type=aws_meta.sub_type,
+            destination=aws_meta.destination,
+        )
+
+
+def record_transient_bounce(aws_meta):
+    exists = TransientBounceEmail.objects.filter(
+        email=aws_meta.email,
+        timestamp=aws_meta.timestamp,
+    ).exists()
+    if not exists:
+        TransientBounceEmail.objects.create(
+            email=aws_meta.email,
+            timestamp=aws_meta.timestamp,
+            headers=aws_meta.headers,
+        )
+
+
+def get_relevant_aws_meta(message_info):
+    """
+    Creates a list of AwsMeta objects from the Message portion of an AWS
+    SNS Notification message.
+    :param message_info: (dict) the "Message" portion of an SNS notification
+    :return: (list) AwsMeta objects
+    """
+    aws_info = []
+    mail_info = message_info.get('mail', {})
+    if message_info['notificationType'] == NotificationType.BOUNCE:
+        bounce_info = message_info['bounce']
+        for recipient in bounce_info['bouncedRecipients']:
+            aws_info.append(AwsMeta(
+                notification_type=message_info['notificationType'],
+                main_type=bounce_info['bounceType'],
+                sub_type=bounce_info['bounceSubType'],
+                timestamp=parse_datetime(bounce_info['timestamp']),
+                email=recipient['emailAddress'],
+                reason=recipient.get('diagnosticCode'),
+                headers=mail_info.get('commonHeaders', {}),
+                destination=mail_info.get('destination', []),
+            ))
+    elif message_info['notificationType'] == NotificationType.COMPLAINT:
+        complaint_info = message_info['complaint']
+        for recipient in complaint_info['complainedRecipients']:
+            aws_info.append(AwsMeta(
+                notification_type=message_info['notificationType'],
+                main_type=message_info.get('complaintFeedbackType'),
+                sub_type=complaint_info.get('complaintSubType'),
+                timestamp=parse_datetime(complaint_info['timestamp']),
+                email=recipient['emailAddress'],
+                reason=None,
+                headers=mail_info.get('commonHeaders', {}),
+                destination=mail_info.get('destination', []),
+            ))
+    return aws_info

--- a/corehq/util/management/commands/process_bounced_emails.py
+++ b/corehq/util/management/commands/process_bounced_emails.py
@@ -14,6 +14,12 @@ class Command(BaseCommand):
             default=False,
             help='Move processed messages to trash.',
         )
+        parser.add_argument(
+            '--process-aws',
+            action='store_true',
+            default=False,
+            help='Process only AWS notifications.',
+        )
 
     def _print_processed_emails(self, emails):
         for email in emails:
@@ -35,17 +41,19 @@ class Command(BaseCommand):
 
         try:
             delete_messages = options['delete_messages']
+            process_aws = options['process_aws']
             self.stdout.write(
                 '\n\nLogging into account for {}\n'.format(settings.RETURN_PATH_EMAIL)
             )
             with BouncedEmailManager(
                 delete_processed_messages=delete_messages
             ) as bounced_manager:
-                self.stdout.write('\n\nProcessing AWS Notifications\n')
-                bounced_manager.process_aws_notifications()
-
-                self.stdout.write('\n\nProcessing Mailer Daemon Emails\n')
-                bounced_manager.process_daemon_messages()
+                if process_aws:
+                    self.stdout.write('\n\nProcessing AWS Notifications\n')
+                    bounced_manager.process_aws_notifications()
+                else:
+                    self.stdout.write('\n\nProcessing Mailer Daemon Emails\n')
+                    bounced_manager.process_daemon_messages()
 
             self.stdout.write('\nDone\n\n')
         except OSError:

--- a/corehq/util/models.py
+++ b/corehq/util/models.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.contrib.postgres.fields import ArrayField, JSONField
 from django.db import models
 from collections import namedtuple
@@ -36,21 +38,61 @@ class BounceSubType(object):
     )
 
 
-# The number of General bounces we accept before rejecting an email hard
-GENERAL_BOUNCE_THRESHOLD = 3
+# The number of non supressed or undetermined bounces
+# we accept before hard rejecting an email
+BOUNCE_EVENT_THRESHOLD = 3
+
+HOURS_UNTIL_TRANSIENT_BOUNCES_EXPIRE = 24
+
+# Prior to this date we do not have reliable SNS metadata for emails.
+# In order to get rid of this, we'll want to slowly roll the date back and
+# let the emails re-bounce while keeping an eye on the bounce rate. Once we're
+# confident the rate is stable, continue rolling back until Jan 1st 2020 and then
+# this date requirement can be removed. The slow rollback is to avoid having a sudden
+# jump in email bounces from the initial bounces we had cut off in the beginning.
+LEGACY_BOUNCE_MANAGER_DATE = datetime.datetime(2020, 2, 10)
 
 
 class BouncedEmail(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     email = models.EmailField(db_index=True, unique=True)
 
-    @staticmethod
-    def get_hard_bounced_emails(list_of_emails):
+    @classmethod
+    def is_email_over_limits(cls, email):
+        """
+        Determines if an email has passed bounce event limits for general
+        and transient bounces
+        :param email: string
+        :return: boolean
+        """
+        transient_bounce_query = TransientBounceEmail.get_active_query().filter(
+            email=email,
+        )
+        general_bounce_query = PermanentBounceMeta.objects.filter(
+            bounced_email__email=email,
+            sub_type=BounceSubType.GENERAL,
+        )
+        return (
+            transient_bounce_query.count() + general_bounce_query.count() > BOUNCE_EVENT_THRESHOLD
+        )
+
+    @classmethod
+    def get_hard_bounced_emails(cls, list_of_emails):
         # these are any Bounced Email Records we have
         bounced_emails = set(
             BouncedEmail.objects.filter(email__in=list_of_emails).values_list(
-                'email', flat=True)
+                'email', flat=True
+            )
         )
+
+        transient_emails = set(
+            TransientBounceEmail.get_active_query().filter(
+                email__in=list_of_emails,
+            ).values_list(
+                'email', flat=True
+            )
+        )
+        bounced_emails.update(transient_emails)
 
         # These are emails that were marked as Suppressed or Undetermined
         # by SNS metadata, meaining they definitely hard bounced
@@ -69,20 +111,19 @@ class BouncedEmail(models.Model):
         )
         bad_emails.update(complaints)
 
+        # see note surrounding LEGACY_BOUNCE_MANAGER_DATE above
+        legacy_bounced_emails = set(
+            BouncedEmail.objects.filter(
+                email__in=list_of_emails,
+                created__lte=LEGACY_BOUNCE_MANAGER_DATE,
+            ).values_list(
+                'email', flat=True
+            )
+        )
+        bad_emails.update(legacy_bounced_emails)
+
         for remaining_email in bounced_emails.difference(bad_emails):
-            meta_query = PermanentBounceMeta.objects.filter(
-                bounced_email__email=remaining_email)
-            if not meta_query.exists():
-                # check to see if this is Transiently bouncing
-                transient_bounce_query = TransientBounceEmail.objects.filter(
-                    email=remaining_email
-                )
-                if not transient_bounce_query.exists():
-                    # There is no metadata at all for this email, so we assume
-                    # a hard bounce
-                    bad_emails.add(remaining_email)
-            elif meta_query.count() > GENERAL_BOUNCE_THRESHOLD:
-                # This email has too many general bounces recorded against it
+            if cls.is_email_over_limits(remaining_email):
                 bad_emails.add(remaining_email)
 
         return bad_emails
@@ -93,6 +134,25 @@ class TransientBounceEmail(models.Model):
     email = models.EmailField(db_index=True)
     timestamp = models.DateTimeField(db_index=True)
     headers = JSONField(blank=True, null=True)
+
+    @classmethod
+    def get_expired_query(cls):
+        return cls.objects.filter(
+            created__lt=datetime.datetime.utcnow() - datetime.timedelta(
+                hours=HOURS_UNTIL_TRANSIENT_BOUNCES_EXPIRE + 1
+            )
+        )
+
+    @classmethod
+    def delete_expired_bounces(cls):
+        cls.get_expired_query().delete()
+
+    @classmethod
+    def get_active_query(cls):
+        return cls.objects.filter(
+            created__gte=datetime.datetime.utcnow() - datetime.timedelta(
+                hours=HOURS_UNTIL_TRANSIENT_BOUNCES_EXPIRE)
+        )
 
 
 class PermanentBounceMeta(models.Model):

--- a/corehq/util/tests/data/email/scheduled_complaint.json
+++ b/corehq/util/tests/data/email/scheduled_complaint.json
@@ -1,0 +1,93 @@
+{
+    "notificationType": "Complaint",
+    "complaint": {
+        "complaintSubType": null,
+        "complainedRecipients": [
+            {
+                "emailAddress": "alicedoe@univeristy.edu"
+            },
+            {
+                "emailAddress": "janedoe@company.com"
+            }
+        ],
+        "timestamp": "2020-07-16T03:16:55.129Z",
+        "feedbackId": "redacted",
+        "userAgent": "Yahoo!-Mail-Feedback/2.0",
+        "complaintFeedbackType": "abuse",
+        "arrivalDate": "2020-07-16T03:02:25.000Z"
+    },
+    "mail": {
+        "timestamp": "2020-07-16T03:02:22.000Z",
+        "source": "noreplyemail@company.com",
+        "sourceArn": "arn:aws:ses:us-east-1:redacted:identity/noreplyemail@company.com",
+        "sourceIp": "35.175.35.59",
+        "sendingAccountId": "redacted",
+        "messageId": "redacted",
+        "destination": [
+            "alicedoe@univeristy.edu",
+            "janedoe@company.com"
+        ],
+        "headersTruncated": false,
+        "headers": [
+            {
+                "name": "Received",
+                "value": "from server-name (ec2-fake.compute-1.amazonaws.com [redacted]) by email-smtp.amazonaws.com with SMTP (SimpleEmailService-d-redacted) id redacted; Thu, 16 Jul 2020 03:02:22 +0000 (UTC)"
+            },
+            {
+                "name": "Content-Type",
+                "value": "multipart/alternative; boundary=\"===============2410380162893072365==\""
+            },
+            {
+                "name": "MIME-Version",
+                "value": "1.0"
+            },
+            {
+                "name": "Subject",
+                "value": "Invitation from Alice Doe to join CommCareHQ"
+            },
+            {
+                "name": "From",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "To",
+                "value": "alicedoe@univeristy.edu"
+            },
+            {
+                "name": "Cc",
+                "value": "janedoe@company.com"
+            },
+            {
+                "name": "Date",
+                "value": "Thu, 16 Jul 2020 03:02:22 -0000"
+            },
+            {
+                "name": "Message-ID",
+                "value": "<redacted@server-name>"
+            },
+            {
+                "name": "Return-Path",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "X-SES-CONFIGURATION-SET",
+                "value": "fake-email-events"
+            }
+        ],
+        "commonHeaders": {
+            "returnPath": "noreplyemail@company.com",
+            "from": [
+                "noreplyemail@company.com"
+            ],
+            "date": "Thu, 16 Jul 2020 03:02:22 -0000",
+            "to": [
+                "alicedoe@univeristy.edu"
+            ],
+            "cc": [
+                "janedoe@company.com"
+            ],
+            "messageId": "<redacted@server-name>",
+            "subject": "Invitation from Alice Doe to join CommCareHQ"
+        }
+    }
+}

--- a/corehq/util/tests/data/email/scheduled_general_bounce.json
+++ b/corehq/util/tests/data/email/scheduled_general_bounce.json
@@ -1,0 +1,93 @@
+{
+    "notificationType": "Bounce",
+    "bounce": {
+        "bounceType": "Permanent",
+        "bounceSubType": "General",
+        "bouncedRecipients": [
+            {
+                "emailAddress": "permanent_general_bounce@company.org",
+                "action": "failed",
+                "status": "5.4.1",
+                "diagnosticCode": "smtp; 550 5.4.1 Recipient address rejected: Access denied. AS(redacted) [redacted.outlook.com]"
+            }
+        ],
+        "timestamp": "2020-07-31T20:09:56.637Z",
+        "feedbackId": "<redacted>",
+        "remoteMtaIp": "255.255.255.255",
+        "reportingMTA": "dsn; test.smtp-out.amazonses.com"
+    },
+    "mail": {
+        "timestamp": "2020-07-31T20:09:55.000Z",
+        "source": "noreplyemail@company.com",
+        "sourceArn": "arn:aws:ses:<redacted>:identity/noreplyemail@company.com",
+        "sourceIp": "255.255.255.255",
+        "sendingAccountId": "<redacted>",
+        "messageId": "<redacted>",
+        "destination": [
+            "permanent_general_bounce@company.org",
+            "johnDoe@university.edu"
+        ],
+        "headersTruncated": false,
+        "headers": [
+            {
+                "name": "Received",
+                "value": "from server-name (ec2-fake.compute-1.amazonaws.com [redacted]) by email-smtp.amazonaws.com with SMTP (SimpleEmailService-d-redacted) id redacted; Fri, 31 Jul 2020 20:09:55 +0000 (UTC)"
+            },
+            {
+                "name": "Content-Type",
+                "value": "multipart/alternative; boundary=\"===============0743801462091346307==\""
+            },
+            {
+                "name": "MIME-Version",
+                "value": "1.0"
+            },
+            {
+                "name": "Subject",
+                "value": "Invitation from John Doe to join CommCareHQ"
+            },
+            {
+                "name": "From",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "To",
+                "value": "permanent_general_bounce@company.org"
+            },
+            {
+                "name": "Cc",
+                "value": "johnDoe@university.edu"
+            },
+            {
+                "name": "Date",
+                "value": "Fri, 31 Jul 2020 20:09:55 -0000"
+            },
+            {
+                "name": "Message-ID",
+                "value": "<redacted@server-name>"
+            },
+            {
+                "name": "Return-Path",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "X-SES-CONFIGURATION-SET",
+                "value": "fake-email-events"
+            }
+        ],
+        "commonHeaders": {
+            "returnPath": "noreplyemail@company.com",
+            "from": [
+                "noreplyemail@company.com"
+            ],
+            "date": "Fri, 31 Jul 2020 20:09:55 -0000",
+            "to": [
+                "permanent_general_bounce@company.org"
+            ],
+            "cc": [
+                "johnDoe@university.edu"
+            ],
+            "messageId": "<redacted@server-name>",
+            "subject": "Invitation from John Doe to join CommCareHQ"
+        }
+    }
+}

--- a/corehq/util/tests/data/email/scheduled_suppressed_bounce.json
+++ b/corehq/util/tests/data/email/scheduled_suppressed_bounce.json
@@ -1,0 +1,92 @@
+{
+    "notificationType": "Bounce",
+    "bounce": {
+        "bounceType": "Permanent",
+        "bounceSubType": "Suppressed",
+        "bouncedRecipients": [
+            {
+                "emailAddress": "permanent.suppressed@company.org",
+                "action": "failed",
+                "status": "5.1.1",
+                "diagnosticCode": "Amazon SES has suppressed sending to this address because it has a recent history of bouncing as an invalid address. For more information about how to remove an address from the suppression list, see the Amazon SES Developer Guide: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/remove-from-suppressionlist.html "
+            }
+        ],
+        "timestamp": "2020-07-28T00:28:28.622Z",
+        "feedbackId": "redacted",
+        "reportingMTA": "dns; amazonses.com"
+    },
+    "mail": {
+        "timestamp": "2020-07-28T00:28:28.000Z",
+        "source": "noreplyemail@company.com",
+        "sourceArn": "arn:aws:ses:redacted:identity/noreplyemail@company.com",
+        "sourceIp": "255.255.255.255",
+        "sendingAccountId": "redacted",
+        "messageId": "redacted",
+        "destination": [
+            "permanent.suppressed@company.org",
+            "john.doe@agency.gov"
+        ],
+        "headersTruncated": false,
+        "headers": [
+            {
+                "name": "Received",
+                "value": "from server-name (ec2-redacted.compute-1.amazonaws.com [redacted]) by email-smtp.amazonaws.com with SMTP (SimpleEmailService-d-redacted) id redacted; Tue, 28 Jul 2020 00:28:28 +0000 (UTC)"
+            },
+            {
+                "name": "Content-Type",
+                "value": "multipart/alternative; boundary=\"===============7698755700248601042==\""
+            },
+            {
+                "name": "MIME-Version",
+                "value": "1.0"
+            },
+            {
+                "name": "Subject",
+                "value": "Invitation from John Doe to join CommCareHQ"
+            },
+            {
+                "name": "From",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "To",
+                "value": "permanent.suppressed@company.org"
+            },
+            {
+                "name": "Cc",
+                "value": "john.doe@agency.gov"
+            },
+            {
+                "name": "Date",
+                "value": "Tue, 28 Jul 2020 00:28:28 -0000"
+            },
+            {
+                "name": "Message-ID",
+                "value": "<redacted@server-name>"
+            },
+            {
+                "name": "Return-Path",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "X-SES-CONFIGURATION-SET",
+                "value": "fake-email-events"
+            }
+        ],
+        "commonHeaders": {
+            "returnPath": "noreplyemail@company.com",
+            "from": [
+                "noreplyemail@company.com"
+            ],
+            "date": "Tue, 28 Jul 2020 00:28:28 -0000",
+            "to": [
+                "permanent.suppressed@company.org"
+            ],
+            "cc": [
+                "john.doe@agency.gov"
+            ],
+            "messageId": "<redacted@server-name>",
+            "subject": "Invitation from John Doe to join CommCareHQ"
+        }
+    }
+}

--- a/corehq/util/tests/data/email/scheduled_transient_bounce.json
+++ b/corehq/util/tests/data/email/scheduled_transient_bounce.json
@@ -1,0 +1,84 @@
+{
+    "notificationType": "Bounce",
+    "bounce": {
+        "bounceType": "Transient",
+        "bounceSubType": "General",
+        "bouncedRecipients": [
+            {
+                "emailAddress": "transientEmail@company.org",
+                "action": "failed",
+                "status": "4.4.7",
+                "diagnosticCode": "smtp; 554 4.4.7 Message expired: unable to deliver in 840 minutes.<421 4.4.0 Unable to lookup DNS for company.org>"
+            }
+        ],
+        "timestamp": "2020-07-31T21:08:57.723Z",
+        "feedbackId": "<redacted>",
+        "reportingMTA": "dsn; test.smtp-out.amazonses.com"
+    },
+    "mail": {
+        "timestamp": "2020-07-31T06:01:50.000Z",
+        "source": "noreplyemail@company.com",
+        "sourceArn": "arn:aws:ses:<redacted>:identity/noreplyemail@company.com",
+        "sourceIp": "255.255.255.255",
+        "sendingAccountId": "<redacted>",
+        "messageId": "<redacted>",
+        "destination": [
+            "transientEmail@company.org"
+        ],
+        "headersTruncated": false,
+        "headers": [
+            {
+                "name": "Received",
+                "value": "from server-name (ec2-fake.compute-1.amazonaws.com [redacted]) by email-smtp.amazonaws.com with SMTP (SimpleEmailService-d-redacted) id redacted for transientEmail@company.org; Fri, 31 Jul 2020 06:01:50 +0000 (UTC)"
+            },
+            {
+                "name": "Content-Type",
+                "value": "multipart/mixed; boundary=\"===============2714251937794784700==\""
+            },
+            {
+                "name": "MIME-Version",
+                "value": "1.0"
+            },
+            {
+                "name": "Subject",
+                "value": "Scheduled report from CommCare HQ"
+            },
+            {
+                "name": "From",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "To",
+                "value": "transientEmail@company.org"
+            },
+            {
+                "name": "Date",
+                "value": "Fri, 31 Jul 2020 06:01:50 -0000"
+            },
+            {
+                "name": "Message-ID",
+                "value": "<redacted@server-name>"
+            },
+            {
+                "name": "Return-Path",
+                "value": "noreplyemail@company.com"
+            },
+            {
+                "name": "X-SES-CONFIGURATION-SET",
+                "value": "fake-email-events"
+            }
+        ],
+        "commonHeaders": {
+            "returnPath": "noreplyemail@company.com",
+            "from": [
+                "noreplyemail@company.com"
+            ],
+            "date": "Fri, 31 Jul 2020 06:01:50 -0000",
+            "to": [
+                "transientEmail@company.org"
+            ],
+            "messageId": "<redacted>",
+            "subject": "Scheduled report from CommCare HQ"
+        }
+    }
+}

--- a/corehq/util/tests/test_bounced_emails.py
+++ b/corehq/util/tests/test_bounced_emails.py
@@ -6,8 +6,10 @@ from corehq.util.models import (
     BouncedEmail,
     PermanentBounceMeta,
     BounceSubType,
-    GENERAL_BOUNCE_THRESHOLD,
+    BOUNCE_EVENT_THRESHOLD,
     ComplaintBounceMeta,
+    TransientBounceEmail,
+    LEGACY_BOUNCE_MANAGER_DATE,
 )
 
 
@@ -17,8 +19,11 @@ class TestBouncedEmails(TestCase):
     GENERAL_BOUNCE = 'general_bounce@gmail.com'
     GENERAL_AT_TRESH = 'general_bounce_stillok@gmail.com'
     GENERAL_ABOVE_THRESH = 'general_bounce_bad@gmail.com'
+    TRANSIENT_AT_THRESH = 'transient_bounce_stillok@gmail.com'
+    EXPIRED_TRANSIENT_AT_THRESH = 'expired_transient@gmail.com'
+    TRANSIENT_ABOVE_THRESH = 'transient_bounce_bad@gmail.com'
     COMPLAINT = 'complaint@gmail.com'
-    NO_META_BOUNCE = 'no_meta@gmail.com'
+    LEGACY_BOUNCE = 'legacy_bounce@gmail.com'
 
     @staticmethod
     def _create_permanent_meta(email_address, sub_type, num_records=1):
@@ -26,9 +31,20 @@ class TestBouncedEmails(TestCase):
         for rec_num in range(0, num_records):
             PermanentBounceMeta.objects.create(
                 bounced_email=bounced_email,
-                timestamp=datetime.datetime.now(),
+                timestamp=datetime.datetime.utcnow(),
                 sub_type=sub_type,
             )
+
+    @staticmethod
+    def _create_transient_meta(email_address, num_records=1, timestamp=None):
+        for rec_num in range(0, num_records):
+            transient_bounce = TransientBounceEmail.objects.create(
+                email=email_address,
+                timestamp=timestamp or datetime.datetime.utcnow(),
+            )
+            if timestamp:
+                transient_bounce.created = timestamp
+                transient_bounce.save()
 
     def setUp(self):
         super().setUp()
@@ -47,14 +63,32 @@ class TestBouncedEmails(TestCase):
         self._create_permanent_meta(
             self.GENERAL_AT_TRESH,
             BounceSubType.GENERAL,
-            GENERAL_BOUNCE_THRESHOLD,
+            BOUNCE_EVENT_THRESHOLD,
         )
         self._create_permanent_meta(
             self.GENERAL_ABOVE_THRESH,
             BounceSubType.GENERAL,
-            GENERAL_BOUNCE_THRESHOLD + 1,
+            BOUNCE_EVENT_THRESHOLD + 1,
         )
-        BouncedEmail.objects.create(email=self.NO_META_BOUNCE)
+        self._create_transient_meta(
+            self.TRANSIENT_AT_THRESH,
+            BOUNCE_EVENT_THRESHOLD,
+        )
+        self._create_transient_meta(
+            self.TRANSIENT_ABOVE_THRESH,
+            BOUNCE_EVENT_THRESHOLD + 1,
+        )
+        self._create_transient_meta(
+            self.EXPIRED_TRANSIENT_AT_THRESH,
+            BOUNCE_EVENT_THRESHOLD + 1,
+            timestamp=datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        )
+        legacy_email = BouncedEmail.objects.create(
+            email=self.LEGACY_BOUNCE,
+            created=LEGACY_BOUNCE_MANAGER_DATE - datetime.timedelta(days=1)
+        )
+        legacy_email.created = LEGACY_BOUNCE_MANAGER_DATE - datetime.timedelta(days=1)
+        legacy_email.save()
         complaint_email = BouncedEmail.objects.create(email=self.COMPLAINT)
         ComplaintBounceMeta.objects.create(
             bounced_email=complaint_email,
@@ -64,6 +98,7 @@ class TestBouncedEmails(TestCase):
     def tearDown(self):
         ComplaintBounceMeta.objects.all().delete()
         PermanentBounceMeta.objects.all().delete()
+        TransientBounceEmail.objects.all().delete()
         BouncedEmail.objects.all().delete()
         super().tearDown()
 
@@ -75,18 +110,34 @@ class TestBouncedEmails(TestCase):
             self.GENERAL_BOUNCE,
             self.GENERAL_AT_TRESH,
             self.GENERAL_ABOVE_THRESH,
+            self.TRANSIENT_AT_THRESH,
+            self.TRANSIENT_ABOVE_THRESH,
+            self.EXPIRED_TRANSIENT_AT_THRESH,
             self.COMPLAINT,
-            self.NO_META_BOUNCE,
+            self.LEGACY_BOUNCE,
         ]
 
         bounced_emails = BouncedEmail.get_hard_bounced_emails(recipients)
+        print(bounced_emails)
         self.assertEqual(
             bounced_emails,
             {
                 self.SUPPRESSED_BOUNCE,
                 self.UNDETERMINED_BOUNCE,
                 self.GENERAL_ABOVE_THRESH,
+                self.TRANSIENT_ABOVE_THRESH,
                 self.COMPLAINT,
-                self.NO_META_BOUNCE,
+                self.LEGACY_BOUNCE,
             }
+        )
+
+    def test_expired_transient_cleanup(self):
+        self.assertEqual(
+            TransientBounceEmail.get_expired_query().count(),
+            BOUNCE_EVENT_THRESHOLD + 1
+        )
+        TransientBounceEmail.delete_expired_bounces()
+        self.assertEqual(
+            TransientBounceEmail.get_expired_query().count(),
+            0
         )

--- a/corehq/util/tests/test_email_event_utils.py
+++ b/corehq/util/tests/test_email_event_utils.py
@@ -1,0 +1,219 @@
+import json
+import os
+import datetime
+
+from django.test import TestCase
+
+from corehq.util.email_event_utils import get_relevant_aws_meta, \
+    handle_email_sns_event
+from corehq.util.models import (
+    ComplaintBounceMeta,
+    PermanentBounceMeta,
+    BouncedEmail,
+    TransientBounceEmail,
+    AwsMeta,
+    BounceSubType,
+)
+from corehq.util.test_utils import TestFileMixin
+
+
+class TestBouncedEmailManager(TestCase, TestFileMixin):
+    file_path = ('data', 'email')
+    root = os.path.dirname(__file__)
+
+    def tearDown(self):
+        ComplaintBounceMeta.objects.all().delete()
+        PermanentBounceMeta.objects.all().delete()
+        TransientBounceEmail.objects.all().delete()
+        BouncedEmail.objects.all().delete()
+        super().tearDown()
+
+    def _get_message(self, filename):
+        bounce_file = self.get_path(filename, 'json')
+        with open(bounce_file, "r") as f:
+            bounce_message = json.loads(f.read())
+        return bounce_message
+
+    def test_scheduled_complaint(self):
+        complaint_message = self._get_message('scheduled_complaint')
+        self.assertEqual(
+            get_relevant_aws_meta(complaint_message),
+            [
+                AwsMeta(
+                    notification_type='Complaint',
+                    main_type=None,
+                    sub_type=None,
+                    email='alicedoe@univeristy.edu',
+                    reason=None,
+                    headers={
+                        'returnPath': 'noreplyemail@company.com',
+                        'from': ['noreplyemail@company.com'],
+                        'date': 'Thu, 16 Jul 2020 03:02:22 -0000',
+                        'to': ['alicedoe@univeristy.edu'],
+                        'cc': ['janedoe@company.com'],
+                        'messageId': '<redacted@server-name>',
+                        'subject': 'Invitation from Alice Doe to join CommCareHQ'
+                    },
+                    timestamp=datetime.datetime(2020, 7, 16, 3, 16, 55, 129000,
+                                                tzinfo=datetime.timezone.utc),
+                    destination=[
+                        'alicedoe@univeristy.edu',
+                        'janedoe@company.com'
+                    ]
+                ),
+                AwsMeta(
+                    notification_type='Complaint',
+                    main_type=None,
+                    sub_type=None,
+                    email='janedoe@company.com',
+                    reason=None,
+                    headers={
+                        'returnPath': 'noreplyemail@company.com',
+                        'from': ['noreplyemail@company.com'],
+                        'date': 'Thu, 16 Jul 2020 03:02:22 -0000',
+                        'to': ['alicedoe@univeristy.edu'],
+                        'cc': ['janedoe@company.com'],
+                        'messageId': '<redacted@server-name>',
+                        'subject': 'Invitation from Alice Doe to join CommCareHQ'
+                    },
+                    timestamp=datetime.datetime(2020, 7, 16, 3, 16, 55, 129000,
+                                                tzinfo=datetime.timezone.utc),
+                    destination=[
+                        'alicedoe@univeristy.edu',
+                        'janedoe@company.com'
+                    ]
+                ),
+            ]
+        )
+        handle_email_sns_event(complaint_message)
+
+        first_bounced_email = BouncedEmail.objects.filter(email='alicedoe@univeristy.edu')
+        second_bounced_email = BouncedEmail.objects.filter(email='janedoe@company.com')
+        self.assertTrue(first_bounced_email.exists())
+        self.assertTrue(second_bounced_email.exists())
+
+        self.assertTrue(
+            ComplaintBounceMeta.objects.filter(
+                bounced_email=first_bounced_email.first()
+            ).exists()
+        )
+        self.assertTrue(
+            ComplaintBounceMeta.objects.filter(
+                bounced_email=second_bounced_email.first()
+            ).exists()
+        )
+
+    def test_scheduled_general_bounce(self):
+        bounce_message = self._get_message('scheduled_general_bounce')
+        self.assertEqual(
+            get_relevant_aws_meta(bounce_message),
+            [
+                AwsMeta(
+                    notification_type='Bounce',
+                    main_type='Permanent',
+                    sub_type='General',
+                    email='permanent_general_bounce@company.org',
+                    reason='smtp; 550 5.4.1 Recipient address rejected: Access denied. AS(redacted) [redacted.outlook.com]',
+                    headers={
+                        'returnPath': 'noreplyemail@company.com',
+                        'from': ['noreplyemail@company.com'],
+                        'date': 'Fri, 31 Jul 2020 20:09:55 -0000',
+                        'to': ['permanent_general_bounce@company.org'],
+                        'cc': ['johnDoe@university.edu'],
+                        'messageId': '<redacted@server-name>',
+                        'subject': 'Invitation from John Doe to join CommCareHQ'
+                    },
+                    timestamp=datetime.datetime(2020, 7, 31, 20, 9, 56, 637000,
+                                                tzinfo=datetime.timezone.utc),
+                    destination=[
+                        'permanent_general_bounce@company.org',
+                        'johnDoe@university.edu'
+                    ]
+                )
+            ]
+        )
+        handle_email_sns_event(bounce_message)
+
+        bounced_email = BouncedEmail.objects.filter(email='permanent_general_bounce@company.org')
+        self.assertTrue(bounced_email.exists())
+
+        permanent_meta = PermanentBounceMeta.objects.filter(bounced_email=bounced_email.first())
+        self.assertTrue(permanent_meta.exists())
+        self.assertEqual(permanent_meta.first().sub_type, BounceSubType.GENERAL)
+
+    def test_scheduled_suppressed_bounce(self):
+        bounce_message = self._get_message('scheduled_suppressed_bounce')
+        self.assertEqual(
+            get_relevant_aws_meta(bounce_message),
+            [
+                AwsMeta(
+                    notification_type='Bounce',
+                    main_type='Permanent',
+                    sub_type='Suppressed',
+                    email='permanent.suppressed@company.org',
+                    reason='Amazon SES has suppressed sending to this address because '
+                           'it has a recent history of bouncing as an invalid address. '
+                           'For more information about how to remove an address from the '
+                           'suppression list, see the Amazon SES Developer Guide: '
+                           'http://docs.aws.amazon.com/ses/latest/DeveloperGuide/remove-from-suppressionlist.html ',
+                    headers={
+                        'returnPath': 'noreplyemail@company.com',
+                        'from': ['noreplyemail@company.com'],
+                        'date': 'Tue, 28 Jul 2020 00:28:28 -0000',
+                        'to': ['permanent.suppressed@company.org'],
+                        'cc': ['john.doe@agency.gov'],
+                        'messageId': '<redacted@server-name>',
+                        'subject': 'Invitation from John Doe to join CommCareHQ'
+                    },
+                    timestamp=datetime.datetime(2020, 7, 28, 0, 28, 28, 622000,
+                                                tzinfo=datetime.timezone.utc),
+                    destination=[
+                        'permanent.suppressed@company.org',
+                        'john.doe@agency.gov'
+                    ]
+                )
+            ]
+        )
+        handle_email_sns_event(bounce_message)
+
+        bounced_email = BouncedEmail.objects.filter(email='permanent.suppressed@company.org')
+        self.assertTrue(bounced_email.exists())
+
+        permanent_meta = PermanentBounceMeta.objects.filter(bounced_email=bounced_email.first())
+        self.assertTrue(permanent_meta.exists())
+        self.assertEqual(permanent_meta.first().sub_type, BounceSubType.SUPPRESSED)
+
+    def test_scheduled_transient_bounce(self):
+        transient_message = self._get_message('scheduled_transient_bounce')
+        transient_email = 'transientEmail@company.org'
+        self.assertEqual(
+            get_relevant_aws_meta(transient_message),
+            [
+                AwsMeta(
+                    notification_type='Bounce',
+                    main_type='Transient',
+                    sub_type='General',
+                    email='transientEmail@company.org',
+                    reason='smtp; 554 4.4.7 Message expired: unable to deliver in 840 minutes.<421 4.4.0 Unable to lookup DNS for company.org>',
+                    headers={
+                        'returnPath': 'noreplyemail@company.com',
+                        'from': ['noreplyemail@company.com'],
+                        'date': 'Fri, 31 Jul 2020 06:01:50 -0000',
+                        'to': ['transientEmail@company.org'],
+                        'messageId': '<redacted>',
+                        'subject': 'Scheduled report from CommCare HQ'
+                    },
+                    timestamp=datetime.datetime(2020, 7, 31, 21, 8, 57, 723000,
+                                                tzinfo=datetime.timezone.utc),
+                    destination=['transientEmail@company.org']
+                )
+            ]
+        )
+
+        handle_email_sns_event(transient_message)
+
+        bounced_email = BouncedEmail.objects.filter(email=transient_email)
+        self.assertFalse(bounced_email.exists())
+
+        transient_info = TransientBounceEmail.objects.filter(email=transient_email)
+        self.assertTrue(transient_info.exists())


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11172

##### SUMMARY
The SNS endpoint that was setup by @proteusvacuum to handle the status of messaging emails should also process bounces & complaints instantly, rather than relying on the `BouncedEmailManager` to process the bounced emails once a day. I will have to modify the SNS topics once this is merged to make sure complaints are being properly sent as well.

A followup PR to this will be to track Complaints in the Messaging Events report and add tests for messaging events.
I will have to make sure that India also has the SNS endpoint configured, so there will be an accompanying commcare-cloud PR shortly.

##### RISK ASSESSMENT / QA PLAN
This uses the same logic that has been working with the current email manager (the SSL connection just drops because so many emails have to be processed now)
