### PR TITLE
Added git hook installation instructions to the dev guide

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -116,6 +116,7 @@ Once all the dependencies are in order, please do the following:
     $ git clone https://github.com/dimagi/commcare-hq.git
     $ cd commcare-hq
     $ git submodule update --init --recursive
+    $ git-hooks/install.sh
     $ setvirtualenvproject  # optional - sets this directory as the project root
 
 Next, install the appropriate requirements (only one is necessary).


### PR DESCRIPTION
As described above. I ran tests to verify that the precommit hook would not run until the requirements were installed, but adding that information, as well as the purpose for the command, didn't seem in-line with the existing documentation.