### PR TITLE
Support encrypted empty passwords

### DIFF
--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -15,6 +15,7 @@ from corehq.motech.utils import (
     b64_aes_encrypt,
     pformat_json,
     simple_pad,
+    unpad,
 )
 
 
@@ -34,6 +35,21 @@ class SimplePadTests(SimpleTestCase):
         """
         padded = simple_pad(b'xy\xc5\xba\xc5\xbay', 8, b'*')
         self.assertEqual(padded, b'xy\xc5\xba\xc5\xbay*')
+
+
+class UnpadTests(SimpleTestCase):
+
+    def test_unpad_simple(self):
+        unpadded = unpad(b'xyzzy   ')
+        self.assertEqual(unpadded, b'xyzzy')
+
+    def test_unpad_crypto(self):
+        unpadded = unpad(b'xyzzy\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+        self.assertEqual(unpadded, b'xyzzy')
+
+    def test_unpad_empty(self):
+        unpadded = unpad(b'')
+        self.assertEqual(unpadded, b'')
 
 
 @override_settings(SECRET_KEY='xyzzy')

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -101,6 +101,8 @@ def unpad(bytestring):
 
     .. _iso7816: https://en.wikipedia.org/wiki/Padding_(cryptography)#ISO/IEC_7816-4
     """
+    if bytestring == b'':
+        return bytestring
     if bord(bytestring[-1]) in (0, 128):
         return crypto_unpad(bytestring, AES_BLOCK_SIZE, style='iso7816')
     return bytestring.rstrip(PAD_CHAR)


### PR DESCRIPTION
[Sentry](https://sentry.io/organizations/dimagi/issues/1838661168/?project=136860)

##### SUMMARY
Resolves a bug where `unpad()` raises `IndexError` when trying to unpad an empty bytestring.
