### PR TITLE
treat null and blank the same in pre filters

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -221,7 +221,7 @@ class PreFilterValue(FilterValue):
 
     def _is_empty(self):
         """
-        Returns true if operand should be treated like an empty string.
+        Returns true if operand has no value.
         """
         return self.value['operand'] == '' or self._is_null()
 

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -223,15 +223,7 @@ class PreFilterValue(FilterValue):
         """
         Returns true if operand should be treated like an empty string.
         """
-        return self.value['operand'] == ''
-
-    @property
-    def _null_filter(self):
-        operator = self.value.get('operator') or 'is'
-        try:
-            return self.null_operator_filters[operator]
-        except KeyError:
-            raise TypeError('Null value does not support "{}" operator'.format(operator))
+        return self.value['operand'] == '' or self._is_null()
 
     @property
     def _array_filter(self):
@@ -260,8 +252,6 @@ class PreFilterValue(FilterValue):
                 EQFilter(self.filter['field'], self.filter['slug']),
                 ISNULLFilter(self.filter['field']),
             ])
-        elif self._is_null():
-            return self._null_filter(self.filter['field'])
         elif self._is_list():
             return self._array_filter(
                 self.filter['field'],
@@ -281,8 +271,6 @@ class PreFilterValue(FilterValue):
             return {
                 self.filter['slug']: '',
             }
-        elif self._is_null():
-            return {}
         elif self._is_list():
             # Array params work like IN bind params
             return {

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -420,10 +420,10 @@ class PreFilterTestCase(SimpleTestCase):
             'pre_value': pre_value
         }
         filter_value = PreFilterValue(filter_, {'operand': pre_value})
-        self.assertEqual(filter_value.to_sql_values(), {})
+        self.assertEqual(filter_value.to_sql_values(), {'at_risk_slug': ''})
         self.assertEqual(
             str(filter_value.to_sql_filter().build_expression()),
-            'at_risk_field IS NULL'
+            'at_risk_field = :at_risk_slug OR at_risk_field IS NULL'
         )
 
     def test_pre_filter_value_array(self):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Implementation of https://github.com/dimagi/commcare-hq/pull/28313/files#r466225716 for discussion from @dimagi/product or others. Don't merge unless it's cleared.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This treats prefilters against null the same as prefilters against empty strings.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

Main risk is that someone is actually relying on the fact that these are different.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Some reports that are filtering on nulls may show more data. (I don't think this is worth announcing but worth noting in case it comes up via support)