### PR TITLE
Add task and management command for keeping most active couch db backend domains from having stale es data

### DIFF
--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -96,9 +96,9 @@ def _get_all_form_ids(domain, start, end):
 
 def _get_forms_in_es(form_ids):
     return (
-        FormES(es_instance_alias=ES_EXPORT_INSTANCE).remove_default_filters()
-            .form_ids(form_ids)
-            .values_list('_id', flat=True)
+        FormES(
+            es_instance_alias=ES_EXPORT_INSTANCE
+        ).remove_default_filters().form_ids(form_ids).values_list('_id', flat=True)
     )
 
 
@@ -146,4 +146,3 @@ def _get_changes(domain, doc_ids):
         ]
         c.extend(changes)
     return c
-

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -1,0 +1,149 @@
+import datetime
+
+from corehq.toggles import ACTIVE_COUCH_DOMAINS
+from corehq.util.metrics import metrics_gauge
+from couchforms.models import XFormInstance
+
+from corehq.apps.es import FormES
+from corehq.elastic import ES_EXPORT_INSTANCE
+from dimagi.utils.chunked import chunked
+from dimagi.utils.parsing import json_format_datetime
+
+from corehq.pillows.xform import get_xform_pillow
+from corehq.util.couch import bulk_get_revs
+from corehq.apps.hqcase.management.commands.backfill_couch_forms_and_cases import (
+    create_form_change_meta,
+)
+
+
+def cleanup_stale_es_on_couch_domains(
+    start_date=None, end_date=None, domains=None, stdout=None
+):
+    """
+    This is the response to https://dimagi-dev.atlassian.net/browse/SAAS-11489
+    and basically makes sure that there are no stale docs in the most active
+    domains still using the couch db backend until we can get them migrated.
+    """
+    end = end_date or datetime.datetime.utcnow()
+    start = start_date or (end - datetime.timedelta(days=5))
+
+    couch_domains = domains or ACTIVE_COUCH_DOMAINS.get_enabled_domains()
+
+    for domain in couch_domains:
+        form_ids, has_discrepancies = _get_all_form_ids(domain, start, end)
+        if has_discrepancies:
+            metrics_gauge(
+                'commcare.es.couch_domain.couch_discrepancy_detected',
+                1,
+                tags={
+                    'domain': domain,
+                }
+            )
+            if stdout:
+                stdout.write(f"\nFound discrepancies in form counts for domain {domain}")
+        forms_not_in_es = _get_forms_not_in_es(form_ids)
+        if forms_not_in_es:
+            metrics_gauge(
+                'commcare.es.couch_domain.stale_docs_in_es',
+                1,
+                tags={
+                    'domain': domain,
+                }
+            )
+            if stdout:
+                stdout.write(f"\nFound {len(forms_not_in_es)} forms not in es "
+                             f"for {domain}")
+            changes = _get_changes(domain, forms_not_in_es)
+            form_es_processor = get_xform_pillow().processors[0]
+            for change in changes:
+                form_es_processor.process_change(change)
+
+
+def _get_couch_form_ids(domain, start, end):
+    "Get form IDs from the 'by_domain_doc_type_date/view' couch view"
+    form_ids = set()
+    for doc_type in ['XFormInstance']:
+        startkey = [domain, doc_type, json_format_datetime(start)]
+        endkey = [domain, doc_type, json_format_datetime(end)]
+        results = XFormInstance.get_db().view(
+            'by_domain_doc_type_date/view', startkey=startkey, endkey=endkey,
+            reduce=False, include_docs=False
+        )
+        form_ids.update({row['id'] for row in results})
+    return form_ids
+
+
+def _get_all_form_ids(domain, start, end):
+    """Get form IDs from couch multiple times to ensure we get them all
+    This should not be necessary but for some reason we are seeing partial results.
+    Also returns a boolean in the second parameter to indicate if there were
+    any discrepancies in the results.
+    """
+    all_form_ids = None
+    previous_form_ids = None
+    form_id_differences = []
+    for i in range(10):
+        form_ids = _get_couch_form_ids(domain, start, end)
+        if not all_form_ids:
+            all_form_ids = form_ids
+        else:
+            form_id_differences.append(previous_form_ids.difference(form_ids))
+            all_form_ids |= form_ids
+        previous_form_ids = form_ids
+    diff_counts = [len(diff) for diff in form_id_differences]
+    return all_form_ids, any(diff_counts)
+
+
+def _get_forms_in_es(form_ids):
+    return (
+        FormES(es_instance_alias=ES_EXPORT_INSTANCE).remove_default_filters()
+            .form_ids(form_ids)
+            .values_list('_id', flat=True)
+    )
+
+
+def _get_forms_not_in_es(form_ids):
+    not_in_es = []
+    for chunk in chunked(list(form_ids), 1000):
+        in_es = _get_forms_in_es(chunk)
+        missing = set(chunk) - set(in_es)
+        not_in_es.extend(missing)
+    return not_in_es
+
+
+def _change_from_meta(change_meta):
+    from corehq.apps.change_feed.data_sources import get_document_store
+    from pillowtop.feed.interface import Change
+
+    document_store = get_document_store(
+        data_source_type=change_meta.data_source_type,
+        data_source_name=change_meta.data_source_name,
+        domain=change_meta.domain,
+        load_source="change_feed",
+    )
+    return Change(
+        id=change_meta.document_id,
+        sequence_id=None,
+        document=None,
+        deleted=change_meta.is_deletion,
+        metadata=change_meta,
+        document_store=document_store,
+        topic=None,
+        partition=None,
+    )
+
+
+def _get_changes(domain, doc_ids):
+    c = []
+    for ids in chunked(doc_ids, 500):
+        doc_id_rev_list = {r[0]: r[1] for r in
+                           bulk_get_revs(XFormInstance.get_db(), ids)}
+        changes = [
+            _change_from_meta(
+                create_form_change_meta(domain, doc_id, doc_id_rev_list[doc_id])
+            )
+            for doc_id in ids
+        ]
+        c.extend(changes)
+    return c
+

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -45,7 +45,7 @@ def cleanup_stale_es_on_couch_domains(
         if forms_not_in_es:
             metrics_gauge(
                 'commcare.es.couch_domain.stale_docs_in_es',
-                1,
+                len(forms_not_in_es),
                 tags={
                     'domain': domain,
                 }

--- a/corehq/apps/hqadmin/management/commands/sync_stale_couch_domains.py
+++ b/corehq/apps/hqadmin/management/commands/sync_stale_couch_domains.py
@@ -1,0 +1,38 @@
+import dateutil
+from django.core.management import BaseCommand
+
+from corehq.apps.hqadmin.couch_domain_utils import (
+    cleanup_stale_es_on_couch_domains,
+)
+
+ALL_COUCH_DOMAINS = object()
+
+
+class Command(BaseCommand):
+    help = """Force a sync of data on all high priority couch db domains 
+    (determined by the feature flag ACTIVE_COUCH_DOMAINS)"""
+
+    def add_arguments(self, parser):
+        parser.add_argument('--domains', default=ALL_COUCH_DOMAINS)
+        parser.add_argument(
+            '--start',
+            action='store',
+            help='Only include data modified after this date',
+        )
+        parser.add_argument(
+            '--end',
+            action='store',
+            help='Only include data modified before this date',
+        )
+
+    def handle(self, **options):
+        start = dateutil.parser.parse(options['start']) if options[
+            'start'] else None
+        end = dateutil.parser.parse(options['end']) if options[
+            'end'] else None
+        domains = options['domains'].split(',') if options['domains'] else None
+        num_domains = len(domains) if domains else "ALL"
+        self.stdout.write(f"\nSyncing {num_domains} couch domains:\n")
+        cleanup_stale_es_on_couch_domains(
+            start_date=start, end_date=end, domains=domains, stdout=self.stdout
+        )

--- a/corehq/apps/hqadmin/management/commands/sync_stale_couch_domains.py
+++ b/corehq/apps/hqadmin/management/commands/sync_stale_couch_domains.py
@@ -9,7 +9,7 @@ ALL_COUCH_DOMAINS = object()
 
 
 class Command(BaseCommand):
-    help = """Force a sync of data on all high priority couch db domains 
+    help = """Force a sync of data on all high priority couch db domains
     (determined by the feature flag ACTIVE_COUCH_DOMAINS)"""
 
     def add_arguments(self, parser):

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -13,6 +13,9 @@ from celery.schedules import crontab
 from celery.task import task
 from celery.task.base import periodic_task
 
+from corehq.apps.hqadmin.couch_domain_utils import (
+    cleanup_stale_es_on_couch_domains,
+)
 from dimagi.utils.django.email import send_HTML_email
 from dimagi.utils.logging import notify_error
 from dimagi.utils.web import get_static_url_prefix
@@ -154,3 +157,8 @@ def _mass_email_attachment(name, rows):
         'file_obj': csv_file,
     }
     return attachment
+
+
+@periodic_task_when_true(settings.IS_SAAS_ENVIRONMENT, run_every=crontab(minute="0", hour="*/4"), queue='background_queue')
+def cleanup_stale_es_on_couch_domains_task():
+    cleanup_stale_es_on_couch_domains()

--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -13,9 +13,6 @@ from celery.schedules import crontab
 from celery.task import task
 from celery.task.base import periodic_task
 
-from corehq.apps.hqadmin.couch_domain_utils import (
-    cleanup_stale_es_on_couch_domains,
-)
 from dimagi.utils.django.email import send_HTML_email
 from dimagi.utils.logging import notify_error
 from dimagi.utils.web import get_static_url_prefix
@@ -161,4 +158,5 @@ def _mass_email_attachment(name, rows):
 
 @periodic_task_when_true(settings.IS_SAAS_ENVIRONMENT, run_every=crontab(minute="0", hour="*/4"), queue='background_queue')
 def cleanup_stale_es_on_couch_domains_task():
+    from corehq.apps.hqadmin.couch_domain_utils import cleanup_stale_es_on_couch_domains
     cleanup_stale_es_on_couch_domains()

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -1350,6 +1350,14 @@ COUCH_SQL_MIGRATION_BLACKLIST = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+ACTIVE_COUCH_DOMAINS = StaticToggle(
+    'active_couch_domains',
+    "Domains that are still on the Couch DB backend which we consider most "
+    "active / important to ensure that data in ES is never stale.",
+    TAG_INTERNAL,
+    [NAMESPACE_DOMAIN],
+)
+
 PAGINATED_EXPORTS = StaticToggle(
     'paginated_exports',
     'Allows for pagination of exports for very large exports',


### PR DESCRIPTION
## Summary
This is a follow-up to https://dimagi-dev.atlassian.net/browse/SAAS-11513 and is basically a bandaid to keep data in couch domains from going stale in es while we figure out the root cause for the out of sync data and/or migrate these domains to postgres.

It introduces a periodic task that runs every 4 hours that runs through the list of active couch domains defined by the feature flag `ACTIVE_COUCH_DOMAINS` and makes sure that no data is stale in es within the past 5 days. There are also a few metrics that keep track of instances where we find discrepancies in form counts on a domain and when we find stale forms.

## Feature Flag
`ACTIVE_COUCH_DOMAINS`

## Product Description
All invisible changes.

## Safety Assurance / Safety Story
Low risk as these are all new utilities and don't touch any existing code/workflow. Also, everything is behind a feature flag. Lastly, I went ahead and tested out the code in a limited release to make sure nothing errors out and it all works as expected.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
