### PR TITLE
webapps remove prevalidate

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -428,12 +428,8 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
                             });
                         }
                     } else {
-                        if (o.isValid()) {
-                            if (ko.utils.unwrapObservable(o.datatype) !== "info") {
-                                _answers[UI.getIx(o)] = ko.utils.unwrapObservable(o.answer);
-                            }
-                        } else {
-                            prevalidated = false;
+                        if (ko.utils.unwrapObservable(o.datatype) !== "info") {
+                            _answers[UI.getIx(o)] = ko.utils.unwrapObservable(o.answer);
                         }
                     }
                 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -414,6 +414,8 @@ hqDefine("cloudcare/js/form_entry/webformsession", function () {
         self.submitForm = function (form) {
             var self = this,
                 accumulateAnswers,
+                // currently we always send up prevalidated=true. TODO: once confident that the var is not necessary
+                // remove from formplayer and here.
                 prevalidated = true;
 
             accumulateAnswers = function (o) {


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/SAAS-11161

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently when we submit we send up only answers that are [valid](https://github.com/dimagi/commcare-hq/blob/fd3e7ac68c78e08851f7773c2ff5adae2b0e1c61/corehq/apps/cloudcare/static/cloudcare/js/form_entry/fullform-ui.js#L487) (do not have any errors) and if there are any invalid answers, we send up a `prevalidated=false` flag. 

When formplayer receives the submission, it rejects if [one of the 2](https://github.com/dimagi/formplayer/blob/130b830764e9307e78ba8283e760fe410fafd6a4/src/main/java/org/commcare/formplayer/application/FormController.java#L166-L167):
1. it's own validation check based on the answers submitted fail
2. `prevalidated=false` is sent up

It seems like this has logic has been there since the beginning. This change does the following:
1. Sends up all answers (including invalid/errored ones)
2. sends up `prevalidated=true` (cannot remove this var yet, must remove from formplayer first)


##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->

This is deployed to staging and can be seen in this [app](https://staging.commcarehq.org/a/test-42/apps/view/0d5d20962b58c3f9ccca6b577de376bc/).

![required-conditions](https://user-images.githubusercontent.com/615126/97232385-6d950680-17b3-11eb-9ef6-e579ecda1eed.gif)

Also ccing @ctsims in case he knows something about `prevalidated`.

