### PR TITLE
OTP Config Settings - adds filler text for auth_token field input

### DIFF
--- a/corehq/apps/integration/forms.py
+++ b/corehq/apps/integration/forms.py
@@ -117,7 +117,7 @@ class GaenOtpServerSettingsForm(forms.ModelForm):
 
     auth_token = forms.CharField(
         label=_('Server Auth Token'),
-        widget=forms.PasswordInput
+        widget=forms.PasswordInput(render_value=True)
     )
 
     class Meta:


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
This desired change was brought up in the comments of this ticket: https://dimagi-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=143&projectKey=USH&modal=detail&selectedIssue=USH-224&assignee=5f314baf6db35e0039014d73

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Minor-- previously the auth_token field would be blank even if a value was saved. Now it adds a bullet for each character in the saved auth_token
<img width="1067" alt="Screen Shot 2020-10-28 at 9 05 03 AM" src="https://user-images.githubusercontent.com/36681924/97441993-bd80e400-18ff-11eb-9527-c84051b03d5a.png">


##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->
[Enable retrieving OTPs from a GAEN Server](https://confluence.dimagi.com/display/ccinternal/COVID%3A+Enable+retrieving+OTPs+from+a+GAEN+Server)
##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
Not requesting QA. Did local testing and it does not affect auth_token values previously saved. 
