### PR TITLE
Drop "/api" prefix for DHIS2 prod server

### DIFF
--- a/custom/onse/tasks.py
+++ b/custom/onse/tasks.py
@@ -14,6 +14,13 @@ from corehq.motech.models import ConnectionSettings
 from corehq.util.soft_assert import soft_assert
 from custom.onse.const import CASE_TYPE, CONNECTION_SETTINGS_NAME, DOMAIN
 
+# The production DHIS2 server is on the other side of an
+# interoperability service that changes the URL schema from
+# "base_url/api/resource" to "service/dhis2core/api/v0/resource".
+# Its ConnectionSettings instance uses URL "service/dhis2core/api/v0/"
+# Set ``DROP_API_PREFIX = True`` to drop the "/api" before "/resource",
+# so that resource URLs end up as "service/dhis2core/api/v0/resource".
+DROP_API_PREFIX = True
 
 _soft_assert = soft_assert('@'.join(('nhooper', 'dimagi.com')))
 
@@ -145,7 +152,7 @@ def fetch_data_set(
 
     """
     requests = dhis2_server.get_requests()
-    endpoint = '/api/dataValueSets'
+    endpoint = '/dataValueSets' if DROP_API_PREFIX else '/api/dataValueSets'
     params = {
         'period': get_last_quarter(),
         'dataSet': data_set_id,


### PR DESCRIPTION
## Summary

Accommodate non-standard DHIS2 URL schema for production DHIS2 server for ONSE


## Feature Flag

ONSE-specific custom code. No FF.


## Product Description

N/A


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

N/A


### QA Plan

N/A


### Safety story

This change is safe because it only affects the URL used by the onse-iss domain to interact with a specific and unusual DHIS2 server. If the URL is wrong, the DHIS2 server responds with a 404.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
