### PR TITLE
Fixed Web Apps tile misalignment

### DIFF
--- a/corehq/apps/cloudcare/templates/formplayer/menu_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/menu_list.html
@@ -74,7 +74,7 @@
 </script>
 
 <script type="text/template" id="menu-view-grid-item-template">
-  <div class="col-xs-6 col-sm-4 col-lg-3">
+  <div class="col-xs-6 col-sm-4 col-md-3">
     <% if (imageUrl) { %>
     <div class="gridicon badge-container" style="background-image: url('<%- imageUrl %>');">
       <%= _.template($('#maybe-custom-badge-template').text())(arguments[0]) %>
@@ -100,7 +100,7 @@
   <div class="clearfix visible-sm"></div>
   <% } %>
   <% if (menuIndex % 4 === 3) { %>
-  <div class="clearfix visible-lg"></div>
+  <div class="clearfix visible-md visible-lg"></div>
   <% } %>
 </script>
 


### PR DESCRIPTION
##### SUMMARY
Re-applies https://github.com/dimagi/commcare-hq/pull/28709/

`col-xs-6 col-sm-4 col-md-3` will apply a width of 3 to both medium and large screens, since any screen categories larger than the largest one specified will use the same class as the largest specified one.

But the clearfix divs, which make sure the next row of tiles is aligned correctly, apply only to their specific category. So the 4-column clearfix divs (width 3 => 3/12 => 4 columns) need to use both `visible-md` and `visible-lg`.

##### RISK ASSESSMENT / QA PLAN
Requesting QA, given visibility of this screen. [QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-2078)

##### PRODUCT DESCRIPTION
Fixes bug where web apps tiles get mis-aligned at screen resolutions approximately 990-1200px, this time without breaking alignment for screens wider than 1200px.