### PR TITLE
Touch up generate_request_report

### DIFF
--- a/corehq/ex-submodules/auditcare/management/commands/generate_request_report.py
+++ b/corehq/ex-submodules/auditcare/management/commands/generate_request_report.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('filename', help="Output file path")
         parser.add_argument(
-            '-d'
+            '-d',
             '--domain',
             dest='domain',
             help="Limit logs to only this domain"
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             action='store_true',
             dest='display_superuser',
             default=False,
-            help="Include superusers in report, otherwise 'Dimagi User'",
+            help="Include superusers in report, otherwise 'Dimagi Support'",
         )
 
     def handle(self, filename, **options):


### PR DESCRIPTION
##### SUMMARY
This management command is already useful for dumping lightly filtered auditcare logs to a tmp file that we can then grep. This PR just fixes some minor blemishes.

Once this is merged you can use `--domain` instead of the awkward and unintended `-d--domain`
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
