### PR TITLE
Allow customized form pre processing

### DIFF
--- a/.travis/setup_icds.sh
+++ b/.travis/setup_icds.sh
@@ -13,7 +13,7 @@ ssh-add $TRAVIS_BUILD_DIR/.travis/deploy_key.pem
 mkdir -p $TRAVIS_BUILD_DIR/extensions/icds/
 git clone git@github.com:dimagi/commcare-icds.git $TRAVIS_BUILD_DIR/extensions/icds/ --depth=1
 cd $TRAVIS_BUILD_DIR/extensions/icds/ \
-    && git fetch origin $TRAVIS_PULL_REQUEST_BRANCH \
-    && git checkout $TRAVIS_PULL_REQUEST_BRANCH \
-    || echo "Branch $TRAVIS_PULL_REQUEST_BRANCH not found in ICDS repo. Defaulting to 'master'"
+    && git fetch origin mk/extract-sensitive-vault-data \
+    && git checkout mk/extract-sensitive-vault-data \
+    || echo "Branch mk/extract-sensitive-vault-data not found in ICDS repo. Defaulting to 'master'"
 cd $TRAVIS_BUILD_DIR

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -232,7 +232,7 @@ class SubmissionErrorTest(TestCase, TestFileMixin):
         self._test_case_processing_error(OPENROSA_VERSION_3)
 
     def test_no_form_lock_on_submit_device_log(self):
-        from corehq.form_processor.submission_post import FormProcessingResult as FPR
+        from corehq.form_processor.submission_post import FormProcessingResponse as FPR
         from corehq.form_processor.parsers.form import FormProcessingResult
 
         class FakeResponse(dict):

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -232,7 +232,7 @@ def _notify_ignored_form_submission(request, form_meta):
     })
 
 
-def should_ignore_submission(request):
+def should_ignore_submission(instance, request):
     """
     If IGNORE_ALL_DEMO_USER_SUBMISSIONS is True then ignore submission if from demo user.
     Else
@@ -241,7 +241,6 @@ def should_ignore_submission(request):
     """
     form_json = None
     if IGNORE_ALL_DEMO_USER_SUBMISSIONS:
-        instance, _ = couchforms.get_instance_and_attachment(request)
         try:
             form_json = convert_xform_to_json(instance)
         except couchforms.XMLSyntaxError:
@@ -257,7 +256,6 @@ def should_ignore_submission(request):
         return False
 
     if form_json is None:
