### PR TITLE
Uninstall enum34

### DIFF
--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -15,3 +15,4 @@ subprocess32
 eventlet
 contextlib2
 redis-py-cluster
+enum34


### PR DESCRIPTION
Fixes a bug in pip install during deploy. Found while attempting to deploy https://github.com/dimagi/commcare-hq/pull/28487 (and other changes).

This is a holdover from long since passed Python 2.7 days. It probably should have been removed long ago. `enum34` is a backport of the stdlib enum module for Python versions < 3.4, so we no longer need it since we require 3.6.

Error seen attempting to `pip install psycogreen==1.0.2` when `enum34` is installed, which applies to some of machines on prod but not all of them:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "lib/python3.6/site-packages/pip/__main__.py", line 23, in <module>
    from pip._internal.cli.main import main as _main  # isort:skip # noqa
  File "lib/python3.6/site-packages/pip/_internal/cli/main.py", line 5, in <module>
    import locale
  File "lib/python3.6/locale.py", line 16, in <module>
    import re
  File "lib/python3.6/re.py", line 142, in <module>
    class RegexFlag(enum.IntFlag):
AttributeError: module 'enum' has no attribute 'IntFlag'
```

Relevant links:
https://stackoverflow.com/q/43124775/10840
https://github.com/pypa/pip/issues/8214