### PR TITLE
Track role update

### DIFF
--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -147,11 +147,13 @@ class MyAccountSettingsView(BaseMyAccountView):
                 self.request.POST,
                 domain=domain,
                 existing_user=self.request.couch_user,
+                request=self.request,
             )
         else:
             form = UpdateMyAccountInfoForm(
                 domain=domain,
                 existing_user=self.request.couch_user,
+                request=self.request,
             )
         form.load_language(language_choices)
         return form

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -478,7 +478,8 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                     user_current_role = user.get_role(domain=domain)
                     role_updated = not (user_current_role and
                                         user_current_role.get_qualified_id() == role_qualified_id)
-                    user.set_role(domain, role_qualified_id)
+                    if role_updated:
+                        user.set_role(domain, role_qualified_id)
 
                 if web_user:
                     user.update_metadata({'login_as_user': web_user})

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -476,8 +476,8 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                 if role:
                     role_qualified_id = domain_info.roles_by_name[role].get_qualified_id()
                     user_current_role = user.get_role(domain=domain)
-                    role_updated = not (user_current_role and
-                                        user_current_role.get_qualified_id() == role_qualified_id)
+                    role_updated = not (user_current_role
+                                        and user_current_role.get_qualified_id() == role_qualified_id)
                     if role_updated:
                         user.set_role(domain, role_qualified_id)
 

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -32,7 +32,8 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.domain_name = 'mydomain'
         cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
         cls.other_domain = Domain.get_or_create_with_name(name='other-domain')
-        cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None, is_superuser=True)
+        cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None,
+                                            is_superuser=True)
 
         permissions = Permissions(edit_apps=True, view_apps=True, view_reports=True)
         cls.role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'edit-apps')
@@ -695,7 +696,8 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
         cls.domain = Domain(name=cls.domain_name)
         cls.domain.strong_mobile_passwords = True
         cls.domain.save()
-        cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None, is_superuser=True)
+        cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None,
+                                            is_superuser=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -32,6 +32,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         cls.domain_name = 'mydomain'
         cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
         cls.other_domain = Domain.get_or_create_with_name(name='other-domain')
+        cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None, is_superuser=True)
 
         permissions = Permissions(edit_apps=True, view_apps=True, view_reports=True)
         cls.role = UserRole.get_or_create_with_permissions(cls.domain.name, permissions, 'edit-apps')
@@ -104,7 +105,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(user_id='missing')],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
 
@@ -119,7 +120,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=self.loc1.site_code)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.location_id, self.loc1._id)
@@ -136,7 +137,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         result = create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code='unknownsite')],
-            None
+            self.uploading_user
         )
         self.assertEqual(len(result["rows"]), 1)
 
@@ -147,7 +148,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=[a.site_code for a in [self.loc1, self.loc2]])],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         # first location should be primary location
@@ -166,7 +167,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=[a.site_code for a in [self.loc1, self.loc2]])],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
 
@@ -175,7 +176,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(location_code=[], user_id=self.user._id)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
 
@@ -191,7 +192,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code=[a.site_code for a in [self.loc1, self.loc2]])],
-            None
+            self.uploading_user
         )
 
         # user's primary location should be loc1
@@ -204,7 +205,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code=[self.loc2.site_code], user_id=self.user._id)],
-            None
+            self.uploading_user
         )
 
         # user's location should now be loc2
@@ -221,14 +222,14 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code=[self.loc1.site_code])],
-            None
+            self.uploading_user
         )
 
         # reassign to loc2
         create_or_update_users_and_groups(
             self.domain.name,
             [self._get_spec(location_code=[self.loc2.site_code], user_id=self.user._id)],
-            None
+            self.uploading_user
         )
 
         # user's location should now be loc2
