### PR TITLE
Removed django admin for domain mirrors

### DIFF
--- a/corehq/apps/domain/views/base.py
+++ b/corehq/apps/domain/views/base.py
@@ -124,7 +124,7 @@ def _domains_to_links(domain_objects, view_name):
         'name': o.name,
         'display_name': o.display_name(),
         'url': reverse(view_name, args=[o.name]),
-    } for o in domain_objects], key=lambda link: link['display_name'].lower())
+    } for o in domain_objects if o], key=lambda link: link['display_name'].lower())
 
 
 class DomainViewMixin(object):

--- a/corehq/apps/users/admin.py
+++ b/corehq/apps/users/admin.py
@@ -39,14 +39,6 @@ admin.site.unregister(User)
 admin.site.register(User, CustomUserAdmin)
 
 
-class DomainPermissionsMirrorAdmin(admin.ModelAdmin):
-    list_display = ['source', 'mirror']
-    list_filter = ['source', 'mirror']
-
-
-admin.site.register(DomainPermissionsMirror, DomainPermissionsMirrorAdmin)
-
-
 class HQApiKeyAdmin(admin.ModelAdmin):
     list_display = ['user', 'name', 'created', 'domain']
     list_filter = ['created', 'domain']


### PR DESCRIPTION
## Summary
There's a [UI](https://github.com/dimagi/commcare-hq/pull/28511) for this now.

Also fixes https://sentry.io/organizations/dimagi/issues/2052162872/ which can happen if a mirror domain was created with an invalid domain name.

## Product Description
Only developers ever used this. No need to announce.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

No tests.

### QA Plan

Smoke tested dropdown change locally.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
