### PR TITLE
Resolve xframe options warning

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -18,6 +18,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.views.generic.base import TemplateView
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 
 import six.moves.urllib.error
 import six.moves.urllib.parse
@@ -289,6 +290,7 @@ class PreviewAppView(TemplateView):
     template_name = 'preview_app/base.html'
     urlname = 'preview_app'
 
+    @xframe_options_sameorigin
     def get(self, request, *args, **kwargs):
         app = get_app(request.domain, kwargs.pop('app_id'))
         return self.render_to_response({

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -41,6 +41,7 @@ from django.utils.translation import ugettext_noop
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_GET, require_POST
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.generic import TemplateView
 from django.views.generic.base import View
 
@@ -468,6 +469,7 @@ def domain_login(req, domain, custom_template_name=None, extra_context=None):
     return _login(req, domain, custom_template_name, extra_context)
 
 
+@xframe_options_sameorigin
 @location_safe
 def iframe_domain_login(req, domain):
     return domain_login(req, domain, custom_template_name="hqwebapp/iframe_domain_login.html", extra_context={

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -548,6 +548,7 @@ def login_new_window(request):
     return render_static(request, "hqwebapp/close_window.html", _("Thank you for logging in!"))
 
 
+@xframe_options_sameorigin
 @location_safe
 @login_required
 def iframe_domain_login_new_window(request):

--- a/settings.py
+++ b/settings.py
@@ -164,6 +164,8 @@ MIDDLEWARE = [
     'corehq.apps.cloudcare.middleware.CloudcareMiddleware',
 ]
 
+X_FRAME_OPTIONS = 'DENY'
+
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 # time in minutes before forced logout due to inactivity


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Resolve security warnings](https://dimagi-dev.atlassian.net/browse/SAAS-11207)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This addresses resolving one of the warnings from the ticket above.

My understanding is the `@xframe_options_sameorigin` decorator applies to commcare views that we intend to load inside of a frame, not views that contain a frame. 

The ability for 3rd party views to load inside of a frame are dictated by the 3rd party developers. So for example, our site contains an iframe that loads a page from google tag manager. Those developers are responsible for allowing that page to load inside of a frame regardless of the origin of the request.

In our case we need to apply the decorator to views that we know are loaded inside of a frame, but only when the request originates from our site. The default behavior for pages will be to never allow loading inside of a frame, regardless of origin.

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
Yes. [Ticket here](https://dimagi-dev.atlassian.net/browse/QA-2069)
##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
