### PR TITLE
extract setting to configure autocomplete

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1172,7 +1172,7 @@ class NoAutocompleteMixin(object):
 
     def __init__(self, *args, **kwargs):
         super(NoAutocompleteMixin, self).__init__(*args, **kwargs)
-        if settings.ENABLE_DRACONIAN_SECURITY_FEATURES:
+        if settings.DISABLE_AUTOCOMPLETE_ON_SENSITIVE_FORMS:
             for field in self.fields.values():
                 field.widget.attrs.update({'autocomplete': 'off'})
 

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -88,7 +88,7 @@ class BaseAutocompleteTest(TestCase):
 
     def verify(self, autocomplete_enabled, view_path, *fields):
         flag = not autocomplete_enabled
-        setting_path = 'django.conf.settings.ENABLE_DRACONIAN_SECURITY_FEATURES'
+        setting_path = 'django.conf.settings.DISABLE_AUTOCOMPLETE_ON_SENSITIVE_FORMS'
         # HACK use patch to work around bug in override_settings
         # https://github.com/django-compressor/django-appconf/issues/30
         with patch(setting_path, flag):

--- a/settings.py
+++ b/settings.py
@@ -171,6 +171,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 # time in minutes before forced logout due to inactivity
 INACTIVITY_TIMEOUT = 60 * 24 * 14
 SECURE_TIMEOUT = 30
+DISABLE_AUTOCOMPLETE_ON_SENSITIVE_FORMS = False
 ENABLE_DRACONIAN_SECURITY_FEATURES = False
 
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
## Summary
On same lines as https://github.com/dimagi/commcare-hq/pull/28785 but just simple extraction to a new setting.
Changes in this PR only effects ICDS environments and has no effect on HQ environments.

To Do post review
- [x] Add ability in commcare-cloud to overrite this setting and update icds-commcare-environments accordingly 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

There is a test that should help validate changes.

### QA Plan

QA requested. https://dimagi-dev.atlassian.net/browse/QA-2138

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 

This PR can be reverted back if `ENABLE_DRACONIAN_SECURITY_FEATURES` has not be removed completely. I am working on all PRs currently associated with removing it. There will be some time before the old setting is removed post release of the new PRs.