### PR TITLE
Set python version for dependabot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ ptop*.json
 /coverage-report
 
 # pyenv
-.python-version
+/.python-version
 
 # Sphinx
 docs/_build

--- a/requirements/.python-version
+++ b/requirements/.python-version
@@ -1,0 +1,5 @@
+3.6.9
+# python version for dependabot
+#
+# must use one of the versions from here
+# https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/python_versions.rb#L12-L17

--- a/requirements/.python-version
+++ b/requirements/.python-version
@@ -1,5 +1,1 @@
 3.6.9
-# python version for dependabot
-#
-# must use one of the versions from here
-# https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/python_versions.rb#L12-L17


### PR DESCRIPTION
must use one of the versions from here
https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/python_versions.rb#L12-L17

Note that this file is also read by pyenv.

Source: https://github.com/dependabot/dependabot-core/issues/1455