### PR TITLE
Add New UCR Filter "Case Owner (Location w/ Descendants and Archived Locations)"

### DIFF
--- a/corehq/apps/userreports/reports/builder/const.py
+++ b/corehq/apps/userreports/reports/builder/const.py
@@ -2,6 +2,7 @@ COMPUTED_USER_NAME_PROPERTY_ID = "computed/user_name"
 COMPUTED_OWNER_NAME_PROPERTY_ID = "computed/owner_name"
 COMPUTED_OWNER_LOCATION_PROPERTY_ID = "computed/owner_location"
 COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID = "computed/owner_location_with_descendants"
+COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID = "computed/owner_location_archived_with_descendants"
 
 UI_AGG_AVERAGE = "Average"
 UI_AGG_COUNT_PER_CHOICE = "Count per Choice"

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -56,6 +56,7 @@ from corehq.apps.userreports.reports.builder.columns import (
 from corehq.apps.userreports.reports.builder.const import (
     COMPUTED_OWNER_LOCATION_PROPERTY_ID,
     COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
+    COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID,
     COMPUTED_OWNER_NAME_PROPERTY_ID,
     COMPUTED_USER_NAME_PROPERTY_ID,
     PROPERTY_TYPE_CASE_PROP,
@@ -172,8 +173,11 @@ class DataSourceProperty(object):
             return FormMetaColumnOption(self._id, self._data_types, self._text, self._source)
         elif self._type == PROPERTY_TYPE_CASE_PROP:
             if self._id in (
-                    COMPUTED_OWNER_NAME_PROPERTY_ID, COMPUTED_OWNER_LOCATION_PROPERTY_ID,
-                    COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID):
+                    COMPUTED_OWNER_NAME_PROPERTY_ID,
+                    COMPUTED_OWNER_LOCATION_PROPERTY_ID,
+                    COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
+                    COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID
+            ):
                 return OwnernameComputedCasePropertyOption(self._id, self._data_types, self._text)
             elif self._id == COMPUTED_USER_NAME_PROPERTY_ID:
                 return UsernameComputedCasePropertyOption(self._id, self._data_types, self._text)
@@ -228,6 +232,7 @@ class DataSourceProperty(object):
         }
         if configuration['format'] == const.FORMAT_DATE:
             filter.update({'compare_as_string': True})
+
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_NAME_PROPERTY_ID:
             filter.update({"choice_provider": {"type": "owner"}})
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_USER_NAME_PROPERTY_ID:
@@ -236,6 +241,8 @@ class DataSourceProperty(object):
             filter.update({"choice_provider": {"type": "location"}})
         if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID:
             filter.update({"choice_provider": {"type": "location", "include_descendants": True}})
+        if filter_format == 'dynamic_choice_list' and self._id == COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID:
+            filter.update({"choice_provider": {"type": "location", "include_descendants": True, "show_all_locations": True}})
         if configuration.get('pre_value') or configuration.get('pre_operator'):
             filter.update({
                 'type': 'pre',  # type could have been "date"
@@ -585,6 +592,8 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
             properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID] = self._get_owner_location_pseudo_property()
             properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID] = \
                 self._get_owner_location_with_descendants_pseudo_property()
+            properties[COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID] = \
+                self._get_owner_location_archived_with_descendants_pseudo_property()
 
         return properties
 
@@ -631,6 +640,17 @@ class DataSourceBuilder(ReportBuilderDataSourceInterface):
             id=COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
             text=_('Case Owner (Location w/ Descendants)'),
             source=COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
+            data_types=["string"],
+        )
+
+    @classmethod
+    def _get_owner_location_archived_with_descendants_pseudo_property(cls):
+        # similar to the location property but also include descendants
+        return DataSourceProperty(
+            type=PROPERTY_TYPE_CASE_PROP,
+            id=COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID,
+            text=_('Case Owner (Location w/ Descendants and Archived Locations)'),
+            source=COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID,
             data_types=["string"],
         )
 

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -263,14 +263,16 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         self.include_descendants = False
         self.show_full_path = False
         self.location_type = None
+        self.show_all_locations = False  # archived or unarchived
 
     def configure(self, spec):
         self.include_descendants = spec.get('include_descendants', self.include_descendants)
         self.show_full_path = spec.get('show_full_path', self.show_full_path)
         self.location_type = spec.get('location_type', self.location_type)
