### PR TITLE
Further improve dump/reload logging

### DIFF
--- a/corehq/apps/dump_reload/couch/load.py
+++ b/corehq/apps/dump_reload/couch/load.py
@@ -72,7 +72,7 @@ class LoaderCallback(IterDBCallback):
             doc_id = doc['_id']
             doc_type = drop_suffix(doc['doc_type'])
             doc_class = get_document_class_by_doc_type(doc_type)
-            doc_label = '(couch) {}.{}'.format(doc_class._meta.app_label, doc_type)
+            doc_label = '{}.{}'.format(doc_class._meta.app_label, doc_type)
             if doc_id in success_ids:
                 success_doc_types.append(doc_label)
 

--- a/corehq/apps/dump_reload/couch/load.py
+++ b/corehq/apps/dump_reload/couch/load.py
@@ -29,9 +29,7 @@ class CouchDataLoader(DataLoader):
         self._success_counter = Counter()
 
     def load_objects(self, object_strings, force=False):
-        total_object_count = 0
         for obj_string in object_strings:
-            total_object_count += 1
             doc = json.loads(obj_string)
             doc_type = drop_suffix(doc['doc_type'])
             if self._doc_type_matches_filter(doc_type):
@@ -41,7 +39,7 @@ class CouchDataLoader(DataLoader):
         for db in self._dbs.values():
             db.commit()
 
-        return total_object_count, self._success_counter
+        return self._success_counter
 
     def _doc_type_matches_filter(self, doc_type):
         return not self.object_filter or self.object_filter.findall(doc_type)
@@ -105,7 +103,7 @@ class ToggleLoader(DataLoader):
             count += 1
 
         self.stdout.write('Loaded {} Toggles'.format(count))
-        return count, Counter({'Toggle': count})
+        return Counter({'Toggle': count})
 
 
 class DomainLoader(DataLoader):
@@ -133,4 +131,4 @@ class DomainLoader(DataLoader):
         Domain.get_db().bulk_save([domain_dict], new_edits=False)
         self.stdout.write('Loaded Domain')
 
-        return 1, Counter({'Domain': 1})
+        return Counter({'Domain': 1})

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -49,7 +49,7 @@ class DataLoader(metaclass=ABCMeta):
         """
         :param object_strings: iterable of JSON encoded object strings
         :param force: True if objects should be loaded into an existing domain
-        :return: tuple(total object count, loaded object count)
+        :return: loaded object Counter
         """
         raise NotImplementedError
 
@@ -62,7 +62,7 @@ class DataLoader(metaclass=ABCMeta):
         expected_count = sum(dump_meta[self.slug].values())
         with gzip.open(file_path) as dump_file:
             object_strings = with_progress_bar(dump_file, length=expected_count, stream=self.stdout)
-            total_object_count, loaded_object_count = self.load_objects(object_strings, force)
+            loaded_object_count = self.load_objects(object_strings, force)
 
         # Warn if the file we loaded contains 0 objects.
         if sum(loaded_object_count.values()) == 0:
@@ -72,4 +72,4 @@ class DataLoader(metaclass=ABCMeta):
                 RuntimeWarning
             )
 
-        return total_object_count, loaded_object_count
+        return loaded_object_count

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -58,10 +58,10 @@ class DataLoader(metaclass=ABCMeta):
         if not os.path.isfile(file_path):
             raise Exception("Dump file not found: {}".format(file_path))
 
-        self.stdout.write(f"Inspecting {file_path} using '{self.slug}' data loader.")
+        self.stdout.write(f"\nLoading {file_path} using '{self.slug}' data loader.")
         expected_count = sum(dump_meta[self.slug].values())
         with gzip.open(file_path) as dump_file:
-            object_strings = with_progress_bar(dump_file, length=expected_count, stream=self.stdout)
+            object_strings = with_progress_bar(dump_file, length=expected_count)
             loaded_object_count = self.load_objects(object_strings, force)
 
         # Warn if the file we loaded contains 0 objects.

--- a/corehq/apps/dump_reload/interface.py
+++ b/corehq/apps/dump_reload/interface.py
@@ -58,7 +58,7 @@ class DataLoader(metaclass=ABCMeta):
         if not os.path.isfile(file_path):
             raise Exception("Dump file not found: {}".format(file_path))
 
