### PR TITLE
allow ignoring demo user submissions

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -198,7 +198,7 @@ class PracticeMobileWorkerSubmissionTest(BaseSubmissionTest):
         # skip any authorization
         self.client = Client()
 
-    @patch('corehq.apps.receiverwrapper.util.IGNORE_ALL_DEMO_USER_SUBMISSIONS', True)
+    @override_settings(IGNORE_ALL_DEMO_USER_SUBMISSIONS=True)
     @patch('corehq.apps.users.models.CommCareUser.get_by_user_id')
     def test_ignore_all_practice_mobile_worker_submissions_in_demo_mode(self, user_stub, *_):
         # ignore submission if from a practice mobile worker and HQ is ignoring all demo user submissions
@@ -221,10 +221,10 @@ class NormalModeSubmissionTest(BaseSubmissionTest):
         response = self._submit('simple_form.xml')
         self.assertTrue('X-CommCareHQ-FormID' in response, 'Non Demo user ID form not processed in normal mode')
 
-    @patch('corehq.apps.receiverwrapper.util.IGNORE_ALL_DEMO_USER_SUBMISSIONS', True)
+    @override_settings(IGNORE_ALL_DEMO_USER_SUBMISSIONS=True)
     @patch('corehq.apps.users.models.CommCareUser.get_by_user_id')
     @softer_assert()
-    def test_ignore_all_practice_mobile_worker_submissions_in_normal_mode(self, user_stub, *_):
+    def test_ignore_all_practice_mobile_worker_submissions_in_normal_mode(self, user_stub):
         user_stub.return_value = self.couch_user
         response = self._submit('simple_form.xml')
         self.assertTrue('X-CommCareHQ-FormID' in response, 'Normal user form not processed in non-demo mode')
@@ -234,16 +234,16 @@ class NormalModeSubmissionTest(BaseSubmissionTest):
         self.assertFalse('X-CommCareHQ-FormID' in response,
                          'Practice mobile worker form processed in non-demo mode')
 
-    @patch('corehq.apps.receiverwrapper.util.IGNORE_ALL_DEMO_USER_SUBMISSIONS', True)
-    def test_invalid_form_xml(self, *_):
+    @override_settings(IGNORE_ALL_DEMO_USER_SUBMISSIONS=True)
+    def test_invalid_form_xml(self):
         response = self._submit('invalid_form_xml.xml')
         self.assertTrue(response.status_code, 422)
         self.assertTrue("There was an error processing the form: Invalid XML" in response.content.decode('utf-8'))
 
-    @patch('corehq.apps.receiverwrapper.util.IGNORE_ALL_DEMO_USER_SUBMISSIONS', True)
+    @override_settings(IGNORE_ALL_DEMO_USER_SUBMISSIONS=True)
     @patch('corehq.apps.receiverwrapper.util._notify_ignored_form_submission')
     @patch('corehq.apps.users.models.CommCareUser.get_by_user_id')
-    def test_notification(self, user_stub, notification, *_):
+    def test_notification(self, user_stub, notification):
         user_stub.return_value = self.couch_user
         self.couch_user.is_demo_user = True
 

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -205,10 +205,9 @@ def from_demo_user(form_json):
     except (KeyError, ValueError):
         return False
 
+
 # Form-submissions with request.GET['submit_mode'] as 'demo' are ignored, if not from demo-user
 DEMO_SUBMIT_MODE = 'demo'
-
-IGNORE_ALL_DEMO_USER_SUBMISSIONS = settings.SERVER_ENVIRONMENT in settings.ICDS_ENVS
 
 
 def _submitted_by_demo_user(form_meta, domain):
@@ -240,7 +239,7 @@ def should_ignore_submission(request):
     the submissions should be ignored
     """
     form_json = None
-    if IGNORE_ALL_DEMO_USER_SUBMISSIONS:
+    if settings.IGNORE_ALL_DEMO_USER_SUBMISSIONS:
         instance, _ = couchforms.get_instance_and_attachment(request)
         try:
             form_json = convert_xform_to_json(instance)

--- a/settings.py
+++ b/settings.py
@@ -1065,6 +1065,8 @@ DEFAULT_COMMCARE_EXTENSIONS = [
 ]
 COMMCARE_EXTENSIONS = []
 
+IGNORE_ALL_DEMO_USER_SUBMISSIONS = False
+
 try:
     # try to see if there's an environmental variable set for local_settings
     custom_settings = os.environ.get('CUSTOMSETTINGS', None)


### PR DESCRIPTION
On same lines as https://github.com/dimagi/commcare-hq/pull/28690
One set of changes to be rolled out for https://dimagi-dev.atlassian.net/browse/ICDS-1785
Doing changes on case by case basis and this looked better to be moved as a setting

##### SUMMARY
This moves the ability to ignore form submissions as a setting instead of checking on the environment
- [x] To make changes for commcare-cloud and icds-commcare-environments post approval
       https://github.com/dimagi/icds-commcare-environments/pull/22 https://github.com/dimagi/commcare-cloud/pull/4300/files

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
