### PR TITLE
add case property recipients

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1088,8 +1088,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
 
     @classmethod
     def get_recipient_type(cls, recipient):
-        doc_type = getattr(recipient, 'doc_type', None)
-        return cls.get_recipient_type_from_doc_type(doc_type)
+        return cls.get_recipient_type_from_doc_type(recipient.doc_type)
 
     @classmethod
     def _get_recipient_doc_type(cls, recipient_type):
@@ -1266,9 +1265,6 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
                 recipient_type = cls.RECIPIENT_LOCATION
 
             recipient_id = schedule_instance.recipient.location_id
-        elif isinstance(schedule_instance.recipient, str):
-            recipient_type = cls.RECIPIENT_UNKNOWN
-            recipient_id = None
         elif schedule_instance.recipient is None:
             recipient_type = cls.RECIPIENT_UNKNOWN
             recipient_id = None

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1266,6 +1266,9 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
                 recipient_type = cls.RECIPIENT_LOCATION
 
             recipient_id = schedule_instance.recipient.location_id
+        elif isinstance(schedule_instance.recipient, str):
+            recipient_type = cls.RECIPIENT_UNKNOWN
+            recipient_id = None
         elif schedule_instance.recipient is None:
             recipient_type = cls.RECIPIENT_UNKNOWN
             recipient_id = None

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1088,7 +1088,8 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
 
     @classmethod
     def get_recipient_type(cls, recipient):
-        return cls.get_recipient_type_from_doc_type(recipient.doc_type)
+        doc_type = getattr(recipient, 'doc_type')
+        return cls.get_recipient_type_from_doc_type(doc_type)
 
     @classmethod
     def _get_recipient_doc_type(cls, recipient_type):

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1088,7 +1088,7 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
 
     @classmethod
     def get_recipient_type(cls, recipient):
-        doc_type = getattr(recipient, 'doc_type')
+        doc_type = getattr(recipient, 'doc_type', None)
         return cls.get_recipient_type_from_doc_type(doc_type)
 
     @classmethod

--- a/corehq/messaging/scheduling/forms.py
+++ b/corehq/messaging/scheduling/forms.py
@@ -2956,7 +2956,7 @@ class ConditionalAlertScheduleForm(ScheduleForm):
                 initial['custom_recipient'] = recipient_id
             if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER:
                 initial['username_case_property'] = recipient_id
-            if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_USER:
+            if recipient_type == CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
                 initial['email_case_property'] = recipient_id
 
     def add_initial_for_custom_metadata(self, result):

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -131,10 +131,7 @@ class EmailContent(Content):
             logged_subevent.error(MessagingEvent.ERROR_NO_MESSAGE)
             return
 
-        if isinstance(recipient, str):
-            email_address = recipient
-        else:
-            email_address = recipient.get_email()
+        email_address = recipient.get_email()
         if not email_address:
             logged_subevent.error(MessagingEvent.ERROR_NO_EMAIL_ADDRESS)
             return

--- a/corehq/messaging/scheduling/models/content.py
+++ b/corehq/messaging/scheduling/models/content.py
@@ -131,7 +131,10 @@ class EmailContent(Content):
             logged_subevent.error(MessagingEvent.ERROR_NO_MESSAGE)
             return
 
-        email_address = recipient.get_email()
+        if isinstance(recipient, str):
+            email_address = recipient
+        else:
+            email_address = recipient.get_email()
         if not email_address:
             logged_subevent.error(MessagingEvent.ERROR_NO_EMAIL_ADDRESS)
             return

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -612,7 +612,7 @@ class CaseScheduleInstanceMixin(object):
             full_username = format_username(username, self.domain)
             return CommCareUser.get_by_username(full_username)
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
-            return self.recipient_id
+            return self.case.get_case_property(self.recipient_id)
         else:
             return super(CaseScheduleInstanceMixin, self).recipient
 

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -275,6 +275,9 @@ class ScheduleInstance(PartitionedModel):
         if is_commcarecase(recipient):
             doc_type = 'CommCareCase'
             doc_id = recipient.case_id
+        elif isinstance(recipient, str):
+            doc_type = recipient
+            doc_id = recipient
         else:
             doc_type = recipient.doc_type
             doc_id = recipient.get_id

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -1,3 +1,4 @@
+import attr
 import pytz
 import sys
 import uuid
@@ -126,7 +127,7 @@ class ScheduleInstance(PartitionedModel):
         return (
             isinstance(recipient, (CommCareUser, WebUser)) or
             is_commcarecase(recipient) or
-            isinstance(recipient, str)
+            isinstance(recipient, EmailAddressRecipient)
         )
 
     @property
