### PR TITLE
Add role column to mobile worker enterprise export

### DIFF
--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -199,8 +199,8 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
     @property
     def headers(self):
         headers = super(EnterpriseMobileWorkerReport, self).headers
-        return [_('Username'), _('Name'), _('Email Address'), _('Created Date [UTC]'), _('Last Sync [UTC]'),
-                _('Last Submission [UTC]'), _('CommCare Version'), _('User ID')] + headers
+        return [_('Username'), _('Name'), _('Email Address'), _('Role'), _('Created Date [UTC]'),
+                _('Last Sync [UTC]'), _('Last Submission [UTC]'), _('CommCare Version'), _('User ID')] + headers
 
     def rows_for_domain(self, domain_obj):
         rows = []
@@ -211,6 +211,7 @@ class EnterpriseMobileWorkerReport(EnterpriseReport):
                 re.sub(r'@.*', '', user.username),
                 user.full_name,
                 user.email,
+                user.role_label(domain_obj.name),
                 self.format_date(user.created_on),
                 self.format_date(user.reporting_metadata.last_sync_for_user.sync_date),
                 self.format_date(user.reporting_metadata.last_submission_for_user.submission_date),


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[JIRA ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11266)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As the ticket states, the Enterprise Mobile Worker Report does not include a role column, while the Enterprise Web User Report does. To fix, I followed the same convention found in the `EnterpriseWebUserReport` [here](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/accounting/enterprise.py#L170). Tested locally and on staging to verify the report contains a role column and populates correctly.
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