@@ -248,7 +249,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(name=1234)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.full_name, "1234")
@@ -262,7 +263,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(name=None)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.full_name, "")
@@ -273,7 +274,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'key': 'F#'})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain', 'key': 'F#'})
@@ -283,7 +284,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'key': 'Bb'}, user_id=self.user._id)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain', 'key': 'Bb'})
@@ -293,7 +294,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'key': ''}, user_id=self.user._id)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain'})
@@ -303,7 +304,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'play_count': 0}, user_id=self.user._id)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain', 'play_count': 0})
@@ -314,7 +315,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(uncategorized_data={'tempo': 'presto'})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain', 'tempo': 'presto'})
@@ -324,7 +325,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(uncategorized_data={'tempo': 'andante'}, user_id=self.user._id)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain', 'tempo': 'andante'})
@@ -334,7 +335,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(uncategorized_data={'tempo': ''}, user_id=self.user._id)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain'})
@@ -344,7 +345,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'tempo': 'andante'})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain', 'tempo': 'andante'})
@@ -353,7 +354,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'tempo': ''}, user_id=self.user._id)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {'commcare_project': 'mydomain'})
@@ -365,7 +366,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'key': 'F#'}, location_code=self.loc1.site_code)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {
@@ -380,7 +381,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(user_id=self.user.user_id, data={'key': 'G#'}, location_code=self.loc1.site_code)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {
@@ -396,7 +397,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={'key': 'F#', PROFILE_SLUG: self.profile.id})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {
@@ -411,7 +412,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={PROFILE_SLUG: self.profile.id, 'mode': 'minor'})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {
@@ -430,7 +431,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={PROFILE_SLUG: self.profile.id, 'mode': ''})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.metadata, {
@@ -444,7 +445,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={PROFILE_SLUG: self.profile.id, 'mode': 'major'})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )['messages']['rows']
         self.assertEqual(rows[0]['flag'], "metadata properties conflict with profile: mode")
@@ -455,7 +456,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(data={PROFILE_SLUG: bad_id})],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )['messages']['rows']
         self.assertEqual(rows[0]['flag'], "Could not find profile with id {}".format(bad_id))
@@ -469,7 +470,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(email=email)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.email, email.lower())
@@ -479,17 +480,18 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(role=self.role.name)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(self.user.get_role(self.domain_name).name, self.role.name)
+
 
     def test_blank_is_active(self):
         import_users_and_groups(
             self.domain.name,
             [self._get_spec(is_active='')],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertTrue(self.user.is_active)
@@ -499,7 +501,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec()],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertIsNotNone(self.user)
@@ -508,7 +510,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(user_id=self.user._id, username='')],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
 
@@ -517,7 +519,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(username=123)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertIsNotNone(
@@ -529,7 +531,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(delete_keys=['is_active'], is_account_confirmed='False')],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         user = self.user
@@ -561,7 +563,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
                 ),
             ],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(mock_account_confirm_email.call_count, 1)
@@ -569,8 +571,6 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
 
     @mock.patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
     def test_upload_invite_web_user(self, mock_send_activation_email):
-        upload_user = mock.MagicMock()
-        upload_user.user_id = "31415926"
         import_users_and_groups(
             self.domain.name,
             [
@@ -582,7 +582,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
                 )
             ],
             [],
-            upload_user,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(mock_send_activation_email.call_count, 1)
@@ -596,7 +596,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(web_user='a@a.com', is_account_confirmed='True', role=self.role.name)],
             [],
-            mock.MagicMock(),
+            self.uploading_user,
             mock.MagicMock()
         )
         web_user = WebUser.get_by_username(username)
@@ -610,7 +610,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(web_user='a@a.com', role=self.role.name)],
             [],
-            mock.MagicMock(),
+            self.uploading_user,
             mock.MagicMock()
         )
         web_user = WebUser.get_by_username(username)
@@ -623,7 +623,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(web_user='a@a.com', remove_web_user='True')],
             [],
-            mock.MagicMock(),
+            self.uploading_user,
             mock.MagicMock()
         )
         web_user = WebUser.get_by_username(username)
@@ -636,7 +636,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             [self._get_spec(username=123, domain=self.other_domain.name)],
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertIsNotNone(
@@ -645,8 +645,6 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
 
     @mock.patch('corehq.apps.user_importer.importer.Invitation.send_activation_email')
     def test_update_pending_user_role(self, mock_send_activation_email):
-        upload_user = mock.MagicMock()
-        upload_user.user_id = "31415926"
         import_users_and_groups(
             self.domain.name,
             [
@@ -658,7 +656,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
                 )
             ],
             [],
-            upload_user,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(mock_send_activation_email.call_count, 1)
@@ -678,7 +676,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
                 )
             ],
             [],
-            upload_user,
+            self.uploading_user,
             mock.MagicMock()
         )
         self.assertEqual(mock_send_activation_email.call_count, 1)  # invite only sent once
@@ -693,19 +691,21 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
         super().setUpClass()
         cls.patcher = patch('corehq.apps.user_importer.tasks.UserUploadRecord')
         cls.patcher.start()
+        cls.domain_name = 'mydomain'
+        cls.domain = Domain(name=cls.domain_name)
+        cls.domain.strong_mobile_passwords = True
+        cls.domain.save()
+        cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None, is_superuser=True)
 
     @classmethod
     def tearDownClass(cls):
+        cls.domain.delete()
         cls.patcher.stop()
         super().tearDownClass()
 
     def setUp(self):
         super(TestUserBulkUploadStrongPassword, self).setUp()
         delete_all_users()
