### PR TITLE
refactoring of couch dump code to allow excludes

### DIFF
--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -17,6 +17,7 @@ from dimagi.utils.couch.database import iter_docs
 
 DOC_PROVIDERS = {
     DocTypeIDProvider('Application'),
+    DocTypeIDProvider('LinkedApplication'),
     DocTypeIDProvider('CommtrackConfig'),
     ViewIDProvider('CommCareMultimedia', 'hqmedia/by_domain', DomainKeyGenerator()),
     DocTypeIDProvider('MobileAuthKeyRecord'),

--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -88,7 +88,8 @@ class ToggleDumper(DataDumper):
 
     def dump(self, output_stream):
         count = 0
-        for toggle in self._get_toggles_to_migrate():
+        user_ids = _user_ids_in_domain(self.domain)
+        for toggle in _get_toggles_to_migrate(self.domain, user_ids):
             count += 1
             output_stream.write(json.dumps(toggle))
             output_stream.write('\n')
@@ -96,42 +97,39 @@ class ToggleDumper(DataDumper):
         self.stdout.write('Dumped {} Toggles\n'.format(count))
         return Counter({'Toggle': count})
 
-    def _get_toggles_to_migrate(self):
-        from corehq.toggles import all_toggles, NAMESPACE_DOMAIN
-        from toggle.models import Toggle
-        from toggle.shortcuts import namespaced_item
 
-        all_user_ids = self._user_ids_in_domain()
+def _get_toggles_to_migrate(domain, user_ids):
+    from corehq.toggles import all_toggles, NAMESPACE_DOMAIN
+    from toggle.models import Toggle
+    from toggle.shortcuts import namespaced_item
 
-        toggles_to_migrate = []
-        domain_item = namespaced_item(self.domain, NAMESPACE_DOMAIN)
+    domain_item = namespaced_item(domain, NAMESPACE_DOMAIN)
 
-        for toggle in all_toggles() + all_previews():
-            try:
-                current_toggle = Toggle.get(toggle.slug)
-            except ResourceNotFound:
-                continue
+    for toggle in all_toggles() + all_previews():
+        try:
+            current_toggle = Toggle.get(toggle.slug)
+        except ResourceNotFound:
+            continue
 
-            enabled_for = set(current_toggle.enabled_users)
+        enabled_for = set(current_toggle.enabled_users)
 
-            new_toggle = Toggle(slug=toggle.slug, enabled_users=[])
-            if domain_item in enabled_for:
-                new_toggle.enabled_users.append(domain_item)
+        new_toggle = Toggle(slug=toggle.slug, enabled_users=[])
+        if domain_item in enabled_for:
+            new_toggle.enabled_users.append(domain_item)
 
-            enabled_users = enabled_for & all_user_ids
-            new_toggle.enabled_users.extend(list(enabled_users))
+        enabled_users = enabled_for & user_ids
+        new_toggle.enabled_users.extend(list(enabled_users))
 
-            if new_toggle.enabled_users:
-                toggles_to_migrate.append(new_toggle.to_json())
+        if new_toggle.enabled_users:
+            yield new_toggle.to_json()
 
-        return toggles_to_migrate
 
-    def _user_ids_in_domain(self):
-        from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_type
-        user_ids = set()
-        for doc_type in ('CommCareUser', 'WebUser'):
-            user_ids.update(set(get_doc_ids_in_domain_by_type(self.domain, doc_type)))
-        return user_ids
+def _user_ids_in_domain(domain):
+    from corehq.apps.domain.dbaccessors import get_doc_ids_in_domain_by_type
+    user_ids = set()
+    for doc_type in ('CommCareUser', 'WebUser'):
+        user_ids.update(set(get_doc_ids_in_domain_by_type(domain, doc_type)))
+    return user_ids
 
 
 class DomainDumper(DataDumper):

--- a/corehq/apps/dump_reload/couch/dump.py
+++ b/corehq/apps/dump_reload/couch/dump.py
@@ -71,12 +71,12 @@ class CouchDataDumper(DataDumper):
         return Counter({model_label: count})
 
 
-def get_doc_ids_to_dump(domain, exclude_doc_types):
+def get_doc_ids_to_dump(domain, exclude_doc_types=None):
     """
     :return: A generator of (doc_class, list(doc_ids))
     """
     for id_provider in DOC_PROVIDERS:
-        if id_provider.doc_type in exclude_doc_types:
+        if exclude_doc_types and id_provider.doc_type in exclude_doc_types:
             continue
 
         for doc_type, doc_ids in id_provider.get_doc_ids(domain):

--- a/corehq/apps/dump_reload/management/commands/dump_domain_data.py
+++ b/corehq/apps/dump_reload/management/commands/dump_domain_data.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         parser.add_argument('domain_name')
         parser.add_argument(
             '-e', '--exclude', dest='exclude', action='append', default=[],
-            help='An app_label or app_label.ModelName to exclude '
+            help='An app_label, app_label.ModelName or CouchDB doc_type to exclude '
                  '(use multiple --exclude to exclude multiple apps/models).'
         )
         parser.add_argument(

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -8,7 +8,7 @@ from io import StringIO
 from django.test import SimpleTestCase, TestCase
 
 from couchdbkit.exceptions import ResourceNotFound
-from mock import Mock, patch
+from mock import patch
 
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.bulk import get_docs

--- a/corehq/apps/dump_reload/tests/test_couch_dump_load.py
+++ b/corehq/apps/dump_reload/tests/test_couch_dump_load.py
@@ -8,7 +8,7 @@ from io import StringIO
 from django.test import SimpleTestCase, TestCase
 
 from couchdbkit.exceptions import ResourceNotFound
-from mock import Mock
+from mock import Mock, patch
 
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.bulk import get_docs
@@ -110,7 +110,7 @@ class CouchDumpLoadTest(TestCase):
         }
         for provider in DOC_PROVIDERS:
             if isinstance(provider, DocTypeIDProvider):
-                doc_types.extend(provider.doc_types)
+                doc_types.append(provider.doc_type)
 
         def _make_doc(doc_type, domain):
             doc_class = get_document_class_by_doc_type(doc_type)
@@ -215,11 +215,12 @@ class TestDumpLoadToggles(SimpleTestCase):
 
     def test_dump_toggles(self):
         dumper = ToggleDumper(self.domain_name, [])
-        dumper._user_ids_in_domain = Mock(return_value={'user1', 'user2', 'user3'})
+        users = {'user1', 'user2', 'user3'}
 
         output_stream = StringIO()
 
-        with mock_out_couch(docs=[doc.to_json() for doc in self.mocked_toggles.values()]):
+        with mock_out_couch(docs=[doc.to_json() for doc in self.mocked_toggles.values()]), \
+             patch("corehq.apps.dump_reload.couch.dump._user_ids_in_domain", return_value=users):
             dumper.dump(output_stream)
         output_stream.seek(0)
         lines = output_stream.readlines()


### PR DESCRIPTION
## Summary
I'm working on this as part of a task to extract data from a domain based on location.

Best reviewed by commit:

* remove code related to having attachments in couch
* simplify doc ID providers to map to a single doc_type each
* split out function for extracting toggles
* include "LinkedApplications"

## Feature Flag
NA

## Product Description
NA

## Safety Assurance
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [X] If QA is part of the safety story, the "Awaiting QA" label is used
- [X] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
Covered by existing tests.

### QA Plan
This only affects a management command and not any user facing features.

### Safety story
Changes isolated to a management command.

### Rollback instructions
- [X] This PR can be reverted after deploy with no further considerations 
