### PR TITLE
Modify blob export for multiple existing archives

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -11,8 +11,8 @@ from .targzipdb import TarGzipBlobDB
 
 class BlobDbBackendExporter(object):
 
-    def __init__(self, filename, extends):
-        self.db = TarGzipBlobDB(filename, extends)
+    def __init__(self, filename, already_exported):
+        self.db = TarGzipBlobDB(filename, already_exported)
         self.src_db = get_blob_db()
         self.total_blobs = 0
         self.not_found = 0
@@ -46,8 +46,8 @@ class BlobExporter(ABC):
     def slug(self):
         raise NotImplementedError
 
-    def migrate(self, filename, chunk_size=100, limit_to_db=None, extends=(),
-                force=False):
+    def migrate(self, filename, chunk_size=100, limit_to_db=None,
+                already_exported=None, force=False):
         if not self.domain:
             raise ExportError("Must specify domain")
 
@@ -57,7 +57,7 @@ class BlobExporter(ABC):
                 "To re-run the export use 'reset'".format(self.slug)
             )
 
-        migrator = BlobDbBackendExporter(filename, extends)
+        migrator = BlobDbBackendExporter(filename, already_exported)
         with migrator:
             self._migrate(migrator, chunk_size, limit_to_db)
         print("Processed {} {} objects".format(migrator.total_blobs, self.slug))

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -25,6 +25,11 @@ class Command(BaseCommand):
         ./manage.py run_blob_export -e sql_xforms --limit-to-db p0 domain
          ...
         ./manage.py run_blob_export -e sql_xforms --limit-to-db pN domain
+
+    To top-up an older blob dump, first extract a list of names from the archive:
+        $ tar --list -f blob_export.tar.gz > blob_export.list
+    Then provide this file to the `--already_exported` argument to skip over
+    those objects in this dump.
     """
     help = USAGE
 
@@ -40,16 +45,15 @@ class Command(BaseCommand):
         parser.add_argument('--limit-to-db', dest='limit_to_db',
                             help="When specifying a SQL importer use this to restrict "
                                  "the exporter to a single database.")
-        parser.add_argument('--extend', dest='extends', action='append', default=[],
-                            help='Extend a previous export file. '
-                                 'You can extend multiple files.')
+        parser.add_argument('--already_exported', dest='already_exported',
+                            help='Pass a file with a list of blob names already exported')
 
     @change_log_level('boto3', logging.WARNING)
     @change_log_level('botocore', logging.WARNING)
     def handle(self, domain=None, reset=False,
                chunk_size=100, all=None, limit_to_db=None, **options):
         exporters = options.get('exporters')
-        extends = options['extends']
+        already_exported = _get_names_from_file(options['already_exported'])
 
         if not domain:
             raise CommandError(USAGE)
@@ -64,7 +68,7 @@ class Command(BaseCommand):
                 raise CommandError(USAGE)
 
             self.stdout.write("\nRunning exporter: {}\n{}".format(exporter_slug, '-' * 50))
-            export_filename = _get_export_filename(exporter_slug, domain, extends)
+            export_filename = _get_export_filename(exporter_slug, domain, already_exported)
             if os.path.exists(export_filename):
                 raise CommandError(f"Export file '{export_filename}' exists. "
                                    f"Remove the file and re-run the command.")
@@ -74,13 +78,22 @@ class Command(BaseCommand):
                 export_filename,
                 chunk_size=chunk_size,
                 limit_to_db=limit_to_db,
-                extends=extends,
+                already_exported=already_exported,
             )
             if skips:
                 sys.exit(skips)
 
 
-def _get_export_filename(slug, domain, extends):
+def _get_names_from_file(filename):
+    if not filename:
+        return set()
+    with open(filename) as f:
+        names = {line.strip() for line in f}
+    print("Found {} existing blobs, these will be skipped".format(len(names)))
+    return names
+
+
+def _get_export_filename(slug, domain, already_exported):
     timestamp = datetime.datetime.now().strftime('%Y-%m-%d_%H.%M')
-    _extends = '-extended' if extends else ''
-    return f'{timestamp}-{domain}-{slug}{_extends}.tar.gz'
+    part = '-part' if already_exported else ''
+    return f'{timestamp}-{domain}-{slug}{part}.tar.gz'

--- a/corehq/blobs/management/commands/run_blob_export.py
+++ b/corehq/blobs/management/commands/run_blob_export.py
@@ -1,11 +1,12 @@
+import datetime
 import logging
 import os
 import sys
-from django.core.management import BaseCommand, CommandError
-from corehq.blobs.export import EXPORTERS
-from corehq.blobs.targzipdb import get_export_filename
-from corehq.util.decorators import change_log_level
 
+from django.core.management import BaseCommand, CommandError
+
+from corehq.blobs.export import EXPORTERS
+from corehq.util.decorators import change_log_level
 
 USAGE = """Usage: ./manage.py run_blob_export [options] <slug> <domain>
 
