### PR TITLE
Skip blobs before fetching them

### DIFF
--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -27,6 +27,9 @@ class BlobDbBackendExporter(object):
 
     def process_object(self, meta):
         self.total_blobs += 1
+        if self.db.exists(meta.key):
+            return
+
         try:
             content = self.src_db.get(meta.key, CODES.maybe_compressed)
         except NotFound:
@@ -34,7 +37,6 @@ class BlobDbBackendExporter(object):
         else:
             with content:
                 self.db.copy_blob(content, key=meta.key)
-        return True
 
 
 class BlobExporter(ABC):

--- a/corehq/blobs/export.py
+++ b/corehq/blobs/export.py
@@ -12,7 +12,8 @@ from .targzipdb import TarGzipBlobDB
 class BlobDbBackendExporter(object):
 
     def __init__(self, filename, already_exported):
-        self.db = TarGzipBlobDB(filename, already_exported)
+        self.db = TarGzipBlobDB(filename)
+        self._already_exported = already_exported or set()
         self.src_db = get_blob_db()
         self.total_blobs = 0
         self.not_found = 0
@@ -27,7 +28,8 @@ class BlobDbBackendExporter(object):
 
     def process_object(self, meta):
         self.total_blobs += 1
-        if self.db.exists(meta.key):
+        if meta.key in self._already_exported:
+            # This object is already in an another dump
             return
 
         try:

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -12,10 +12,9 @@ class TarGzipBlobDB(AbstractBlobDB):
     into memory first.
     """
 
-    def __init__(self, filename, already_exported):
+    def __init__(self, filename):
         super().__init__()
         self.filename = filename
-        self._already_exported = already_exported or set()
         self._tgzfile = None
 
     def open(self, mode='r:gz'):
@@ -52,7 +51,7 @@ class TarGzipBlobDB(AbstractBlobDB):
         self._tgzfile.addfile(tarinfo, in_fileobj)
 
     def exists(self, key):
-        return key in self._already_exported
+        raise NotImplementedError
 
     def size(self, key):
         raise NotImplementedError

--- a/corehq/blobs/targzipdb.py
+++ b/corehq/blobs/targzipdb.py
@@ -47,10 +47,9 @@ class TarGzipBlobDB(AbstractBlobDB):
             need to use the ``dump_domain_data`` management command.
 
         """
-        if not self.exists(key):
-            tarinfo = tarfile.TarInfo(name=key)
-            tarinfo.size = in_fileobj.content_length
-            self._tgzfile.addfile(tarinfo, in_fileobj)
+        tarinfo = tarfile.TarInfo(name=key)
+        tarinfo.size = in_fileobj.content_length
+        self._tgzfile.addfile(tarinfo, in_fileobj)
 
     def exists(self, key):
         return key in self._already_exported


### PR DESCRIPTION
##### SUMMARY
PRing into https://github.com/dimagi/commcare-hq/pull/28725

This move the existence check before the `.get`, which seems like a huge performance win when topping up blobs.  Am I missing something or is this correct?

##### FEATURE FLAG
<!-- If this is specific to a feature flag, which one? -->

##### RISK ASSESSMENT / QA PLAN
<!--
    Is there test coverage? Is there manual QA planned? Link QA ticket.
    Is there anything a deployer should know about rolling back this change?
-->

##### PRODUCT DESCRIPTION
<!-- For non-invisible changes, describe user-facing effects. -->
