### PR TITLE
Added support for deleting linked reports

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -69,8 +69,10 @@ from corehq.apps.userreports.reports.util import (
 )
 from corehq.apps.userreports.tasks import export_ucr_async
 from corehq.apps.userreports.util import (
+    can_delete_report,
     can_edit_report,
     default_language,
+    get_referring_apps,
     get_ucr_class_name,
     has_report_builder_access,
     has_report_builder_trial,
@@ -343,6 +345,8 @@ class ConfigurableReportView(JSONResponseMixin, BaseDomainView):
             'method': 'POST',
             'headers': self.headers,
             'can_edit_report': can_edit_report(self.request, self),
+            'can_delete_report': can_delete_report(self.request, self),
+            'referring_apps': get_referring_apps(self.domain, self.report_config_id),
             'has_report_builder_trial': has_report_builder_trial(self.request),
             'report_filter_form_action_css_class': CSS_ACTION_CLASS,
         }

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -51,6 +51,8 @@
   {% endif %}
   {% if can_edit_report %}
     {% include 'userreports/partials/edit_report_button.html' %}
+  {% elif can_delete_report %}
+    {% include 'userreports/partials/delete_report_button.html' with report_id=report.report_config_id %}
   {% endif %}
 {% endblock %}
 

--- a/corehq/apps/userreports/templates/userreports/edit_report_config.html
+++ b/corehq/apps/userreports/templates/userreports/edit_report_config.html
@@ -20,18 +20,7 @@
              data-label="Report Config">{% trans 'Report Source' %}</a>
         </div>
         {% if not report.is_static%}
-          <div class="btn-group">
-            {% if referring_apps %}
-              <a href="#confirm_delete" class="btn btn-danger pull-right" data-toggle="modal">
-                {% trans 'Delete Report' %}
-              </a>
-            {% else %}
-              <form method='post' action="{% url 'delete_configurable_report' domain report.get_id %}" >
-                {% csrf_token %}
-                <input type="submit" value="{% trans 'Delete Report'%}" class="btn btn-danger disable-on-submit pull-right">
-              </form>
-            {% endif %}
-          </div>
+          {% include 'userreports/partials/delete_report_button.html' with report_id=report.get_id %}
         {% endif %}
       {% endif %}
     </div>
@@ -111,45 +100,4 @@
       </div>
     {% endif %}
   </div>
-{% endblock %}
-
-{% block modals %}{{ block.super }}
-  {% if referring_apps %}
-    <div id="confirm_delete" class="modal fade" tabindex="-1" role="dialog">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-            <h4 class="modal-title">{% trans 'Are you sure you want to delete this report?' %}</h4>
-          </div>
-          <div class="modal-body">
-            {% blocktrans %}
-              Deleting this will break the apps below, which refer to this report.
-              In addition, there may be older app versions that depend on these reports but are not displayed here.
-              Please delete with caution.
-            {% endblocktrans %}
-            <ul>
-              {% for app in referring_apps %}
-                <li>
-                  <a href="{{ app.module_url }}">{{ app.module_name}}</a> module in
-                  <a href="{{ app.app_url }}">{{app.app_name}}</a> app
-                </li>
-              {% endfor %}
-            </ul>
-          </div>
-          <form method='post' action="{% url 'delete_configurable_report' domain report.get_id %}" >
-            {% csrf_token %}
-            <div class="modal-footer">
-              <button type="button" class="btn btn-default btn-primary" data-dismiss="modal">
-                {% trans "Cancel" %}
-              </button>
-              <button type="submit" value="{% trans 'Delete Report'%}" class="disable-on-submit btn btn-danger">{% trans 'Delete Report'%}</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-  {% endif %}
 {% endblock %}

