### PR TITLE
Clean up global wiring for CryptoJS dependency

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -63,6 +63,7 @@ function hqDefine(path, dependencies, moduleAccessor) {
                     'ace-builds/src-min-noconflict/ace': 'ace',
                     'DOMPurify/dist/purify.min': 'DOMPurify',
                     'moment/moment': 'moment',
+                    'crypto-js/crypto-js': 'CryptoJS',
                 },
                 thirdPartyPlugins = [
                     'jquery-form/dist/jquery.form.min',

--- a/corehq/apps/integration/static/integration/js/hmac_callout.js
+++ b/corehq/apps/integration/static/integration/js/hmac_callout.js
@@ -1,6 +1,10 @@
-/* globals CryptoJS */
-
-hqDefine("integration/js/hmac_callout", ["hqwebapp/js/initial_page_data"], function (initialPageData) {
+hqDefine("integration/js/hmac_callout", [
+    "hqwebapp/js/initial_page_data",
+    "crypto-js/crypto-js"
+], function (
+    initialPageData,
+    CryptoJS
+) {
     var randomString = function (nBytes) {
         return CryptoJS.lib.WordArray.random(nBytes).toString();
     };

--- a/corehq/apps/integration/static/integration/js/hmac_callout.js
+++ b/corehq/apps/integration/static/integration/js/hmac_callout.js
@@ -1,6 +1,6 @@
 hqDefine("integration/js/hmac_callout", [
     "hqwebapp/js/initial_page_data",
-    "crypto-js/crypto-js"
+    "crypto-js/crypto-js",
 ], function (
     initialPageData,
     CryptoJS


### PR DESCRIPTION
Followup from wiring [HMAC Code](https://github.com/dimagi/commcare-hq/pull/28300/files/d1eeb1d168c061fab707eb1f78689d1c681c0a6c#r468056366) to use the appropriate module pattern.