### PR TITLE
Truncate tab name from middle

### DIFF
--- a/corehq/ex-submodules/couchexport/tests/test_writers.py
+++ b/corehq/ex-submodules/couchexport/tests/test_writers.py
@@ -171,7 +171,7 @@ class HeaderNameTest(SimpleTestCase):
             )
         )
 
-    def test_max_header_length(self):
+    def test_even_max_header_length(self):
         writer = PythonDictWriter()
         writer.max_table_name_size = 10
         stringio = io.StringIO()
@@ -184,6 +184,37 @@ class HeaderNameTest(SimpleTestCase):
         writer.close()
         preview = writer.get_preview()
         self.assertGreater(len(table_index), writer.max_table_name_size)
+        self.assertEqual(preview[0]['table_name'], "my_t...dex")
+        self.assertLessEqual(len(preview[0]['table_name']), writer.max_table_name_size)
+
+    def test_odd_max_header_length(self):
+        writer = PythonDictWriter()
+        writer.max_table_name_size = 15
+        stringio = io.StringIO()
+        table_index = "another sheet tab name"
+        table_headers = [("header1", "header2")]
+        writer.open(
+            [(table_index, table_headers)],
+            stringio
+        )
+        writer.close()
+        preview = writer.get_preview()
+        self.assertEqual(preview[0]['table_name'], "anothe...b name")
+        self.assertLessEqual(len(preview[0]['table_name']), writer.max_table_name_size)
+
+    def test_exact_max_header_length(self):
+        writer = PythonDictWriter()
+        writer.max_table_name_size = 19
+        stringio = io.StringIO()
+        table_index = "sheet_name_for_tabs"
+        table_headers = [("header1", "header2")]
+        writer.open(
+            [(table_index, table_headers)],
+            stringio
+        )
+        writer.close()
+        preview = writer.get_preview()
+        self.assertEqual(preview[0]['table_name'], "sheet_name_for_tabs")
         self.assertLessEqual(len(preview[0]['table_name']), writer.max_table_name_size)
 
     def test_max_header_length_duplicates(self):

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -10,6 +10,7 @@ import json
 import bz2
 from collections import OrderedDict
 import openpyxl
+import math
 
 from django.template.loader import render_to_string, get_template
 from django.utils.functional import Promise
@@ -41,14 +42,15 @@ class UniqueHeaderGenerator(object):
 
     def _next_unique(self, string):
         counter = 1
+        split = (self.max_column_size - 3) / 2
         if len(string) > self.max_column_size:
             # truncate the middle
-            string = "{}...{}".format(string[:14], string[-14:])
+            string = "{}...{}".format(string[:math.ceil(split)], string[-math.floor(split):])
         orig_string = string
         while string.lower() in self.used:
             string = "%s%s" % (orig_string, counter)
             if len(string) > self.max_column_size:
-                string = "{}...{}".format(string[:14], string[-14:])
+                string = "{}...{}".format(string[:math.ceil(split)], string[-math.floor(split):])
             counter += 1
 
         return string

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -42,14 +42,13 @@ class UniqueHeaderGenerator(object):
     def _next_unique(self, string):
         counter = 1
         if len(string) > self.max_column_size:
-            # truncate from the beginning since the end has more specific information
-            string = string[-self.max_column_size:]
+            # truncate the middle
+            string = "{}...{}".format(string[:14], string[-14:])
         orig_string = string
         while string.lower() in self.used:
             string = "%s%s" % (orig_string, counter)
             if len(string) > self.max_column_size:
-                counterlen = len(str(counter))
-                string = "%s%s" % (orig_string[-(self.max_column_size - counterlen):], counter)
+                string = "{}...{}".format(string[:14], string[-14:])
             counter += 1
 
         return string


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10911

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Follow up to PR#28298. 

Truncate the middle part of the excel tab name to retain the most relevant information.
If there's an uneven split of characters between beginning and end part of the name, favor the beginning.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
N/A

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
N/A

