### PR TITLE
upgrade datatables to 1.10.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "css-grid-polyfill-binaries": "FremyCompany/css-grid-polyfill-binaries#1.1.1",
         "d3": "3.5.17",
         "datamaps": "0.5.9",
-        "datatables": "1.10.9",
+        "datatables": "1.10.12",
         "datatables-bootstrap3": "Jowin/Datatables-Bootstrap3",
         "datatables-buttons": "DataTables/Buttons#^1.5.6",
         "datatables-colreorder": "DataTables/ColReorder#^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,10 +1272,10 @@ datatables.net@1.10.21, datatables.net@^1.10.11:
   dependencies:
     jquery ">=1.7"
 
-datatables@1.10.9:
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/datatables/-/datatables-1.10.9.tgz#4f12247275077e1b0243836111ec5c4603fa14f4"
-  integrity sha1-TxIkcnUHfhsCQ4NhEexcRgP6FPQ=
+datatables@1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/datatables/-/datatables-1.10.12.tgz#046f537d0516ebf7007ca7f6c1cad2f2ea0c19d8"
+  integrity sha1-BG9TfQUW6/cAfKf2wcrS8uoMGdg=
   dependencies:
     jquery ">=1.7"
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11290

##### SUMMARY
`dependabot` raised a high severity security issue with `datatables`, so I've bumped our version from `1.10.8` to `1.10.12`.

##### RISK ASSESSMENT / QA PLAN
This is currently on staging and things are looking good so far. no errors after digging through reports, but I've flagged with Ben to be on the lookout this week. Going to leave this on staging for a week and merge Wednesday if there are no reported issues. This is a minor version change so I think it's somewhat safe, but this is the javascript community we are talking about so all bets are off on diligence. 🤷 
