### PR TITLE
Track user create on upload

### DIFF
--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -344,6 +344,7 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                 update_progress(current)
                 current += 1
             role_updated = False
+            log_user_create = False
 
             username = row.get('username')
             domain = row.get('domain') or upload_domain
@@ -419,6 +420,7 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                         kwargs['is_account_confirmed'] = is_account_confirmed
                     user = CommCareUser.create(domain, username, password, created_by=upload_user,
                                                created_via=USER_CHANGE_VIA_BULK_IMPORTER, commit=False, **kwargs)
+                    log_user_create = True
                     status_row['flag'] = 'created'
 
                 if phone_number:
@@ -485,6 +487,8 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                     user.update_metadata({'login_as_user': web_user})
 
                 user.save()
+                if log_user_create:
+                    user.log_user_create(upload_user, USER_CHANGE_VIA_BULK_IMPORTER)
                 if role_updated:
                     log_user_role_update(domain, user, upload_user, USER_CHANGE_VIA_BULK_IMPORTER)
                 if web_user:

--- a/corehq/apps/user_importer/importer.py
+++ b/corehq/apps/user_importer/importer.py
@@ -343,8 +343,8 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
             if update_progress:
                 update_progress(current)
                 current += 1
-            role_updated = False
             log_user_create = False
+            log_role_update = False
 
             username = row.get('username')
             domain = row.get('domain') or upload_domain
@@ -478,9 +478,9 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                 if role:
                     role_qualified_id = domain_info.roles_by_name[role].get_qualified_id()
                     user_current_role = user.get_role(domain=domain)
-                    role_updated = not (user_current_role
+                    log_role_update = not (user_current_role
                                         and user_current_role.get_qualified_id() == role_qualified_id)
-                    if role_updated:
+                    if log_role_update:
                         user.set_role(domain, role_qualified_id)
 
                 if web_user:
@@ -489,7 +489,7 @@ def create_or_update_users_and_groups(upload_domain, user_specs, upload_user, gr
                 user.save()
                 if log_user_create:
                     user.log_user_create(upload_user, USER_CHANGE_VIA_BULK_IMPORTER)
-                if role_updated:
+                if log_role_update:
                     log_user_role_update(domain, user, upload_user, USER_CHANGE_VIA_BULK_IMPORTER)
                 if web_user:
                     if not upload_user.can_edit_web_users():

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -498,7 +498,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.uploading_user,
             mock.MagicMock()
         )
-        log_entry = LogEntry.objects.last()
+        log_entry = LogEntry.objects.order_by('action_time').last()
         self.assertEqual(
             log_entry.change_message,
             f"role: {self.role.name}[{self.role.get_id}], updated_via: {USER_CHANGE_VIA_BULK_IMPORTER}")

--- a/corehq/apps/user_importer/tests/test_importer.py
+++ b/corehq/apps/user_importer/tests/test_importer.py
@@ -489,7 +489,7 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
         )
         self.assertEqual(self.user.get_role(self.domain_name).name, self.role.name)
 
-    def test_track_role_update(self):
+    def test_tracking_updates(self):
         self.assertEqual(LogEntry.objects.count(), 0)
         import_users_and_groups(
             self.domain.name,
@@ -498,6 +498,10 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             self.uploading_user,
             mock.MagicMock()
         )
+        log_entry = LogEntry.objects.order_by('action_time').first()
+        self.assertEqual(
+            log_entry.change_message,
+            f"created_via: {USER_CHANGE_VIA_BULK_IMPORTER}")
         log_entry = LogEntry.objects.order_by('action_time').last()
         self.assertEqual(
             log_entry.change_message,


### PR DESCRIPTION
An oversight in https://github.com/dimagi/commcare-hq/commit/0e31408657563e731cda0e1016e0c2b824ff50ef#diff-72cb8ba3bb5b51c7450986f76285fc191501fc01ba292789849e90d794fb7662R1769 that led to user create not getting tracked during upload where `WebUser.create` is called with `commit=False` and is saved later.

##### SUMMARY
This PR logs user creation after user is saved successfully and if it was created as a part of the upload

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
