### PR TITLE
Fixed required asterisk not displaying for nested collapsible groups

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js
@@ -384,7 +384,7 @@ hqDefine("cloudcare/js/form_entry/fullform-ui", function () {
 
         self.childrenRequired = ko.computed(function () {
             return _.find(self.children(), function (child) {
-                return child.required() || self.childrenRequired && self.childrenRequired();
+                return child.required() || child.childrenRequired && child.childrenRequired();
             });
         });
 


### PR DESCRIPTION
##### SUMMARY
Collapsible groups have been displaying asterisks if a child is required, but not is a grandchild or deeper descendant is required.

##### RISK ASSESSMENT / QA PLAN
Minor, no QA.