### PR TITLE
Fix QR code not displaying due to invalid URL

### DIFF
--- a/corehq/apps/settings/tests/test_views.py
+++ b/corehq/apps/settings/tests/test_views.py
@@ -1,0 +1,22 @@
+from django.test import SimpleTestCase
+from unittest.mock import Mock, patch
+
+from corehq.apps.settings.views import EnableMobilePrivilegesView
+
+
+class EnableMobilePrivilegesViewTests(SimpleTestCase):
+
+    def test_qr_code(self):
+        """
+        Check that the qr code in the context is a string, as opposed to a byte object
+        """
+        view = EnableMobilePrivilegesView()
+        view.get_context_data = Mock(return_value={})
+        view.render_to_response = lambda x: x
+        mock_request = Mock()
+        mock_request.user.username = "test"
+
+        with patch('corehq.apps.settings.views.sign', lambda x: b'foo'):
+            context = view.get(mock_request)
+
+        self.assertTrue(isinstance(context['qrcode_64'], str))

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -497,7 +497,7 @@ class EnableMobilePrivilegesView(BaseMyAccountView):
         qrcode = get_qrcode(qrcode_data)
 
         context = self.get_context_data(**kwargs)
-        context['qrcode_64'] = b64encode(qrcode)
+        context['qrcode_64'] = b64encode(qrcode).decode('utf8')
         return self.render_to_response(context)
 
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[JIRA ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11150)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The QR Code was failing to load because the key 'qrcode_64' in the view's context had a value of type bytes, not string. The fix was to decode the literal bytes to a string, using the utf-8 format. 

The issue was most likely caused by the Django 2 upgrade, specifically the [removal of support for bytestrings in some places](https://docs.djangoproject.com/en/3.0/releases/2.0/#removed-support-for-bytestrings-in-some-places). 

A test was added to ensure the QR code generated data passed into the view's context is a string.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
