### PR TITLE
improve pillow ES error logs

### DIFF
--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -1,6 +1,5 @@
 import math
 import time
-import traceback
 
 from django.conf import settings
 
@@ -173,9 +172,9 @@ def send_to_elasticsearch(index_info, doc_type, doc_id, es_getter, name, data=No
     alias = index_info.alias
     data = data if data is not None else {}
     current_tries = 0
-    es_interface = ElasticsearchInterface(es_getter())
-    retries = 1 if settings.UNIT_TESTING else MAX_RETRIES
-    propagate_failure = settings.UNIT_TESTING
+    es_interface = _get_es_interface(es_getter)
+    retries = _retries()
+    propagate_failure = _propagate_failure()
     while current_tries < retries:
         try:
             if delete:
@@ -188,7 +187,7 @@ def send_to_elasticsearch(index_info, doc_type, doc_id, es_getter, name, data=No
                     # use the same index API to create or update doc
                     es_interface.index_doc(alias, doc_type, doc_id, doc=data, params=params)
             break
-        except ConnectionError as ex:
+        except ConnectionError:
             current_tries += 1
             if current_tries == retries:
                 message = "[%s] Max retry error on %s/%s/%s"
@@ -200,8 +199,8 @@ def send_to_elasticsearch(index_info, doc_type, doc_id, es_getter, name, data=No
             else:
                 pillow_logging.exception("[%s] put_robust error attempt %s/%s", name, current_tries, retries)
 
-            time.sleep(math.pow(RETRY_INTERVAL, current_tries))
-        except RequestError as ex:
+            _sleep_between_retries(current_tries)
+        except RequestError:
             message = "[%s] put_robust error: %s/%s/%s"
             args = (name, alias, doc_type, doc_id)
             if propagate_failure:
@@ -213,3 +212,19 @@ def send_to_elasticsearch(index_info, doc_type, doc_id, es_getter, name, data=No
             break  # ignore the error if a doc already exists when trying to create it in the index
         except NotFoundError:
             break
+
+
+def _propagate_failure():
+    return settings.UNIT_TESTING
+
+
+def _retries():
+    return 1 if settings.UNIT_TESTING else MAX_RETRIES
+
+
+def _sleep_between_retries(current_tries):
+    time.sleep(math.pow(RETRY_INTERVAL, current_tries))
+
+
+def _get_es_interface(es_getter):
+    return ElasticsearchInterface(es_getter())


### PR DESCRIPTION
## Summary
Changes to error logging for elasticsearch errors.

* More consistent message formats
* Tracebacks included automatically by python logging framework (using `log.exeception` instead of `log.error`)
* Removed newlines in log output which can mess up log line grouping in CloudWatch

## Feature Flag
NA

## Product Description
NA

## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Unit tests did exist for one case. More tests added to test production code paths.

### QA Plan
NA

### Safety story
While this only makes changes to log output it could be possible to generate an error while handling an exception. There was one unit test and more have been added to test the production code paths when errors are raised.

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
