### PR TITLE
Update django-websocket-redis for django 2.1.5+ compatibility

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -66,7 +66,7 @@ django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
-django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django-websocket-redis==0.6.0  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-debug-toolbar, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -57,7 +57,7 @@ django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
-django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django-websocket-redis==0.6.0  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator, eventlet

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -81,7 +81,7 @@ django-otp~=0.9.3
 django-two-factor-auth~=1.12
 datadog==0.15.0
 ddtrace==0.14.1
-django-websocket-redis==0.5.2
+django-websocket-redis==0.6.0
 django-redis-sessions==0.6.1
 SQLAlchemy~=1.3.0
 alembic==0.8.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -55,7 +55,7 @@ django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
-django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django-websocket-redis==0.6.0  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -60,7 +60,7 @@ django-tastypie==0.14.2   # via -r requirements/requirements.in
 django-transfer==0.4      # via -r requirements/requirements.in
 django-two-factor-auth==1.12.1  # via -r requirements/requirements.in
 django-user-agents==0.3.2  # via -r requirements/requirements.in
-django-websocket-redis==0.5.2  # via -r requirements/requirements.in
+django-websocket-redis==0.6.0  # via -r requirements/requirements.in
 django==2.2.13            # via -r requirements/requirements.in, django-angular, django-appconf, django-bulk-update, django-formtools, django-logentry-admin, django-oauth-toolkit, django-otp, django-phonenumber-field, django-prbac, django-ranged-response, django-redis, django-simple-captcha, django-statici18n, django-two-factor-auth, django-user-agents, djangorestframework, jsonfield
 djangorestframework==3.11.0  # via -r requirements/requirements.in
 dnspython==1.15.0         # via -r requirements/requirements.in, email-validator


### PR DESCRIPTION
Since recent django upgrades, when using Formplayer locally my console has been spammed with

```
2020-08-25 15:42:22,374 ERROR Other Exception: 'LimitedStream' object has no attribute 'raw'
Traceback (most recent call last):
  File "/home/ctsims/venv/cchq/lib/python3.6/site-packages/ws4redis/wsgi_server.py", line 113, in __call__
    websocket = self.upgrade_websocket(environ, start_response)
  File "/home/ctsims/venv/cchq/lib/python3.6/site-packages/ws4redis/django_runserver.py", line 97, in upgrade_websocket
    return WebSocket(environ['wsgi.input'])
  File "/home/ctsims/venv/cchq/lib/python3.6/site-packages/ws4redis/websocket.py", line 29, in __init__
    self.stream = Stream(wsgi_input)
  File "/home/ctsims/venv/cchq/lib/python3.6/site-packages/ws4redis/websocket.py", line 296, in __init__
    self.read = wsgi_input.raw._sock.recv
```

exception tracebacks due to a [django 2.1.5 compatiblity issue](https://github.com/jrief/django-websocket-redis/issues/286) with the websocket-redis library which was [fixed in a newer version](https://github.com/jrief/django-websocket-redis/pull/288
). Not clear on whether this is affecting production environments the same way, but I don't see why it wouldn't.

Updates the core lib to the latest version.