### PR TITLE
send_datasets command: Make `send_date` param optional

### DIFF
--- a/corehq/motech/dhis2/management/commands/send_datasets.py
+++ b/corehq/motech/dhis2/management/commands/send_datasets.py
@@ -6,15 +6,19 @@ from corehq.motech.dhis2.tasks import send_datasets
 
 
 class Command(BaseCommand):
-    """
-    Manually send datasets for a project assuming it was run at a date in the past
-    """
+    help = ('Manually send datasets for a domain. Specify --send-date '
+            'to simulate a date in the past')
 
     def add_arguments(self, parser):
         parser.add_argument('domain_name')
-        parser.add_argument('send_date', help="YYYY-MM-DD")
+        parser.add_argument('--send_date', help="YYYY-MM-DD")
 
-    def handle(self, domain_name, send_date, **options):
-        send_date = datetime.strptime(send_date, '%Y-%m-%d')
+    def handle(self, domain_name, **options):
+        if 'send_date' in options:
+            send_date = datetime.strptime(options['send_date'], '%Y-%m-%d')
+        else:
+            send_date = None
         print("Sending dataset")
-        send_datasets(domain_name, send_now=True, send_date=send_date)
+        send_datasets.apply(domain_name, kwargs={
+            'send_now': True, 'send_date': send_date,
+        })


### PR DESCRIPTION
## Summary

Allows the command to preproduce the "Send now" button exactly, by not having to specify "send_date" as today.

https://dimagi-dev.atlassian.net/browse/SC-1053?focusedCommentId=100900

## Feature Flag
"DHIS2 Integration"

## Product Description
N/A

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below


### Automated test coverage
N/A


### QA Plan
N/A


### Safety story

This makes a parameter of a management command optional. The management command is only applicable to domains that have DHIS2 Aggregated Data integration.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
