### PR TITLE
use standard date format

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -321,7 +321,7 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
         return render_to_string('hqcase/xml/case_block.xml', {
             'xmlns': SYSTEM_FORM_XMLNS,
             'case_block': case_blocks,
-            'time': datetime.utcnow(),
+            'time': json_format_datetime(datetime.utcnow()),
             'uid': uuid4().hex,
             'username': self.repeater.connection_settings.username,
             'user_id': CouchUser.get_by_username(self.repeater.connection_settings.username).user_id,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes the root cause of https://dimagi-dev.atlassian.net/browse/SAAS-11277. There is still an open question about the pillow fix, but new forms will have the standard date format after this.