### PR TITLE
Bmb/stale es followup

### DIFF
--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -36,6 +36,8 @@ def cleanup_stale_es_on_couch_domains(
 
     for domain in couch_domains:
         form_ids, has_discrepancies = _get_all_form_ids(domain, start, end)
+        if stdout:
+            stdout.write(f"Found {len(form_ids)} in {domain} for between {start_date} and {end_date}.")
         if has_discrepancies:
             metrics_gauge(
                 'commcare.es.couch_domain.couch_discrepancy_detected',
@@ -45,7 +47,7 @@ def cleanup_stale_es_on_couch_domains(
                 }
             )
             if stdout:
-                stdout.write(f"\nFound discrepancies in form counts for domain {domain}")
+                stdout.write(f"\tFound discrepancies in form counts for domain {domain}")
         forms_not_in_es = _get_forms_not_in_es(form_ids)
         if forms_not_in_es:
             metrics_gauge(
@@ -56,7 +58,7 @@ def cleanup_stale_es_on_couch_domains(
                 }
             )
             if stdout:
-                stdout.write(f"\nFound {len(forms_not_in_es)} forms not in es "
+                stdout.write(f"\tFound {len(forms_not_in_es)} forms not in es "
                              f"for {domain}")
             changes = _get_changes(domain, forms_not_in_es)
             form_es_processor = get_xform_pillow().processors[0]

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -67,7 +67,7 @@ def _get_couch_form_ids(domain, start, end):
         endkey = [domain, doc_type, json_format_datetime(end)]
         results = XFormInstance.get_db().view(
             'by_domain_doc_type_date/view', startkey=startkey, endkey=endkey,
-            reduce=False, include_docs=False
+            reduce=False, include_docs=False, r=3
         )
         form_ids.update({row['id'] for row in results})
     return form_ids

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -62,7 +62,7 @@ def cleanup_stale_es_on_couch_domains(
 def _get_couch_form_ids(domain, start, end):
     "Get form IDs from the 'by_domain_doc_type_date/view' couch view"
     form_ids = set()
-    for doc_type in ['XFormInstance']:
+    for doc_type in ['XFormArchived', 'XFormInstance']:
         startkey = [domain, doc_type, json_format_datetime(start)]
         endkey = [domain, doc_type, json_format_datetime(end)]
         results = XFormInstance.get_db().view(

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -1,19 +1,24 @@
 import datetime
+from urllib.parse import urljoin, urlparse, urlunparse
 
-from corehq.toggles import ACTIVE_COUCH_DOMAINS
-from corehq.util.metrics import metrics_gauge
+from couchdbkit import Database
 from couchforms.models import XFormInstance
+from django.conf import settings
 
-from corehq.apps.es import FormES
-from corehq.elastic import ES_EXPORT_INSTANCE
 from dimagi.utils.chunked import chunked
 from dimagi.utils.parsing import json_format_datetime
 
+from corehq.toggles import ACTIVE_COUCH_DOMAINS
+from corehq.util.metrics import metrics_gauge
+from corehq.apps.es import FormES
+from corehq.elastic import ES_EXPORT_INSTANCE
 from corehq.pillows.xform import get_xform_pillow
 from corehq.util.couch import bulk_get_revs
 from corehq.apps.hqcase.management.commands.backfill_couch_forms_and_cases import (
     create_form_change_meta,
 )
+
+COUCH_NODE_PORT = 15984
 
 
 def cleanup_stale_es_on_couch_domains(
@@ -59,15 +64,28 @@ def cleanup_stale_es_on_couch_domains(
                 form_es_processor.process_change(change)
 
 
-def _get_couch_form_ids(domain, start, end):
-    "Get form IDs from the 'by_domain_doc_type_date/view' couch view"
+def _get_couch_node_databases(db, node_port=COUCH_NODE_PORT):
+    def node_url(proxy_url, node):
+        return urlunparse(proxy_url._replace(netloc=f'{auth}@{node}:{node_port}'))
+
+    resp = db.server._request_session.get(urljoin(db.server.uri, '/_membership'))
+    resp.raise_for_status()
+    membership = resp.json()
+    nodes = [node.split("@")[1] for node in membership["cluster_nodes"]]
+    proxy_url = urlparse(settings.COUCH_DATABASE)._replace(path=f"/{db.dbname}")
+    auth = proxy_url.netloc.split('@')[0]
+    return [Database(node_url(proxy_url, node)) for node in nodes]
+
+
+def _get_couch_form_ids(node_db, domain, start, end):
+    """Get form IDs from the 'by_domain_doc_type_date/view' couch view"""
     form_ids = set()
     for doc_type in ['XFormArchived', 'XFormInstance']:
         startkey = [domain, doc_type, json_format_datetime(start)]
         endkey = [domain, doc_type, json_format_datetime(end)]
-        results = XFormInstance.get_db().view(
+        results = node_db.view(
             'by_domain_doc_type_date/view', startkey=startkey, endkey=endkey,
-            reduce=False, include_docs=False, r=3
+            reduce=False, include_docs=False
         )
         form_ids.update({row['id'] for row in results})
     return form_ids
@@ -82,8 +100,8 @@ def _get_all_form_ids(domain, start, end):
     all_form_ids = None
     previous_form_ids = None
     form_id_differences = []
-    for i in range(10):
-        form_ids = _get_couch_form_ids(domain, start, end)
+    for node_db in _get_couch_node_databases(XFormInstance.get_db()):
+        form_ids = _get_couch_form_ids(node_db, domain, start, end)
         if not all_form_ids:
             all_form_ids = form_ids
         else:

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -15,8 +15,6 @@ from corehq.apps.hqcase.management.commands.backfill_couch_forms_and_cases impor
     create_form_change_meta,
 )
 
-COUCH_NODE_PORT = 15984
-
 
 def cleanup_stale_es_on_couch_domains(
     start_date=None, end_date=None, domains=None, stdout=None

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -37,7 +37,8 @@ def cleanup_stale_es_on_couch_domains(
     for domain in couch_domains:
         form_ids, has_discrepancies = _get_all_form_ids(domain, start, end)
         if stdout:
-            stdout.write(f"Found {len(form_ids)} in {domain} for between {start_date} and {end_date}.")
+            stdout.write(f"Found {len(form_ids)} in {domain} for between "
+                         f"{start.isoformat()} and {end.isoformat()}.")
         if has_discrepancies:
             metrics_gauge(
                 'commcare.es.couch_domain.couch_discrepancy_detected',

--- a/corehq/apps/hqadmin/couch_domain_utils.py
+++ b/corehq/apps/hqadmin/couch_domain_utils.py
@@ -25,7 +25,7 @@ def cleanup_stale_es_on_couch_domains(
     domains still using the couch db backend until we can get them migrated.
     """
     end = end_date or datetime.datetime.utcnow()
-    start = start_date or (end - datetime.timedelta(days=5))
+    start = start_date or (end - datetime.timedelta(days=2))
 
     couch_domains = domains or ACTIVE_COUCH_DOMAINS.get_enabled_domains()
 

--- a/corehq/apps/hqadmin/management/commands/sync_stale_couch_domains.py
+++ b/corehq/apps/hqadmin/management/commands/sync_stale_couch_domains.py
@@ -5,15 +5,13 @@ from corehq.apps.hqadmin.couch_domain_utils import (
     cleanup_stale_es_on_couch_domains,
 )
 
-ALL_COUCH_DOMAINS = object()
-
 
 class Command(BaseCommand):
     help = """Force a sync of data on all high priority couch db domains
     (determined by the feature flag ACTIVE_COUCH_DOMAINS)"""
 
     def add_arguments(self, parser):
-        parser.add_argument('--domains', default=ALL_COUCH_DOMAINS)
+        parser.add_argument('--domains', default=None)
         parser.add_argument(
             '--start',
             action='store',


### PR DESCRIPTION
## Summary
This is the follow up to my previous PR creating a schedule to keep es data in sync for couch domains (https://github.com/dimagi/commcare-hq/pull/28767)
Instead of looping through the `view` command 10 times hoping to get consistent results, this pulls the data from each of the nodes directly.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### QA Plan
No QA needed. Very minor change

### Safety story
Super minor non-workflow breaking change. Tested it on a limited release and runs smoothly

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