-        self.stdout.write(f"Inspecting {extracted_dump_path} using '{self.slug}' data loader.")
+        self.stdout.write(f"Inspecting {file_path} using '{self.slug}' data loader.")
         line_count = _get_gzfile_line_count(file_path)
         with gzip.open(file_path) as dump_file:
             object_strings = with_progress_bar(dump_file, length=line_count, stream=self.stdout)

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -46,7 +46,6 @@ class Command(BaseCommand):
         self.stdout.write("Loading data from %s." % dump_file_path)
         extracted_dir = self.extract_dump_archive(dump_file_path)
 
-        total_object_count = 0
         loaded_meta = {}
         loaders = options.get('loaders')
         object_filter = options.get('object_filter')
@@ -57,13 +56,11 @@ class Command(BaseCommand):
 
         dump_meta = _get_dump_meta(extracted_dir)
         for loader in loaders:
-            loader_count, loader_model_counts = self._load_data(loader, extracted_dir, object_filter, dump_meta)
-            total_object_count += loader_count
-            loaded_meta[loader.slug] = loader_model_counts
+            loaded_meta[loader.slug] = self._load_data(loader, extracted_dir, object_filter, dump_meta)
 
-        self._print_stats(loaded_meta, total_object_count)
+        self._print_stats(loaded_meta, dump_meta)
 
-    def _print_stats(self, loaded_meta, total_object_count):
+    def _print_stats(self, loaded_meta, dump_meta):
         self.stdout.write('{0} Load Stats {0}'.format('-' * 40))
         for loader, models in sorted(loaded_meta.items()):
             self.stdout.write(loader)
@@ -71,6 +68,7 @@ class Command(BaseCommand):
                 self.stdout.write(f"  {model:<50}: {count}")
         self.stdout.write('{0}{0}'.format('-' * 46))
         loaded_object_count = sum(count for model in loaded_meta.values() for count in model.values())
+        total_object_count = sum(count for model in dump_meta.values() for count in model.values())
         self.stdout.write(f'Loaded {loaded_object_count}/{total_object_count} objects')
         self.stdout.write('{0}{0}'.format('-' * 46))
 

--- a/corehq/apps/dump_reload/management/commands/load_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/load_domain_data.py
@@ -65,7 +65,8 @@ class Command(BaseCommand):
         for loader, models in sorted(loaded_meta.items()):
             self.stdout.write(loader)
             for model, count in sorted(models.items()):
-                self.stdout.write(f"  {model:<50}: {count}")
+                expected = dump_meta[loader][model]
+                self.stdout.write(f"  {model:<50}: {count} / {expected}")
         self.stdout.write('{0}{0}'.format('-' * 46))
         loaded_object_count = sum(count for model in loaded_meta.values() for count in model.values())
         total_object_count = sum(count for model in dump_meta.values() for count in model.values())

--- a/corehq/apps/dump_reload/sql/load.py
+++ b/corehq/apps/dump_reload/sql/load.py
@@ -24,14 +24,11 @@ class SqlDataLoader(DataLoader):
     slug = 'sql'
 
     def load_objects(self, object_strings, force=False):
-        object_count = 0
 
         def enqueue_object(dbalias_to_workerqueue, obj):
-            nonlocal object_count
             db_alias = get_db_alias(obj)
             __, queue = dbalias_to_workerqueue[db_alias]
             queue.put(obj)
-            object_count += 1
 
         def collect_results(dbalias_to_workerqueue) -> Tuple[list, list]:
             load_stats = []
@@ -78,7 +75,7 @@ class SqlDataLoader(DataLoader):
             model_labels = (f'{get_model_label(model)}'
                             for model in db_stats.model_counter.elements())
             loaded_model_counts.update(model_labels)
-        return object_count, loaded_model_counts
+        return loaded_model_counts
 
     def line_to_object(self, line):
         line = line.strip()

