### PR TITLE
add email domain namespace to toggles & demo implementation for blocking hubspot for certain users 

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -503,7 +503,7 @@ def track_periodic_data():
                     'commcare.hubspot.web_user_rejected.email_domain',
                     1,
                     tags={
-                      'email_domain': email.split('@')[-1],
+                        'email_domain': email.split('@')[-1],
                     }
                 )
                 continue
@@ -522,7 +522,7 @@ def track_periodic_data():
                         'commcare.hubspot.web_user_rejected.domain',
                         1,
                         tags={
-                          'domain': domain,
+                            'domain': domain,
                         }
                     )
                     is_member_of_blocked_domain = True

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -41,7 +41,7 @@ from corehq.apps.domain.utils import get_domains_created_by_user
 from corehq.apps.es.forms import FormES
 from corehq.apps.es.users import UserES
 from corehq.apps.users.models import WebUser
-from corehq.toggles import deterministic_random
+from corehq.toggles import deterministic_random, DISABLE_HUBSPOT_DATA
 from corehq.util.dates import unix_time
 from corehq.util.decorators import analytics_task
 from corehq.util.soft_assert import soft_assert
@@ -494,8 +494,18 @@ def track_periodic_data():
         # max number of mobile workers
         submit = []
         for user in users_to_domains:
-            email = user.get('email')
+            email = user.get('email') or user.get('username')
             if not _email_is_valid(email):
+                continue
+
+            if DISABLE_HUBSPOT_DATA.enabled(email):
+                metrics_gauge(
+                    'commcare.hubspot.web_user_rejected.email_domain',
+                    1,
+                    tags={
+                      'email_domain': email.split('@')[-1],
+                    }
+                )
                 continue
 
             hubspot_number_of_users += 1
@@ -505,7 +515,17 @@ def track_periodic_data():
             max_export = 0
             max_report = 0
 
+            is_member_of_blocked_domain = False
             for domain in user['domains']:
+                if DISABLE_HUBSPOT_DATA.enabled(domain):
+                    metrics_gauge(
+                        'commcare.hubspot.web_user_rejected.domain',
+                        1,
+                        tags={
+                          'domain': domain,
+                        }
+                    )
+                    is_member_of_blocked_domain = True
                 if domain in domains_to_forms and domains_to_forms[domain] > max_forms:
                     max_forms = domains_to_forms[domain]
                 if domain in domains_to_mobile_users and domains_to_mobile_users[domain] > max_workers:
@@ -514,6 +534,9 @@ def track_periodic_data():
                     max_export = _get_export_count(domain)
                 if _get_report_count(domain) > max_report:
                     max_report = _get_report_count(domain)
+
+            if is_member_of_blocked_domain:
+                continue
 
             project_spaces_created = ", ".join(get_domains_created_by_user(email))
 

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -33,6 +33,7 @@ from corehq.toggles import (
     DynamicallyPredictablyRandomToggle,
     PredictablyRandomToggle,
     all_toggles,
+    NAMESPACE_EMAIL_DOMAIN,
 )
 from corehq.util.soft_assert import soft_assert
 
@@ -238,7 +239,7 @@ def _call_save_fn_and_clear_cache(static_toggle, previously_enabled, currently_e
             domain = entry
             if static_toggle.save_fn is not None:
                 static_toggle.save_fn(domain, enabled)
-        else:
+        elif namespace != NAMESPACE_EMAIL_DOMAIN:
             # these are sent down with no namespace
             assert ':' not in entry, entry
             username = entry

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2469,6 +2469,23 @@ class WebUser(CouchUser, MultiMembershipMixin, CommCareMobileContactMixin):
             self,
         )
 
+    @property
+    def is_allowed_on_hubspot(self):
+        """
+        This determines whether this user's data can be present on Hubspot.
+        FYI If analytics is disabled by default in localsettings,
+        then this code is never reached.
+        """
+        from corehq.toggles import DISABLE_HUBSPOT_DATA
+        if DISABLE_HUBSPOT_DATA.enabled(self.username):
+            return False
+
+        for domain in self.get_domains():
+            if DISABLE_HUBSPOT_DATA.enabled(domain):
+                return False
+
+        return self.analytics_enabled
+
     def get_email(self):
         # Do not change the name of this method because this is implementing
         # get_email() from the CommCareMobileContactMixin

--- a/corehq/ex-submodules/toggle/shortcuts.py
+++ b/corehq/ex-submodules/toggle/shortcuts.py
@@ -8,6 +8,10 @@ def toggle_enabled(slug, item, namespace=None):
     """
     Given a toggle and a username, whether the toggle is enabled for that user
     """
+    from corehq.toggles import NAMESPACE_EMAIL_DOMAIN
+    if namespace == NAMESPACE_EMAIL_DOMAIN and '@' in item:
+        item = item.split('@')[-1]
+
     item = namespaced_item(item, namespace)
     if not settings.UNIT_TESTING or getattr(settings, 'DB_ENABLED', True):
         toggle = Toggle.cached_get(slug)
