### PR TITLE
fix "exists" pre-filter

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -223,6 +223,9 @@ class PreFilterValue(FilterValue):
         return self.value['operand'] == '' or self.value['operand'] is None
 
     def _is_empty(self):
+        """
+        Returns true if the value should be treated a filter to show only empty data
+        """
         operator = self.value.get('operator') or '='
         return self._has_empty_value() and operator == '='
 

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -219,12 +219,15 @@ class PreFilterValue(FilterValue):
         """
         return isinstance(self.value['operand'], list)
 
+    def _has_empty_value(self):
+        return self.value['operand'] == '' or self._is_null()
+
     def _is_empty(self):
         """
         Returns true if operand has no value.
         """
         operator = self.value.get('operator') or '='
-        return (self.value['operand'] == '' or self._is_null()) and operator == '='
+        return self._has_empty_value() and operator == '='
 
     @property
     def _array_filter(self):

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -223,7 +223,8 @@ class PreFilterValue(FilterValue):
         """
         Returns true if operand has no value.
         """
-        return self.value['operand'] == '' or self._is_null()
+        operator = self.value.get('operator') or '='
+        return (self.value['operand'] == '' or self._is_null()) and operator == '='
 
     @property
     def _array_filter(self):

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -229,6 +229,12 @@ class PreFilterValue(FilterValue):
         operator = self.value.get('operator') or '='
         return self._has_empty_value() and operator == '='
 
+    def _is_exists(self):
+        """
+        Returns true if the value should be treated a filter to show non-empty data
+        """
+        return self._has_empty_value() and self.value.get('operator') == '!='
+
     @property
     def _array_filter(self):
         operator = self.value.get('operator') or 'in'
@@ -256,6 +262,8 @@ class PreFilterValue(FilterValue):
                 EQFilter(self.filter['field'], self.filter['slug']),
                 ISNULLFilter(self.filter['field']),
             ])
+        elif self._is_exists():
+            return NOTEQFilter(self.filter['field'], self.filter['slug'])
         elif self._is_list():
             return self._array_filter(
                 self.filter['field'],
@@ -271,7 +279,7 @@ class PreFilterValue(FilterValue):
                 get_INFilter_element_bindparam(self.filter['slug'], i): str(v)
                 for i, v in enumerate([start_date, end_date])
             }
-        elif self._is_empty():
+        elif self._is_empty() or self._is_exists():
             return {
                 self.filter['slug']: '',
             }

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -209,9 +209,6 @@ class PreFilterValue(FilterValue):
     def _is_dyn_date(self):
         return self.value.get('operator') in self.dyn_date_operators
 
-    def _is_null(self):
-        return self.value['operand'] is None
-
     def _is_list(self):
         """
         Returns true if operand should be treated like an array when building
@@ -220,7 +217,7 @@ class PreFilterValue(FilterValue):
         return isinstance(self.value['operand'], list)
 
     def _has_empty_value(self):
