### PR TITLE
remove unused methods

### DIFF
--- a/corehq/apps/toggle_ui/models.py
+++ b/corehq/apps/toggle_ui/models.py
@@ -17,12 +17,6 @@ class ToggleAuditManager(models.Manager):
                 randomness=randomness
             )
 
-    def log_toggle_set(self, slug, username, namespaced_items):
-        self.log_toggle_action(slug, username, namespaced_items, ToggleAudit.ACTION_ADD)
-
-    def log_toggle_unset(self, slug, username, namespaced_items):
-        self.log_toggle_action(slug, username, namespaced_items, ToggleAudit.ACTION_REMOVE)
-
     def log_toggle_action(self, slug, username, namespaced_items, action):
         for namespaced_item in namespaced_items:
             namespace, item = parse_item(namespaced_item)


### PR DESCRIPTION
## Summary
Remove methods that are unused.

## Feature Flag
NA

## Product Description
NA

## Safety Assurance

- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
NA

### QA Plan
These were recently added by me and are not used. Removing them based on PR feedback.

### Safety story
Dead code

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
