### PR TITLE
Allow 'can view' web users to view pending invites

### DIFF
--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -197,7 +197,7 @@
     </div><!-- end .panel-body -->
   </div><!-- end .panel -->
 
-  {% if invitations and not request.is_view_only %}
+  {% if invitations %}
     <div class="panel panel-info ko-template" id="invitations-panel">
       <div class="panel-heading">
         <div class="row">
@@ -230,7 +230,9 @@
               <th>{% trans "Role" %}</th>
               <th>{% trans "Date" %} (UTC)</th>
               <th>{% trans "Email Status" %}</th>
+              {% if not request.is_view_only %}
               <th>{% trans "Actions" %}</th>
+              {% endif %}
             </tr>
           </thead>
           <tbody data-bind="foreach: currentPageInvitations">
@@ -249,6 +251,7 @@
                 <!-- ko text: email_status --><!-- /ko -->
               </td>
               <td>
+                {% if not request.is_view_only %}
                 <div data-bind="visible: !actionMessage()">
                   <button type="button" class="resend-invite btn btn-default"
                           data-bind="click: resend, disable: actionInProgress">
@@ -262,6 +265,7 @@
                   </button>
                 </div>
                 <span data-bind="visible: actionMessage, text: actionMessage"></span>
+                {% endif %}
               </td>
             </tr>
           </tbody>

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -231,7 +231,7 @@
               <th>{% trans "Date" %} (UTC)</th>
               <th>{% trans "Email Status" %}</th>
               {% if not request.is_view_only %}
-              <th>{% trans "Actions" %}</th>
+                <th>{% trans "Actions" %}</th>
               {% endif %}
             </tr>
           </thead>

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -230,7 +230,9 @@
               <th>{% trans "Role" %}</th>
               <th>{% trans "Date" %} (UTC)</th>
               <th>{% trans "Email Status" %}</th>
+              {% if not request.is_view_only %}
               <th>{% trans "Actions" %}</th>
+              {% endif %}
             </tr>
           </thead>
           <tbody data-bind="foreach: currentPageInvitations">

--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -197,7 +197,7 @@
     </div><!-- end .panel-body -->
   </div><!-- end .panel -->
 
-  {% if invitations and not request.is_view_only %}
+  {% if invitations %}
     <div class="panel panel-info ko-template" id="invitations-panel">
       <div class="panel-heading">
         <div class="row">
@@ -249,6 +249,7 @@
                 <!-- ko text: email_status --><!-- /ko -->
               </td>
               <td>
+                {% if not request.is_view_only %}
                 <div data-bind="visible: !actionMessage()">
                   <button type="button" class="resend-invite btn btn-default"
                           data-bind="click: resend, disable: actionInProgress">
@@ -262,6 +263,7 @@
                   </button>
                 </div>
                 <span data-bind="visible: actionMessage, text: actionMessage"></span>
+                {% endif %}
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
https://dimagi-dev.atlassian.net/browse/USH-362
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This makes all of the pending invite section (except the Actions column that contains the 'Delete Invite' and 'Resend Invite' buttons) visible to 'can view' web users. A 'can view' web user will now see:
<img width="817" alt="Screen Shot 2020-10-28 at 2 12 43 PM" src="https://user-images.githubusercontent.com/36681924/97479932-24ff5980-1929-11eb-81cc-376aa45852be.png">


##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->
I am not requesting QA. 
