### PR TITLE
Added standard toggles javascript to web apps

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/main.js
@@ -1,6 +1,7 @@
 hqDefine("cloudcare/js/formplayer/main", function () {
     $(function () {
-        var initialPageData = hqImport("hqwebapp/js/initial_page_data").get;
+        var initialPageData = hqImport("hqwebapp/js/initial_page_data").get,
+            toggles = hqImport("hqwebapp/js/toggles");
         window.MAPBOX_ACCESS_TOKEN = initialPageData('mapbox_access_token'); // maps api is loaded on-demand
         var options = {
             apps: initialPageData('apps'),
@@ -12,8 +13,8 @@ hqDefine("cloudcare/js/formplayer/main", function () {
             debuggerEnabled: initialPageData('debugger_enabled'),
             singleAppMode: initialPageData('single_app_mode'),
             environment: initialPageData('environment'),
-            useLiveQuery: initialPageData('use_live_query'),
-            changeFormLanguage: initialPageData('change_form_language'),
+            useLiveQuery: toggles.toggleEnabled('FORMPLAYER_USE_LIVEQUERY'),
+            changeFormLanguage: toggles.toggleEnabled('CHANGE_FORM_LANGUAGE'),
         };
         hqImport("cloudcare/js/formplayer/app").start(options);
 

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -78,14 +78,12 @@
   {% initial_page_data 'default_geocoder_location' default_geocoder_location %}
   {% initial_page_data 'single_app_mode' single_app_mode %}
   {% initial_page_data 'username' username %}
-  {% initial_page_data 'use_live_query' use_live_query %}
   {% initial_page_data 'has_geocoder_privs' has_geocoder_privs %}
   {% initial_page_data 'dialer_enabled' integrations.dialer_enabled %}
   {% initial_page_data 'gaen_otp_enabled' integrations.gaen_otp_enabled %}
   {% initial_page_data 'hmac_root_url' integrations.hmac_root_url %}
   {% initial_page_data 'hmac_api_key' integrations.hmac_api_key %}
   {% initial_page_data 'hmac_hashed_secret' integrations.hmac_hashed_secret %}
-  {% initial_page_data 'change_form_language' change_form_language %}
   {% registerurl 'list_case_exports' request.domain %}
   {% registerurl 'list_form_exports' request.domain %}
   {% registerurl 'case_data' request.domain '---' %}

--- a/corehq/apps/cloudcare/templates/formplayer-common/base.html
+++ b/corehq/apps/cloudcare/templates/formplayer-common/base.html
@@ -47,6 +47,7 @@
   <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
 
   {% compress js %}
+    <script src="{% static 'hqwebapp/js/toggles.js' %}"></script>
     <script src="{% static 'cloudcare/js/preview_app/dragscroll.js' %}"></script>
   {% endcompress %}
 
@@ -75,6 +76,8 @@
   {% include 'formplayer/dependencies.html' %}
 {% endblock %}
 
+{% initial_page_data 'toggles_dict' toggles_dict %}
+{% initial_page_data 'previews_dict' previews_dict %}
 <div class="initial-page-data" class="hide">
   {% block initial_page_data %}
     {# do not override this block, use initial_page_data template tag to populate #}

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -217,9 +217,7 @@ class FormplayerMain(View):
             "single_app_mode": False,
             "home_url": reverse(self.urlname, args=[domain]),
             "environment": WEB_APPS_ENVIRONMENT,
-            'use_live_query': toggles.FORMPLAYER_USE_LIVEQUERY.enabled(domain),
             "integrations": integration_contexts(domain),
-            "change_form_language": toggles.CHANGE_FORM_LANGUAGE.enabled(domain),
             "has_geocoder_privs": domain_has_privilege(domain, privileges.GEOCODER),
         }
         return set_cookie(
@@ -281,7 +279,6 @@ class FormplayerPreviewSingleApp(View):
             "single_app_mode": True,
             "home_url": reverse(self.urlname, args=[domain, app_id]),
             "environment": WEB_APPS_ENVIRONMENT,
-            'use_live_query': toggles.FORMPLAYER_USE_LIVEQUERY.enabled(domain),
             "integrations": integration_contexts(domain),
             "has_geocoder_privs": domain_has_privilege(domain, privileges.GEOCODER),
         }

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/toggles.js
@@ -10,7 +10,7 @@ hqDefine('hqwebapp/js/toggles', [
         if (typeof value === 'undefined') {
             throw new Error(
                 'Toggle ' + toggleName + ' not recognized. Must be one of: \n\n' +
-                _.sortBy(_.keys(allToggles).join("\n"))
+                _.sortBy(_.keys(allToggles)).join("\n")
             );
         }
         return value;

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -6,8 +6,7 @@ from django.urls import resolve, reverse
 from django_prbac.utils import has_privilege
 from ws4redis.context_processors import default
 
-from corehq import privileges, toggles
-from corehq.apps.analytics import ab_tests
+from corehq import feature_previews, privileges, toggles
 from corehq.apps.accounting.models import BillingAccount, SubscriptionType
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.hqwebapp.utils import get_environment_friendly_name
@@ -37,10 +36,9 @@ def is_commtrack(project, request):
 
 
 def get_per_domain_context(project, request=None):
-    from corehq import toggles
     custom_logo_url = None
-    if (project and project.has_custom_logo and
-            domain_has_privilege(project.name, privileges.CUSTOM_BRANDING)):
+    if (project and project.has_custom_logo
+            and domain_has_privilege(project.name, privileges.CUSTOM_BRANDING)):
         custom_logo_url = reverse('logo', args=[project.name])
 
     def allow_report_issue(user, domain):
@@ -128,10 +126,16 @@ def js_api_keys(request):
 def js_toggles(request):
     if not getattr(request, 'couch_user', None):
         return {}
-    if not getattr(request, 'project', None):
+
+    domain = None
+    if getattr(request, 'project', None):
+        domain = request.project.name
+    elif getattr(request, 'domain', None):
+        domain = request.domain
+
+    if not domain:
         return {}
-    from corehq import toggles, feature_previews
-    domain = request.project.name
+
     return {
         'toggles_dict': toggles.toggle_values_by_name(username=request.couch_user.username, domain=domain),
         'previews_dict': feature_previews.preview_values_by_name(domain=domain)


### PR DESCRIPTION
## Summary
I keep forgetting this hasn't been done yet.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

No automated test coverage.

### QA Plan

Not planning to QA this. I've verified locally in the console & debugger that the two feature flags affected are populated correctly in `main.js`.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
