### PR TITLE
reduce oauth access token expiry to 15 minutes

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -834,6 +834,10 @@ ES_SEARCH_TIMEOUT = 30
 BITLY_OAUTH_TOKEN = None
 
 OAUTH2_PROVIDER = {
+    # until we have clearer project-level checks on this, just expire the token every
+    # 15 minutes to match HIPAA constraints.
+    # https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#access-token-expire-seconds
+    'ACCESS_TOKEN_EXPIRE_SECONDS': 15 * 60,
     'SCOPES': {
         'access_apis': 'Access API data on all your CommCare projects',
     },


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->


##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
wasn't sure how to categorize this. Only user-facing difference is people will need to re-auth on [API explorer](https://commcare-api-explorer.dimagi.com/) every 15 minutes now (previously was every 10 hours).