### PR TITLE
Prevent multiple clicks on the Confirm Import button

### DIFF
--- a/corehq/apps/case_importer/templates/case_importer/excel_fields.html
+++ b/corehq/apps/case_importer/templates/case_importer/excel_fields.html
@@ -44,7 +44,7 @@
         <button type="button" class="btn btn-primary" id="back_button">
           <i class="fa fa-backward"></i> {% trans "Back" %}
         </button>
-        <button type="submit" class="btn btn-primary">
+        <button type="submit" class="btn btn-primary disable-on-submit">
           <i class="fa fa-forward"></i>
           {% trans "Confirm Import" %}
         </button>


### PR DESCRIPTION

https://dimagi-dev.atlassian.net/browse/SAAS-11170

##### SUMMARY
Prevent multiple clicks on the Confirm Import button to prevent a race condition resulting sometimes in a single import being run twice. It's also just a better UX.

##### FEATURE FLAG
None

##### RISK ASSESSMENT / QA PLAN
No serious risk. Tested locally that the button (1) is still clickable and results in a case import and (2) is no longer clickable after the first click.

##### PRODUCT DESCRIPTION
On the final confirmation page for the case importer, it used to be possible to click the submit button ("Confirm Import") twice, with the same import being run twice in the background, resulting in a single "case import" in the case import history, but all actions being taken twice, resulting in many duplicate cases. This change disables the button after the first click, preventing this bad behavior.