### PR TITLE
Pass arguments (--push) through to safe-commit-files

### DIFF
--- a/scripts/commit-staging
+++ b/scripts/commit-staging
@@ -1,3 +1,2 @@
 #!/bin/bash
-
-safe-commit-files scripts/staging.yaml
+safe-commit-files "$@" scripts/staging.yaml


### PR DESCRIPTION
Make `./scripts/commit-staging --push` work again.