### PR TITLE
Fixed YAML in risk labels config

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -16,7 +16,7 @@ rules:
     patterns: ['requirements/**|package.json|yarn.lock']
 
   - labels: ['Risk: High']
-    patterns: []
+    patterns:
       - 'corehq/apps/registration/**.py'
       - 'corehq/apps/registration/**.js'
       - 'corehq/apps/api/**'


### PR DESCRIPTION
Guessing this is why the label bot is failing.