### PR TITLE
Clarify disable vs remove Two-Factor Authentication

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/two_factor/profile/disable.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/profile/disable.html
@@ -9,6 +9,6 @@
     {% csrf_token %}
     <table>{{ form }}</table>
     <button class="btn btn-danger"
-            type="submit">{% trans "Disable" %}</button>
+            type="submit">{% trans "Remove" %}</button>
   </form>
 {% endblock %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/profile/disable.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/profile/disable.html
@@ -2,8 +2,8 @@
 {% load i18n %}
 
 {% block page_content %}
-  <h1>{% block title %}{% trans "Disable Two-factor Authentication" %}{% endblock %}</h1>
-  <p>{% blocktrans %}You are about to disable two-factor authentication. This
+  <h1>{% block title %}{% trans "Remove Two-factor Authentication" %}{% endblock %}</h1>
+  <p>{% blocktrans %}You are about to <strong>remove</strong> two-factor authentication. This
     compromises your account security, are you sure?{% endblocktrans %}</p>
   <form method="post">
     {% csrf_token %}

--- a/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
+++ b/corehq/apps/domain/templates/login_and_password/two_factor/profile/profile.html
@@ -42,11 +42,11 @@
     </fieldset>
 
     <fieldset>
-      <legend>{% trans "Disable Two-Factor Authentication" %}</legend>
+      <legend>{% trans "Remove Two-Factor Authentication" %}</legend>
       <p>{% blocktrans %}However strongly we discourage you to do so, you can
-        also disable two-factor authentication for your account.{% endblocktrans %}</p>
+        also <strong>remove</strong> two-factor authentication for your account.{% endblocktrans %}</p>
       <p><a class="btn btn-danger" href="{% url 'two_factor:disable' %}">
-        {% trans "Disable Two-Factor Authentication" %}</a></p>
+        {% trans "Remove Two-Factor Authentication" %}</a></p>
       <br/>
     </fieldset>
     <fieldset>

--- a/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/disable_two_factor.html
@@ -3,11 +3,11 @@
 {% load crispy_forms_tags %}
 
 {% block reportcontent %}
-  <h1>{% block title %}{% trans "Disable Two-factor Authentication" %}{% endblock %}</h1>
-  <p>{% blocktrans %}You are about to disable two-factor authentication for {{ username }}. This
+  <h1>{% block title %}{% trans "Temporarily Disable Two-factor Authentication" %}{% endblock %}</h1>
+  <p>{% blocktrans %}You are about to temporarily disable two-factor authentication for {{ username }}. This
     compromises their account security, are you sure?{% endblocktrans %}</p>
   <div class="alert alert-warning">
-    <p>When resetting Two-Factor Auth it is important to verify that the request was made by the owner of the account (and not faked by someone else).</p>
+    <p>When temporarily disabling and resetting Two-Factor Auth it is important to verify that the request was made by the owner of the account (and not faked by someone else).</p>
     <p>Please follow the <a href=\"https://confluence.dimagi.com/pages/viewpage.action?pageId=27362739"#Two-StepAuthentication(2FA)-StepsforsupporttoresetCommCareHQaccount\">guidelines on the wiki</a>.</p>
   </div>
   {% crispy form %}

--- a/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/web_user_lookup.html
@@ -23,7 +23,7 @@
     <div class="btn-toolbar">
       <a class="btn btn-default" href="{{ audit_report_url }}?username={{ web_user.username|urlencode }}">View User Audit Report</a>
       <a class="btn btn-default" href="{% url 'disable_user' %}?username={{ web_user.username|urlencode }}">Disable/Enable User Account</a>
-      <a class="btn btn-default {% if not has_two_factor %}disabled{% endif %}" href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}">Disable Two-Factor Authentication</a>
+      <a class="btn btn-default {% if not has_two_factor %}disabled{% endif %}" href="{% url 'disable_two_factor' %}?q={{ web_user.username|urlencode }}">Temporarily Disable Two-Factor Authentication</a>
     </div>
     <h3>{% trans "Domains" %}</h3>
     <div class="col-md-6">

--- a/corehq/apps/hqadmin/views/users.py
+++ b/corehq/apps/hqadmin/views/users.py
@@ -478,6 +478,12 @@ class DisableTwoFactorView(FormView):
             'disable_for_days': 0,
         }
 
+    def render_to_response(self, context, **response_kwargs):
+        context.update({
+            'username': self.request.GET.get("q"),
+        })
+        return super().render_to_response(context, **response_kwargs)
+
     def get(self, request, *args, **kwargs):
         from django_otp import user_has_device
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -385,7 +385,7 @@ def _show_link_to_webapps(user):
 class TwoFactorDisableView(BaseMyAccountView, DisableView):
     urlname = 'two_factor_disable'
     template_name = 'two_factor/profile/disable.html'
-    page_title = ugettext_lazy("Disable Two Factor Authentication")
+    page_title = ugettext_lazy("Remove Two-Factor Authentication")
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11210

##### SUMMARY
This clarifies the use of "Disable Two-Factor Authentication" on two UIs that use it but do very different things.

##### RISK ASSESSMENT / QA PLAN
Mostly straightforward text changes. Low risk. Worked fine locally.

##### PRODUCT DESCRIPTION
In the User Account Settings > Two-Factor Authentication page, "Disable Two-Factor Authentication" is changed to "Remove Two-Factor Authentication"
![Screen Shot 2020-09-04 at 12 55 09 PM](https://user-images.githubusercontent.com/716573/92275018-eb274f00-eeb3-11ea-9987-223895e60487.png)
![Screen Shot 2020-09-04 at 12 55 04 PM](https://user-images.githubusercontent.com/716573/92275029-efec0300-eeb3-11ea-9e74-2d9607db1806.png)
![Screen Shot 2020-09-04 at 12 55 20 PM](https://user-images.githubusercontent.com/716573/92275044-f67a7a80-eeb3-11ea-8aa2-00b4fe9ce07e.png)

And then in the admin view for looking up users it makes sure to emphasize that the Disabling action is Temporary.
![Screen Shot 2020-09-04 at 12 56 26 PM](https://user-images.githubusercontent.com/716573/92275098-1447df80-eeb4-11ea-87c5-89989c90d231.png)
![Screen Shot 2020-09-04 at 1 35 27 PM](https://user-images.githubusercontent.com/716573/92275105-1742d000-eeb4-11ea-988e-b9ade82bdf8f.png)

Also fixes a minor bug where the username wasn't showing up in this UI:
![Screen Shot 2020-09-04 at 1 40 30 PM](https://user-images.githubusercontent.com/716573/92275149-393c5280-eeb4-11ea-8255-d7e3556e0a32.png)
