### PR TITLE
Added git-heat script

### DIFF
--- a/scripts/git-heat.sh
+++ b/scripts/git-heat.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build a commit frequency list.
+
+function git-heat() {
+    git log --name-status --after=2018-01-01 $*  | \
+        grep -E '^[A-Z]\s+'                      | \
+        grep -v "django.po"                      | \
+        grep -v "requirements/"                  | \
+        grep -v "requirements-python3/"          | \
+        grep -v "custom/"                        | \
+        cut -c3-500                              | \
+        sort                                     | \
+        uniq -c                                  | \
+        grep -vE '^ {6}1 '                       | \
+        sort -n                                  | \
+        tail -n 20
+}


### PR DESCRIPTION
Playing around with ways to look at which files have the most turnover.

It takes 20 sec or so to run. I'd like to exclude files/directories from the `log` instead of grepping them away afterwards but didn't find a way to do this.