### PR TITLE
start adding some tests for API auth

### DIFF
--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -2,9 +2,10 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 from django.test import TestCase, RequestFactory
 
-from corehq.apps.api.resources.auth import LoginAuthentication, LoginAndDomainAuthentication
+from corehq.apps.api.resources.auth import LoginAuthentication, LoginAndDomainAuthentication, \
+    RequirePermissionAuthentication
 from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import WebUser, HQApiKey
+from corehq.apps.users.models import WebUser, HQApiKey, Permissions, UserRole
 
 
 class AuthenticationTestBase(TestCase):
@@ -82,3 +83,72 @@ class LoginAndDomainAuthenticationTest(AuthenticationTestBase):
         self.addCleanup(project.delete)
         self.assertAuthenticationFail(LoginAndDomainAuthentication(),
                                       self._get_request_with_api_key(domain=project.name))
+
+
+class RequirePermissionAuthenticationTest(AuthenticationTestBase):
+    require_edit_data = RequirePermissionAuthentication(Permissions.edit_data)
+
+    def test_login_no_auth_no_domain(self):
+        self.assertAuthenticationFail(self.require_edit_data, self._get_request())
+
+    def test_login_no_auth_with_domain(self):
+        self.assertAuthenticationFail(self.require_edit_data, self._get_request(domain=self.domain))
+
+    def test_login_with_wrong_domain(self):
+        project = Domain.get_or_create_with_name('api-test-fail', is_active=True)
+        self.addCleanup(project.delete)
+        self.assertAuthenticationFail(self.require_edit_data,
+                                      self._get_request_with_api_key(domain=project.name))
+
+    def test_login_with_domain_no_permissions(self):
+        self.assertAuthenticationFail(self.require_edit_data,
+                                      self._get_request_with_api_key(domain=self.domain))
+
+    def test_login_with_domain_admin(self):
+        user_with_permission = WebUser.create(self.domain, 'domain_admin', '***', None, None, is_admin=True)
+        api_key_with_permissions, _ = HQApiKey.objects.get_or_create(
+            user=WebUser.get_django_user(user_with_permission)
+        )
+        self.addCleanup(lambda: user_with_permission.delete(None))
+        self.assertAuthenticationSuccess(self.require_edit_data,
+                                         self._get_request(
+                                             domain=self.domain,
+                                             HTTP_AUTHORIZATION=self._contruct_api_auth_header(
+                                                 user_with_permission.username,
+                                                 api_key_with_permissions
+                                             )
+                                         ))
+
+    def test_login_with_explicit_permission(self):
+        role = UserRole.get_or_create_with_permissions(self.domain, Permissions(edit_data=True), 'edit-data')
+        self.addCleanup(role.delete)
+        user_with_permission = WebUser.create(self.domain, 'permission', '***', None, None, role_id=role.get_id)
+        api_key_with_permissions, _ = HQApiKey.objects.get_or_create(
+            user=WebUser.get_django_user(user_with_permission)
+        )
+        self.addCleanup(lambda: user_with_permission.delete(None))
+        self.assertAuthenticationSuccess(self.require_edit_data,
+                                         self._get_request(
+                                             domain=self.domain,
+                                             HTTP_AUTHORIZATION=self._contruct_api_auth_header(
+                                                 user_with_permission.username,
+                                                 api_key_with_permissions
+                                             )
+                                         ))
+
+    def test_login_with_wrong_permission(self):
+        role = UserRole.get_or_create_with_permissions(self.domain, Permissions(edit_data=False), 'edit-data')
+        self.addCleanup(role.delete)
+        user_with_permission = WebUser.create(self.domain, 'permission', '***', None, None, role_id=role.get_id)
+        api_key_with_permissions, _ = HQApiKey.objects.get_or_create(
+            user=WebUser.get_django_user(user_with_permission)
+        )
+        self.addCleanup(lambda: user_with_permission.delete(None))
+        self.assertAuthenticationFail(self.require_edit_data,
+                                         self._get_request(
+                                             domain=self.domain,
+                                             HTTP_AUTHORIZATION=self._contruct_api_auth_header(
+                                                 user_with_permission.username,
+                                                 api_key_with_permissions
+                                             )
+                                         ))

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -6,11 +6,10 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser, HQApiKey
 
 
-class LoginAuthenticationTest(TestCase):
-
+class AuthenticationTestBase(TestCase):
     @classmethod
     def setUpClass(cls):
