### PR TITLE
Make enterprise permissions UI editable

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1322,3 +1322,7 @@ class CommCareUserFilterForm(forms.Form):
         if "*" in search_string or "?" in search_string:
             raise forms.ValidationError(_("* and ? are not allowed"))
         return search_string
+
+
+class CreateDomainPermissionsMirrorForm(forms.Form):
+    mirror_domain = forms.CharField(label=ugettext_lazy('Mirror'), max_length=30, required=True)

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1325,4 +1325,4 @@ class CommCareUserFilterForm(forms.Form):
 
 
 class CreateDomainPermissionsMirrorForm(forms.Form):
-    mirror_domain = forms.CharField(label=ugettext_lazy('Mirror'), max_length=30, required=True)
+    mirror_domain = forms.CharField(label=ugettext_lazy('Project Space'), max_length=30, required=True)

--- a/corehq/apps/users/templates/users/domain_permissions_mirror.html
+++ b/corehq/apps/users/templates/users/domain_permissions_mirror.html
@@ -24,6 +24,17 @@
           <td>
             {{ mirror }}
           </td>
+          <td>
+            <form class="form form-horizontal hq-form disable-on-submit"
+                  name="delete_mirror"
+                  action="{% url "delete_mirror" domain mirror%}"
+                  method="POST">
+              {% csrf_token %}
+              <input type="hidden" name="form_type" value="delete-mirror"/>
+              <input type="hidden" name="mirror" value="{{ mirror }}"/>
+              <button type="submit" style="float: right" class="btn btn-danger"><i class="fa fa-remove"></i> {% trans "Delete" %}</button>
+            </form>
+          </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/corehq/apps/users/templates/users/domain_permissions_mirror.html
+++ b/corehq/apps/users/templates/users/domain_permissions_mirror.html
@@ -17,53 +17,29 @@
     {% endblocktrans %}
   </p>
 
- <form class="form form-horizontal hq-form"
-       name="create_new_mirror"
-       action="{% url 'create_new_mirror' domain %}"
-       method="POST">
-  {% csrf_token %}
-  <input type="hidden" name="form_type" value="create_new_mirror"/>
-  <button type="button"
-          class="btn btn-primary"
-          data-toggle="modal"
-          data-target="#myModal">
-    <i class="fa fa-plus"></i> {% trans "Create New Domain Permission Mirror" %}</button>
-  <div id="myModal" class="modal fade" role="dialog">
-    <div class="modal-dialog" style="width:600px; margin:30px auto">
-      <div class="modal-content rounded-0" style="background: #fff">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h3 class="modal-title">{% trans "Create a new domain permission mirror" %}</h3>
-        </div>
-        <div class="modal-body">
-          <label for="mirror_domain" style="padding:8px">{% trans "Mirror: " %}</label>
-          <input type="text" id="mirror_domain" name="mirror_domain" value="{{ mirror_domain }}"/>
-        </div>
-        <div class="modal-footer">
-          <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>
-          <button type="submit" class="btn btn-primary"> {% trans "Create Mirror" %}</button>
-        </div>
-      </div>
-    </div>
-  </div>
-</form>
+  <form class="well well-sm form-inline" method="POST" action="{% url "create_domain_permission_mirror" domain %}" id="create_group_form">
+    {% csrf_token %}
+    <input type="text" placeholder="{% trans "Project Space" %}" id="mirror_domain" name="mirror_domain" class="form-control" />
+    <button class="btn btn-primary" type="submit">
+      <i class="fa fa-plus"></i>
+      {% trans "Add Project Space" %}
+    </button>
+  </form>
 
   <table class="table table-striped table-responsive">
     <tbody>
       {% for mirror in mirrors %}
         <tr>
-          <td>
+          <td class="col-sm-10">
             {{ mirror }}
           </td>
-          <td>
-            <form class="form form-horizontal hq-form disable-on-submit"
-                  name="delete_mirror"
-                  action="{% url 'delete_mirror' domain mirror%}"
+          <td class="col-sm-2">
+            <form class="form form-horizontal disable-on-submit"
+                  action="{% url 'delete_domain_permission_mirror' domain mirror%}"
                   method="POST">
               {% csrf_token %}
-              <input type="hidden" name="form_type" value="delete-mirror"/>
               <input type="hidden" name="mirror" value="{{ mirror }}"/>
