### PR TITLE
add public docs about our usage of labels

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,7 +106,8 @@ PR labels
 
 Product labels
 ~~~~~~~~~~~~~~
-All PRs must be tagged with one of the following PR labels:
+All PRs must be tagged with one of the following PR labels. For PRs from external
+contributors the onus is on the reviewer to add the labels.
 
 - product/all-users-all-environments
 - product/prod-india-all-users

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -100,3 +100,43 @@ and run ``make requirements``.
 To upgrade all requirements to their latest allowed version you can run
 ``make upgrade-requirements``—this usually results in a large number of upgrades
 and is not something we can merge easily, but it is sometimes a useful exploratory first step.
+
+PR labels
+---------
+
+Product labels
+~~~~~~~~~~~~~~
+All PRs must be tagged with one of the following PR labels:
+
+- product/all-users-all-environments
+- product/prod-india-all-users
+- product/custom
+- product/feature-flag
+- product/invisible
+- product/admin
+
+Label descriptions can be seen on the GitHub `labels`_ page or in the
+`.github/labels.yml`_ configuration file.
+
+.. _labels: https://github.com/dimagi/commcare-hq/labels
+.. _.github/labels.yml: .github/labels.yml
+
+Reindex / migration
+~~~~~~~~~~~~~~~~~~~
+Any PR that will require a database migration or some kind of data reindexing to be done
+must be labeled with the `reindex/migration` label. This label will get automatically applied
+if the PR changes `certain files`_ but it can also be added manually.
+
+Any PR with this label will fail the `required-labels` check. This is intentional to prevent
+premature merging of the PR.
+
+.. _certain files: .github/labels.yml#L12-L13
+
+QA / Work in progress
+~~~~~~~~~~~~~~~~~~~~~~
+PRs that are not ready to be merged can be labeled with one of the following labels:
+
+- awaiting QA
+- Open for review: do not merge
+
+As long as either of these labels are present on the PR it will have a pending status.


### PR DESCRIPTION
##### SUMMARY
The docs we have on Confluence are private and do not include info about WIP / reindex/migration workflows.