### PR TITLE
require timezone in date regex

### DIFF
--- a/corehq/ex-submodules/dimagi/ext/jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/jsonobject.py
@@ -104,7 +104,7 @@ re_loose_datetime = re.compile(r"""
     ([0-5]\d)?  # second
     \D?
     (\d{3,6})?  # millisecond
-    ([zZ]|([\+-])([01]\d|2[0-3])\D?([0-5]\d)?)?  # timezone
+    ([zZ]|([\+-])([01]\d|2[0-3])\D?([0-5]\d)?)  # timezone
     $
 """, re.VERBOSE)
 

--- a/corehq/ex-submodules/dimagi/ext/jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/jsonobject.py
@@ -86,28 +86,6 @@ re_trans_datetime = re.compile(r"""
     $
 """, re.VERBOSE)
 
-# this is like jsonobject.api.re_datetime,
-# but without the "time" part being optional
-# i.e. I just removed (...)? surrounding the second two lines
-re_loose_datetime = re.compile(r"""
-    ^
-    (\d{4})  # year
-    \D?
-    (0[1-9]|1[0-2])  # month
-    \D?
-    ([12]\d|0[1-9]|3[01])  # day
-    [ T]
-    ([01]\d|2[0-3])  # hour
-    \D?
-    ([0-5]\d)  # minute
-    \D?
-    ([0-5]\d)?  # second
-    \D?
-    (\d{3,6})?  # millisecond
-    ([zZ]|([\+-])([01]\d|2[0-3])\D?([0-5]\d)?)  # timezone
-    $
-""", re.VERBOSE)
-
 
 class USecDateTimeMeta(object):
     update_properties = {

--- a/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
@@ -35,17 +35,6 @@ class TransitionalExactDateTimePropertyTest(SimpleTestCase):
 
 
 class TestDateRegex(SimpleTestCase):
-    def test_loose_match(self):
-        cases = [
-            ('2015-04-03', False),
-            ('2013-03-09T06:30:09.007', True),
-            ('2013-03-09T06:30:09.007+03', True),
-            ('351602061044374', False),
-            ('2015-01-01T12:00:00.120054Z', True),
-            ('2015-10-01T14:05:45.087434Z', True),
-        ]
-        for candidate, expected in cases:
-            self.assertEqual(bool(re_loose_datetime.match(candidate)), expected, candidate)
 
     def test_strict_match(self):
         cases = [

--- a/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
+++ b/corehq/ex-submodules/dimagi/ext/tests/test_jsonobject.py
@@ -2,7 +2,7 @@ import datetime
 from django.test import SimpleTestCase
 import jsonobject
 from jsonobject.exceptions import BadValueError
-from dimagi.ext.jsonobject import DateTimeProperty, re_loose_datetime, re_trans_datetime
+from dimagi.ext.jsonobject import DateTimeProperty, re_trans_datetime
 
 
 class Foo(jsonobject.JsonObject):

--- a/corehq/form_processor/tests/test_utils.py
+++ b/corehq/form_processor/tests/test_utils.py
@@ -88,7 +88,7 @@ class TestDateTimeRegexMatch(SimpleTestCase):
     def test_datetime_match(self):
         cases = [
             ('2015-04-03', False),
-            ('2013-03-09T06:30:09.007', False),
+            ('2013-03-09T06:30:09.007', True),
             ('2013-03-09T06:30:09.007+03', True),
             ('2013-03-09T06:30:09.007-0530', True),
             ('351602061044374', False),

--- a/corehq/form_processor/tests/test_utils.py
+++ b/corehq/form_processor/tests/test_utils.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from django.test import SimpleTestCase
 
 from corehq.form_processor.exceptions import XFormQuestionValueNotFound
-from corehq.form_processor.utils.xform import build_form_xml_from_property_dict, get_node
+from corehq.form_processor.utils.xform import build_form_xml_from_property_dict, get_node, RE_DATETIME_MATCH
 from lxml import etree
 
 
@@ -82,3 +82,18 @@ class FormSubmissionBuilderTest(SimpleTestCase):
         self.assertEqual('remus', get_node(root, '/data/twin[2]/name').text)
         with self.assertRaises(XFormQuestionValueNotFound):
             get_node(root, '/data/has_attribute/@dirty')
+
+
+class TestDateTimeRegexMatch(SimpleTestCase):
+    def test_datetime_match(self):
+        cases = [
+            ('2015-04-03', False),
+            ('2013-03-09T06:30:09.007', False),
+            ('2013-03-09T06:30:09.007+03', True),
+            ('2013-03-09T06:30:09.007-0530', True),
+            ('351602061044374', False),
+            ('2015-01-01T12:00:00.120054Z', True),
+            ('2015-10-01T14:05:45.087434Z', True),
+        ]
+        for candidate, expected in cases:
+            self.assertEqual(bool(RE_DATETIME_MATCH.match(candidate)), expected, candidate)

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -33,8 +33,8 @@ SIMPLE_FORM = """<?xml version='1.0' ?>
 
 
 # this is like jsonobject.api.re_datetime,
-# but without the "time" or timezone parts being optional
-# i.e. I just removed (...)? surrounding the second two lines and the last line
+# but without the "time" parts being optional
+# i.e. I just removed (...)? surrounding the second two lines
 # This is used to in our form processor so we detect what strings are datetimes.
 RE_DATETIME_MATCH = re.compile(r"""
     ^
@@ -51,7 +51,7 @@ RE_DATETIME_MATCH = re.compile(r"""
     ([0-5]\d)?  # second
     \D?
     (\d{3,6})?  # millisecond
-    ([zZ]|([\+-])([01]\d|2[0-3])\D?([0-5]\d)?)  # timezone
+    ([zZ]|([\+-])([01]\d|2[0-3])\D?([0-5]\d)?)?  # timezone
     $
 """, re.VERBOSE)
 


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11203

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Makes the timezone required. This allows strings from `date-format` to be treated as strings instead of being coerced into a date. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
As far as I know this affects the presentation layer only, not the encoding, so it should be easy to revert.
As far as we know, any string that is generated from our end should have the timezone, and the `date-format` is the only thing without a timezone. However, if that is not the case this might change the appearance of some date strings.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
This regex is to detect strings that are a date and to display them in a standard format as datestrings. However, it also treats strings from `format-date` as dates, which causes issues because the timezone is not provided and the default utc is used.

## Testing

Tested locally with this configuration
<img width="495" alt="Screen Shot 2020-09-14 at 5 31 23 PM" src="https://user-images.githubusercontent.com/615126/93141089-90f76c80-f6b1-11ea-98d6-556b5a56c980.png">

Before: 
<img width="642" alt="Screen Shot 2020-09-14 at 5 30 55 PM" src="https://user-images.githubusercontent.com/615126/93141106-994fa780-f6b1-11ea-8d2a-50918276272b.png">

After:
<img width="586" alt="Screen Shot 2020-09-14 at 5 30 00 PM" src="https://user-images.githubusercontent.com/615126/93141125-a076b580-f6b1-11ea-9a05-331758c8dde9.png">

Server provided datestrings are still treated as datestrings:
<img width="353" alt="Screen Shot 2020-09-14 at 5 30 10 PM" src="https://user-images.githubusercontent.com/615126/93141446-301c6400-f6b2-11ea-9daa-3cbf99a935e4.png">


TODO: We will consider adding timezones as an option in the format string. However, I just noticed that this could cause problems. I didn't detect this before, but when we treat it as a datestring, we standardize the format and ignore the users requested format (e.g. `2020-09-14T17:28:16.000000Z` is used instead of `2020-09-14 17:28:16` as requested by format `%Y-%m-%d %H:%M:%S`). If we introduce the timezone, we would revert back to ignore the user's format and use our standard format).



