### PR TITLE
task to export couchdb shard counts to DD

### DIFF
--- a/corehq/apps/hqadmin/tasks.py
+++ b/corehq/apps/hqadmin/tasks.py
@@ -163,7 +163,7 @@ def cleanup_stale_es_on_couch_domains_task():
     cleanup_stale_es_on_couch_domains()
 
 
-@periodic_task_when_true(settings.IS_SAAS_ENVIRONMENT, run_every=crontab(minute="0", hour="*/4"), queue='background_queue')
+@periodic_task_when_true(settings.IS_SAAS_ENVIRONMENT, run_every=crontab(minute="15", hour="*"), queue='background_queue')
 def collect_couchdb_shard_count_metrics():
     from corehq.apps.hqadmin.corrupt_couch import get_cluster_shard_details
     shard_details = get_cluster_shard_details()


### PR DESCRIPTION
## Summary
New periodic task to get shard counts from CouchDB and send them to the metrics provider.

## Feature Flag
NA

## Product Description
NA

## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
No test coverage. This is isolated to a single periodic task which only does metrics. Any failures will be notified to Sentry but will not impact any production systems.

### QA Plan
Do it live. (the bulk of the code has already been tested in CommCare Cloud)

### Safety story
Since this only adds some code + a single periodic task it will not affect any other parts of the system. The task runs every 15 minutes and will not add load to CouchDB.

### Rollback instructions
Revert the PR

- [X] This PR can be reverted after deploy with no further considerations 
