### PR TITLE
Fix Dockerhub Build Part 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,4 @@ RUN npm -g install \
     mocha-headless-chrome \
  && cd /vendor \
  && npm shrinkwrap \
- && yarn global add phantomjs-prebuilt \
- && npm -g install
+ && yarn global add phantomjs-prebuilt


### PR DESCRIPTION
##### SUMMARY
`npm -g install` causes the build to fail because `package.json` is formatted for `yarn` now

canceling travis build on purpose