### PR TITLE
Use keywords in ES aggs

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -569,13 +569,13 @@ def track_periodic_data():
 
         # users_to_domains is a list of dicts
         domains_to_forms = (FormES()
-                            .terms_aggregation('domain', 'domain')
+                            .terms_aggregation('domain.exact', 'domain')
                             .size(0)
                             .run()
                             .aggregations.domain.counts_by_bucket())
         domains_to_mobile_users = (UserES()
                                    .mobile_users()
-                                   .terms_aggregation('domain', 'domain')
+                                   .terms_aggregation('domain.exact', 'domain')
                                    .size(0)
                                    .run()
                                    .aggregations

--- a/corehq/apps/es/forms.py
+++ b/corehq/apps/es/forms.py
@@ -42,7 +42,7 @@ class FormES(HQESQuery):
         return self.date_histogram('date_histogram', 'received_on', 'day', timezone=timezone)
 
     def domain_aggregation(self):
-        return self.terms_aggregation('domain', 'domain')
+        return self.terms_aggregation('domain.exact', 'domain')
 
     def only_archived(self):
         """Include only archived forms, which are normally excluded"""

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -533,7 +533,7 @@ def get_form_counts_for_domains(domains):
 
 def get_case_and_action_counts_for_domains(domains):
     actions_agg = aggregations.NestedAggregation('actions', 'actions')
-    aggregation = aggregations.TermsAggregation('domain', 'domain').aggregation(actions_agg)
+    aggregation = aggregations.TermsAggregation('domain.exact', 'domain').aggregation(actions_agg)
     results = CaseES() \
         .filter(filters.term('domain', domains)) \
         .aggregation(aggregation) \

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -533,7 +533,7 @@ def get_form_counts_for_domains(domains):
 
 def get_case_and_action_counts_for_domains(domains):
     actions_agg = aggregations.NestedAggregation('actions', 'actions')
-    aggregation = aggregations.TermsAggregation('domain.exact', 'domain').aggregation(actions_agg)
+    aggregation = aggregations.TermsAggregation('domain', 'domain.exact').aggregation(actions_agg)
     results = CaseES() \
         .filter(filters.term('domain', domains)) \
         .aggregation(aggregation) \

--- a/corehq/apps/reports/management/commands/project_stats_report.py
+++ b/corehq/apps/reports/management/commands/project_stats_report.py
@@ -239,7 +239,7 @@ class Command(BaseCommand):
         avg_ledgers_per_case = ledger_count / len(case_ids)
         case_types_result = CaseES(es_instance_alias=ES_EXPORT_INSTANCE)\
             .domain(self.domain).case_ids(case_ids)\
-            .aggregation(TermsAggregation('types', 'type'))\
+            .aggregation(TermsAggregation('types', 'type.exact'))\
             .size(0).run()
 
         case_types = case_types_result.aggregations.types.keys

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -142,7 +142,7 @@ def get_domains_to_update_es_filter():
     less_than_a_week_ago = filters.date_range('cp_last_updated', gte=last_week)
     not_updated = filters.missing('cp_last_updated')
     domains_submitted_today = (FormES().submitted(gte=datetime.utcnow() - timedelta(days=1))
-        .terms_aggregation('domain', 'domain').size(0).run().aggregations.domain.keys)
+        .terms_aggregation('domain.exact', 'domain').size(0).run().aggregations.domain.keys)
     return filters.OR(
         not_updated,
         more_than_a_week_ago,

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -363,19 +363,6 @@ class TestFormESAccessors(BaseESAccessorsTest):
             {self.domain: 2, 'other': 1}
         )
 
-    def test_get_case_and_action_counts_for_domains(self):
-        self._send_case_to_es()
-        self._send_case_to_es()
-        self._send_case_to_es('other')
-        results = get_case_and_action_counts_for_domains([self.domain, 'other'])
-        self.assertEqual(
-            results,
-            {
-                self.domain: {'cases': 2, 'case_actions': 2},
-                'other': {'cases': 1, 'case_actions': 1}
-            }
-        )
-
     @run_with_all_backends
     def test_completed_out_of_range_by_user(self):
         start = datetime(2013, 7, 1)
@@ -1172,6 +1159,19 @@ class TestCaseESAccessors(BaseESAccessorsTest):
 
         results = get_total_case_counts_by_owner(self.domain, datespan)
         self.assertEqual(results[self.owner_id], 1)
+
+    def test_get_case_and_action_counts_for_domains(self):
+        self._send_case_to_es()
+        self._send_case_to_es()
+        self._send_case_to_es('other')
+        results = get_case_and_action_counts_for_domains([self.domain, 'other'])
+        self.assertEqual(
+            results,
+            {
+                self.domain: {'cases': 2, 'case_actions': 2},
+                'other': {'cases': 1, 'case_actions': 1}
+            }
+        )
 
     def test_get_total_case_counts_opened_after(self):
         """Test a case opened after the startdate datespan"""


### PR DESCRIPTION
## Summary

In ES7, aggregations aren't allowed on non-keyword type fields (unless it's specifically allowed at mapping level before reindex) and there isn't any need to not use non-keyword fields. So in this PR, I am replacing some of such use cases.

## Feature Flag

## Product Description

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below


### QA Plan

New tests are added to make sure aggregation works correctly.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 




@snopoke @millerdev @esoergel @dannyroberts 