### PR TITLE
Exclude nulls when using the "is empty" default filters

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -219,6 +219,12 @@ class PreFilterValue(FilterValue):
         """
         return isinstance(self.value['operand'], list)
 
+    def _is_empty(self):
+        """
+        Returns true if operand should be treated like an empty string.
+        """
+        return self.value['operand'] == ''
+
     @property
     def _null_filter(self):
         operator = self.value.get('operator') or 'is'
@@ -249,6 +255,11 @@ class PreFilterValue(FilterValue):
                 self.filter['field'],
                 get_INFilter_bindparams(self.filter['slug'], ['start_date', 'end_date'])
             )
+        elif self._is_empty():
+            return ORFilter([
+                EQFilter(self.filter['field'], self.filter['slug']),
+                ISNULLFilter(self.filter['field']),
+            ])
         elif self._is_null():
             return self._null_filter(self.filter['field'])
         elif self._is_list():
@@ -265,6 +276,10 @@ class PreFilterValue(FilterValue):
             return {
                 get_INFilter_element_bindparam(self.filter['slug'], i): str(v)
                 for i, v in enumerate([start_date, end_date])
+            }
+        elif self._is_empty():
+            return {
+                self.filter['slug']: '',
             }
         elif self._is_null():
             return {}

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -394,6 +394,22 @@ class PreFilterTestCase(SimpleTestCase):
         filter_value = PreFilterValue(filter_, {'operand': pre_value})
         self.assertEqual(filter_value.to_sql_values(), {'at_risk_slug': 'yes'})
 
+    def test_pre_filter_value_empty(self):
+        pre_value = ''
+        filter_ = {
+            'type': 'pre',
+            'field': 'empty_field',
+            'slug': 'empty_field_slug',
+            'datatype': 'string',
+            'pre_value': pre_value,
+        }
+        filter_value = PreFilterValue(filter_, {'operand': pre_value})
+        self.assertEqual(filter_value.to_sql_values(), {'empty_field_slug': ''})
+        self.assertEqual(
+            str(filter_value.to_sql_filter().build_expression()),
+            'empty_field = :empty_field_slug OR empty_field IS NULL'
+        )
+
     def test_pre_filter_value_null(self):
         pre_value = None
         filter_ = {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

https://dimagi-dev.atlassian.net/browse/SAAS-11184 (the best explanation of the change is in [this comment](https://dimagi-dev.atlassian.net/browse/SAAS-11184?focusedCommentId=72817))

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The "is empty" filter was resolving to `value = ''`. Now it resolves to `value is NULL OR value = ''`.

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

Don't see any major risks.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Report builder reports using the "is empty" filter may show data that they previously were not showing.