### PR TITLE
Added README for django apps

### DIFF
--- a/corehq/README.rst
+++ b/corehq/README.rst
@@ -6,7 +6,7 @@ A few broad areas of functionality are stored directly in this directory.
 apps
     Most functionality lives in this directory. See README in this directory for details.
 blobs
-    The blob db stores large, schema-less pieces of data. It's where XForms and multimedia are stored.
+    The blob db stores large pieces of binary data. It's where form XML, multimedia, exports, temporary files, etc. are stored.
 celery_monitoring
     Tools to monitor `Celery <https://docs.celeryproject.org/en/stable/>`_, which we use for async task processing.
 couchapps

--- a/corehq/README.rst
+++ b/corehq/README.rst
@@ -26,9 +26,9 @@ messaging
     Code to manage direct-to-user messages in CommCare HQ, most often SMS but also channels like email and
     whatsapp. Also see the ``sms`` and ``sms`` apps in ``corehq.apps``.
 motech
-    Code relating to `MOTECH <http://docs.motechproject.org/en/latest/>`_, an open source mHealth platform that HQ
-    integrates with, particularly on large solutions projects, that also integrate with other systems such as DHIS2
-    and OpenClinica.
+    MOTECH is CommCare HQ's integration layer, and allows HQ to forward data to
+    remote systems' APIs, to import data from them, and to follow workflows for
+    more complex integrations with systems like OpenMRS and DHIS2.
 pillows
     HQ-specific mappings that use the ``pillowtop`` framework in ``ex-submodules``.
 preindex

--- a/corehq/README.rst
+++ b/corehq/README.rst
@@ -23,7 +23,7 @@ fluff
 form_processor
     Code to handle receiving, processing, and storing form submissions from CommCare mobile and Web Apps.
 messaging
-    Code to manage direct-to-user messages in CammCare HQ, most often SMS but also channels like email and
+    Code to manage direct-to-user messages in CommCare HQ, most often SMS but also channels like email and
     whatsapp. Also see the ``sms`` and ``sms`` apps in ``corehq.apps``.
 motech
     Code relating to `MOTECH <http://docs.motechproject.org/en/latest/>`_, an open source mHealth platform that HQ

--- a/corehq/README.rst
+++ b/corehq/README.rst
@@ -1,0 +1,57 @@
+corehq
+############################
+
+A few broad areas of functionality are stored directly in this directory.
+
+apps
+    Most functionality lives in this directory. See README in this directory for details.
+blobs
+    The blob db stores large, schema-less pieces of data. It's where XForms and multimedia are stored.
+celery_monitoring
+    Tools to monitor `Celery <https://docs.celeryproject.org/en/stable/>`_, which we use for async task processing.
+couchapps
+    Certain couch views are stored here, instead of inside the relevant django app, because storing them separately
+    gives us performance benefits.
+dbaccessors
+    Part of ``couchapps``
+ex-submodules
+    Assorted functionality that used to live in separate repositories. See README in this directory for details.
+extensions
+    Framework for extending HQ functionality is a fork-like way. Used to handle code specific to ICDS-CAS.
+fluff
+    HQ-specific calculations that work with the ``fluff`` code in ``ex-submodules``.
+form_processor
+    Code to handle receiving, processing, and storing form submissions from CommCare mobile and Web Apps.
+messaging
+    Code to manage direct-to-user messages in CammCare HQ, most often SMS but also channels like email and
+    whatsapp. Also see the ``sms`` and ``sms`` apps in ``corehq.apps``.
+motech
+    Code relating to `MOTECH <http://docs.motechproject.org/en/latest/>`_, an open source mHealth platform that HQ
+    integrates with, particularly on large solutions projects, that also integrate with other systems such as DHIS2
+    and OpenClinica.
+pillows
+    HQ-specific mappings that use the ``pillowtop`` framework in ``ex-submodules``.
+preindex
+    Code for handling preindexing, which updates CouchDB views and ElasticSearch indices.
+    Preindex is run as part of deploy and can also be run ad hoc.
+privileges.py
+    Privileges allow HQ to limit functionality based on software plan.
+project_limits
+    Framework for throttling actions like form submissions on a domain-specific basis.
+sql_accessors
+    Stores custom postgres functions.
+sql_db
+    TODO
+sql_proxy_accessors
+    Stores custom postgres functions that use `PL/Proxy <https://plproxy.github.io/>`_.
+sql_proxy_standby_accessors
+    Stores custom postgres functions relevant to standby servers.
+tabs
+    Menu structure for CommCare HQ.
+tests
+    Contains a few tests for high-level functionality like locks, as well as tooling to run tests with
+    `nose <https://nose.readthedocs.io/en/latest/>`_, an extension of ``unittest``.
+toggles.py
+    Toggles allow limiting functionality based on user or domain. Also see ``ex-submodules/toggle`` and ``corehq.apps.toggle_ui``.
+util
+    Miscellaneous utilities. Also see ``ex-submodules/dimagi``.

