### PR TITLE
wait a minute before requesting confirmation email for project again

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -60,7 +60,7 @@ _domainless_new_user_soft_assert = soft_assert(to=[
 ], send_to_ops=False, fail_if_debug=False)
 
 
-RESEND_INVITATION_TIME_INTERVAL = 60  # seconds
+CONFIRMATION_RESEND_LIMIT_SECONDS = 60
 
 
 def get_domain_context():
@@ -377,9 +377,9 @@ def resend_confirmation(request):
     default_page_name = _('Resend Confirmation Email')
 
     if request.method == 'POST':
-        if (datetime.utcnow() - dom_req.request_time).seconds < RESEND_INVITATION_TIME_INTERVAL:
+        if (datetime.utcnow() - dom_req.request_time).seconds < CONFIRMATION_RESEND_LIMIT_SECONDS:
             context = {
-                'message_body': _(f'Please wait at least {RESEND_INVITATION_TIME_INTERVAL} '
+                'message_body': _(f'Please wait at least {CONFIRMATION_RESEND_LIMIT_SECONDS} '
                                   f'seconds before requesting again.'),
                 'current_page': {'page_name': default_page_name},
             }

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -60,6 +60,9 @@ _domainless_new_user_soft_assert = soft_assert(to=[
 ], send_to_ops=False, fail_if_debug=False)
 
 
+RESEND_INVITATION_TIME_INTERVAL = 60  # seconds
+
+
 def get_domain_context():
     return get_per_domain_context(Domain())
 
@@ -371,9 +374,20 @@ def resend_confirmation(request):
         return redirect('domain_select')
 
     context = get_domain_context()
+    default_page_name = _('Resend Confirmation Email')
 
     if request.method == 'POST':
+        if (datetime.utcnow() - dom_req.request_time).seconds < RESEND_INVITATION_TIME_INTERVAL:
+            context = {
+                'message_body': _(f'Please wait at least {RESEND_INVITATION_TIME_INTERVAL} '
+                                  f'seconds before requesting again.'),
+                'current_page': {'page_name': default_page_name},
+            }
+            return render(request, 'registration/confirmation_error.html', context)
         try:
+            dom_req.request_time = datetime.utcnow()
+            dom_req.request_ip = get_ip(request)
+            dom_req.save()
             send_domain_registration_email(dom_req.new_user_username,
                     dom_req.domain, dom_req.activation_guid,
                     request.user.get_full_name(), request.user.first_name)
@@ -387,14 +401,14 @@ def resend_confirmation(request):
         else:
             context.update({
                 'requested_domain': dom_req.domain,
-                'current_page': {'page_name': ('Confirmation Email Sent')},
+                'current_page': {'page_name': _('Confirmation Email Sent')},
             })
             return render(request, 'registration/confirmation_sent.html',
                 context)
 
     context.update({
         'requested_domain': dom_req.domain,
-        'current_page': {'page_name': _('Resend Confirmation Email')},
+        'current_page': {'page_name': default_page_name},
     })
     return render(request, 'registration/confirmation_resend.html', context)
 


### PR DESCRIPTION
As a part of a security audit for ICDS, it was highlighted that there should be a check to ensure emails are not requested repeatedly leading to resources exhaustion. Though the link for requesting confirmation email for project again, is behind a login, it still looks like a legit concern where a user can keep requesting again and again. Suggested interval was 60 seconds.

##### SUMMARY
This PR adds a check for user to wait at least 60 seconds before requesting another confirmation email.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
Tested locally and works okay

##### PRODUCT DESCRIPTION
If a user re-requests within 60 seconds of requesting a confirmation, they would see an error message.
Open to suggestions on the message.
![Screenshot from 2020-09-06 01-49-51](https://user-images.githubusercontent.com/3864163/92312927-4dcb3880-efe3-11ea-96d5-f37c45516ec6.png)

@dimagi/product 

I have updated the IP address with that of the new request now. Just flagging that in case we want to keep a record of the original IP.
