### PR TITLE
authenticate download index page

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -36,6 +36,7 @@ from corehq.apps.app_manager.util import (
 )
 from corehq.apps.app_manager.views.utils import back_to_main, get_langs
 from corehq.apps.builds.jadjar import convert_XML_To_J2ME
+from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.hqmedia.views import DownloadMultimediaZip
 from corehq.util.metrics import metrics_counter
 from corehq.util.soft_assert import soft_assert
@@ -388,6 +389,7 @@ def download_practice_user_restore(request, domain, app_id):
     )
 
 
+@login_and_domain_required
 @safe_download
 def download_index(request, domain, app_id):
     """


### PR DESCRIPTION
Download index page should be behind authentication. Found while working on https://github.com/dimagi/commcare-hq/pull/28614

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