--- a/corehq/README.rst
+++ b/corehq/README.rst
@@ -24,7 +24,7 @@ form_processor
     Code to handle receiving, processing, and storing form submissions from CommCare mobile and Web Apps.
 messaging
     Code to manage direct-to-user messages in CommCare HQ, most often SMS but also channels like email and
-    whatsapp. Also see the ``sms`` and ``sms`` apps in ``corehq.apps``.
+    whatsapp. Also see the ``sms`` and ``smsforms`` apps in ``corehq.apps``.
 motech
     MOTECH is CommCare HQ's integration layer, and allows HQ to forward data to
     remote systems' APIs, to import data from them, and to follow workflows for

--- a/corehq/README.rst
+++ b/corehq/README.rst
@@ -17,7 +17,7 @@ dbaccessors
 ex-submodules
     Assorted functionality that used to live in separate repositories. See README in this directory for details.
 extensions
-    Framework for extending HQ functionality is a fork-like way. Used to handle code specific to ICDS-CAS.
+    Framework for extending HQ functionality in a fork-like way. Used to handle code specific to ICDS-CAS.
 fluff
     HQ-specific calculations that work with the ``fluff`` code in ``ex-submodules``.
 form_processor

--- a/corehq/README.rst
+++ b/corehq/README.rst
@@ -41,7 +41,7 @@ project_limits
 sql_accessors
     Stores custom postgres functions.
 sql_db
-    TODO
+    Code related to partitioning postgres.
 sql_proxy_accessors
     Stores custom postgres functions that use `PL/Proxy <https://plproxy.github.io/>`_.
 sql_proxy_standby_accessors

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -70,9 +70,7 @@ data_interfaces
    Functionality for taking a few specific actions on project data, such as reassigning cases in bulk.
    Most of this app relies heavily on standard reporting functionality.
 fixtures
-   "Fixtures" is used generally in the codebase to refer to datasets sent to the phone, which includes the
-   casedb, mobile report data, etc., but the fixtures app primarily deals with one specific type of fixture,
-   which is lookup tables.
+   The term "fixtures" comes from the `XML data model <https://github.com/dimagi/commcare-core/wiki/fixtures>`_ used to send custom structured data to the mobile devices (separate from case data). During the sync request with the mobile device, various different fixtures may be sent to the device including lookup tables, locations and mobile reports. This Django app only deals with the "lookup table" fixtures. It provides the UI for creating and editing them and the code to serialize them to XML.
 groups
    Users can be assigned to groups for the purposes of sharing cases within a group and for reporting purposes.
 hqadmin

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -34,6 +34,8 @@ hqwebapp
    javascript widgets, login views, etc.
 locations
    Locations provide a hierarchical way to organize CommCare users and data.
+ota
+   Contains a number of the API endpoints used by CommCare mobile including sync / restore, case search, case claim, heartbeat and  recovery measures.
 reports
    Standard, pre-canned reports to view project data: Submit History, Worker Activity Report, etc.
 reports_core
@@ -117,8 +119,6 @@ mobile_auth
 notifications
    "Banner" notifications used by the support team to notify users of upcoming downtime,
    ongoing issues, etc.
-ota
-   Contains a number of the API endpoints used by CommCare mobile including sync / restore, case search, case claim, heartbeat and  recovery measures.
 receiverwrapper
    Contains the API for receiving XML form submissions. This app mostly deals with the interfacing portion of the
    API including auth, rate limiting etc. but not the actual data processing which is contained in the

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -154,7 +154,10 @@ data_pipeline_audit
    Tools used to audit the async data pipeline (change feeds / pillows) to validate the integrity of secondary
    sources (mostly Elasticsearch). These tools are not used routinely.
 domain_migration_flags