-        super(LoginAuthenticationTest, cls).setUpClass()
+        super().setUpClass()
         cls.factory = RequestFactory()
         cls.domain = Domain.get_or_create_with_name('api-test', is_active=True)
         cls.username = 'alice@example.com'
@@ -36,6 +35,9 @@ class LoginAuthenticationTest(TestCase):
 
     def assertAuthenticationFail(self, auth_instance, request):
         self.assertFalse(auth_instance.is_authenticated(request))
+
+
+class LoginAuthenticationTest(AuthenticationTestBase):
 
     def test_login_no_auth(self):
         self.assertAuthenticationFail(LoginAuthentication(), self._get_request())

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -47,7 +47,7 @@ class AuthenticationTestBase(TestCase):
         # this should likely be changed to always return False
         # more discussion here: https://github.com/dimagi/commcare-hq/pull/28201#discussion_r461082885
         if isinstance(result, HttpResponse):
-            self.assertTrue(result.status_code in (401, 403))
+            self.assertIn(result.status_code, (401, 403))
         else:
             self.assertFalse(result)
 

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -25,7 +25,11 @@ class AuthenticationTestBase(TestCase):
         super().tearDownClass()
 
     def _get_request_with_api_key(self, domain=None):
-        return self._get_request(domain, HTTP_AUTHORIZATION=f'ApiKey {self.username}:{self.api_key.key}')
+        return self._get_request(domain,
+                                 HTTP_AUTHORIZATION=self._contruct_api_auth_header(self.username, self.api_key))
+
+    def _contruct_api_auth_header(self, username, api_key):
+        return f'ApiKey {username}:{api_key.key}'
 
     def _get_request(self, domain=None, **extras):
         path = self._get_domain_path() if domain else ''

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -63,10 +63,18 @@ class LoginAuthenticationTest(AuthenticationTestBase):
 
 class LoginAndDomainAuthenticationTest(AuthenticationTestBase):
 
+    def test_login_no_auth_no_domain(self):
+        self.assertAuthenticationFail(LoginAndDomainAuthentication(), self._get_request())
+
+    def test_login_no_auth_with_domain(self):
+        self.assertAuthenticationFail(LoginAndDomainAuthentication(), self._get_request(domain=self.domain))
+
     def test_login_with_domain(self):
-        self.assertAuthenticationSuccess(LoginAndDomainAuthentication(), self._get_request(domain=self.domain))
+        self.assertAuthenticationSuccess(LoginAndDomainAuthentication(),
+                                         self._get_request_with_api_key(domain=self.domain))
 
     def test_login_with_wrong_domain(self):
-        domain = Domain.get_or_create_with_name('api-test-fail', is_active=True)
-        self.addCleanup(domain.delete)
-        self.assertAuthenticationFail(LoginAndDomainAuthentication(), self._get_request(domain=domain))
+        project = Domain.get_or_create_with_name('api-test-fail', is_active=True)
+        self.addCleanup(project.delete)
+        self.assertAuthenticationFail(LoginAndDomainAuthentication(),
+                                      self._get_request_with_api_key(domain=project.name))

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -145,10 +145,10 @@ class RequirePermissionAuthenticationTest(AuthenticationTestBase):
         )
         self.addCleanup(lambda: user_with_permission.delete(None))
         self.assertAuthenticationFail(self.require_edit_data,
-                                         self._get_request(
-                                             domain=self.domain,
-                                             HTTP_AUTHORIZATION=self._contruct_api_auth_header(
-                                                 user_with_permission.username,
-                                                 api_key_with_permissions
-                                             )
-                                         ))
+                                      self._get_request(
+                                          domain=self.domain,
+                                          HTTP_AUTHORIZATION=self._contruct_api_auth_header(
+                                              user_with_permission.username,
+                                              api_key_with_permissions
+                                          )
+                                      ))

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -12,19 +12,20 @@ class AuthenticationTestBase(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.factory = RequestFactory()
-        cls.domain = Domain.get_or_create_with_name('api-test', is_active=True)
+        cls.domain = 'api-test'
+        cls.project = Domain.get_or_create_with_name(cls.domain, is_active=True)
         cls.username = 'alice@example.com'
         cls.password = '***'
-        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None)
+        cls.user = WebUser.create(cls.domain, cls.username, cls.password, None, None)
         cls.api_key, _ = HQApiKey.objects.get_or_create(user=WebUser.get_django_user(cls.user))
 
     @classmethod
     def tearDownClass(cls):
