### PR TITLE
Fixed web apps js error due to undefined object

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/controller.js
@@ -17,7 +17,9 @@ FormplayerFrontend.module("Menus", function (Menus, FormplayerFrontend, Backbone
             $.when(fetchingNextMenu).done(function (menuResponse) {
 
                 //set title of tab to application name
-                document.title = menuResponse.breadcrumbs[0];
+                if (menuResponse.breadcrumbs) {
+                    document.title = menuResponse.breadcrumbs[0];
+                }
 
                 // show any notifications from Formplayer
                 if (menuResponse.notification && !_.isNull(menuResponse.notification.message)) {


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-11298

It seems that `breadcrumbs` isn't always defined, specifically when the menu request returns an error. I think the most reasonable thing to do in this case is leave the title as whatever it already was, since an error means the user didn't make it to the new screen.

Introduced in https://github.com/dimagi/commcare-hq/pull/28392

##### RISK ASSESSMENT / QA PLAN
Minor bugfix, no QA.

##### PRODUCT DESCRIPTION
Fixes issue with web apps sometimes not displaying error messages.
