### PR TITLE
Form multimedia exports now ignore invalid list items

### DIFF
--- a/corehq/apps/reports/tests/test_tasks.py
+++ b/corehq/apps/reports/tests/test_tasks.py
@@ -1,0 +1,37 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.reports.tasks import find_question_id
+
+
+class FindQuestionIdTests(SimpleTestCase):
+    def test_returns_none_when_not_found(self):
+        form = {}
+
+        result = find_question_id(form, 'my_attachment')
+        self.assertIsNone(result)
+
+    def test_finds_attachment_in_property(self):
+        form = {'attachment': 'my_attachment'}
+
+        result = find_question_id(form, 'my_attachment')
+        self.assertEqual(result, ['attachment'])
+
+    def test_finds_property_in_nested_form(self):
+        nested_form = {'attachment': 'my_attachment'}
+        form = {'nested': nested_form}
+
+        result = find_question_id(form, 'my_attachment')
+        self.assertEqual(result, ['nested', 'attachment'])
+
+    def test_finds_property_in_list(self):
+        nested_form = {'attachment': 'my_attachment'}
+        form = {'nested_list': [nested_form]}
+
+        result = find_question_id(form, 'my_attachment')
+        self.assertEqual(result, ['nested_list', 'attachment'])
+
+    def test_handles_invalid_list_item(self):
+        form = {'bad_list': ['']}
+
+        result = find_question_id(form, 'my_attachment')
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary
Original ticket: https://dimagi-dev.atlassian.net/browse/SAAS-11326
Multimedia downloads were failing because forms with repeats could contain lists like:
`[valid_form, valid_form, '']`.  The task would error out when it encountered that empty string.
The correct, long-term fix is for resized repeats to not insert these empty tokens.
However, this is a quicker and easier fix that basically just does defensive programming.

### Automated test coverage
Introduced a new test suite in `corehq/apps/reports/tests/test_tasks.py`. I saw there was a related suite in `corehq/apps/reports/tests/test_form_export.py`, but I'd like to start following a module_name->test_module_name pattern so that there is no confusion on where to find tests. If there is too much within a test module, the parent module is too large and should be broken up.

### QA Plan
Reproduced locally and made sure the unit tests catch the regression. I don't believe QA is necessary.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
