### PR TITLE
notify_addresses_str required, bump visibility

### DIFF
--- a/corehq/motech/forms.py
+++ b/corehq/motech/forms.py
@@ -48,7 +48,7 @@ class ConnectionSettingsForm(forms.ModelForm):
         label=_('Addresses to send notifications'),
         help_text=_('A comma-separated list of email addresses to send error '
                     'notifications'),
-        required=False,
+        required=True,
     )
 
     class Meta:
@@ -98,6 +98,7 @@ class ConnectionSettingsForm(forms.ModelForm):
             crispy.Fieldset(
                 _('Remote API Connection'),
                 crispy.Field('name'),
+                crispy.Field('notify_addresses_str'),
                 crispy.Field('url'),
                 crispy.Field('auth_type'),
                 crispy.Field('api_auth_settings'),
@@ -106,7 +107,6 @@ class ConnectionSettingsForm(forms.ModelForm):
                 crispy.Field('client_id'),
                 crispy.Field('plaintext_client_secret'),
                 twbscrispy.PrependedText('skip_cert_verify', ''),
-                crispy.Field('notify_addresses_str'),
                 self.test_connection_button,
             ),
             hqcrispy.FormActions(


### PR DESCRIPTION
Context: [CEP comment](https://github.com/dimagi/commcare-hq/issues/28314#issuecomment-672851628)

##### SUMMARY

Make the "Addresses to send notifications" field required for data forwarding, so that errors don't go unnoticed.


###### BEFORE:

![image](https://user-images.githubusercontent.com/708421/90039027-66874d80-dcc6-11ea-8980-779b84acca0e.png)


###### AFTER:

![image](https://user-images.githubusercontent.com/708421/90034918-810af800-dcc1-11ea-8573-843a380486df.png)


##### PRODUCT DESCRIPTION

Make the "Addresses to send notifications" field required for data forwarding, so that errors don't go unnoticed.
