### PR TITLE
added support to import cases in multiple domains

### DIFF
--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -42,38 +42,34 @@ def do_import(spreadsheet, config, domain, task=None, record_form_callback=None)
     if has_domain_column:
         mirror_domains = DomainPermissionsMirror.mirror_domains(domain)
         sub_domains = set()
-        results = _ImportResults()
+        import_results = _ImportResults()
         for row_num, row in enumerate(spreadsheet.iter_row_dicts(), start=1):
             if row_num == 1:
-                continue
+                continue # skip first row (header row)
             sheet_domain = row.get('domain')
             if sheet_domain != domain and sheet_domain not in mirror_domains:
                 err = exceptions.CaseRowError(column_name='domain')
                 err.title = _('Invalid domain')
                 err.message = _('Following rows contain invalid value for domain column.')
-                results.add_error(row_num, err)
+                import_results.add_error(row_num, err)
             else:
                 sub_domains.add(sheet_domain)
         for sub_domain in sub_domains:
-            importer = _TimedAndThrottledImporter(sub_domain, config, task, record_form_callback)
-            importer.results = results
-            importer.has_domain_column = True
+            importer = _TimedAndThrottledImporter(sub_domain, config, task, record_form_callback, import_results)
             importer.do_import(spreadsheet)
-        return results.to_json()
+        return import_results.to_json()
     else:
         importer = _TimedAndThrottledImporter(domain, config, task, record_form_callback)
         return importer.do_import(spreadsheet)
 
 
 class _Importer(object):
-    def __init__(self, domain, config, task, record_form_callback):
+    def __init__(self, domain, config, task, record_form_callback, import_results=None):
         self.domain = domain
         self.config = config
         self.task = task
         self.record_form_callback = record_form_callback
-
-        self.results = _ImportResults()
-
+        self.results = import_results or _ImportResults()
         self.owner_accessor = _OwnerAccessor(domain, self.user)
         self.uncreated_external_ids = set()
         self._unsubmitted_caseblocks = []
@@ -192,8 +188,8 @@ class _Importer(object):
 
 
 class _TimedAndThrottledImporter(_Importer):
-    def __init__(self, domain, config, task, record_form_callback):
-        super().__init__(domain, config, task, record_form_callback)
+    def __init__(self, domain, config, task, record_form_callback, import_results=None):
+        super().__init__(domain, config, task, record_form_callback, import_results)
 
         self._last_submission_duration = 1  # duration in seconds; start with a value of 1s
         self._total_delayed_duration = 0  # sum of all rate limiter delays, in seconds

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -45,7 +45,7 @@ def do_import(spreadsheet, config, domain, task=None, record_form_callback=None)
         import_results = _ImportResults()
         for row_num, row in enumerate(spreadsheet.iter_row_dicts(), start=1):
             if row_num == 1:
-                continue # skip first row (header row)
+                continue  # skip first row (header row)
             sheet_domain = row.get('domain')
             if sheet_domain != domain and sheet_domain not in mirror_domains:
                 err = exceptions.CaseRowError(column_name='domain')

--- a/corehq/apps/case_importer/do_import.py
+++ b/corehq/apps/case_importer/do_import.py
@@ -21,7 +21,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.users.cases import get_wrapped_owner
-from corehq.apps.users.models import CouchUser
+from corehq.apps.users.models import CouchUser, DomainPermissionsMirror
 from corehq.apps.users.util import format_username
 from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 from corehq.util.metrics.load_counters import case_load_counter

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     get_all_case_properties_for_case_type,
 )
 from corehq.apps.case_importer.util import RESERVED_FIELDS
-from corehq.toggles import BULK_UPLOAD_DATE_OPENED
+from corehq.toggles import BULK_UPLOAD_DATE_OPENED, DOMAIN_PERMISSIONS_MIRROR
 
 
 def _combine_field_specs(field_specs, exclude_fields):
@@ -99,6 +99,15 @@ def get_special_fields(domain=None):
                 description=_(
                     "The date opened property for this case will be changed. "
                     "Please do not use unless you know what you are doing"
+                )
+            )
+        )
+    if domain and DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
+        special_fields.append(
+            FieldSpec(
+                field='domain',
+                description=_(
+                    "This field will create/update the case in the domain specified."
                 )
             )
         )

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -102,13 +102,4 @@ def get_special_fields(domain=None):
                 )
             )
         )
