### PR TITLE
Add ability to customize form processing

### DIFF
--- a/corehq/form_processor/extension_points.py
+++ b/corehq/form_processor/extension_points.py
@@ -3,7 +3,7 @@ from corehq.extensions import extension_point, ResultFormat
 
 @extension_point(result_format=ResultFormat.FIRST)
 def get_submission_post_form_processor_class():
-    """A sub class of SubmissionPostFormProcessor class to be
+    """A sub class of FormXmlProcessor class to be
     used to form processing
 
     Returns:

--- a/corehq/form_processor/extension_points.py
+++ b/corehq/form_processor/extension_points.py
@@ -1,0 +1,11 @@
+from corehq.extensions import extension_point, ResultFormat
+
+
+@extension_point(result_format=ResultFormat.FIRST)
+def get_submission_post_form_processor_class():
+    """A sub class of SubmissionPostFormProcessor class to be
+    used to form processing
+
+    Returns:
+        A class to be instantiated, or None
+    """

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -514,7 +514,7 @@ def notify_submission_error(instance, message, exec_info=None):
         logging.error(message, exc_info=sys.exc_info(), extra={'details': details})
 
 
-class SubmissionPostFormProcessor(object):
+class FormXmlProcessor(object):
     def __init__(self, *, domain, instance, attachments, auth_context, submit_ip, path, openrosa_headers,
                  last_sync_token, received_on, date_header, app_id, build_id, partial_submission):
         self.domain = domain
@@ -600,4 +600,4 @@ class SubmissionPostFormProcessor(object):
 
 @memoized
 def form_submission_context_class():
-    return get_submission_post_form_processor_class() or SubmissionPostFormProcessor
+    return get_submission_post_form_processor_class() or FormXmlProcessor

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -568,7 +568,6 @@ class SubmissionPostFormProcessor(object):
         xform.build_id = self.build_id
         xform.export_tag = ["domain", "xmlns"]
         xform.partial_submission = self.partial_submission
-        return xform
 
     def _invalidate_caches(self, xform):
         for device_id in {None, xform.metadata.deviceID if xform.metadata else None}:

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -1,4 +1,6 @@
 import logging
+import lxml.etree
+import xml2json
 from collections import namedtuple
 
 from ddtrace import tracer
@@ -516,7 +518,7 @@ class SubmissionPostFormProcessor(object):
     def __init__(self, *, domain, instance, attachments, auth_context, submit_ip, path, openrosa_headers,
                  last_sync_token, received_on, date_header, app_id, build_id, partial_submission):
         self.domain = domain
-        self.instance = instance
+        self._instance = instance
         self.attachments = attachments or {}
         self.auth_context = auth_context or DefaultAuthContext()
         self.submit_ip = submit_ip
@@ -530,9 +532,14 @@ class SubmissionPostFormProcessor(object):
         self.partial_submission = partial_submission
 
     def process_form(self):
-        result = process_xform_xml(self.domain, self.instance, self.attachments, self.auth_context.to_json())
+        self.pre_process_form()
+        result = process_xform_xml(self.domain, self.get_instance(), self.attachments, self.auth_context.to_json())
         self.post_process_form(result.submitted_form)
         return result
+
+    def pre_process_form(self):
+        # over write this method to add pre processing to form
+        pass
 
     def post_process_form(self, xform):
         self._set_submission_properties(xform)
@@ -590,3 +597,15 @@ class SubmissionPostFormProcessor(object):
         if task_id is not None:
             revoke_celery_task(task_id)
             async_restore_task_id_cache.invalidate()
+
+    def get_instance_xml(self):
+        try:
+            return xml2json.get_xml_from_string(self._instance)
+        except xml2json.XMLSyntaxError:
+            return None
+
+    def get_instance(self):
+        return self._instance
+
+    def update_instance(self, xml):
+        self._instance = lxml.etree.tostring(xml)


### PR DESCRIPTION
Re-Do of https://github.com/dimagi/commcare-hq/pull/28409, with lesser changes in core HQ.

This PR makes it possible for extensions to hook into the form processing workflow.
This would then be used by ICDS right away for https://github.com/dimagi/commcare-icds/pull/54
Related PR https://github.com/dimagi/xml2json/pull/10

##### SUMMARY
The first commit is mainly extraction of a class that trims down SubmissionPost. 
Then in following commit, new class `SubmissionPostFormProcessor` is updated to provide a clear api to access/update the form xml. Then eventually we provide an extension point for extensions to hook their custom form processor.


##### RISK ASSESSMENT / QA PLAN
None

##### PRODUCT DESCRIPTION
No real change for core product
