### PR TITLE
Match roles by id

### DIFF
--- a/corehq/apps/linked_domain/tests/test_update_roles.py
+++ b/corehq/apps/linked_domain/tests/test_update_roles.py
@@ -62,3 +62,45 @@ class TestUpdateRoles(BaseLinkedAppsTest):
 
         self.assertTrue(roles['other_test'].permissions.edit_web_users)
         self.assertEqual(roles['other_test'].assignable_by, [roles['test'].get_id])
+
+    def test_match_names(self):
+        self.assertEqual([], UserRole.by_domain(self.linked_domain))
+
+        role = UserRole(
+            domain=self.linked_domain,
+            name='other_test',
+            permissions=Permissions(
+                edit_web_users=False,
+                view_locations=True,
+            ),
+            assignable_by=[self.role.get_id],
+        )
+        role.save()
+
+        update_user_roles(self.domain_link)
+        roles = {r.name: r for r in UserRole.by_domain(self.linked_domain)}
+        self.assertEqual(2, len(roles))
+        self.assertTrue(roles['other_test'].permissions.edit_web_users)
+        self.assertEqual(roles['other_test'].upstream_id, self.other_role.get_id)
+
+    def test_match_ids(self):
+        self.assertEqual([], UserRole.by_domain(self.linked_domain))
+
+        role = UserRole(
+            domain=self.linked_domain,
+            name='id_test',
+            permissions=Permissions(
+                edit_web_users=False,
+                view_locations=True,
+            ),
+            assignable_by=[self.role.get_id],
+            upstream_id=self.other_role.get_id
+        )
+        role.save()
+
+        update_user_roles(self.domain_link)
+        roles = {r.name: r for r in UserRole.by_domain(self.linked_domain)}
+        self.assertEqual(2, len(roles))
+        self.assertIsNotNone(roles.get('other_test'))
+        self.assertTrue(roles['other_test'].permissions.edit_web_users)
+        self.assertEqual(roles['other_test'].upstream_id, self.other_role.get_id)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -308,6 +308,7 @@ class UserRole(QuickCachedDocumentMixin, Document):
     # role assignable by specific non-admins
     assignable_by = StringListProperty(default=[])
     is_archived = BooleanProperty(default=False)
+    upstream_id = StringProperty()
 
     def get_qualified_id(self):
         return 'user-role:%s' % self.get_id


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://trello.com/c/FJWf2qPH/122-make-linked-domain-userrole-not-name-dependent

This matches linked user roles by upstream id, falling back to name if the id has not been set. That behavior allows built in or other existing matching roles to be overwritten on the initial copy and has the added benefit of not requiring a migration of existing roles. Name changes in the linked domain will now no longer unlink linked roles. Name changes in the master domain will propagate down.

The fallback means this does not resolve concerns about the behavior if multiple roles in a domain have the same name. But people really shouldn't do that, and we use name matching for roles elsewhere (like in user uploads), so I think it is reasonable to use the same here.