### PR TITLE
Created unit test suite for 'login_and_domain_required' decorator

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -82,6 +82,9 @@ def login_and_domain_required(view_func):
             msg = _('The domain "{domain}" was not found.').format(domain=domain_name)
             raise Http404(msg)
 
+        if not domain_obj.is_active:
+            return _inactive_domain_response(req, domain_name)
+
         if not (user.is_authenticated and user.is_active):
             if _is_public_custom_report(req.path, domain_name):
                 return call_view()
@@ -90,10 +93,8 @@ def login_and_domain_required(view_func):
                 return redirect_for_login_or_domain(req, login_url=login_url)
 
         couch_user = _ensure_request_couch_user(req)
-        if not domain_obj.is_active:
-            return _inactive_domain_response(req, domain_name)
         if domain_obj.is_snapshot:
-            if not hasattr(req, 'couch_user') or not req.couch_user.is_previewer():
+            if not req.couch_user.is_previewer():
                 raise Http404()
             return call_view()
 

--- a/corehq/apps/domain/tests/test_login_and_domain_required.py
+++ b/corehq/apps/domain/tests/test_login_and_domain_required.py
@@ -1,4 +1,4 @@
-from unittest import skip # pylint: disable=unused-import
+from unittest import skip  # pylint: disable=unused-import  # noqa: F401
 import mock
 
 from django.http import HttpResponse, Http404
@@ -98,7 +98,7 @@ class TestLoginAndDomainRequired(SimpleTestCase):
 
     @mock.patch('corehq.apps.domain.decorators.has_privilege', mock.Mock(return_value=False))
     @mock.patch('corehq.apps.domain.views.accounting.SubscriptionUpgradeRequiredView')
-    def test_domain_user_does_not_have_project_access__renders_subscription_upgrade(self, upgrade_required_view_class):
+    def test_domain_user_does_not_have_project_access__renders_subscription_upgrade(self, upgrade_required_view_class):  # noqa: E501
         self.user.is_member_of.return_value = True
         upgrade_required_view = mock.Mock()
         upgrade_required_view_class.return_value = upgrade_required_view

--- a/corehq/apps/domain/tests/test_login_and_domain_required.py
+++ b/corehq/apps/domain/tests/test_login_and_domain_required.py
@@ -10,10 +10,10 @@ from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.models import Domain
 
 
-
 @login_and_domain_required
 def process_request(*args, **kwargs):
     return HttpResponse('')
+
 
 @tag('unit')
 class TestLoginAndDomainRequired(SimpleTestCase):
@@ -52,7 +52,6 @@ class TestLoginAndDomainRequired(SimpleTestCase):
 
     def process_request(self):
         return process_request(self.request, self.domain_name)
-
 
     def test_invalid_domain__displays_404(self):
         self.get_domain_by_name.return_value = None
@@ -148,4 +147,3 @@ class TestLoginAndDomainRequired(SimpleTestCase):
 
         with self.assertRaises(Http404):
             self.process_request()
-

--- a/corehq/apps/domain/tests/test_login_and_domain_required.py
+++ b/corehq/apps/domain/tests/test_login_and_domain_required.py
@@ -1,8 +1,7 @@
-from unittest import skip  # pylint: disable=unused-import  # noqa: F401
 import mock
 
 from django.http import HttpResponse, Http404
-from django.test import SimpleTestCase, tag
+from django.test import SimpleTestCase, override_settings
 from django.test.client import RequestFactory
 from rest_framework import status
 
@@ -15,25 +14,28 @@ def process_request(*args, **kwargs):
     return HttpResponse('')
 
 
-@tag('unit')
+REQUEST_PATH = '/some/url'
+
+
 class TestLoginAndDomainRequired(SimpleTestCase):
     def setUp(self):
-        self.domain_name = 'some_domain'
-        self.domain = self._create_domain()
+        self.domain = 'some_domain'
+        self.domain_obj = self._create_domain()
         self.factory = RequestFactory()
         self.user = self._create_user()
-        self.request = self._create_request('/some/url', self.user)
+        self.request = self._create_request(REQUEST_PATH, self.user)
 
-        self.domain_patcher = mock.patch('corehq.apps.domain.models.Domain.get_by_name', return_value=self.domain)
+        self.domain_patcher = mock.patch('corehq.apps.domain.models.Domain.get_by_name',
+            return_value=self.domain_obj)
         self.get_domain_by_name = self.domain_patcher.start()
         self.addCleanup(self.domain_patcher.stop)
 
     @staticmethod
     def _create_domain():
