### PR TITLE
moving migrations to a dedicated_process_num 

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -192,7 +192,6 @@ class ConfigurableReportTableManagerMixin(object):
             self.table_adapters_by_domain[config.domain].append(
                 self._get_indicator_adapter(config)
             )
-
         if self.run_migrations:
             self.rebuild_tables_if_necessary()
 
@@ -546,7 +545,7 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
 
 def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
                          include_ucrs=None, exclude_ucrs=None, topics=None,
-                         num_processes=1, process_num=0,
+                         num_processes=1, process_num=0, dedicated_migration_process=False,
                          processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
     """UCR pillow that reads from all Kafka topics and writes data into the UCR database tables.
 
@@ -568,13 +567,14 @@ def get_kafka_ucr_pillow(pillow_id='kafka-ucr-main', ucr_division=None,
         topics=topics,
         num_processes=num_processes,
         process_num=process_num,
+        is_dedicated_migration_process=dedicated_migration_process and (process_num == 0),
         processor_chunk_size=processor_chunk_size,
     )
 
 
 def get_kafka_ucr_static_pillow(pillow_id='kafka-ucr-static', ucr_division=None,
                                 include_ucrs=None, exclude_ucrs=None, topics=None,
-                                num_processes=1, process_num=0,
+                                num_processes=1, process_num=0, dedicated_migration_process=False,
                                 processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
     """UCR pillow that reads from all Kafka topics and writes data into the UCR database tables.
 
@@ -600,6 +600,7 @@ def get_kafka_ucr_static_pillow(pillow_id='kafka-ucr-static', ucr_division=None,
         num_processes=num_processes,
         process_num=process_num,
         retry_errors=True,
+        is_dedicated_migration_process=dedicated_migration_process and (process_num == 0),
         processor_chunk_size=processor_chunk_size,
     )
 

--- a/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
@@ -78,6 +78,13 @@ class Command(BaseCommand):
             help="The batch size for this pillow. Some pillows process changes in bulk, "
             "setting this value to 1 will process each change as it comes in.",
         )
+        parser.add_argument(
+            '--dedicated-migration-process',
+            action='store_true',
+            dest='dedicated_migration_process',
+            default=False,
+            help="Set if you want to Move migrations on to side process",
+        )
 
     def handle(self, **options):
         run_all = options['run_all']
@@ -88,6 +95,7 @@ class Command(BaseCommand):
         num_processes = options['num_processes']
         process_number = options['process_number']
         processor_chunk_size = options['processor_chunk_size']
+        dedicated_migration_process = options['dedicated_migration_process']
         assert 0 <= process_number < num_processes
         assert processor_chunk_size
         if list_all:
@@ -112,7 +120,8 @@ class Command(BaseCommand):
                                   for config in settings.PILLOWTOPS[pillow_key]]
 
         elif not run_all and not pillow_key and pillow_name:
-            pillow = get_pillow_by_name(pillow_name, num_processes=num_processes, process_num=process_number, processor_chunk_size=processor_chunk_size)
+            pillow = get_pillow_by_name(pillow_name, num_processes=num_processes, process_num=process_number, processor_chunk_size=processor_chunk_size,
+            dedicated_migration_process=dedicated_migration_process)
             start_pillow(pillow)
             sys.exit()
         elif list_checkpoints:

--- a/corehq/ex-submodules/pillowtop/processors/interface.py
+++ b/corehq/ex-submodules/pillowtop/processors/interface.py
@@ -11,6 +11,9 @@ class PillowProcessor(metaclass=ABCMeta):
     def checkpoint_updated(self):
         pass
 
+    def bootstrap_if_needed(self):
+        pass
+
 
 class BulkPillowProcessor(PillowProcessor):
     # To make the pillow process in chunks, create and use a processor

--- a/corehq/messaging/pillow.py
+++ b/corehq/messaging/pillow.py
@@ -73,9 +73,8 @@ class CaseMessagingSyncProcessor(BulkPillowProcessor):
         return [], errors
 
 
