### PR TITLE
catch errored SMSBillables that were delivered but have a null price 

### DIFF
--- a/corehq/apps/smsbillables/exceptions.py
+++ b/corehq/apps/smsbillables/exceptions.py
@@ -8,3 +8,7 @@ class SMSRateCalculatorError(Exception):
 
 class RetryBillableTaskException(Exception):
     pass
+
+
+class DeliveredBillableException(Exception):
+    pass


### PR DESCRIPTION
##### SUMMARY
do this as a completely separate error, and don't retry fetching api information

this is tangentially related to the potential fallout from
https://dimagi-dev.atlassian.net/browse/SAAS-11371
and the merging of https://github.com/dimagi/commcare-hq/pull/28577

##### RISK ASSESSMENT / QA PLAN
small risk, high reward. just logs
