### PR TITLE
Update staging.yaml for data dictionary linking

### DIFF
--- a/scripts/staging.yaml
+++ b/scripts/staging.yaml
@@ -68,4 +68,5 @@ branches:
   - sk/remove-icdsI  # Simon Aug 5
   - sr/es7-ref1 # Sravan Aug 4
   - ce/lxml-restore
+  - solleks:cdg/data_dictionary_erm  # Charlie August 6
 submodules: {}


### PR DESCRIPTION
Stage the branch which adds data dictionaries to the functionality of linked domains.

This was added before and deployed, but later [removed from staging](https://github.com/dimagi/commcare-hq/commit/8f69eab1980d8ec46e4c6df342b33618201e7c31). I haven't found the reason for its removal yet, but Cal said it was probably safe to add it again.

[Trello card.](https://trello.com/c/ybj7n7AG/105-add-data-dictionary-to-enterprise-release-management)

