### PR TITLE
Clarify QA label checkbox in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 - [ ] Risk label is set correctly
 - [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
-- [ ] QA labels are set correctly: if QA is part of the safety story, the "Awaiting QA" label is used
+- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
 - [ ] I am certain that this PR will not introduce a regression for the reasons below
 
 ### Automated test coverage

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 - [ ] Risk label is set correctly
 - [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
-- [ ] QA labels are set correctly
+- [ ] QA labels are set correctly: if QA is part of the safety story, the "Awaiting QA" label is used
 - [ ] I am certain that this PR will not introduce a regression for the reasons below
 
 ### Automated test coverage


### PR DESCRIPTION
## Summary
Followup from https://github.com/dimagi/commcare-hq/pull/28781

It also occurs to me though that if we added a "No QA Needed" label, and made required-labels require exactly one of "No QA Needed", "Awaiting QA", and "QA Passed" (similar to our setup for product/* labels) then we wouldn't need this checkbox in the PR template.

## Feature Flag
None

## Product Description
None

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] QA labels are set correctly
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
None
### QA Plan
None

### Safety story
Since this changes only our PR template, it can't directly cause a product defect.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
