### PR TITLE
Allow running stale_data_in_es only on specified backend

### DIFF
--- a/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
+++ b/corehq/apps/hqadmin/management/commands/stale_data_in_es.py
@@ -163,10 +163,10 @@ DATA_MODEL_HELPERS = {
 
 
 class CaseHelper:
-    @staticmethod
-    def run(run_config):
-        for chunk in _get_doc_chunks(CaseHelper, run_config):
-            yield from CaseHelper._yield_missing_in_es(chunk)
+    @classmethod
+    def run(cls, run_config):
+        for chunk in _get_doc_chunks(cls, run_config):
+            yield from cls._yield_missing_in_es(chunk)
 
     @staticmethod
     def get_sql_chunks(run_config):
@@ -237,10 +237,10 @@ class CaseHelper:
 
 
 class FormHelper:
-    @staticmethod
-    def run(run_config):
-        for chunk in _get_doc_chunks(FormHelper, run_config):
-            yield from FormHelper._yield_missing_in_es(chunk)
+    @classmethod
+    def run(cls, run_config):
+        for chunk in _get_doc_chunks(cls, run_config):
+            yield from cls._yield_missing_in_es(chunk)
 
     @staticmethod
     def get_sql_chunks(run_config):

--- a/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
+++ b/corehq/apps/hqadmin/tests/test_stale_data_in_es.py
@@ -82,7 +82,7 @@ class TestStaleDataInESSQL(TestCase):
             _fake_es_check = _make_fake_es_check(num_to_process)
             patch_path = 'corehq.apps.hqadmin.management.commands.stale_data_in_es'
             with mock.patch(f'{patch_path}.CHUNK_SIZE', 1),\
-                    mock.patch(f'{patch_path}.CaseBackend._yield_missing_in_es', _fake_es_check):
+                    mock.patch(f'{patch_path}.CaseHelper._yield_missing_in_es', _fake_es_check):
                 return self._stale_data_in_es(
                     'case', iteration_key=iteration_key, expect_exception=expect_exception
                 )
@@ -127,7 +127,7 @@ class TestStaleDataInESSQL(TestCase):
             _fake_es_check = _make_fake_es_check(num_to_process)
             patch_path = 'corehq.apps.hqadmin.management.commands.stale_data_in_es'
             with mock.patch(f'{patch_path}.CHUNK_SIZE', 1), \
-                    mock.patch(f'{patch_path}.FormBackend._yield_missing_in_es', _fake_es_check):
+                    mock.patch(f'{patch_path}.FormHelper._yield_missing_in_es', _fake_es_check):
                 return self._stale_data_in_es(
                     'form', iteration_key=iteration_key, expect_exception=expect_exception
                 )


### PR DESCRIPTION
##### SUMMARY
Add argument to management command to allow restricting the processing to either 'couch' or 'sql' backend.

2nd commit is just a refactor

##### RISK ASSESSMENT / QA PLAN
Change to non-critical management command. No QA needed.