### PR TITLE
disable static device throttling

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1033,6 +1033,9 @@ SESSION_BYPASS_URLS = [
     r'^/a/{domain}/apps/download/',
 ]
 
+# Disable builtin throttling for two factor backup tokens
+OTP_STATIC_THROTTLE_FACTOR = 0
+
 ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE = False
 RATE_LIMIT_SUBMISSIONS = False
 

--- a/settings.py
+++ b/settings.py
@@ -1033,7 +1033,8 @@ SESSION_BYPASS_URLS = [
     r'^/a/{domain}/apps/download/',
 ]
 
-# Disable builtin throttling for two factor backup tokens
+# Disable builtin throttling for two factor backup tokens, since we have our own
+# See corehq.apps.hqwebapp.signals and corehq.apps.hqwebapp.forms for details
 OTP_STATIC_THROTTLE_FACTOR = 0
 
 ALLOW_PHONE_AS_DEFAULT_TWO_FACTOR_DEVICE = False


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Due to the way our two factor is set up, submitted tokens are tried against all possible devices (including backup tokens) until one is successful. The failed match against backup tokens was causing the backup tokens to be locked even when users logged in successfully, since a successful phone token was still a failed match against the backup tokens. This settings change disables throttling for backup tokens, which should be fine because we already lock users out for unsuccessful two factor tokens, but properly reset on successful attempts.

Docs on this setting https://django-otp-official.readthedocs.io/en/stable/overview.html?highlight=throttling#static-settings
Relevant ticket https://dimagi-dev.atlassian.net/browse/USH-206