### PR TITLE
Web Apps: serialize formplayer requests

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
@@ -66,6 +66,11 @@ describe('WebForm', function () {
             Utils = hqImport("cloudcare/js/form_entry/utils"),
             WebFormSession = hqImport("cloudcare/js/form_entry/webformsession").WebFormSession;
 
+        hqImport("hqwebapp/js/initial_page_data").registerUrl(
+            "report_formplayer_error",
+            "/a/domain/cloudcare/apps/report_formplayer_error"
+        );
+
         beforeEach(function () {
             // Setup HTML
             try {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
@@ -5,9 +5,7 @@ describe('WebForm', function () {
         UI = hqImport("cloudcare/js/form_entry/fullform-ui");
 
     describe('TaskQueue', function () {
-        var taskOne,
-            taskTwo,
-            callCount,
+        var callCount,
             flag,
             queue = hqImport("cloudcare/js/form_entry/task_queue").TaskQueue(),
             promise1,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/webformsession_spec.js
@@ -5,53 +5,58 @@ describe('WebForm', function () {
         UI = hqImport("cloudcare/js/form_entry/fullform-ui");
 
     describe('TaskQueue', function () {
-        var tq,
-            taskOne,
-            taskTwo;
+        var taskOne,
+            taskTwo,
+            callCount,
+            flag,
+            queue = hqImport("cloudcare/js/form_entry/task_queue").TaskQueue(),
+            promise1,
+            promise2,
+            updateFlag = function (newValue, promise) {
+                flag = newValue;
+                callCount++;
+                return promise;
+            };
+
         beforeEach(function () {
-            tq = hqImport("cloudcare/js/form_entry/task_queue").TaskQueue();
-            taskOne = sinon.spy();
-            taskTwo = sinon.spy();
-            tq.addTask('one', taskOne, [1,2,3]);
-            tq.addTask('two', taskTwo, [5,6,7]);
+            flag = undefined;
+            callCount = 0;
+
+            promise1 = new $.Deferred(),
+            promise2 = new $.Deferred();
+            queue.addTask('updateFlag', updateFlag, ['one', promise1]);
+            queue.addTask('updateFlag', updateFlag, ['two', promise2]);
         });
 
         it('Executes tasks in order', function () {
-            tq.execute();
-            assert.isTrue(taskOne.calledOnce);
-            assert.isTrue(taskOne.calledWith(1, 2, 3));
-            assert.isFalse(taskTwo.calledOnce);
+            // First task should have been executed immediately
+            assert.equal(flag, "one");
+            assert.equal(callCount, 1);
 
-            tq.execute();
-            assert.isTrue(taskTwo.calledOnce);
-            assert.isTrue(taskTwo.calledWith(5, 6, 7));
-            assert.equal(tq.queue.length, 0);
+            // Second task should execute when first one is resolved
+            promise1.resolve();
+            assert.equal(flag, "two");
+            assert.equal(callCount, 2);
 
-            tq.execute(); // ensure no hard failure when no tasks in queue
+            promise2.resolve();
+            queue.execute(); // ensure no hard failure when no tasks in queue
         });
 
-        it('Executes tasks by name', function () {
-            tq.execute('two');
-            assert.isFalse(taskOne.calledOnce);
-            assert.isTrue(taskTwo.calledOnce);
-            assert.equal(tq.queue.length, 1);
-
-            tq.execute('cannot find me');
-            assert.equal(tq.queue.length, 1);
-
-            tq.execute();
-            tq.execute();
+        it('Executes task even when previous task failed', function () {
+            promise1.reject();
+            assert.equal(flag, "two");
+            assert.equal(callCount, 2);
+            promise2.resolve();
         });
 
         it('Clears tasks by name', function () {
-            tq.addTask('two', taskTwo, [5,6,7]);
-            assert.equal(tq.queue.length, 3);
-
-            tq.clearTasks('two');
-            assert.equal(tq.queue.length, 1);
-
-            tq.clearTasks();
-            assert.equal(tq.queue.length, 0);
+            assert.equal(queue.queue.length, 1);
+            queue.addTask('doSomethingElse', function () {}, []);
+            assert.equal(queue.queue.length, 2);
+            queue.clearTasks('updateFlag');
+            assert.equal(queue.queue.length, 1);
+            queue.clearTasks();
+            assert.equal(queue.queue.length, 0);
         });
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
@@ -1,6 +1,8 @@
 /*
- * Executes the queue in a FIFO action. If name is supplied, will execute the first
- * task for that name.
+ * Executes the queue in a FIFO action. When a task is added, it will be immediately
+ * executed if the queue was previously empty.
+ *
+ * All task functions are expected to return a promise.
  */
 hqDefine("cloudcare/js/form_entry/task_queue", function () {
     var TaskQueue = function () {
@@ -39,6 +41,9 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
                 thisArg: thisArg,
             };
             self.queue.push(task);
+            if (!self.inProgress) {
+                self.execute();
+            }
             return task;
         };
 
@@ -54,12 +59,6 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
                 self.queue = [];
             }
         };
-
-        setInterval(function () {
-            if (self.queue.length && !self.inProgress) {
-                self.execute();
-            }
-        }, 5 * 1000);
 
         return self;
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
@@ -12,13 +12,13 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
             var task,
                 idx;
             if (name) {
-                idx = _.indexOf(_.pluck(this.queue, 'name'), name);
+                idx = _.indexOf(_.pluck(self.queue, 'name'), name);
                 if (idx === -1) {
                     return;
                 }
-                task = this.queue.splice(idx, 1)[0];
+                task = self.queue.splice(idx, 1)[0];
             } else {
-                task = this.queue.shift();
+                task = self.queue.shift();
             }
             if (!task) {
                 return;
@@ -33,20 +33,20 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
                 parameters: parameters,
                 thisArg: thisArg,
             };
-            this.queue.push(task);
+            self.queue.push(task);
             return task;
         };
 
         self.clearTasks = function (name) {
             var idx;
             if (name) {
-                idx = _.indexOf(_.pluck(this.queue, 'name'), name);
+                idx = _.indexOf(_.pluck(self.queue, 'name'), name);
                 while (idx !== -1) {
-                    this.queue.splice(idx, 1);
-                    idx = _.indexOf(_.pluck(this.queue, 'name'), name);
+                    self.queue.splice(idx, 1);
+                    idx = _.indexOf(_.pluck(self.queue, 'name'), name);
                 }
             } else {
-                this.queue = [];
+                self.queue = [];
             }
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
@@ -7,6 +7,7 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
         var self = {};
 
         self.queue = [];
+        self.inProgress = undefined;
 
         self.execute = function (name) {
             var task,
@@ -21,9 +22,13 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
                 task = self.queue.shift();
             }
             if (!task) {
+                self.inProgress = undefined;
                 return;
             }
-            task.fn.apply(task.thisArg, task.parameters);
+            self.inProgress = task.fn.apply(task.thisArg, task.parameters);
+            self.inProgress.always(function () {
+                self.execute();
+            });
         };
 
         self.addTask = function (name, fn, parameters, thisArg) {
@@ -49,6 +54,12 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
                 self.queue = [];
             }
         };
+
+        setInterval(function () {
+            if (self.queue.length && !self.inProgress) {
+                self.execute();
+            }
+        }, 5 * 1000);
 
         return self;
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/task_queue.js
@@ -11,18 +11,10 @@ hqDefine("cloudcare/js/form_entry/task_queue", function () {
         self.queue = [];
         self.inProgress = undefined;
 
-        self.execute = function (name) {
+        self.execute = function () {
             var task,
                 idx;
-            if (name) {
-                idx = _.indexOf(_.pluck(self.queue, 'name'), name);
-                if (idx === -1) {
-                    return;
-                }
-                task = self.queue.splice(idx, 1)[0];
-            } else {
-                task = self.queue.shift();
-            }
+            task = self.queue.shift();
             if (!task) {
                 self.inProgress = undefined;
                 return;

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -89,7 +89,7 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
          *      this function should return true to also run default behavior afterwards, or false to prevent it
          */
         self.serverRequest = function (requestParams, successCallback, blocking, failureCallback, errorResponseCallback) {
-            self._serverRequest(requestParams, successCallback, blocking, failureCallback, errorResponseCallback);
+            self.taskQueue.addTask(requestParams.action, self._serverRequest, arguments, self);
         };
 
         self._serverRequest = function (requestParams, successCallback, blocking, failureCallback, errorResponseCallback) {
@@ -113,7 +113,7 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
             this.numPendingRequests++;
             this.onLoading();
 
-            $.ajax({
+            return $.ajax({
                 type: 'POST',
                 url: self.urls.xform + "/" + requestParams.action,
                 data: JSON.stringify(requestParams),

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -108,13 +108,13 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
             requestParams['session_id'] = self.session_id;
             requestParams['debuggerEnabled'] = self.debuggerEnabled;
             requestParams['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
-            if (this.blockingStatus === Const.BLOCK_ALL) {
+            if (self.blockingStatus === Const.BLOCK_ALL) {
                 return;
             }
-            this.blockingStatus = blocking || Const.BLOCK_NONE;
+            self.blockingStatus = blocking || Const.BLOCK_NONE;
             $.publish('session.block', blocking);
 
-            this.onLoading();
+            self.onLoading();
 
             return $.ajax({
                 type: 'POST',
@@ -166,8 +166,8 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
                 }
             }
 
-            this.blockingStatus = Const.BLOCK_NONE;
-            $.publish('session.block', this.blockingStatus);
+            self.blockingStatus = Const.BLOCK_NONE;
+            $.publish('session.block', self.blockingStatus);
         };
 
         self.handleFailure = function (resp, action, textStatus, failureCallback) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -88,6 +88,13 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
          *      this function should return true to also run default behavior afterwards, or false to prevent it
          */
         self.serverRequest = function (requestParams, successCallback, blocking, failureCallback, errorResponseCallback) {
+            if (self.blockingStatus === Const.BLOCK_ALL) {
+                return;
+            }
+            self.blockingStatus = blocking || Const.BLOCK_NONE;
+            $.publish('session.block', blocking);
+            self.onLoading();
+
             if (requestParams.action === Const.SUBMIT) {
                 // Remove any submission tasks that have been queued up from spamming the submit button
                 self.taskQueue.clearTasks(Const.SUBMIT);
@@ -108,13 +115,6 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
             requestParams['session_id'] = self.session_id;
             requestParams['debuggerEnabled'] = self.debuggerEnabled;
             requestParams['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
-            if (self.blockingStatus === Const.BLOCK_ALL) {
-                return;
-            }
-            self.blockingStatus = blocking || Const.BLOCK_NONE;
-            $.publish('session.block', blocking);
-
-            self.onLoading();
 
             return $.ajax({
                 type: 'POST',

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -90,11 +90,16 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
          *      this function should return true to also run default behavior afterwards, or false to prevent it
          */
         self.serverRequest = function (requestParams, successCallback, blocking, failureCallback, errorResponseCallback) {
-            var self = this;
-            var url = self.urls.xform;
             if (requestParams.action === Const.SUBMIT && self.NUM_PENDING_REQUESTS) {
-                self.taskQueue.addTask(requestParams.action, self.serverRequest, arguments, self);
+                self.taskQueue.addTask(requestParams.action, self._serverRequest, arguments, self);
+                return;
             }
+
+            self._serverRequest(requestParams, successCallback, blocking, failureCallback, errorResponseCallback);
+        };
+
+        self._serverRequest = function (requestParams, successCallback, blocking, failureCallback, errorResponseCallback) {
+            var self = this;
 
             requestParams.form_context = self.formContext;
             requestParams.domain = self.domain;
@@ -116,7 +121,7 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
 
             $.ajax({
                 type: 'POST',
-                url: url + "/" + requestParams.action,
+                url: self.urls.xform + "/" + requestParams.action,
                 data: JSON.stringify(requestParams),
                 contentType: "application/json",
                 dataType: "json",

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -62,7 +62,6 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
 
         // workaround for "forever loading" bugs...
         $(document).ajaxStop(function () {
-            self.NUM_PENDING_REQUESTS = 0;
             self.blockingStaus = Const.BLOCK_NONE;
         });
 
@@ -90,11 +89,6 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
          *      this function should return true to also run default behavior afterwards, or false to prevent it
          */
         self.serverRequest = function (requestParams, successCallback, blocking, failureCallback, errorResponseCallback) {
-            if (requestParams.action === Const.SUBMIT && self.NUM_PENDING_REQUESTS) {
-                self.taskQueue.addTask(requestParams.action, self._serverRequest, arguments, self);
-                return;
-            }
-
             self._serverRequest(requestParams, successCallback, blocking, failureCallback, errorResponseCallback);
         };
 


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/USH-275

Web apps sends ajax requests to formplayer as they come in, but formplayer can only process them one at a time. When performance is slow and/or requests are sent in rapid succession, this can result in locking issues, since there's a [21-second lock timeout](https://github.com/dimagi/formplayer/blob/84eb4c4dc0f1f0c245c3e673a377798182d443c7/src/main/java/org/commcare/formplayer/util/Constants.java#L112).

Web apps already has a task queue that executes tasks on demand and is used only to prevent multiple submit requests. This PR makes web apps route all formplayer requests through that queue, and it updates the queue itself to execute the next task once the current task has finished.

Review by commit.

##### RISK ASSESSMENT / QA PLAN
[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-1977)