### PR TITLE
Kick retries on paused repeaters 7 days later

### DIFF
--- a/corehq/motech/repeaters/tasks.py
+++ b/corehq/motech/repeaters/tasks.py
@@ -16,6 +16,7 @@ from corehq.motech.models import RequestLog
 from corehq.motech.repeaters.const import (
     CHECK_REPEATERS_INTERVAL,
     CHECK_REPEATERS_KEY,
+    MAX_RETRY_WAIT,
     RECORD_FAILURE_STATE,
     RECORD_PENDING_STATE,
 )
@@ -136,7 +137,7 @@ def process_repeat_record(repeat_record):
         if repeater.paused:
             # postpone repeat record by 1 day so that these don't get picked in each cycle and
             # thus clogging the queue with repeat records with paused repeater
-            repeat_record.postpone_by(timedelta(days=1))
+            repeat_record.postpone_by(MAX_RETRY_WAIT)
             return
 
         if repeater.doc_type.endswith(DELETED_SUFFIX):


### PR DESCRIPTION
##### SUMMARY

Currently, the repeat records of paused repeaters are retried after 1 day. This change kicks them 7 days into the future..

The change is intended to reduce the number of repeat records in the repeat records queue.

##### FEATURE FLAG
None. (Pro Plan and higher.)

##### RISK ASSESSMENT / QA PLAN
This change affects when repeat records are sent after a repeater is unpaused. The behaviour might be unexpected. But repeat records can be requeued or resent manually from the Repeat Records Report.
