### PR TITLE
Updated the pre-commit hook to ignore context

### DIFF
--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -50,7 +50,7 @@ fi
 status=0
 git diff-index --check --cached $against --
 if [ $? != 0 ]; then status=1; fi
-git diff --cached | flake8 --diff --show-source --config=.flake8
+git diff --cached -U0 | flake8 --diff --show-source --config=.flake8
 if [ $? != 0 ]; then status=1; fi
 
 if [ $status != 0 ]


### PR DESCRIPTION
The pre-commit hook relies on `git diff --staged`, which uses 3 lines of context, by default, all of which is eligible for warnings. If any of that context have warnings, your commit will currently be blocked. Using the `-U0` option limits the diff output to only your changes.