### PR TITLE
Tests and fixes for MobileAuthKeyRecord couch to sql migration

### DIFF
--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -58,7 +58,7 @@ class PopulateSQLCommand(BaseCommand):
         if wrap:
             couch = wrap(couch)
         if couch != sql:
-            return f"{name}: couch value '{couch}' != sql value '{sql}'"
+            return f"{name}: couch value {couch!r} != sql value {sql!r}"
 
     @classmethod
     def count_items_to_be_migrated(cls):

--- a/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
+++ b/corehq/apps/cleanup/management/commands/populate_sql_model_from_couch_model.py
@@ -52,6 +52,15 @@ class PopulateSQLCommand(BaseCommand):
         raise NotImplementedError()
 
     @classmethod
+    def diff_attr(cls, name, doc, obj, wrap=None):
+        couch = doc.get(name, None)
+        sql = getattr(obj, name, None)
+        if wrap:
+            couch = wrap(couch)
+        if couch != sql:
+            return f"{name}: couch value '{couch}' != sql value '{sql}'"
+
+    @classmethod
     def count_items_to_be_migrated(cls):
         couch_count = get_doc_count_by_type(cls.couch_db(), cls.couch_doc_type())
         sql_count = cls.sql_class().objects.count()

--- a/corehq/apps/cleanup/tests/test_couch_to_sql_mobile_auth.py
+++ b/corehq/apps/cleanup/tests/test_couch_to_sql_mobile_auth.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from corehq.apps.mobile_auth.management.commands.populate_mobileauthkeyrecord import Command
+from corehq.apps.mobile_auth.models import (
+    MobileAuthKeyRecord,
+    SQLMobileAuthKeyRecord,
+)
+from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
+from dimagi.utils.parsing import string_to_utc_datetime
+
+
+class TestCouchToSQLMobileAuth(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.db = MobileAuthKeyRecord.get_db()
+
+    def tearDown(self):
+        SQLMobileAuthKeyRecord.objects.all().delete()
+        for doc in get_all_docs_with_doc_types(self.db, ['MobileAuthKeyRecord']):
+            MobileAuthKeyRecord.wrap(doc).delete()
+        super().tearDown()
+
+    def test_diff_identical(self):
+        key = '234'
+        valid = datetime.utcnow()
+        expires = valid + timedelta(days=30)
+        couch = MobileAuthKeyRecord(domain='my-domain', user_id='123', valid=valid, expires=expires, key=key)
+        sql = SQLMobileAuthKeyRecord(domain='my-domain', user_id='123', valid=valid, expires=expires, key=key)
+        self.assertIsNone(Command.diff_couch_and_sql(couch.to_json(), sql))
+
+    def test_diff_top_level_attributes(self):
+        valid = datetime.utcnow()
+        expires1 = valid + timedelta(days=30)
+        expires2 = valid + timedelta(days=31)
+        couch = MobileAuthKeyRecord(domain='my-domain', user_id='123', valid=valid, expires=expires1)
+        sql = SQLMobileAuthKeyRecord(domain='other-domain', user_id='123', valid=valid, expires=expires2)
+
+        (domain_diff, key_diff, expires_diff) = Command.diff_couch_and_sql(couch.to_json(), sql).split("\n")
+        self.assertEqual(domain_diff, "domain: couch value 'my-domain' != sql value 'other-domain'")
+        self.assertRegex(
+            key_diff,
+            r"key: couch value '.+' != sql value '.+'"
+        )
+        self.assertRegex(
+            expires_diff,
+            r"expires: couch value '\d{4}-..-.. ..:..:..\.\d+' != sql value '\d{4}-..-.. ..:..:..\.\d+'"
+        )

--- a/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
+++ b/corehq/apps/custom_data_fields/management/commands/populate_custom_data_fields.py
@@ -21,13 +21,6 @@ class Command(PopulateSQLCommand):
         return "bb82e5c3d2840d6e3e3a6f5ebf1a0c7e817f4613"
 
     @classmethod
-    def diff_attr(cls, name, doc, obj):
-        couch = doc.get(name, None)
-        sql = getattr(obj, name, None)
-        if couch != sql:
-            return f"{name}: couch value '{couch}' != sql value '{sql}'"
-
-    @classmethod
     def diff_couch_and_sql(cls, doc, obj):
         diffs = []
         for attr in ('field_type', 'domain'):

--- a/corehq/apps/mobile_auth/management/commands/populate_mobileauthkeyrecord.py
+++ b/corehq/apps/mobile_auth/management/commands/populate_mobileauthkeyrecord.py
@@ -30,7 +30,7 @@ class Command(PopulateSQLCommand):
     def update_or_create_sql_object(self, doc):
         # Use get_or_create so that if sql model exists we don't bother saving it,
         # since these models are read-only
-        model, created = self.sql_class().objects.get_or_create(
+        model, created = self.sql_class().objects.update_or_create(
             id=doc['_id'],
             defaults={
                 "domain": doc.get("domain"),

--- a/corehq/apps/mobile_auth/management/commands/populate_mobileauthkeyrecord.py
+++ b/corehq/apps/mobile_auth/management/commands/populate_mobileauthkeyrecord.py
@@ -1,4 +1,4 @@
-from dimagi.utils.dates import force_to_datetime
+from dimagi.utils.parsing import string_to_utc_datetime
 
 from corehq.apps.cleanup.management.commands.populate_sql_model_from_couch_model import PopulateSQLCommand
 
@@ -17,6 +17,16 @@ class Command(PopulateSQLCommand):
     def commit_adding_migration(cls):
         return "TODO"
 
+    @classmethod
+    def diff_couch_and_sql(cls, couch, sql):
+        diffs = []
+        for attr in ["domain", "user_id", "type", "key"]:
+            diffs.append(cls.diff_attr(attr, couch, sql))
+        for attr in ["valid", "expires"]:
+            diffs.append(cls.diff_attr(attr, couch, sql, wrap=string_to_utc_datetime))
+        diffs = [d for d in diffs if d]
+        return "\n".join(diffs) if diffs else None
+
     def update_or_create_sql_object(self, doc):
         # Use get_or_create so that if sql model exists we don't bother saving it,
         # since these models are read-only
@@ -25,8 +35,8 @@ class Command(PopulateSQLCommand):
             defaults={
                 "domain": doc.get("domain"),
                 "user_id": doc.get("user_id"),
-                "valid": force_to_datetime(doc.get("valid")),
-                "expires": force_to_datetime(doc.get("expires")),
+                "valid": string_to_utc_datetime(doc.get("valid")),
+                "expires": string_to_utc_datetime(doc.get("expires")),
                 "type": doc.get("type"),
                 "key": doc.get("key"),
             })

--- a/corehq/ex-submodules/dimagi/utils/couch/migration.py
+++ b/corehq/ex-submodules/dimagi/utils/couch/migration.py
@@ -2,6 +2,8 @@ from collections import namedtuple
 
 from django.conf import settings
 
+from couchdbkit import ResourceNotFound
+
 from dimagi.utils.logging import notify_exception
 
 SubModelSpec = namedtuple('SubModelSpec', [
@@ -189,7 +191,10 @@ class SyncSQLToCouchMixin(object):
         if not self._migration_couch_id:
             return None
         cls = self._migration_get_couch_model_class()
-        return cls.get(str(self._migration_couch_id))
+        try:
+            return cls.get(str(self._migration_couch_id))
+        except ResourceNotFound:
+            return None
 
     def _migration_get_or_create_couch_object(self):
         cls = self._migration_get_couch_model_class()


### PR DESCRIPTION
The first MobileAuthKeyRecord migration PR, https://github.com/dimagi/commcare-hq/pull/27516, was merged back in May, so now there's both SQL and couch data on prod (and india, swiss, and icds), but all the code is still reading from couch.

However, couch and sql aren't perfectly in sync on prod, so something isn't right. I wrote these tests and in the process found a couple of possible causes. I'm planning to merge this, re-run the migration, and hopefully that will get sql back in sync with couch.

[Docs](https://github.com/dimagi/commcare-hq/blob/master/docs/couch_to_sql_models.rst)