### PR TITLE
remove supply_point_dynamically_created soft assert

### DIFF
--- a/corehq/form_processor/backends/couch/supply.py
+++ b/corehq/form_processor/backends/couch/supply.py
@@ -5,12 +5,6 @@ from dimagi.utils.couch.database import iter_docs
 from corehq.apps.commtrack.helpers import make_supply_point
 from corehq.apps.commtrack.models import SupplyPointCase
 from corehq.form_processor.abstract_models import AbstractSupplyInterface
-from corehq.util.soft_assert import soft_assert
-
-_supply_point_dynamically_created = soft_assert(
-    to='{}@{}'.format('skelly', 'dimagi.com'),
-    exponential_backoff=False,
-)
 
 
 class SupplyPointCouch(AbstractSupplyInterface):
@@ -20,14 +14,6 @@ class SupplyPointCouch(AbstractSupplyInterface):
         sp = location.linked_supply_point()
         if not sp:
             sp = make_supply_point(location.domain, location)
-
-            if not settings.UNIT_TESTING:
-                _supply_point_dynamically_created(False, 'supply_point_dynamically_created, {}, {}, {}'.format(
-                    location.name,
-                    sp.case_id,
-                    location.domain,
-                ))
-
         return sp
 
     @classmethod

--- a/corehq/form_processor/backends/sql/supply.py
+++ b/corehq/form_processor/backends/sql/supply.py
@@ -1,14 +1,6 @@
-from django.conf import settings
-
 from corehq.apps.commtrack.helpers import make_supply_point
 from corehq.form_processor.abstract_models import AbstractSupplyInterface
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.util.soft_assert import soft_assert
-
-_supply_point_dynamically_created = soft_assert(
-    to='{}@{}'.format('skelly', 'dimagi.com'),
-    exponential_backoff=False,
-)
 
 
 class SupplyPointSQL(AbstractSupplyInterface):
@@ -18,14 +10,6 @@ class SupplyPointSQL(AbstractSupplyInterface):
         sp = SupplyPointSQL.get_by_location(location)
         if not sp:
             sp = make_supply_point(location.domain, location)
-
-            if not settings.UNIT_TESTING:
-                _supply_point_dynamically_created(False, 'supply_point_dynamically_created, {}, {}, {}'.format(
-                    location.name,
-                    sp.case_id,
-                    location.domain,
-                ))
-
         return sp
 
     @classmethod


### PR DESCRIPTION
These were originally added as logging and then converted to soft asserts:
* https://github.com/dimagi/commcare-hq/commit/e1a9033f2b544a66e5a90b5e646d9430cf467362#diff-b4d5f0320423b15a52b6a4690abbe820913743223a73ff9b9ec06660f39e782bR19
* https://github.com/dimagi/commcare-hq/commit/8cb3761f937a45dd77b3298ada33d5053e018e71

I no longer recall why this was an issue (I think it was just an optimisation).