### PR TITLE
Add more detailed assurance steps to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,9 @@
 ## Safety Assurance
 
 - [ ] Risk label is set correctly
+- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
+- [ ] QA labels are set correctly
 - [ ] I am certain that this PR will not introduce a regression for the reasons below
-- [ ] Someone on SaaS has been added as a reviewer
 
 ### Automated test coverage
 
@@ -22,11 +23,15 @@
 
 ### QA Plan
 
-- [ ] QA labels are set correctly
-
 <!--
 - Describe QA plan that along with automated test coverages proves this PR is regression free
 - Link to QA Ticket
+-->
+
+### Safety story
+<!--
+Describe any other pieces to the safety story including
+local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
 -->
 
 ### Rollback instructions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,39 @@
-##### SUMMARY
+## Summary
 <!--
     Provide a link to the ticket or document which prompted this change,
     Describe the rationale and design decisions.
 -->
 
-##### FEATURE FLAG
+## Feature Flag
 <!-- If this is specific to a feature flag, which one? -->
 
-##### RISK ASSESSMENT / QA PLAN
+## Product Description
+<!-- For non-invisible changes, describe user-facing effects. -->
+
+## Safety Assurance
+
+- [ ] Risk label is set correctly
+- [ ] I am certain that this PR will not introduce a regression for the reasons below
+- [ ] Someone on SaaS has been added as a reviewer
+
+### Automated test coverage
+
+<!-- Identify the related test coverage and the tests it would catch -->
+
+### QA Plan
+
+- [ ] QA labels are set correctly
+
 <!--
-    Is there test coverage? Is there manual QA planned? Link QA ticket.
-    Is there anything a deployer should know about rolling back this change?
+- Describe QA plan that along with automated test coverages proves this PR is regression free
+- Link to QA Ticket
 -->
 
-##### PRODUCT DESCRIPTION
-<!-- For non-invisible changes, describe user-facing effects. -->
+### Rollback instructions
+
+<!--
+If this PR follows standards of revertability, check the box below.
+Otherwise replace it with detailed instructions or reasons a rollback is impossible.
+-->
+
+- [ ] This PR can be reverted after deploy with no further considerations 


### PR DESCRIPTION
## Summary
This PR puts some further boilerplate and checklist items in place to guide PR authors into following a conservative path when it comes to proof that a PR is regression-free. I have also separately installed the https://github.com/marketplace/task-list-completed plugin which will make PRs stay as pending until all boxes are checked.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

None

### QA Plan

None

### Safety story

This is a change that affects only the PR template, which is not tested, but could not introduce a product defect.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 