-        return self.value['operand'] == '' or self._is_null()
+        return self.value['operand'] == '' or self.value['operand'] is None
 
     def _is_empty(self):
         """

--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -217,12 +217,12 @@ class PreFilterValue(FilterValue):
         return isinstance(self.value['operand'], list)
 
     def _has_empty_value(self):
-        return self.value['operand'] == '' or self.value['operand'] is None
-
-    def _is_empty(self):
         """
         Returns true if operand has no value.
         """
+        return self.value['operand'] == '' or self.value['operand'] is None
+
+    def _is_empty(self):
         operator = self.value.get('operator') or '='
         return self._has_empty_value() and operator == '='
 

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -430,7 +430,7 @@ class PreFilterTestCase(SimpleTestCase):
             self.assertEqual(filter_value.to_sql_values(), {'exists_field_slug': ''})
             self.assertEqual(
                 str(filter_value.to_sql_filter().build_expression()),
-                'exists_field != :exists_field_slug OR exists_field IS NOT NULL'
+                'exists_field != :exists_field_slug'
             )
 
     def test_pre_filter_value_array(self):

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -395,36 +395,24 @@ class PreFilterTestCase(SimpleTestCase):
         self.assertEqual(filter_value.to_sql_values(), {'at_risk_slug': 'yes'})
 
     def test_pre_filter_value_empty(self):
-        pre_value = ''
-        filter_ = {
-            'type': 'pre',
-            'field': 'empty_field',
-            'slug': 'empty_field_slug',
-            'datatype': 'string',
-            'pre_value': pre_value,
-        }
-        filter_value = PreFilterValue(filter_, {'operand': pre_value})
-        self.assertEqual(filter_value.to_sql_values(), {'empty_field_slug': ''})
-        self.assertEqual(
-            str(filter_value.to_sql_filter().build_expression()),
-            'empty_field = :empty_field_slug OR empty_field IS NULL'
-        )
-
-    def test_pre_filter_value_null(self):
-        pre_value = None
-        filter_ = {
-            'type': 'pre',
-            'field': 'at_risk_field',
-            'slug': 'at_risk_slug',
-            'datatype': 'string',
-            'pre_value': pre_value
-        }
-        filter_value = PreFilterValue(filter_, {'operand': pre_value})
-        self.assertEqual(filter_value.to_sql_values(), {'at_risk_slug': ''})
-        self.assertEqual(
-            str(filter_value.to_sql_filter().build_expression()),
-            'at_risk_field = :at_risk_slug OR at_risk_field IS NULL'
-        )
+        pre_values = ['', None]
+        operators = ['', '=']
+        for pre_value in pre_values:
+            for operator in operators:
+                filter_ = {
+                    'type': 'pre',
+                    'field': 'empty_field',
+                    'slug': 'empty_field_slug',
+                    'datatype': 'string',
+                    'pre_value': pre_value,
+                    'operator': operator
+                }
+                filter_value = PreFilterValue(filter_, {'operand': pre_value})
+                self.assertEqual(filter_value.to_sql_values(), {'empty_field_slug': ''})
+                self.assertEqual(
+                    str(filter_value.to_sql_filter().build_expression()),
+                    'empty_field = :empty_field_slug OR empty_field IS NULL'
+                )
 
     def test_pre_filter_value_array(self):
         pre_value = ['yes', 'maybe']

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -414,6 +414,24 @@ class PreFilterTestCase(SimpleTestCase):
                     'empty_field = :empty_field_slug OR empty_field IS NULL'
                 )
 
+    def test_pre_filter_value_exists(self):
+        pre_values = ['', None]
+        for pre_value in pre_values:
+            filter_ = {
+                'type': 'pre',
+                'field': 'exists_field',
+                'slug': 'exists_field_slug',
+                'datatype': 'string',
+                'pre_value': pre_value,
+                'operator': '!='
+            }
+            filter_value = PreFilterValue(filter_, {'operand': pre_value})
+            self.assertEqual(filter_value.to_sql_values(), {'exists_field_slug': ''})
+            self.assertEqual(
+                str(filter_value.to_sql_filter().build_expression()),
+                'exists_field != :exists_field_slug OR exists_field IS NOT NULL'
+            )
+
     def test_pre_filter_value_array(self):
         pre_value = ['yes', 'maybe']
         filter_ = {

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -405,9 +405,9 @@ class PreFilterTestCase(SimpleTestCase):
                     'slug': 'empty_field_slug',
                     'datatype': 'string',
                     'pre_value': pre_value,
-                    'operator': operator
+                    'pre_operator': operator
                 }
-                filter_value = PreFilterValue(filter_, {'operand': pre_value})
+                filter_value = PreFilterValue(filter_, {'operand': pre_value, 'operator': operator})
                 self.assertEqual(filter_value.to_sql_values(), {'empty_field_slug': ''})
                 self.assertEqual(
                     str(filter_value.to_sql_filter().build_expression()),
@@ -416,6 +416,7 @@ class PreFilterTestCase(SimpleTestCase):
 
     def test_pre_filter_value_exists(self):
         pre_values = ['', None]
+        operator = '!='
         for pre_value in pre_values:
             filter_ = {
                 'type': 'pre',
@@ -423,9 +424,9 @@ class PreFilterTestCase(SimpleTestCase):
                 'slug': 'exists_field_slug',
                 'datatype': 'string',
                 'pre_value': pre_value,
-                'operator': '!='
+                'pre_operator': operator
             }
-            filter_value = PreFilterValue(filter_, {'operand': pre_value})
+            filter_value = PreFilterValue(filter_, {'operand': pre_value, 'operator': operator})
             self.assertEqual(filter_value.to_sql_values(), {'exists_field_slug': ''})
             self.assertEqual(
                 str(filter_value.to_sql_filter().build_expression()),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

https://dimagi-dev.atlassian.net/browse/SAAS-11225

Review by commit.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/dimagi/commcare-hq/pull/28313 accidentally neglected to check for operators, so the "exists" filter (which used `!= ''`) was being interpreted as "is empty" which is the exact wrong behavior :man_facepalming: 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

Fixes the bug which was live for a few days.
