### PR TITLE
Updated data table formatting to fill the width available

### DIFF
--- a/corehq/apps/reports/templates/reports/tabular.html
+++ b/corehq/apps/reports/templates/reports/tabular.html
@@ -41,7 +41,7 @@
         {% if report.needs_filters %}
           {% include 'reports/partials/description.html' %}
         {% else %}
-          <table id="report_table_{{ report.slug }}" class="table table-striped datatable" {% if pagination.filter %} data-filter="true"{% endif %}>
+          <table id="report_table_{{ report.slug }}" class="table table-striped datatable" width="100%" {% if pagination.filter %} data-filter="true"{% endif %}>
             <thead>
             {%  if report_table.headers.complex %}
               {{ report_table.headers.render_html|safe }}


### PR DESCRIPTION
For: https://dimagi-dev.atlassian.net/browse/SAAS-11382
Expands the tables for the Reassign Cases and Manage Forms reports to fill the screen's width.

Minimal one-line change. No tests, as I'm not sure what we'd verify against. I assumed there was a CSS way to modify the width, but the datatables documentation, as well as [our existing code](https://github.com/dimagi/commcare-hq/blob/cb263b6784d4fb5b12c09abb227b46622adebdcc/corehq/apps/reports/templates/reports/project_health/partials/user_list.html#L3) set the `width` attribute.

