### PR TITLE
Updated SQLAppGroup.group_id to allow nulls

### DIFF
--- a/corehq/apps/cloudcare/models.py
+++ b/corehq/apps/cloudcare/models.py
@@ -68,8 +68,8 @@ class ApplicationAccess(models.Model):
 
 
 class SQLAppGroup(models.Model):
-    app_id = models.CharField(max_length=255, null=False)
-    group_id = models.CharField(max_length=255)
+    app_id = models.CharField(max_length=255)
+    group_id = models.CharField(max_length=255, null=True)
     application_access = models.ForeignKey('ApplicationAccess', on_delete=models.CASCADE)
 
     class Meta(object):


### PR DESCRIPTION
##### SUMMARY
Stop `makemigrations` from complaining about switching `group_id` to non-nullable without providing a default value. Looking at prod data, this can be null, so just make it nullable.

##### RISK ASSESSMENT / QA PLAN
No