### PR TITLE
Fix form submissions counts returning zero

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -727,7 +727,7 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
             if self.all_relevant_forms:
                 for form in self.all_relevant_forms.values():
                     row.append(self._form_counts[
-                        (simplified_user.user_id, form['app_id'], form['xmlns'].lower())
+                        (simplified_user.user_id, form['app_id'], form['xmlns'])
                     ])
                 row_sum = sum(row)
                 row = (


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[JIRA ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11286)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The recent change to [support ES 7](https://github.com/dimagi/commcare-hq/pull/28270) resulted in changing the xmlns match to be exact for the query that retrieves form submissions. The method that uses this query relied on the ES bucket key when building the dictionary to return. 

Originally, the comparison was case-insensitive and it appears ES handles this by lowercasing the input (which would become the bucket key). Now that the comparison is case-sensitive, the input is no longer lowercased, and the bucket key is now case-sensitive as well. 

We were already compensating for the case-insensitive key by lowercasing the xmlns identifier when searching in the dictionary. The easiest solution is to no longer lowercase the xmlns identifier when searching in the dictionary, so that it too is now case-sensitive.

It is also worth noting that this worked for some reports because if the xmlns already contained all lowercase characters, it would match correctly. A search was done for any other code that lowercases the xmlns identifier and nothing was found. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
