### PR TITLE
Added user_id to update_case_index_relationship

### DIFF
--- a/custom/covid/management/commands/update_case_index_relationship.py
+++ b/custom/covid/management/commands/update_case_index_relationship.py
@@ -7,6 +7,7 @@ from dimagi.utils.chunked import chunked
 
 from corehq.apps.linked_domain.dbaccessors import get_linked_domains
 from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.users.util import SYSTEM_USER_ID
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
@@ -51,7 +52,7 @@ def update_cases(domain):
 
     total = 0
     for chunk in chunked(case_blocks, BATCH_SIZE):
-        submit_case_blocks(chunk, domain, device_id=DEVICE_ID)
+        submit_case_blocks(chunk, domain, device_id=DEVICE_ID, user_id=SYSTEM_USER_ID)
         total += len(chunk)
         print("Updated {} cases on domain {}".format(total, domain))
 


### PR DESCRIPTION
Minor followup for https://github.com/dimagi/commcare-hq/pull/28655

This still doesn't make the forms show up in submit history, but better to have a user id than not have one.