### PR TITLE
update label bot to handle WIP workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,7 +2,6 @@
 disabled_actions:
   - triage
   - review
-  - wip
   - lgtm
 
 # Label rules
@@ -15,6 +14,11 @@ rules:
 
   - labels: ['dependencies']
     patterns: ['requirements/**|package.json|yarn.lock']
+
+# WIP
+wip:
+  - 'Open for review: do not merge'
+  - 'awaiting QA'
 
 # Label management
 delete_labels: false


### PR DESCRIPTION
##### SUMMARY
Any PRs tagged with these labels will be marked pending until the labels are removed.

This is currently handled by the `required-labels` workflow but since these labels are temporary a 'pending' state is better suited.
