### PR TITLE
Refactor JS to remove global module definition

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -1,7 +1,14 @@
 /*global FormplayerFrontend */
 
-hqDefine('cloudcare/js/util',['hqwebapp/js/initial_page_data', 'jquery', 'integration/js/hmac_callout'],
-function (initialPageData, $, HMACCallout) {
+hqDefine('cloudcare/js/util', [
+'hqwebapp/js/initial_page_data',
+'jquery',
+'integration/js/hmac_callout'
+], function (
+initialPageData,
+$,
+HMACCallout
+) {
     if (!String.prototype.startsWith) {
         String.prototype.startsWith = function (searchString, position) {
             position = position || 0;

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -212,7 +212,7 @@ hqDefine('cloudcare/js/util',['hqwebapp/js/initial_page_data', 'integration/js/h
 
     var addDelegatedClickDispatch = function (linkTarget, linkDestination) {
         document.addEventListener('click', function (event) {
-            if (event.target.target == linkTarget) {
+            if (event.target.target === linkTarget) {
                 linkDestination(event.target);
                 event.preventDefault();
             }
@@ -247,7 +247,7 @@ hqDefine('cloudcare/js/util',['hqwebapp/js/initial_page_data', 'integration/js/h
                     "gaen_otp"
                 ));
                 addDelegatedClickDispatch('gaen_otp',
-                    function(element) {
+                    function (element) {
                         HMACCallout.unsignedCallout(element, 'otp_view', true);
                     });
             }
@@ -255,11 +255,11 @@ hqDefine('cloudcare/js/util',['hqwebapp/js/initial_page_data', 'integration/js/h
             if (initialPageData.get('hmac_root_url')) {
                 renderers.push(chainedRenderer(
                     function (href) { return href.startsWith(initialPageData.get('hmac_root_url')); },
-                    function (href, hIndex, anchor) {},
+                    function () {},
                     "hmac_callout"
                 ));
                 addDelegatedClickDispatch('hmac_callout',
-                    function(element) {
+                    function (element) {
                         HMACCallout.signedCallout(element);
                     });
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -3,7 +3,7 @@
 hqDefine('cloudcare/js/util', [
     'hqwebapp/js/initial_page_data',
     'jquery',
-    'integration/js/hmac_callout'
+    'integration/js/hmac_callout',
 ], function (
     initialPageData,
     $,

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -1,6 +1,7 @@
 /*global FormplayerFrontend */
 
-hqDefine('cloudcare/js/util',['hqwebapp/js/initial_page_data', 'integration/js/hmac_callout'], function (initialPageData) {
+hqDefine('cloudcare/js/util',['hqwebapp/js/initial_page_data', 'jquery', 'integration/js/hmac_callout'],
+function (initialPageData, $, HMACCallout) {
     if (!String.prototype.startsWith) {
         String.prototype.startsWith = function (searchString, position) {
             position = position || 0;

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -229,7 +229,6 @@ hqDefine('cloudcare/js/util', [
 
     var injectMarkdownAnchorTransforms = function () {
         if (window.mdAnchorRender) {
-            var HMACCallout = hqImport('integration/js/hmac_callout');
             var renderers = [];
 
             if (initialPageData.get('dialer_enabled')) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -1,13 +1,13 @@
 /*global FormplayerFrontend */
 
 hqDefine('cloudcare/js/util', [
-'hqwebapp/js/initial_page_data',
-'jquery',
-'integration/js/hmac_callout'
+    'hqwebapp/js/initial_page_data',
+    'jquery',
+    'integration/js/hmac_callout'
 ], function (
-initialPageData,
-$,
-HMACCallout
+    initialPageData,
+    $,
+    HMACCallout
 ) {
     if (!String.prototype.startsWith) {
         String.prototype.startsWith = function (searchString, position) {

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -15,13 +15,14 @@
   <script src="{% static 'ace-builds/src-min-noconflict/ext-searchbox.js' %}"></script>
   <script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.js' %}"></script>
   <script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
+  <script src="{% static 'crypto-js/crypto-js.js' %}"></script>
+  <script src="{% static 'integration/js/hmac_callout.js' %}"></script>
   <script src="{% static 'cloudcare/js/util.js' %}"></script>
   <script src="{% static 'Caret.js/dist/jquery.caret.js' %}"></script>
   <script src="{% static 'At.js/dist/js/jquery.atwho.js' %}"></script>
   <script src="{% static 'fast-levenshtein/levenshtein.js' %}"></script>
   <script src="{% static 'clipboard/dist/clipboard.js' %}"></script>
   <script src="{% static 'reports/js/readable_form.js' %}"></script>
-  <script src="{% static 'crypto-js/crypto-js.js' %}"></script>
   <script src="{% static 'url-polyfill/url-polyfill.js' %}"></script>
 
   <script src="{% static 'cloudcare/js/formplayer/utils/util.js' %}"></script>
@@ -61,8 +62,6 @@
   <script src="{% static 'cloudcare/js/formplayer/sessions/collections.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/sessions/views.js' %}"></script>
   <script src="{% static 'cloudcare/js/formplayer/sessions/controller.js' %}"></script>
-
-  <script src="{% static 'integration/js/hmac_callout.js' %}"></script>
 {% endcompress %}
 
 {% include 'hqwebapp/includes/ui_element_js.html' %}

--- a/corehq/apps/integration/static/integration/js/hmac_callout.js
+++ b/corehq/apps/integration/static/integration/js/hmac_callout.js
@@ -94,7 +94,5 @@ hqDefine("integration/js/hmac_callout", [
         unsignedCallout: unsignedCallout,
     };
 
-    window.HMACCallout = moduleMap;
-
     return moduleMap;
 });

--- a/corehq/apps/integration/static/integration/js/hmac_callout.js
+++ b/corehq/apps/integration/static/integration/js/hmac_callout.js
@@ -89,10 +89,8 @@ hqDefine("integration/js/hmac_callout", [
         document.body.removeChild(form);
     };
 
-    var moduleMap = {
+    return {
         signedCallout: signedCallout,
         unsignedCallout: unsignedCallout,
     };
-
-    return moduleMap;
 });


### PR DESCRIPTION
Refactor followup to https://github.com/dimagi/commcare-hq/pull/28401.

Migrates click handling from inline HTML to event delegation to remove the need for the integration HMACCallout module (or any future hijacked anchor element callouts) to be global.