-        domain = mock.Mock(Domain)
-        domain.is_active = True
-        domain.is_snapshot = False
-        return domain
+        domain_obj = Domain()
+        domain_obj.is_active = True
+        domain_obj.is_snapshot = False
+        return domain_obj
 
     @staticmethod
     def _create_user():
@@ -45,13 +47,13 @@ class TestLoginAndDomainRequired(SimpleTestCase):
     def _create_request(self, url, user):
         request = self.factory.get(url)
         request.user = request.couch_user = user
-        request.path = 'access_required.html'
-        request.domain = self.domain_name
+        request.path = url
+        request.domain = self.domain
 
         return request
 
     def process_request(self):
-        return process_request(self.request, self.domain_name)
+        return process_request(self.request, self.domain)
 
     def test_invalid_domain__displays_404(self):
         self.get_domain_by_name.return_value = None
@@ -63,7 +65,7 @@ class TestLoginAndDomainRequired(SimpleTestCase):
     @mock.patch('corehq.apps.domain.decorators.reverse')
     @mock.patch('corehq.apps.domain.decorators.messages', mock.Mock())
     def test_inactive_domain__redirects_to_domain_selection(self, reverse):
-        self.domain.is_active = False
+        self.domain_obj.is_active = False
         reverse.return_value = '/domain/select/'
 
         response = self.process_request()
@@ -71,7 +73,7 @@ class TestLoginAndDomainRequired(SimpleTestCase):
         reverse.assert_called_with('domain_select')
 
     def test_two_factor_required_but_missing__displays_alert(self):
-        self.domain.two_factor_auth = True
+        self.domain_obj.two_factor_auth = True
         self.user.is_member_of.return_value = True
         self.user.two_factor_disabled = False
         self.user.is_verified = mock.Mock(return_value=False)
