### PR TITLE
add allow bulk form actions feature flag for vellum

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -893,12 +893,12 @@ VELLUM_DATA_IN_SETVALUE = StaticToggle(
 
 VELLUM_ALLOW_BULK_FORM_ACTIONS = StaticToggle(
     'allow_bulk_form_actions',
-    "Allow bulk form actions in Vellum / Formdesigner",
+    "Allow bulk form actions in the Form Builder",
     TAG_PRODUCT,
     [NAMESPACE_DOMAIN],
     description="This shows Bulk Form Actions (mark all questions required, "
                 "set default values to matching case properties) in "
-                "Vellum's main dropdown menu.",
+                "the Form Builder's main dropdown menu.",
 )
 
 CACHE_AND_INDEX = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -891,6 +891,16 @@ VELLUM_DATA_IN_SETVALUE = StaticToggle(
                 "This may still cause issues if the other questions have not been calculated yet",
 )
 
+VELLUM_ALLOW_BULK_FORM_ACTIONS = StaticToggle(
+    'allow_bulk_form_actions',
+    "Allow bulk form actions in Vellum / Formdesigner",
+    TAG_PRODUCT,
+    [NAMESPACE_DOMAIN],
+    description="This shows Bulk Form Actions (mark all questions required, "
+                "set default values to matching case properties) in "
+                "Vellum's main dropdown menu.",
+)
+
 CACHE_AND_INDEX = StaticToggle(
     'cache_and_index',
     'REC: Enable the "Cache and Index" format option when choosing sort properties '


### PR DESCRIPTION
## Summary
related to https://dimagi-dev.atlassian.net/browse/SAAS-11387
This makes the current work for this feature request a feature flag, as we still want to make additional substantial changes to the UX that can't be completed timely enough for our clients. At the same time, we don't want the wider user base to get used to these features just yet...hence hiding them behind a flag.

## Feature Flag
This introduces the `VELLUM_ALLOW_BULK_FORM_ACTIONS` / `Allow bulk form actions in Vellum / Formdesigner` feature flag.

## Product Description
this will be related to changes [here](https://github.com/dimagi/Vellum/pull/980), but in itself is just a flag.

## Safety Assurance
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
There are new tests for the vellum feature, but this PR is only a feature flag, so pretty low risk.

### QA Plan
QA is happening for the vellum feature here:
https://dimagi-dev.atlassian.net/browse/QA-2079

### Safety story
This PR only introduces a feature flag. Ultra low risk.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
