### PR TITLE
Refresh using alias instead of index in prep for ILM

### DIFF
--- a/corehq/apps/api/tests/form_resources.py
+++ b/corehq/apps/api/tests/form_resources.py
@@ -56,7 +56,7 @@ class TestXFormInstanceResource(APIResourceTest):
         )[0]
 
         send_to_elasticsearch('forms', transform_xform_for_elasticsearch(form.to_json()))
-        self.es.indices.refresh(XFORM_INDEX_INFO.index)
+        self.es.indices.refresh(XFORM_INDEX_INFO.alias)
 
         # Fetch the xform through the API
         response = self._assert_auth_get_resource(self.single_endpoint(form.form_id) + "?cases__full=true")
@@ -91,7 +91,7 @@ class TestXFormInstanceResource(APIResourceTest):
             to_ret.append(backend_form)
             self.addCleanup(backend_form.delete)
             send_to_elasticsearch('forms', transform_xform_for_elasticsearch(backend_form.to_json()))
-        self.es.indices.refresh(XFORM_INDEX_INFO.index)
+        self.es.indices.refresh(XFORM_INDEX_INFO.alias)
         return to_ret
 
     def test_get_list(self):
@@ -202,7 +202,7 @@ class TestXFormInstanceResource(APIResourceTest):
         update = forms[0].to_json()
         update['doc_type'] = 'xformarchived'
         send_to_elasticsearch('forms', transform_xform_for_elasticsearch(update))
-        self.es.indices.refresh(XFORM_INDEX_INFO.index)
+        self.es.indices.refresh(XFORM_INDEX_INFO.alias)
 
         # archived form should not be included by default
         response = self._assert_auth_get_resource(self.list_endpoint)

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -128,7 +128,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
 
         es_form = transform_xform_for_elasticsearch(form_pair.json_form)
         send_to_elasticsearch('forms', es_form)
-        self.es.indices.refresh(XFORM_INDEX_INFO.index)
+        self.es.indices.refresh(XFORM_INDEX_INFO.alias)
         return form_pair
 
     def _send_group_to_es(self, _id=None, users=None):

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -156,7 +156,7 @@ def prepare_index_for_reindex(es, index_info):
 
 def prepare_index_for_usage(es, index_info):
     set_index_normal_settings(es, index_info.index)
-    es.indices.refresh(index_info.index)
+    es.indices.refresh(index_info.alias)
 
 
 def _set_checkpoint(pillow):

--- a/testapps/test_elasticsearch/tests/test_xform_es.py
+++ b/testapps/test_elasticsearch/tests/test_xform_es.py
@@ -40,14 +40,14 @@ class XFormESTestCase(SimpleTestCase):
             cls.forms.append(form_pair)
             send_to_elasticsearch('forms', form_pair.json_form)
         # have to refresh the index to make sure changes show up
-        cls.es.indices.refresh(XFORM_INDEX_INFO.index)
+        cls.es.indices.refresh(XFORM_INDEX_INFO.alias)
 
     @classmethod
     def tearDownClass(cls):
         interface = ElasticsearchInterface(cls.es)
         for form in cls.forms:
             interface.delete_doc(XFORM_INDEX_INFO.alias, XFORM_INDEX_INFO.type, form.wrapped_form.form_id)
-        cls.es.indices.refresh(XFORM_INDEX_INFO.index)
+        cls.es.indices.refresh(XFORM_INDEX_INFO.alias)
         cls.forms = []
         super(XFormESTestCase, cls).tearDownClass()
 


### PR DESCRIPTION
## Summary

Refresh Elasticsearch indices using index alias instead of index in prep for rolling index work using ILM. 

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

 This affects the reindex workflow for which test coverage exists


### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations 


@stephherbers @snopoke 