### PR TITLE
don't commit to a timeline we can't hold

### DIFF
--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -42,7 +42,7 @@
 
   <div class='alert alert-info'>
     {% blocktrans %}
-      This page will be removed in September 2019. Use the "Clean Form Submission" button on the form submission page
+      This page is being removed. Use the "Clean Form Submission" button on the form submission page
       to edit this form.
     {% endblocktrans %}
   </div>

--- a/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
+++ b/corehq/apps/reports/templates/reports/partials/data_corrections_modal.html
@@ -45,7 +45,7 @@
           <div class='alert alert-warning'>
             <i class="fa fa-exclamation-triangle"></i>
             {% blocktrans %}
-              This feature is replacing the old "Edit this form" functionality, which will be removed in September 2019.
+              This feature is replacing the old "Edit this form" functionality, which will be removed soon.
             {% endblocktrans %}
             <a href="{% url 'edit_form_instance' domain instance.form_id %}" target="_blank" id="edit-form">
               {% trans 'Click here to access the old "edit this form" page.' %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Changes the text of these two images to no longer specify a date but just say "soon" instead of a year ago.

![image](https://user-images.githubusercontent.com/66555/90634679-5fad8d00-e228-11ea-9d2a-72bc8c5d30bb.png)
![image](https://user-images.githubusercontent.com/66555/90634693-65a36e00-e228-11ea-95dc-b1ef585853e4.png)



##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
