### PR TITLE
escape first/last name

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/users.html
+++ b/corehq/apps/cloudcare/templates/formplayer/users.html
@@ -70,7 +70,7 @@
   <td class="module-column module-column-name">
     <h3>
       <b><%= username %></b>
-      <span><%= first_name + ' ' + last_name %></span>
+      <span><%- first_name + ' ' + last_name %></span>
       <i><small><%= location ? location.name + ' (' + location.location_type + ')' : '' %></small></i>
     </h3>
   </td>
@@ -81,7 +81,7 @@
     <tbody>
     <tr>
       <th>{% trans "Name" %}</th>
-      <td><%= user.first_name + ' ' + user.last_name %></td>
+      <td><%- user.first_name + ' ' + user.last_name %></td>
     </tr>
     <% if (user.location) { %>
     <tr>


### PR DESCRIPTION
Escape user's first and last name on WebApps during listing

![Screenshot from 2020-10-08 15-35-32](https://user-images.githubusercontent.com/3864163/95444909-fcb0ba80-097b-11eb-8c15-3ad91d415701.png)

This was flagged during an audit

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
