### PR TITLE
Navigate home if we are likely to be in an error loop

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -47,7 +47,16 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                                 response.exception || FormplayerFrontend.Constants.GENERIC_ERROR,
                                 response.type === 'html'
                             );
-                            FormplayerFrontend.trigger('navigation:back');
+
+                            var currentUrl = FormplayerFrontend.getCurrentRoute();
+                            if (FormplayerFrontend.lastError === currentUrl) {
+                                FormplayerFrontend.lastError = null;
+                                FormplayerFrontend.trigger('navigateHome');
+                            } else {
+                                FormplayerFrontend.lastError = currentUrl;
+                                FormplayerFrontend.trigger('navigation:back');
+                            }
+
                         } else {
                             FormplayerFrontend.trigger('clearProgress');
                             defer.resolve(parsedMenus);


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://trello.com/c/MGklmSkK/120-fix-formplayer-error-loop


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Formplayer gets stuck in a loop if the previous page it is trying to go to also causes an error.
You can see this here: [Link](
https://www.commcarehq.org/a/corpora/cloudcare/apps/v2/preview/#{%22appId%22:%22ee0728e83f2d42cc0badd852548f44dd94%22,%22steps%22:[0],%22page%22:null,%22search%22:null})
(The app ID is non-existant, and you will get stuck in a "permission denied" loop.)

This code just checks that the page you are trying to navigate to wasn't the previously seen error. Note that this does still hit the error twice. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