-def get_case_messaging_sync_pillow(pillow_id='case_messaging_sync_pillow', topics=None,
-                         num_processes=1, process_num=0,
-                         processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
+def get_case_messaging_sync_pillow(pillow_id='case_messaging_sync_pillow', topics=None, process_num=0,
+                         num_processes=1, processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
     """Pillow for synchronizing messaging data with case data.
 
         Processors:

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -50,7 +50,7 @@ def transform_case_for_elasticsearch(doc_dict):
 
 
 def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow', num_processes=1,
-                                     process_num=0, **kwargs):
+                                    process_num=0, **kwargs):
     """Return a pillow that processes cases to Elasticsearch.
 
     Processors:
@@ -82,7 +82,8 @@ def get_case_pillow(
         pillow_id='case-pillow', ucr_division=None,
         include_ucrs=None, exclude_ucrs=None,
         num_processes=1, process_num=0, ucr_configs=None, skip_ucr=False,
-        processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, topics=None, **kwargs):
+        processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, topics=None,
+        dedicated_migration_process=False, **kwargs):
     """Return a pillow that processes cases. The processors include, UCR and elastic processors
 
     Processors:
@@ -95,7 +96,8 @@ def get_case_pillow(
         assert set(topics).issubset(CASE_TOPICS), "This is a pillow to process cases only"
     topics = topics or CASE_TOPICS
     change_feed = KafkaChangeFeed(
-        topics, client_id=pillow_id, num_processes=num_processes, process_num=process_num
+        topics, client_id=pillow_id, num_processes=num_processes, process_num=process_num,
+        dedicated_migration_process=dedicated_migration_process
     )
     ucr_processor = ConfigurableReportPillowProcessor(
         data_source_providers=[DynamicDataSourceProvider('CommCareCase'), StaticDataSourceProvider('CommCareCase')],
@@ -134,7 +136,9 @@ def get_case_pillow(
         checkpoint=checkpoint,
         change_processed_event_handler=event_handler,
         processor=processors,
-        processor_chunk_size=processor_chunk_size
+        processor_chunk_size=processor_chunk_size,
+        process_num=process_num,
+        is_dedicated_migration_process=dedicated_migration_process and (process_num == 0)
     )
 
 

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -145,7 +145,7 @@ def get_user_pillow_old(pillow_id='UserPillow', num_processes=1, process_num=0, 
     )
 
 
-def get_user_pillow(pillow_id='user-pillow', num_processes=1, process_num=0,
+def get_user_pillow(pillow_id='user-pillow', num_processes=1, dedicated_migration_process=False, process_num=0,
         skip_ucr=False, processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, **kwargs):
     """Processes users and sends them to ES and UCRs.
 
@@ -162,7 +162,8 @@ def get_user_pillow(pillow_id='user-pillow', num_processes=1, process_num=0,
         run_migrations=(process_num == 0),  # only first process runs migrations
     )
     change_feed = KafkaChangeFeed(
-        topics=topics.USER_TOPICS, client_id='users-to-es', num_processes=num_processes, process_num=process_num
+        topics=topics.USER_TOPICS, client_id='users-to-es', num_processes=num_processes, process_num=process_num,
+        dedicated_migration_process=dedicated_migration_process
     )
     return ConstructedPillow(
         name=pillow_id,
@@ -172,7 +173,9 @@ def get_user_pillow(pillow_id='user-pillow', num_processes=1, process_num=0,
         change_processed_event_handler=KafkaCheckpointEventHandler(
             checkpoint=checkpoint, checkpoint_frequency=100, change_feed=change_feed
         ),
-        processor_chunk_size=processor_chunk_size
+        processor_chunk_size=processor_chunk_size,
+        process_num=process_num,
+        is_dedicated_migration_process=dedicated_migration_process and (process_num == 0)
     )
 
 

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -170,7 +170,7 @@ def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow', nu
 def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
                      include_ucrs=None, exclude_ucrs=None,
                      num_processes=1, process_num=0, ucr_configs=None, skip_ucr=False,
-                     processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, topics=None, **kwargs):
+                     processor_chunk_size=DEFAULT_PROCESSOR_CHUNK_SIZE, topics=None, dedicated_migration_process=False, **kwargs):
     """Generic XForm change processor
 
     Processors:
@@ -186,7 +186,8 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         assert set(topics).issubset(FORM_TOPICS), "This is a pillow to process cases only"
     topics = topics or FORM_TOPICS
     change_feed = KafkaChangeFeed(
-        topics, client_id=pillow_id, num_processes=num_processes, process_num=process_num
+        topics, client_id=pillow_id, num_processes=num_processes, process_num=process_num,
+        dedicated_migration_process=dedicated_migration_process
     )
 
     ucr_processor = ConfigurableReportPillowProcessor(
@@ -234,7 +235,9 @@ def get_xform_pillow(pillow_id='xform-pillow', ucr_division=None,
         checkpoint=checkpoint,
         change_processed_event_handler=event_handler,
         processor=processors,
-        processor_chunk_size=processor_chunk_size
+        processor_chunk_size=processor_chunk_size,
+        process_num=process_num,
+        is_dedicated_migration_process=dedicated_migration_process and (process_num == 0)
     )
 
 


### PR DESCRIPTION
moving migrations to a dedicated_process_num (i.e on first process_num) and not to run any other processes when run_migrations is set to True.
To handle this behavior, introduced variable dedicated_migration_process which will be passed from the app_processes.yml if required.

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
