### PR TITLE
Make sure api-key auth user is populated before LocationAccessMiddleware

### DIFF
--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -4,6 +4,7 @@ from django.template.response import TemplateResponse
 from django.utils.deprecation import MiddlewareMixin
 
 from corehq import toggles
+from corehq.apps.domain.auth import HQApiKeyAuthentication
 from corehq.apps.users.models import AnonymousCouchUser, CouchUser, InvalidUser
 from corehq.apps.users.util import username_to_user_id
 from corehq.toggles import PUBLISH_CUSTOM_REPORTS
@@ -40,6 +41,9 @@ class UsersMiddleware(MiddlewareMixin):
             request.domain = view_kwargs['domain']
         if 'org' in view_kwargs:
             request.org = view_kwargs['org']
+        if not (request.user and request.user.is_authenticated):
+            # use this to add in the user if the request is using API key auth
+            HQApiKeyAuthentication().is_authenticated(request)
         if request.user and request.user.is_authenticated:
             user_id = username_to_user_id(request.user.username)
             couch_user = CouchUser.get_by_user_id(user_id)


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/SAAS-11458

##### RISK ASSESSMENT / QA PLAN
The only risk I can think of is if running `HQApiKeyAuthentication().is_authenticated(request)` twice on the same request causes issues, which (1) I don't think it does and (2) I tested locally and this change doesn't break basic usage of api keys.
