### PR TITLE
increase limit for case api

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -285,7 +285,7 @@ class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResourc
         return self.case_es(domain).get_document(case_id)
 
     class Meta(v0_3.CommCareCaseResource.Meta):
-        max_limit = 1000
+        max_limit = 5000
         serializer = CommCareCaseSerializer()
         ordering = ['server_date_modified', 'date_modified', 'indexed_on']
         object_class = ESCase


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some projects have more than 1k cases with the same timestamp. They need to  be able to pull all of them at once for the data export tool to work. This can unblock them while we fix the data export tool