### PR TITLE
pass timezone to formplayer

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/debugger/debugger.js
@@ -466,6 +466,7 @@ hqDefine('cloudcare/js/debugger/debugger', function () {
         },
         request: function (url, action, params) {
             params['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
+            params['tz_from_browser'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
             return $.ajax({
                 type: 'POST',
                 url: url + "/" + action,

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -115,6 +115,7 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
             requestParams['session_id'] = self.session_id;
             requestParams['debuggerEnabled'] = self.debuggerEnabled;
             requestParams['tz_offset_millis'] = (new Date()).getTimezoneOffset() * 60 * 1000 * -1;
+            requestParams['tz_from_browser'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
             return $.ajax({
                 type: 'POST',

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/menus/api.js
@@ -10,6 +10,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
             var user = FormplayerFrontend.getChannel().request('currentUser'),
                 lastRecordedLocation = FormplayerFrontend.getChannel().request('lastRecordedLocation'),
                 timezoneOffsetMillis = (new Date()).getTimezoneOffset() * 60 * 1000 * -1,
+                tzFromBrowser = Intl.DateTimeFormat().resolvedOptions().timeZone,
                 formplayerUrl = user.formplayer_url,
                 displayOptions = user.displayOptions || {},
                 defer = $.Deferred(),
@@ -105,6 +106,7 @@ hqDefine("cloudcare/js/formplayer/menus/api", function () {
                     "preview": params.preview,
                     "geo_location": lastRecordedLocation,
                     "tz_offset_millis": timezoneOffsetMillis,
+                    "tz_from_browser": tzFromBrowser,
                 });
                 options.url = formplayerUrl + '/' + route;
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/sessions/api.js
@@ -55,6 +55,7 @@ hqDefine("cloudcare/js/formplayer/sessions/api", function () {
                     "domain": user.domain,
                     "restoreAs": user.restoreAs,
                     "tz_offset_millis": (new Date()).getTimezoneOffset() * 60 * 1000 * -1,
+                    "tz_from_browser": Intl.DateTimeFormat().resolvedOptions().timeZone,
                 }),
                 url: formplayerUrl + '/incomplete-form',
                 success: function (request) {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11203

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In order to get the right timezone, we have to pass the timezone ID up to formplayer. 

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
Supported in all modern browsers (not IE) https://caniuse.com/mdn-javascript_builtins_intl_datetimeformat_resolvedoptions_computed_timezone

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
I pretty much grepped for `tz_offset_millis` and created another parameter for the timezone.  Found on [stackoverflow](https://stackoverflow.com/a/37512371), browsers seem to pass up the IANA timezone ID which to [an extent](https://stackoverflow.com/questions/45592878/java-doesnt-have-information-about-all-iana-time-zones) is supported by the Java TimeZone library. 


## Flow
[Browser](https://github.com/dimagi/commcare-hq/pull/28647) sends up IANA tz (e.g. "America/New_York"). ---> 
[Formplayer](https://github.com/dimagi/formplayer/pull/768) uses the tz from the browser as a info for its timezone provider --> 
[the shared commcare-core ](https://github.com/dimagi/commcare-core/pull/935)code that does date maniplations uses the timezone provider.

## Final Result
(deployed on staging)
<img width="455" alt="Screen Shot 2020-10-08 at 7 16 45 PM" src="https://user-images.githubusercontent.com/615126/95926009-340ed500-0d89-11eb-97b4-7e4ab38291a8.png">
Note: -5 from EST when current offset is -4 in EDT.