### PR TITLE
Added query support to case search endpoint

### DIFF
--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -54,7 +54,7 @@ class CaseSearchCriteria(object):
 
     def _assemble_optional_search_params(self):
         self._add_include_closed()
-        self._add_query()
+        self._add_xpath_query()
         self._add_owner_id()
         self._add_blacklisted_owner_ids()
         self._add_case_property_queries()
@@ -67,8 +67,8 @@ class CaseSearchCriteria(object):
         if include_closed != 'True':
             self.search_es = self.search_es.is_closed(False)
 
-    def _add_query(self):
-        query = self.criteria.pop('_query', None)
+    def _add_xpath_query(self):
+        query = self.criteria.pop('_xpath_query', None)
         if query:
             self.search_es = self.search_es.xpath_query(self.domain, query)
 

--- a/corehq/apps/case_search/utils.py
+++ b/corehq/apps/case_search/utils.py
@@ -54,6 +54,7 @@ class CaseSearchCriteria(object):
 
     def _assemble_optional_search_params(self):
         self._add_include_closed()
+        self._add_query()
         self._add_owner_id()
         self._add_blacklisted_owner_ids()
         self._add_case_property_queries()
@@ -65,6 +66,11 @@ class CaseSearchCriteria(object):
             include_closed = False
         if include_closed != 'True':
             self.search_es = self.search_es.is_closed(False)
+
+    def _add_query(self):
+        query = self.criteria.pop('_query', None)
+        if query:
+            self.search_es = self.search_es.xpath_query(self.domain, query)
 
     def _add_owner_id(self):
         owner_id = self.criteria.pop('owner_id', False)

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -447,8 +447,8 @@ class CaseClaimEndpointTests(TestCase):
 
         matching_criteria = [
             {'name': 'Jamie Hand'},
-            {'name': 'Jamie Hand', '_query': 'date_opened > "2015-03-25"'},
-            {'_query': 'name = "not Jamie" or name = "Jamie Hand"'},
+            {'name': 'Jamie Hand', '_xpath_query': 'date_opened > "2015-03-25"'},
+            {'_xpath_query': 'name = "not Jamie" or name = "Jamie Hand"'},
         ]
         for params in matching_criteria:
             params.update({'case_type': CASE_TYPE})
@@ -457,8 +457,8 @@ class CaseClaimEndpointTests(TestCase):
 
         non_matching_criteria = [
             {'name': 'Jamie Face'},
-            {'name': 'Jamie Hand', '_query': 'date_opened < "2015-03-25"'},
-            {'_query': 'name = "not Jamie" and name = "Jamie Hand"'},
+            {'name': 'Jamie Hand', '_xpath_query': 'date_opened < "2015-03-25"'},
+            {'_xpath_query': 'name = "not Jamie" and name = "Jamie Hand"'},
         ]
         for params in non_matching_criteria:
             params.update({'case_type': CASE_TYPE})


### PR DESCRIPTION
## Summary
The case search endpoint currently supports key/value pairs. This PR adds support for a `_query` param that accepts an arbitrary XPath filter.

This is for the sake of the [commcare-perf](https://github.com/dimagi/commcare-perf/) load testing scripts.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

Test coverage added in this PR.

### QA Plan

No QA planned.

### Safety story
This is an additive change to an internal API. It includes appropriate test coverage.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
