### PR TITLE
Truncate excel tab name

### DIFF
--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -367,7 +367,7 @@ class DownloadFormSummaryView(LoginAndDomainMixin, ApplicationViewMixin, View):
         headers = [(_('All Forms'),
                     ('module_name', 'form_name', 'comment', 'module_display_condition', 'form_display_condition'))]
         headers += [
-            (self._get_form_sheet_name(module, form, language), tuple(FORM_SUMMARY_EXPORT_HEADER_NAMES))
+            (self._get_form_sheet_name(form, language), tuple(FORM_SUMMARY_EXPORT_HEADER_NAMES))
             for module in modules for form in module.get_forms()
         ]
         data = list((
@@ -375,7 +375,7 @@ class DownloadFormSummaryView(LoginAndDomainMixin, ApplicationViewMixin, View):
             self.get_all_forms_row(module, form, language)
         ) for module in modules for form in module.get_forms())
         data += list(
-            (self._get_form_sheet_name(module, form, language), self._get_form_row(form, language, case_meta))
+            (self._get_form_sheet_name(form, language), self._get_form_row(form, language, case_meta))
             for module in modules for form in module.get_forms()
         )
         export_string = io.BytesIO()
@@ -429,10 +429,9 @@ class DownloadFormSummaryView(LoginAndDomainMixin, ApplicationViewMixin, View):
             )
         return tuple(form_summary_rows)
 
-    def _get_form_sheet_name(self, module, form, language):
-        return "{} - {}".format(
-            _get_translated_module_name(self.app, module.unique_id, language),
-            _get_translated_form_name(self.app, form.get_unique_id(), language),
+    def _get_form_sheet_name(self, form, language):
+        return "{}".format(
+            _get_translated_form_name(self.app, form.get_unique_id(), language)
         )
 
     def get_all_forms_row(self, module, form, language):

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -430,9 +430,8 @@ class DownloadFormSummaryView(LoginAndDomainMixin, ApplicationViewMixin, View):
         return tuple(form_summary_rows)
 
     def _get_form_sheet_name(self, form, language):
-        return "{}".format(
-            _get_translated_form_name(self.app, form.get_unique_id(), language)
-        )
+        return _get_translated_form_name(self.app, form.get_unique_id(), language)
+
 
     def get_all_forms_row(self, module, form, language):
         return ((


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-10911

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before, the Excel tab names included the module and form name but we decided to truncate it and just have the form name to prevent confusion when the tab names exceed 31 characters and get cut off.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
N/A

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
N/A

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
Users only see form names on the excel tab names.