### PR TITLE
clear opened_on

### DIFF
--- a/corehq/motech/repeaters/repeater_generators.py
+++ b/corehq/motech/repeaters/repeater_generators.py
@@ -379,6 +379,8 @@ class ReferCasePayloadGenerator(BasePayloadGenerator):
     def _set_referral_properties(self, case, original_case_id):
         # make sure new case is open
         case.closed = False
+        # clear opened_on so that it is set on case creation in receiving domain
+        case.opened_on = None
         case.case_json['cchq_referral_source_domain'] = self.repeater.domain
         case.case_json['cchq_referral_source_case_id'] = original_case_id
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This removed `opened_on` from the case payloads in ReferCaseRepeaters, which causes that field to be filled at case creation time, as it is for other cases.
https://dimagi-dev.atlassian.net/browse/USH-411

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
refer_case_repeater

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->
This feature is used only by USH projects and the effect of this change on generated XML was tested locally.

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
