### PR TITLE
Sort on keyword type not text field

### DIFF
--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -309,6 +309,24 @@ def get_group_stubs(group_ids):
         .values('_id', 'name', 'case_sharing', 'reporting'))
 
 
+def get_groups_by_querystring(domain, query, case_sharing_only):
+    group_result = (
+        GroupES()
+        .domain(domain)
+        .not_deleted()
+        .search_string_query(query, default_fields=['name'])
+        .size(10)
+        .sort('name.exact')
+        .source(('_id', 'name'))
+    )
+    if case_sharing_only:
+        group_result = group_result.is_case_sharing()
+    return [
+        {'id': group['_id'], 'text': group['name']}
+        for group in group_result.run().hits
+    ]
+
+
 def get_user_stubs(user_ids, extra_fields=None):
     from corehq.apps.reports.util import SimplifiedUserInfo
     return (UserES()

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -46,6 +46,7 @@ from corehq.apps.reports.analytics.esaccessors import (
     get_submission_counts_by_user,
     get_total_case_counts_by_owner,
     get_user_stubs,
+    get_groups_by_querystring,
     get_username_in_last_form_user_id_submitted,
     guess_form_name_from_submissions_using_xmlns,
     scroll_case_names,
@@ -971,18 +972,16 @@ class TestUserESAccessors(TestCase):
 class TestGroupESAccessors(SimpleTestCase):
 
     def setUp(self):
-        self.group_name = 'justice league'
         self.domain = 'group-esaccessors-test'
         self.reporting = True
-        self.case_sharing = False
         self.es = get_es_new()
         reset_es_index(GROUP_INDEX_INFO)
 
-    def _send_group_to_es(self, _id=None):
+    def _send_group_to_es(self, name, _id=None, case_sharing=False):
         group = Group(
             domain=self.domain,
-            name=self.group_name,
-            case_sharing=self.case_sharing,
+            name=name,
+            case_sharing=case_sharing,
             reporting=self.reporting,
             _id=_id or uuid.uuid4().hex,
         )
@@ -991,16 +990,35 @@ class TestGroupESAccessors(SimpleTestCase):
         return group
 
     def test_group_query(self):
-        self._send_group_to_es('123')
+        name = 'justice-league'
+        self._send_group_to_es(name, '123')
         results = get_group_stubs(['123'])
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], {
             '_id': '123',
-            'name': self.group_name,
-            'case_sharing': self.case_sharing,
+            'name': name,
+            'case_sharing': False,
             'reporting': self.reporting,
         })
+
+    def test_group_search_query(self):
+        self._send_group_to_es('Milkyway', '1')
+        self._send_group_to_es('Freeroad', '2')
+        self._send_group_to_es('Freeway', '3', True)
+        self.assertEqual(
+            get_groups_by_querystring(self.domain, 'Free', False),
+            [
+                {'id': '2', 'text': 'Freeroad'},
+                {'id': '3', 'text': 'Freeway'},
+            ]
+        )
+        self.assertEqual(
+            get_groups_by_querystring(self.domain, 'way', True),
+            [
+                {'id': '3', 'text': 'Freeway'},
+            ]
+        )
 
 
 class TestCaseESAccessors(BaseESAccessorsTest):

--- a/corehq/messaging/scheduling/async_handlers.py
+++ b/corehq/messaging/scheduling/async_handlers.py
@@ -69,7 +69,7 @@ class MessagingRecipientHandler(BaseAsyncHandler):
             .not_deleted()
             .search_string_query(query, default_fields=['name'])
             .size(10)
-            .sort('name')
+            .sort('name.exact')
             .source(('_id', 'name'))
         )
         if case_sharing_only:


### PR DESCRIPTION
https://sentry.io/organizations/dimagi/issues/1923428824/?environment=staging&project=136860

Introduced in when the exact mapping was changed to keyword to be used for sorting and this use case was missed. https://github.com/dimagi/commcare-hq/pull/28268/

@calellowitz 