### PR TITLE
Fixed web apps tile display for medium-width screens

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -74,7 +74,7 @@
 </script>
 
 <script type="text/template" id="menu-view-grid-item-template">
-  <div class="col-xs-6 col-sm-4 col-lg-3">
+  <div class="col-xs-6 col-sm-4 col-md-3">
     <% if (imageUrl) { %>
     <div class="gridicon badge-container" style="background-image: url('<%- imageUrl %>');">
       <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
@@ -100,7 +100,7 @@
   <div class="clearfix visible-sm"></div>
   <% } %>
   <% if (menuIndex % 4 === 3) { %>
-  <div class="clearfix visible-lg"></div>
+  <div class="clearfix visible-md"></div>
   <% } %>
 </script>
 


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/USH-361

This has existed ~forever. The tile UI code and accompany clearfix logic wasn't specifying anything for [medium-width](https://getbootstrap.com/docs/3.4/css/#grid-media-queries) screens, so tiles weren't being properly aligned for browsers in that width range.

##### RISK ASSESSMENT / QA PLAN
Minor, no QA.

##### PRODUCT DESCRIPTION
See ticket for screenshots.