+        self.show_all_locations = spec.get('show_all_locations', self.show_all_locations)
 
     def _locations_query(self, query_text, user):
-        locations = SQLLocation.active_objects
+        locations = SQLLocation.objects if self.show_all_locations else SQLLocation.active_objects
         if query_text:
             locations = locations.filter_by_user_input(
                 domain=self.domain,
@@ -297,8 +299,9 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         return self._locations_query(query, user).count()
 
     def get_choices_for_known_values(self, values, user):
+        base_query = SQLLocation.objects if self.show_all_locations else SQLLocation.active_objects
         if user is not None:
-            selected_locations = (SQLLocation.active_objects.filter(location_id__in=values)
+            selected_locations = (base_query.filter(location_id__in=values)
                                   .accessible_to_user(self.domain, user))
         else:
             assert_user_passed_in(False, "get_choices_for_known_values was called without a user")

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -21,8 +21,11 @@ from corehq.apps.userreports.models import (
 from corehq.apps.userreports.reports.builder.columns import (
     MultiselectQuestionColumnOption,
 )
-from corehq.apps.userreports.reports.builder.const import COMPUTED_OWNER_LOCATION_PROPERTY_ID
-from corehq.apps.userreports.reports.builder.const import COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID
+from corehq.apps.userreports.reports.builder.const import (
+    COMPUTED_OWNER_LOCATION_PROPERTY_ID,
+    COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
+    COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID,
+)
 from corehq.apps.userreports.reports.builder.forms import (
     ConfigureListReportForm,
     ConfigureTableReportForm,
@@ -133,16 +136,29 @@ class DataSourceBuilderTest(ReportBuilderDBTest):
     @flag_enabled('SHOW_OWNER_LOCATION_PROPERTY_IN_REPORT_BUILDER')
     def test_owner_as_location(self):
         builder = DataSourceBuilder(self.domain, self.app, DATA_SOURCE_TYPE_CASE, self.case_type)
+
         self.assertTrue(COMPUTED_OWNER_LOCATION_PROPERTY_ID in builder.data_source_properties)
         self.assertTrue(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID in builder.data_source_properties)
+        self.assertTrue(COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID in builder.data_source_properties)
+
         owner_location_prop = builder.data_source_properties[COMPUTED_OWNER_LOCATION_PROPERTY_ID]
         self.assertEqual(COMPUTED_OWNER_LOCATION_PROPERTY_ID, owner_location_prop.get_id())
         self.assertEqual('Case Owner (Location)', owner_location_prop.get_text())
+
         owner_location_prop_w_descendants = \
             builder.data_source_properties[COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID]
         self.assertEqual(COMPUTED_OWNER_LOCATION_WITH_DESENDANTS_PROPERTY_ID,
                          owner_location_prop_w_descendants.get_id())
         self.assertEqual('Case Owner (Location w/ Descendants)', owner_location_prop_w_descendants.get_text())
+
+        owner_location_prop_archived_w_descendants = \
+            builder.data_source_properties[COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID]
+        self.assertEqual(COMPUTED_OWNER_LOCATION_ARCHIVED_WITH_DESCENDANTS_PROPERTY_ID,
+                         owner_location_prop_archived_w_descendants.get_id())
+        self.assertEqual(
+            'Case Owner (Location w/ Descendants and Archived Locations)',
+            owner_location_prop_archived_w_descendants.get_text()
+        )
 
 
 class DataSourceReferenceTest(ReportBuilderDBTest):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11122

##### SUMMARY
I hate that this is the easiest solution to adding support for showing archived locations in the Case Owner (Locations) filter. After some investigation, adding options to the `DynamicChoiceFilter` directly looked far more daunting. I feel this is really messy and feels like such a hack, but it is the simplest solution.

##### RISK ASSESSMENT / QA PLAN
Thoroughly tested locally. Added tests. And the change is fairly straightforward. I'm pretty confident no QA is needed

##### PRODUCT DESCRIPTION
Adds yet another filter option in UCR called "Case Owner (Location w/ Descendants and Archived Locations)" which does the same thing as "Case Owner (Location w/ Descendants)" but includes archived locations in the select 2 search results.
![Screen Shot 2020-09-09 at 8 26 11 PM](https://user-images.githubusercontent.com/716573/92671414-d0057680-f2db-11ea-9f1e-1fa4991c7cb7.png)
