### PR TITLE
Only allow ipv4 addresses when specifying the api key allowlist

### DIFF
--- a/corehq/apps/settings/forms.py
+++ b/corehq/apps/settings/forms.py
@@ -259,9 +259,11 @@ class HQPhoneNumberForm(PhoneNumberForm):
 class HQApiKeyForm(forms.Form):
     name = forms.CharField()
     ip_allowlist = SimpleArrayField(
-        forms.GenericIPAddressField(),
+        forms.GenericIPAddressField(
+            protocol='ipv4',
+        ),
         label=ugettext_lazy("Allowed IP Addresses (comma separated)"),
-        required=False
+        required=False,
     )
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
The error message was showing "Item 1 in the array did not validate: Enter a valid IPv4 or IPv6 address."

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
