### PR TITLE
Expose Manage Releases by App Profiles in the Application View.

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/build_profiles.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/build_profiles.html
@@ -7,6 +7,9 @@
     <h4 class="panel-title-nolink">
       {% trans "Current Profiles" %}
     </h4>
+    {% if can_manage_releases_by_build_profile %}
+      <a class="text-right" href="{% url 'manage_releases_by_app_profile' domain %}">Manage Releases By App Profile</a>
+    {% endif %}
   </div>
   <div class="panel-body">
     {% if app.is_remote_app %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/build_profiles.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/build_profiles.html
@@ -23,8 +23,8 @@
         and options on different phones. Application profiles will appear in <em>new</em> versions
         of the application.
       {% endblocktrans %}
-      {% if can_manage_releases_by_build_profile %}
-        <a class="text-right" href="{% url 'manage_releases_by_app_profile' domain %}">{% trans "Manage application profiles here."%}</a>
+      {% if can_edit_apps and request|toggle_enabled:"RELEASE_BUILDS_PER_PROFILE" %}
+        <a href="{% url 'manage_releases_by_app_profile' domain %}">{% trans "Manage application profiles here."%}</a>
       {% endif %}
       {% blocktrans %}
         Learn more about Application Profiles on our <a href='https://confluence.dimagi.com/display/commcarepublic/Application+Profiles'>Help Site</a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/build_profiles.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/build_profiles.html
@@ -7,9 +7,7 @@
     <h4 class="panel-title-nolink">
       {% trans "Current Profiles" %}
     </h4>
-    {% if can_manage_releases_by_build_profile %}
-      <a class="text-right" href="{% url 'manage_releases_by_app_profile' domain %}">Manage Releases By App Profile</a>
-    {% endif %}
+
   </div>
   <div class="panel-body">
     {% if app.is_remote_app %}
@@ -25,14 +23,12 @@
         and options on different phones. Application profiles will appear in <em>new</em> versions
         of the application.
       {% endblocktrans %}
-      <span class="hq-help-template"
-            data-title="{% trans "Application Profiles" %}"
-            data-placement="left"
-            data-content="
-              {% blocktrans %}
-                  Learn more about Application Profiles on our <a href='https://confluence.dimagi.com/display/commcarepublic/Application+Profiles'>Help Site</a>
-              {% endblocktrans %}">
-        </span>
+      {% if can_manage_releases_by_build_profile %}
+        <a class="text-right" href="{% url 'manage_releases_by_app_profile' domain %}">{% trans "Manage application profiles here."%}</a>
+      {% endif %}
+      {% blocktrans %}
+        Learn more about Application Profiles on our <a href='https://confluence.dimagi.com/display/commcarepublic/Application+Profiles'>Help Site</a>
+      {% endblocktrans %}
     </div>
     <table class="table table-profiles">
       <thead>

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -82,7 +82,7 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.apps.sms.views import get_sms_autocomplete_context
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
 from corehq.apps.users.models import CommCareUser, CouchUser
-from corehq.apps.users.permissions import can_manage_releases, can_manage_releases_by_build_profile
+from corehq.apps.users.permissions import can_manage_releases
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import reverse
 
@@ -203,7 +203,7 @@ def get_releases_context(request, domain, app_id):
         'prompt_settings_form': prompt_settings_form,
         'full_name': request.couch_user.full_name,
         'can_manage_releases': can_manage_releases(request.couch_user, request.domain, app_id),
-        'can_manage_releases_by_build_profile': can_manage_releases_by_build_profile(request.couch_user, domain),
+        'can_edit_apps': request.couch_user.can_edit_apps(),
     }
     if not app.is_remote_app():
         context.update({

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -82,7 +82,7 @@ from corehq.apps.locations.permissions import location_safe
 from corehq.apps.sms.views import get_sms_autocomplete_context
 from corehq.apps.userreports.exceptions import ReportConfigurationNotFoundError
 from corehq.apps.users.models import CommCareUser, CouchUser
-from corehq.apps.users.permissions import can_manage_releases
+from corehq.apps.users.permissions import can_manage_releases, can_manage_releases_by_build_profile
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import reverse
 
@@ -202,7 +202,8 @@ def get_releases_context(request, domain, app_id):
         'prompt_settings_url': reverse(PromptSettingsUpdateView.urlname, args=[domain, app_id]),
         'prompt_settings_form': prompt_settings_form,
         'full_name': request.couch_user.full_name,
-        'can_manage_releases': can_manage_releases(request.couch_user, request.domain, app_id)
+        'can_manage_releases': can_manage_releases(request.couch_user, request.domain, app_id),
+        'can_manage_releases_by_build_profile': can_manage_releases_by_build_profile(request.couch_user, domain),
     }
     if not app.is_remote_app():
         context.update({

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -94,3 +94,11 @@ def _can_manage_releases_for_all_apps(couch_user, domain):
         domain, get_permission_name(Permissions.manage_releases),
         restrict_global_admin=True
     )
+
+
+def can_manage_releases_by_build_profile(couch_user, domain):
+    from corehq.apps.users.decorators import get_permission_name
+    from corehq.apps.users.models import Permissions
+    is_toggle_enabled = toggles.RELEASE_BUILDS_PER_PROFILE.enabled(domain)
+    can_edit_app = couch_user.has_permission(domain, get_permission_name(Permissions.edit_apps))
+    return is_toggle_enabled and can_edit_app

--- a/corehq/apps/users/permissions.py
+++ b/corehq/apps/users/permissions.py
@@ -94,11 +94,3 @@ def _can_manage_releases_for_all_apps(couch_user, domain):
         domain, get_permission_name(Permissions.manage_releases),
         restrict_global_admin=True
     )
-
-
-def can_manage_releases_by_build_profile(couch_user, domain):
-    from corehq.apps.users.decorators import get_permission_name
-    from corehq.apps.users.models import Permissions
-    is_toggle_enabled = toggles.RELEASE_BUILDS_PER_PROFILE.enabled(domain)
-    can_edit_app = couch_user.has_permission(domain, get_permission_name(Permissions.edit_apps))
-    return is_toggle_enabled and can_edit_app

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1786,12 +1786,6 @@ def _get_administration_section(domain):
             'url': reverse(ManageReleasesByLocation.urlname, args=[domain])
         })
 
-    if toggles.RELEASE_BUILDS_PER_PROFILE.enabled(domain):
-        administration.append({
-            'title': _(ManageReleasesByAppProfile.page_title),
-            'url': reverse(ManageReleasesByAppProfile.urlname, args=[domain])
-        })
-
     return administration
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/ICDS-1531
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The PR adds a link to the "Manage Releases by App Profiles" page in the App menu and also removes the link from the Project Administration Page.

This is how it will look like
![Screenshot 2020-08-11 at 3 08 52 PM](https://user-images.githubusercontent.com/7694243/89888870-500dc300-dbee-11ea-81a0-3fb208c6b7bb.png)

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
RELEASE_BUILDS_PER_PROFILE
##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
