### PR TITLE
Add API support for linked applications

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -460,7 +460,7 @@ class ApplicationResource(BaseApplicationResource):
         app = bundle.obj
 
         # support returning linked applications upon receiving an application list request
-        if app.doc_type == Application._doc_type or app.doc_type == LinkedApplication._doc_type:
+        if app.doc_type in [Application._doc_type, LinkedApplication._doc_type]:
             return [self.dehydrate_module(app, module, app.langs) for module in bundle.obj.modules]
         elif app.doc_type == RemoteApp._doc_type:
             return []


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[JIRA ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11261)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `ApplicationResource` API class currently only supports a doc type of "Application". This change adds support for a doc type of "Linked Application" for both a request for a specific application within a project, and a request for all applications within a project. 

Updated [Confluence documentation](https://confluence.dimagi.com/display/commcarepublic/Application+Structure+API) as well to explicitly say we support this.
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
