### PR TITLE
Don't assign directly to many-to-many field

### DIFF
--- a/corehq/apps/domain/views/settings.py
+++ b/corehq/apps/domain/views/settings.py
@@ -391,11 +391,11 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
         else:
             disable_case_search(self.domain)
 
-        CaseSearchConfig.objects.update_or_create(domain=self.domain, defaults={
+        config, _ = CaseSearchConfig.objects.update_or_create(domain=self.domain, defaults={
             'enabled': request_json.get('enable'),
-            'fuzzy_properties': updated_fuzzies,
-            'ignore_patterns': updated_ignore_patterns,
         })
+        config.ignore_patterns.set(updated_ignore_patterns)
+        config.fuzzy_properties.set(updated_fuzzies)
         return json_response(self.page_context)
 
     @property


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/QA-1666

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I think this is since the Django 2 upgrade. Which also means this feature (fuzzy properties, ignore patterns) is probably due for removal since no one else other than QA has received this error.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
case-search

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
