### PR TITLE
Add ES query tests for recent bugs found

### DIFF
--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -481,6 +481,26 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEqual(results['2013-07-14'], 1)
 
+    @run_with_all_backends
+    def test_timezones_ahead_utc_in_get_submission_counts_by_date(self):
+        """
+        When bucketing form submissions, the returned bucket key needs to be converted to a datetime with
+        the timezone specified. Specifically an issue for timezones ahead of UTC (positive offsets)
+        """
+        start = datetime(2013, 7, 1)
+        end = datetime(2013, 7, 30)
+        received_on = datetime(2013, 7, 15)
+
+        self._send_form_to_es(received_on=received_on)
+        self._send_form_to_es(received_on=received_on, xmlns=SYSTEM_FORM_XMLNS)
+
+        results = get_submission_counts_by_date(
+            self.domain,
+            ['cruella_deville'],
+            DateSpan(start, end),
+            pytz.timezone('Africa/Johannesburg')
+        )
+        self.assertEqual(results['2013-07-15'], 1)
 
     @run_with_all_backends
     def test_get_form_counts_by_user_xmlns(self):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -493,7 +493,8 @@ class TestFormESAccessors(BaseESAccessorsTest):
 
         received_on = datetime(2013, 7, 15, 0, 0, 0)
         received_on_out = datetime(2013, 6, 15, 0, 0, 0)
-        self._send_form_to_es(received_on=received_on_out, completion_time=received_on, user_id=user1, app_id=app1, xmlns=xmlns1)
+        self._send_form_to_es(received_on=received_on_out, completion_time=received_on,
+                              user_id=user1, app_id=app1, xmlns=xmlns1)
         self._send_form_to_es(received_on=received_on, user_id=user1, app_id=app1, xmlns=xmlns1)
         self._send_form_to_es(received_on=received_on, user_id=user1, app_id=app1, xmlns=xmlns1)
         self._send_form_to_es(received_on=received_on, user_id=user1, app_id=app2, xmlns=xmlns2)
@@ -527,6 +528,25 @@ class TestFormESAccessors(BaseESAccessorsTest):
         counts_missing_user = get_form_counts_by_user_xmlns(self.domain, start, end, user_ids=[None])
         self.assertEqual(counts_missing_user, {
             (None, app2, xmlns2): 1,
+        })
+
+    @run_with_all_backends
+    def test_xmlns_case_sensitivity_for_get_form_counts_by_user_xmlns(self):
+        user = 'u1'
+        app = '123'
+        # the important part of this test is an xmlns identifier with both lower and uppercase characters
+        xmlns = 'LmN'
+
+        start = datetime(2013, 7, 1)
+        end = datetime(2013, 7, 30)
+
+        received_on = datetime(2013, 7, 15, 0, 0, 0)
+        self._send_form_to_es(received_on=received_on, user_id=user, app_id=app, xmlns=xmlns)
+
+        check_case_sensitivity = get_form_counts_by_user_xmlns(self.domain, start, end,
+                                                               user_ids=[user], xmlnss=[xmlns])
+        self.assertEqual(check_case_sensitivity, {
+            (user, app, xmlns): 1,
         })
 
     @run_with_all_backends


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Adding tests for bugs addressed on these PRs: 
[Daily Form Activity results appear a day behind](https://github.com/dimagi/commcare-hq/pull/28488)  
[Form submission counts returning zero](https://github.com/dimagi/commcare-hq/pull/28481)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a test to verify that the xmlns received from the `get_form_counts_by_user_xmlns` method is case sensitive. Previously was lowercased, but a recent ES change resulted in the query returning a case sensitive string. If a change like this occurs in the future, this test should catch it. 

Add a test to verify the results date key is what we expect. An incorrect conversion of the bucket key epoch timestamp to a datetime resulted in dates being converted to the previous day. This ensures the conversion is accurate when in a timezone ahead of UTC. 
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
