### PR TITLE
add "closed by" to the case api

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -277,6 +277,7 @@ class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResourc
     server_date_modified = fields.CharField(attribute='server_modified_on', default="1900-01-01")
     server_date_opened = fields.CharField(attribute='server_opened_on', default="1900-01-01")
     opened_by = fields.CharField(attribute='opened_by', null=True)
+    closed_by = fields.CharField(attribute='closed_by', null=True)
 
     def obj_get(self, bundle, **kwargs):
         case_id = kwargs['pk']


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

This is a useful property that for some reason was never included.

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

It's a new field and there aren't any namespacing issues, so the only reason this would case an issue is if someone was explicitly relying on the field not being there which I don't really see a use case for.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Not worth announching