-   TODO
+   Dynamic flags that are used to indicate when a data migration is taking place for a specific domain. The flags are
+   checked in various places thought the code and will restrict access to certain features when enabled. These flags
+   are set during large data migrations such as moving case & form data from Couch -> SQL, migrating a domain to a
+   different CommCare instance.
 dump_reload
    TODO
 es

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -170,7 +170,7 @@ hqcase
 mocha
    JavaScript testing framework.
 tzmigration
-   TODO
+   This relates to a timezone migration doine in 2015. See `#6341 <https://github.com/dimagi/commcare-hq/pull/6341>`_ if curious.
 
 Limited-Use and Retired Apps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -182,7 +182,7 @@ These apps are limited to a small set of clients or on a deprecation path.
 appstore
    The CommCare Exchange, a deprecated feature that allowed projects to publish their projects in a self-service manner
    and download other organizations' projects. This process is now supported internally by the support team. The UI
-   portions of this app have been removed, but the data models are still necessary for the internal process.
+   portions of this app have been removed, but the data models are still necessary for the internal processes.
 callcenter
    The call center application setting allows an application to reference a mobile user as a case that can be monitored using CommCare.  This allows supervisors to view their workforce within CommCare.
 casegroups

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -168,7 +168,7 @@ hqcase
 mocha
    JavaScript testing framework.
 tzmigration
-   This relates to a timezone migration doine in 2015. See `#6341 <https://github.com/dimagi/commcare-hq/pull/6341>`_ if curious.
+   This relates to a timezone migration done in 2015. See `#6341 <https://github.com/dimagi/commcare-hq/pull/6341>`_ if curious.
 
 Limited-Use and Retired Apps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -161,7 +161,7 @@ data_pipeline_audit
    sources (mostly Elasticsearch). These tools are not used routinely.
 domain_migration_flags
    Dynamic flags that are used to indicate when a data migration is taking place for a specific domain. The flags are
-   checked in various places thought the code and will restrict access to certain features when enabled. These flags
+   checked in various places throughout the code and will restrict access to certain features when enabled. These flags
    are set during large data migrations such as moving case & form data from Couch -> SQL, migrating a domain to a
    different CommCare instance.
 dump_reload

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -77,7 +77,7 @@ linked_domain
    Functionality to share certain configuration data between domains: apps, lookup tables, report definitions, etc.
    Work is done in a primary "upstream" domain, and then that domain's data models are copied to one or more
    "downstream" domains. This is most often used to set up a development => production workflow, where changes are made
-   in the development domain and then pushed to the production domain, where is where real project data is entered.
+   in the development domain and then pushed to the production domain, where real project data is entered.
    Linked domains are also used by certain enterprise-type projects that manage one program across multiple regions
    and use a separate downstream domain for each region.
 registration

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -105,7 +105,7 @@ analytics
 builds
    Models relating to CommCare Mobile builds, so that app builders can control which mobile version their apps use.
 case_search
-   TODO
+   Models and utils related to searching for cases using Elasticsearch. Used for Case Claim and the Case List Explorer. 
 dashboard
    The tiled UI that acts as the main landing page for HQ.
 formplayer_api

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -13,7 +13,7 @@ api
    APIs to read and write CommCare data for a given project space. Most APIs are externally facing however there a 
    are a few that are used internally e.g. for report filters. APIs are built using Tastypie.
 app_manager
-   UI for configuring and releasing CommCare applications.
+   UI and tooling for configuring and releasing CommCare applications.
    Form Builder, for configuring forms themselves, is called here but
    it primarily stored in the separate `Vellum <https://github.com/dimagi/Vellum/>`_ repo.
 cloudcare

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -159,7 +159,7 @@ domain_migration_flags
    are set during large data migrations such as moving case & form data from Couch -> SQL, migrating a domain to a
    different CommCare instance.
 dump_reload
-   TODO
+   Tools used to dump a domain's data to disk and reload it from disk. This is used to move a domain from one CommCare instance to another e.g. from a managed environment to self hosted environment.
 es
    Internal APIs for creating and running ElasticSearch queries.
 hqcase

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -14,7 +14,7 @@ accounting
    This includes the UI for internal operations users to modify these objects.
    Accessing this UI requires running the ``add_operations_user`` command.
 api
-   APIs to read and write CommCare data for a given project space. Most APIs are externally facing. However there a 
+   APIs to read and write CommCare data for a given project space. Most APIs are externally facing. However, there
    are a few that are used internally e.g. for report filters. APIs are built using Tastypie.
 app_manager
    UI and tooling for configuring and releasing CommCare applications.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -100,7 +100,7 @@ Tertiary Apps
 These apps may be useful parts of the system but don't have as much active development as the groups above.
 
 aggregate_ucrs
