### PR TITLE
Fix django-nose and celery requirements for pip-sync

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -18,7 +18,7 @@ boto3==1.15.12            # via -r requirements.in
 botocore==1.18.12         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements.in, django-celery-results
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results
 certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -51,7 +51,7 @@ django-debug-toolbar==3.1  # via -r dev-requirements.in
 django-extensions==3.0.9  # via -r dev-requirements.in
 django-formtools==2.1     # via -r requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements.in
-git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r test-requirements.in
+https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl  # via -r test-requirements.in
 django-oauth-toolkit==1.3.2  # via -r requirements.in
 django-otp==0.9.4         # via -r requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements.in

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -15,7 +15,7 @@ boto3==1.15.12            # via -r requirements.in
 botocore==1.18.12         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements.in, django-celery-results, flower
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results, flower
 certifi==2020.6.20        # via -r prod-requirements.in, elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, cryptography, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -5,7 +5,7 @@ boto3~=1.15
 # celery 4.1.1 forked to work around https://github.com/celery/celery/issues/4737	celery==4.4.7
 # upgrade when https://github.com/celery/celery/issues/4980 is fixed
 # originally changes were made on nickpell/celery, but this was moved to dimagi/celery
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery
+celery @ https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl
 CommcareTranslationChecker==0.9.7
 concurrent-log-handler==0.9.12
 csiphash==0.0.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,7 +14,7 @@ boto3==1.15.12            # via -r requirements.in
 botocore==1.18.12         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements.in, django-celery-results
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results
 certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests

--- a/requirements/test-requirements.in
+++ b/requirements/test-requirements.in
@@ -2,7 +2,7 @@
 
 beautifulsoup4>=4.4.1
 coverage==4.5.1
-git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose
+django-nose @ https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl
 fakecouch==0.0.15
 nose==1.3.7
 nose-exclude==0.5.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -16,7 +16,7 @@ boto3==1.15.12            # via -r requirements.in
 botocore==1.18.12         # via boto3, s3transfer
 cairocffi==1.1.0          # via cairosvg, weasyprint
 cairosvg==2.4.2           # via weasyprint
-git+git://github.com/dimagi/celery@dc7253614fd8500af78b09d1ceb79c50f1baac8d#egg=celery  # via -r requirements.in, django-celery-results
+https://github.com/dimagi/celery/raw/4e4ad229423db5568186c94fdbfaa00f0d5b76c9/releases/celery-4.1.1.1-py2.py3-none-any.whl  # via -r requirements.in, django-celery-results
 certifi==2020.6.20        # via elasticsearch7, requests, sentry-sdk
 cffi==1.14.3              # via cairocffi, csiphash, weasyprint
 chardet==3.0.4            # via ghdiff, requests
@@ -45,7 +45,7 @@ django-crispy-forms==1.7.0  # via -r requirements.in
 django-cte==1.1.4         # via -r requirements.in
 django-formtools==2.1     # via -r requirements.in, django-two-factor-auth
 django-logentry-admin==1.0.6  # via -r requirements.in
-git+git://github.com/dimagi/django-nose@fast-first-1.4.6#egg=django-nose  # via -r test-requirements.in
+https://github.com/dimagi/django-nose/raw/fast-first-1.4.6.1/releases/django_nose-1.4.6.1-py2.py3-none-any.whl  # via -r test-requirements.in
 django-oauth-toolkit==1.3.2  # via -r requirements.in
 django-otp==0.9.4         # via -r requirements.in, django-two-factor-auth
 django-partial-index==0.6.0  # via -r requirements.in


### PR DESCRIPTION
Another attempt at fixing ongoing dependabot failures. This should prevent pip-sync from re-installing these requirements on every pip-sync run, which is what happens with git+ URL requirements.

