### PR TITLE
Added feature flag for mirrored permissions

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1426,7 +1426,8 @@ class ProjectUsersTab(UITab):
 
         if self.couch_user.is_superuser:
             from corehq.apps.users.models import DomainPermissionsMirror
-            if DomainPermissionsMirror.mirror_domains(self.domain):
+            if toggles.DOMAIN_PERMISSIONS_MIRROR.enabled_for_request(self._request) \
+                    or DomainPermissionsMirror.mirror_domains(self.domain):
                 from corehq.apps.users.views import DomainPermissionsMirrorView
                 menu.append({
                     'title': _(DomainPermissionsMirrorView.page_title),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1800,6 +1800,14 @@ RESTRICT_MOBILE_ACCESS = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+DOMAIN_PERMISSIONS_MIRROR = StaticToggle(
+    'domain_permissions_mirror',
+    "COVID: Enterprise Permissions: mirror a project space's permissions in other project spaces",
+    TAG_CUSTOM,
+    [NAMESPACE_DOMAIN],
+    help_link='https://confluence.dimagi.com/display/ccinternal/Enterprise+Permissions',
+)
+
 SHOW_BUILD_PROFILE_IN_APPLICATION_STATUS = StaticToggle(
     'show_build_profile_in_app_status',
     'Show build profile installed on phone tracked via heartbeat request in App Status Report',


### PR DESCRIPTION
##### SUMMARY
Adds a feature flag for https://github.com/dimagi/commcare-hq/pull/27510

##### FEATURE FLAG
New flag: "COVID: Enterprise Permissions"

##### RISK ASSESSMENT / QA PLAN
Low risk, tested locally.

##### PRODUCT DESCRIPTION
Any configured mirrors will be respected regardless of whether or not the flag is on. All this does is add the "Enterprise Permissions" page to the menu if the flag is turned on. This is needed because right now, the page doesn't show up unless the config exists, so there's no way for a user to create the config in the first place.