### PR TITLE
remove app json from being downloaded

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -234,9 +234,6 @@ def download_file(request, domain, app_id, path):
         assert target != 'none'
         path = parts[0] + '-' + target + '.' + parts[1]
 
-    if path == "app.json":
-        return JsonResponse(request.app.to_json())
-
     content_type_map = {
         'ccpr': 'commcare/profile',
         'jad': 'text/vnd.sun.j2me.app-descriptor',
@@ -518,8 +515,5 @@ def source_files(app):
     files = download_index_files(app)
     app_json = json.dumps(
         app.to_json(), sort_keys=True, indent=4, separators=(',', ': ')
-    )
-    files.append(
-        ("app.json", app_json)
     )
     return sorted(files)

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -168,7 +168,6 @@ def _build_ccz_files(build, build_profile_id, include_multimedia_files, include_
             'compress_zip': compress_zip,
             'filename': filename,
             'download_targeted_version': download_targeted_version,
-            'app': build.to_json(),
         }, indent=4)
         manifest_filename = '{} - {} - v{} manifest.json'.format(
             build.domain,


### PR DESCRIPTION
During an audit it was flagged that one can see a field called "admin_password" present in app.json without needing authentication since the download link is public. "admin_password" is deprecated and was used to support old phones. I could just remove "admin_password" as field and also pop it from the app json on download for older apps but I want to check if it is better to just remove app.json itself from the list of files available for download and from ccz(in case of feature flag `CAUTIOUS_MULTIMEDIA`). 
(I also raised a concern around it on slack # product)

##### SUMMARY
app.json file is not used by mobile during installation. 
It was added here in https://github.com/dimagi/commcare-hq/pull/8290#discussion_r40095390 for version diff which I think is not very useful when it comes to app.json and was kept to keep things similar? (@orangejenny  if you remember now?)
Additionally app json is also added to ccz in case the toggle `CAUTIOUS_MULTIMEDIA` is enabled, which i believe was added for debugging and is not needed anymore.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
the file is not used for mobile app installation so should be okay.
@shubham1g5 I asked you this offline but just pinging here to confirm that app.json file is not used during app installation and removing it won't break anything.

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
