### PR TITLE
Notify on HTTP errors

### DIFF
--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -263,5 +263,6 @@ def simple_post(domain, url, data, *, headers, auth_manager, verify,
         requests.notify_error(str(err))
         raise
     if not 200 <= response.status_code < 300:
-        requests.notify_error(response.text)
+        message = f'HTTP status code {response.status_code}: {response.text}'
+        requests.notify_error(message)
     return response

--- a/corehq/motech/requests.py
+++ b/corehq/motech/requests.py
@@ -258,7 +258,10 @@ def simple_post(domain, url, data, *, headers, auth_manager, verify,
         payload_id=payload_id,
     )
     try:
-        return requests.post(None, data=data, headers=default_headers)
+        response = requests.post(None, data=data, headers=default_headers)
     except Exception as err:
         requests.notify_error(str(err))
         raise
+    if not 200 <= response.status_code < 300:
+        requests.notify_error(response.text)
+    return response

--- a/corehq/motech/tests/test_simple_post.py
+++ b/corehq/motech/tests/test_simple_post.py
@@ -7,7 +7,7 @@ from nose.tools import assert_equal
 from corehq.motech.auth import BasicAuthManager
 from corehq.motech.const import REQUEST_TIMEOUT
 from corehq.motech.models import RequestLog
-from corehq.motech.requests import simple_post
+from corehq.motech.requests import Requests, simple_post
 
 TEST_DOMAIN = 'pet-shop'
 TEST_API_URL = 'https://www.example.com/api/'
@@ -16,11 +16,21 @@ TEST_API_PASSWORD = 'Norwegi4n_Blue'
 TEST_PAYLOAD_ID = 'abc123'
 
 
+class Response:
+    status_code = 200
+    content = b'OK'
+
+    @property
+    def text(self):
+        return self.content.decode('utf-8')
+
+
 def test_simple_post():
     with patch.object(requests.Session, 'request') as request_mock, \
             patch.object(RequestLog, 'log') as log_mock:
+        request_mock.return_value = Response()
         auth_manager = BasicAuthManager(TEST_API_USERNAME, TEST_API_PASSWORD)
-        simple_post(
+        response = simple_post(
             domain=TEST_DOMAIN,
             url=TEST_API_URL,
             data='<payload id="abc123"><parrot status="déad" /></payload>',
@@ -44,3 +54,26 @@ def test_simple_post():
         ((__, (level, log_entry), ___),) = log_mock.mock_calls
         assert_equal(level, logging.INFO)
         assert_equal(log_entry.payload_id, TEST_PAYLOAD_ID)
+        assert_equal(response.status_code, 200)
+
+
+def test_simple_post_400():
+    with patch.object(requests.Session, 'request') as request_mock, \
+            patch.object(Requests, 'notify_error') as notify_mock, \
+            patch.object(RequestLog, 'log'):
+        response = Response()
+        response.status_code = 400
+        response.content = b'Bad request'
+        request_mock.return_value = response
+        auth_manager = BasicAuthManager(TEST_API_USERNAME, TEST_API_PASSWORD)
+        response = simple_post(
+            domain=TEST_DOMAIN,
+            url=TEST_API_URL,
+            data='<payload id="abc123"><parrot status="déad" /></payload>',
+            headers={'Content-Type': 'text/xml+parrot'},
+            auth_manager=auth_manager,
+            verify=True,
+            payload_id=TEST_PAYLOAD_ID,
+        )
+        notify_mock.assert_called_with('Bad request')
+        assert_equal(response.status_code, 400)

--- a/corehq/motech/tests/test_simple_post.py
+++ b/corehq/motech/tests/test_simple_post.py
@@ -75,5 +75,5 @@ def test_simple_post_400():
             verify=True,
             payload_id=TEST_PAYLOAD_ID,
         )
-        notify_mock.assert_called_with('Bad request')
+        notify_mock.assert_called_with('HTTP status code 400: Bad request')
         assert_equal(response.status_code, 400)


### PR DESCRIPTION
##### SUMMARY

Related to [SUPPORT-5014](https://dimagi-dev.atlassian.net/browse/SUPPORT-5014)

Most data forwarders use `simple_post()` to send requests to remote APIs. Currently `simple_post()` sends error notifications on exceptions, but not on HTTP errors. This PR will send notifications on HTTP responses outside the 200 range as well as on exceptions.

(The **requests** library follows redirects by default. `simple_post()` will not send error notifications for redirect responses.)

##### FEATURE FLAG

N/A

##### RISK ASSESSMENT / QA PLAN

Despite that this function gets a lot of high-priority use, this change adds a side effect without changing its behaviour or its return value. I think this change is low risk.
