### PR TITLE
Updated default module name for flagged module types to use 'Menu' not 'Module'

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2421,7 +2421,7 @@ class Module(ModuleBase, ModuleDetailsMixin):
             )]
         )
         module = cls(
-            name={(lang or 'en'): name or _("Untitled Module")},
+            name={(lang or 'en'): name or _("Untitled Menu")},
             forms=[],
             case_type='',
             case_details=DetailPair(
@@ -2924,7 +2924,7 @@ class AdvancedModule(ModuleBase):
         )
 
         module = AdvancedModule(
-            name={(lang or 'en'): name or _("Untitled Module")},
+            name={(lang or 'en'): name or _("Untitled Menu")},
             forms=[],
             case_type='',
             case_details=DetailPair(
@@ -3716,7 +3716,7 @@ class ShadowModule(ModuleBase, ModuleDetailsMixin):
             )]
         )
         module = ShadowModule(
-            name={(lang or 'en'): name or _("Untitled Module")},
+            name={(lang or 'en'): name or _("Untitled Menu")},
             case_details=DetailPair(
                 short=Detail(detail.to_json()),
                 long=Detail(detail.to_json()),

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -673,7 +673,7 @@ def new_app(request, domain):
     form_args = []
     if cls == Application:
         app = cls.new_app(domain, "Untitled Application", lang=lang)
-        module = Module.new_module("Untitled Module", lang)
+        module = Module.new_module("Untitled Menu", lang)
         app.add_module(module)
         form = app.new_form(0, "Untitled Form", lang)
         form_args = [module.id, form.id]


### PR DESCRIPTION
##### SUMMARY
Tiny, noticed while testing something else that we still use "Module" sometimes.

Marking feature flag because I think regular modules always supply a name, either "Case List" or "Surveys", so this only affects shadow & advanced modules. Not worth announcing.

##### RISK ASSESSMENT / QA PLAN
No QA.