### PR TITLE
Kev/email logging

### DIFF
--- a/corehq/util/email_event_utils.py
+++ b/corehq/util/email_event_utils.py
@@ -13,8 +13,6 @@ from corehq.util.models import (
     TransientBounceEmail,
 )
 
-logger = logging.getLogger('email_events')
-
 
 def log_email_sns_event(message):
     log_event = {
@@ -25,7 +23,7 @@ def log_email_sns_event(message):
     for key in ['bounce', 'complaint', 'delivery', 'reject', 'failure', 'deliveryDelay']:
         if key in message:
             log_event[key] = message.get(key)
-    logger.info(log_event)
+    logging.info(log_event)
 
 
 def handle_email_sns_event(message):

--- a/corehq/util/email_event_utils.py
+++ b/corehq/util/email_event_utils.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.utils.dateparse import parse_datetime
 
 from corehq.util.metrics import metrics_counter
@@ -10,6 +12,20 @@ from corehq.util.models import (
     ComplaintBounceMeta,
     TransientBounceEmail,
 )
+
+logger = logging.getLogger('email_events')
+
+
+def log_email_sns_event(message):
+    log_event = {
+        'eventType': message.get('eventType'),
+        'eventTimestamp': message.get('mail', {}).get('timestamp'),
+        'commonHeaders': message.get('mail', {}).get('commonHeaders')
+    }
+    for key in ['bounce', 'complaint', 'delivery', 'reject', 'failure', 'deliveryDelay']:
+        if key in message:
+            log_event[key] = message.get(key)
+    logger.info(log_event)
 
 
 def handle_email_sns_event(message):
@@ -34,6 +50,7 @@ def handle_email_sns_event(message):
         elif aws_meta.notification_type == NotificationType.COMPLAINT:
             record_complaint(aws_meta)
             metrics_counter('commcare.email_sns_event.complaint_recorded')
+    log_email_sns_event(message)
 
 
 def record_permanent_bounce(aws_meta):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11216

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We want to log all events from the email SNS that notifies us of the delivery status of our emails. A longer term solution might involve better logging, but for now these logs will go to a file which will be shipped to cloudwatch logs and queryable there. 

tested on staging
<img width="865" alt="Screen Shot 2020-09-17 at 6 24 44 PM" src="https://user-images.githubusercontent.com/615126/93534877-de731400-f913-11ea-8b17-2941d54e1491.png">


##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
This is not in the critical path of users--it is in the context of the route `log_email_event` which is used by AWS SNS to notify us of email delivery statuses.  

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
Uses     https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-retrieving-sns-examples.html
 to fetch the relevant information to log.