-   TODO
+   An experimental framework for creating more complex reporting pipelines based off the UCR framework.
 analytics
    Integrations with third-party analytics tools such as Google Analytics and Kissmetrics.
    Also contains internal product-focused tools such as AB testing functionality.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -62,7 +62,8 @@ custom_data_fields
    be referenced in applications.
 data_dictionary
    The data dictionary documents a project's data model, specifically, its case types and case properties.
-   This makes it possible to reference those definitions throughout the app-building process.
+   This makes it possible to reference those definitions throughout the app-building process without needing
+   to repeatedly re-parse it out of the application configuration.
    The data dictionary is used partially for project documentation but is also referenced in a few other
    parts of HQ: for example, when configuring case properties to be updated in a form, app manager will
    pull the properties' descriptions from the data dictionary.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -94,7 +94,7 @@ reminders
 saved_reports
    Functionality to let users save a specific set of report filters and optionally run reports with those filters on a scheduled basis.
 toggle_ui
-   Framework for feature flags, which are used to limit internal feature to specific domains and/or users.
+   Framework for feature flags, which are used to limit internal features to specific domains and/or users.
 translations
    Functionality for managing application translations, including integration with Transifex, which is used by a small number of projects.
 user_importer

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -108,6 +108,8 @@ analytics
    Also contains internal product-focused tools such as AB testing functionality.
 builds
    Models relating to CommCare Mobile builds, so that app builders can control which mobile version their apps use.
+   Some of this app relates to J2ME builds: historically, CommCare mobile supported both J2ME and Android devices.
+   The J2ME functionality is largely deprecated, but most of the related code remains, in both this app and ``app_manager``.
 case_search
    Models and utils related to searching for cases using Elasticsearch. Used for Case Claim and the Case List Explorer. 
 dashboard

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -1,0 +1,11 @@
+Django Apps in CommCareHQ
+#########################
+
+Frequently-Used Apps
+^^^^^^^^^^^^^^^^^^^^
+
+Moderately-Used Apps
+^^^^^^^^^^^^^^^^^^^^
+
+Rarely-Used Apps
+^^^^^^^^^^^^^^^^

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -15,7 +15,7 @@ api
 app_manager
    UI and tooling for configuring and releasing CommCare applications.
    Form Builder, for configuring forms themselves, is called here but
-   it primarily stored in the separate `Vellum <https://github.com/dimagi/Vellum/>`_ repo.
+   is primarily stored in the separate `Vellum <https://github.com/dimagi/Vellum/>`_ repo.
 cloudcare
    Web Apps, a web-based interface for data entry, with essentially the same functionality
    as CommCare Mobile, but available via HQ to both web and mobile users. This app contains the HQ

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -6,88 +6,185 @@ Primary Apps
 These apps are major parts of the system and most have frequent, active development.
 
 accounting
+   Billing functionality: accounts, subscriptions, software plans, etc.
+   This includes the UI for internal operations users to modify these objects.
+   Accessing this UI requires running the ``add_operations_user`` command.
 api
+   Externally-facing APIs to read and write CommCare data for a given project space.
 app_manager
+   UI for configuring and releasing CommCare applications.
+   Form Builder, for configuring forms themselves, is called here but
+   it primarily stored in the separate `Vellum <https://github.com/dimagi/Vellum/>`_ repo.
 cloudcare
+   Web Apps, a web-based interface for data entry, with essentially the same functionality
+   as CommCare Mobile, but available via HQ to both web and mobile users. This app contains the HQ
+   parts of this code, which interfaces with `Formplayer <https://github.com/dimagi/formplayer/>`_
+   to ultimately run functionality in the `commcare-core <https://github.com/dimagi/commcare-core/>`_
+   repo, which is shared with CommCare Mobile.
 domain
+   Domains, called "project spaces" in user-facing content, are the core sandboxes of CommCare. Almost
+   all features and UIs in CommCare are in the context of a domain.
 export
-fixtures
-hqcase
+   Configurations for exporting project data, typically forms or cases, to an excel download.
 hqmedia
+   Multimedia handling, primarily used in applications.
 hqwebapp
+   Core UI code for the HQ site. Includes things like the standard error pages,
+   javascript widgets, login views, etc.
 locations
