### PR TITLE
Removed references to legacy select2

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/hqModules.js
@@ -68,7 +68,6 @@ function hqDefine(path, dependencies, moduleAccessor) {
                     'jquery-form/dist/jquery.form.min',
                     'jquery.rmi/jquery.rmi',
                     'jquery-ui/ui/sortable',
-                    'select2-3.5.2-legacy/select2',
                     'select2/dist/js/select2.full.min',
                 ];
             var args = [];

--- a/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/select2s.less
+++ b/corehq/apps/hqwebapp/static/hqwebapp/less/_hq/select2s.less
@@ -17,10 +17,6 @@
 .case-config-select2s(@width) {
     .select2-container {
         width: @width;
-
-        // Fix firefox bug in select 2 v3.5.2
-        // https://github.com/select2/select2/issues/2078
-        display: inline-block !important;
     }
 
     // This needs a static width so that text-overflow: ellipsis will work in Firefox.


### PR DESCRIPTION
##### SUMMARY
Trivial, noticed while reviewing something else. We no longer use this version of select2.