### PR TITLE
Added web_user column to exports

### DIFF
--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -216,6 +216,19 @@ BOTTOM_MAIN_FORM_TABLE_PROPERTIES = [
         help_text=_('Link to this form'),
         selected=True,
     ),
+    ExportColumn(
+        tags=[PROPERTY_TAG_INFO],
+        label="web_user",
+        item=ExportItem(
+            path=[
+                PathNode(name='auth_context'),
+                PathNode(name='user_id'),
+            ],
+            transform=USERNAME_TRANSFORM,
+        ),
+        help_text=_('The web user who submitted the form'),
+        selected=True,
+    ),
 ]
 MAIN_FORM_TABLE_PROPERTIES = TOP_MAIN_FORM_TABLE_PROPERTIES + BOTTOM_MAIN_FORM_TABLE_PROPERTIES
 

--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -218,7 +218,7 @@ BOTTOM_MAIN_FORM_TABLE_PROPERTIES = [
     ),
     ExportColumn(
         tags=[PROPERTY_TAG_INFO],
-        label="web_user",
+        label="hq_user",
         item=ExportItem(
             path=[
                 PathNode(name='auth_context'),
@@ -226,7 +226,8 @@ BOTTOM_MAIN_FORM_TABLE_PROPERTIES = [
             ],
             transform=USERNAME_TRANSFORM,
         ),
-        help_text=_('The web user who submitted the form'),
+        help_text=_('The HQ user who submitted the form. This will be the same as username '
+                    'unless the form was submitted via Login As.'),
         selected=True,
     ),
 ]

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -176,7 +176,7 @@ class DataSourceReferenceTest(ReportBuilderDBTest):
             "partial_submission", "received_on", "edited_on", "submit_ip",
             "form.first_name", "form.last_name", "form.children", "form.dob", "form.state",
             "form.case.@date_modified", 'form.case.@user_id', 'form.case.@case_id', 'form.case.update.first_name',
-            'form.case.update.last_name', "count",
+            'form.case.update.last_name', "count", "web_user",
         ]
 
         self.assertItemsEqual(expected_property_names, list(reference.data_source_properties))

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -176,7 +176,7 @@ class DataSourceReferenceTest(ReportBuilderDBTest):
             "partial_submission", "received_on", "edited_on", "submit_ip",
             "form.first_name", "form.last_name", "form.children", "form.dob", "form.state",
             "form.case.@date_modified", 'form.case.@user_id', 'form.case.@case_id', 'form.case.update.first_name',
-            'form.case.update.last_name', "count", "web_user",
+            'form.case.update.last_name', "count", "hq_user",
         ]
 
         self.assertItemsEqual(expected_property_names, list(reference.data_source_properties))


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/USH-87

##### RISK ASSESSMENT / QA PLAN
Low risk, not requesting QA. Tested locally and verified that both web apps and mobile submissions populate auth_context > user_id, though it's null for mobile submissions.

##### PRODUCT DESCRIPTION
Adds a `web_user` property to exports to show the web user who submitted a form using login as.

For mobile submissions, this will display nothing. For web submissions using login as, `username` will have the mobile username and the new column will have the web user. For web submissions not using login as, both `username` and the new column will be the same, regardless of whether the person logged into HQ as a web user or as a mobile user.

@dimagi/product I'll hold off on merge until you give a 👍    Let me know if you want to rename the column, don't want it selected by default, or have any other feedback.

![Screen Shot 2020-09-22 at 2 33 58 PM](https://user-images.githubusercontent.com/1486591/93922949-ad625d00-fce0-11ea-9b63-66af4afddb64.png)
