### PR TITLE
Removed @freeze_time from TestReportMultipleAggregationsSQL

### DIFF
--- a/corehq/apps/userreports/tests/test_report_aggregation.py
+++ b/corehq/apps/userreports/tests/test_report_aggregation.py
@@ -2,8 +2,6 @@ from django.http import HttpRequest
 from django.test import TestCase
 from datetime import datetime, timedelta
 
-from freezegun import freeze_time
-
 from corehq.apps.userreports.exceptions import BadSpecError, UserReportsError
 from corehq.apps.userreports.models import (
     DataSourceConfiguration,
@@ -607,7 +605,6 @@ class TestReportAggregationSQL(ConfigurableReportAggregationTestMixin, TestCase)
         )
 
 
-@freeze_time("2020-01-15")
 class TestReportMultipleAggregationsSQL(ConfigurableReportAggregationTestMixin, TestCase):
     # Note that these constants are subtracted from today's date, so the month parts of the names
     # are approximations: the first one will usually fall one year and two months ago, but will


### PR DESCRIPTION
## Summary

`test_age_in_months_buckets` is [failing](https://travis-ci.com/github/dimagi/commcare-hq/jobs/442906884):

```
FAIL: corehq.apps.userreports.tests.test_report_aggregation:TestReportMultipleAggregationsSQL.test_age_in_months_buckets
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/commcare-hq-ro/corehq/apps/userreports/tests/test_report_aggregation.py", line 1091, in test_age_in_months_buckets
    self.assertEqual(len(table), 3)
AssertionError: 4 != 3
```

Writing a novel explaining this because these tests are brittle and there will likely be more work to do on them. This PR reverts https://github.com/dimagi/commcare-hq/pull/26520, which temporarily fixed this test by freezing the class at an arbitrary date...but that freezing makes it much harder to genuinely fix the problem, because python and postgres are now working off of different dates.

The test uses the [AgeInMonthsBucketsColumn](https://github.com/dimagi/commcare-hq/blob/adf46d61a6372999461bd9bb1ca80e732abdd525/corehq/apps/userreports/reports/specs.py#L366), calculating age based on the `date` column in the [test data](https://github.com/dimagi/commcare-hq/blob/adf46d61a6372999461bd9bb1ca80e732abdd525/corehq/apps/userreports/tests/test_report_aggregation.py#L634-L661), and grouping into [3 buckets](https://github.com/dimagi/commcare-hq/blob/adf46d61a6372999461bd9bb1ca80e732abdd525/corehq/apps/userreports/tests/test_report_aggregation.py#L1073-L1077). This should result in [these two rows](https://github.com/dimagi/commcare-hq/blob/adf46d61a6372999461bd9bb1ca80e732abdd525/corehq/apps/userreports/tests/test_report_aggregation.py#L1094-L1095).

The `date` column relies on `_relative_date`, which uses `datetime.utc`, so it's affected by `freeze_time`. But the age calculations are done in postgres by the `AgeInMonthsBucketsColumn`, where time is not frozen (I don't think...). That disparity makes this test quite difficult to reason about, so I'm removing `freeze_time`. These tests are meant to work with relative dates.

The immediate cause of the failure is that the test expects the `ONE_YEAR_THREE_MONTHS` and `ONE_YEAR_THREE_MONTHS_OTHER` rows to end up in the same bucket. But they evaluate to `2020-10-18` and `2020-10-17` (based on the frozen time) so today, Nov 18, their ages are 2 years 30 days and 2 years 1 month, so they land in different buckets. Removing `freeze_time` does fix the test for the moment, but just because those dates are now `2019-08-24` and `2019-08-23` so the failure no longer happens today. Guessing it'll break again soon, maybe on the 24th. The right way to fix this is likely to do something similar to https://github.com/dimagi/commcare-hq/pull/26376/


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

This is a test.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
