### PR TITLE
"Test Connection" button must send required field

### DIFF
--- a/corehq/motech/static/motech/js/connection_settings_detail.js
+++ b/corehq/motech/static/motech/js/connection_settings_detail.js
@@ -98,6 +98,7 @@ hqDefine("motech/js/connection_settings_detail", [
         $testConnectionButton.click(function () {
             var data = {
                 name: $('#id_name').val(),
+                notify_addresses_str: $('#id_notify_addresses_str').val(),
                 url: $('#id_url').val(),
                 auth_type: $('#id_auth_type').val(),
                 api_auth_settings: $('#id_api_auth_settings').val(),

--- a/corehq/motech/tests/test_utils.py
+++ b/corehq/motech/tests/test_utils.py
@@ -13,6 +13,7 @@ from corehq.motech.utils import (
     AES_KEY_MAX_LEN,
     b64_aes_decrypt,
     b64_aes_encrypt,
+    get_endpoint_url,
     pformat_json,
     simple_pad,
     unpad,
@@ -206,6 +207,21 @@ class EncryptionTests(SimpleTestCase):
     def test_encrypt_decrypt_utf8(self):
         message = 'आपके आसपास एक जंगल है'
         self.assert_message_equals_plaintext(message)
+
+
+class GetEndpointUrlTests(SimpleTestCase):
+
+    def test_base_url_none(self):
+        url = get_endpoint_url(None, 'https://example.com/foo')
+        self.assertEqual(url, 'https://example.com/foo')
+
+    def test_trailing_slash(self):
+        url = get_endpoint_url('https://example.com/foo', '')
+        self.assertEqual(url, 'https://example.com/foo/')
+
+    def test_no_urls_given(self):
+        with self.assertRaises(ValueError):
+            get_endpoint_url(None, None)
 
 
 class DocTests(SimpleTestCase):

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -157,14 +157,8 @@ def get_endpoint_url(
     >>> get_endpoint_url('https://example.com', 'foo')
     'https://example.com/foo'
 
-    >>> get_endpoint_url(None, 'https://example.com/foo')
-    'https://example.com/foo'
-
     >>> get_endpoint_url('https://example.com/foo', None)
     'https://example.com/foo'
-
-    >>> get_endpoint_url('https://example.com/foo', '')  # NOTE: Trailing "/"
-    'https://example.com/foo/'
 
     """
     if base_url is None and endpoint is None:

--- a/corehq/motech/utils.py
+++ b/corehq/motech/utils.py
@@ -143,9 +143,13 @@ def unpack_request_args(request_method, args, kwargs):
     return params, data, headers
 
 
-def get_endpoint_url(base_url: Optional[str], endpoint: str) -> str:
+def get_endpoint_url(
+    base_url: Optional[str],
+    endpoint: Optional[str],
+) -> str:
     """
-    Joins ``endpoint`` to ``base_url`` if ``base_url`` is not None.
+    Joins ``endpoint`` to ``base_url``. If either are None, returns the
+    other. If both are None, raises ValueError.
 
     >>> get_endpoint_url('https://example.com/', '/foo')
     'https://example.com/foo'
@@ -156,7 +160,17 @@ def get_endpoint_url(base_url: Optional[str], endpoint: str) -> str:
     >>> get_endpoint_url(None, 'https://example.com/foo')
     'https://example.com/foo'
 
+    >>> get_endpoint_url('https://example.com/foo', None)
+    'https://example.com/foo'
+
+    >>> get_endpoint_url('https://example.com/foo', '')  # NOTE: Trailing "/"
+    'https://example.com/foo/'
+
     """
+    if base_url is None and endpoint is None:
+        raise ValueError('No URLs given')
     if base_url is None:
         return endpoint
+    if endpoint is None:
+        return base_url
     return '/'.join((base_url.rstrip('/'), endpoint.lstrip('/')))

--- a/corehq/motech/views.py
+++ b/corehq/motech/views.py
@@ -252,7 +252,7 @@ def test_connection_settings(request, domain):
         try:
             # Send a GET request to the base URL. That should be enough
             # to test the URL and authentication.
-            response = requests.get('')
+            response = requests.get(endpoint=None)
             if 200 <= response.status_code < 300:
                 return JsonResponse({
                     "success": True,


### PR DESCRIPTION
##### SUMMARY
"notify_addresses_str" is now a required field. This change makes the "Test Connection" button send it.

It also ensures that a trailing "/" is not appended to URLs when only the connection's `base_url`  is used (which, for some APIs, can result in a 404).