+   Locations provide a hierarchical way to organize CommCare users and data.
 reports
+   Standard, pre-canned reports to view project data: Submit History, Worker Activity Report, etc.
 reports_core
+   More reporting code.
 sms
+   Features to send SMS and emails via CommCare HQ. Much of the underlying code is in ``corehq.messaging``.
 userreports
+   User-defined reports. Intertwined with other report-related apps.
 users
+   Users of CommCare HQ and/or CommCare mobile. The primary class dealing with users is ``CouchUser``,
+   a representation of the user in couch. ``CouchUser`` has the subclasses ``WebUser`` and ``CommCareUser``
+   to distinguish between admin-type users who primarily use CommCare HQ and data entry users who primarily use
+   CommCare Mobile. The distinction between web and mobile users is blurry, especially with the advent of
+   Web Apps for data entry in HQ.
 
 Secondary Apps
 ^^^^^^^^^^^^^^^^^^^^
 These apps are maintained and updated regularly, but are a bit less core than the set above.
 
+case_importer
+   Bulk import of cases.
 custom_data_fields
+   This allows users to add arbitrary data to mobile users, locations, and products, which can then
+   be referenced in applications.
 data_dictionary
+   A set of models that a project can use to define its data model: case types and case properties.
+   The data dictionary is used partially for project documentation but is also referenced in a few other
+   parts of HQ: for example, when configuring case properties to be updated in a form, app manager will
+   pull the properties' descriptions from the data dictionary.
 data_interfaces
+   Functionality for taking a few specific actions on project data, such as reassigning cases in bulk.
+   Most of this app relies heavily on standard reporting functionality.
+fixtures
+   "Fixtures" is used generally in the codebase to refer to datasets sent to the phone, which includes the
+   casedb, mobile report data, etc., but the fixtures app primarily deals with one specific type of fixture,
+   which is lookup tables.
 groups
+   Users can be assigned to groups for the purposes of sharing cases within a group and for reporting purposes.
 hqadmin
+   Internal admin functionality used by the development, support, QA, and product teams.
 linked_domain
+   Functionality to share certain configuration data between domains: apps, lookup tables, report definitions, etc.
+   Work is done in a primary "upstream" domain, and then that domain's data models are copied to one or more
+   "downstream" domains. This is most often used to set up a development => production workflow, where changes are made
+   in the development domain and then pushed to the production domain, where is where real project data is entered.
+   Linekd domains are also used by certain enterprise-type projects that manage one program across multiple regions
+   and use a separate downstream domain for each region.
 registration
+   Workflows for creating new accounts on HQ.
 reminders
+   A subset of SMS/messaging, including functionality around incoming SMS keywords. "Reminders" is a leftover term from a previous iteration of the messaging framework.
 saved_reports
+   Functionality to let users save a specific set of report filters and optionally run reports with those filters on a scheduled basis.
 toggle_ui
+   Framework for feature flags, which are used to limit internatl feature to specific domains and/or users.
 translations
+   Functionality for managing application translations, including integration with Transifex, which is used by a small number of projects.
 user_importer
+   Bulk importing of users.
 
 Tertiary Apps
 ^^^^^^^^^^^^^
 These apps may be useful parts of the system but don't have as much active development as the groups above.
 
 aggregate_ucrs
+   TODO
 analytics
+   Integrations with third-party analytics tools such as Google Analytics and Kissmetrics.
+   Also contains internal product-focused tools such as AB testing functionality.
 builds
-case_importer
+   Models relating to CommCare Mobile builds, so that app builders can control which mobile version their apps use.
 case_search
+   TODO
 dashboard
+   The tiled UI that acts as the main landing page for HQ.
 formplayer_api
+   Functionality interacting with formplayer, primarily used by SMS surveys.
 mobile_auth
+   Generates the XML needed to authorize mobile users.
 notifications
+   "Banner" notifications used by the support team to notify users of upcoming downtime,
+   ongoing issues, etc.
 ota
+   Functionality at the interface of CommCare HQ and CommCare Mobile: demo users, device logs, mobile recovery, etc.
 receiverwrapper
+   TODO
 settings
+   API keys and 2FA functionality.
 smsbillables
+   Billing functionality relating to charging for SMS, allowing us to pass carrier charges on to clients.
 smsforms
+   SMS surveys, a part of messaging that allow end users to interact with a CommCare form via SMS instead of
+   via mobile or Web Apps.
 styleguide
