### PR TITLE
Daily Form Activity report results appear to be a day behind

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -292,11 +292,12 @@ def _get_form_counts_by_date(domain, user_ids, datespan, timezone, is_submission
 
     results = form_query.run().aggregations.date_histogram.buckets_list
 
-    # Convert timestamp into timezone aware datetime. Must divide timestamp by 1000 since python's
-    # fromtimestamp takes a timestamp in seconds, whereas elasticsearch's timestamp is in milliseconds
+    # Convert timestamp from millis -> seconds -> aware datetime
+    # ES bucket key is an epoch timestamp relative to the timezone specified,
+    # so pass timezone into fromtimestamp() to create an accurate datetime, otherwise will be treated as UTC
     results = list(map(
         lambda result:
-            (datetime.fromtimestamp(result.key // 1000).date().isoformat(), result.doc_count),
+            (datetime.fromtimestamp(result.key // 1000, timezone).date().isoformat(), result.doc_count),
         results,
     ))
     return dict(results)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[JIRA ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11034)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The ES query that retrieves form counts for users by date, [found here](https://github.com/dimagi/commcare-hq/blob/70e0665317bbdb65c1323479f57040c4d8f2312d/corehq/apps/reports/analytics/esaccessors.py#L272-L302), causes an issue when the report timezone is ahead of UTC (positive offset). The bucket keys returned are epoch timestamps that correspond to the start of the day specified for that bucket. Because we specify a timezone in the DateHistogram aggregation, bucketing is performed using this timezone, as per [documentation states here](https://github.com/dimagi/commcare-hq/blob/70e0665317bbdb65c1323479f57040c4d8f2312d/corehq/apps/es/aggregations.py#L512). 

Here is a screenshot of using an epoch timestamp that is the start of August 17th, 2020 in South Africa Standard Time, obtained by performing the same ESQuery and inspecting the bucket key, and what happens when using the `fromtimestamp` method. 
<img width="841" alt="Screen Shot 2020-09-09 at 11 30 58 AM" src="https://user-images.githubusercontent.com/15785053/92624906-091af800-f296-11ea-8ddb-2ea0762f26a3.png">

So with the bucket keys formatted as epoch timestamps relative to their timezone, using `datetime.fromtimestamp()` they are converted into datetime objects. Without specifying a timezone in `fromtimestamp()`, these timestamps are treated as UTC so what was once the start of the day in South Africa Standard Time (+2:00), will now be 22:00 for the previous day. The time gets truncated and we are left with a key/datetime representing a day earlier than the bucket value actually corresponds with. 

It is unclear how long this has been an issue. The timezone was originally removed from the `fromtimestamp()` call in [this commit](https://github.com/dimagi/commcare-hq/commit/06215a415dc54d8320076747e448aeb7b0a64f07#diff-8b0ba6d870315e679331ae0fa50dbb39), but I expect the bug to be related to a more recent change. My best guess is a recent ES change resulted in timestamps returned with timezones factored in. That would explain why previously Simon needed to remove the timezone from `fromtimestamp` to avoid 'double converting' time, as the commit specified. @snopoke could maybe provide more context around this timestamp conversion, and why it was necessary in the past? 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
