### PR TITLE
All data forwarders notify on errors

### DIFF
--- a/corehq/motech/openmrs/tests/test_tasks.py
+++ b/corehq/motech/openmrs/tests/test_tasks.py
@@ -26,6 +26,8 @@ from corehq.motech.openmrs.tasks import (
     import_patients_with_importer,
     poll_openmrs_atom_feeds,
 )
+from corehq.motech.views import ConnectionSettingsListView
+from corehq.util.view_utils import absolute_reverse
 
 TEST_DOMAIN = 'test-domain'
 
@@ -321,6 +323,9 @@ class OwnerTests(LocationHierarchyTestCase):
         """
         Notify on invalid owner_id
         """
+        connection_settings_url = absolute_reverse(
+            ConnectionSettingsListView.urlname, args=[TEST_DOMAIN])
+
         with get_importer() as importer:
             self.assertEqual(importer.owner_id, '123456')
             import_patients_with_importer(importer.to_json())
@@ -330,8 +335,20 @@ class OwnerTests(LocationHierarchyTestCase):
                 'Error importing patients for project space "test-domain" from '
                 'OpenMRS Importer "<OpenmrsImporter None admin@http://www.example.com/openmrs>": '
                 'owner_id "123456" is invalid.\r\n'
-                'Project space: test-domain\r\n'
-                'Remote API base URL: http://www.example.com/openmrs',
+                '\r\n'
+                f'Project space: {TEST_DOMAIN}\r\n'
+                'Remote API base URL: http://www.example.com/openmrs\r\n'
+                '\r\n'
+                '*Why am I getting this email?*\r\n'
+                'This address is configured in CommCare HQ as a notification '
+                'address for integration errors.\r\n'
+                '\r\n'
+                '*How do I unsubscribe?*\r\n'
+                'Open Connection Settings in CommCare HQ '
+                f'({connection_settings_url}) and remove your email address '
+                'from the "Addresses to send notifications" field for remote '
+                'connections. If necessary, please provide an alternate '
+                'address.',
 
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=['admin@example.com'],
@@ -341,17 +358,33 @@ class OwnerTests(LocationHierarchyTestCase):
         """
         Notify if owner_id is set to a NON-case-sharing group
         """
