### PR TITLE
Updated captcha templates to fix deprecation warning

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -35,7 +35,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ugettext_noop
 
-from captcha.fields import CaptchaField
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import StrictButton
@@ -111,6 +110,7 @@ from corehq.apps.hqwebapp.crispy import HQFormHelper
 from corehq.apps.hqwebapp.fields import MultiCharField
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.hqwebapp.widgets import BootstrapCheckboxInput, Select2Ajax, GeoCoderInput
+from corehq.apps.hqwebapp.fields import CaptchaField
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.apps.users.permissions import can_manage_releases

--- a/corehq/apps/hqwebapp/fields.py
+++ b/corehq/apps/hqwebapp/fields.py
@@ -1,6 +1,9 @@
 from django import forms
 from django.core.validators import validate_email
 from django.forms import fields
+from captcha.fields import CaptchaField as BaseCaptchaField
+
+from .widgets import HQCaptchaTextInput
 
 
 class CSVListField(fields.CharField):
@@ -59,3 +62,10 @@ class MultiEmailField(MultiCharField):
     default_error_messages = {
         'invalid': 'Please enter only valid email addresses.'
     }
+
+
+class CaptchaField(BaseCaptchaField):
+    def __init__(self, *args, **kwargs):
+        if 'widget' not in kwargs:
+            kwargs['widget'] = HQCaptchaTextInput
+        super().__init__(*args, **kwargs)

--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -11,7 +11,6 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
-from captcha.fields import CaptchaField
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import InlineField, StrictButton
 from crispy_forms.helper import FormHelper
@@ -20,6 +19,8 @@ from two_factor.forms import AuthenticationTokenForm, BackupTokenForm
 
 from corehq.apps.domain.forms import NoAutocompleteMixin
 from corehq.apps.users.models import CouchUser
+
+from .fields import CaptchaField
 
 LOCKOUT_MESSAGE = mark_safe(_('Sorry - you have attempted to login with an incorrect password too many times. Please <a href="/accounts/password_reset_email/">click here</a> to reset your password or contact the domain administrator.'))
 

--- a/corehq/apps/hqwebapp/templates/hq-captcha-field.html
+++ b/corehq/apps/hqwebapp/templates/hq-captcha-field.html
@@ -1,3 +1,11 @@
-{# hidden submit button to enable [enter] key #}
-<div style="display: none"><input type="submit" value=""/></div>
-{{image}}{{hidden_field}}<br />{{text_field}}
+{% load i18n %}
+{% spaceless %}
+    {# hidden submit button to enable [enter] key #}
+    <div style="display: none"><input type="submit" value=""/></div>
+    {% if audio %}
+        <a title="{% trans "Play CAPTCHA as audio file" %}" href="{{ audio }}">
+    {% endif %}
+    <img src="{{ image }}" alt="captcha" class="captcha" />
+    {% if audio %}</a>{% endif %}
+{% endspaceless %}
+{% include "django/forms/widgets/multiwidget.html" %}

--- a/corehq/apps/hqwebapp/widgets.py
+++ b/corehq/apps/hqwebapp/widgets.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop
+from captcha.fields import CaptchaTextInput
 
 from dimagi.utils.dates import DateSpan
 
@@ -173,3 +174,7 @@ class GeoCoderInput(Input):
         return mark_safe("""
             <div class="geocoder-proximity">{}</div>
         """.format(output))
+
+
+class HQCaptchaTextInput(CaptchaTextInput):
+    template_name = 'hq-captcha-field.html'

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -10,7 +10,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
-from captcha.fields import CaptchaField
 from crispy_forms import bootstrap as twbscrispy
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
@@ -19,6 +18,7 @@ from corehq.apps.analytics.tasks import track_workflow
 from corehq.apps.domain.forms import NoAutocompleteMixin, clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp import crispy as hqcrispy
+from corehq.apps.hqwebapp.fields import CaptchaField
 from corehq.apps.locations.forms import LocationSelectWidget
 from corehq.apps.programs.models import Program
 from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter as EMWF

--- a/settings.py
+++ b/settings.py
@@ -220,7 +220,6 @@ DEFAULT_APPS = (
     'oauth2_provider',
 )
 
-CAPTCHA_FIELD_TEMPLATE = 'hq-captcha-field.html'
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 CRISPY_ALLOWED_TEMPLATE_PACKS = (
     'bootstrap',


### PR DESCRIPTION
## Summary
When running manage.py, we currently see: `DeprecationWarning: CAPTCHA_FIELD_TEMPLATE setting is deprecated in favor of widget's template_name.`

This was being caused by us explicitly setting the CAPTCHA_FIELD_TEMPLATE within settings.py, causing captcha to revert into legacy behavior.  The correct pattern is shown [here](https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#rendering)

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I am certain that this PR will not introduce a regression for the reasons below

### Automated test coverage
No automated test coverage. I manually tested the 3 parts of the code that use a captcha, but as this is largely a config/html change, it's difficult to create tests for.

### QA Plan
Should not need QA

### Safety story
There are only 3 locations that use captchas: users logging in, users trying to reset their passwords, and users accepting an invitation. All 3 require the `ENABLE_DRACONIAN_SECURITY_FEATURES` setting. Because I locally tested the template changes, the code changes are minimal, and it's difficult to turn on those features, I don't think this feature benefits from QA.

### Rollback instructions


- [x] This PR can be reverted after deploy with no further considerations 
