### PR TITLE
Removed show account service type from individual feature flag page

### DIFF
--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -39,12 +39,8 @@
         <a href="{{ page_url }}?usage_info=true">
           <i class="icon-white icon-info-sign"></i>
           {% trans "Show usage" %}
-        </a> |
-      {% endif %}
-        <a href="{{ page_url }}?show_service_type=true">
-          <i class="icon-white icon-info-sign"></i>
-          {% trans "Show account service type" %}
         </a>
+      {% endif %}
       </span>
       {% if static_toggle.description %}
         <p>{{ static_toggle.description|safe }}</p>

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -117,10 +117,6 @@ class ToggleEditView(BasePageView):
         return self.request.GET.get('usage_info') == 'true'
 
     @property
-    def show_service_type(self):
-        return self.request.GET.get('show_service_type') == 'true'
-
-    @property
     def toggle_slug(self):
         return self.args[0] if len(self.args) > 0 else self.kwargs.get('toggle', "")
 
@@ -164,9 +160,6 @@ class ToggleEditView(BasePageView):
         if self.usage_info:
             context['last_used'] = _get_usage_info(toggle)
 
-        if self.show_service_type:
-            context['service_type'] = _get_service_type(toggle)
-
         return context
 
     def post(self, request, *args, **kwargs):
@@ -195,8 +188,6 @@ class ToggleEditView(BasePageView):
         }
         if self.usage_info:
             data['last_used'] = _get_usage_info(toggle)
-        if self.show_service_type:
-            data['service_type'] = _get_service_type(toggle)
         return HttpResponse(json.dumps(data), content_type="application/json")
 
     def _save_randomness(self, toggle, randomness):
@@ -272,19 +263,6 @@ def _get_usage_info(toggle):
     last_used["_latest"] = _get_most_recently_used(last_used)
     last_used["_active_domains"] = active_domains
     return last_used
-
-
-def _get_service_type(toggle):
-    """Returns subscription service type for each toggle
-    """
-    service_type = {}
-    for enabled in toggle.enabled_users:
-        name = _enabled_item_name(enabled)
-        if _namespace_domain(enabled):
-            subscription = Subscription.get_active_subscription_by_domain(name)
-            if subscription:
-                service_type[name] = subscription.service_type
-    return service_type
 
 
 def _namespace_domain(enabled_item):

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -16,7 +16,6 @@ from couchforms.analytics import get_last_form_submission_received
 from toggle.models import Toggle
 from toggle.shortcuts import parse_toggle
 
-from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import require_superuser_or_contractor
 from corehq.apps.hqwebapp.decorators import use_datatables
 from corehq.apps.hqwebapp.views import BasePageView


### PR DESCRIPTION
https://docs.google.com/document/d/16PfuyNALsoC7dUxMze8QhvO709zVmzekOjm2JaQo9fk/edit?usp=sharing
Specified in the "Mini Specs" section at the bottom of the doc (only available to those in the 'Dimagi' Google group).

##### SUMMARY
The 'show account service type' option on the individual feature flag page will be moved under the 'show usage' option as detailed in the doc.

##### PRODUCT DESCRIPTION
Will no longer be able to use the 'show account service type' option on the individual feature flag page. That page is only relevant for internal Dimagi engineers.
