### PR TITLE
Web Apps: switched combobox to select2

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -606,7 +606,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
                     } else {
                         return null;
                     }
-                }
+                },
             };
         };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -537,13 +537,12 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         };
 
         self.options = ko.computed(function () {
-            return _.map(question.choices(), function (choice, idx) {
+            return [{text: "", id: undefined}].concat(_.map(question.choices(), function (choice, idx) {
                 return {
                     text: choice,
-                    idx: idx + 1,
                     id: idx + 1,
                 };
-            });
+            }));
         });
 
         self.options.subscribe(function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -533,7 +533,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         self.placeholderText = gettext('Please choose an item');
 
         self.helpText = function () {
-            return gettext('Dropdown');
+            return "";
         };
 
         self.options = ko.computed(function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -545,12 +545,27 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             }));
         });
 
+        self.isValid = function (value) {
+            if (!value) {
+                return true;
+            }
+            return _.contains(_.pluck(self.options(), 'text'), value);
+        };
+
         self.options.subscribe(function () {
             self.renderSelect2();
             if (!self.isValid(self.rawAnswer())) {
                 self.question.error(gettext('Not a valid choice'));
             }
         });
+
+        // If there is a prexisting answer, set the rawAnswer to the corresponding text.
+        if (question.answer()) {
+            var initialOption = _.findWhere(self.options(), {id: self.answer()});
+            self.rawAnswer(
+                initialOption ? initialOption.text : Const.NO_ANSWER
+            );
+        }
 
         self.additionalSelect2Options = function () {
             return {};
@@ -589,8 +604,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
      * Docs: https://confluence.dimagi.com/display/commcarepublic/Advanced+CommCare+Android+Formatting#AdvancedCommCareAndroidFormatting-SingleSelect"ComboBox"
      */
     function ComboboxEntry(question, options) {
-        var self = this,
-            initialOption;
+        var self = this;
         DropdownEntry.call(this, question, options);
 
         // Specifies the type of matching we will do when a user types a query
@@ -611,13 +625,6 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
                     }
                 },
             };
-        };
-
-        self.isValid = function (value) {
-            if (!value) {
-                return true;
-            }
-            return _.contains(_.pluck(self.options(), 'text'), value);
         };
 
         self.enableReceiver(question, options);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -649,6 +649,13 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
 
     ComboboxEntry.prototype = Object.create(DropdownEntry.prototype);
     ComboboxEntry.prototype.constructor = DropdownEntry;
+    ComboboxEntry.prototype.onAnswerChange = function (newValue) {
+        var self = this;
+        DropdownEntry.prototype.onAnswerChange.call(self, newValue);
+        _.delay(function () {
+            $("#" + self.entryId).trigger("change.select2");
+        });
+    };
     ComboboxEntry.prototype.onPreProcess = function (newValue) {
         var value;
         if (newValue === Const.NO_ANSWER || newValue === '') {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -526,6 +526,11 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         }
     };
 
+    /**
+     *  For dropdowns, each option is assigned an id, which is its index,
+     *  with the first option given index 1. Both the entry's answer and
+     *  rawAnswer contain this index value.
+     */
     function DropdownEntry(question, options) {
         var self = this;
         EntrySingleAnswer.call(this, question, options);
@@ -544,28 +549,6 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
                 };
             }));
         });