+   Documentation of best practices for UI development, including live examples of common patterns.
 zapier
+   Integration with `Formplayer <https://zapier.com/>`_
 
 Engineering Apps
 ^^^^^^^^^^^^^^^^
 These apps are developer-facing tools.
 
 cachehq
+   Caching functinality for CouchDB.
 case_migrations
+   Functionality to support users defining and excuting data migrations on cases. Candidate for deprecation.
 change_feed
+   Infrastructure for propagating changes in primary data stores (couch, postgres) to secondary sources (ElasticSearch).
 cleanup
+   Miscellaneous commands for cleaning up data: deleting duplicate mobile users, deleting couch documents for models that have been moved to postgres, etc.
 couch_sql_migration
+   Utiltiy code for migration form and case data from couch to postgres.
 data_analytics
+   Internal impact-related metrics.
 data_pipeline_audit
+   TODO
 domain_migration_flags
+   TODO
 dump_reload
+   TODO
 es
+   Internal APIs for creating and running ElasticSearch queries.
+hqcase
+   Utility functions for handling cases, such as the ability to programmatically submit cases.
 mocha
+   JavaScript testing framework.
 tzmigration
+   TODO
 
 Limited-Use and Retired Apps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 These apps are limited to a small set of clients or on a deprecation path.
 
 appstore
+   The CommCare Exchange, a deprecated feature that allowed projects to publish their projects in a self-service manner
+   and download other organizations' projects. This process is now supported internally by the support team. The UI
+   portions of this app have been removed, but the data models are still necessary for the internal process.
 callcenter
+   The call center application setting allows an application to reference a mobile user as a case that can be monitored using CommCare.  This allows supervisors to view their workforce within CommCare.
 casegroups
+   Functionality around grouping cases in large projects and then taking action on those groups.
 commtrack
+   CommCare Supply, a large and advanced set of functionality for using CommCare in logistics management.
 consumption
+   Part of CommCare Supply.
 dropbox
+   Functionality to allow users to download large HQ files to dropbox instead of their local machines. This is likely being deprecated.
 integration
+   Various integrations with biometrics devices, third-party APIs, etc.
 ivr
+   Functionality to allow users to fill out forms using interactive voice response. Largely deprecated.
 products
+   Part of CommCare Supply.
 programs
+   Part of CommCare Supply.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -1,6 +1,10 @@
 Django Apps in CommCareHQ
 #########################
 
+Most CommCare HQ functionality is contained in a django app.
+A few areas are contained in ``corehq`` or ``corehq/ex-submodules``,
+so for a full overview, check those READMEs as well.
+
 Primary Apps
 ^^^^^^^^^^^^
 These apps are major parts of the system and most have frequent, active development.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -58,7 +58,8 @@ custom_data_fields
    This allows users to add arbitrary data to mobile users, locations, and products, which can then
    be referenced in applications.
 data_dictionary
-   A set of models that a project can use to define its data model: case types and case properties.
+   The data dictionary documents a project's data model, specifically, its case types and case properties.
+   This makes it possible to reference those definitions throughout the app-building process.
    The data dictionary is used partially for project documentation but is also referenced in a few other
    parts of HQ: for example, when configuring case properties to be updated in a form, app manager will
    pull the properties' descriptions from the data dictionary.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -133,8 +133,8 @@ settings
 smsbillables
    Billing functionality relating to charging for SMS, allowing us to pass carrier charges on to clients.
 smsforms
-   SMS surveys, a part of messaging that allow end users to interact with a CommCare form via SMS instead of
-   via mobile or Web Apps.
+   SMS surveys allow end users to interact with a CommCare form via SMS instead of
+   via mobile or Web Apps. This is part of ``messaging``.
 styleguide
    Documentation of best practices for UI development, including live examples of common patterns.
 zapier

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -87,7 +87,7 @@ reminders
 saved_reports
    Functionality to let users save a specific set of report filters and optionally run reports with those filters on a scheduled basis.
 toggle_ui
-   Framework for feature flags, which are used to limit internatl feature to specific domains and/or users.
+   Framework for feature flags, which are used to limit internal feature to specific domains and/or users.
 translations
    Functionality for managing application translations, including integration with Transifex, which is used by a small number of projects.
 user_importer

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -119,7 +119,9 @@ notifications
 ota
    Functionality at the interface of CommCare HQ and CommCare Mobile: demo users, device logs, mobile recovery, etc.
 receiverwrapper
