### PR TITLE
Link MessageSubEvent to inbound and outbound survey SMS events

### DIFF
--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -52,12 +52,8 @@ def form_session_handler(v, text, msg):
             session.modified_time = datetime.utcnow()
             session.save()
 
-            # fetch subevent pk to link inbound sms to
-            try:
-                subevent_id = MessagingSubEvent.objects.values_list("id", flat=True)\
-                    .get(xforms_session_id=session.pk)
-            except MessagingSubEvent.DoesNotExist:
-                subevent_id = None
+            subevent = session.related_subevent
+            subevent_id = subevent.id if subevent else None
 
             # Metadata to be applied to the inbound message
             inbound_metadata = MessageMetadata(

--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -54,7 +54,8 @@ def form_session_handler(v, text, msg):
 
             # fetch subevent pk to link inbound sms to
             try:
-                subevent_id = MessagingSubEvent.objects.get(xforms_session_id=session.pk).pk
+                subevent_id = MessagingSubEvent.objects.values_list("id", flat=True)\
+                    .get(xforms_session_id=session.pk)
             except MessagingSubEvent.DoesNotExist:
                 subevent_id = None
 

--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -10,7 +10,6 @@ from corehq.apps.sms.api import (
     send_sms_to_verified_number,
 )
 from corehq.apps.sms.messages import *
-from corehq.apps.sms.models import MessagingSubEvent
 from corehq.apps.sms.util import format_message_list, get_date_format
 from corehq.apps.smsforms.app import _responses_to_text, get_responses, get_events_from_responses
 from corehq.apps.smsforms.models import SQLXFormsSession, XFormsSessionSynchronization, \

--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -52,23 +52,23 @@ def form_session_handler(v, text, msg):
             session.modified_time = datetime.utcnow()
             session.save()
 
-            # fetch subevent to link inbound sms to
+            # fetch subevent pk to link inbound sms to
             try:
-                subevent = MessagingSubEvent.objects.get(xforms_session_id=session.pk)
+                subevent_id = MessagingSubEvent.objects.get(xforms_session_id=session.pk).pk
             except MessagingSubEvent.DoesNotExist:
-                subevent = None
+                subevent_id = None
 
             # Metadata to be applied to the inbound message
             inbound_metadata = MessageMetadata(
                 workflow=session.workflow,
                 reminder_id=session.reminder_id,
                 xforms_session_couch_id=session._id,
-                messaging_subevent_id=subevent.pk,
+                messaging_subevent_id=subevent_id,
             )
             add_msg_tags(msg, inbound_metadata)
             msg.save()
             try:
-                answer_next_question(v, text, msg, session, subevent.pk)
+                answer_next_question(v, text, msg, session, subevent_id)
             except Exception:
                 # Catch any touchforms errors
                 log_sms_exception(msg)

--- a/corehq/apps/sms/tests/inbound_handlers.py
+++ b/corehq/apps/sms/tests/inbound_handlers.py
@@ -1,4 +1,5 @@
-from datetime import date, time
+import contextlib
+from datetime import time
 
 from mock import patch
 
@@ -7,12 +8,12 @@ from corehq.apps.reminders.models import RECIPIENT_OWNER, RECIPIENT_USER_GROUP
 from corehq.apps.sms.api import incoming
 from corehq.apps.sms.messages import *
 from corehq.apps.sms.models import WORKFLOW_KEYWORD
-from corehq.apps.sms.tests.util import TouchformsTestCase, time_parser, mock_critical_section_for_smsforms_sessions
+from corehq.apps.sms.tests.util import TouchformsTestCase, time_parser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 
 
 @patch('corehq.apps.smsforms.util.critical_section_for_smsforms_sessions',
-       new=mock_critical_section_for_smsforms_sessions)
+       new=lambda contact_id: contextlib.supress())
 class KeywordTestCase(TouchformsTestCase):
     """
     Must be run manually (see util.TouchformsTestCase)
@@ -757,7 +758,7 @@ class KeywordTestCase(TouchformsTestCase):
 
 
 @patch('corehq.apps.smsforms.util.critical_section_for_smsforms_sessions',
-       new=mock_critical_section_for_smsforms_sessions)
+       new=lambda contact_id: contextlib.supress())
 class PartialFormSubmissionTestCase(TouchformsTestCase):
     """
     Must be run manually (see util.TouchformsTestCase)

--- a/corehq/apps/sms/tests/inbound_handlers.py
+++ b/corehq/apps/sms/tests/inbound_handlers.py
@@ -7,22 +7,8 @@ from corehq.apps.reminders.models import RECIPIENT_OWNER, RECIPIENT_USER_GROUP
 from corehq.apps.sms.api import incoming
 from corehq.apps.sms.messages import *
 from corehq.apps.sms.models import WORKFLOW_KEYWORD
