### PR TITLE
Fix hyperlink on limited use feature flag toggle text

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
+++ b/corehq/apps/domain/templates/domain/admin/flags_and_privileges.html
@@ -118,7 +118,7 @@
               <span data-bind="css: ('label-' + tagCssClass),
                                                     text: tag"
                     class="label"></span>
-              <!--ko text: tagDescription --><!--/ko-->
+              <span data-bind="html: tagDescription"></span>
 
               <div class="text-right">
                 <small><a class="text-uppercase" data-bind="attr: {href: editLink}, text: slug"></a></small>


### PR DESCRIPTION
##### SUMMARY
Small fix to some text so that the hyperlink on the Limited Use Feature Flags toggles on `a/<domain>/settings/projects/flag` is displayed as html.

##### PRODUCT DESCRIPTION
Users will now see a hyperlink as expected, instead of plaintext html code.