@@ -275,9 +276,6 @@ class ScheduleInstance(PartitionedModel):
         if is_commcarecase(recipient):
             doc_type = 'CommCareCase'
             doc_id = recipient.case_id
-        elif isinstance(recipient, str):
-            doc_type = recipient
-            doc_id = recipient
         else:
             doc_type = recipient.doc_type
             doc_id = recipient.get_id
@@ -526,6 +524,25 @@ class TimedScheduleInstance(AbstractTimedScheduleInstance):
         )
 
 
+@attr.s
+class EmailAddressRecipient(object):
+    email_address = attr.ib()
+
+    @property
+    def doc_type(self):
+        return None
+
+    @property
+    def get_id(self):
+        return self.email_address
+
+    def get_email(self):
+        return self.email_address
+
+    def get_language_code(self):
+        return None
+
+
 class CaseScheduleInstanceMixin(object):
 
     RECIPIENT_TYPE_SELF = 'Self'
@@ -615,7 +632,8 @@ class CaseScheduleInstanceMixin(object):
             full_username = format_username(username, self.domain)
             return CommCareUser.get_by_username(full_username)
         elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
-            return self.case.get_case_property(self.recipient_id)
+            email = self.case.get_case_property(self.recipient_id)
+            return EmailAddressRecipient(email)
         else:
             return super(CaseScheduleInstanceMixin, self).recipient
 

--- a/corehq/messaging/scheduling/scheduling_partitioned/models.py
+++ b/corehq/messaging/scheduling/scheduling_partitioned/models.py
@@ -8,6 +8,7 @@ from corehq.apps.locations.models import SQLLocation
 from corehq.apps.sms.models import MessagingEvent
 from corehq.apps.users.cases import get_owner_id, get_wrapped_owner
 from corehq.apps.users.models import CommCareUser, WebUser, CouchUser
+from corehq.apps.users.util import format_username
 from corehq.form_processor.abstract_models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.exceptions import CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
@@ -124,7 +125,8 @@ class ScheduleInstance(PartitionedModel):
     def recipient_is_an_individual_contact(recipient):
         return (
             isinstance(recipient, (CommCareUser, WebUser)) or
-            is_commcarecase(recipient)
+            is_commcarecase(recipient) or
+            isinstance(recipient, str)
         )
 
     @property
@@ -529,6 +531,8 @@ class CaseScheduleInstanceMixin(object):
     RECIPIENT_TYPE_PARENT_CASE = 'ParentCase'
     RECIPIENT_TYPE_ALL_CHILD_CASES = 'AllChildCases'
     RECIPIENT_TYPE_CUSTOM = 'CustomRecipient'
+    RECIPIENT_TYPE_CASE_PROPERTY_USER = 'CasePropertyUser'
+    RECIPIENT_TYPE_CASE_PROPERTY_EMAIL = 'CasePropertyEmail'
 
     @property
     @memoized
@@ -603,6 +607,12 @@ class CaseScheduleInstanceMixin(object):
                 settings.AVAILABLE_CUSTOM_SCHEDULING_RECIPIENTS[self.recipient_id][0]
             )
             return custom_function(self)
+        elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_USER:
+            username = self.case.get_case_property(self.recipient_id)
+            full_username = format_username(username, self.domain)
+            return CommCareUser.get_by_username(full_username)
+        elif self.recipient_type == self.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL:
+            return self.recipient_id
         else:
             return super(CaseScheduleInstanceMixin, self).recipient
 

--- a/corehq/messaging/scheduling/tests/test_recipients.py
+++ b/corehq/messaging/scheduling/tests/test_recipients.py
@@ -666,7 +666,7 @@ class SchedulingRecipientTest(TestCase):
                 recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL,
                 recipient_id='recipient'
             )
-            self.assertEqual(instance.recipient, 'fake@mail.com')
+            self.assertEqual(instance.recipient.get_email(), 'fake@mail.com')
 
         with create_case(
                 self.domain,
@@ -679,7 +679,7 @@ class SchedulingRecipientTest(TestCase):
                 recipient_type=CaseScheduleInstanceMixin.RECIPIENT_TYPE_CASE_PROPERTY_EMAIL,
                 recipient_id='recipient'
             )
-            self.assertIsNone(instance.recipient)
+            self.assertIsNone(instance.recipient.get_email())
 
     def create_user_case(self, user):
         create_case_kwargs = {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://dimagi-dev.atlassian.net/browse/USH-225

This adds two new recipients for conditional alerts.
1) Specify mobile worker by username
2) Specify email by username

The first works for both SMS or Email alerts, the second only for email (for obvious reasons)