### PR TITLE
Added tests to document GZipFile's file handling behavior

### DIFF
--- a/lib_tests/test_gzipfile.py
+++ b/lib_tests/test_gzipfile.py
@@ -1,0 +1,30 @@
+import gzip
+import io
+from unittest import mock
+from django.test import SimpleTestCase
+
+
+class GZipFileTests(SimpleTestCase):
+    def setUp(self):
+        self.data = gzip.compress(b"Some Test Data")
+
+    def test_existing_file_handle_is_not_closed_when_gzip_is_closed(self):
+        existing_handle = io.BytesIO(self.data)
+        gzip_file = gzip.GzipFile(fileobj=existing_handle)
+        with gzip_file:
+            pass
+
+        self.assertTrue(gzip_file.closed)
+        self.assertFalse(existing_handle.closed)
+
+    def test_filename_closes_properly(self):
+        existing_handle = io.BytesIO(self.data)
+        mocked_open = mock.MagicMock(return_value=existing_handle)
+
+        with mock.patch('builtins.open', mocked_open):
+            gzip_file = gzip.GzipFile(filename='somefile')
+            with gzip_file:
+                pass
+
+            self.assertTrue(gzip_file.closed)
+            self.assertTrue(existing_handle.closed)


### PR DESCRIPTION
A small test suite to document that GZipFile will not close existing file objects.

Eventually, I'd like to create a location for third-party library tests like this, but this change does not necessarily need to be merged.