-              <button type="submit" style="float:right" class="btn btn-danger"><i class="fa fa-remove"></i> {% trans "Delete" %}</button>
+              <button type="submit" class="btn btn-danger"><i class="fa fa-remove"></i> {% trans "Delete" %}</button>
             </form>
           </td>
         </tr>

--- a/corehq/apps/users/templates/users/domain_permissions_mirror.html
+++ b/corehq/apps/users/templates/users/domain_permissions_mirror.html
@@ -18,26 +18,31 @@
   </p>
 
  <form class="form form-horizontal hq-form"
-      name="create_new_mirror"
-      action="{% url "create_new_mirror" domain %}"
-      method="POST">
+       name="create_new_mirror"
+       action="{% url 'create_new_mirror' domain %}"
+       method="POST">
   {% csrf_token %}
   <input type="hidden" name="form_type" value="create_new_mirror"/>
-  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal"></i> {% trans "Create New Mirror for Domain" %}</button>
-  <div id="myModal" class="modal fade" role="dialog" style="background: #fff">
-    <div class="modal-dialog" style="width:600px margin:30px auto">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h3 class="modal-title">Create Mirror</h3>
-      </div>
-      <div class="modal-body">
-        <label for="mirror_domain">{% trans "Mirror: " %}</label>
-        <input type="text" id="mirror_domain" name="mirror_domain" value="{{ mirror_domain }}"/>
-
-      </div>
-      <div class="modal-footer">
-        <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>
-        <button type="submit" class="btn btn-primary"> {% trans "Create Mirror" %}</button>
+  <button type="button"
+          class="btn btn-primary"
+          data-toggle="modal"
+          data-target="#myModal">
+    <i class="fa fa-plus"></i> {% trans "Create New Domain Permission Mirror" %}</button>
+  <div id="myModal" class="modal fade" role="dialog">
+    <div class="modal-dialog" style="width:600px; margin:30px auto">
+      <div class="modal-content rounded-0" style="background: #fff">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h3 class="modal-title">{% trans "Create a new domain permission mirror" %}</h3>
+        </div>
+        <div class="modal-body">
+          <label for="mirror_domain" style="padding:8px">{% trans "Mirror: " %}</label>
+          <input type="text" id="mirror_domain" name="mirror_domain" value="{{ mirror_domain }}"/>
+        </div>
+        <div class="modal-footer">
+          <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>
+          <button type="submit" class="btn btn-primary"> {% trans "Create Mirror" %}</button>
+        </div>
       </div>
     </div>
   </div>
@@ -53,7 +58,7 @@
           <td>
             <form class="form form-horizontal hq-form disable-on-submit"
                   name="delete_mirror"
-                  action="{% url "delete_mirror" domain mirror%}"
+                  action="{% url 'delete_mirror' domain mirror%}"
                   method="POST">
               {% csrf_token %}
               <input type="hidden" name="form_type" value="delete-mirror"/>

--- a/corehq/apps/users/templates/users/domain_permissions_mirror.html
+++ b/corehq/apps/users/templates/users/domain_permissions_mirror.html
@@ -17,6 +17,32 @@
     {% endblocktrans %}
   </p>
 
+ <form class="form form-horizontal hq-form"
+      name="create_new_mirror"
+      action="{% url "create_new_mirror" domain %}"
+      method="POST">
+  {% csrf_token %}
+  <input type="hidden" name="form_type" value="create_new_mirror"/>
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal"></i> {% trans "Create New Mirror for Domain" %}</button>
+  <div id="myModal" class="modal fade" role="dialog" style="background: #fff">
+    <div class="modal-dialog" style="width:600px margin:30px auto">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h3 class="modal-title">Create Mirror</h3>
+      </div>
+      <div class="modal-body">
+        <label for="mirror_domain">{% trans "Mirror: " %}</label>
+        <input type="text" id="mirror_domain" name="mirror_domain" value="{{ mirror_domain }}"/>
+
+      </div>
+      <div class="modal-footer">
+        <a href="#" data-dismiss="modal" class="btn btn-default">{% trans "Cancel" %}</a>
+        <button type="submit" class="btn btn-primary"> {% trans "Create Mirror" %}</button>
+      </div>
+    </div>
+  </div>
+</form>
+
   <table class="table table-striped table-responsive">
     <tbody>
       {% for mirror in mirrors %}