-   TODO
+   Contains the API for receiving XML form submissions. This app mostly deals with the interfacing portion of the
+   API including auth, rate limiting etc. but not the actual data processing which is contained in the
+   `form_processor` app.
 settings
    API keys and 2FA functionality.
 smsbillables

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -37,7 +37,7 @@ locations
 reports
    Standard, pre-canned reports to view project data: Submit History, Worker Activity Report, etc.
 reports_core
-   More reporting code.
+   More reporting code that resulted from an attempt to re-architect the report class structure.
 sms
    Features to send SMS and emails via CommCare HQ. Much of the underlying code is in ``corehq.messaging``.
 userreports

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -78,7 +78,7 @@ linked_domain
    Work is done in a primary "upstream" domain, and then that domain's data models are copied to one or more
    "downstream" domains. This is most often used to set up a development => production workflow, where changes are made
    in the development domain and then pushed to the production domain, where is where real project data is entered.
-   Linekd domains are also used by certain enterprise-type projects that manage one program across multiple regions
+   Linked domains are also used by certain enterprise-type projects that manage one program across multiple regions
    and use a separate downstream domain for each region.
 registration
    Workflows for creating new accounts on HQ.

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -151,7 +151,8 @@ couch_sql_migration
 data_analytics
    Internal impact-related metrics.
 data_pipeline_audit
-   TODO
+   Tools used to audit the async data pipeline (change feeds / pillows) to validate the integrity of secondary
+   sources (mostly Elasticsearch). These tools are not used routinely.
 domain_migration_flags
    TODO
 dump_reload

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -1,11 +1,93 @@
 Django Apps in CommCareHQ
 #########################
 
-Frequently-Used Apps
-^^^^^^^^^^^^^^^^^^^^
+Primary Apps
+^^^^^^^^^^^^
+These apps are major parts of the system and most have frequent, active development.
 
-Moderately-Used Apps
-^^^^^^^^^^^^^^^^^^^^
+accounting
+api
+app_manager
+cloudcare
+domain
+export
+fixtures
+hqcase
+hqmedia
+hqwebapp
+locations
+reports
+reports_core
+sms
+userreports
+users
 
-Rarely-Used Apps
+Secondary Apps
+^^^^^^^^^^^^^^^^^^^^
+These apps are maintained and updated regularly, but are a bit less core than the set above.
+
+custom_data_fields
+data_dictionary
+data_interfaces
+groups
+hqadmin
+linked_domain
+registration
+reminders
+saved_reports
+toggle_ui
+translations
+user_importer
+
+Tertiary Apps
+^^^^^^^^^^^^^
+These apps may be useful parts of the system but don't have as much active development as the groups above.
+
+aggregate_ucrs
+analytics
+builds
+case_importer
+case_search
+dashboard
+formplayer_api
+mobile_auth
+notifications
+ota
+receiverwrapper
+settings
+smsbillables
+smsforms
+styleguide
+zapier
+
+Engineering Apps
 ^^^^^^^^^^^^^^^^
+These apps are developer-facing tools.
+
+cachehq
+case_migrations
+change_feed
+cleanup
+couch_sql_migration
+data_analytics
+data_pipeline_audit
+domain_migration_flags
+dump_reload
+es
+mocha
+tzmigration
+
+Limited-Use and Retired Apps
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+These apps are limited to a small set of clients or on a deprecation path.
+
+appstore
+callcenter
+casegroups
+commtrack
+consumption
+dropbox
+integration
+ivr
+products
+programs

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -129,7 +129,7 @@ smsforms
 styleguide
    Documentation of best practices for UI development, including live examples of common patterns.
 zapier
-   Integration with `Formplayer <https://zapier.com/>`_
+   Integration with `Zapier <https://zapier.com/>`_
 
 Engineering Apps
 ^^^^^^^^^^^^^^^^

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -118,7 +118,7 @@ notifications
    "Banner" notifications used by the support team to notify users of upcoming downtime,
    ongoing issues, etc.
 ota
-   Functionality at the interface of CommCare HQ and CommCare Mobile: demo users, device logs, mobile recovery, etc.
+   Contains a number of the API endpoints used by CommCare mobile including sync / restore, case search, case claim, heartbeat and  recovery measures.
 receiverwrapper
    Contains the API for receiving XML form submissions. This app mostly deals with the interfacing portion of the
    API including auth, rate limiting etc. but not the actual data processing which is contained in the

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -10,7 +10,8 @@ accounting
    This includes the UI for internal operations users to modify these objects.
    Accessing this UI requires running the ``add_operations_user`` command.
 api
