### PR TITLE
Rollback celery 4.4.7 (and kombu) due to pickling issues on prod

### DIFF
--- a/corehq/apps/userreports/rebuild.py
+++ b/corehq/apps/userreports/rebuild.py
@@ -37,6 +37,8 @@ class DataSourceResumeHelper(object):
         return self._client.lrange(self._key, 0, -1)
 
     def add_completed_case_type_or_xmlns(self, case_type_or_xmlns):
+        if case_type_or_xmlns is None:
+            case_type_or_xmlns = 'None'
         self._client.rpush(self._key, case_type_or_xmlns)
 
     def clear_resume_info(self):

--- a/corehq/apps/userreports/rebuild.py
+++ b/corehq/apps/userreports/rebuild.py
@@ -37,8 +37,6 @@ class DataSourceResumeHelper(object):
         return self._client.lrange(self._key, 0, -1)
 
     def add_completed_case_type_or_xmlns(self, case_type_or_xmlns):
-        if case_type_or_xmlns is None:
-            case_type_or_xmlns = 'None'
         self._client.rpush(self._key, case_type_or_xmlns)
 
     def clear_resume_info(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -145,7 +145,6 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         async_restore_task_id_cache.set_value('im going to be deleted by the next command')
         restore_config.timing_context.start()
         restore_config.timing_context("wait_for_task_to_start").start()
-        get_async_restore_payload.apply([restore_config])
         self.assertTrue(restore_config.timing_context.is_finished())
         self.assertIsNone(async_restore_task_id_cache.get_value())
 
@@ -153,7 +152,6 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         restore_config = self._restore_config(is_async=True)
         restore_config.timing_context.start()
         restore_config.timing_context("wait_for_task_to_start").start()
-        get_async_restore_payload.apply([restore_config])
         self.assertTrue(restore_config.timing_context.is_finished())
         self.assertIsNotNone(restore_config.restore_state.current_sync_log)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -145,6 +145,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         async_restore_task_id_cache.set_value('im going to be deleted by the next command')
         restore_config.timing_context.start()
         restore_config.timing_context("wait_for_task_to_start").start()
+        get_async_restore_payload.delay(restore_config)
         self.assertTrue(restore_config.timing_context.is_finished())
         self.assertIsNone(async_restore_task_id_cache.get_value())
 
@@ -152,6 +153,7 @@ class AsyncRestoreTestCouchOnly(BaseAsyncRestoreTest):
         restore_config = self._restore_config(is_async=True)
         restore_config.timing_context.start()
         restore_config.timing_context("wait_for_task_to_start").start()
+        get_async_restore_payload.delay(restore_config)
         self.assertTrue(restore_config.timing_context.is_finished())
         self.assertIsNotNone(restore_config.restore_state.current_sync_log)
 

--- a/corehq/motech/repeaters/tests/test_repeater.py
+++ b/corehq/motech/repeaters/tests/test_repeater.py
@@ -349,7 +349,6 @@ class RepeaterTest(BaseRepeaterTest):
     @run_with_all_backends
     def test_automatic_cancel_repeat_record(self):
         repeat_record = self.case_repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
-        repeat_record = RepeatRecord.get(repeat_record.record_id)
         self.assertEqual(1, repeat_record.overall_tries)
         with patch('corehq.motech.repeaters.models.simple_post', side_effect=Exception('Boom!')):
             for __ in range(repeat_record.max_possible_tries - repeat_record.overall_tries):
@@ -642,7 +641,6 @@ class RepeaterFailureTest(BaseRepeaterTest):
     @run_with_all_backends
     def test_failure(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
-        repeat_record = RepeatRecord.get(repeat_record.record_id)
         with patch('corehq.motech.repeaters.models.simple_post', side_effect=Exception('Boom!')):
             repeat_record.fire()
 
@@ -776,7 +774,6 @@ class TestRepeaterFormat(BaseRepeaterTest):
     @run_with_all_backends
     def test_new_format_payload(self):
         repeat_record = self.repeater.register(CaseAccessors(self.domain).get_case(CASE_ID))
-        repeat_record = RepeatRecord.get(repeat_record.record_id)
         with patch('corehq.motech.repeaters.models.simple_post') as mock_post, \
                 patch.object(ConnectionSettings, 'get_auth_manager') as mock_manager:
             mock_post.return_value.status_code = 200

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -96,7 +96,7 @@ PILLOWTOP_MACHINE_ID = 'testhq'  # for tests
 #  make celery synchronous
 CELERY_TASK_ALWAYS_EAGER = True
 # Fail hard in tasks so you get a traceback
-CELERY_TASK_EAGER_PROPAGATES = True
+CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
 # default inactivity timeout to 1 year
 INACTIVITY_TIMEOUT = 60 * 24 * 365

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -13,12 +13,12 @@ attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.8.0              # via django-phonenumber-field, sphinx
 backcall==0.2.0           # via ipython
 beautifulsoup4==4.9.1     # via -r requirements/test-requirements.in
-billiard==3.6.3.0         # via celery
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.15.3             # via -r requirements/requirements.in
 botocore==1.18.3          # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-celery==4.4.7             # via -r requirements/requirements.in, django-celery-results
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -98,7 +98,7 @@ html5lib==1.1             # via weasyprint
 httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.10                # via email-validator, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.0.0  # via flake8, kombu
+importlib-metadata==2.0.0  # via flake8
 ipdb==0.11                # via -r requirements/dev-requirements.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.15.0           # via -r requirements/dev-requirements.in, ipdb
@@ -114,7 +114,7 @@ jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, git-build-branch, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
 kafka-python==1.4.7       # via -r requirements/requirements.in
-kombu==4.6.11             # via celery
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
 laboratory==0.2.0         # via -r requirements/requirements.in
 linecache2==1.0.0         # via traceback2
 lxml==4.3.5               # via -r requirements/requirements.in, eulxml
@@ -221,7 +221,7 @@ ua-parser==0.10.0         # via user-agents
 unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk, transifex-client
 user-agents==2.2.0        # via django-user-agents
-vine==1.3.0               # via amqp, celery
+vine==1.3.0               # via amqp
 wcwidth==0.2.5            # via prompt-toolkit
 weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via cssselect2, html5lib, tinycss2

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -10,12 +10,12 @@ architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.8.0              # via django-phonenumber-field, flower
 backcall==0.2.0           # via ipython
-billiard==3.6.3.0         # via celery
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.15.3             # via -r requirements/requirements.in
 botocore==1.18.3          # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-celery==4.4.7             # via -r requirements/requirements.in, django-celery-results, flower
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results, flower
 certifi==2020.6.20        # via -r requirements/prod-requirements.in, elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -81,7 +81,6 @@ hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.1             # via weasyprint
 httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.10                # via -r requirements/prod-requirements.in, email-validator, requests
-importlib-metadata==2.0.0  # via kombu
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.15.0           # via -r requirements/prod-requirements.in
 iso8601==0.1.12           # via -r requirements/requirements.in
@@ -95,7 +94,7 @@ jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
 kafka-python==1.4.7       # via -r requirements/requirements.in
-kombu==4.6.11             # via celery
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
 laboratory==0.2.0         # via -r requirements/requirements.in
 lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.3               # via alembic
@@ -177,7 +176,7 @@ ua-parser==0.10.0         # via user-agents
 urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk
 user-agents==2.2.0        # via django-user-agents
 uwsgi==2.0.18             # via -r requirements/prod-requirements.in
-vine==1.3.0               # via amqp, celery
+vine==1.3.0               # via amqp
 wcwidth==0.2.5            # via prompt-toolkit
 weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via cssselect2, html5lib, tinycss2
@@ -185,7 +184,6 @@ werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.12.1             # via ddtrace
 xlrd==1.0.0               # via -r requirements/requirements.in
 xlwt==1.3.0               # via -r requirements/requirements.in
-zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.3               # via -r requirements/prod-requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,10 @@ alembic==0.8.6
 architect==0.5.6
 attrs~=18.1
 boto3~=1.9
-celery==4.4.7
+# celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737	celery==4.4.7
+# upgrade when https://github.com/celery/celery/issues/4980 is fixed
+# originally changes were made on nickpell/celery, but this was moved to dimagi/celery
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
 CommcareTranslationChecker==0.9.7
 concurrent-log-handler==0.9.12
 csiphash==0.0.5
@@ -62,6 +65,8 @@ jsonobject-couchdbkit~=1.0.1
 jsonobject==0.9.9
 jsonpath-rw==1.4.0
 kafka-python==1.4.7
+kombu==4.2.2.post1
+billiard!=3.5.0.5  # Should be resolved in celery 4.3: https://github.com/celery/billiard/issues/260
 laboratory==0.2.0
 lxml~=4.3.0
 markdown==2.2.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,12 +9,12 @@ amqp==2.6.1               # via kombu
 architect==0.5.6          # via -r requirements/requirements.in
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.8.0              # via django-phonenumber-field
-billiard==3.6.3.0         # via celery
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.15.3             # via -r requirements/requirements.in
 botocore==1.18.3          # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-celery==4.4.7             # via -r requirements/requirements.in, django-celery-results
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -77,7 +77,6 @@ hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.1             # via weasyprint
 httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.10                # via email-validator, requests
-importlib-metadata==2.0.0  # via kombu
 iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via -r requirements/requirements.in
@@ -88,7 +87,7 @@ jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
 kafka-python==1.4.7       # via -r requirements/requirements.in
-kombu==4.6.11             # via celery
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
 laboratory==0.2.0         # via -r requirements/requirements.in
 lxml==4.3.5               # via -r requirements/requirements.in, eulxml
 mako==1.1.3               # via alembic
@@ -158,14 +157,13 @@ twilio==6.5.1             # via -r requirements/requirements.in
 ua-parser==0.10.0         # via user-agents
 urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk
 user-agents==2.2.0        # via django-user-agents
-vine==1.3.0               # via amqp, celery
+vine==1.3.0               # via amqp
 weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via cssselect2, html5lib, tinycss2
 werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.12.1             # via ddtrace
 xlrd==1.0.0               # via -r requirements/requirements.in
 xlwt==1.3.0               # via -r requirements/requirements.in
-zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==50.3.0        # via cairocffi, cssselect2, django-websocket-redis, gunicorn, python-levenshtein, tinycss2

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -11,12 +11,12 @@ argparse==1.4.0           # via unittest2
 attrs==18.2.0             # via -r requirements/requirements.in
 babel==2.8.0              # via django-phonenumber-field
 beautifulsoup4==4.9.1     # via -r requirements/test-requirements.in
-billiard==3.6.3.0         # via celery
+billiard==3.5.0.4         # via -r requirements/requirements.in, celery
 boto3==1.15.3             # via -r requirements/requirements.in
 botocore==1.18.3          # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-celery==4.4.7             # via -r requirements/requirements.in, django-celery-results
+git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements/requirements.in, django-celery-results
 certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -85,7 +85,6 @@ hiredis==0.2.0            # via -r requirements/requirements.in
 html5lib==1.1             # via weasyprint
 httpagentparser==1.9.0    # via -r requirements/requirements.in
 idna==2.10                # via email-validator, requests
-importlib-metadata==2.0.0  # via kombu
 iso8601==0.1.12           # via -r requirements/requirements.in
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via -r requirements/requirements.in
@@ -96,7 +95,7 @@ jsonobject-couchdbkit==1.0.1  # via -r requirements/requirements.in
 jsonobject==0.9.9         # via -r requirements/requirements.in, jsonobject-couchdbkit
 jsonpath-rw==1.4.0        # via -r requirements/requirements.in
 kafka-python==1.4.7       # via -r requirements/requirements.in
-kombu==4.6.11             # via celery
+kombu==4.2.2.post1        # via -r requirements/requirements.in, celery
 laboratory==0.2.0         # via -r requirements/requirements.in
 linecache2==1.0.0         # via traceback2
 lxml==4.3.5               # via -r requirements/requirements.in, eulxml
@@ -176,14 +175,13 @@ ua-parser==0.10.0         # via user-agents
 unittest2==1.1.0          # via -r requirements/test-requirements.in
 urllib3==1.25.10          # via botocore, elasticsearch, elasticsearch2, elasticsearch7, py-kissmetrics, requests, sentry-sdk
 user-agents==2.2.0        # via django-user-agents
-vine==1.3.0               # via amqp, celery
+vine==1.3.0               # via amqp
 weasyprint==0.42.3        # via -r requirements/requirements.in
 webencodings==0.5.1       # via cssselect2, html5lib, tinycss2
 werkzeug==0.11.15         # via -r requirements/requirements.in
 wrapt==1.12.1             # via ddtrace
 xlrd==1.0.0               # via -r requirements/requirements.in
 xlwt==1.3.0               # via -r requirements/requirements.in
-zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.3               # via pip-tools

--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -16,3 +16,4 @@ eventlet
 contextlib2
 redis-py-cluster
 enum34
+celery # Remove once we are back to regular celery releases

--- a/scripts/uninstall-requirements.sh
+++ b/scripts/uninstall-requirements.sh
@@ -4,8 +4,8 @@ set -ev
 uninstall=requirements/uninstall-requirements.txt
 tmp=requirements/uninstall-tmp.txt
 
-join <(grep -v '#' $uninstall | sort -n) <(pip freeze | grep -v '^-' | cut -d'=' -f1 | sort -n) > $tmp
-join <(grep -v '#' $uninstall | sort -n) <(pip freeze | grep -v '^-' | sort -n) >> $tmp
+join <(grep -v '^\s*#' $uninstall | sort -n) <(pip freeze | grep -v '^-' | cut -d'=' -f1 | sort -n) > $tmp
+join <(grep -v '^\s*#' $uninstall | sort -n) <(pip freeze | grep -v '^-' | sort -n) >> $tmp
 
 # if $tmp isn't just a single newline character
 if [ -s $tmp ]


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11371

##### SUMMARY
The Celery 4.4.7 rollout seemed to have missed some very silent pickling fails on celery, most specifically with processing SMS billables. I'm uncomfortable keeping this change on prod for too much longer, and want to alleviate the pressure of figuring out what's going on without the fear we might not be catching some `SMSBillables`.

##### RISK ASSESSMENT / QA PLAN
I'm slightly concerned about not rolling back the `redis-py` and `django-redis` versions, so I'm going to do a quick smoke test on staging before deploying this to production, swiss, and India just to make sure we don't bring down things in a major way.
