### PR TITLE
Add trailing slash when linking remote domains

### DIFF
--- a/corehq/apps/linked_domain/applications.py
+++ b/corehq/apps/linked_domain/applications.py
@@ -60,7 +60,11 @@ def create_linked_app(master_domain, master_id, target_domain, target_name, remo
 
 
 def link_app(linked_app, master_domain, master_id, remote_details=None):
-    DomainLink.link_domains(linked_app.domain, master_domain, remote_details)
+    linked_app_domain = linked_app.domain
+    if remote_details:
+        linked_app_domain = f"{linked_app_domain}/"
+
+    DomainLink.link_domains(linked_app_domain, master_domain, remote_details)
 
     linked_app.family_id = master_id
     linked_app.doc_type = 'LinkedApplication'


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This check means the linked (downstream) domain needs a trailing slash: 

https://github.com/dimagi/commcare-hq/pull/26926

I'm not sure what that check is doing... 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