+        connection_settings_url = absolute_reverse(
+            ConnectionSettingsListView.urlname, args=[TEST_DOMAIN])
+
         with get_importer() as importer:
             importer.owner_id = self.bad_group._id
             import_patients_with_importer(importer.to_json())
             self.send_mail_mock.delay.assert_called_with(
                 'MOTECH Error',
 
-                'Error importing patients for project space "test-domain" from '
-                'OpenMRS Importer "<OpenmrsImporter None admin@http://www.example.com/openmrs>": '
-                f'owner_id "{importer.owner_id}" is invalid.\r\n'
-                'Project space: test-domain\r\n'
-                'Remote API base URL: http://www.example.com/openmrs',
+                f'Error importing patients for project space "{TEST_DOMAIN}" '
+                'from OpenMRS Importer "<OpenmrsImporter None '
+                'admin@http://www.example.com/openmrs>": owner_id '
+                f'"{importer.owner_id}" is invalid.\r\n'
+                '\r\n'
+                f'Project space: {TEST_DOMAIN}\r\n'
+                'Remote API base URL: http://www.example.com/openmrs\r\n'
+                '\r\n'
+                '*Why am I getting this email?*\r\n'
+                'This address is configured in CommCare HQ as a notification '
+                'address for integration errors.\r\n'
+                '\r\n'
+                '*How do I unsubscribe?*\r\n'
+                'Open Connection Settings in CommCare HQ '
+                f'({connection_settings_url}) and remove your email address '
+                'from the "Addresses to send notifications" field for remote '
+                'connections. If necessary, please provide an alternate '
+                'address.',
 
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=['admin@example.com'],

--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -380,10 +380,6 @@ class Repeater(QuickCachedDocumentMixin, Document):
     def verify(self):
         return not self.skip_cert_verify
 
-    @property
-    def notify_addresses(self):
-        return [addr for addr in re.split('[, ]+', self.notify_addresses_str) if addr]
-
     def send_request(self, repeat_record, payload):
         url = self.get_url(repeat_record)
         return simple_post(
@@ -391,7 +387,7 @@ class Repeater(QuickCachedDocumentMixin, Document):
             headers=self.get_headers(repeat_record),
             auth_manager=self.connection_settings.get_auth_manager(),
             verify=self.verify,
-            notify_addresses=self.notify_addresses,
+            notify_addresses=self.connection_settings.notify_addresses,
             payload_id=repeat_record.payload_id,
         )
 

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -1170,53 +1170,6 @@ class FormatResponseTests(SimpleTestCase):
         self.assertEqual(formatted, '500: The core is exposed.\n')
 
 
-class NotifyAddressesTests(SimpleTestCase):
-
-    def test_default(self):
-        repeater = DummyRepeater.wrap({})
-        self.assertEqual(repeater.notify_addresses, [])
-
-    def test_empty(self):
-        repeater = DummyRepeater.wrap({
-            "notify_addresses_str": "",
-        })
-        self.assertEqual(repeater.notify_addresses, [])
-
-    def test_one(self):
-        repeater = DummyRepeater.wrap({
-            "notify_addresses_str": "admin@example.com"
-        })
-        self.assertEqual(repeater.notify_addresses, ["admin@example.com"])
-
-    def test_comma(self):
-        repeater = DummyRepeater.wrap({
-            "notify_addresses_str": "admin@example.com,user@example.com"
-        })
-        self.assertEqual(repeater.notify_addresses, ["admin@example.com",
-                                                     "user@example.com"])
-
-    def test_space(self):
-        repeater = DummyRepeater.wrap({
-            "notify_addresses_str": "admin@example.com user@example.com"
-        })
-        self.assertEqual(repeater.notify_addresses, ["admin@example.com",
-                                                     "user@example.com"])
-
-    def test_commaspace(self):
-        repeater = DummyRepeater.wrap({
-            "notify_addresses_str": "admin@example.com, user@example.com"
-        })
-        self.assertEqual(repeater.notify_addresses, ["admin@example.com",
-                                                     "user@example.com"])
-
-    def test_mess(self):
-        repeater = DummyRepeater.wrap({
-            "notify_addresses_str": "admin@example.com,,, ,  user@example.com"
-        })
-        self.assertEqual(repeater.notify_addresses, ["admin@example.com",
-                                                     "user@example.com"])
-
-
 class TestGetRetryInterval(SimpleTestCase):
 
     def test_min_interval(self):

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -3,11 +3,11 @@ from functools import wraps
 from typing import Callable, Optional
 
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 import attr
 from requests.structures import CaseInsensitiveDict
 
-from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.logging import notify_exception
 
 from corehq.apps.hqwebapp.tasks import send_mail_async
@@ -19,6 +19,7 @@ from corehq.motech.utils import (
     pformat_json,
     unpack_request_args,
 )
+from corehq.util.view_utils import absolute_reverse
 
 
 @attr.s(frozen=True)
@@ -178,29 +179,29 @@ class Requests(object):
         message_lines = [
             message,
             '',
-            f'Project space: {self.domain_name}',
-            f'Remote API base URL: {self.base_url}',
+            _('Project space: {}').format(self.domain_name),
+            _('Remote API base URL: {}').format(self.base_url),
         ]
         if self.payload_id:
-            message_lines.append(f'Payload ID: {self.payload_id}')
+            message_lines.append(_('Payload ID: {}').format(self.payload_id))
         if details:
             message_lines.extend(['', details])
         connection_settings_url = absolute_reverse(
             ConnectionSettingsListView.urlname, args=[self.domain_name])
         message_lines.extend([
             '',
-            '*Why am I getting this email?*',
-            'This address is configured in CommCare HQ as a notification '
-            'address for integration errors.',
+            _('*Why am I getting this email?*'),
+            _('This address is configured in CommCare HQ as a notification '
+              'address for integration errors.'),
             '',
-            '*How do I unsubscribe?*',
-            'Open Connection Settings in CommCare HQ '
-            f'({connection_settings_url}) and remove your email address from '
-            'the "Addresses to send notifications" field for remote '
-            'connections. If necessary, please provide an alternate address.',
+            _('*How do I unsubscribe?*'),
+            _('Open Connection Settings in CommCare HQ ({}) and remove your '
+              'email address from the "Addresses to send notifications" field '
+              'for remote connections. If necessary, please provide an '
+              'alternate address.').format(connection_settings_url),
         ])
         send_mail_async.delay(
-            'MOTECH Error',
+            _('MOTECH Error'),
             '\r\n'.join(message_lines),
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=self.notify_addresses,

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -250,14 +250,14 @@ def simple_post(domain, url, data, *, headers, auth_manager, verify,
     default_headers.update(headers)
     requests = Requests(
         domain,
-        base_url=None,
+        base_url=url,
         verify=verify,
         auth_manager=auth_manager,
         notify_addresses=notify_addresses,
         payload_id=payload_id,
     )
     try:
-        return requests.post(url, data=data, headers=default_headers)
+        return requests.post(None, data=data, headers=default_headers)
     except Exception as err:
         requests.notify_error(str(err))
         raise

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -3,7 +3,7 @@ from functools import wraps
 from typing import Callable, Optional
 
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
 import attr
 from requests.structures import CaseInsensitiveDict

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -238,4 +238,8 @@ def simple_post(domain, url, data, *, headers, auth_manager, verify,
         notify_addresses=notify_addresses,
         payload_id=payload_id,
     )
-    return requests.post(url, data=data, headers=default_headers)
+    try:
+        return requests.post(url, data=data, headers=default_headers)
+    except Exception as err:
+        requests.notify_error(str(err))
+        raise

--- a/corehq/motech/tests/test_models.py
+++ b/corehq/motech/tests/test_models.py
@@ -182,3 +182,44 @@ class ConnectionSettingsPropertiesTests(SimpleTestCase):
         cs = ConnectionSettings()
         cs.client_secret = 'secret'
         self.assertEqual(cs.plaintext_client_secret, 'secret')
+
+
+class NotifyAddressesTests(SimpleTestCase):
+
+    def test_default(self):
+        cs = ConnectionSettings()
+        self.assertEqual(cs.notify_addresses, [])
+
+    def test_empty(self):
+        cs = ConnectionSettings()
+        cs.notify_addresses_str = ""
+        self.assertEqual(cs.notify_addresses, [])
+
+    def test_one(self):
+        cs = ConnectionSettings()
+        cs.notify_addresses_str = "admin@example.com"
+        self.assertEqual(cs.notify_addresses, ["admin@example.com"])
+
+    def test_comma(self):
+        cs = ConnectionSettings()
+        cs.notify_addresses_str = "admin@example.com,user@example.com"
+        self.assertEqual(cs.notify_addresses, ["admin@example.com",
+                                               "user@example.com"])
+
+    def test_space(self):
+        cs = ConnectionSettings()
+        cs.notify_addresses_str = "admin@example.com user@example.com"
+        self.assertEqual(cs.notify_addresses, ["admin@example.com",
+                                               "user@example.com"])
+
+    def test_commaspace(self):
+        cs = ConnectionSettings()
+        cs.notify_addresses_str = "admin@example.com, user@example.com"
+        self.assertEqual(cs.notify_addresses, ["admin@example.com",
+                                               "user@example.com"])
+
+    def test_mess(self):
+        cs = ConnectionSettings()
+        cs.notify_addresses_str = "admin@example.com,,, ,  user@example.com"
+        self.assertEqual(cs.notify_addresses, ["admin@example.com",
+                                               "user@example.com"])


### PR DESCRIPTION
Context: [SAAS-11310](https://dimagi-dev.atlassian.net/browse/SAAS-11310)

##### SUMMARY

Customers are not receiving email notifications when Case Forwarders encounter errors ... because HQ is not sending them.

Currently notifications are sent for OpenMRS and DHIS2 data forwarders. This change sends notifications for all other data forwarding too.

It uses the `notify_error()` method instead of the `notify_exception()` method so that Sentry will not get new error logs that are not caused by CommCare.

Only customers who have given email addresses to send notifications to will be affected by this change. This was made a required field on the "Connection Settings" form recently, but isn't mandatory for the underlying model. Most data forwarders don't use it.


##### RISK ASSESSMENT / QA PLAN
I'm not sure whether sending error notifications for data forwarders that have never sent them before is a risk. I'm interested in feedback on how best to think about this.


##### PRODUCT DESCRIPTION
Send error notifications for all types of data forwarding, not just OpenMRS and DHIS2
