### PR TITLE
Feature/ush 348 updates overwrite caselist

### DIFF
--- a/corehq/apps/app_manager/add_ons.py
+++ b/corehq/apps/app_manager/add_ons.py
@@ -100,6 +100,8 @@ _ADD_ONS = {
         name=_("Case Detail Overwrite"),
         description=_("Ability to overwrite one case list or detail's settings with another's. "
         "Available in menu settings, in the actions tab."),
+        help_link="https://confluence.dimagi.com/display/commcarepublic/\
+                   Overwriting+Case+List+and+Case+Detail+Configuration"
     ),
     "case_list_menu_item": AddOn(
         name=_("Case List Menu Item"),

--- a/corehq/apps/app_manager/add_ons.py
+++ b/corehq/apps/app_manager/add_ons.py
@@ -100,8 +100,7 @@ _ADD_ONS = {
         name=_("Case Detail Overwrite"),
         description=_("Ability to overwrite one case list or detail's settings with another's. "
         "Available in menu settings, in the actions tab."),
-        help_link="https://confluence.dimagi.com/display/commcarepublic/\
-                   Overwriting+Case+List+and+Case+Detail+Configuration"
+        help_link="https://confluence.dimagi.com/display/commcarepublic/Overwriting+Case+List+and+Case+Detail+Configuration"
     ),
     "case_list_menu_item": AddOn(
         name=_("Case List Menu Item"),

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2039,19 +2039,22 @@ class Detail(IndexedSchema, CaseListLookupMixin):
         in attr_dict(column, filter, and other_configurations)
         from source module to current object.
         """
-        src_module_attrs = list(src_module_detail_type.to_json().keys())
+        case_tile_configuration_list = [
+            'use_case_tiles',
+            'persist_tile_on_forms',
+            'persistent_case_tile_from_module',
+            'pull_down_tile',
+            'persist_case_context',
+            'persistent_case_context_xml',
+            'print_template'
+        ]
         for k, v in attr_dict.items():
-            if k != '*':
-                if v:
+            if v:
+                if k == "case_tile_configuration":
+                    for ele in case_tile_configuration_list:
+                        setattr(self, ele, getattr(src_module_detail_type, ele))
+                else:
                     setattr(self, k, getattr(src_module_detail_type, k))
-                src_module_attrs.remove(k)
-            else:
-                if not v:
-                    continue
-                for a in src_module_attrs:
-                    if a.startswith('__') or a.startswith('_'):
-                        continue
-                    setattr(self, a, getattr(src_module_detail_type, a))
 
 
 class CaseList(IndexedSchema, NavMenuItemMediaMixin):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2046,7 +2046,6 @@ class Detail(IndexedSchema, CaseListLookupMixin):
             'pull_down_tile',
             'persist_case_context',
             'persistent_case_context_xml',
-            'print_template'
         ]
         for k, v in attr_dict.items():
             if v:

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -1,13 +1,15 @@
 hqDefine("app_manager/js/modules/module_view", function () {
     $(function () {
         $('.multiselect-caselist').select2();
+        $('#overwrite-danger').on("click", function(){
+            hqImport('analytix/js/kissmetrix').track.event("Overwrite Case Lists/Case Details");
+        });
         var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,
             moduleBrief = initial_page_data('module_brief'),
             moduleType = moduleBrief.module_type,
             options = initial_page_data('js_options') || {};
 
         hqImport('app_manager/js/app_manager').setAppendedPageTitle(django.gettext("Menu Settings"));
-        
         // Set up details
         if (moduleBrief.case_type) {
             var state = hqImport('app_manager/js/details/screen_config').state;

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -1,7 +1,11 @@
 hqDefine("app_manager/js/modules/module_view", function () {
     $(function () {
         $('.multiselect-caselist').select2();
-        
+        $('.dialog').on("click", function(event){
+            if(!confirm("Are you sure you want to overwrite the properties or filters in these Case Lists/Case Details? This action is irreversible.")){
+            event.preventDefault();
+            }
+        });
         var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,
             moduleBrief = initial_page_data('module_brief'),
             moduleType = moduleBrief.module_type,

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -1,7 +1,7 @@
 hqDefine("app_manager/js/modules/module_view", function () {
     $(function () {
         $('.multiselect-caselist').select2();
-        $('#overwrite-danger').on("click", function(){
+        $('#overwrite-danger').on("click", function () {
             hqImport('analytix/js/kissmetrix').track.event("Overwrite Case Lists/Case Details");
         });
         var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -1,11 +1,6 @@
 hqDefine("app_manager/js/modules/module_view", function () {
     $(function () {
         $('.multiselect-caselist').select2();
-        $('.dialog').on("click", function(event){
-            if(!confirm("Are you sure you want to overwrite the properties or filters in these Case Lists/Case Details? This action is irreversible.")){
-            event.preventDefault();
-            }
-        });
         var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,
             moduleBrief = initial_page_data('module_brief'),
             moduleType = moduleBrief.module_type,

--- a/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
+++ b/corehq/apps/app_manager/static/app_manager/js/modules/module_view.js
@@ -1,7 +1,7 @@
 hqDefine("app_manager/js/modules/module_view", function () {
     $(function () {
         $('.multiselect-caselist').select2();
-        $('#overwrite-danger').on("click", function () {
+        $('.overwrite-danger').on("click", function () {
             hqImport('analytix/js/kissmetrix').track.event("Overwrite Case Lists/Case Details");
         });
         var initial_page_data = hqImport('hqwebapp/js/initial_page_data').get,

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -93,7 +93,7 @@
                       <button type="button" class="btn btn-default" data-dismiss="modal">
                         {% trans "Cancel" %}
                       </button>
-                      <button type="submit" class="btn btn-danger" id="overwrite-danger">
+                      <button type="submit" class="btn btn-danger overwrite-danger">
                         <i class="fa fa-copy"></i>
                         {% trans "Overwrite" %}
                       </button>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -30,10 +30,40 @@
                   <input type="checkbox" name="case_list_filter" id="case_list_filter"/>
                   {% trans "Case List Filter" %}
                 </label><br>
-                <label for="other_configuration">
-                  <input type="checkbox" name="other_configuration" id="other_configuration"/>
-                  {% trans "Sort Properties" %}
-                </label>
+                <label for="sort_configuration">
+                  <input type="checkbox" name="sort_configuration" id="sort_configuration"/>
+                  {% trans "Sort Configuration" %}
+                </label><br>
+                {% if request|toggle_enabled:'DETAIL_LIST_TAB_NODESETS' %}
+                  <label for="nodeset_sorting">
+                    <input type="checkbox" name="nodeset_sorting" id="nodeset_sorting"/>
+                    {% trans "Nodeset sorting" %}
+                  </label><br>
+                {% endif %}
+                {% if request|toggle_enabled:'CASE_LIST_CUSTOM_VARIABLES' %}
+                  <label for="custom_variables">
+                    <input type="checkbox" name="custom_variables" id="custom_variables"/>
+                    {% trans "Custom variables" %}
+                  </label><br>
+                {% endif %}
+                {% if request|toggle_enabled:'CASE_LIST_CUSTOM_XML' %}
+                  <label for="custom_case_list_xml">
+                    <input type="checkbox" name="custom_case_list_xml" id="custom_case_list_xml"/>
+                    {% trans "Custom Case List XML" %}
+                  </label><br>
+                {% endif %}
+                {% if request|toggle_enabled:'CASE_LIST_TILE' or request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
+                  <label for="case_tile_configuration">
+                    <input type="checkbox" name="case_tile_configuration" id="case_tile_configuration"/>
+                    {% trans "Case tile Configuration" %}
+                  </label><br>
+                {% endif %}
+                {% if request|toggle_enabled:'CASE_DETAIL_PRINT' %}
+                  <label for="print_template">
+                    <input type="checkbox" name="print_template" id="print_template"/>
+                    {% trans "Print template" %}
+                  </label>
+                {% endif %}
             </div>
           </div>
           {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -24,15 +24,15 @@
               <div class="checkbox col-sm-4 col-sm-offset-1">
                 <label for="display_properties">
                   <input type="checkbox" name="display_properties" id="display_properties"/>
-                  {% trans "Display Properties" %}
+                  {% trans "Display properties" %}
                 </label><br>
                 <label for="case_list_filter">
                   <input type="checkbox" name="case_list_filter" id="case_list_filter"/>
-                  {% trans "Case List Filter" %}
+                  {% trans "Case list filter" %}
                 </label><br>
                 <label for="sort_configuration">
                   <input type="checkbox" name="sort_configuration" id="sort_configuration"/>
-                  {% trans "Sort Configuration" %}
+                  {% trans "Sort configuration" %}
                 </label><br>
                 {% if request|toggle_enabled:'DETAIL_LIST_TAB_NODESETS' %}
                   <label for="nodeset_sorting">
@@ -49,13 +49,13 @@
                 {% if request|toggle_enabled:'CASE_LIST_CUSTOM_XML' %}
                   <label for="custom_case_list_xml">
                     <input type="checkbox" name="custom_case_list_xml" id="custom_case_list_xml"/>
-                    {% trans "Custom Case List XML" %}
+                    {% trans "Custom case list XML" %}
                   </label><br>
                 {% endif %}
                 {% if request|toggle_enabled:'CASE_LIST_TILE' or request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
                   <label for="case_tile_configuration">
                     <input type="checkbox" name="case_tile_configuration" id="case_tile_configuration"/>
-                    {% trans "Case tile Configuration" %}
+                    {% trans "Case tile configuration" %}
                   </label><br>
                 {% endif %}
                 {% if request|toggle_enabled:'CASE_DETAIL_PRINT' %}
@@ -70,7 +70,7 @@
           <br>
           <div class="row">
             <div class="col-sm-4 col-sm-offset-1">
-              <button class='btn btn-danger' data-toggle="modal" data-target="#overwrite-conformation-model" type="button">
+              <button class='btn btn-danger' data-toggle="modal" data-target="#overwrite-confirmation-model" type="button">
                 <i class="fa fa-copy"></i>
                 {% if detail_type == 'short' %}
                   {% trans "Overwrite Case List" %}
@@ -78,16 +78,16 @@
                   {% trans "Overwrite Case Detail" %}
                 {% endif %}
               </button>
-              <div class="modal fade" id="overwrite-conformation-model">
+              <div class="modal fade" id="overwrite-confirmation-model">
                 <div class="modal-dialog">
                   <div class="modal-content">
                     <div class="modal-header">
                       <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span>
                         <span class="sr-only">{% trans "Close" %}</span></button>
-                      <h4 class="modal-title">{% trans "Overwrite Case Lists/Detail" %}</h4>
+                      <h4 class="modal-title">{% trans "Overwrite Case Lists/Case Details?" %}</h4>
                     </div>
                     <div class="modal-body">
-                      {% trans "Are you sure you want to overwrite the properties or filters in these Case Lists/Case Details? This action is irreversible" %}.
+                      {% trans "Are you sure you want to overwrite this configuration? This action is irreversible." %}.
                     </div>
                     <div class="modal-footer">
                       <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -84,16 +84,16 @@
                     <div class="modal-header">
                       <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span>
                         <span class="sr-only">{% trans "Close" %}</span></button>
-                      <h4 class="modal-title">{% trans "Overwrite Case Lists/Case Details?" %}</h4>
+                      <h4 class="modal-title">{% trans "Overwrite Case Lists/Case Details" %}</h4>
                     </div>
                     <div class="modal-body">
-                      {% trans "Are you sure you want to overwrite this configuration? This action is irreversible." %}.
+                      {% trans "Are you sure you want to overwrite this configuration? This action is irreversible." %}
                     </div>
                     <div class="modal-footer">
                       <button type="button" class="btn btn-default" data-dismiss="modal">
                         {% trans "Cancel" %}
                       </button>
-                      <button type="submit" class="btn btn-danger">
+                      <button type="submit" class="btn btn-danger" id="overwrite-danger">
                         <i class="fa fa-copy"></i>
                         {% trans "Overwrite" %}
                       </button>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -32,7 +32,7 @@
                 </label><br>
                 <label for="other_configuration">
                   <input type="checkbox" name="other_configuration" id="other_configuration"/>
-                  {% trans "Other Configuration" %}
+                  {% trans "Sort Properties" %}
                 </label>
             </div>
           </div>
@@ -40,7 +40,7 @@
           <br>
           <div class="row">
             <div class="col-sm-4 col-sm-offset-1">
-              <button class='btn btn-danger' type="submit">
+              <button class='btn btn-danger dialog' type="submit">
                 <i class="fa fa-copy"></i>
                 {% if detail_type == 'short' %}
                   {% trans "Overwrite Case List" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/case_list_module_overwrite.html
@@ -40,13 +40,37 @@
           <br>
           <div class="row">
             <div class="col-sm-4 col-sm-offset-1">
-              <button class='btn btn-danger dialog' type="submit">
+              <button class='btn btn-danger' data-toggle="modal" data-target="#overwrite-conformation-model" type="button">
                 <i class="fa fa-copy"></i>
                 {% if detail_type == 'short' %}
                   {% trans "Overwrite Case List" %}
                 {% else %}
                   {% trans "Overwrite Case Detail" %}
                 {% endif %}
+              </button>
+              <div class="modal fade" id="overwrite-conformation-model">
+                <div class="modal-dialog">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span>
+                        <span class="sr-only">{% trans "Close" %}</span></button>
+                      <h4 class="modal-title">{% trans "Overwrite Case Lists/Detail" %}</h4>
+                    </div>
+                    <div class="modal-body">
+                      {% trans "Are you sure you want to overwrite the properties or filters in these Case Lists/Case Details? This action is irreversible" %}.
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-default" data-dismiss="modal">
+                        {% trans "Cancel" %}
+                      </button>
+                      <button type="submit" class="btn btn-danger">
+                        <i class="fa fa-copy"></i>
+                        {% trans "Overwrite" %}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
        </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
@@ -14,15 +14,16 @@
           Please select the case lists/detail menu(s) that needs to be overwritten.
         {% endblocktrans %}
     </p>
-    <p>
-      <a class="btn btn-primary-dark"
-         target="_blank"
-         href="https://confluence.dimagi.com/display/commcarepublic/Overwriting+Case+List+and+Case+Detail+Configuration">
-        {% trans "Learn More" %}
-      </a>
-    </p>
   </div>
 {% endif %}
+<div>
+  <p>{% trans 'Overwritting Case List and Case Detail Configuration.' %}
+    <a target="_blank"
+       href="https://confluence.dimagi.com/display/commcarepublic/Overwriting+Case+List+and+Case+Detail+Configuration">
+      {% trans "Learn More" %}
+    </a>
+  </p>
+</div>
 <div class="panel panel-appmanager">
   <div class="panel-heading">
     <h4 class="panel-title panel-title-nolink">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
@@ -14,6 +14,13 @@
           Please select the case lists/detail menu(s) that needs to be overwritten.
         {% endblocktrans %}
     </p>
+    <p>
+      <a class="btn btn-primary-dark"
+         target="_blank"
+         href="https://confluence.dimagi.com/display/commcarepublic/Overwriting+Case+List+and+Case+Detail+Configuration">
+        {% trans "Learn More" %}
+      </a>
+    </p>
   </div>
 {% endif %}
 <div class="panel panel-appmanager">

--- a/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/modules/module_actions.html
@@ -8,7 +8,7 @@
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
     </button>
-    <p class="lead">{% trans 'New feature to overwrite case lists/Detail in bulk.' %}</p>
+    <p class="lead">{% trans 'New feature to overwrite case lists/case details in bulk.' %}</p>
     <p>
         {% blocktrans %}
           Please select the case lists/detail menu(s) that needs to be overwritten.
@@ -17,7 +17,7 @@
   </div>
 {% endif %}
 <div>
-  <p>{% trans 'Overwritting Case List and Case Detail Configuration.' %}
+  <p>{% trans "To save time when building large applications, it can be useful to copy one menu's entire case list or case details configuration to another menu." %}
     <a target="_blank"
        href="https://confluence.dimagi.com/display/commcarepublic/Overwriting+Case+List+and+Case+Detail+Configuration">
       {% trans "Learn More" %}

--- a/corehq/apps/app_manager/tests/test_modules.py
+++ b/corehq/apps/app_manager/tests/test_modules.py
@@ -160,17 +160,32 @@ class OverwriteModuleDetailTests(SimpleTestCase):
         self.attrs_dict1 = {
             'columns': True,
             'filter': True,
-            '*': True
+            'sort_elements': True,
+            'sort_nodeset_columns': True,
+            'custom_variables': True,
+            'custom_xml': True,
+            'case_tile_configuration': True,
+            'print_template': True
         }
         self.attrs_dict2 = {
             'columns': True,
             'filter': True,
-            '*': False
+            'sort_elements': False,
+            'sort_nodeset_columns': False,
+            'custom_variables': False,
+            'custom_xml': False,
+            'case_tile_configuration': False,
+            'print_template': False
         }
         self.attrs_dict3 = {
             'columns': False,
             'filter': False,
-            '*': True
+            'sort_elements': False,
+            'sort_nodeset_columns': False,
+            'custom_variables': False,
+            'custom_xml': False,
+            'case_tile_configuration': True,
+            'print_template': False
         }
 
         self.app = Application.new_app('domain', "Untitled Application")
@@ -179,15 +194,18 @@ class OverwriteModuleDetailTests(SimpleTestCase):
         self.header_ = getattr(self.src_module_detail_type.columns[0], 'header')
         self.header_['en'] = 'status'
         self.filter_ = setattr(self.src_module_detail_type, 'filter', 'a > b')
-        self.lookup_enabled = setattr(self.src_module_detail_type, 'lookup_enabled', True)
+        self.sort_nodeset_columns = setattr(self.src_module_detail_type, 'sort_nodeset_columns', True)
+        self.custom_variables = setattr(self.src_module_detail_type, 'custom_variables', 'def')
+        self.custom_xml = setattr(self.src_module_detail_type, 'custom_xml', 'ghi')
+        self.print_template = getattr(self.src_module_detail_type, 'print_template')
+        self.print_template['name'] = 'test'
+        self.case_tile_configuration = setattr(self.src_module_detail_type, 'persist_tile_on_forms', True)
 
     def test_overwrite_all(self):
         dest_module = self.app.add_module(Module.new_module('Dest Module', lang='en'))
         dest_module_detail_type = getattr(dest_module.case_details, "short")
         dest_module_detail_type.overwrite_from_module_detail(self.src_module_detail_type, self.attrs_dict1)
         self.assertEqual(self.src_module_detail_type.to_json(), dest_module_detail_type.to_json())
-        setattr(self.src_module_detail_type, 'filter', 'c < b')
-        self.assertNotEqual(self.src_module_detail_type.to_json(), dest_module_detail_type.to_json())
 
     def test_overwrite_filter_column(self):
         dest_module = self.app.add_module(Module.new_module('Dest Module', lang='en'))
@@ -206,8 +224,8 @@ class OverwriteModuleDetailTests(SimpleTestCase):
 
         self.assertNotEqual(str(self.src_module_detail_type.columns), str(dest_module_detail_type.columns))
         self.assertNotEqual(self.src_module_detail_type.filter, dest_module_detail_type.filter)
-        self.remove_attrs(dest_module_detail_type)
-        self.assertEqual(self.src_module_detail_type.to_json(), dest_module_detail_type.to_json())
+        self.assertEqual(self.src_module_detail_type.persist_tile_on_forms,
+                 dest_module_detail_type.persist_tile_on_forms)
 
     def remove_attrs(self, dest_module_detail_type):
         delattr(self.src_module_detail_type, 'filter')

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -781,7 +781,12 @@ def overwrite_module_case_list(request, domain, app_id, module_unique_id):
     attrs_dict = {
         'columns': request.POST.get('display_properties') == 'on',
         'filter': request.POST.get('case_list_filter') == 'on',
-        '*': request.POST.get('other_configuration') == 'on'
+        'sort_elements': request.POST.get('sort_configuration') == 'on',
+        'sort_nodeset_columns': request.POST.get('nodeset_sorting') == 'on',
+        'custom_variables': request.POST.get('custom_variables') == 'on',
+        'custom_xml': request.POST.get('custom_case_list_xml') == 'on',
+        'case_tile_configuration': request.POST.get('case_tile_configuration') == 'on',
+        'print_template': request.POST.get('print_template') == 'on',
     }
     src_module = app.get_module_by_unique_id(module_unique_id)
     detail_type = request.POST['detail_type']
@@ -852,6 +857,7 @@ def _update_module_case_list(detail_type, src_module, dest_module, attrs_dict):
         setattr(dest_module.case_details, detail_type, getattr(src_module.case_details, detail_type))
     else:
         src_module_detail_type = getattr(src_module.case_details, detail_type)
+        print(f"===src_module_detail_type======={src_module_detail_type}================")
         dest_module_detail_type = getattr(dest_module.case_details, detail_type)
 
         # begin overwrite

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -857,7 +857,6 @@ def _update_module_case_list(detail_type, src_module, dest_module, attrs_dict):
         setattr(dest_module.case_details, detail_type, getattr(src_module.case_details, detail_type))
     else:
         src_module_detail_type = getattr(src_module.case_details, detail_type)
-        print(f"===src_module_detail_type======={src_module_detail_type}================")
         dest_module_detail_type = getattr(dest_module.case_details, detail_type)
 
         # begin overwrite


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

https://dimagi-dev.atlassian.net/jira/software/c/projects/USH/issues/USH-348

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The product team discussed about this and decided it would be clearer to support the flagged features as individual items instead of one big “Other” bucket. This would mean replacing the current “Other” checkbox with a number of new checkboxes, each one controlling a specific feature, and the checkboxes for flagged features should only be visible if the relevant flag is turned on. These are the checkboxes, with the Detail class attribute(s) they affect, and the flag that controls them:
“Sort configuration” - sort_elements - visible to everyone
“Nodeset sorting” - sort_nodeset_columns - visible if DETAIL_LIST_TAB_NODESETS flag is on
“Custom variables” - custom_variables - visible if CASE_LIST_CUSTOM_VARIABLES flag is on
“Custom Case List XML“ - custom_xml - visible if CASE_LIST_CUSTOM_XML flag is on
“Case tile configuration” - use_case_tiles, persist_tile_on_forms, persistent_case_tile_from_module, pull_down_tile, persist_case_context, and persistent_case_context_xml - visible if either CASE_LIST_TILE or SHOW_PERSIST_CASE_CONTEXT_SETTING is on
“Print template” - print_template attribute - visible if CASE_DETAIL_PRINT flag is on

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
