### PR TITLE
upgrade to redis-py 3.3.0

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -175,7 +175,7 @@ qrcode==4.0.4             # via -r requirements/requirements.in, django-two-fact
 quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
 recommonmark==0.6.0       # via -r requirements/dev-requirements.in
-redis==3.2.1              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
+redis==3.3.0              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
 reportlab==3.0            # via -r requirements/requirements.in
 requests-mock==1.7.0      # via -r requirements/test-requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -146,7 +146,7 @@ pyzxcvbn==0.8.0           # via -r requirements/requirements.in
 qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
 quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis==3.2.1              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
+redis==3.3.0              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
 reportlab==3.0            # via -r requirements/requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
 requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-oauthlib, stripe, tinys3, twilio

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -56,7 +56,7 @@ socketpool==0.5.3
 markdown==2.2.1
 sqlagg==0.16.2
 django-redis==4.11.0
-redis==3.2.1
+redis==3.3.0
 twilio==6.5.1
 django-countries==4.6
 reportlab==3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -131,7 +131,7 @@ pyzxcvbn==0.8.0           # via -r requirements/requirements.in
 qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
 quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis==3.2.1              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
+redis==3.3.0              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
 reportlab==3.0            # via -r requirements/requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in
 requests==2.22.0          # via -r requirements/requirements.in, cloudant, datadog, django-oauth-toolkit, dropbox, requests-oauthlib, stripe, tinys3, twilio

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -143,7 +143,7 @@ pyzxcvbn==0.8.0           # via -r requirements/requirements.in
 qrcode==4.0.4             # via -r requirements/requirements.in, django-two-factor-auth
 quickcache==0.5.4         # via -r requirements/requirements.in
 rcssmin==1.0.6            # via django-compressor
-redis==3.2.1              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
+redis==3.3.0              # via -r requirements/requirements.in, django-redis, django-redis-sessions, django-websocket-redis
 reportlab==3.0            # via -r requirements/requirements.in
 requests-mock==1.7.0      # via -r requirements/test-requirements.in
 requests-oauthlib==1.3.0  # via -r requirements/requirements.in


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11355

##### SUMMARY
We need to use `health_check_interval` in the redis-py config to stop intermittent failures due to the celery upgrade. (Details in ticket). `health_check_interval` is only available starting redis-py 3.3.0, and the celery PR only upgraded to 2.3.1.

##### RISK ASSESSMENT / QA PLAN
Pushing to staging for QA, which should be able to prioritize it in the next few days
