### PR TITLE
Safety check before creating rate limit log entry

### DIFF
--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -145,6 +145,8 @@ def rate_limit_two_factor_setup(device):
         if status == _status_accepted:
             _report_usage(ip_address, number, username)
         else:
+            window = window or 'unknown'
+            status = status or 'unknown'
             # log any attempts that are rate limited
             RateLimitedTwoFactorLog.objects.create(ip_address=ip_address, phone_number=number,
                                                    username=username, method=method, status=status,

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -145,8 +145,6 @@ def rate_limit_two_factor_setup(device):
         if status == _status_accepted:
             _report_usage(ip_address, number, username)
         else:
-            window = window or 'unknown'
-            status = status or 'unknown'
             # log any attempts that are rate limited
             RateLimitedTwoFactorLog.objects.create(ip_address=ip_address, phone_number=number,
                                                    username=username, method=method, status=status,

--- a/corehq/apps/hqwebapp/two_factor_gateways.py
+++ b/corehq/apps/hqwebapp/two_factor_gateways.py
@@ -147,8 +147,8 @@ def rate_limit_two_factor_setup(device):
         else:
             # log any attempts that are rate limited
             RateLimitedTwoFactorLog.objects.create(ip_address=ip_address, phone_number=number,
-                                                   username=username, method=method, status=status,
-                                                   window=window)
+                                                   username=username, method=method,
+                                                   status=status or 'unknown', window=window or 'unknown')
 
     else:
         window = None

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -32,7 +32,7 @@ class RateLimitedTwoFactorLog(models.Model):
     phone_number = models.CharField(max_length=127, null=False, db_index=True)
     # 'sms', 'call' don't expect this to change
     method = models.CharField(max_length=4, null=False)
-    # 'second' and 'minute' are 6 characters, 15 for headroom
+    # largest input is 'unknown', 15 for headroom
     window = models.CharField(max_length=15, null=False)
-    # 'number_rate_limited' is 19 characters, 31 for headroom
+    # largest input is 'number_rate_limited', 31 for headroom
     status = models.CharField(max_length=31, null=False)

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -36,3 +36,8 @@ class RateLimitedTwoFactorLog(models.Model):
     window = models.CharField(max_length=15, null=False)
     # 'number_rate_limited' is 19 characters, 31 for headroom
     status = models.CharField(max_length=31, null=False)
+
+    def save(self, *args, **kwargs):
+        kwargs['window'] = kwargs['window'] or 'unknown'
+        kwargs['status'] = kwargs['status'] or 'unknown'
+        super(RateLimitedTwoFactorLog, self).save(*args, **kwargs)

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -36,8 +36,3 @@ class RateLimitedTwoFactorLog(models.Model):
     window = models.CharField(max_length=15, null=False)
     # 'number_rate_limited' is 19 characters, 31 for headroom
     status = models.CharField(max_length=31, null=False)
-
-    def save(self, *args, **kwargs):
-        kwargs['window'] = kwargs['window'] or 'unknown'
-        kwargs['status'] = kwargs['status'] or 'unknown'
-        super(RateLimitedTwoFactorLog, self).save(*args, **kwargs)

--- a/corehq/project_limits/models.py
+++ b/corehq/project_limits/models.py
@@ -32,7 +32,7 @@ class RateLimitedTwoFactorLog(models.Model):
     phone_number = models.CharField(max_length=127, null=False, db_index=True)
     # 'sms', 'call' don't expect this to change
     method = models.CharField(max_length=4, null=False)
-    # 'second' and 'minute' are 6 characters, 16 for headroom
+    # 'second' and 'minute' are 6 characters, 15 for headroom
     window = models.CharField(max_length=15, null=False)
-    # 'number_rate_limited' is 19 characters, 32 for headroom
+    # 'number_rate_limited' is 19 characters, 31 for headroom
     status = models.CharField(max_length=31, null=False)


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With the downtime I had to think while deploying this [PR](https://github.com/dimagi/commcare-hq/pull/28639), a wave of paranoia came over me and I figured it would be good to add these checks on non-null fields before attempting to create the rate limited log object.

Assuming an exception is thrown if a field is null, maybe it would be even better to catch an exception raised upon insertion? 
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
