### PR TITLE
Improved wording on pause screen

### DIFF
--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -415,6 +415,7 @@ def get_paused_plan_context(request, domain):
     previous_edition = (current_sub.previous_subscription.plan_version.plan.edition
                         if current_sub.previous_subscription else "")
     return {
+        'is_trial' : current_sub.previous_subscription.is_trial,
         'is_paused': True,
         'previous_edition': previous_edition,
         'paused_date': current_sub.date_start.strftime(USER_DATE_FORMAT),

--- a/corehq/apps/accounting/utils/__init__.py
+++ b/corehq/apps/accounting/utils/__init__.py
@@ -415,7 +415,7 @@ def get_paused_plan_context(request, domain):
     previous_edition = (current_sub.previous_subscription.plan_version.plan.edition
                         if current_sub.previous_subscription else "")
     return {
-        'is_trial' : current_sub.previous_subscription.is_trial,
+        'is_trial': current_sub.previous_subscription.is_trial,
         'is_paused': True,
         'previous_edition': previous_edition,
         'paused_date': current_sub.date_start.strftime(USER_DATE_FORMAT),

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/paused_plan_notice.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/paused_plan_notice.html
@@ -7,10 +7,16 @@
     </div>
     <div class="col-xs-9 column-text">
       <h3>
-        {% blocktrans %}
-          Your previous <strong>{{ previous_edition }} Edition</strong> subscription was paused
-          on {{ paused_date }}.
-        {% endblocktrans %}
+        {% if is_trial %}
+          {% blocktrans %}
+            Your CommCare trial ended on {{ paused_date }}.
+          {% endblocktrans %}
+        {% else %}
+          {% blocktrans %}
+            Your previous <strong>{{ previous_edition }} Edition</strong> subscription was paused
+            on {{ paused_date }}.
+          {% endblocktrans %}
+        {% endif %}
       </h3>
       {% if can_edit_billing_info %}
         <p class="lead">


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11130

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated the Pause page in HQ so that when a trial project space is automatically paused at the end of the trial period, the header text reads "Your CommCare trial ended on [date]" rather than "Your previous [plan name] subscription was paused on [date]".

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
N/A

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
N/A
