### PR TITLE
Extract captcha from draconian features as HQ feature

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1186,7 +1186,7 @@ class HQPasswordResetForm(NoAutocompleteMixin, forms.Form):
     """
     email = forms.EmailField(label=ugettext_lazy("Email"), max_length=254,
                              widget=forms.TextInput(attrs={'class': 'form-control'}))
-    if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
+    if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
         captcha = CaptchaField(label=ugettext_lazy("Type the letters in the box"))
     error_messages = {
         'unknown': ugettext_lazy("That email address doesn't have an associated user account. Are you sure you've "

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -44,7 +44,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
         if not password:
             raise ValidationError(_("Please enter a password."))
 
-        if 'captcha' in self.fields:
+        if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
             if not self.cleaned_data.get('captcha'):
                 raise ValidationError(_("Please enter valid CAPTCHA"))
 

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -28,7 +28,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
     username = forms.EmailField(label=_("Email Address"), max_length=75,
                                 widget=forms.TextInput(attrs={'class': 'form-control'}))
     password = forms.CharField(label=_("Password"), widget=forms.PasswordInput(attrs={'class': 'form-control'}))
-    if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
+    if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
         captcha = CaptchaField(label=_("Type the letters in the box"))
 
     def clean_username(self):
@@ -44,7 +44,7 @@ class EmailAuthenticationForm(NoAutocompleteMixin, AuthenticationForm):
         if not password:
             raise ValidationError(_("Please enter a password."))
 
-        if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
+        if 'captcha' in self.fields:
             if not self.cleaned_data.get('captcha'):
                 raise ValidationError(_("Please enter valid CAPTCHA"))
 

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -330,7 +330,7 @@ class BaseUserInvitationForm(NoAutocompleteMixin, forms.Form):
                                help_text=mark_safe("""
                                <span data-bind="text: passwordHelp, css: color">
                                """))
-    if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
+    if settings.ADD_CAPTCHA_FIELD_TO_FORMS:
         captcha = CaptchaField(label=_("Type the letters in the box"))
     # Must be set to False to have the clean_*() routine called
     eula_confirmed = forms.BooleanField(required=False,

--- a/settings.py
+++ b/settings.py
@@ -172,6 +172,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 INACTIVITY_TIMEOUT = 60 * 24 * 14
 SECURE_TIMEOUT = 30
 ENABLE_DRACONIAN_SECURITY_FEATURES = False
+ADD_CAPTCHA_FIELD_TO_FORMS = False
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/ICDS-1718
In order to align code better and have less explicit "icds" reference/context in HQ code, we are trying to move code out in icds repo or do renaming in code.
`ENABLE_DRACONIAN_SECURITY_FEATURES` was added specifically for ICDS and provides various features in HQ.
This PR extracts captcha implementation done as a part of it, as its own feature in HQ. I did try extracting it out of HQ code but it's knit deep in HQ codebase [My attempt in [HQ Code Changes](https://github.com/dimagi/commcare-hq/compare/mk/remove-icds-ref/draconian-security?expand=1)  & [ICDS Code Changes](https://github.com/dimagi/commcare-icds/compare/mk/remove-icds-ref/draconian-security?expand=1)]

To Do post review
- [x] Add ability in commcare-cloud to overrite this setting and update icds-commcare-environments accordingly 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-2138

### Safety story
Tested it locally. HQ is just made to use a different setting. It will effect only ICDS environments.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
