### PR TITLE
Add ESQuery wrapper for user data searches

### DIFF
--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -171,12 +171,7 @@ class CustomDataFieldsProfile(models.Model):
             UserES().domain(self.definition.domain)
                     .mobile_users()
                     .show_inactive()
-                    .filter(
-                        filters.nested('user_data_es',
-                        filters.AND(
-                            filters.term('user_data_es.key', PROFILE_SLUG),
-                            filters.term('user_data_es.value', self.id)
-                        )))
+                    .metadata(PROFILE_SLUG, self.id)
         )
 
     def to_json(self):

--- a/corehq/apps/es/tests/test_user_es.py
+++ b/corehq/apps/es/tests/test_user_es.py
@@ -1,0 +1,52 @@
+import uuid
+
+from django.test import TestCase
+
+from pillowtop.es_utils import initialize_index_and_mapping
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.es import UserES
+from corehq.apps.es.tests.utils import es_test
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
+from corehq.apps.users.models import CommCareUser
+from corehq.elastic import get_es_new
+from corehq.pillows.mappings.user_mapping import USER_INDEX, USER_INDEX_INFO
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.es.testing import sync_users_to_es
+
+
+@es_test
+class TestUserES(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        initialize_index_and_mapping(get_es_new(), USER_INDEX_INFO)
+        cls.elasticsearch = get_es_new()
+        cls.domain = 'test-user-es'
+        cls.domain_obj = create_domain(cls.domain)
+
+    @classmethod
+    def tearDownClass(cls):
+        delete_all_users()
+        cls.domain_obj.delete()
+        ensure_index_deleted(USER_INDEX)
+        super().tearDownClass()
+
+    def _create_mobile_worker(self, metadata):
+        CommCareUser.create(
+            domain=self.domain,
+            username=uuid.uuid4().hex,
+            password="*****",
+            created_by=None,
+            created_via=None,
+            metadata=metadata,
+        )
+
+    def test_user_data_query(self):
+        with sync_users_to_es():
+            self._create_mobile_worker(metadata={'foo': 'bar'})
+            self._create_mobile_worker(metadata={'foo': 'baz'})
+            self._create_mobile_worker(metadata={'foo': 'womp', 'fu': 'bar'})
+        get_es_new().indices.refresh(USER_INDEX)
+        self.assertEqual(UserES().metadata('foo', 'bar').count(), 1)

--- a/corehq/apps/es/tests/test_user_es.py
+++ b/corehq/apps/es/tests/test_user_es.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.test import TestCase
 
 from pillowtop.es_utils import initialize_index_and_mapping
@@ -26,6 +24,23 @@ class TestUserES(TestCase):
         cls.domain = 'test-user-es'
         cls.domain_obj = create_domain(cls.domain)
 
+        with sync_users_to_es():
+            cls._create_mobile_worker('stark', metadata={'sigil': 'direwolf', 'seat': 'Winterfell'})
+            cls._create_mobile_worker('lannister', metadata={'sigil': 'lion', 'seat': 'Casterly Rock'})
+            cls._create_mobile_worker('targaryen', metadata={'sigil': 'dragon', 'false_sigil': 'direwolf'})
+        cls.elasticsearch.indices.refresh(USER_INDEX)
+
+    @classmethod
+    def _create_mobile_worker(cls, username, metadata):
+        CommCareUser.create(
+            domain=cls.domain,
+            username=username,
+            password="*****",
+            created_by=None,
+            created_via=None,
+            metadata=metadata,
+        )
+
     @classmethod
     def tearDownClass(cls):
         delete_all_users()
@@ -33,20 +48,20 @@ class TestUserES(TestCase):
         ensure_index_deleted(USER_INDEX)
         super().tearDownClass()
 
-    def _create_mobile_worker(self, metadata):
-        CommCareUser.create(
-            domain=self.domain,
-            username=uuid.uuid4().hex,
-            password="*****",
-            created_by=None,
-            created_via=None,
-            metadata=metadata,
-        )
+    def test_basic_metadata_query(self):
+        direwolf_families = UserES().metadata('sigil', 'direwolf').values_list('username', flat=True)
+        self.assertEqual(direwolf_families, ['stark'])
 
-    def test_user_data_query(self):
-        with sync_users_to_es():
-            self._create_mobile_worker(metadata={'foo': 'bar'})
-            self._create_mobile_worker(metadata={'foo': 'baz'})
-            self._create_mobile_worker(metadata={'foo': 'womp', 'fu': 'bar'})
-        self.elasticsearch.indices.refresh(USER_INDEX)
-        self.assertEqual(UserES().metadata('foo', 'bar').count(), 1)
+    def test_chained_metadata_queries_where_both_match(self):
+        direwolf_families = (UserES()
+                             .metadata('sigil', 'direwolf')
+                             .metadata('seat', 'Winterfell')
+                             .values_list('username', flat=True))
+        self.assertEqual(direwolf_families, ['stark'])
+
+    def test_chained_metadata_queries_with_only_one_match(self):
+        direwolf_families = (UserES()
+                             .metadata('sigil', 'direwolf')
+                             .metadata('seat', 'Casterly Rock')
+                             .values_list('username', flat=True))
+        self.assertEqual(direwolf_families, [])

--- a/corehq/apps/es/tests/test_user_es.py
+++ b/corehq/apps/es/tests/test_user_es.py
@@ -21,8 +21,8 @@ class TestUserES(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        initialize_index_and_mapping(get_es_new(), USER_INDEX_INFO)
         cls.elasticsearch = get_es_new()
+        initialize_index_and_mapping(cls.elasticsearch, USER_INDEX_INFO)
         cls.domain = 'test-user-es'
         cls.domain_obj = create_domain(cls.domain)
 
@@ -48,5 +48,5 @@ class TestUserES(TestCase):
             self._create_mobile_worker(metadata={'foo': 'bar'})
             self._create_mobile_worker(metadata={'foo': 'baz'})
             self._create_mobile_worker(metadata={'foo': 'womp', 'fu': 'bar'})
-        get_es_new().indices.refresh(USER_INDEX)
+        self.elasticsearch.indices.refresh(USER_INDEX)
         self.assertEqual(UserES().metadata('foo', 'bar').count(), 1)

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -170,6 +170,9 @@ def is_active(active=True):
 
 
 def metadata(key, value):
+    # Note that this dict is stored in ES under the `user_data` field, and
+    # transformed into a queryable format (in ES) as `user_data_es`, but it's
+    # referenced in python as `metadata`
     return queries.nested(
         'user_data_es',
         filters.AND(

--- a/corehq/apps/es/users.py
+++ b/corehq/apps/es/users.py
@@ -24,7 +24,7 @@ of all unknown users, web users, and demo users on a domain.
 """
 from copy import deepcopy
 
-from . import filters
+from . import filters, queries
 from .es_query import HQESQuery
 
 
@@ -51,6 +51,7 @@ class UserES(HQESQuery):
             role_id,
             is_active,
             username,
+            metadata,
         ] + super(UserES, self).builtin_filters
 
     def show_inactive(self):
@@ -166,3 +167,13 @@ def role_id(role_id):
 
 def is_active(active=True):
     return filters.term("is_active", active)
+
+
+def metadata(key, value):
+    return queries.nested(
+        'user_data_es',
+        filters.AND(
+            filters.term(field='user_data_es.key', value=key),
+            queries.match(field='user_data_es.value', search_string=value, fuzziness=0),
+        )
+    )


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
This seems like it warrants a first-class abstraction, so I'm adding one in.  Being that this is [an analyzed field](https://github.com/dimagi/commcare-hq/blob/dffe10b0b4dc1ed29fed8b4f40184d0c7f631163/corehq/pillows/mappings/user_mapping.py#L212-L212), a `match` query is a better fit, as described [here](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-term-query.html).

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
