### PR TITLE
Increase MAX_CASE_IMPORTER_COLUMNS 300 -> 1600

### DIFF
--- a/corehq/apps/case_importer/const.py
+++ b/corehq/apps/case_importer/const.py
@@ -3,9 +3,9 @@ from django.utils.translation import ugettext_noop
 # Each column results in 3 form fields so this must be true:
 #   num_columns * 3 < DATA_UPLOAD_MAX_NUMBER_FIELDS
 #
-# DATA_UPLOAD_MAX_NUMBER_FIELDS defaults to 1000 but there are
-# a few other fields as well. Also 300 is a nice round number.
-MAX_CASE_IMPORTER_COLUMNS = 300
+# DATA_UPLOAD_MAX_NUMBER_FIELDS defaults to 5000 but there are
+# a few other fields as well. Also 1600 is a nice round number.
+MAX_CASE_IMPORTER_COLUMNS = 1600
 
 
 class LookupErrors(object):


### PR DESCRIPTION
It looks like `DATA_UPLOAD_MAX_NUMBER_FIELDS` has increased a bit since this was first written. Can we increase `MAX_CASE_IMPORTER_COLUMNS` to match the current value of `DATA_UPLOAD_MAX_NUMBER_FIELDS`?

I'm hitting the max columns error trying to re-upload patients in the Covid CT app.

![Screenshot 2020-08-05 16 41 13](https://user-images.githubusercontent.com/160132/89462483-7689b500-d73b-11ea-9a21-f65b83d77619.png)
