### PR TITLE
modified searchText to keep search in search bar for the Case List se…

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -41,6 +41,10 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 }
 
                 Menus.Controller.showMenu(menuResponse);
+                // If menuResponse is an entities type, make set search bar continues to show search
+                if (menuResponse.type == "entities") {
+                    $('#searchText').val(urlObject.search);
+                }
 
                 if (menuResponse.shouldRequestLocation) {
                     Menus.Util.handleLocationRequest(options);

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -41,8 +41,8 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
                 }
 
                 Menus.Controller.showMenu(menuResponse);
-                // If menuResponse is an entities type, make set search bar continues to show search
-                if (menuResponse.type == "entities") {
+                // If a search exists in urlObject, make set search bar continues to show search
+                if (urlObject.search !== null) {
                     $('#searchText').val(urlObject.search);
                 }
 


### PR DESCRIPTION
https://trello.com/c/KHPkJbSu/134-keep-search-criteria-in-the-search-box-and-display-it-when-you-run-the-search

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When searching a case list, the search criteria remains in the search box when the user runs the search.
