### PR TITLE
remove trailing slash on url

### DIFF
--- a/corehq/apps/linked_domain/management/commands/link_app_to_remote.py
+++ b/corehq/apps/linked_domain/management/commands/link_app_to_remote.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         parser.add_argument('-l', '--linked_id', required=True,
                             help="ID of the local app to be linked")
         parser.add_argument('-r', '--url_base', required=True,
-                            help="Base URL of remote system e.g. https://www.commcarehq.org/")
+                            help="Base URL of remote system e.g. https://www.commcarehq.org")
         parser.add_argument('-d', '--domain', required=True,
                             help="Domain of master app.")
         parser.add_argument('-u', '--username', required=True,


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
The trailing slash causes an invalid URL as a slash is automatically added, so you end up with commcarehq.org//a