### PR TITLE
log possible duplicate SMS events

### DIFF
--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -27,6 +27,11 @@ monitor_2fa_soft_assert = soft_assert(
     send_to_ops=False
 )
 
+log_sms_duplicates_soft_assert = soft_assert(
+    to=['{}@{}'.format('biyeun', 'dimagi.com')],
+    send_to_ops=False
+)
+
 
 @memoized
 def get_hq_private_key():

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -649,6 +649,14 @@ MONITOR_2FA_CHANGES = StaticToggle(
 )
 
 
+LOG_SMS_DUPLICATION = StaticToggle(
+    'log_sms_duplication',
+    'Monitor SMS duplication activity for SAAS-10861 ticket',
+    TAG_CUSTOM,
+    namespaces=[NAMESPACE_DOMAIN]
+)
+
+
 USER_CONFIGURABLE_REPORTS = StaticToggle(
     'user_reports',
     'User configurable reports UI',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10861

##### SUMMARY
Adds some very rudimentary logging to see if my hunch on `Exception`s re-triggering an SMS send after the SMS was successfully sent (but an exception was triggered) is valid.

##### FEATURE FLAG
LOG_SMS_DUPLICATION

##### RISK ASSESSMENT / QA PLAN
This is a really isolated change. low risk...
