### PR TITLE
add Identity api

### DIFF
--- a/corehq/apps/api/resources/serializers.py
+++ b/corehq/apps/api/resources/serializers.py
@@ -1,0 +1,16 @@
+import json
+
+from tastypie.serializers import Serializer
+
+
+class ListToSingleObjectSerializer(Serializer):
+    """
+    Serializer class that takes a list of one object and removes the other metadata
+    around the list view so that just the object is returned.
+
+    See IdentityResource for an example.
+    """
+
+    def to_json(self, data, options=None):
+        # note: this is not valid if there is ever not exactly one object returned
+        return json.dumps(data['objects'][0].data)

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -4,7 +4,7 @@ from itertools import chain
 from django.conf.urls import url
 from django.contrib.auth.models import User
 from django.forms import ValidationError
-from django.http import Http404, HttpResponse, HttpResponseNotFound
+from django.http import Http404, HttpResponse, HttpResponseNotFound, request
 from django.urls import reverse
 from django.utils.translation import ugettext_noop
 
@@ -18,6 +18,7 @@ from tastypie.resources import ModelResource, Resource, convert_post_to_patch
 from tastypie.utils import dict_strip_unicode_keys
 
 from casexml.apps.stock.models import StockTransaction
+from corehq.apps.api.resources.serializers import ListToSingleObjectSerializer
 from phonelog.models import DeviceReportEntry
 
 from corehq import privileges
@@ -862,6 +863,7 @@ class IdentityResource(CorsResourceMixin, Resource):
     class Meta(object):
         resource_name = 'identity'
         authentication = LoginAuthentication()
+        serializer = ListToSingleObjectSerializer()
         detail_allowed_methods = []
         list_allowed_methods = ['get']
         object_class = CouchUser

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -851,6 +851,23 @@ class UserDomainsResource(CorsResourceMixin, Resource):
         return results
 
 
+class IdentityResource(CorsResourceMixin, Resource):
+    id = fields.CharField(attribute='get_id', readonly=True)
+    username = fields.CharField(attribute='username', readonly=True)
+    email = fields.CharField(attribute='email', readonly=True)
+
+    def obj_get_list(self, bundle, **kwargs):
+        return [bundle.request.couch_user]
+
+    class Meta(object):
+        resource_name = 'identity'
+        authentication = LoginAuthentication()
+        detail_allowed_methods = []
+        list_allowed_methods = ['get']
+        object_class = CouchUser
+        include_resource_uri = False
+
+
 Form = namedtuple('Form', 'form_xmlns form_name')
 Form.__new__.__defaults__ = ('', '')
 

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -124,6 +124,7 @@ def _set_role_for_bundle(kwargs, bundle):
         if permission_preset_name:
             bundle.obj.set_role(kwargs['domain'], permission_preset_name)
 
+
 class BulkUserResource(HqBaseResource, DomainSpecificResourceMixin):
     """
     A read-only user data resource based on elasticsearch.
@@ -389,6 +390,7 @@ class WebUserResource(v0_1.WebUserResource):
     def _admin_assigned_another_role(self, details):
         # default value Admin since that will be assigned later anyway since is_admin is True
         return details.get('role', 'Admin') != 'Admin'
+
 
 class AdminWebUserResource(v0_1.UserResource):
     domains = fields.ListField(attribute='domains')
@@ -855,6 +857,8 @@ class UserDomainsResource(CorsResourceMixin, Resource):
 class IdentityResource(CorsResourceMixin, Resource):
     id = fields.CharField(attribute='get_id', readonly=True)
     username = fields.CharField(attribute='username', readonly=True)
+    first_name = fields.CharField(attribute='first_name', readonly=True)
+    last_name = fields.CharField(attribute='last_name', readonly=True)
     email = fields.CharField(attribute='email', readonly=True)
 
     def obj_get_list(self, bundle, **kwargs):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -4,7 +4,7 @@ from itertools import chain
 from django.conf.urls import url
 from django.contrib.auth.models import User
 from django.forms import ValidationError
-from django.http import Http404, HttpResponse, HttpResponseNotFound, request
+from django.http import Http404, HttpResponse, HttpResponseNotFound
 from django.urls import reverse
 from django.utils.translation import ugettext_noop
 

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -479,3 +479,30 @@ class TestBulkUserAPI(APIResourceTest):
     def test_basic(self):
         response = self.query()
         self.assertEqual(response.status_code, 200)
+
+
+@es_test
+class TestIdentityResource(APIResourceTest):
+
+    resource = v0_5.IdentityResource
+    api_name = 'v0.5'
+
+    @classmethod
+    def setUpClass(cls):
+        reset_es_index(USER_INDEX_INFO)
+        super().setUpClass()
+
+    @classmethod
+    def _get_list_endpoint(cls):
+        return reverse('api_dispatch_list',
+                kwargs=dict(api_name=cls.api_name,
+                            resource_name=cls.resource._meta.resource_name))
+
+    @sync_users_to_es()
+    def test_get_list(self):
+        response = self._assert_auth_get_resource(self.list_endpoint)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(data['id'], self.user.get_id)
+        self.assertEqual(data['username'], self.username)
+        self.assertEqual(data['email'], self.username)

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -505,4 +505,6 @@ class TestIdentityResource(APIResourceTest):
         data = json.loads(response.content)
         self.assertEqual(data['id'], self.user.get_id)
         self.assertEqual(data['username'], self.username)
-        self.assertEqual(data['email'], self.username)
+        self.assertEqual(data['first_name'], self.user.first_name)
+        self.assertEqual(data['last_name'], self.user.last_name)
+        self.assertEqual(data['email'], self.user.email)

--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -28,7 +28,7 @@ from .utils import APIResourceTest
 @es_test
 class TestCommCareUserResource(APIResourceTest):
     """
