### PR TITLE
Fix params

### DIFF
--- a/corehq/motech/openmrs/repeaters.py
+++ b/corehq/motech/openmrs/repeaters.py
@@ -202,7 +202,7 @@ class OpenmrsRepeater(CaseRepeater):
             extra_fields=[conf["case_property"] for conf in value_source_configs if "case_property" in conf],
             form_question_values=get_form_question_values(payload),
         )
-        requests = self.connection_settings.get_requests(self, repeat_record.payload_id)
+        requests = self.connection_settings.get_requests(repeat_record.payload_id)
         try:
             response = send_openmrs_data(
                 requests,


### PR DESCRIPTION
Support ticket: [SAAS-11231](https://dimagi-dev.atlassian.net/browse/SAAS-11231)
Traceback: [Sentry](https://sentry.io/organizations/dimagi/issues/1838567153/?environment=production&project=136860)


##### SUMMARY

This call was passing `self` to the `payload_id` param, and `repeat_record.payload_id` to the `logger` param.


##### FEATURE FLAG
OpenMRS Integration
