### PR TITLE
correctly update form on ajax

### DIFF
--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -47,10 +47,6 @@ hqDefine('users/js/edit_commcare_user', [
                     googleAnalytics.track.event("Edit Mobile Worker", "Reset password", couchUserId);
                 } else {
                     var message = gettext('Password was not changed ');
-                    if (initialPageData.get('hide_password_feedback')) {
-                        message += gettext("Password Requirements: 1 special character, " +
-                            "1 number, 1 capital letter, minimum length of 8 characters.");
-                    }
                     alertUser.alert_user(message, 'danger');
                 }
             },

--- a/corehq/apps/users/static/users/js/edit_commcare_user.js
+++ b/corehq/apps/users/static/users/js/edit_commcare_user.js
@@ -41,7 +41,7 @@ hqDefine('users/js/edit_commcare_user', [
             type: 'POST',
             dataType: 'json',
             success: function (response, status, xhr, form) {
-                form.find('#user-password').html(response.formHTML);
+                $('#reset-password-form-container').html(response.formHTML);
                 if (response.status === "OK") {
                     alertUser.alert_user(gettext("Password changed successfully"), 'success');
                     googleAnalytics.track.event("Edit Mobile Worker", "Reset password", couchUserId);

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -63,7 +63,12 @@
     <div class="tab-pane" id="user-password">
       <div class="panel-body">
         {% if not request.is_view_only %}
-          {% include 'users/partials/reset_password.html' %}
+          <form id="reset-password-form" class="form-horizontal" action="{% url "change_password" domain couch_user.user_id %}" method="post">
+            {% csrf_token %}
+            <div id="reset-password-form-container">
+              {% include 'users/partials/reset_password.html' %}
+            </div>
+          </form>
           <div class="spacer"></div>
         {% endif %}
         {% if token %}

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -65,7 +65,7 @@
           <form id="reset-password-form" class="form-horizontal" action="{% url "change_password" domain couch_user.user_id %}" method="post">
             {% csrf_token %}
             <div id="reset-password-form-container">
-              {% include 'users/partials/reset_password.html' %}
+              {% crispy reset_password_form %}
             </div>
           </form>
           <div class="spacer"></div>

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -13,7 +13,6 @@
   {% initial_page_data 'custom_fields_slugs' custom_fields_slugs %}
   {% initial_page_data 'custom_fields_profiles' custom_fields_profiles %}
   {% initial_page_data 'custom_fields_profile_slug' custom_fields_profile_slug %}
-  {% initial_page_data "hide_password_feedback" hide_password_feedback %}
   {% initial_page_data "is_currently_logged_in_user" is_currently_logged_in_user %}
   {% initial_page_data "path" request.path %}
   {% initial_page_data "is_delete_allowed" is_delete_allowed %}

--- a/corehq/apps/users/templates/users/partials/reset_password.html
+++ b/corehq/apps/users/templates/users/partials/reset_password.html
@@ -1,2 +1,0 @@
-{% load crispy_forms_tags %}
-{% crispy reset_password_form %}

--- a/corehq/apps/users/templates/users/partials/reset_password.html
+++ b/corehq/apps/users/templates/users/partials/reset_password.html
@@ -1,5 +1,2 @@
 {% load crispy_forms_tags %}
-<form id="reset-password-form" class="form-horizontal" action="{% url "change_password" domain couch_user.user_id %}" method="post">
-  {% csrf_token %}
-  {% crispy reset_password_form %}
-</form>
+{% crispy reset_password_form %}

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -6,6 +6,7 @@ import six.moves.urllib.error
 import six.moves.urllib.parse
 import six.moves.urllib.request
 from couchdbkit.exceptions import ResourceNotFound
+from crispy_forms.utils import render_crispy_form
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.web import json_response
 from django.conf import settings
@@ -1231,7 +1232,7 @@ def add_domain_membership(request, domain, couch_user_id, domain_name):
 @sensitive_post_parameters('new_password1', 'new_password2')
 @login_and_domain_required
 @location_safe
-def change_password(request, domain, login_id, template="users/partials/reset_password.html"):
+def change_password(request, domain, login_id):
     # copied from auth's password_change
 
     commcare_user = CommCareUser.get_by_user_id(login_id, domain)
@@ -1247,11 +1248,7 @@ def change_password(request, domain, login_id, template="users/partials/reset_pa
             form = SetUserPasswordForm(request.project, login_id, user='')
     else:
         form = SetUserPasswordForm(request.project, login_id, user=django_user)
-    context = _users_context(request, domain)
-    context.update({
-        'reset_password_form': form,
-    })
-    json_dump['formHTML'] = render_to_string(template, context)
+    json_dump['formHTML'] = render_crispy_form(form)
     return HttpResponse(json.dumps(json_dump))
 
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -291,7 +291,6 @@ class EditCommCareUserView(BaseEditUserView):
                 not has_privilege(self.request, privileges.LOCATIONS)
             ),
             'demo_restore_date': naturaltime(demo_restore_date_created(self.editable_user)),
-            'hide_password_feedback': settings.ENABLE_DRACONIAN_SECURITY_FEATURES,
             'group_names': [g.name for g in self.groups],
         }
         if self.commtrack_form.errors:


### PR DESCRIPTION
## Summary
Found this while working on another ticket where i am trying to remove things related to `ENABLE_DRACONIAN_SECURITY_FEATURES`

In JS file, currently we search for `form.find('#user-password')` which is not present. `user-password` container is actually above the form itself and hence the update does not work. To replicate just add a simple password on a domain that needs strong password.
I also tried replacing the complete form but that lead to issues with CSRF token with the "Cookies must be enabled" page shown. 
So I moved the form tag and the csrf token setup in the main view itself while just the form fields in the partial. 
The partial is also used to render response to the ajax request that submits the form.
Then added a container for the form fields to update them correctly.

I also removed the redundant alert message in case the draconian setting is on (used only by ICDS) which is not needed anymore since the form itself has the error message, which is useful as well for the ticket I was originally working on.

I think this UI can be further improved like the default message about the suggested password does not go away even if you edit the password and also now shows in case the password is not accepted. This happens when we create a new mobile worker correctly.
But this at least fixes the form replacement which is better than how it currently stands

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
This is only for projects which have "Require Strong Passwords for Mobile Workers" set.
In case the password entered is not acceptable, now user would see a error message after submit on the form itself along with the alert that said "Password was not changed ". I think we can get rid of the alert entirely now. 
Earlier, there was no message shown on the form.
In case the setting `ENABLE_DRACONIAN_SECURITY_FEATURES` is set to true, which is only on ICDS, users won't see the extra message about password in the red alert message anymore but would see it on the form itself.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
Would pass this through QA considering its a sensitive area. Passwords should continue to meet requirements as set by the project and the environment. 
https://dimagi-dev.atlassian.net/browse/QA-2138

### Safety story
I tested this locally to get the correct error message and then successfully update password after that.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 


Before
![Screenshot from 2020-11-15 17-49-50](https://user-images.githubusercontent.com/3864163/99184776-5d959480-276b-11eb-9511-ab87540e1f34.png)

After
![Screenshot from 2020-11-15 17-48-46](https://user-images.githubusercontent.com/3864163/99184777-62f2df00-276b-11eb-8f8b-25b4172b6893.png)

