### PR TITLE
Added soft assert on creating users with user_data kwarg

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -110,7 +110,7 @@ class TempCommCareUser(CommCareUser):
             _id=uuid,
             date_joined=datetime.utcnow(),
             is_active=False,
-            user_data={},
+            metadata={},
             first_name='',
             last_name='',
             filter_flag=filter_flag

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1505,6 +1505,8 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, EulaMixin):
         else:
             couch_user.created_on = datetime.utcnow()
 
+        if 'user_data' in kwargs:
+            notify_exception(None, "Created user using user_data")
         metadata = metadata or {}
         metadata.update({'commcare_project': domain})
         couch_user.update_metadata(metadata)
@@ -1826,6 +1828,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         commcare_user.is_account_confirmed = is_account_confirmed
         commcare_user.domain_membership = DomainMembership(domain=domain, **kwargs)
         # metadata can't be set until domain is present
+        if 'user_data' in kwargs:
+            notify_exception(None, "Created user using user_data")
         commcare_user.update_metadata(metadata or {})
 
         if location:


### PR DESCRIPTION
## Summary
This is a more conservative version of https://github.com/dimagi/commcare-hq/pull/28751 as discussed [here](https://github.com/dimagi/commcare-hq/pull/28751#pullrequestreview-524736918)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

First commit just adds soft asserts. Tested `get_all_users_by_domain` locally for second commit, which is the only place `TempCommCareUser` is used.

### QA Plan

No QA planned, see above.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
