### PR TITLE
skip UCRs during migrations

### DIFF
--- a/corehq/apps/domain_migration_flags/api.py
+++ b/corehq/apps/domain_migration_flags/api.py
@@ -111,6 +111,14 @@ def any_migrations_in_progress(domain, strict=False):
     ).exists()
 
 
+def all_domains_with_migrations_in_progress():
+    toggle_enabled = set(DATA_MIGRATION.get_enabled_domains())
+    flag_set = set(DomainMigrationProgress.objects.filter(
+        migration_status=MigrationStatus.IN_PROGRESS
+    ).values_list('domain', flat=True))
+    return toggle_enabled | flag_set
+
+
 def reset_caches(domain, slug):
     any_migrations_in_progress(domain, strict=True)
     get_migration_status(domain, slug, strict=True)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -97,7 +97,7 @@ def _filter_by_hash(configs, ucr_division):
 
 def _filter_domains_to_skip(configs):
     """Return a list of configs whose domain exists on this environment"""
-    domain_names = [config.domain for config in configs if config.is_static]
+    domain_names = list({config.domain for config in configs if config.is_static})
     existing_domains = list(get_domain_ids_by_names(domain_names))
     migrating_domains = [domain for domain in existing_domains if any_migrations_in_progress(domain)]
     return [

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 
+from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
 from corehq.util.metrics import metrics_counter, metrics_histogram_timer
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
@@ -94,13 +95,14 @@ def _filter_by_hash(configs, ucr_division):
     return filtered_configs
 
 
-def _filter_missing_domains(configs):
+def _filter_domains_to_skip(configs):
     """Return a list of configs whose domain exists on this environment"""
     domain_names = [config.domain for config in configs if config.is_static]
     existing_domains = list(get_domain_ids_by_names(domain_names))
+    migrating_domains = [domain for domain in existing_domains if any_migrations_in_progress(domain)]
     return [
         config for config in configs
-        if not config.is_static or config.domain in existing_domains
+        if config.domain not in migrating_domains and (not config.is_static or config.domain in existing_domains)
     ]
 
 
@@ -162,7 +164,7 @@ class ConfigurableReportTableManagerMixin(object):
         elif self.ucr_division:
             configs = _filter_by_hash(configs, self.ucr_division)
 
-        configs = _filter_missing_domains(configs)
+        configs = _filter_domains_to_skip(configs)
         configs = _filter_invalid_config(configs)
 
         return configs

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 
-from corehq.apps.domain_migration_flags.api import any_migrations_in_progress
+from corehq.apps.domain_migration_flags.api import all_domains_with_migrations_in_progress
 from corehq.util.metrics import metrics_counter, metrics_histogram_timer
 from pillowtop.checkpoints.manager import KafkaPillowCheckpoint
 from pillowtop.const import DEFAULT_PROCESSOR_CHUNK_SIZE
@@ -99,7 +99,7 @@ def _filter_domains_to_skip(configs):
     """Return a list of configs whose domain exists on this environment"""
     domain_names = list({config.domain for config in configs if config.is_static})
     existing_domains = list(get_domain_ids_by_names(domain_names))
-    migrating_domains = [domain for domain in existing_domains if any_migrations_in_progress(domain)]
+    migrating_domains = all_domains_with_migrations_in_progress()
     return [
         config for config in configs
         if config.domain not in migrating_domains and (not config.is_static or config.domain in existing_domains)

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -171,5 +171,5 @@ def mock_filter_missing_domains(configs):
 
 
 skip_domain_filter_patch = patch(
-    'corehq.apps.userreports.pillow._filter_missing_domains', mock_filter_missing_domains
+    'corehq.apps.userreports.pillow._filter_domains_to_skip', mock_filter_missing_domains
 )


### PR DESCRIPTION
##### SUMMARY
Exclude UCR datasources that belong to domains which have active data migrations.

##### RISK ASSESSMENT / QA PLAN
This mechanism is already in place for SMS and other areas.

As a future note we don't currently have a way to 'deactivate' a domain after a migration is complete. For domains that get migrated to a different environment or some other migration where the original domain is no longer in use it would be nice to have a way to mark that domain as deactivated so that it get's excluded from all processing / queries etc. The domain model does have an `is_active` property but it is used as part of the domain registration workflow so I'm hesitant to re-use it. One option would be to delete the domain. Curious to get thoughts on this.