-    if domain and DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
-        special_fields.append(
-            FieldSpec(
-                field='domain',
-                description=_(
-                    "This field will create/update the case in the domain specified."
-                )
-            )
-        )
     return special_fields

--- a/corehq/apps/case_importer/suggested_fields.py
+++ b/corehq/apps/case_importer/suggested_fields.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.app_schemas.case_properties import (
     get_all_case_properties_for_case_type,
 )
 from corehq.apps.case_importer.util import RESERVED_FIELDS
-from corehq.toggles import BULK_UPLOAD_DATE_OPENED, DOMAIN_PERMISSIONS_MIRROR
+from corehq.toggles import BULK_UPLOAD_DATE_OPENED
 
 
 def _combine_field_specs(field_specs, exclude_fields):

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -23,7 +23,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
 from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import restrict_user_by_location
-from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.models import CommCareUser, WebUser, DomainPermissionsMirror
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.util.test_utils import flag_enabled

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -384,12 +384,29 @@ class ImporterTest(TestCase):
             ['', 'name-0', 'artist-0', self.domain],
             ['', 'name-1', 'artist-1', mirror_domain1.mirror],
             ['', 'name-2', 'artist-2', mirror_domain2.mirror],
-            ['', 'name-3', 'artist-3', 'not-existing-domain']
+            ['', 'name-3', 'artist-3', self.domain],
+            ['', 'name-4', 'artist-4', self.domain],
+            ['', 'name-5', 'artist-5', 'not-existing-domain']
         )
         res = do_import(case_with_domain_file, config_1, self.domain)
-        self.assertEqual(3, res['created_count'])
+        self.assertEqual(5, res['created_count'])
         self.assertEqual(0, res['match_count'])
         self.assertEqual(1, res['failed_count'])
+
+        # Asserting current domain
+        cur_case_ids = self.accessor.get_case_ids_in_domain()
+        cur_cases = list(self.accessor.get_cases(cur_case_ids))
+        self.assertEqual(3, len(cur_cases))
+
+        # Asserting mirror domain 1
+        md1_case_ids = CaseAccessors(mirror_domain1.mirror).get_case_ids_in_domain()
+        md1_cases = list(self.accessor.get_cases(md1_case_ids))
+        self.assertEqual(1, len(md1_cases))
+
+        # Asserting mirror domain 2
+        md2_case_ids = CaseAccessors(mirror_domain2.mirror).get_case_ids_in_domain()
+        md2_cases = list(self.accessor.get_cases(md2_case_ids))
+        self.assertEqual(1, len(md2_cases))
 
     def import_mock_file(self, rows):
         config = self._config(rows[0])

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -26,7 +26,7 @@ from corehq.apps.locations.tests.util import restrict_user_by_location
 from corehq.apps.users.models import CommCareUser, WebUser, DomainPermissionsMirror
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
-from corehq.util.test_utils import flag_enabled
+from corehq.util.test_utils import flag_enabled, flag_disabled
 from corehq.util.timezones.conversions import PhoneTime
 from corehq.util.workbook_reading import make_worksheet
 
@@ -407,6 +407,37 @@ class ImporterTest(TestCase):
         md2_case_ids = CaseAccessors(mirror_domain2.mirror).get_case_ids_in_domain()
         md2_cases = list(self.accessor.get_cases(md2_case_ids))
         self.assertEqual(1, len(md2_cases))