-
-        self.isValid = function (value) {
-            if (!value) {
-                return true;
-            }
-            return _.contains(_.pluck(self.options(), 'text'), value);
-        };
-
-        self.options.subscribe(function () {
-            self.renderSelect2();
-            if (!self.isValid(self.rawAnswer())) {
-                self.question.error(gettext('Not a valid choice'));
-            }
-        });
-
-        // If there is a prexisting answer, set the rawAnswer to the corresponding text.
-        if (question.answer()) {
-            var initialOption = _.findWhere(self.options(), {id: self.answer()});
-            self.rawAnswer(
-                initialOption ? initialOption.text : Const.NO_ANSWER
-            );
-        }
 
         self.additionalSelect2Options = function () {
             return {};
@@ -675,7 +658,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         }
 
         value = _.find(this.options(), function (d) {
-            return d.text === newValue;
+            return d.id === newValue;
         });
         if (value) {
             this.answer(value.id);
@@ -696,8 +679,8 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             var fieldByPriority = fieldsByPriority[i];
             for (var j = 0; j < options.length; j++) {
                 var option = options[j];
-                if (option.name === message[fieldByPriority]) {
-                    self.rawAnswer(option.name);
+                if (option.text === message[fieldByPriority]) {
+                    self.rawAnswer(option.id);
                     return;
                 }
             }

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -548,9 +548,6 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
 
         self.options.subscribe(function () {
             self.renderSelect2();
-            if (!self.isValid(self.rawAnswer())) {
-                self.question.error(gettext('Not a valid choice'));
-            }
         });
 
         self.renderSelect2 = function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -1,4 +1,4 @@
-/* globals moment, MapboxGeocoder */
+/* globals moment, MapboxGeocoder, DOMPurify */
 hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
     var Const = hqImport("cloudcare/js/form_entry/const"),
         Utils = hqImport("cloudcare/js/form_entry/utils"),
@@ -561,70 +561,55 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
     function ComboboxEntry(question, options) {
         var self = this,
             initialOption;
-        EntrySingleAnswer.call(this, question, options);
+        DropdownEntry.call(this, question, options);
 
         // Specifies the type of matching we will do when a user types a query
         self.matchType = options.matchType;
         self.lengthLimit = Infinity;
-        self.templateType = 'str';
         self.placeholderText = gettext('Type to filter answers');
 
         self.options = ko.computed(function () {
             return _.map(question.choices(), function (choice, idx) {
                 return {
-                    name: choice,
+                    text: choice,
+                    idx: idx + 1,
                     id: idx + 1,
                 };
             });
         });
         self.options.subscribe(function () {
-            self.renderAtwho();
+            self.renderSelect2();
             if (!self.isValid(self.rawAnswer())) {
                 self.question.error(gettext('Not a valid choice'));
             }
         });
         self.helpText = function () {
-            return 'Combobox';
+            return gettext('Combobox');
         };
 
         // If there is a prexisting answer, set the rawAnswer to the corresponding text.
         if (question.answer()) {
             initialOption = self.options()[self.answer() - 1];
             self.rawAnswer(
-                initialOption ? initialOption.name : Const.NO_ANSWER
+                initialOption ? initialOption.id : Const.NO_ANSWER
             );
         }
 
-        self.renderAtwho = function () {
-            var $input = $('#' + self.entryId),
-                limit = Infinity,
-                $atwhoView;
-            $input.atwho('destroy');
-            $input.atwho('setIframe', window.frameElement, true);
-            $input.atwho({
-                at: '',
-                data: self.options(),
-                maxLen: Infinity,
-                tabSelectsMatch: false,
-                limit: limit,
-                suffix: '',
-                callbacks: {
-                    filter: function (query, data) {
-                        var results = _.filter(data, function (item) {
-                            return ComboboxEntry.filter(query, item, self.matchType);
-                        });
-                        $atwhoView = $('.atwho-container .atwho-view');
-                        $atwhoView.attr({
-                            'data-message': 'Showing ' + Math.min(limit, results.length) + ' of ' + results.length,
-                        });
-                        return results;
-                    },
-                    matcher: function () {
-                        return $input.val();
-                    },
-                    sorter: function (query, data) {
+        self.renderSelect2 = function () {
+            var $input = $('#' + self.entryId);
+            $input.select2({
+                allowClear: true,
+                placeholder: self.placeholderText,
+                escapeMarkup: function (m) { return DOMPurify.sanitize(m); },
+                matcher: function (params, data) {
+                    params.term = $.trim(params.term);
+                    if (!params.term) {
                         return data;
-                    },
+                    }
+                    if (ComboboxEntry.filter(params.term, data, self.matchType)) {
+                        return data;
+                    }
+                    return null;
                 },
             });
         };
@@ -632,22 +617,21 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             if (!value) {
                 return true;
             }
-            return _.include(
-                _.map(self.options(), function (option) {
-                    return option.name;
-                }),
-                value
-            );
+            return _.contains(self.choices(), value);
         };
 
         self.afterRender = function () {
-            self.renderAtwho();
+            self.renderSelect2();
         };
 
         self.enableReceiver(question, options);
     }
 
-    ComboboxEntry.filter = function (query, d, matchType) {
+    ComboboxEntry.filter = function (query, option, matchType) {
+        if (!query || !option.text) {
+            return true;
+        }
+
         var match;
         if (matchType === Const.COMBOBOX_MULTIWORD) {
             // Multiword filter, matches any choice that contains all of the words in the query
@@ -655,7 +639,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             // Assumption is both query and choice will not be very long. Runtime is O(nm)
             // where n is number of words in the query, and m is number of words in the choice
             var wordsInQuery = query.split(' ');
-            var wordsInChoice = d.name.split(' ');
+            var wordsInChoice = option.text.split(' ');
 
             match = _.all(wordsInQuery, function (word) {
                 return _.include(wordsInChoice, word);
@@ -663,8 +647,8 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         } else if (matchType === Const.COMBOBOX_FUZZY) {
             // Fuzzy filter, matches if query is "close" to answer
             match = (
-                (window.Levenshtein.get(d.name.toLowerCase(), query.toLowerCase()) <= 2 && query.length > 3) ||
-                d.name.toLowerCase() === query.toLowerCase()
+                (window.Levenshtein.get(option.text.toLowerCase(), query.toLowerCase()) <= 2 && query.length > 3) ||
+                option.text.toLowerCase() === query.toLowerCase()
             );
         }
 
@@ -674,29 +658,11 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         }
 
         // Standard filter, matches only start of word
-        return d.name.toLowerCase().startsWith(query.toLowerCase());
+        return option.text.toLowerCase().startsWith(query.toLowerCase());
     };
 
-    ComboboxEntry.prototype = Object.create(EntrySingleAnswer.prototype);
-    ComboboxEntry.prototype.constructor = EntrySingleAnswer;
-    ComboboxEntry.prototype.onPreProcess = function (newValue) {
-        var value;
-        if (newValue === Const.NO_ANSWER || newValue === '') {
-            this.answer(Const.NO_ANSWER);
-            this.question.error(null);
-            return;
-        }
-
-        value = _.find(this.options(), function (d) {
-            return d.name === newValue;
-        });
-        if (value) {
-            this.answer(value.id);
-            this.question.error(null);
-        } else {
-            this.question.error(gettext('Not a valid choice'));
-        }
-    };
+    ComboboxEntry.prototype = Object.create(DropdownEntry.prototype);
+    ComboboxEntry.prototype.constructor = DropdownEntry;
     ComboboxEntry.prototype.receiveMessage = function (message, field) {
         // Iterates through options and selects an option that matches message[field].
         // Registers a no answer if message[field] is not in options.

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -573,6 +573,13 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
     }
     DropdownEntry.prototype = Object.create(EntrySingleAnswer.prototype);
     DropdownEntry.prototype.constructor = EntrySingleAnswer;
+    DropdownEntry.prototype.onAnswerChange = function (newValue) {
+        var self = this;
+        EntrySingleAnswer.prototype.onAnswerChange.call(self, newValue);
+        _.delay(function () {
+            $("#" + self.entryId).trigger("change.select2");
+        });
+    };
     DropdownEntry.prototype.onPreProcess = function (newValue) {
         // When newValue is undefined it means we've unset the select question.
         if (newValue === Const.NO_ANSWER || newValue === undefined) {
@@ -654,13 +661,6 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
 
     ComboboxEntry.prototype = Object.create(DropdownEntry.prototype);
     ComboboxEntry.prototype.constructor = DropdownEntry;
-    ComboboxEntry.prototype.onAnswerChange = function (newValue) {
-        var self = this;
-        DropdownEntry.prototype.onAnswerChange.call(self, newValue);
-        _.delay(function () {
-            $("#" + self.entryId).trigger("change.select2");
-        });
-    };
     ComboboxEntry.prototype.onPreProcess = function (newValue) {
         var value;
         if (newValue === Const.NO_ANSWER || newValue === '') {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -550,6 +550,11 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             }));
         });
 
+        self.options.subscribe(function () {
+            // Clear answer if options change
+            self.rawAnswer(undefined);
+        });
+
         self.additionalSelect2Options = function () {
             return {};
         };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -547,6 +547,9 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
 
         self.options.subscribe(function () {
             self.renderSelect2();
+            if (!self.isValid(self.rawAnswer())) {
+                self.question.error(gettext('Not a valid choice'));
+            }
         });
 
         self.additionalSelect2Options = function () {
@@ -614,7 +617,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
             if (!value) {
                 return true;
             }
-            return _.contains(self.choices(), value);
+            return _.contains(_.pluck(self.options(), 'text'), value);
         };
 
         self.enableReceiver(question, options);
@@ -656,6 +659,24 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
 
     ComboboxEntry.prototype = Object.create(DropdownEntry.prototype);
     ComboboxEntry.prototype.constructor = DropdownEntry;
+    ComboboxEntry.prototype.onPreProcess = function (newValue) {
+        var value;
+        if (newValue === Const.NO_ANSWER || newValue === '') {
+            this.answer(Const.NO_ANSWER);
+            this.question.error(null);
+            return;
+        }
+
+        value = _.find(this.options(), function (d) {
+            return d.text === newValue;
+        });
+        if (value) {
+            this.answer(value.id);
+            this.question.error(null);
+        } else {
+            this.question.error(gettext('Not a valid choice'));
+        }
+    };
     ComboboxEntry.prototype.receiveMessage = function (message, field) {
         // Iterates through options and selects an option that matches message[field].
         // Registers a no answer if message[field] is not in options.

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -389,7 +389,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         };
 
         this.helpText = function () {
-            return 'Phone number or Numeric ID';
+            return gettext('Phone number or Numeric ID');
         };
 
         this.enableReceiver(question, options);
@@ -418,7 +418,7 @@ hqDefine("cloudcare/js/form_entry/entrycontrols_full", function () {
         };
 
         this.helpText = function () {
-            return 'Decimal';
+            return gettext('Decimal');
         };
     }
     FloatEntry.prototype = Object.create(IntEntry.prototype);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
@@ -137,32 +137,32 @@ describe('Entries', function () {
 
     it('Should properly filter combobox', function () {
         // Standard filter
-        assert.isTrue(Controls.ComboboxEntry.filter('o', { name: 'one two', id: 1 }, null));
-        assert.isFalse(Controls.ComboboxEntry.filter('t', { name: 'one two', id: 1 }, null));
+        assert.isTrue(Controls.ComboboxEntry.filter('o', { text: 'one two', id: 1 }, null));
+        assert.isFalse(Controls.ComboboxEntry.filter('t', { text: 'one two', id: 1 }, null));
 
         // Multiword filter
         assert.isTrue(
-            Controls.ComboboxEntry.filter('one three', { name: 'one two three', id: 1 }, Const.COMBOBOX_MULTIWORD)
+            Controls.ComboboxEntry.filter('one three', { text: 'one two three', id: 1 }, Const.COMBOBOX_MULTIWORD)
         );
         assert.isFalse(
-            Controls.ComboboxEntry.filter('two three', { name: 'one two', id: 1 }, Const.COMBOBOX_MULTIWORD)
+            Controls.ComboboxEntry.filter('two three', { text: 'one two', id: 1 }, Const.COMBOBOX_MULTIWORD)
         );
 
         // Fuzzy filter
         assert.isTrue(
-            Controls.ComboboxEntry.filter('onet', { name: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
+            Controls.ComboboxEntry.filter('onet', { text: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
         );
         assert.isTrue(
-            Controls.ComboboxEntry.filter('OneT', { name: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
+            Controls.ComboboxEntry.filter('OneT', { text: 'onetwo', id: 1 }, Const.COMBOBOX_FUZZY)
         );
         assert.isFalse(
-            Controls.ComboboxEntry.filter('one tt', { name: 'one', id: 1 }, Const.COMBOBOX_FUZZY)
+            Controls.ComboboxEntry.filter('one tt', { text: 'one', id: 1 }, Const.COMBOBOX_FUZZY)
         );
         assert.isTrue(
-            Controls.ComboboxEntry.filter('o', { name: 'one', id: 1 }, Const.COMBOBOX_FUZZY)
+            Controls.ComboboxEntry.filter('o', { text: 'one', id: 1 }, Const.COMBOBOX_FUZZY)
         );
         assert.isTrue(
-            Controls.ComboboxEntry.filter('on', { name: 'on', id: 1 }, Const.COMBOBOX_FUZZY)
+            Controls.ComboboxEntry.filter('on', { text: 'on', id: 1 }, Const.COMBOBOX_FUZZY)
         );
     });
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
@@ -105,35 +105,16 @@ describe('Entries', function () {
 
         entry = UI.Question(questionJSON).entry;
         assert.isTrue(entry instanceof Controls.ComboboxEntry);
-        assert.equal(entry.rawAnswer(), 'b');
+        assert.equal(entry.rawAnswer(), 2);
 
-        entry.rawAnswer('a');
+        entry.rawAnswer(1);
         assert.equal(entry.answer(), 1);
 
         entry.rawAnswer('');
         assert.equal(entry.answer(), Const.NO_ANSWER);
 
-        entry.rawAnswer('abc');
+        entry.rawAnswer(15);
         assert.equal(entry.answer(), Const.NO_ANSWER);
-    });
-
-    it('Should validate Combobox properly', function () {
-        var entry,
-            question;
-        questionJSON.datatype = Const.SELECT;
-        questionJSON.style = { raw: Const.COMBOBOX };
-        questionJSON.choices = ['a', 'b'];
-        question = UI.Question(questionJSON);
-
-        entry = question.entry;
-        assert.isTrue(entry instanceof Controls.ComboboxEntry);
-
-        entry.rawAnswer('a');
-        assert.equal(entry.answer(), 1);
-
-        question.choices(['c', 'd']);
-        assert.isFalse(entry.isValid(entry.rawAnswer()));
-        assert.isTrue(!!question.error());
     });
 
     it('Should properly filter combobox', function () {

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
@@ -59,12 +59,13 @@ describe('Entries', function () {
         entry = UI.Question(questionJSON).entry;
         assert.isTrue(entry instanceof Controls.DropdownEntry);
         assert.equal(entry.templateType, 'dropdown');
-        assert.deepEqual(entry.options(), [{
+        var options = _.rest(entry.options());      // drop placeholder
+        assert.deepEqual(options, [{
             text: 'a',
-            idx: 1,
+            id: 1,
         }, {
             text: 'b',
-            idx: 2,
+            id: 2,
         }]);
 
         entry.rawAnswer(1);

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/spec/entrycontrols_full_spec.js
@@ -78,6 +78,27 @@ describe('Entries', function () {
         assert.isTrue(spy.calledTwice);
     });
 
+    it('Should clear Dropdown on options change', function () {
+        var entry,
+            question;
+        questionJSON.datatype = Const.SELECT;
+        questionJSON.style = { raw: Const.MINIMAL };
+        questionJSON.choices = ['a', 'b'];
+        question = UI.Question(questionJSON);
+
+        entry = question.entry;
+        assert.isTrue(entry instanceof Controls.DropdownEntry);
+
+        entry.rawAnswer(2);     // 'b'
+        assert.equal(entry.answer(), 2);
+
+        question.choices(['b', 'c', 'd']);
+        assert.equal(entry.answer(), Const.NO_ANSWER);
+
+        question.choices(['e', 'f']);
+        assert.equal(entry.answer(), Const.NO_ANSWER);
+    });
+
     it('Should return FloatEntry', function () {
         questionJSON.datatype = Const.FLOAT;
         var entry = UI.Question(questionJSON).entry;
@@ -114,6 +135,27 @@ describe('Entries', function () {
         assert.equal(entry.answer(), Const.NO_ANSWER);
 
         entry.rawAnswer(15);
+        assert.equal(entry.answer(), Const.NO_ANSWER);
+    });
+
+    it('Should clear Combobox on options change', function () {
+        var entry,
+            question;
+        questionJSON.datatype = Const.SELECT;
+        questionJSON.style = { raw: Const.COMBOBOX };
+        questionJSON.choices = ['a', 'b'];
+        question = UI.Question(questionJSON);
+
+        entry = question.entry;
+        assert.isTrue(entry instanceof Controls.ComboboxEntry);
+
+        entry.rawAnswer(2);     // 'b'
+        assert.equal(entry.answer(), 2);
+
+        question.choices(['b', 'c', 'd']);
+        assert.equal(entry.answer(), Const.NO_ANSWER);
+
+        question.choices(['e', 'f']);
         assert.equal(entry.answer(), Const.NO_ANSWER);
     });
 

--- a/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/spec/form_entry/mocha.html
@@ -1,8 +1,16 @@
 {% extends "mocha/base.html" %}
 {% load hq_shared_tags %}
 
+{% block stylesheets %}{{ block.super }}
+  <link type="text/css"
+        rel="stylesheet"
+        media="all"
+        href="{% static 'select2/dist/css/select2.min.css' %}" />
+{% endblock %}
+
 {% block dependencies %}
   {% include "formplayer/dependencies.html" %}
+  <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
   <script src="{% static 'jasmine-fixture/dist/jasmine-fixture.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -361,7 +361,7 @@
             'aria-required': $parent.required() ? 'true' : 'false',
         },
         ">
-    <option data-bind="value: idx, text: text"></option>
+    <option data-bind="value: id, text: text"></option>
   </select>
   <span class="help-block type" data-bind="
         text: helpText(),

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -360,6 +360,7 @@
             id: entryId,
             'aria-required': $parent.required() ? 'true' : 'false',
         },
+        valueAllowUnset: true,
         ">
     <option data-bind="value: id, text: text"></option>
   </select>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -364,7 +364,8 @@
     <option data-bind="value: idx, text: text"></option>
   </select>
   <span class="help-block type" data-bind="
-        text: helpText()
+        text: helpText(),
+        visible: helpText(),
     "></span>
 </script>
 <script type="text/html" id="choice-label-entry-ko-template">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -354,17 +354,14 @@
 </script>
 <script type="text/html" id="dropdown-entry-ko-template">
   <select class="form-control" data-bind="
-        options: options,
-        optionsValue: 'idx',
-        optionsText: 'text',
+        foreach: options,
         value: rawAnswer,
-        valueAllowUnset: true,
-        optionsCaption: '{% trans_html_attr 'Choose...' %}',
         attr: {
             id: entryId,
             'aria-required': $parent.required() ? 'true' : 'false',
         },
         ">
+    <option data-bind="value: idx, text: text"></option>
   </select>
 </script>
 <script type="text/html" id="choice-label-entry-ko-template">

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -360,8 +360,10 @@
         value: rawAnswer,
         valueAllowUnset: true,
         optionsCaption: '{% trans_html_attr 'Choose...' %}',
-        id: entryId,
-        'aria-required': $parent.required() ? 'true' : 'false',
+        attr: {
+            id: entryId,
+            'aria-required': $parent.required() ? 'true' : 'false',
+        },
         ">
   </select>
 </script>

--- a/corehq/apps/cloudcare/templates/form_entry/templates.html
+++ b/corehq/apps/cloudcare/templates/form_entry/templates.html
@@ -363,6 +363,9 @@
         ">
     <option data-bind="value: idx, text: text"></option>
   </select>
+  <span class="help-block type" data-bind="
+        text: helpText()
+    "></span>
 </script>
 <script type="text/html" id="choice-label-entry-ko-template">
   <div class="row">

--- a/corehq/apps/cloudcare/templates/preview_app/base.html
+++ b/corehq/apps/cloudcare/templates/preview_app/base.html
@@ -9,6 +9,10 @@
           rel="stylesheet"
           media="all"
           href="{% static 'preview_app/less/preview_app.less' %}"/>
+      <link type="text/css"
+            rel="stylesheet"
+            media="all"
+            href="{% static 'select2/dist/css/select2.min.css' %}" />
   {% endcompress %}
 {% endblock %}
 
@@ -75,7 +79,10 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-  <script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
-  <script src="{% static 'cloudcare/js/preview_app/preview_app.js' %}"></script>
-  <script src="{% static 'cloudcare/js/preview_app/main.js' %}"></script>
+  {% compress js %}
+    <script src="{% static 'select2/dist/js/select2.full.min.js' %}"></script>
+    <script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
+    <script src="{% static 'cloudcare/js/preview_app/preview_app.js' %}"></script>
+    <script src="{% static 'cloudcare/js/preview_app/main.js' %}"></script>
+  {% endcompress %}
 {% endblock %}

--- a/corehq/apps/mocha/templates/mocha/base.html
+++ b/corehq/apps/mocha/templates/mocha/base.html
@@ -18,6 +18,8 @@
       }
     </style>
 
+    {% block stylesheets %}{% endblock %}
+
     <script src="{% static 'mocha/mocha.js' %}"></script>
     <script src="{% static 'chai/chai.js' %}"></script>
     <script src="{% static 'sinon/pkg/sinon.js' %}"></script>


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/USH-394

The atwho widget used for comboboxes is not at all accessible to screen readers. atwho is [no longer maintained](https://github.com/ichord/At.js/#%EF%B8%8F-announcement-%EF%B8%8F), so that's not going to improve.

select2's upcoming release has [a number of accessibility improvements](https://github.com/select2/select2/issues/3744), although it isn't yet released and there's [some debate](https://github.com/woocommerce/selectWoo/issues/35) about whether those improvements will be sufficient. My hope is that switching over to select2 will be enough of an improvement for the functionality needed in web apps, which is pretty basic. At a minimum, select2 is at least backed by a select element instead of a text box. We'll be testing this from an accessibility perspective and can consider additional changes, possibly switching to [selectWoo](https://developer.woocommerce.com/2017/08/08/selectwoo-an-accessible-replacement-for-select2/), if necessary.

This PR also updates "minimal" select questions, which were previously using plain HTML select elements, to use select2 for the sake of consistency. This makes the minimal and combobox options on web apps very similar, with the only difference being that the combobox allows for selecting the specific matching algorithm, whereas minimal uses select2's default search.

##### RISK ASSESSMENT / QA PLAN
[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2058)

##### PRODUCT DESCRIPTION
Makes fairly minor changes to the appearance both both comboboxes and "minimal" select questions in web apps.

Before, comboboxes use atwho and minimal questions use standard HTML dropdowns:
![Screen Shot 2020-10-28 at 12 36 52 PM](https://user-images.githubusercontent.com/1486591/97467165-4c025f00-191a-11eb-9eb8-e53290f55bae.png)

![Screen Shot 2020-10-28 at 12 37 21 PM](https://user-images.githubusercontent.com/1486591/97467228-5c1a3e80-191a-11eb-9fc1-6c9f2abee9cb.png)

After, both widgets use select2:
![Screen Shot 2020-10-28 at 12 39 10 PM](https://user-images.githubusercontent.com/1486591/97467463-9c79bc80-191a-11eb-8f26-a65d014b8bab.png)


![Screen Shot 2020-10-28 at 12 24 31 PM](https://user-images.githubusercontent.com/1486591/97465634-9edb1700-1918-11eb-9a3e-118a4f5030c6.png)