-        self.domain_name = 'mydomain'
-        self.domain = Domain(name=self.domain_name)
-        self.domain.strong_mobile_passwords = True
-        self.domain.save()
         self.user_specs = [{
             'username': 'tswift',
             'user_id': '1989',
@@ -716,10 +716,6 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
             'password': 'TaylorSwift89!',
             'email': None
         }]
-
-    def tearDown(self):
-        self.domain.delete()
-        super(TestUserBulkUploadStrongPassword, self).tearDown()
 
     def test_duplicate_password(self):
         user_spec = [{
@@ -737,7 +733,7 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             list(user_spec + self.user_specs),
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )['messages']['rows']
         self.assertEqual(rows[0]['flag'], "'password' values must be unique")
@@ -750,7 +746,7 @@ class TestUserBulkUploadStrongPassword(TestCase, DomainSubscriptionMixin):
             self.domain.name,
             list([updated_user_spec]),
             [],
-            None,
+            self.uploading_user,
             mock.MagicMock()
         )['messages']['rows']
         self.assertEqual(rows[0]['flag'], 'Password is not strong enough. Try making your password more complex.')

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -763,6 +763,8 @@ class TestUserUploadRecord(TestCase):
         delete_all_users()
         cls.domain_name = 'mydomain'
         cls.domain = Domain.get_or_create_with_name(name=cls.domain_name)
+        cls.uploading_user = WebUser.create(cls.domain_name, "admin@xyz.com", 'password', None, None,
+                                            is_superuser=True)
         cls.spec = {
             'username': 'hello',
             'name': 'Another One',
@@ -789,7 +791,7 @@ class TestUserUploadRecord(TestCase):
             self.domain.name,
             [self.spec],
             [],
-            None,
+            self.uploading_user,
             upload_record.pk
         ).apply()
         rows = task_result.result

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -16,6 +16,7 @@ from casexml.apps.case.const import (
 
 from corehq import privileges, toggles
 from corehq.apps.callcenter.const import CALLCENTER_USER
+from corehq.util.model_log import log_model_change
 from corehq.util.quickcache import quickcache
 from django.core.exceptions import ValidationError
 
@@ -307,3 +308,19 @@ def _last_sync_needs_update(last_sync, sync_datetime):
     if sync_datetime > last_sync.sync_date:
         return True
     return False
+
+
+def log_user_role_update(domain, user, by_user):
+    """
+    :param domain: domain name
+    :param user: couch user that got updated
+    :param by_user: django/couch user that made the update
+    """
+    user_role = user.get_role(domain)
+    message = "role: None"
+    if user_role:
+        if user_role.get_qualified_id() == 'admin':
+            message = f"role: {user_role.name}"
+        else:
+            message = f"role: {user_role.name}[{user_role.get_id}]"
+    log_model_change(by_user, user.get_django_user(), message=message)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -358,7 +358,8 @@ class EditWebUserView(BaseEditUserView):
             data = self.request.POST
         else:
             data = None
-        form = UpdateUserRoleForm(data=data, domain=self.domain, existing_user=self.editable_user)
+        form = UpdateUserRoleForm(data=data, domain=self.domain, existing_user=self.editable_user,
+                                  request=self.request)
 
         if self.can_change_user_roles:
             form.load_roles(current_role=self.existing_role, role_choices=self.user_role_choices)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -322,7 +322,7 @@ class EditCommCareUserView(BaseEditUserView):
         else:
             data = None
         form = CommCareUserFormSet(data=data, domain=self.domain,
-            editable_user=self.editable_user, request_user=self.request.couch_user)
+            editable_user=self.editable_user, request_user=self.request.couch_user, request=self.request)
 
         form.user_form.load_language(language_choices=get_domain_languages(self.domain))
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/ICDS-1505

##### SUMMARY
Track updates to roles

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
I have already tested the changes via forms, would be testing bulk upload as well though there were great tests for bulk upload. Not planning on raising a QA request, as of now but happy to reconsider.

##### PRODUCT DESCRIPTION
No user facing change.
Only on Django Admin End one would see updates as
1. role: Role name[Role ID]
we have ID and name both, in case role is deleted, we would at least have its name
2. role: Admin
admin roles are in-built and don't have ID
3. role: None
In case the role is revoked, possible only for mobile users though since web users always have a role assigned.
Example: (please ignore Admin[None])
![Screenshot from 2020-10-12 22-28-53](https://user-images.githubusercontent.com/3864163/95772474-69a8b500-0cda-11eb-89ba-58ad16676e64.png)

