### PR TITLE
Remove incorrect validation

### DIFF
--- a/corehq/apps/linked_domain/models.py
+++ b/corehq/apps/linked_domain/models.py
@@ -102,12 +102,6 @@ class DomainLink(models.Model):
             # if there is already an active link, just update it with the new information
             link = active_links_with_this_domain[0]
         else:
-            # make a new link
-            if remote_details and linked_domain[-1] != '/':
-                raise DomainLinkError("""
-                    When linking remote domain, linked_domain "{}" should end with a slash.
-                    Please try again using "{}/".
-                """.format(linked_domain, linked_domain))
             link = DomainLink(linked_domain=linked_domain, master_domain=master_domain)
 
         if remote_details:


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
As described in https://github.com/dimagi/commcare-hq/pull/26926#issuecomment-671582771 this validation is incorrect, and forces you to create improperly configured `DomainLinks`. It likely stopped being correct when the first argument was switched from full URLs to a domain name