--- a/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
+++ b/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
@@ -1,0 +1,63 @@
+{% load i18n %}
+
+{% if report.spec.report_meta.created_by_builder %}
+  <a
+    id="deleteReport"
+    class="btn btn-danger"
+    href="{% url 'delete_configurable_report' domain report_id %}?redirect={% url 'reports_home' domain %}"
+  >
+    {% trans 'Delete Report' %}
+  </a>
+{% else %}
+  <div class="btn-group">
+    {% if referring_apps %}
+      <a href="#confirm_delete" class="btn btn-danger pull-right" data-toggle="modal">
+        {% trans 'Delete Report' %}
+      </a>
+    {% else %}
+      <form method='post' action="{% url 'delete_configurable_report' domain report_id %}" >
+        {% csrf_token %}
+        <input type="submit" value="{% trans 'Delete Report'%}" class="btn btn-danger disable-on-submit pull-right">
+      </form>
+    {% endif %}
+  </div>
+
+  {% if referring_apps %}
+    <div id="confirm_delete" class="modal fade" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h4 class="modal-title">{% trans 'Are you sure you want to delete this report?' %}</h4>
+          </div>
+          <div class="modal-body">
+            {% blocktrans %}
+              Deleting this will break the apps below, which refer to this report.
+              In addition, there may be older app versions that depend on these reports but are not displayed here.
+              Please delete with caution.
+            {% endblocktrans %}
+            <ul>
+              {% for app in referring_apps %}
+                <li>
+                  <a href="{{ app.module_url }}">{{ app.module_name}}</a> module in
+                  <a href="{{ app.app_url }}">{{app.app_name}}</a> app
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+          <form method='post' action="{% url 'delete_configurable_report' domain report_id %}" >
+            {% csrf_token %}
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default btn-primary" data-dismiss="modal">
+                {% trans "Cancel" %}
+              </button>
+              <button type="submit" value="{% trans 'Delete Report'%}" class="disable-on-submit btn btn-danger">{% trans 'Delete Report'%}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endif %}

--- a/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
+++ b/corehq/apps/userreports/templates/userreports/partials/delete_report_button.html
@@ -41,8 +41,8 @@
             <ul>
               {% for app in referring_apps %}
                 <li>
-                  <a href="{{ app.module_url }}">{{ app.module_name}}</a> module in
-                  <a href="{{ app.app_url }}">{{app.app_name}}</a> app
+                  <a href="{{ app.app_url }}">{{app.app_name}}</a> &rarr;
+                  <a href="{{ app.module_url }}">{{ app.module_name}}</a>
                 </li>
               {% endfor %}
             </ul>

--- a/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/reportbuilder/configure_report.html
@@ -63,13 +63,8 @@
   <div id="reportConfig" class="ko-template">
     <div class="pull-right page-actions-toolbar">
       {% if existing_report %}
-        <a
-          id="deleteReport"
-          class="btn btn-danger"
-          href="{% url 'delete_configurable_report' domain  existing_report.get_id %}?redirect={% url 'reports_home' domain %}"
-        >
-          Delete Report
-        </a>&nbsp;
+        {% include 'userreports/partials/delete_report_button.html' with report_id=existing_report.get_id %}
+        &nbsp;
       {% endif %}
       {% if request|toggle_enabled:"LINKED_DOMAINS" %}
         {% if existing_report %}


### PR DESCRIPTION
##### SUMMARY
https://dimagi-dev.atlassian.net/browse/USH-230

This was bigger than expected because report builder reports are handled differently than UCRs and because there's a confirmation popup for UCRs that are referenced in an app's ReportModule. I'm surprised this popup is only for UCRs, not report builder reports, but decided not to change that.

There are three conceptual changes:
* Split off "can delete" from "can edit" since linked reports can be deleted but not edited.
* Move logic to get referring apps into a util so it's available to both the view report and edit report pages.
* Extract `delete_report_button.html` partial so it can be used on both view report and edit report pages.

##### FEATURE FLAG
Linked Project Spaces

##### RISK ASSESSMENT / QA PLAN
Not requesting QA. Tested locally that I can delete both linked and regular reports, for both report builder reports and UCRs.

##### PRODUCT DESCRIPTION
Adds a "Delete Report" button to linked reports, in the same location that normal reports have their "Edit Report" button.