### PR TITLE
Toggle mistaken reindex/standard ES settings

### DIFF
--- a/corehq/ex-submodules/pillowtop/index_settings.py
+++ b/corehq/ex-submodules/pillowtop/index_settings.py
@@ -23,7 +23,7 @@ def _get_es_settings(es_settings):
     return es_settings
 
 
-def get_standard_es_settings():
+def get_reindex_es_settings():
     return _get_es_settings(
         {
             "index": {
@@ -39,7 +39,7 @@ def get_standard_es_settings():
     )
 
 
-def get_reindex_es_settings():
+def get_standard_es_settings():
     return _get_es_settings({
         "index": {
             "refresh_interval": "5s",


### PR DESCRIPTION
This was introduced in a refactor I did [here](https://github.com/dimagi/commcare-hq/commit/d1509ba1cd8bbe402b676f156e486d2a27a84e27#diff-b6fc14484a02346c1280d73d651f1dd2)