-    Basic sanity checking of v0_1.CommCareUserResource
+    Basic sanity checking of v0_5.CommCareUserResource
     """
     resource = v0_5.CommCareUserResource
     api_name = 'v0.5'

--- a/corehq/apps/api/tests/utils.py
+++ b/corehq/apps/api/tests/utils.py
@@ -77,7 +77,7 @@ class APIResourceTest(TestCase, metaclass=PatchMeta):
         cls.list_endpoint = cls._get_list_endpoint()
         cls.username = 'rudolph@qwerty.commcarehq.org'
         cls.password = '***'
-        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None)
+        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None, email=cls.username)
         cls.user.set_role(cls.domain.name, 'admin')
         cls.user.save()
 

--- a/corehq/apps/api/tests/utils.py
+++ b/corehq/apps/api/tests/utils.py
@@ -77,7 +77,8 @@ class APIResourceTest(TestCase, metaclass=PatchMeta):
         cls.list_endpoint = cls._get_list_endpoint()
         cls.username = 'rudolph@qwerty.commcarehq.org'
         cls.password = '***'
-        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None, email=cls.username)
+        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None,
+                                  email='rudoph@example.com', first_name='rudolph', last_name='commcare')
         cls.user.set_role(cls.domain.name, 'admin')
         cls.user.save()
 

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -156,9 +156,17 @@ ADMIN_API_LIST = (
 )
 
 
-USER_API_LIST = (
+# these APIs are duplicated to /hq/admin/global for backwards compatibility
+GLOBAL_USER_API_LIST = (
     UserDomainsResource,
 )
+
+NON_GLOBAL_USER_API_LIST = (
+    v0_5.IdentityResource,
+)
+
+
+USER_API_LIST = GLOBAL_USER_API_LIST + NON_GLOBAL_USER_API_LIST
 
 
 def get_global_api_url_patterns(resources):
@@ -169,7 +177,7 @@ def get_global_api_url_patterns(resources):
 
 
 admin_urlpatterns = list(get_global_api_url_patterns(ADMIN_API_LIST)) + \
-                    list(get_global_api_url_patterns(USER_API_LIST))
+                    list(get_global_api_url_patterns(GLOBAL_USER_API_LIST))
 
 
 VERSIONED_USER_API_LIST = (


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

For integrations it's useful to be able to get some information about the user who is authenticating. This adds an "identity" API that just returns a few of those details. Ideally we'd use something like [OpenID connect](https://openid.net/connect/) for this, but I looked into it and it seems to be more complex than I'm willing to bite off for now

The api is at https://www.commcarehq.org/api/v0.5/identity and returns something like the below:

```json
{
  "id": "85ed28df34105072a461c9f58ccdad0e",
  "username": "czue@dimagi.com",
  "first_name": "Cory",
  "last_name": "Zue",
  "email": "czue@dimagi.com"
}
```

Review by commit.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

Low risk, new endpoint.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

I can add API docs for this once it's approved/merged.