### PR TITLE
Add click tracking for app diff buttons on releases table

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases/releases.js
@@ -341,6 +341,11 @@ hqDefine('app_manager/js/releases/releases', function () {
             return '';
         });
 
+        self.trackClick = function (message) {
+            hqImport('analytix/js/kissmetrix').track.event(message);
+            return true;
+        };
+
         self.onViewChanges = function (appIdOne, appIdTwo) {
             appDiff.renderDiff(appIdOne, appIdTwo);
         };

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -38,10 +38,7 @@
       <a class="btn btn-default" data-bind="
                 attr: {href: compareUnbuiltChangesUrl},
                 visible: savedApps().length,
-                click: function () {
-                    hqImport('analytix/js/kissmetrix').track.event('Compare App Versions: Clicked Version Preview');
-                    return true;
-                }
+                click: function () { return trackClick('Compare App Versions: Clicked Version Preview'); }
                 ">
         <i class="fa fa-exchange"></i>
         {% trans "Version Preview" %}
@@ -49,8 +46,8 @@
     {% endif %}
     <button class="btn btn-primary" data-bind="
             click: function() {
-                hqImport('analytix/js/kissmetrix').track.event('Clicked Make New Version');
-                          return makeNewBuild();
+              trackClick('Clicked Make New Version')
+              return makeNewBuild();
             },
             attr: {disabled: !buildButtonEnabled() ? 'disabled' : undefined},
             css: {disabled: !buildButtonEnabled()}">
@@ -209,8 +206,7 @@
                             $data.id())
                           },
                     click: function () {
-                        hqImport('analytix/js/kissmetrix').track.event('Compare App Versions: Clicked View Changes');
-                        return true;
+                        return trackClick('Compare App Versions: Clicked View Changes');
                     }
                     visible: $parent.previousBuildId($index())">
             <i class="fa fa-exchange"></i>

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases/releases_table.html
@@ -35,7 +35,14 @@
   </p>
   <p>
     {% if request|toggle_enabled:"VIEW_APP_CHANGES" %}
-      <a class="btn btn-default" data-bind="attr: {href: compareUnbuiltChangesUrl}, visible: savedApps().length">
+      <a class="btn btn-default" data-bind="
+                attr: {href: compareUnbuiltChangesUrl},
+                visible: savedApps().length,
+                click: function () {
+                    hqImport('analytix/js/kissmetrix').track.event('Compare App Versions: Clicked Version Preview');
+                    return true;
+                }
+                ">
         <i class="fa fa-exchange"></i>
         {% trans "Version Preview" %}
       </a>
@@ -201,6 +208,10 @@
                             $parent.previousBuildId($index()),
                             $data.id())
                           },
+                    click: function () {
+                        hqImport('analytix/js/kissmetrix').track.event('Compare App Versions: Clicked View Changes');
+                        return true;
+                    }
                     visible: $parent.previousBuildId($index())">
             <i class="fa fa-exchange"></i>
             {% trans "View Changes" %}


### PR DESCRIPTION
<!--- Provide a link to the ticket or document which prompted this change -->
Adds kissmetrics analytics to app diff buttons on the releases page. :chart_with_upwards_trend: 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### FEATURE FLAG
<!--- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!-- Does this need QA before or after merge? Link QA ticket. -->

##### PRODUCT DESCRIPTION
<!--- For non-invisible changes, describe user-facing effects. -->
FF: VIEW_APP_CHANGES
