### PR TITLE
add new user api root

### DIFF
--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -157,14 +157,14 @@ USER_API_LIST = (
 )
 
 
-def global_api_url_patterns():
+def get_global_api_url_patterns(resources):
     api = CommCareHqApi(api_name='global')
-    for resource in ADMIN_API_LIST + USER_API_LIST:
+    for resource in resources:
         api.register(resource())
         yield url(r'^', include(api.urls))
 
 
-admin_urlpatterns = list(global_api_url_patterns())
-
+admin_urlpatterns = list(get_global_api_url_patterns(ADMIN_API_LIST)) + \
+                    list(get_global_api_url_patterns(USER_API_LIST))
 
 waf_allow('XSS_BODY', hard_code_pattern=r'^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$')

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -157,14 +157,14 @@ USER_API_LIST = (
 )
 
 
-def api_url_patterns():
+def global_api_url_patterns():
     api = CommCareHqApi(api_name='global')
     for resource in ADMIN_API_LIST + USER_API_LIST:
         api.register(resource())
         yield url(r'^', include(api.urls))
 
 
-admin_urlpatterns = list(api_url_patterns())
+admin_urlpatterns = list(global_api_url_patterns())
 
 
 waf_allow('XSS_BODY', hard_code_pattern=r'^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$')

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -171,4 +171,13 @@ def get_global_api_url_patterns(resources):
 admin_urlpatterns = list(get_global_api_url_patterns(ADMIN_API_LIST)) + \
                     list(get_global_api_url_patterns(USER_API_LIST))
 
+
+
+VERSIONED_USER_API_LIST = (
+    ((0, 5), USER_API_LIST),
+)
+
+
+user_urlpatterns = list(versioned_apis(VERSIONED_USER_API_LIST))
+
 waf_allow('XSS_BODY', hard_code_pattern=r'^/a/([\w\.:-]+)/api/v([\d\.]+)/form/$')

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -172,7 +172,6 @@ admin_urlpatterns = list(get_global_api_url_patterns(ADMIN_API_LIST)) + \
                     list(get_global_api_url_patterns(USER_API_LIST))
 
 
-
 VERSIONED_USER_API_LIST = (
     ((0, 5), USER_API_LIST),
 )

--- a/urls.py
+++ b/urls.py
@@ -7,6 +7,7 @@ from django.views.generic import RedirectView, TemplateView
 from corehq.extensions import extension_points
 from corehq.apps.accounting.urls import \
     domain_specific as accounting_domain_specific
+from corehq.apps.api.urls import user_urlpatterns as user_api_urlpatterns
 from corehq.apps.app_manager.views.formdesigner import ping
 from corehq.apps.app_manager.views.phone import list_apps
 from corehq.apps.domain.decorators import login_and_domain_required
@@ -100,6 +101,7 @@ urlpatterns = [
     url(r'^auditcare/', include('auditcare.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^analytics/', include('corehq.apps.analytics.urls')),
+    url(r'^api/', include(user_api_urlpatterns)),
     url(r'^register/', include('corehq.apps.registration.urls')),
     url(r'^a/(?P<domain>%s)/' % legacy_domain_re, include(domain_specific)),
     url(r'^account/', include('corehq.apps.settings.urls')),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Currently there are two types of (tastypie) CommCare APIs:

1. A set of domain-level versioned APIs at `/a/domain/api/v0.X/`
2. A set of global *non-versioned* APIs at `/hq/admin/api/global/`

This adds a new *versioned* API root at `/api/v0.X/` for non-admin, non-domain-specific APIs. It also duplicates the user domains resource there.

Moving forwards I'm proposing that all non-admin, non-domain-specific APIs follow this scheme, which has several advantages to the current set up. Specifically it allows for API versioning and provides more sensible URIs to our consumers.

For backwards compatibility, the non-admin APIs need to be duplicated here, but new APIs can move here (and we can update all docs to point here).

I didn't think this was controversial enough to warrant a CEP but let me know if anyone thinks I should do that and I can.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

None.

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

I think this is low risk since at the moment all it does is duplicate one API to a new place.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Changes how non-admin, non-domain-specific APIs are accessed moving forwards (I don't think any are documented so don't think there is anything to announce until they are).