@@ -80,13 +82,13 @@ class TestLoginAndDomainRequired(SimpleTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_snapshot_domain_without_previewer__returns_not_found(self):
-        self.domain.is_snapshot = True
+        self.domain_obj.is_snapshot = True
         self.user.is_previewer = mock.Mock(return_value=False)
         with self.assertRaises(Http404):
             self.process_request()
 
     def test_snapshot_domain_with_previewer__allows_access(self):
-        self.domain.is_snapshot = True
+        self.domain_obj.is_snapshot = True
         self.user.is_previewer = mock.Mock(return_value=True)
         response = self.process_request()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -98,43 +100,43 @@ class TestLoginAndDomainRequired(SimpleTestCase):
 
     @mock.patch('corehq.apps.domain.decorators.has_privilege', mock.Mock(return_value=False))
     @mock.patch('corehq.apps.domain.views.accounting.SubscriptionUpgradeRequiredView')
-    def test_domain_user_does_not_have_project_access__renders_subscription_upgrade(self, upgrade_required_view_class):  # noqa: E501
+    @override_settings(IS_SAAS_ENVIRONMENT=True)
+    def test_domain_user_with_inaccessible_project__renders_subscription_upgrade(self, upgrade_required_view_class):  # noqa: E501
         self.user.is_member_of.return_value = True
         upgrade_required_view = mock.Mock()
         upgrade_required_view_class.return_value = upgrade_required_view
 
-        with self.settings(IS_SAAS_ENVIRONMENT=True):
-            self.process_request()
-            upgrade_required_view.get.assert_called()
+        self.process_request()
+        upgrade_required_view.get.assert_called()
 
     @mock.patch('corehq.apps.domain.decorators.has_privilege', mock.Mock(return_value=False))
-    def test_domain_user_does_not_have_project_access_but_is_non_saas__allows_access(self):
-        with self.settings(IS_SAAS_ENVIRONMENT=False):
-            self.user.is_member_of.return_value = True
-            response = self.process_request()
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
+    @override_settings(IS_SAAS_ENVIRONMENT=False)
+    def test_domain_user_with_inaccessible_non_saas_project__allows_access(self):
+        self.user.is_member_of.return_value = True
+        response = self.process_request()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @mock.patch('corehq.apps.hqwebapp.views.loader.get_template', mock.Mock())
     def test_superuser_when_superusers_restricted__is_forbidden(self):
-        self.domain.restrict_superuers = True
+        self.domain_obj.restrict_superusers = True
         self.user.is_superuser = True
 
         response = self.process_request()
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @mock.patch('corehq.apps.hqwebapp.views.loader.get_template', mock.Mock())
+    @override_settings(PAGES_NOT_RESTRICTED_FOR_DIMAGI=[REQUEST_PATH])
     def test_superuser_when_page_is_whitelisted__is_granted_access(self):
-        with self.settings(PAGES_NOT_RESTRICTED_FOR_DIMAGI=[self.request.path]):
-            self.domain.restrict_superusers = True
-            self.user.is_superuser = True
+        self.domain_obj.restrict_superusers = True
+        self.user.is_superuser = True
 
-            response = self.process_request()
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.process_request()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @mock.patch('corehq.apps.users.views.DomainRequestView')
     def test_web_user_where_domain_allows_requests__is_granted_access(self, domain_request_view_class):
         self.user.is_web_user.return_value = True
-        self.domain.allow_domain_requests = True
+        self.domain_obj.allow_domain_requests = True
         domain_request_view = mock.Mock()
         domain_request_view_class.as_view.return_value = domain_request_view
 

--- a/corehq/apps/domain/tests/test_login_and_domain_required.py
+++ b/corehq/apps/domain/tests/test_login_and_domain_required.py
@@ -1,0 +1,151 @@
+from unittest import skip # pylint: disable=unused-import
+import mock
+
+from django.http import HttpResponse, Http404
+from django.test import SimpleTestCase, tag
+from django.test.client import RequestFactory
+from rest_framework import status
+
+from corehq.apps.domain.decorators import login_and_domain_required
+from corehq.apps.domain.models import Domain
+
+
+
+@login_and_domain_required
+def process_request(*args, **kwargs):
+    return HttpResponse('')
+
+@tag('unit')
+class TestLoginAndDomainRequired(SimpleTestCase):
+    def setUp(self):
+        self.domain_name = 'some_domain'
+        self.domain = self._create_domain()
+        self.factory = RequestFactory()
+        self.user = self._create_user()
+        self.request = self._create_request('/some/url', self.user)
+
+        self.domain_patcher = mock.patch('corehq.apps.domain.models.Domain.get_by_name', return_value=self.domain)
+        self.get_domain_by_name = self.domain_patcher.start()
+        self.addCleanup(self.domain_patcher.stop)
+
+    @staticmethod
+    def _create_domain():
+        domain = mock.Mock(Domain)
+        domain.is_active = True
+        domain.is_snapshot = False
+        return domain
+
+    @staticmethod
+    def _create_user():
+        user = mock.Mock()
+        user.is_superuser = False
+        user.is_member_of = mock.Mock(return_value=False)
+        return user
+
+    def _create_request(self, url, user):
+        request = self.factory.get(url)
+        request.user = request.couch_user = user
+        request.path = 'access_required.html'
+        request.domain = self.domain_name
+
+        return request
+
+    def process_request(self):
+        return process_request(self.request, self.domain_name)
+
+
+    def test_invalid_domain__displays_404(self):
+        self.get_domain_by_name.return_value = None
+
+        with self.assertRaises(Http404):
+            self.process_request()
+
+    # Reverse is stubbed here because actual reverse lookups take ~ 1 second
+    @mock.patch('corehq.apps.domain.decorators.reverse')
+    @mock.patch('corehq.apps.domain.decorators.messages', mock.Mock())
+    def test_inactive_domain__redirects_to_domain_selection(self, reverse):
+        self.domain.is_active = False
+        reverse.return_value = '/domain/select/'
+
+        response = self.process_request()
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        reverse.assert_called_with('domain_select')
+
+    def test_two_factor_required_but_missing__displays_alert(self):
+        self.domain.two_factor_auth = True
+        self.user.is_member_of.return_value = True
+        self.user.two_factor_disabled = False
+        self.user.is_verified = mock.Mock(return_value=False)
+
+        response = self.process_request()
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_snapshot_domain_without_previewer__returns_not_found(self):
+        self.domain.is_snapshot = True
+        self.user.is_previewer = mock.Mock(return_value=False)
+        with self.assertRaises(Http404):
+            self.process_request()
+
+    def test_snapshot_domain_with_previewer__allows_access(self):
+        self.domain.is_snapshot = True
+        self.user.is_previewer = mock.Mock(return_value=True)
+        response = self.process_request()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_user_belongs_to_domain__returns_200(self):
+        self.user.is_member_of.return_value = True
+        response = self.process_request()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @mock.patch('corehq.apps.domain.decorators.has_privilege', mock.Mock(return_value=False))
+    @mock.patch('corehq.apps.domain.views.accounting.SubscriptionUpgradeRequiredView')
+    def test_domain_user_does_not_have_project_access__renders_subscription_upgrade(self, upgrade_required_view_class):
+        self.user.is_member_of.return_value = True
+        upgrade_required_view = mock.Mock()
+        upgrade_required_view_class.return_value = upgrade_required_view
+
+        with self.settings(IS_SAAS_ENVIRONMENT=True):
+            self.process_request()
+            upgrade_required_view.get.assert_called()
+
+    @mock.patch('corehq.apps.domain.decorators.has_privilege', mock.Mock(return_value=False))
+    def test_domain_user_does_not_have_project_access_but_is_non_saas__allows_access(self):
+        with self.settings(IS_SAAS_ENVIRONMENT=False):
+            self.user.is_member_of.return_value = True
+            response = self.process_request()
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @mock.patch('corehq.apps.hqwebapp.views.loader.get_template', mock.Mock())
+    def test_superuser_when_superusers_restricted__is_forbidden(self):
+        self.domain.restrict_superuers = True
+        self.user.is_superuser = True
+
+        response = self.process_request()
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @mock.patch('corehq.apps.hqwebapp.views.loader.get_template', mock.Mock())
+    def test_superuser_when_page_is_whitelisted__is_granted_access(self):
+        with self.settings(PAGES_NOT_RESTRICTED_FOR_DIMAGI=[self.request.path]):
+            self.domain.restrict_superusers = True
+            self.user.is_superuser = True
+
+            response = self.process_request()
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @mock.patch('corehq.apps.users.views.DomainRequestView')
+    def test_web_user_where_domain_allows_requests__is_granted_access(self, domain_request_view_class):
+        self.user.is_web_user.return_value = True
+        self.domain.allow_domain_requests = True
+        domain_request_view = mock.Mock()
+        domain_request_view_class.as_view.return_value = domain_request_view
+
+        self.process_request()
+        domain_request_view.assert_called()
+
+    # Non-domain, non-web user is denied access
+    def test_non_domain_user__is_denied_access(self):
+        self.user.is_web_user.return_value = False
+
+        with self.assertRaises(Http404):
+            self.process_request()
+


### PR DESCRIPTION
One of the initial setup tasks for https://dimagi-dev.atlassian.net/browse/SAAS-11390.

As refactoring user.is_superuser touches so many files (and has the potential to break things), we want to focus our testing efforts on the most common pathways -- in this case the `login_and_domain_required` decorator.

Ideally, existing tests would cover the refactor, but no existing tests were found. The closest example was `test_two_factor_check.py`, which unfortunately does not cover the broader decorator.

The primary aim here was to get the decorator under test -- there is a lot of logic here that is likely not covered by any existing tests (even if the coverage report says otherwise). It might be relevant to test, for example, that a superuser who is part of a domain, but lacks two-factor authentication will get rejected, whereas a superuser who isn't part of the domain will not.  Because of the scope of my ticket, as well as being unsure of the real requirements for the decorator, I limited my tests towards the blocks of code as they were written -- not all the possible permutations.

My secondary motivation was to create a reference file for pure unit tests. The bulk of our tests rely on the TestCase class and interacting with the database -- integration tests. This isn't ideal for 2 reasons:
1) Integration tests take a long time. Tests are meant to be run regularly. Test Driven Development (TDD) involves a continuous back-and-forth between editing and running the tests that becomes impractical if the tests are slow.
2) Integration tests encourage untested logic. Because of the pain of mocking out irrelevant dependencies, unit tests tend to remain small and focused -- and that feeds back into the code under test. While there is nothing stopping an integration test from being as narrow as a unit test, in reality, being able to rely on external dependencies generally means code inherits more responsibilities, creating more permutations of logic, which is often left untested.

As this is a different style of testing, I would like reviewers to pay particular attention to readability and maintainability. Is this pattern impractical? Do the mocks used make it hard to understand? Is it overkill?

Other notes:
- I left the pylint message in at the top for debugging convenience. I think the ugliness of the unused include is offset by the convenience of being able to toggle on/off tests while debugging
- The tests are tagged as 'unit', which I was hoping would allow us to begin to separate unit tests and integration tests. Nose doesn't support tags (its a unittest feature), but they have a similar functionality that I still need to look into.
- Tests are generally described as having 3 parts:
  - Given conditions
  - When something happens
  - Expect this result
  I tried to structure my test names to resemble given_condition_when_happens__get_this_result. I'd love to hear if we have an existing standard elsewhere.