### PR TITLE
Add some monitoring for determining mobile worker 2FA issues

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -115,7 +115,7 @@ from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.permissions import can_manage_releases
 from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, \
-    SECURE_SESSION_TIMEOUT, MONTIOR_2FA_CHANGES
+    SECURE_SESSION_TIMEOUT, MONITOR_2FA_CHANGES
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
@@ -657,7 +657,7 @@ class PrivacySecurityForm(forms.Form):
         domain.secure_sessions_timeout = self.cleaned_data.get('secure_sessions_timeout', None)
 
         new_two_factor_auth_setting = self.cleaned_data.get('two_factor_auth', False)
-        if domain.two_factor_auth != new_two_factor_auth_setting and MONTIOR_2FA_CHANGES.enabled(domain.name):
+        if domain.two_factor_auth != new_two_factor_auth_setting and MONITOR_2FA_CHANGES.enabled(domain.name):
             from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
             status = "ON" if new_two_factor_auth_setting else "OFF"
             monitor_2fa_soft_assert(False, f'{domain.name} turned 2FA {status}')

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -114,7 +114,8 @@ from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.permissions import can_manage_releases
-from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, SECURE_SESSION_TIMEOUT
+from corehq.toggles import HIPAA_COMPLIANCE_CHECKBOX, MOBILE_UCR, \
+    SECURE_SESSION_TIMEOUT, MONTIOR_2FA_CHANGES
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 from custom.nic_compliance.forms import EncodedPasswordChangeFormMixin
@@ -654,7 +655,14 @@ class PrivacySecurityForm(forms.Form):
         domain.allow_domain_requests = self.cleaned_data.get('allow_domain_requests', False)
         domain.secure_sessions = self.cleaned_data.get('secure_sessions', False)
         domain.secure_sessions_timeout = self.cleaned_data.get('secure_sessions_timeout', None)
-        domain.two_factor_auth = self.cleaned_data.get('two_factor_auth', False)
+
+        new_two_factor_auth_setting = self.cleaned_data.get('two_factor_auth', False)
+        if domain.two_factor_auth != new_two_factor_auth_setting and MONTIOR_2FA_CHANGES.enabled(domain.name):
+            from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
+            status = "ON" if new_two_factor_auth_setting else "OFF"
+            monitor_2fa_soft_assert(False, f'{domain.name} turned 2FA {status}')
+        domain.two_factor_auth = new_two_factor_auth_setting
+
         domain.strong_mobile_passwords = self.cleaned_data.get('strong_mobile_passwords', False)
         secure_submissions = self.cleaned_data.get(
             'secure_submissions', False)

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -11,6 +11,7 @@ from Crypto.PublicKey import RSA
 from Crypto.Signature import PKCS1_PSS
 from memoized import memoized
 
+from corehq.util.soft_assert import soft_assert
 from dimagi.utils.logging import notify_exception
 
 from corehq.apps.hqwebapp.forms import BulkUploadForm
@@ -20,6 +21,11 @@ from corehq.util.view_utils import get_request
 from custom.nic_compliance.utils import get_raw_password
 
 logger = logging.getLogger(__name__)
+
+monitor_2fa_soft_assert = soft_assert(
+    to=['{}@{}'.format('biyeun', 'dimagi.com')],
+    send_to_ops=False
+)
 
 
 @memoized

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -51,7 +51,7 @@ from memoized import memoized
 from sentry_sdk import last_event_id
 from two_factor.views import LoginView
 
-from corehq.toggles import MONTIOR_2FA_CHANGES
+from corehq.toggles import MONITOR_2FA_CHANGES
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
 from corehq.apps.users.event_handlers import handle_email_invite_message
@@ -206,7 +206,7 @@ def redirect_to_default(req, domain=None):
         else:
             url = reverse('login')
     elif domain and _two_factor_needed(domain, req):