@@ -63,7 +64,7 @@ class Command(BaseCommand):
                 raise CommandError(USAGE)
 
             self.stdout.write("\nRunning exporter: {}\n{}".format(exporter_slug, '-' * 50))
-            export_filename = get_export_filename(exporter_slug, domain, extends)
+            export_filename = _get_export_filename(exporter_slug, domain, extends)
             if os.path.exists(export_filename):
                 raise CommandError(f"Export file '{export_filename}' exists. "
                                    f"Remove the file and re-run the command.")
@@ -77,3 +78,9 @@ class Command(BaseCommand):
             )
             if skips:
                 sys.exit(skips)
+
+
+def _get_export_filename(slug, domain, extends):
+    timestamp = datetime.datetime.now().strftime('%Y-%m-%d_%H.%M')
+    _extends = '-extended' if extends else ''
+    return f'{timestamp}-{domain}-{slug}{_extends}.tar.gz'

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -55,11 +55,21 @@ class TarGzipBlobDB(AbstractBlobDB):
 
     def exists(self, key):
         if self._names is None:
-            self._names = set()
-            for filename in self.extends:
-                with tarfile.open(filename, 'r:gz') as tgzfile:
-                    self._names.update(tgzfile.getnames())
+            self._names = _get_existing_names(self.extends)
         return key in self._names
 
     def size(self, key):
         raise NotImplementedError
+
+
+def _get_existing_names(existing_blob_archives):
+    if existing_blob_archives:
+        print("Loading names from existing archives")
+        print("If this fails, you might try breaking them up into smaller archives")
+        print('  eg: `$ split -n 8 <filename> "<new base filename>"')
+    existing = set()
+    for filename in existing_blob_archives:
+        print(f"Loading {filename}")
+        with tarfile.open(filename, 'r:gz') as tgzfile:
+            existing.update(tgzfile.getnames())
+    return existing

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -63,32 +63,3 @@ class TarGzipBlobDB(AbstractBlobDB):
 
     def size(self, key):
         raise NotImplementedError
-
-
-def get_export_filename(slug, domain, extends):
-    """
-    Returns a filename that includes filenames in ``extends``
-
-    >>> get_export_filename('multimedia', 'domain',
-    ...                     ['oldexport.tar.gz', 'olderexport.tar.gz'])
-    'export-domain-multimedia-blobs-extends-oldexport+olderexport.tar.gz'
-
-    """
-    filenames = [strip_tar_gz(f) for f in extends]
-    _extends = '-extends-' + '+'.join(filenames) if filenames else ''
-    return f'export-{domain}-{slug}-blobs{_extends}.tar.gz'
-
-
-def strip_tar_gz(filename):
-    """
-    Strips ".tar.gz" extensions.
-
-    >>> strip_tar_gz('spam.tar.gz')
-    'spam'
-    >>> strip_tar_gz('spam.ham')
-    'spam.ham'
-
-    """
-    if filename.endswith('.tar.gz'):
-        return filename[:-7]
-    return filename

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -12,12 +12,11 @@ class TarGzipBlobDB(AbstractBlobDB):
     into memory first.
     """
 
-    def __init__(self, filename, extends):
+    def __init__(self, filename, already_exported):
         super().__init__()
         self.filename = filename
-        self.extends = extends
+        self._already_exported = already_exported or set()
         self._tgzfile = None
-        self._names = None
 
     def open(self, mode='r:gz'):
         self._tgzfile = tarfile.open(self.filename, mode)
@@ -48,28 +47,10 @@ class TarGzipBlobDB(AbstractBlobDB):
             need to use the ``dump_domain_data`` management command.
 
         """
-        if not self.exists(key):
+        if key not in self._already_exported:
             tarinfo = tarfile.TarInfo(name=key)
             tarinfo.size = in_fileobj.content_length
             self._tgzfile.addfile(tarinfo, in_fileobj)
 
-    def exists(self, key):
-        if self._names is None:
-            self._names = _get_existing_names(self.extends)
-        return key in self._names
-
     def size(self, key):
         raise NotImplementedError
-
-
-def _get_existing_names(existing_blob_archives):
-    if existing_blob_archives:
-        print("Loading names from existing archives")
-        print("If this fails, you might try breaking them up into smaller archives")
-        print('  eg: `$ split -n 8 <filename> "<new base filename>"')
-    existing = set()
-    for filename in existing_blob_archives:
-        print(f"Loading {filename}")
-        with tarfile.open(filename, 'r:gz') as tgzfile:
-            existing.update(tgzfile.getnames())
-    return existing


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->

##### SUMMARY
The blob exporter skips blobs already present in an existing archive (or more than one), but to do so, it must read the whole archive into memory.  I hit an OOM error trying to this for REC, so I used `split` to break it up into 8 smaller archives.  This PR is two changes to support that:

* Don't concat all existing archive names to get the new one - this hits the filename character limit.
* Add a help message and some basic logging to show progress through the filenames

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
Nah, isn't used in production

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
