### PR TITLE
fixed resource leak with GzipFile

### DIFF
--- a/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data_raw.py
@@ -103,8 +103,10 @@ def _filename(domain, type_, date):
 
 
 def _get_file(doc_type):
-    fileobj = tempfile.NamedTemporaryFile(prefix='domain_dump_raw_{}_'.format(doc_type), mode='wb', delete=False)
-    return fileobj.name, gzip.GzipFile(fileobj=fileobj)
+    with tempfile.NamedTemporaryFile(prefix='domain_dump_raw_{}_'.format(doc_type),
+            mode='wb', delete=False) as fileobj:
+        zipped_obj = gzip.GzipFile(filename=fileobj.name, mode='wb')
+    return zipped_obj.name, zipped_obj
 
 
 def _get_form_query(domain):

--- a/corehq/apps/export/multiprocess.py
+++ b/corehq/apps/export/multiprocess.py
@@ -95,9 +95,9 @@ class OutputPaginator(object):
         if self.file:
             self.file.close()
         prefix = '{}{}_'.format(TEMP_FILE_PREFIX, self.export_id)
-        fileobj = tempfile.NamedTemporaryFile(prefix=prefix, mode='wb', delete=False)
-        self.path = fileobj.name
-        self.file = gzip.GzipFile(fileobj=fileobj)
+        with tempfile.NamedTemporaryFile(prefix=prefix, mode='wb', delete=False) as fileobj:
+            self.path = fileobj.name
+            self.file = gzip.GzipFile(filename=self.path, mode='wb')
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.file.close()

--- a/corehq/blobs/fsdb.py
+++ b/corehq/blobs/fsdb.py
@@ -67,12 +67,12 @@ class FilesystemBlobDB(AbstractBlobDB):
             metrics_counter('commcare.blobdb.notfound')
             raise NotFound(key)
 
-        file_obj = open(path, "rb")
         if meta and meta.is_compressed:
             content_length, compressed_length = meta.content_length, meta.compressed_length
-            file_obj = GzipFile(fileobj=file_obj, mode='rb')
+            file_obj = GzipFile(filename=path, mode='rb')
         else:
             content_length, compressed_length = self.size(key), None
+            file_obj = open(path, "rb")
         return BlobStream(file_obj, self, key, content_length, compressed_length)
 
     def size(self, key):


### PR DESCRIPTION
Our previous usage of GzipFile was causing a resource leak, as GzipFile will not close file handles it receives.
Since GzipFile was typically used right after creating a file handle, it made sense to just pass in the file path, rather than the handle, as GzipFile will close files it opens itself.

Note: I elected not to write tests for these. Part of it was being unable to phrase what was being tested in a way that made sense. The other reason was that, after writing a test for `OutputPaginator` and seeing how much mocking was required, I realized that these tests would probably be brittle. If I find a way to test these changes in a more readable and maintainable manner, I'll revisit this later.