--- a/corehq/apps/dump_reload/sql/load.py
+++ b/corehq/apps/dump_reload/sql/load.py
@@ -32,8 +32,6 @@ class SqlDataLoader(DataLoader):
             __, queue = dbalias_to_workerqueue[db_alias]
             queue.put(obj)
             object_count += 1
-            if not object_count % 1000:
-                self.stdout.write(f'Loaded {object_count} SQL objects')
 
         def collect_results(dbalias_to_workerqueue) -> Tuple[list, list]:
             load_stats = []

--- a/corehq/apps/dump_reload/sql/load.py
+++ b/corehq/apps/dump_reload/sql/load.py
@@ -77,7 +77,7 @@ class SqlDataLoader(DataLoader):
         _reset_sequences(load_stats)
         loaded_model_counts = Counter()
         for db_stats in load_stats:
-            model_labels = (f'(sql) {get_model_label(model)}'
+            model_labels = (f'{get_model_label(model)}'
                             for model in db_stats.model_counter.elements())
             loaded_model_counts.update(model_labels)
         return object_count, loaded_model_counts

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -70,7 +70,7 @@ class CouchDumpLoadTest(TestCase):
         dump_lines = [line.strip() for line in dump_output if line.strip()]
 
         with mock_out_couch() as fake_db:
-            total_object_count, loaded_object_count = CouchDataLoader().load_objects(dump_lines)
+            loaded_object_count = CouchDataLoader().load_objects(dump_lines)
 
         def _dump_line_to_doc_class(line):
             doc = json.loads(line)
@@ -83,10 +83,8 @@ class CouchDumpLoadTest(TestCase):
         expected_object_counts = Counter(
             object.__class__ for object in expected_objects
         )
-        expected_total_objects = len(expected_objects)
         self.assertDictEqual(dict(expected_object_counts), dict(actual_model_counts))
-        self.assertEqual(expected_total_objects, sum(loaded_object_count.values()))
-        self.assertEqual(expected_total_objects, total_object_count)
+        self.assertEqual(len(expected_objects), sum(loaded_object_count.values()))
 
         counts_in_fake_db = _get_doc_counts_from_fake_db(fake_db, doc_to_doc_class)
         self.assertDictEqual(dict(expected_object_counts), counts_in_fake_db)

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -706,8 +706,7 @@ class DefaultDictWithKeyTests(SimpleTestCase):
 def _normalize_object_counter(counter, for_loaded=False):
     """Converts a <Model Class> keyed counter to an model label keyed counter"""
     def _model_class_to_label(model_class):
-        prefix = '(sql) ' if for_loaded else ''
-        label = '{}{}.{}'.format(prefix, model_class._meta.app_label, model_class.__name__)
+        label = '{}.{}'.format(model_class._meta.app_label, model_class.__name__)
         return label if for_loaded else label.lower()
     return Counter({
         _model_class_to_label(model_class): count

--- a/corehq/apps/dump_reload/tests/test_sql_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_sql_dump_load.py
@@ -119,13 +119,11 @@ class BaseDumpLoadTest(TestCase):
 
         # Load
         loader = SqlDataLoader(object_filter=load_filter)
-        total_object_count, loaded_model_counts = loader.load_objects(dump_lines)
+        loaded_model_counts = loader.load_objects(dump_lines)
 
         normalized_expected_loaded_counts = _normalize_object_counter(expected_load_counts, for_loaded=True)
         self.assertDictEqual(dict(normalized_expected_loaded_counts), dict(loaded_model_counts))
-        expected_total_load_objects = sum(expected_load_counts.values())
-        self.assertEqual(expected_total_load_objects, sum(loaded_model_counts.values()))
-        self.assertEqual(expected_total_load_objects, total_object_count)
+        self.assertEqual(sum(expected_load_counts.values()), sum(loaded_model_counts.values()))
 
         return dump_lines
 


### PR DESCRIPTION
## Summary
Followup from https://github.com/dimagi/commcare-hq/pull/28756
The chief change is that this now stores information about what's being dumped in a `meta.json` and references this info in the loader when displaying consistency information.
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
This change only affects a management command that's run only on blank environments to populate them with data. A full QA pass and data integrity checks should be carried out at the end of that process.  This changes a bit more than my last PR in the area, but any failures introduced would only affect that command.
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
