### PR TITLE
Added existence check to form processor index rename

### DIFF
--- a/corehq/form_processor/migrations/0092_auto_20200924_1753.py
+++ b/corehq/form_processor/migrations/0092_auto_20200924_1753.py
@@ -14,8 +14,8 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            f"ALTER INDEX {OLD_NAME} RENAME TO {NEW_NAME}",
-            f"ALTER INDEX {NEW_NAME} RENAME TO {OLD_NAME}",
+            f"ALTER INDEX IF EXISTS {OLD_NAME} RENAME TO {NEW_NAME}",
+            f"ALTER INDEX IF EXISTS {NEW_NAME} RENAME TO {OLD_NAME}",
             state_operations=[
                 migrations.RemoveIndex(
                     model_name='casetransaction',

--- a/corehq/form_processor/migrations/0092_auto_20200924_1753.py
+++ b/corehq/form_processor/migrations/0092_auto_20200924_1753.py
@@ -14,8 +14,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            f"ALTER INDEX IF EXISTS {OLD_NAME} RENAME TO {NEW_NAME}",
-            f"ALTER INDEX IF EXISTS {NEW_NAME} RENAME TO {OLD_NAME}",
+            "",
             state_operations=[
                 migrations.RemoveIndex(
                     model_name='casetransaction',


### PR DESCRIPTION
##### SUMMARY
Followup for https://github.com/dimagi/commcare-hq/pull/28542

A couple of people have recently run into problems with this index not existing and needing to fake the migration. I don't have a solid explanation for why this is happening, but this change is pretty innocuous and should address the problem.

##### RISK ASSESSMENT / QA PLAN
Low-risk change. Ran locally after rolling back to 0090.