### PR TITLE
Create Login-As All Users and remove login privileges from edit user permission

### DIFF
--- a/corehq/apps/api/tests/user_resources.py
+++ b/corehq/apps/api/tests/user_resources.py
@@ -268,7 +268,7 @@ class TestWebUserResource(APIResourceTest):
             "view_web_users": True,
             "view_roles": True,
             "edit_reports": True,
-            "view_reports": True
+            "view_reports": True,
         },
         "phone_numbers": [
         ],

--- a/corehq/apps/cloudcare/esaccessors.py
+++ b/corehq/apps/cloudcare/esaccessors.py
@@ -1,7 +1,5 @@
 from corehq.apps.es import UserES, filters, queries
 from corehq.apps.locations.models import SQLLocation
-from corehq.apps.users.decorators import get_permission_name
-from corehq.apps.users.models import Permissions
 
 
 def login_as_user_query(
@@ -65,5 +63,5 @@ def login_as_user_query(
 
 
 def _limit_login_as(couch_user, domain):
-    return (couch_user.has_permission(domain, 'limited_login_as')
-            and not couch_user.has_permission(domain, 'edit_commcare_users'))
+    return couch_user.has_permission(domain, 'limited_login_as') \
+        and not couch_user.has_permission(domain, 'login_as_all_users')

--- a/corehq/apps/users/migrations/0024_add_login_as_all_users.py
+++ b/corehq/apps/users/migrations/0024_add_login_as_all_users.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+from dimagi.utils.couch.database import iter_docs
+
+from corehq.apps.users.models import UserRole
+from corehq.util.django_migrations import skip_on_fresh_install
+
+
+@skip_on_fresh_install
+def migrate_login_as_all_users_permission(apps, schema_editor):
+    roles = UserRole.view(
+        'users/roles_by_domain',
+        include_docs=False,
+        reduce=False
+    ).all()
+    for role_doc in iter_docs(UserRole.get_db(), [r['id'] for r in roles]):
+        role = UserRole.wrap(role_doc)
+
+        if role.permissions.edit_commcare_users:
+            role.permissions.login_as_all_users = True
+            role.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0023_hqapikey_role_id'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_login_as_all_users_permission,
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True)
+    ]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -151,6 +151,7 @@ class Permissions(DocumentSchema):
     manage_releases = BooleanProperty(default=True)
     manage_releases_list = StringListProperty(default=[])
 
+    login_as_all_users = BooleanProperty(default=False)
     limited_login_as = BooleanProperty(default=False)
     access_default_login_as_user = BooleanProperty(default=False)
 
@@ -1612,7 +1613,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
 
     def can_login_as(self, domain):
         return (
-            self.has_permission(domain, 'edit_commcare_users')
+            self.has_permission(domain, 'login_as_all_users')
             or self.has_permission(domain, 'limited_login_as')
         )
 

--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -93,7 +93,7 @@ hqDefine('users/js/roles',[
                         showOption: true,
                         editPermission: self.permissions.edit_commcare_users,
                         viewPermission: self.permissions.view_commcare_users,
-                        text: gettext("<strong>Mobile Workers</strong> &mdash; create new accounts, manage account settings,deactivate or delete mobile workers. This permission also allows users to login as any mobile worker in Web Apps."),
+                        text: gettext("<strong>Mobile Workers</strong> &mdash; create new accounts, manage account settings,deactivate or delete mobile workers."),
                         showEditCheckbox: true,
                         editCheckboxLabel: "edit-commcare-users-checkbox",
                         showViewCheckbox: true,

--- a/corehq/apps/users/templates/users/partials/edit_role_modal.html
+++ b/corehq/apps/users/templates/users/partials/edit_role_modal.html
@@ -262,13 +262,37 @@
                 </div>
               </div>
             {% endif %}
+            <div class="form-group">
+              <label class="col-sm-4 control-label">
+                {% trans "Login-As All Users" %}
+              </label>
+              <div class="col-sm-8 controls">
+                <div class="form-check">
+                  <input type="checkbox"
+                         id="login-as-all-users-checkbox"
+                         data-bind="checked: permissions.login_as_all_users,
+                                    disable: !$root.allowEdit" />
+                  <label for="login-as-all-users-checkbox">
+                    {% trans "Allow the user to login as any mobile worker in Web Apps." %}
+                  </label>
+                </div>
+              </div>
+            </div>
             {% if request|toggle_enabled:"RESTRICT_LOGIN_AS" %}
               <div class="form-group">
               <label class="col-sm-4 control-label">
                 {% trans "Limit Login-As" %}
               </label>
               <div class="col-sm-8 controls">
-                <div class="form-check">
+                {# PLACEHOLDER WHEN login_as_all_users IS TRUE #}
+                <div class="form-check" data-bind="visible: permissions.login_as_all_users()">
+                  <input type="checkbox" disabled="disabled" />
+                  <label for="limited-login-as-checkbox">
+                    {% trans "Allow the user to login as only specified users in Web Apps." %}
+                  </label>
+                </div>
+                {# REAL CHECKBOX WHEN login_as_all_users IS FALSE #}
+                <div class="form-check" data-bind="visible: !permissions.login_as_all_users()">
                   <input type="checkbox"
                          id="limited-login-as-checkbox"
                          data-bind="checked: permissions.limited_login_as,


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=143&projectKey=USH&modal=detail&selectedIssue=USH-276&assignee=5f314baf6db35e0039014d73 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before the [Restrick Login As](https://www.commcarehq.org/hq/flags/edit/restrict_login_as/) was "overridden" if a user has edit privileges in edit mobile workers (which allows a user to log in as any user). So, this creates a separate permission "Login-As All Users" and the edit user permission will have no effect on login privileges. 
Then, this will have the added ability to have 1) users that can edit workers but can only login as themselves and 2) users that can’t edit workers but can log in as all users.

##### RISK ASSESSMENT / QA PLAN
I am not requesting QA

##### PRODUCT DESCRIPTION
I added so that when "Login-As All Users" is checked, "Limit Login-As" cannot be checked. 
 both are available:
<img width="626" alt="Screen Shot 2020-09-25 at 1 48 37 PM" src="https://user-images.githubusercontent.com/36681924/94624863-67c80600-0285-11eb-87ef-acfd8d3c3795.png">
limit login-as not available:
<img width="626" alt="Screen Shot 2020-09-25 at 1 48 45 PM" src="https://user-images.githubusercontent.com/36681924/94624883-74e4f500-0285-11eb-808a-59565630d92a.png">



One thing I want to note is now that the edit user permission has no bearing on login privileges if no login checkbox is checked, the user is only able to log in as themselves because I put no login privilege as the default.  @calellowitz I was wondering if this would also match the spec. My concern is that roles that once had "login as all" privileges will not until that checkmark is ticked.  