-   Externally-facing APIs to read and write CommCare data for a given project space.
+   APIs to read and write CommCare data for a given project space. Most APIs are externally facing however there a 
+   are a few that are used internally e.g. for report filters. APIs are built using Tastypie.
 app_manager
    UI for configuring and releasing CommCare applications.
    Form Builder, for configuring forms themselves, is called here but

--- a/corehq/apps/README.rst
+++ b/corehq/apps/README.rst
@@ -14,7 +14,7 @@ accounting
    This includes the UI for internal operations users to modify these objects.
    Accessing this UI requires running the ``add_operations_user`` command.
 api
-   APIs to read and write CommCare data for a given project space. Most APIs are externally facing however there a 
+   APIs to read and write CommCare data for a given project space. Most APIs are externally facing. However there a 
    are a few that are used internally e.g. for report filters. APIs are built using Tastypie.
 app_manager
    UI and tooling for configuring and releasing CommCare applications.

--- a/corehq/ex-submodules/README.rst
+++ b/corehq/ex-submodules/README.rst
@@ -26,7 +26,7 @@ dimagi
     Miscellaneous utilities.
 fluff
     Related to ``pillow_top``, ``fluff`` allows you to define a set of computations to perform on all couch
-    documents of a particular type.
+    documents of a particular type for the purposes of reporting. Deprecated and only used by a small number of custom reports. Can be removed once no longer referenced.
 phonelog
     This manages device logs, which are reports of mobile device activity that can be sent to HQ for analysis.
 pillow_retry

--- a/corehq/ex-submodules/README.rst
+++ b/corehq/ex-submodules/README.rst
@@ -1,0 +1,41 @@
+Ex-Submodules in CommCare HQ
+############################
+
+This area contains sections of code that used to be their own repositories but have since been folded back into the
+``commcare-hq`` codebase. For those that do not have READMEs, documentation typically still exists in the archived
+repository.
+
+A lot of this is couch-related and therefore on its way out as we move more functionality to postgres, but a few of
+these are actively used, especially casexml, pillowtop, soil, and toggle.
+
+All of the pillow-y names were created as riffs on the "couch" in CouchDB.
+
+auditcare
+    A couch-based set of auditing tools. All page views in CommCare HQ are recorded in auditcare.
+    This backs the User Audit Log report, which allows admins to view a given user's historical actions.
+    Doing non-user-based queries is prohibitively slow.
+casexml
+    An application for working with `CaseXML <https://github.com/dimagi/commcare-core/wiki/casexml20>`_.
+couchexport
+    Tooling to export couch documents to other formats, particularly Excel. Used by areas of HQ that involve
+    downloading couch-based models in bulk.
+couchforms
+    Puts XForms in CouchDB. Effectively deprecated, as the vast majority of forms have been migrated from couch to
+    postgres.
+dimagi
+    Miscellaneous utilities.
+fluff
+    Related to ``pillow_top``, ``fluff`` allows you to define a set of computations to perform on all couch
+    documents of a particular type.
+phonelog
+    This manages device logs, which are reports of mobile device activity that can be sent to HQ for analysis.
+pillow_retry
+    Related to ``pillow_top``, This manages a queue for retrying pillow errors.
+pillowtop
+    A framework for listening to changes, then transforming and processing them.
+    Originally modeled after CouchDB's ``_changes`` feed.
+soil
+    An application to schedule long-running tasks and later retrieve their results. This is used for
+    many of HQ's long-running tasks that result in a file download.
+toggle
+    A CouchDB-backed app for controlling access to functionality on a user-specific or domain-specific basis.

--- a/corehq/ex-submodules/README.rst
+++ b/corehq/ex-submodules/README.rst
@@ -38,4 +38,4 @@ soil
     An application to schedule long-running tasks and later retrieve their results. This is used for
     many of HQ's long-running tasks that result in a file download.
 toggle
-    A CouchDB-backed app for controlling access to functionality on a user-specific or domain-specific basis.
+    A CouchDB-backed app for feature flags that control access to functionality on a user-specific or domain-specific basis.


### PR DESCRIPTION
In light of today's book club discussion, a rough draft of a doc to orient new devs to our django app structure. I had forgotten just how many apps we have.