### PR TITLE
Revert package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: pip-compile
+- package-ecosystem: pip
   directory: "/requirements"
   schedule:
     interval: daily


### PR DESCRIPTION
The [configuration docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem) are confusing:

> Note: Dependabot also supports the following package managers:
> ...
> - `pipenv`, `pip-compile`, and `poetry` (specify `pip`)

However, `pip-compile` resulted in an error:

Dependabot encountered the following error when parsing your .github/dependabot.yml:
```
The property '#/updates/0/package-ecosystem' value "pip-compile" did not match one of the following values: npm, bundler, composer, maven, mix, cargo, gradle, nuget, gomod, docker, elm, gitsubmodule, github-actions, pip, terraform
```