### PR TITLE
Added predicted risk labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,17 @@
-<!--- Provide a link to the ticket or document which prompted this change -->
-
 ##### SUMMARY
-<!--- Describe the change below, including rationale and design decisions -->
+<!--
+    Provide a link to the ticket or document which prompted this change,
+    Describe the rationale and design decisions.
+-->
 
 ##### FEATURE FLAG
-<!--- If this is specific to a feature flag, which one? -->
+<!-- If this is specific to a feature flag, which one? -->
 
 ##### RISK ASSESSMENT / QA PLAN
-<!-- Does this need QA before or after merge? Link QA ticket. -->
+<!--
+    Is there test coverage? Is there manual QA planned? Link QA ticket.
+    Is there anything a deployer should know about rolling back this change?
+-->
 
 ##### PRODUCT DESCRIPTION
-<!--- For non-invisible changes, describe user-facing effects. -->
+<!-- For non-invisible changes, describe user-facing effects. -->

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -15,7 +15,7 @@ rules:
   - labels: ['dependencies']
     patterns: ['requirements/**|package.json|yarn.lock']
 
-  - labels: ['Expected Risk: High']
+  - labels: ['Risk: High']
     patterns: []
       - 'corehq/apps/registration/**.py'
       - 'corehq/apps/registration/**.js'
@@ -24,7 +24,7 @@ rules:
       - 'corehq/form_processor/**'
       - 'corehq/pillows/mappings/**'
 
-  - labels: ['Expected Risk: Medium']
+  - labels: ['Risk: Medium']
     patterns:
       - 'corehq/apps/cloudcare/**'
       - 'corehq/apps/user_importer/**'
@@ -97,9 +97,9 @@ labels:
 - name: 'product/prod-india-all-users'
   color: burnt_orage
   description: 'Change will only be deployed to Dimagi "SaaS" environments'
-- name: 'Expected Risk: High'
+- name: 'Risk: High'
   color: yellow
   description: 'Change affects files that have been flagged as high risk.'
-- name: 'Expected Risk: Medium'
+- name: 'Risk: Medium'
   color: light_yellow
   description: 'Change affects files that have been flagged as medium risk.'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -15,6 +15,22 @@ rules:
   - labels: ['dependencies']
     patterns: ['requirements/**|package.json|yarn.lock']
 
+  - labels: ['Expected Risk: High']
+    patterns: []
+      - 'corehq/apps/registration/**.py'
+      - 'corehq/apps/registration/**.js'
+      - 'corehq/apps/api/**'
+      - 'corehq/apps/case_importer/views.py'   # bulk case importer API
+      - 'corehq/form_processor/**'
+      - 'corehq/pillows/mappings/**'
+
+  - labels: ['Expected Risk: Medium']
+    patterns:
+      - 'corehq/apps/cloudcare/**'
+      - 'corehq/apps/user_importer/**'
+      - 'corehq/apps/fixtures/**'
+      - 'corehq/apps/custom_data_fields/**'
+
 # WIP
 wip:
   - 'Open for review: do not merge'
@@ -37,6 +53,8 @@ colors:
   burnt_orage: '#bc4b29'
   green: '#009800'
   tan: '#fef2c0'
+  yellow: '#fcfa4e'
+  light_yellow: '#fffeb3'
 
 labels:
 - name: 'reindex/migration'
@@ -79,3 +97,9 @@ labels:
 - name: 'product/prod-india-all-users'
   color: burnt_orage
   description: 'Change will only be deployed to Dimagi "SaaS" environments'
+- name: 'Expected Risk: High'
+  color: yellow
+  description: 'Change affects files that have been flagged as high risk.'
+- name: 'Expected Risk: Medium'
+  color: light_yellow
+  description: 'Change affects files that have been flagged as medium risk.'

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -133,6 +133,14 @@ premature merging of the PR.
 
 .. _certain files: .github/labels.yml#L12-L13
 
+Predicted Risk
+~~~~~~~~~~~~~~
+PRs that touch certain files will be automatically flagged with a "Predicted Risk" label,
+either medium or high. This includes heavily-used workflows where a bug would have a high impact
+and also area that are technically complex, difficult to roll back, etc.
+These PRs will receive extra scrutiny and should have especially solid test coverage and/or
+manual testing. Alternatively, the PR description may explain why the PR is not genuinely high risk.
+
 QA / Work in progress
 ~~~~~~~~~~~~~~~~~~~~~~
 PRs that are not ready to be merged can be labeled with one of the following labels:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -133,9 +133,9 @@ premature merging of the PR.
 
 .. _certain files: .github/labels.yml#L12-L13
 
-Predicted Risk
-~~~~~~~~~~~~~~
-PRs that touch certain files will be automatically flagged with a "Predicted Risk" label,
+Risk
+~~~~
+PRs that touch certain files will be automatically flagged with a "Risk" label,
 either medium or high. This includes heavily-used workflows where a bug would have a high impact
 and also area that are technically complex, difficult to roll back, etc.
 These PRs will receive extra scrutiny and should have especially solid test coverage and/or

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -137,7 +137,7 @@ Risk
 ~~~~
 PRs that touch certain files will be automatically flagged with a "Risk" label,
 either medium or high. This includes heavily-used workflows where a bug would have a high impact
-and also area that are technically complex, difficult to roll back, etc.
+and also areas that are technically complex, difficult to roll back, etc.
 These PRs will receive extra scrutiny and should have especially solid test coverage and/or
 manual testing. Alternatively, the PR description may explain why the PR is not genuinely high risk.
 


### PR DESCRIPTION
##### SUMMARY
Building off the new label bot, this adds two labels to mark PRs as predicted high or medium risk and updates the PR template to stress supplying notes on test coverage and/or QA for these.

@esoergel Will these show up in the deploy script, or does that only pick up the migration label?

Specific patterns are based on [this discussion](https://docs.google.com/document/d/1W3k170-dJfyxA8qDPaMAiEnFKiO2CF67t5NRnPthCwU/edit). There are plenty of additions and refinements we could do.

##### RISK ASSESSMENT / QA PLAN
Nope.