-from corehq.apps.sms.tests.util import TouchformsTestCase, time_parser
-from corehq.apps.smsforms.models import SQLXFormsSession
+from corehq.apps.sms.tests.util import TouchformsTestCase, time_parser, mock_critical_section_for_smsforms_sessions
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
-
-
-class MockContextManager(object):
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
-
-def mock_critical_section_for_smsforms_sessions(contact_id):
-    return MockContextManager()
 
 
 @patch('corehq.apps.smsforms.util.critical_section_for_smsforms_sessions',

--- a/corehq/apps/sms/tests/test_form_session_handler.py
+++ b/corehq/apps/sms/tests/test_form_session_handler.py
@@ -1,5 +1,6 @@
 import contextlib
 from datetime import datetime
+import uuid
 
 from django.test import TestCase
 from mock import patch, Mock, MagicMock
@@ -24,7 +25,7 @@ class FormSessionTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.domain = Domain(name='test')
+        cls.domain = Domain(name=uuid.uuid4().hex)
         cls.domain.save()
 
         cls.number = PhoneNumber(

--- a/corehq/apps/sms/tests/test_form_session_handler.py
+++ b/corehq/apps/sms/tests/test_form_session_handler.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+
+from django.test import TestCase
+from mock import patch, Mock
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.sms.handlers.form_session import form_session_handler
+from corehq.apps.sms.models import (
+    PhoneNumber,
+    SMS,
+    INCOMING,
+)
+from corehq.apps.smsforms.models import SQLXFormsSession
+
+
+class MockContextManager(object):
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+def mock_critical_section_for_smsforms_sessions(contact_id):
+    return MockContextManager()
+
+
+@patch('corehq.apps.smsforms.util.critical_section_for_smsforms_sessions',
+       new=mock_critical_section_for_smsforms_sessions)
+class FormSessionTestCase(TestCase):
+
+    def test_open_form_session(self):
+        Domain(name='test')
+        number = PhoneNumber(
+            domain='test',
+            owner_doc_type='CommCareCase',
+            owner_id='fake-owner-id1',
+            phone_number='01112223333',
+            backend_id=None,
+            ivr_backend_id=None,
+            verified=True,
+            is_two_way=True,
+            pending_verification=False,
+            contact_last_modified=datetime.utcnow()
+        )
+        SQLXFormsSession.create_session_object(
+            'test',
+            Mock(get_id='contact_id'),
+            number.phone_number,
+            Mock(get_id='app_id'),
+            Mock(xmlns='xmlns'),
+            expire_after=24 * 60,
+        )
+        msg = SMS(
+            phone_number=number.phone_number,
+            direction=INCOMING,
+            date=datetime.utcnow(),
+            text="test message",
+            domain_scope=None,
+            backend_api=None,
+            backend_id=None,
+            backend_message_id=None,
+            raw_text=None,
+        )
+        form_session_handler(number, msg.text, msg)
+        self.assertTrue(msg.messaging_subevent is not None)

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -342,3 +342,16 @@ def delete_domain_phone_numbers(domain):
     for p in PhoneNumber.by_domain(domain):
         # Clear cache and delete
         p.delete()
+
+
+class MockContextManager(object):
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+def mock_critical_section_for_smsforms_sessions(contact_id):
+    return MockContextManager()

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -342,16 +342,3 @@ def delete_domain_phone_numbers(domain):
     for p in PhoneNumber.by_domain(domain):
         # Clear cache and delete
         p.delete()
-
-
-class MockContextManager(object):
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
-
-def mock_critical_section_for_smsforms_sessions(contact_id):
-    return MockContextManager()


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
[Message History Report Bug](https://dimagi-dev.atlassian.net/browse/SAAS-11242)
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This was uncovered by a bug in the Message History Report where messages sent with a content type of survey could not be filtered by phone number.

As @millerdev originally discovered the typical message event has this link structure: `MessageEvent` -> `MessageSubEvent` -> `SMS`. For an unknown reason, MessageSubEvents were not being linked to SMS events for surveys. The survey takes a different path than other messages, passing through the `form_session_handler` which previously did not attempt to link the SubEvent and SMS. 

This change links the `MessageSubEvent` fetched via the form session primary key which is stored on the `MessageSubEvent` as noted [here](https://github.com/dimagi/commcare-hq/blob/c06f33c1f9d4025385530619ac279bd9bfc99a6a/corehq/apps/sms/models.py#L1482-L1486).

We will not worry about linking already created `MessageSubEvents` for now. 
##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