-        instance, _ = couchforms.get_instance_and_attachment(request)
         form_json = convert_xform_to_json(instance)
     return False if from_demo_user(form_json) else True
 

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -110,7 +110,7 @@ def _get_instance_and_attachments(request, domain, authenticated,
         if isinstance(instance, BadRequest):
             response = _bad_request_response(instance.message, metric_tags)
         # silently ignore submission if it meets ignore-criteria
-        elif should_ignore_submission(request):
+        elif should_ignore_submission(instance, request):
             response = _ignored_submission_response(metric_tags)
         elif toggles.FORM_SUBMISSION_BLACKLIST.enabled(domain):
             response = _blacklisted_domain_response(metric_tags)

--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -73,38 +73,10 @@ def _process_form(request, domain, app_id, user_id, authenticated,
         'domain': domain
     }
 
-    try:
-        instance, attachments = couchforms.get_instance_and_attachment(request)
-    except MultimediaBug:
-        try:
-            instance = request.FILES[MAGIC_PROPERTY].read()
-            xform = convert_xform_to_json(instance)
-            meta = xform.get("meta", {})
-        except:
-            meta = {}
+    instance, attachments, response = _get_instance_and_attachments(
+        request, domain, authenticated, metric_tags, app_id, user_id)
 
-        metrics_counter('commcare.corrupt_multimedia_submissions', tags={
-            'domain': domain, 'authenticated': authenticated
-        })
-        return _submission_error(
-            request, "Received a submission with POST.keys()", metric_tags,
-            domain, app_id, user_id, authenticated, meta,
-        )
-
-    if isinstance(instance, BadRequest):
-        response = HttpResponseBadRequest(instance.message)
-        _record_metrics(metric_tags, 'known_failures', response)
-        return response
-
-    if should_ignore_submission(request):
-        # silently ignore submission if it meets ignore-criteria
-        response = openrosa_response.SUBMISSION_IGNORED_RESPONSE
-        _record_metrics(metric_tags, 'ignored', response)
-        return response
-
-    if toggles.FORM_SUBMISSION_BLACKLIST.enabled(domain):
-        response = openrosa_response.BLACKLISTED_RESPONSE
-        _record_metrics(metric_tags, 'blacklisted', response)
+    if response:
         return response
 
     with TimingContext() as timer:
@@ -145,6 +117,61 @@ def _process_form(request, domain, app_id, user_id, authenticated,
     response = result.response
     _record_metrics(metric_tags, result.submission_type, result.response, timer, result.xform)
 
+    return response
+
+
+def _get_instance_and_attachments(request, domain, authenticated,
+                                  metric_tags, app_id, user_id):
+    response, instance, attachments = None, None, None
+    try:
+        instance, attachments = couchforms.get_instance_and_attachment(request)
+    except MultimediaBug:
+        response = _multimedia_bug_response(request, domain, authenticated,
+                                            metric_tags, app_id, user_id)
+    else:
+        if isinstance(instance, BadRequest):
+            response = _bad_request_response(instance.message, metric_tags)
+        # silently ignore submission if it meets ignore-criteria
+        elif should_ignore_submission(request):
+            response = _ignored_submission_response(metric_tags)
+        elif toggles.FORM_SUBMISSION_BLACKLIST.enabled(domain):
+            response = _blacklisted_domain_response(metric_tags)
+    return instance, attachments, response
+
+
+def _multimedia_bug_response(request, domain, authenticated, metric_tags,
+                             app_id, user_id):
+    try:
+        instance = request.FILES[MAGIC_PROPERTY].read()
+        xform = convert_xform_to_json(instance)
+        meta = xform.get("meta", {})
+    except:
+        meta = {}
+
+    metrics_counter('commcare.corrupt_multimedia_submissions', tags={
+        'domain': domain, 'authenticated': authenticated
+    })
+    return _submission_error(
+        request, "Received a submission with POST.keys()", metric_tags,
+        domain, app_id, user_id, authenticated, meta,
+    )
+
+
+def _bad_request_response(message, metric_tags):
+    response = HttpResponseBadRequest(message)
+    _record_metrics(metric_tags, 'known_failures', response)
+    return response
+
+
+def _ignored_submission_response(metric_tags):
+    response = openrosa_response.SUBMISSION_IGNORED_RESPONSE
+    _record_metrics(metric_tags, 'ignored', response)
+    return response
+
+
+def _blacklisted_domain_response(metric_tags):
+    response = openrosa_response.BLACKLISTED_RESPONSE
+    _record_metrics(metric_tags, 'blacklisted', response)
     return response
 
 

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -5,6 +5,7 @@ from itertools import chain
 
 import redis
 from contextlib import ExitStack
+from django.conf import settings
 from django.db import transaction, DatabaseError, router
 from lxml import etree
 
@@ -361,7 +362,7 @@ def get_tracked_objects_db_names(form, raise_error_if_saved=False):
                 raise XFormSaveError(
                     '{} {} has already been saved'.format(type(model), model.pk)
                 )
-            if isinstance(model, PartitionedModel):
+            if settings.USE_PARTITIONED_DATABASE and isinstance(model, PartitionedModel):
                 db_names.add(model.db)
             else:
                 db_names.add(router.db_for_write(type(model)))

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -361,7 +361,6 @@ def get_tracked_objects_db_names(form, raise_error_if_saved=False):
                 raise XFormSaveError(
                     '{} {} has already been saved'.format(type(model), model.pk)
                 )
-            model.form_id = form.form_id
             if isinstance(model, PartitionedModel):
                 db_names.add(model.db)
             else:

--- a/corehq/form_processor/const.py
+++ b/corehq/form_processor/const.py
@@ -7,8 +7,3 @@ XFORM_PRE_PROCESSORS = {
     domain: [to_function(class_name) for class_name in preprocessors]
     for domain, preprocessors in settings.XFORM_PRE_PROCESSORS.items()
 }
-
-XFORM_TRACKED_MODELS = {
-    domain: [to_function(model) for model in models]
-    for domain, models in settings.XFORM_TRACKED_MODELS.items()
-}

--- a/corehq/form_processor/const.py
+++ b/corehq/form_processor/const.py
@@ -7,3 +7,8 @@ XFORM_PRE_PROCESSORS = {
     domain: [to_function(class_name) for class_name in preprocessors]
     for domain, preprocessors in settings.XFORM_PRE_PROCESSORS.items()
 }
+
+XFORM_TRACKED_MODELS = {
+    domain: [to_function(model) for model in models]
+    for domain, models in settings.XFORM_TRACKED_MODELS.items()
+}

--- a/corehq/form_processor/const.py
+++ b/corehq/form_processor/const.py
@@ -1,9 +1,0 @@
-from django.conf import settings
-
-from dimagi.utils.modules import to_function
-
-
-XFORM_PRE_PROCESSORS = {
-    domain: [to_function(class_name) for class_name in preprocessors]
-    for domain, preprocessors in settings.XFORM_PRE_PROCESSORS.items()
-}

--- a/corehq/form_processor/const.py
+++ b/corehq/form_processor/const.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+from dimagi.utils.modules import to_function
+
+
+XFORM_PRE_PROCESSORS = {
+    domain: [to_function(class_name) for class_name in preprocessors]
+    for domain, preprocessors in settings.XFORM_PRE_PROCESSORS.items()
+}

--- a/corehq/form_processor/extension_points.py
+++ b/corehq/form_processor/extension_points.py
@@ -1,0 +1,6 @@
+from corehq.extensions import extension_point, ResultFormat
+
+
+@extension_point(result_format=ResultFormat.FIRST)
+def get_form_submission_context_class():
+    """docs"""

--- a/corehq/form_processor/extension_points.py
+++ b/corehq/form_processor/extension_points.py
@@ -3,4 +3,8 @@ from corehq.extensions import extension_point, ResultFormat
 
 @extension_point(result_format=ResultFormat.FIRST)
 def get_form_submission_context_class():
-    """docs"""
+    """Custom form submission context class
+
+    Returns:
+        A class to be instantiated, or None
+    """

--- a/corehq/form_processor/submission_context.py
+++ b/corehq/form_processor/submission_context.py
@@ -13,12 +13,6 @@ class SubmissionFormContext(object):
         self.submission_post = submission_post
         self._instance = submission_post.instance
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc_info):
-        pass
-
     def get_instance_xml(self):
         try:
             return xml2json.get_xml_from_string(self._instance)
@@ -30,6 +24,10 @@ class SubmissionFormContext(object):
 
     def update_instance(self, xml):
         self._instance = lxml.etree.tostring(xml)
+
+    def pre_process_form(self):
+        # over write this method to add pre processing to form
+        pass
 
     def post_process_form(self, xform):
         self.submission_post.set_submission_properties(xform)

--- a/corehq/form_processor/submission_context.py
+++ b/corehq/form_processor/submission_context.py
@@ -1,0 +1,43 @@
+import lxml.etree
+from memoized import memoized
+import xml2json
+
+from corehq.form_processor.extension_points import get_form_submission_context_class
+from corehq.form_processor.utils.metadata import scrub_meta
+
+from couchforms.util import legacy_notification_assert
+
+
+class SubmissionFormContext(object):
+    def __init__(self, submission_post):
+        self.submission_post = submission_post
+        self._instance = submission_post.instance
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        pass
+
+    def get_instance_xml(self):
+        try:
+            return xml2json.get_xml_from_string(self._instance)
+        except xml2json.XMLSyntaxError:
+            return None
+
+    def get_instance(self):
+        return self._instance
+
+    def update_instance(self, xml):
+        self._instance = lxml.etree.tostring(xml)
+
+    def post_process_form(self, xform):
+        self.submission_post.set_submission_properties(xform)
+        found_old = scrub_meta(xform)
+        legacy_notification_assert(not found_old, 'Form with old metadata submitted', xform.form_id)
+        self.submission_post.invalidate_caches(xform)
+
+
+@memoized
+def form_submission_context_class():
+    return get_form_submission_context_class() or SubmissionFormContext

--- a/corehq/form_processor/submission_context.py
+++ b/corehq/form_processor/submission_context.py
@@ -2,16 +2,30 @@ import lxml.etree
 from memoized import memoized
 import xml2json
 
+from corehq import toggles
 from corehq.form_processor.extension_points import get_form_submission_context_class
 from corehq.form_processor.utils.metadata import scrub_meta
 
+from casexml.apps.phone.restore_caching import AsyncRestoreTaskIdCache, RestorePayloadPathCache
 from couchforms.util import legacy_notification_assert
+
+from celery.task.control import revoke as revoke_celery_task
 
 
 class SubmissionFormContext(object):
-    def __init__(self, submission_post):
-        self.submission_post = submission_post
-        self._instance = submission_post.instance
+    def __init__(self, domain, instance, submit_ip, path, openrosa_headers, last_sync_token, received_on,
+                 date_header, app_id, build_id, partial_submission):
+        self.domain = domain
+        self._instance = instance
+        self.submit_ip = submit_ip
+        self.path = path
+        self.openrosa_headers = openrosa_headers
+        self.last_sync_token = last_sync_token
+        self.received_on = received_on
+        self.date_header = date_header
+        self.app_id = app_id
+        self.build_id = build_id
+        self.partial_submission = partial_submission
 
     def get_instance_xml(self):
         try:
@@ -30,10 +44,61 @@ class SubmissionFormContext(object):
         pass
 
     def post_process_form(self, xform):
-        self.submission_post.set_submission_properties(xform)
+        self.set_submission_properties(xform)
         found_old = scrub_meta(xform)
         legacy_notification_assert(not found_old, 'Form with old metadata submitted', xform.form_id)
-        self.submission_post.invalidate_caches(xform)
+        self.invalidate_caches(xform)
+
+    def set_submission_properties(self, xform):
+        # attaches shared properties of the request to the document.
+        # used on forms and errors
+        xform.submit_ip = self.submit_ip
+        xform.path = self.path
+
+        xform.openrosa_headers = self.openrosa_headers
+        xform.last_sync_token = self.last_sync_token
+
+        if self.received_on:
+            xform.received_on = self.received_on
+
+        if self.date_header:
+            xform.date_header = self.date_header
+
+        xform.app_id = self.app_id
+        xform.build_id = self.build_id
+        xform.export_tag = ["domain", "xmlns"]
+        xform.partial_submission = self.partial_submission
+        return xform
+
+    def invalidate_caches(self, xform):
+        for device_id in {None, xform.metadata.deviceID if xform.metadata else None}:
+            self._invalidate_restore_payload_path_cache(xform, device_id)
+            if toggles.ASYNC_RESTORE.enabled(self.domain):
+                self._invalidate_async_restore_task_id_cache(xform, device_id)
+
+    def _invalidate_restore_payload_path_cache(self, xform, device_id):
+        """invalidate cached initial restores"""
+        restore_payload_path_cache = RestorePayloadPathCache(
+            domain=self.domain,
+            user_id=xform.user_id,
+            sync_log_id=xform.last_sync_token,
+            device_id=device_id,
+        )
+        restore_payload_path_cache.invalidate()
+
+    def _invalidate_async_restore_task_id_cache(self, xform, device_id):
+        async_restore_task_id_cache = AsyncRestoreTaskIdCache(
+            domain=self.domain,
+            user_id=xform.user_id,
+            sync_log_id=self.last_sync_token,
+            device_id=device_id,
+        )
+
+        task_id = async_restore_task_id_cache.get_value()
+
+        if task_id is not None:
+            revoke_celery_task(task_id)
+            async_restore_task_id_cache.invalidate()
 
 
 @memoized

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -54,7 +54,7 @@ CaseStockProcessingResult = namedtuple(
 )
 
 
-class FormProcessingResult(namedtuple('FormProcessingResult', 'response xform cases ledgers submission_type')):
+class FormProcessingResponse(namedtuple('FormProcessingResult', 'response xform cases ledgers submission_type')):
     @property
     def case(self):
         assert len(self.cases) == 1
@@ -219,7 +219,7 @@ class SubmissionPost(object):
         report_submission_usage(self.domain)
         failure_response = self._handle_basic_failure_modes()
         if failure_response:
-            return FormProcessingResult(failure_response, None, [], [], 'known_failures')
+            return FormProcessingResponse(failure_response, None, [], [], 'known_failures')
 
         result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
         submitted_form = result.submitted_form
@@ -245,7 +245,7 @@ class SubmissionPost(object):
                 response = self.get_exception_response_and_log(
                     'Problem receiving submission', submitted_form, self.path
                 )
-            return FormProcessingResult(response, None, [], [], 'submission_error_log')
+            return FormProcessingResponse(response, None, [], [], 'submission_error_log')
 
         if submitted_form.xmlns == SYSTEM_ACTION_XMLNS:
             return self.handle_system_action(submitted_form)
@@ -327,7 +327,7 @@ class SubmissionPost(object):
                     submission_type = 'error'
 
             response = self._get_open_rosa_response(instance, **openrosa_kwargs)
-            return FormProcessingResult(response, instance, cases, ledgers, submission_type)
+            return FormProcessingResponse(response, instance, cases, ledgers, submission_type)
 
     def _conditionally_send_device_logs_to_sumologic(self, instance):
         url = getattr(settings, 'SUMOLOGIC_URL', None)
@@ -514,7 +514,7 @@ class SubmissionPost(object):
         handle_system_action(form, self.auth_context)
         self.interface.save_processed_models([form])
         response = HttpResponse(status=201)
-        return FormProcessingResult(response, form, [], [], 'system-action')
+        return FormProcessingResponse(response, form, [], [], 'system-action')
 
     @tracer.wrap(name='submission.process_device_log')
     def process_device_log(self, device_log_form):
@@ -532,7 +532,7 @@ class SubmissionPost(object):
                 raise
 
         response = self._get_open_rosa_response(device_log_form)
-        return FormProcessingResult(response, device_log_form, [], [], 'device-log')
+        return FormProcessingResponse(response, device_log_form, [], [], 'device-log')
 
 
 def _transform_instance_to_error(interface, exception, instance):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -216,7 +216,7 @@ class SubmissionPost(object):
 
         context = form_submission_context_class()(self)
         with context:
-            self.instance = context.get_instance() or self.instance
+            self.instance = context.get_instance()
             result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
             context.post_process_form(result.submitted_form)
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -215,10 +215,10 @@ class SubmissionPost(object):
             return FormProcessingResponse(failure_response, None, [], [], 'known_failures')
 
         context = form_submission_context_class()(self)
-        with context:
-            self.instance = context.get_instance()
-            result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
-            context.post_process_form(result.submitted_form)
+        context.pre_process_form()
+        self.instance = context.get_instance()
+        result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
+        context.post_process_form(result.submitted_form)
 
         submitted_form = result.submitted_form
         if submitted_form.is_submission_error_log:

--- a/settings.py
+++ b/settings.py
@@ -2076,3 +2076,5 @@ PACKAGE_MONITOR_REQUIREMENTS_FILE = os.path.join(FILEPATH, 'requirements', 'requ
 # for each domain provide a list of pre-processors that would be instantiated
 # and passed the form xml for processing
 XFORM_PRE_PROCESSORS = {}
+
+XFORM_TRACKED_MODELS = {}

--- a/settings.py
+++ b/settings.py
@@ -2071,3 +2071,8 @@ if RESTRICT_USED_PASSWORDS_FOR_NIC_COMPLIANCE:
     ]
 
 PACKAGE_MONITOR_REQUIREMENTS_FILE = os.path.join(FILEPATH, 'requirements', 'requirements.txt')
+
+# provides extensions with ability to customize form processing per domain
+# for each domain provide a list of pre-processors that would be instantiated
+# and passed the form xml for processing
+XFORM_PRE_PROCESSORS = {}

--- a/settings.py
+++ b/settings.py
@@ -1061,11 +1061,6 @@ COMMCARE_EXTENSIONS = []
 # and are passed the form xml for processing
 XFORM_PRE_PROCESSORS = {}
 
-# Provides extensions with ability to add models to be saved along with forms on form processing.
-# For each domain provide a list of model classes to be checked for objects added for creation via
-# TrackRelatedChanges
-XFORM_TRACKED_MODELS = {}
-
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)

