### PR TITLE
Enterprise Web User Report name and email columns are swapped

### DIFF
--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -165,8 +165,8 @@ class EnterpriseWebUserReport(EnterpriseReport):
                 last_accessed_domain = domain_membership.last_accessed
             rows.append(
                 [
-                    user.username,
                     user.full_name,
+                    user.username,
                     user.role_label(domain_obj.name),
                     self.format_date(user.last_login),
                     last_accessed_domain,

--- a/corehq/apps/accounting/enterprise.py
+++ b/corehq/apps/accounting/enterprise.py
@@ -138,7 +138,7 @@ class EnterpriseWebUserReport(EnterpriseReport):
     @property
     def headers(self):
         headers = super(EnterpriseWebUserReport, self).headers
-        return [_('Name'), _('Email Address'), _('Role'), _('Last Login [UTC]'),
+        return [_('Email Address'), _('Name'), _('Role'), _('Last Login [UTC]'),
                 _('Last Access Date [UTC]'), _('Status')] + headers
 
     def rows_for_domain(self, domain_obj):
@@ -165,8 +165,8 @@ class EnterpriseWebUserReport(EnterpriseReport):
                 last_accessed_domain = domain_membership.last_accessed
             rows.append(
                 [
-                    user.full_name,
                     user.username,
+                    user.full_name,
                     user.role_label(domain_obj.name),
                     self.format_date(user.last_login),
                     last_accessed_domain,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[JIRA Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-11246)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As the ticket states, the columns are swapped. Just need to correctly fill data in.

Added a commit that instead swaps the headers and returns the data to out it was. @calellowitz noted that this was the original intention [here](https://github.com/dimagi/commcare-hq/pull/28180). 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