@@ -48,9 +52,9 @@ def parse_toggle(entry):
     Split a toggle entry into the namespace an the item.
     :return: tuple(namespace, item)
     """
-    from corehq.toggles import NAMESPACE_DOMAIN
+    from corehq.toggles import NAMESPACE_DOMAIN, NAMESPACE_EMAIL_DOMAIN
     namespace = None
-    if entry.startswith(NAMESPACE_DOMAIN):
+    if entry.startswith(NAMESPACE_DOMAIN) or entry.startswith(NAMESPACE_EMAIL_DOMAIN):
         namespace, entry = entry.split(":")
     return namespace, entry
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -322,7 +322,7 @@ class PredictablyRandomToggle(StaticToggle):
             namespace = None  # because:
             # StaticToggle.__init__(): self.namespaces = [None if n == NAMESPACE_USER else n for n in namespaces]
 
-        all_namespaces = {None if n == NAMESPACE_USER else n for n in ALL_NAMESPACES}
+        all_namespaces = {None if n == NAMESPACE_USER else n for n in ALL_RANDOM_NAMESPACES}
         if namespace is Ellipsis and set(self.namespaces) != all_namespaces:
             raise ValueError(
                 'PredictablyRandomToggle.enabled() cannot be determined for toggle "{slug}" because it is not '
@@ -390,6 +390,7 @@ NAMESPACE_DOMAIN = 'domain'
 NAMESPACE_EMAIL_DOMAIN = 'email_domain'
 NAMESPACE_OTHER = 'other'
 ALL_NAMESPACES = [NAMESPACE_USER, NAMESPACE_DOMAIN, NAMESPACE_EMAIL_DOMAIN]
+ALL_RANDOM_NAMESPACES = [NAMESPACE_USER, NAMESPACE_DOMAIN]
 
 
 def any_toggle_enabled(*toggles):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1815,6 +1815,15 @@ ACCOUNTING_TESTING_TOOLS = StaticToggle(
 )
 
 
+DISABLE_HUBSPOT_DATA = StaticToggle(
+    'disable_hubspot_data',
+    'Disable collecting Hubspot data for users in these domains and '
+    'email-domains.',
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN, NAMESPACE_EMAIL_DOMAIN]
+)
+
+
 ADD_ROW_INDEX_TO_MOBILE_UCRS = StaticToggle(
     'add_row_index_to_mobile_ucrs',
     'Add row index to mobile UCRs as the first column to retain original order of data',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -183,6 +183,13 @@ class StaticToggle(object):
             NAMESPACE_DOMAIN in self.namespaces
             and hasattr(request, 'domain')
             and self.enabled(request.domain, namespace=NAMESPACE_DOMAIN)
+        ) or (
+            NAMESPACE_EMAIL_DOMAIN in self.namespaces
+            and hasattr(request, 'user')
+            and self.enabled(
+                request.user.email or request.user.username,
+                namespace=NAMESPACE_EMAIL_DOMAIN
+            )
         )
 
     def set(self, item, enabled, namespace=None):
@@ -380,8 +387,9 @@ class DynamicallyPredictablyRandomToggle(PredictablyRandomToggle):
 # if no namespaces are specified the user namespace is assumed
 NAMESPACE_USER = 'user'
 NAMESPACE_DOMAIN = 'domain'
+NAMESPACE_EMAIL_DOMAIN = 'email_domain'
 NAMESPACE_OTHER = 'other'
-ALL_NAMESPACES = [NAMESPACE_USER, NAMESPACE_DOMAIN]
+ALL_NAMESPACES = [NAMESPACE_USER, NAMESPACE_DOMAIN, NAMESPACE_EMAIL_DOMAIN]
 
 
 def any_toggle_enabled(*toggles):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11201

##### SUMMARY
There are a few issues with having a per-domain setting to turn off hubspot data, so this is my proposed solution.

First the issues. A domain object setting:
a) will be an expensive lookup when iterating through all recently active users and their domain memberships, as those domain objects will have to either be all queried individually for each user or this information will have to be part of the ES index. Seems rather cumbersome for what can be an easier solution
b) will be much more prone to user error / malice, as we will not be able to adequately monitor the setting being unchecked by another admin
c) can't be checked in a single place across all blocked domains unless we decide to create a separate view
d) users might initially sign up in a through a wrong domain, completely bypassing this domain-level setting

This solution avoids potentially expensive lookups. And with a new `NAMESPACE_EMAIL_DOMAIN` setting for `toggles`, we can block the email domains in `emails`/`usernames`, regardless of what `domain` that user might be a member of.

##### FEATURE FLAG
This is partially a feature for feature flags, and also a new feature flag `DISABLE_HUBSPOT_DATA`/"Disable collecting Hubspot data..."

##### RISK ASSESSMENT / QA PLAN
I'm going to plop this on staging for a few days just in case the new namespace causes any issues. I did my own testing locally, but I want to be doubly-sure