@@ -32,7 +58,7 @@
               {% csrf_token %}
               <input type="hidden" name="form_type" value="delete-mirror"/>
               <input type="hidden" name="mirror" value="{{ mirror }}"/>
-              <button type="submit" style="float: right" class="btn btn-danger"><i class="fa fa-remove"></i> {% trans "Delete" %}</button>
+              <button type="submit" style="float:right" class="btn btn-danger"><i class="fa fa-remove"></i> {% trans "Delete" %}</button>
             </form>
           </td>
         </tr>

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -27,6 +27,7 @@ from .views import (
     test_httpdigest,
     undo_remove_web_user,
     verify_phone_number,
+    delete_mirror,
 )
 from .views.mobile.custom_data_fields import UserFieldsView
 from .views.mobile.groups import (
@@ -92,6 +93,7 @@ urlpatterns = [
     url(r'^web/$', ListWebUsersView.as_view(), name=ListWebUsersView.urlname),
     url(r'^web/json/$', paginate_web_users, name='paginate_web_users'),
     url(r'^enterprise/$', DomainPermissionsMirrorView.as_view(), name=DomainPermissionsMirrorView.urlname),
+    url(r'^delete_mirror/(?P<mirror>[ \w-]+)/$', delete_mirror, name='delete_mirror'),
     url(r'^join/(?P<uuid>[ \w-]+)/$', accept_invitation, name='domain_accept_invitation'),
     url(r'^roles/$', ListRolesView.as_view(), name=ListRolesView.urlname),
     url(r'^roles/save/$', post_user_role, name='post_user_role'),

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -27,8 +27,8 @@ from .views import (
     test_httpdigest,
     undo_remove_web_user,
     verify_phone_number,
-    delete_mirror,
-    create_new_mirror,
+    delete_domain_permission_mirror,
+    create_domain_permission_mirror,
 )
 from .views.mobile.custom_data_fields import UserFieldsView
 from .views.mobile.groups import (
@@ -94,8 +94,10 @@ urlpatterns = [
     url(r'^web/$', ListWebUsersView.as_view(), name=ListWebUsersView.urlname),
     url(r'^web/json/$', paginate_web_users, name='paginate_web_users'),
     url(r'^enterprise/$', DomainPermissionsMirrorView.as_view(), name=DomainPermissionsMirrorView.urlname),
-    url(r'^enterprise/delete_mirror/(?P<mirror>[ \w-]+)/$', delete_mirror, name='delete_mirror'),
-    url(r'^enterprise/create_new_mirror/$', create_new_mirror, name='create_new_mirror'),
+    url(r'^enterprise/delete_domain_permission_mirror/(?P<mirror>[ \w-]+)/$', delete_domain_permission_mirror,
+        name='delete_domain_permission_mirror'),
+    url(r'^enterprise/create_domain_permission_mirror/$', create_domain_permission_mirror,
+        name='create_domain_permission_mirror'),
     url(r'^join/(?P<uuid>[ \w-]+)/$', accept_invitation, name='domain_accept_invitation'),
     url(r'^roles/$', ListRolesView.as_view(), name=ListRolesView.urlname),
     url(r'^roles/save/$', post_user_role, name='post_user_role'),

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -28,6 +28,7 @@ from .views import (
     undo_remove_web_user,
     verify_phone_number,
     delete_mirror,
+    create_new_mirror,
 )
 from .views.mobile.custom_data_fields import UserFieldsView
 from .views.mobile.groups import (
@@ -93,7 +94,8 @@ urlpatterns = [
     url(r'^web/$', ListWebUsersView.as_view(), name=ListWebUsersView.urlname),
     url(r'^web/json/$', paginate_web_users, name='paginate_web_users'),
     url(r'^enterprise/$', DomainPermissionsMirrorView.as_view(), name=DomainPermissionsMirrorView.urlname),
-    url(r'^delete_mirror/(?P<mirror>[ \w-]+)/$', delete_mirror, name='delete_mirror'),
+    url(r'^enterprise/delete_mirror/(?P<mirror>[ \w-]+)/$', delete_mirror, name='delete_mirror'),
+    url(r'^enterprise/create_new_mirror/$', create_new_mirror, name='create_new_mirror'),
     url(r'^join/(?P<uuid>[ \w-]+)/$', accept_invitation, name='domain_accept_invitation'),
     url(r'^roles/$', ListRolesView.as_view(), name=ListRolesView.urlname),
     url(r'^roles/save/$', post_user_role, name='post_user_role'),

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -613,8 +613,8 @@ def delete_domain_permission_mirror(request, domain, mirror):
         message = _('You have successfully deleted the project space "{mirror}".')
         messages.success(request, message.format(mirror=mirror))
     else:
-        message = _('An error occurred while trying to delete the project space.')
-        messages.error(request, message.format())
+        message = _('The project space you are trying to delete was not found.')
+        messages.error(request, message)
     redirect = reverse(DomainPermissionsMirrorView.urlname, args=[domain])
     return HttpResponseRedirect(redirect)
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -93,6 +93,7 @@ from corehq.apps.users.forms import (
     SetUserPasswordForm,
     UpdateUserPermissionForm,
     UpdateUserRoleForm,
+    CreateDomainPermissionsMirrorForm,
 )
 from corehq.apps.users.landing_pages import get_allowed_landing_pages
 from corehq.apps.users.models import (
@@ -608,6 +609,17 @@ def delete_mirror(request, domain, mirror):
     mirror_obj_set = DomainPermissionsMirror.objects.filter(source=domain, mirror=mirror)
     if mirror_obj_set[0]:
         mirror_obj_set[0].delete()
+    redirect = reverse(DomainPermissionsMirrorView.urlname, args=[domain])
+    return HttpResponseRedirect(redirect)
+
+
+@require_POST
+def create_new_mirror(request, domain):
+    form = CreateDomainPermissionsMirrorForm(request.POST)
+    if form.is_valid():
+        mirror_domain = form.cleaned_data.get("mirror_domain")
+        mirror = DomainPermissionsMirror(source=domain, mirror=mirror_domain)
+        mirror.save()
     redirect = reverse(DomainPermissionsMirrorView.urlname, args=[domain])
     return HttpResponseRedirect(redirect)
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -613,6 +613,7 @@ def delete_mirror(request, domain, mirror):
     return HttpResponseRedirect(redirect)
 
 
+@domain_admin_required
 @require_POST
 def create_new_mirror(request, domain):
     form = CreateDomainPermissionsMirrorForm(request.POST)


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=143&projectKey=USH&modal=detail&selectedIssue=USH-200

##### SUMMARY
Now the admin of the domain has the ability to delete individual domain permission mirrors or add new ones on the Enterprise Permission page. 

##### FEATURE FLAG
COVID: Enterprise Permissions: mirror a project space's permissions in other project spaces
https://confluence.dimagi.com/pages/viewpage.action?spaceKey=ccinternal&title=Enterprise+Permissions 

##### PRODUCT DESCRIPTION
A delete button appears on the righthand side of each row which allows for easy deletion of specific mirrors. The "Create New Domain Permission" button at the top of the table allows the user to input the name of the mirror and it will create a new domain permission mirror with the source being the current domain. This uses a pop-up modal that the user can easily exit out of if they do not want to create a new mirror. During either creating or deleting, the user does not leave the enterprise permissions page and the page is instantly updated after each change. 
<img width="1071" alt="Screen Shot 2020-09-15 at 2 06 48 PM" src="https://user-images.githubusercontent.com/36681924/93249541-74b20900-f75f-11ea-8c09-ca50286fb65d.png">
<img width="1071" alt="Screen Shot 2020-09-15 at 2 07 03 PM" src="https://user-images.githubusercontent.com/36681924/93249553-78459000-f75f-11ea-83f4-0c7a3f585d64.png">

Beyond the normal feedback, I would especially love to hear what you have to think about the style of the UI (particularly with the modal). Also, if the naming of variables/buttons is logical-- I don't know if "mirror" is the right word that should be used in some instances. 

##### UPDATE
After UI discussions, I decided to make change the modal into a form directly on the page. Here are updated screenshots along with some of the messages that will appear to users have successful/unsuccessful interactions. 

<img width="1203" alt="Screen Shot 2020-09-16 at 9 00 04 AM" src="https://user-images.githubusercontent.com/36681924/93346987-96180100-f802-11ea-8362-2e314afdb303.png">
<img width="1203" alt="Screen Shot 2020-09-16 at 9 00 26 AM" src="https://user-images.githubusercontent.com/36681924/93347004-9adcb500-f802-11ea-8c49-12a32fbb88d5.png">
