### PR TITLE
Added new cache buster to users/js/bundle on each deploy

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/build_requirejs.py
+++ b/corehq/apps/hqwebapp/management/commands/build_requirejs.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 from collections import defaultdict
+from uuid import uuid4
 from shutil import copyfile
 from subprocess import call
 
@@ -72,6 +73,9 @@ class Command(ResourceStaticCommand):
             # TODO: it'd be a performance improvement to do this after the `open` below
             # and pass in the file contents, since get_hash does another read.
             file_hash = self.get_hash(filename)
+
+            if module['name'] == "users/js/bundle":
+                file_hash = uuid4().hex
 
             # Overwrite source map reference. Source maps are accessed on the CDN,
             # so they need to have the version hash appended.


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11285

HQ is using the wrong version for this file, but I haven't figured out why yet. This will unblock users.

Same general idea as https://github.com/dimagi/commcare-hq/pull/24873 but needs to be done during deploy because requirejs pages don't have script tags.