--- a/settings.py
+++ b/settings.py
@@ -1056,11 +1056,6 @@ DEFAULT_COMMCARE_EXTENSIONS = [
 ]
 COMMCARE_EXTENSIONS = []
 
-# Provides extensions with ability to customize form processing per domain.
-# For each domain provide a list of pre-processors that would be instantiated
-# and are passed the form xml for processing
-XFORM_PRE_PROCESSORS = {}
-
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)

--- a/settings.py
+++ b/settings.py
@@ -1056,6 +1056,16 @@ DEFAULT_COMMCARE_EXTENSIONS = [
 ]
 COMMCARE_EXTENSIONS = []
 
+# Provides extensions with ability to customize form processing per domain.
+# For each domain provide a list of pre-processors that would be instantiated
+# and are passed the form xml for processing
+XFORM_PRE_PROCESSORS = {}
+
+# Provides extensions with ability to add models to be saved along with forms on form processing.
+# For each domain provide a list of model classes to be checked for objects added for creation via
+# TrackRelatedChanges
+XFORM_TRACKED_MODELS = {}
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)
@@ -2071,10 +2081,3 @@ if RESTRICT_USED_PASSWORDS_FOR_NIC_COMPLIANCE:
     ]
 
 PACKAGE_MONITOR_REQUIREMENTS_FILE = os.path.join(FILEPATH, 'requirements', 'requirements.txt')
-
-# provides extensions with ability to customize form processing per domain
-# for each domain provide a list of pre-processors that would be instantiated
-# and passed the form xml for processing
-XFORM_PRE_PROCESSORS = {}
-
-XFORM_TRACKED_MODELS = {}


### PR DESCRIPTION
Related PRs:
https://github.com/dimagi/xml2json/pull/10
https://github.com/dimagi/commcare-icds/pull/41

##### SUMMARY
This PR allows commcare extensions/hq environments to hook into the form processing by inheriting from  "SubmissionContext" that is used for form processing.

Additionally, any newly added models on forms using `track_create` are now saved. This is different from earlier when only selected models were saved. https://github.com/dimagi/commcare-hq/pull/28409/commits/f6728045d58f0b943e2693282aa8b8cb2e5b542b

##### RISK ASSESSMENT / QA PLAN
None

##### PRODUCT DESCRIPTION
This does not cause any change for core HQ environment.