### PR TITLE
Clarify comment about repeat record check

### DIFF
--- a/corehq/motech/repeaters/models.py
+++ b/corehq/motech/repeaters/models.py
@@ -904,11 +904,11 @@ class RepeatRecord(Document):
         if already_processed() or not is_ready():
             return
 
-        # Set the next check to happen an arbitrarily long time from now so
-        # if something goes horribly wrong with the delayed task it will not
-        # be lost forever. A check at this time is expected to occur rarely,
-        # if ever, because `process_repeat_record` will usually succeed or
-        # reset the next check to sometime sooner.
+        # Set the next check to happen an arbitrarily long time from now.
+        # This way if there's a delay in calling `process_repeat_record` (which
+        # also sets or clears next_check) we won't queue this up in duplicate.
+        # If `process_repeat_record` is totally borked, this future date is a
+        # fallback.
         self.next_check = datetime.utcnow() + timedelta(hours=48)
         try:
             self.save()


### PR DESCRIPTION
I'm pretty sure this comment is misleading as currently written.  The main reason we move the date forward is to prevent the next `check_repeaters` from queuing the record in duplicate if that task hasn't yet been processed.  We don't need to bump the date just to get it queued again in the event of failure.  Feel free to rephrase the comment