### PR TITLE
allow mirror domain owners for scheduled reports

### DIFF
--- a/corehq/apps/saved_reports/models.py
+++ b/corehq/apps/saved_reports/models.py
@@ -661,7 +661,7 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
     def send(self):
         # Scenario: user has been removed from the domain that they
         # have scheduled reports for.  Delete this scheduled report
-        if not self.owner.is_member_of(self.domain):
+        if not self.owner.is_member_of(self.domain, allow_mirroring=True):
             self.delete()
             return
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This prevents source domain users from having their scheduled reports deleted.