### PR TITLE
access root properties correctly

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -218,7 +218,7 @@ hqDefine('users/js/roles',[
                         allowCheckboxPermission: null,
                     },
                     {
-                        showOption: self.DataFileDownloadEnabled,
+                        showOption: root.DataFileDownloadEnabled,
                         editPermission: self.permissions.edit_file_dropzone,
                         viewPermission: self.permissions.view_file_dropzone,
                         text: gettext("<strong>Dropzone</strong> &mdash; Upload and download files from the file Dropzone"),
@@ -234,7 +234,7 @@ hqDefine('users/js/roles',[
                         allowCheckboxPermission: null,
                     },
                     {
-                        showOption: self.ExportOwnershipEnabled,
+                        showOption: root.ExportOwnershipEnabled,
                         editPermission: self.permissions.edit_shared_exports,
                         viewPermission: null,
                         text: gettext("<strong>Shared Exports</strong> &mdash; access and edit the content and structure of shared exports"),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes a bug in the recent role modal work, that incorrectly referenced the variables defining various feature flag access. They are defined on the page view model rather than the individual roles, so must be referenced on the `root` object.