+
+    @flag_disabled('DOMAIN_PERMISSIONS_MIRROR')
+    @run_with_all_backends
+    def test_multiple_domain_case_import_without_flag(self):
+        mirror_domain1 = DomainPermissionsMirror(source=self.domain, mirror='mirrordomain1')
+        mirror_domain2 = DomainPermissionsMirror(source=self.domain, mirror='mirrordomain2')
+        mirror_domain1.save()
+        mirror_domain2.save()
+        headers_with_domain = ['case_id', 'name', 'artist', 'domain']
+        config_1 = self._config(headers_with_domain, create_new_cases=True, search_column='case_id')
+        case_with_domain_file = make_worksheet_wrapper(
+            ['case_id', 'name', 'artist', 'domain'],
+            ['', 'name-0', 'artist-0', self.domain],
+            ['', 'name-1', 'artist-1', mirror_domain1.mirror],
+            ['', 'name-2', 'artist-2', mirror_domain2.mirror],
+            ['', 'name-3', 'artist-3', self.domain],
+            ['', 'name-4', 'artist-4', self.domain],
+            ['', 'name-5', 'artist-5', 'not-existing-domain']
+        )
+        res = do_import(case_with_domain_file, config_1, self.domain)
+        print(f"========res======={res}===============")
+        self.assertEqual(6, res['created_count'])
+        self.assertEqual(0, res['match_count'])
+        self.assertEqual(0, res['failed_count'])
+        case_ids = self.accessor.get_case_ids_in_domain()
+        # Asserting current domain
+        cur_cases = list(self.accessor.get_cases(case_ids))
+        self.assertEqual(6, len(cur_cases))
+        #Asserting domain case property
+        cases = {c.name: c for c in list(self.accessor.get_cases(case_ids))}
+        self.assertEqual(cases['name-0'].get_case_property('domain'), self.domain)
 
     def import_mock_file(self, rows):
         config = self._config(rows[0])

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -221,6 +221,9 @@ def excel_fields(request, domain):
     if search_column in excel_fields:
         excel_fields.remove(search_column)
 
+    # 'domain' case property cannot be created if domain mirror flag is enabled,
+    # as this enables a multi-domain case import.
+    # see: https://dimagi-dev.atlassian.net/browse/USH-81
     if 'domain' in excel_fields and DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
         excel_fields.remove('domain')
 

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -226,6 +226,9 @@ def excel_fields(request, domain):
     if search_column in excel_fields:
         excel_fields.remove(search_column)
 
+    if 'domain' in excel_fields and DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
+        excel_fields.remove('domain')
+
     field_specs = get_suggested_case_fields(
         domain, case_type, exclude=[search_field])
 

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -33,6 +33,7 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.util.view_utils import absolute_reverse
 from corehq.util.workbook_reading import valid_extensions, SpreadsheetFileExtError, SpreadsheetFileInvalidError
+from corehq.toggles import DOMAIN_PERMISSIONS_MIRROR
 
 require_can_edit_data = require_permission(Permissions.edit_data)
 
@@ -150,6 +151,11 @@ def _process_file_and_get_upload(uploaded_file_handle, request, domain, max_colu
             'No cases have been submitted to this domain and there are no '
             'applications yet. You cannot import case details from an Excel '
             'file until you have existing cases or applications.')
+
+    if 'domain' in columns and not DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
+        raise ImporterError(
+            "You cannot upload a file without enabling"
+            "mirror a project space's permissions in other project spaces.")
 
     context = {
         'columns': columns,

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -154,8 +154,8 @@ def _process_file_and_get_upload(uploaded_file_handle, request, domain, max_colu
 
     if 'domain' in columns and not DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
         raise ImporterError(
-            "You cannot upload a file without enabling"
-            "mirror a project space's permissions in other project spaces.")
+            "You have a special column `domain` in your Excel file but,"
+            "Mirror domains are not enabled for your project space.")
 
     context = {
         'columns': columns,

--- a/corehq/apps/case_importer/views.py
+++ b/corehq/apps/case_importer/views.py
@@ -152,11 +152,6 @@ def _process_file_and_get_upload(uploaded_file_handle, request, domain, max_colu
             'applications yet. You cannot import case details from an Excel '
             'file until you have existing cases or applications.')
 
-    if 'domain' in columns and not DOMAIN_PERMISSIONS_MIRROR.enabled(domain):
-        raise ImporterError(
-            "You have a special column `domain` in your Excel file but,"
-            "Mirror domains are not enabled for your project space.")
-
     context = {
         'columns': columns,
         'unrecognized_case_types': unrecognized_case_types,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/jira/software/c/projects/USH/issues/USH-81

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a case import feature: If there's a domain column in the spreadsheet, and the domains are sub domains of the main domain the import is being carried out, the cases will be imported into the domain specified in the column .

##### FEATURE FLAG
COVID: Enterprise Permissions

##### RISK ASSESSMENT / QA PLAN
[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2015)