-        cls.domain.delete()
+        cls.project.delete()
         super().tearDownClass()
 
-    def _get_request_with_api_key(self):
-        return self._get_request(HTTP_AUTHORIZATION=f'ApiKey {self.username}:{self.api_key.key}')
+    def _get_request_with_api_key(self, domain=None):
+        return self._get_request(domain, HTTP_AUTHORIZATION=f'ApiKey {self.username}:{self.api_key.key}')
 
     def _get_request(self, domain=None, **extras):
         path = self._get_domain_path() if domain else ''
@@ -34,7 +35,7 @@ class AuthenticationTestBase(TestCase):
         return request
 
     def _get_domain_path(self):
-        return f'/a/{self.domain.name}/'
+        return f'/a/{self.domain}/'
 
     def assertAuthenticationSuccess(self, auth_instance, request):
         # we can't use assertTrue, because auth failures can return "truthy" HttpResponse objects

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -1,0 +1,44 @@
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase, RequestFactory
+
+from corehq.apps.api.resources.auth import LoginAuthentication
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models import WebUser, HQApiKey
+
+
+class LoginAuthenticationTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(LoginAuthenticationTest, cls).setUpClass()
+        cls.factory = RequestFactory()
+        cls.domain = Domain.get_or_create_with_name('api-test', is_active=True)
+        cls.username = 'alice@example.com'
+        cls.password = '***'
+        cls.user = WebUser.create(cls.domain.name, cls.username, cls.password, None, None)
+        cls.api_key, _ = HQApiKey.objects.get_or_create(user=WebUser.get_django_user(cls.user))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain.delete()
+        super().tearDownClass()
+
+    def _get_request_with_api_key(self):
+        return self._get_request(HTTP_AUTHORIZATION=f'ApiKey {self.username}:{self.api_key.key}')
+
+    def _get_request(self, **extras):
+        request = self.factory.get('', **extras)
+        request.user = AnonymousUser()  # this is required for HQ's permission classes to resolve
+        return request
+
+    def assertAuthenticationSuccess(self, auth_instance, request):
+        self.assertTrue(auth_instance.is_authenticated(request))
+
+    def assertAuthenticationFail(self, auth_instance, request):
+        self.assertFalse(auth_instance.is_authenticated(request))
+
+    def test_login_no_auth(self):
+        self.assertAuthenticationFail(LoginAuthentication(), self._get_request())
+
+    def test_login_with_auth(self):
+        self.assertAuthenticationSuccess(LoginAuthentication(), self._get_request_with_api_key())

--- a/corehq/apps/api/tests/test_auth.py
+++ b/corehq/apps/api/tests/test_auth.py
@@ -37,7 +37,8 @@ class AuthenticationTestBase(TestCase):
         return f'/a/{self.domain.name}/'
 
     def assertAuthenticationSuccess(self, auth_instance, request):
-        self.assertTrue(auth_instance.is_authenticated(request))
+        # we can't use assertTrue, because auth failures can return "truthy" HttpResponse objects
+        self.assertEqual(True, auth_instance.is_authenticated(request))
 
     def assertAuthenticationFail(self, auth_instance, request):
         result = auth_instance.is_authenticated(request)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

Related to https://github.com/dimagi/commcare-hq/issues/28388 I thought it'd be good to have a test suite we can use to ensure we don't mess anything up.

We do have some tests around this functionality spread around, but they're all integration tests at the API-level and I thought it'd be better to be able to test the primitives.

This is just a start - planning on expanding it out tomorrow (but fine to review/merge as is)