-        if MONTIOR_2FA_CHANGES.enabled(domain):
+        if MONITOR_2FA_CHANGES.enabled(domain):
             from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
             monitor_2fa_soft_assert(False, f'2FA required page shown to user '
                                            f'{req.user.username} on {domain} after '
@@ -397,7 +397,7 @@ def _login(req, domain_name, custom_login_page, extra_context=None):
             old_lang = req.session.get(LANGUAGE_SESSION_KEY)
             update_session_language(req, old_lang, new_lang)
 
-            # context needed for MONTIOR_2FA_CHANGES toggle in HQLoginView
+            # context needed for MONITOR_2FA_CHANGES toggle in HQLoginView
             context.update({
                 'is_commcare_user': couch_user.is_commcare_user(),
             })
@@ -492,7 +492,7 @@ class HQLoginView(LoginView):
         domain = context.get('domain')
         is_commcare_user = context.get('is_commcare_user', False)
         if (steps and steps.current == 'token'
-                and is_commcare_user and MONTIOR_2FA_CHANGES.enabled(domain)):
+                and is_commcare_user and MONITOR_2FA_CHANGES.enabled(domain)):
             username = self.request.POST['auth-username'].lower()
             from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
             monitor_2fa_soft_assert(

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -51,6 +51,7 @@ from memoized import memoized
 from sentry_sdk import last_event_id
 from two_factor.views import LoginView
 
+from corehq.toggles import MONTIOR_2FA_CHANGES
 from corehq.apps.hqwebapp.decorators import waf_allow
 from corehq.apps.sms.event_handlers import handle_email_messaging_subevent
 from corehq.apps.users.event_handlers import handle_email_invite_message
@@ -205,6 +206,11 @@ def redirect_to_default(req, domain=None):
         else:
             url = reverse('login')
     elif domain and _two_factor_needed(domain, req):
+        if MONTIOR_2FA_CHANGES.enabled(domain):
+            from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
+            monitor_2fa_soft_assert(False, f'2FA required page shown to user '
+                                           f'{req.user.username} on {domain} after '
+                                           f'login')
         return TemplateResponse(
             request=req,
             template='two_factor/core/otp_required.html',

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -27,7 +27,7 @@ from two_factor.views import (
     SetupView,
 )
 
-from corehq.toggles import MONTIOR_2FA_CHANGES
+from corehq.toggles import MONITOR_2FA_CHANGES
 from dimagi.utils.web import json_response
 
 import langcodes
@@ -339,7 +339,7 @@ class TwoFactorSetupCompleteView(BaseMyAccountView, SetupCompleteView):
     def dispatch(self, request, *args, **kwargs):
         # todo this bit of code should be replaced with a better event logging system
         if (request.couch_user.is_commcare_user()
-                and MONTIOR_2FA_CHANGES.enabled(request.couch_user.domain)):
+                and MONITOR_2FA_CHANGES.enabled(request.couch_user.domain)):
             from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
             monitor_2fa_soft_assert(
                 False,

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -27,6 +27,7 @@ from two_factor.views import (
     SetupView,
 )
 
+from corehq.toggles import MONTIOR_2FA_CHANGES
 from dimagi.utils.web import json_response
 
 import langcodes
@@ -336,7 +337,15 @@ class TwoFactorSetupCompleteView(BaseMyAccountView, SetupCompleteView):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
-        # this is only here to add the login_required decorator
+        # todo this bit of code should be replaced with a better event logging system
+        if (request.couch_user.is_commcare_user()
+                and MONTIOR_2FA_CHANGES.enabled(request.couch_user.domain)):
+            from corehq.apps.hqwebapp.utils import monitor_2fa_soft_assert
+            monitor_2fa_soft_assert(
+                False,
+                f'2FA was ENABLED for mobile worker {request.couch_user.username} '
+                f'from {request.couch_user.domain}'
+            )
         return super(TwoFactorSetupCompleteView, self).dispatch(request, *args, **kwargs)
 
     @property

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -662,7 +662,7 @@ VISIT_SCHEDULER = StaticToggle(
 )
 
 
-MONTIOR_2FA_CHANGES = StaticToggle(
+MONITOR_2FA_CHANGES = StaticToggle(
     'monitor_2fa_changes',
     'Monitor 2FA activity for SAAS-11210 ticket',
     TAG_CUSTOM,

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -661,6 +661,15 @@ VISIT_SCHEDULER = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
+
+MONTIOR_2FA_CHANGES = StaticToggle(
+    'monitor_2fa_changes',
+    'Monitor 2FA activity for SAAS-11210 ticket',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)
+
+
 USER_CONFIGURABLE_REPORTS = StaticToggle(
     'user_reports',
     'User configurable reports UI',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11210

##### SUMMARY
I added some very rudimentary soft assert style activity logs to attempt to gather more information about how mobile workers for a non-2FA-required domain are getting the screen asking for a 2FA token.

##### FEATURE FLAG
added the feature flag `MONITOR_2FA_CHANGES`

##### RISK ASSESSMENT / QA PLAN
this is fairly isolated due to the feature flag
